### PR TITLE
[hipsparse] Generate a googletest error if calling generate_csr_matrix fails in testing_xxx.hpp files

### DIFF
--- a/projects/hipsparse/clients/include/testing_bsr2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_bsr2csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsr2csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  m            = 1;
     int                  n            = 1;
     int                  safe_size    = 1;

--- a/projects/hipsparse/clients/include/testing_bsr2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_bsr2csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsr2csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  m            = 1;
     int                  n            = 1;
     int                  safe_size    = 1;
@@ -295,11 +295,8 @@ void testing_bsr2csr(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, csr_row_ptr, csr_col_ind, csr_val, csr_idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, csr_row_ptr, csr_col_ind, csr_val, csr_idx_base));
 
     // m and n can be modifed if we read in a matrix from a file
     int mb = (m + block_dim - 1) / block_dim;

--- a/projects/hipsparse/clients/include/testing_bsric02.hpp
+++ b/projects/hipsparse/clients/include/testing_bsric02.hpp
@@ -45,7 +45,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsric02_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                    mb        = 100;
     int                    nnzb      = 100;
     int                    block_dim = 4;
@@ -338,7 +338,7 @@ void testing_bsric02_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_bsric02(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m         = argus.M;
     int                    block_dim = argus.block_dim;
     hipsparseDirection_t   dir       = argus.dirA;
@@ -375,11 +375,8 @@ void testing_bsric02(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     // m can be modifed if we read in a matrix from a file
     int mb = (m + block_dim - 1) / block_dim;

--- a/projects/hipsparse/clients/include/testing_bsric02.hpp
+++ b/projects/hipsparse/clients/include/testing_bsric02.hpp
@@ -45,7 +45,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsric02_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                    mb        = 100;
     int                    nnzb      = 100;
     int                    block_dim = 4;
@@ -338,7 +338,7 @@ void testing_bsric02_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_bsric02(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m         = argus.M;
     int                    block_dim = argus.block_dim;
     hipsparseDirection_t   dir       = argus.dirA;

--- a/projects/hipsparse/clients/include/testing_bsrilu02.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrilu02.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrilu02_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                    mb        = 100;
     int                    nnzb      = 100;
     int                    block_dim = 4;
@@ -342,7 +342,7 @@ void testing_bsrilu02_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_bsrilu02(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m         = argus.M;
     int                    block_dim = argus.block_dim;
     int                    boost     = argus.numericboost;

--- a/projects/hipsparse/clients/include/testing_bsrilu02.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrilu02.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrilu02_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                    mb        = 100;
     int                    nnzb      = 100;
     int                    block_dim = 4;
@@ -342,7 +342,7 @@ void testing_bsrilu02_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_bsrilu02(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m         = argus.M;
     int                    block_dim = argus.block_dim;
     int                    boost     = argus.numericboost;
@@ -382,11 +382,8 @@ void testing_bsrilu02(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     // m can be modifed if we read in a matrix from a file
     int mb = (m + block_dim - 1) / block_dim;

--- a/projects/hipsparse/clients/include/testing_bsrmm.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrmm.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrmm_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  mb        = 100;
     int                  n         = 100;
     int                  kb        = 100;

--- a/projects/hipsparse/clients/include/testing_bsrmm.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrmm.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrmm_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  mb        = 100;
     int                  n         = 100;
     int                  kb        = 100;
@@ -444,11 +444,8 @@ void testing_bsrmm(const Arguments& argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, k, nnz, csr_row_ptr, csr_col_ind, csr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, k, nnz, csr_row_ptr, csr_col_ind, csr_val, idx_base));
 
     // m and k can be modifed if we read in a matrix from a file
     int mb = (m + block_dim - 1) / block_dim;

--- a/projects/hipsparse/clients/include/testing_bsrmv.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrmv.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrmv_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
 
     int                  safe_size = 100;
     int                  safe_dim  = 2;

--- a/projects/hipsparse/clients/include/testing_bsrmv.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrmv.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrmv_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
 
     int                  safe_size = 100;
     int                  safe_dim  = 2;
@@ -324,11 +324,8 @@ void testing_bsrmv(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     mb = (m + block_dim - 1) / block_dim;
     nb = (n + block_dim - 1) / block_dim;

--- a/projects/hipsparse/clients/include/testing_bsrsm2.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrsm2.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrsm2_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int   mb        = 100;
     int   nrhs      = 100;
     int   nnzb      = 100;
@@ -517,7 +517,7 @@ void testing_bsrsm2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_bsrsm2(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                  m         = argus.M;
     int                  nrhs      = argus.N;
     int                  block_dim = argus.block_dim;

--- a/projects/hipsparse/clients/include/testing_bsrsm2.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrsm2.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrsm2_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int   mb        = 100;
     int   nrhs      = 100;
     int   nnzb      = 100;
@@ -517,7 +517,7 @@ void testing_bsrsm2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_bsrsm2(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                  m         = argus.M;
     int                  nrhs      = argus.N;
     int                  block_dim = argus.block_dim;
@@ -557,11 +557,8 @@ void testing_bsrsm2(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     int mb = (m + block_dim - 1) / block_dim;
 

--- a/projects/hipsparse/clients/include/testing_bsrsv2.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrsv2.hpp
@@ -46,7 +46,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrsv2_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nnz       = 100;
     int                    block_dim = 2;
@@ -420,7 +420,7 @@ void testing_bsrsv2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_bsrsv2(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m         = argus.M;
     int                    block_dim = argus.block_dim;
     hipsparseIndexBase_t   idx_base  = argus.baseA;
@@ -468,11 +468,8 @@ void testing_bsrsv2(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     int mb = (m + block_dim - 1) / block_dim;
 

--- a/projects/hipsparse/clients/include/testing_bsrsv2.hpp
+++ b/projects/hipsparse/clients/include/testing_bsrsv2.hpp
@@ -46,7 +46,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_bsrsv2_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nnz       = 100;
     int                    block_dim = 2;
@@ -420,7 +420,7 @@ void testing_bsrsv2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_bsrsv2(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m         = argus.M;
     int                    block_dim = argus.block_dim;
     hipsparseIndexBase_t   idx_base  = argus.baseA;

--- a/projects/hipsparse/clients/include/testing_cscsort.hpp
+++ b/projects/hipsparse/clients/include/testing_cscsort.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_cscsort_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int m         = 100;
     int n         = 100;
     int nnz       = 100;
@@ -113,7 +113,7 @@ void testing_cscsort_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_cscsort(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     int                  permute  = argus.permute;

--- a/projects/hipsparse/clients/include/testing_cscsort.hpp
+++ b/projects/hipsparse/clients/include/testing_cscsort.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_cscsort_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int m         = 100;
     int n         = 100;
     int nnz       = 100;
@@ -113,7 +113,7 @@ void testing_cscsort_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_cscsort(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     int                  permute  = argus.permute;
@@ -145,11 +145,8 @@ void testing_cscsort(Arguments argus)
 
     // Read or construct CSC matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, n, m, nnz, hcsc_col_ptr, hcsc_row_ind, hcsc_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, n, m, nnz, hcsc_col_ptr, hcsc_row_ind, hcsc_val, idx_base));
 
     // Unsort CSC columns
     std::vector<int>   hperm(nnz);

--- a/projects/hipsparse/clients/include/testing_csr2bsr.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2bsr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2bsr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  m            = 1;
     int                  n            = 1;
     int                  safe_size    = 1;
@@ -406,12 +406,8 @@ void testing_csr2bsr(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(
-           filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, csr_idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, csr_idx_base));
 
     int mb = (m + block_dim - 1) / block_dim;
     int nb = (n + block_dim - 1) / block_dim;

--- a/projects/hipsparse/clients/include/testing_csr2bsr.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2bsr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2bsr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  m            = 1;
     int                  n            = 1;
     int                  safe_size    = 1;

--- a/projects/hipsparse/clients/include/testing_csr2coo.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2coo.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2coo_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  m         = 100;
     int                  nnz       = 100;
     int                  safe_size = 100;

--- a/projects/hipsparse/clients/include/testing_csr2coo.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2coo.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2coo_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  m         = 100;
     int                  nnz       = 100;
     int                  safe_size = 100;
@@ -92,11 +92,8 @@ void testing_csr2coo(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed

--- a/projects/hipsparse/clients/include/testing_csr2csc.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2csc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2csc_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int m         = 100;
     int n         = 100;
     int nnz       = 100;
@@ -167,7 +167,7 @@ void testing_csr2csc_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csr2csc(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     hipsparseIndexBase_t idx_base = argus.baseA;
@@ -186,11 +186,8 @@ void testing_csr2csc(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed

--- a/projects/hipsparse/clients/include/testing_csr2csc.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2csc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2csc_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int m         = 100;
     int n         = 100;
     int nnz       = 100;
@@ -167,7 +167,7 @@ void testing_csr2csc_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csr2csc(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     hipsparseIndexBase_t idx_base = argus.baseA;

--- a/projects/hipsparse/clients/include/testing_csr2csc_ex2.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2csc_ex2.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2csc_ex2_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int    m           = 100;
     int    n           = 100;
     int    nnz         = 100;
@@ -276,7 +276,7 @@ void testing_csr2csc_ex2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csr2csc_ex2(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
     int                   m        = argus.M;
     int                   n        = argus.N;
     hipsparseIndexBase_t  idx_base = argus.baseA;

--- a/projects/hipsparse/clients/include/testing_csr2csc_ex2.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2csc_ex2.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2csc_ex2_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int    m           = 100;
     int    n           = 100;
     int    nnz         = 100;
@@ -276,7 +276,7 @@ void testing_csr2csc_ex2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csr2csc_ex2(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 10010)
     int                   m        = argus.M;
     int                   n        = argus.N;
     hipsparseIndexBase_t  idx_base = argus.baseA;
@@ -298,11 +298,8 @@ void testing_csr2csc_ex2(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed

--- a/projects/hipsparse/clients/include/testing_csr2csr_compress.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2csr_compress.hpp
@@ -45,7 +45,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2csr_compress_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  m            = 1;
     int                  n            = 1;
     int                  nnz_A        = 1;

--- a/projects/hipsparse/clients/include/testing_csr2csr_compress.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2csr_compress.hpp
@@ -45,7 +45,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2csr_compress_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  m            = 1;
     int                  n            = 1;
     int                  nnz_A        = 1;
@@ -335,12 +335,8 @@ void testing_csr2csr_compress(Arguments argus)
 
     // Read or construct CSR matrix
     int hnnz_A = 0;
-    if(!generate_csr_matrix(
-           filename, m, n, hnnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, m, n, hnnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base));
 
     // Allocate memory on the device
     auto dcsr_row_ptr_A_managed

--- a/projects/hipsparse/clients/include/testing_csr2gebsr.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2gebsr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2gebsr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
 
     hipsparseStatus_t              status;
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
@@ -460,12 +460,8 @@ void testing_csr2gebsr(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(
-           filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, csr_idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, csr_idx_base));
 
     int mb = (m + row_block_dim - 1) / row_block_dim;
     int nb = (n + col_block_dim - 1) / col_block_dim;

--- a/projects/hipsparse/clients/include/testing_csr2gebsr.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2gebsr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2gebsr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
 
     hipsparseStatus_t              status;
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);

--- a/projects/hipsparse/clients/include/testing_csr2hyb.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2hyb.hpp
@@ -48,7 +48,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2hyb_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int m         = 100;
     int n         = 100;
     int safe_size = 100;
@@ -121,7 +121,7 @@ void testing_csr2hyb_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csr2hyb(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                     m              = argus.M;
     int                     n              = argus.N;
     hipsparseIndexBase_t    idx_base       = argus.baseA;
@@ -150,11 +150,8 @@ void testing_csr2hyb(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     if(m == 0 || n == 0)
     {

--- a/projects/hipsparse/clients/include/testing_csr2hyb.hpp
+++ b/projects/hipsparse/clients/include/testing_csr2hyb.hpp
@@ -48,7 +48,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csr2hyb_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int m         = 100;
     int n         = 100;
     int safe_size = 100;
@@ -121,7 +121,7 @@ void testing_csr2hyb_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csr2hyb(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                     m              = argus.M;
     int                     n              = argus.N;
     hipsparseIndexBase_t    idx_base       = argus.baseA;

--- a/projects/hipsparse/clients/include/testing_csrcolor.hpp
+++ b/projects/hipsparse/clients/include/testing_csrcolor.hpp
@@ -41,7 +41,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrcolor_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
 
     static constexpr int M               = 10;
     static constexpr int NNZ             = 10;
@@ -228,7 +228,7 @@ void testing_csrcolor_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrcolor(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     hipsparseIndexBase_t idxBase  = argus.baseA;
     std::string          filename = argus.filename;
 
@@ -254,11 +254,8 @@ void testing_csrcolor(const Arguments& argus)
     int m;
     int k;
     int nnz;
-    if(!generate_csr_matrix(filename, m, k, nnz, hrow_ptr, hcol_ind, hval, idxBase))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, k, nnz, hrow_ptr, hcol_ind, hval, idxBase));
 
     hipsparseColorInfo_t colorInfo;
     CHECK_HIPSPARSE_ERROR(hipsparseCreateColorInfo(&colorInfo));

--- a/projects/hipsparse/clients/include/testing_csrcolor.hpp
+++ b/projects/hipsparse/clients/include/testing_csrcolor.hpp
@@ -41,7 +41,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrcolor_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
 
     static constexpr int M               = 10;
     static constexpr int NNZ             = 10;
@@ -228,7 +228,7 @@ void testing_csrcolor_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrcolor(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     hipsparseIndexBase_t idxBase  = argus.baseA;
     std::string          filename = argus.filename;
 

--- a/projects/hipsparse/clients/include/testing_csrgeam.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgeam.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgeam_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int safe_size = 1;
 
     T alpha = make_DataType<T>(1.0);
@@ -694,7 +694,7 @@ void testing_csrgeam_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrgeam(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  M          = argus.M;
     int                  N          = argus.N;
     T                    h_alpha    = make_DataType<T>(argus.alpha);
@@ -730,13 +730,8 @@ void testing_csrgeam(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz_A = 0;
-    if(!generate_csr_matrix(
-           filename, M, N, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base_A))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
-
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, M, N, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base_A));
     // B = A
     int              nnz_B = nnz_A;
     std::vector<int> hcsr_row_ptr_B(M + 1, 0);

--- a/projects/hipsparse/clients/include/testing_csrgeam.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgeam.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgeam_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int safe_size = 1;
 
     T alpha = make_DataType<T>(1.0);
@@ -694,7 +694,7 @@ void testing_csrgeam_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrgeam(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  M          = argus.M;
     int                  N          = argus.N;
     T                    h_alpha    = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_csrgeam2.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgeam2.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgeam2_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int safe_size = 1;
 
     T alpha = make_DataType<T>(1.0);

--- a/projects/hipsparse/clients/include/testing_csrgeam2.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgeam2.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgeam2_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int safe_size = 1;
 
     T alpha = make_DataType<T>(1.0);
@@ -766,12 +766,8 @@ void testing_csrgeam2(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz_A = 0;
-    if(!generate_csr_matrix(
-           filename, M, N, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base_A))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, M, N, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base_A));
 
     if(idx_base_C != idx_base_A || idx_base_C != idx_base_B || M == 0 || N == 0)
     {

--- a/projects/hipsparse/clients/include/testing_csrgemm.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgemm.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgemm_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  M         = 1;
     int                  N         = 1;
     int                  K         = 1;
@@ -699,7 +699,7 @@ static void host_csrgemm(int                  m,
 template <typename T>
 void testing_csrgemm(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  M          = argus.M;
     int                  N          = argus.N;
     int                  K          = argus.K;

--- a/projects/hipsparse/clients/include/testing_csrgemm.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgemm.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgemm_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  M         = 1;
     int                  N         = 1;
     int                  K         = 1;
@@ -699,7 +699,7 @@ static void host_csrgemm(int                  m,
 template <typename T>
 void testing_csrgemm(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  M          = argus.M;
     int                  N          = argus.N;
     int                  K          = argus.K;
@@ -736,12 +736,8 @@ void testing_csrgemm(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz_A = 0;
-    if(!generate_csr_matrix(
-           filename, M, K, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base_A))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, M, K, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base_A));
 
     // B = A^T so that we can compute the square of A
     N                      = M;

--- a/projects/hipsparse/clients/include/testing_csrgemm2_a.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgemm2_a.hpp
@@ -40,7 +40,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgemm2_a_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int M         = 1;
     int N         = 1;
     int K         = 1;
@@ -1040,7 +1040,7 @@ void testing_csrgemm2_a_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrgemm2_a(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                  M          = argus.M;
     int                  N          = argus.N;
     int                  K          = argus.K;
@@ -1091,12 +1091,8 @@ void testing_csrgemm2_a(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz_A = 0;
-    if(!generate_csr_matrix(
-           filename, M, K, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base_A))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, M, K, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idx_base_A));
 
     std::vector<int> hcsr_row_ptr_B;
     std::vector<int> hcsr_col_ind_B;

--- a/projects/hipsparse/clients/include/testing_csrgemm2_a.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgemm2_a.hpp
@@ -40,7 +40,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgemm2_a_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int M         = 1;
     int N         = 1;
     int K         = 1;
@@ -1040,7 +1040,7 @@ void testing_csrgemm2_a_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrgemm2_a(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                  M          = argus.M;
     int                  N          = argus.N;
     int                  K          = argus.K;

--- a/projects/hipsparse/clients/include/testing_csrgemm2_b.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgemm2_b.hpp
@@ -40,7 +40,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgemm2_b_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int M         = 1;
     int N         = 1;
     int nnz_D     = 1;
@@ -815,7 +815,7 @@ void testing_csrgemm2_b_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrgemm2_b(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                  M          = argus.M;
     int                  N          = argus.N;
     hipsparseIndexBase_t idx_base_C = argus.baseC;

--- a/projects/hipsparse/clients/include/testing_csrgemm2_b.hpp
+++ b/projects/hipsparse/clients/include/testing_csrgemm2_b.hpp
@@ -40,7 +40,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrgemm2_b_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int M         = 1;
     int N         = 1;
     int nnz_D     = 1;
@@ -815,7 +815,7 @@ void testing_csrgemm2_b_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrgemm2_b(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                  M          = argus.M;
     int                  N          = argus.N;
     hipsparseIndexBase_t idx_base_C = argus.baseC;
@@ -856,12 +856,8 @@ void testing_csrgemm2_b(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz_D = 0;
-    if(!generate_csr_matrix(
-           filename, M, N, nnz_D, hcsr_row_ptr_D, hcsr_col_ind_D, hcsr_val_D, idx_base_D))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, M, N, nnz_D, hcsr_row_ptr_D, hcsr_col_ind_D, hcsr_val_D, idx_base_D));
 
     std::vector<int> hcsr_row_ptr_A;
     std::vector<int> hcsr_col_ind_A;

--- a/projects/hipsparse/clients/include/testing_csric02.hpp
+++ b/projects/hipsparse/clients/include/testing_csric02.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csric02_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nnz       = 100;
     int                    safe_size = 100;
@@ -159,7 +159,7 @@ void testing_csric02_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csric02(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m        = argus.M;
     hipsparseIndexBase_t   idx_base = argus.baseA;
     hipsparseSolvePolicy_t policy   = argus.solve_policy;
@@ -194,11 +194,8 @@ void testing_csric02(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     std::vector<T> hcsr_val_orig(hcsr_val);
 

--- a/projects/hipsparse/clients/include/testing_csric02.hpp
+++ b/projects/hipsparse/clients/include/testing_csric02.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csric02_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nnz       = 100;
     int                    safe_size = 100;
@@ -159,7 +159,7 @@ void testing_csric02_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csric02(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m        = argus.M;
     hipsparseIndexBase_t   idx_base = argus.baseA;
     hipsparseSolvePolicy_t policy   = argus.solve_policy;

--- a/projects/hipsparse/clients/include/testing_csrilu02.hpp
+++ b/projects/hipsparse/clients/include/testing_csrilu02.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrilu02_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nnz       = 100;
     int                    safe_size = 100;
@@ -178,7 +178,7 @@ void testing_csrilu02_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrilu02(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m         = argus.M;
     int                    boost     = argus.numericboost;
     double                 boost_tol = argus.boosttol;

--- a/projects/hipsparse/clients/include/testing_csrilu02.hpp
+++ b/projects/hipsparse/clients/include/testing_csrilu02.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrilu02_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nnz       = 100;
     int                    safe_size = 100;
@@ -178,7 +178,7 @@ void testing_csrilu02_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrilu02(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                    m         = argus.M;
     int                    boost     = argus.numericboost;
     double                 boost_tol = argus.boosttol;
@@ -216,11 +216,8 @@ void testing_csrilu02(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     std::vector<T> hcsr_val_orig(hcsr_val);
 

--- a/projects/hipsparse/clients/include/testing_csrilusv.hpp
+++ b/projects/hipsparse/clients/include/testing_csrilusv.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrilusv(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     hipsparseIndexBase_t idx_base = argus.baseA;
     std::string          filename = argus.filename;
 

--- a/projects/hipsparse/clients/include/testing_csrilusv.hpp
+++ b/projects/hipsparse/clients/include/testing_csrilusv.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrilusv(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     hipsparseIndexBase_t idx_base = argus.baseA;
     std::string          filename = argus.filename;
 
@@ -68,11 +68,8 @@ void testing_csrilusv(Arguments argus)
     int m;
     int n;
     int nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     // Allocate memory on device
     auto dptr_managed = hipsparse_unique_ptr{device_malloc(sizeof(int) * (m + 1)), device_free};

--- a/projects/hipsparse/clients/include/testing_csrmm.hpp
+++ b/projects/hipsparse/clients/include/testing_csrmm.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrmm_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  N         = 100;
     int                  M         = 100;
     int                  K         = 100;
@@ -294,7 +294,7 @@ void testing_csrmm_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrmm(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  M        = argus.M;
     int                  N        = argus.N;
     int                  K        = argus.K;

--- a/projects/hipsparse/clients/include/testing_csrmm.hpp
+++ b/projects/hipsparse/clients/include/testing_csrmm.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrmm_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  N         = 100;
     int                  M         = 100;
     int                  K         = 100;
@@ -294,7 +294,7 @@ void testing_csrmm_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrmm(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  M        = argus.M;
     int                  N        = argus.N;
     int                  K        = argus.K;
@@ -323,11 +323,8 @@ void testing_csrmm(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, M, K, nnz, hcsr_row_ptrA, hcsr_col_indA, hcsr_valA, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, M, K, nnz, hcsr_row_ptrA, hcsr_col_indA, hcsr_valA, idx_base));
 
     // Some matrix properties
     int A_m = M;

--- a/projects/hipsparse/clients/include/testing_csrmv.hpp
+++ b/projects/hipsparse/clients/include/testing_csrmv.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrmv_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  n         = 100;
     int                  m         = 100;
     int                  nnz       = 100;
@@ -132,7 +132,7 @@ void testing_csrmv_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrmv(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  nrow     = argus.M;
     int                  ncol     = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);
@@ -159,12 +159,8 @@ void testing_csrmv(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(
-           filename, nrow, ncol, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, nrow, ncol, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     int m = (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? nrow : ncol;
     int n = (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? ncol : nrow;

--- a/projects/hipsparse/clients/include/testing_csrmv.hpp
+++ b/projects/hipsparse/clients/include/testing_csrmv.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrmv_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  n         = 100;
     int                  m         = 100;
     int                  nnz       = 100;
@@ -132,7 +132,7 @@ void testing_csrmv_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrmv(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  nrow     = argus.M;
     int                  ncol     = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_csrsm2.hpp
+++ b/projects/hipsparse/clients/include/testing_csrsm2.hpp
@@ -46,7 +46,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrsm2_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nrhs      = 100;
     int                    nnz       = 100;
@@ -582,7 +582,7 @@ void testing_csrsm2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrsm2(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                    m        = argus.M;
     int                    nrhs     = argus.N;
     hipsparseIndexBase_t   idx_base = argus.baseA;

--- a/projects/hipsparse/clients/include/testing_csrsm2.hpp
+++ b/projects/hipsparse/clients/include/testing_csrsm2.hpp
@@ -46,7 +46,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrsm2_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nrhs      = 100;
     int                    nnz       = 100;
@@ -582,7 +582,7 @@ void testing_csrsm2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrsm2(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                    m        = argus.M;
     int                    nrhs     = argus.N;
     hipsparseIndexBase_t   idx_base = argus.baseA;
@@ -621,11 +621,8 @@ void testing_csrsm2(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     int ldb = (transB == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : nrhs;
 

--- a/projects/hipsparse/clients/include/testing_csrsort.hpp
+++ b/projects/hipsparse/clients/include/testing_csrsort.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrsort_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int m         = 100;
     int n         = 100;
     int nnz       = 100;
@@ -113,7 +113,7 @@ void testing_csrsort_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrsort(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     int                  permute  = argus.permute;
@@ -138,11 +138,8 @@ void testing_csrsort(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     // Unsort CSR columns
     std::vector<int>   hperm(nnz);

--- a/projects/hipsparse/clients/include/testing_csrsort.hpp
+++ b/projects/hipsparse/clients/include/testing_csrsort.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrsort_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int m         = 100;
     int n         = 100;
     int nnz       = 100;
@@ -113,7 +113,7 @@ void testing_csrsort_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrsort(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     int                  permute  = argus.permute;

--- a/projects/hipsparse/clients/include/testing_csrsv2.hpp
+++ b/projects/hipsparse/clients/include/testing_csrsv2.hpp
@@ -46,7 +46,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrsv2_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nnz       = 100;
     int                    safe_size = 100;
@@ -323,7 +323,7 @@ void testing_csrsv2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrsv2(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                    m         = argus.M;
     hipsparseIndexBase_t   idx_base  = argus.baseA;
     hipsparseOperation_t   trans     = argus.transA;
@@ -367,11 +367,8 @@ void testing_csrsv2(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, m, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     std::vector<T> hx(m);
     std::vector<T> hy_1(m);

--- a/projects/hipsparse/clients/include/testing_csrsv2.hpp
+++ b/projects/hipsparse/clients/include/testing_csrsv2.hpp
@@ -46,7 +46,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csrsv2_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                    m         = 100;
     int                    nnz       = 100;
     int                    safe_size = 100;
@@ -323,7 +323,7 @@ void testing_csrsv2_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csrsv2(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int                    m         = argus.M;
     hipsparseIndexBase_t   idx_base  = argus.baseA;
     hipsparseOperation_t   trans     = argus.transA;

--- a/projects/hipsparse/clients/include/testing_csru2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_csru2csr.hpp
@@ -40,7 +40,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csru2csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int m         = 100;
     int n         = 100;
     int nnz       = 100;
@@ -246,7 +246,7 @@ void testing_csru2csr_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csru2csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     hipsparseIndexBase_t idx_base = argus.baseA;

--- a/projects/hipsparse/clients/include/testing_csru2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_csru2csr.hpp
@@ -40,7 +40,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_csru2csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int m         = 100;
     int n         = 100;
     int nnz       = 100;
@@ -246,7 +246,7 @@ void testing_csru2csr_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_csru2csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     hipsparseIndexBase_t idx_base = argus.baseA;
@@ -273,12 +273,8 @@ void testing_csru2csr(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(
-           filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind_gold, hcsr_val_gold, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind_gold, hcsr_val_gold, idx_base));
 
     // Unsort CSR columns
     std::vector<int> hperm(nnz);

--- a/projects/hipsparse/clients/include/testing_gebsr2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_gebsr2csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_gebsr2csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  m             = 1;
     int                  n             = 1;
     int                  safe_size     = 1;

--- a/projects/hipsparse/clients/include/testing_gebsr2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_gebsr2csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_gebsr2csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  m             = 1;
     int                  n             = 1;
     int                  safe_size     = 1;
@@ -326,12 +326,8 @@ void testing_gebsr2csr(Arguments argus)
 
     // Read or construct CSR matrix
     int nnzb = 0;
-    if(!generate_csr_matrix(
-           filename, mb, nb, nnzb, bsr_row_ptr, bsr_col_ind, bsr_val, bsr_idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, mb, nb, nnzb, bsr_row_ptr, bsr_col_ind, bsr_val, bsr_idx_base));
 
     m          = mb * row_block_dim;
     n          = nb * col_block_dim;

--- a/projects/hipsparse/clients/include/testing_gebsr2gebsc.hpp
+++ b/projects/hipsparse/clients/include/testing_gebsr2gebsc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_gebsr2gebsc_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
 
     hipsparseStatus_t              status;
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
@@ -464,11 +464,8 @@ void testing_gebsr2gebsc(Arguments argus)
 
     // Read or construct CSR matrix
     int nnzb = 0;
-    if(!generate_csr_matrix(filename, mb, nb, nnzb, hbsr_row_ptr, hbsr_col_ind, hbsr_val, base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, mb, nb, nnzb, hbsr_row_ptr, hbsr_col_ind, hbsr_val, base));
 
     m          = mb * row_block_dim;
     n          = nb * col_block_dim;

--- a/projects/hipsparse/clients/include/testing_gebsr2gebsc.hpp
+++ b/projects/hipsparse/clients/include/testing_gebsr2gebsc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_gebsr2gebsc_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
 
     hipsparseStatus_t              status;
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);

--- a/projects/hipsparse/clients/include/testing_gebsr2gebsr.hpp
+++ b/projects/hipsparse/clients/include/testing_gebsr2gebsr.hpp
@@ -40,7 +40,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_gebsr2gebsr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  mb              = 1;
     int                  nb              = 1;
     int                  nnzb            = 1;
@@ -936,11 +936,8 @@ void testing_gebsr2gebsr(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base_A))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base_A));
 
     // mb and nb can be modified if reading from a file
     int mb   = (m + row_block_dim_A - 1) / row_block_dim_A;

--- a/projects/hipsparse/clients/include/testing_gebsr2gebsr.hpp
+++ b/projects/hipsparse/clients/include/testing_gebsr2gebsr.hpp
@@ -40,7 +40,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_gebsr2gebsr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  mb              = 1;
     int                  nb              = 1;
     int                  nnzb            = 1;

--- a/projects/hipsparse/clients/include/testing_gemmi.hpp
+++ b/projects/hipsparse/clients/include/testing_gemmi.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_gemmi_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int safe_size = 100;
     T   alpha     = make_DataType<T>(0.6);
     T   beta      = make_DataType<T>(0.2);
@@ -278,7 +278,7 @@ void testing_gemmi_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_gemmi(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int         M        = argus.M;
     int         N        = argus.N;
     int         K        = argus.K;

--- a/projects/hipsparse/clients/include/testing_gemmi.hpp
+++ b/projects/hipsparse/clients/include/testing_gemmi.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_gemmi_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int safe_size = 100;
     T   alpha     = make_DataType<T>(0.6);
     T   beta      = make_DataType<T>(0.2);
@@ -278,7 +278,7 @@ void testing_gemmi_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_gemmi(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 12000)
     int         M        = argus.M;
     int         N        = argus.N;
     int         K        = argus.K;
@@ -305,12 +305,8 @@ void testing_gemmi(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(
-           filename, N, K, nnz, hcsc_col_ptrB, hcsc_row_indB, hcsc_valB, HIPSPARSE_INDEX_BASE_ZERO))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, N, K, nnz, hcsc_col_ptrB, hcsc_row_indB, hcsc_valB, HIPSPARSE_INDEX_BASE_ZERO));
 
     int lda = std::max(1, M);
     int ldc = std::max(1, M);

--- a/projects/hipsparse/clients/include/testing_hyb2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_hyb2csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_hyb2csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int safe_size = 100;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
@@ -98,7 +98,7 @@ void testing_hyb2csr_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_hyb2csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     hipsparseIndexBase_t idx_base = argus.baseA;

--- a/projects/hipsparse/clients/include/testing_hyb2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_hyb2csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_hyb2csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int safe_size = 100;
 
     std::unique_ptr<handle_struct> unique_ptr_handle(new handle_struct);
@@ -98,7 +98,7 @@ void testing_hyb2csr_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_hyb2csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                  m        = argus.M;
     int                  n        = argus.N;
     hipsparseIndexBase_t idx_base = argus.baseA;
@@ -124,12 +124,8 @@ void testing_hyb2csr(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(
-           filename, m, n, nnz, hcsr_row_ptr_gold, hcsr_col_ind_gold, hcsr_val_gold, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, m, n, nnz, hcsr_row_ptr_gold, hcsr_col_ind_gold, hcsr_val_gold, idx_base));
 
     // Allocate memory on the device
     auto dcsr_row_ptr_managed

--- a/projects/hipsparse/clients/include/testing_hybmv.hpp
+++ b/projects/hipsparse/clients/include/testing_hybmv.hpp
@@ -47,7 +47,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_hybmv_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int                  safe_size = 100;
     T                    alpha     = make_DataType<T>(0.6);
     T                    beta      = make_DataType<T>(0.2);
@@ -100,7 +100,7 @@ void testing_hybmv_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_hybmv(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                     m              = argus.M;
     int                     n              = argus.N;
     T                       h_alpha        = make_DataType<T>(argus.alpha);
@@ -135,11 +135,8 @@ void testing_hybmv(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcol_ind, hval, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcol_ind, hval, idx_base));
 
     std::vector<T> hx(n);
     std::vector<T> hy_1(m);

--- a/projects/hipsparse/clients/include/testing_hybmv.hpp
+++ b/projects/hipsparse/clients/include/testing_hybmv.hpp
@@ -47,7 +47,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_hybmv_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int                  safe_size = 100;
     T                    alpha     = make_DataType<T>(0.6);
     T                    beta      = make_DataType<T>(0.2);
@@ -100,7 +100,7 @@ void testing_hybmv_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_hybmv(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 11000)
     int                     m              = argus.M;
     int                     n              = argus.N;
     T                       h_alpha        = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_prune_csr2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_prune_csr2csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_prune_csr2csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     size_t safe_size = 1;
 
     int    M                      = 1;
@@ -520,7 +520,7 @@ void testing_prune_csr2csr_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_prune_csr2csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                  M              = argus.M;
     int                  N              = argus.N;
     T                    threshold      = make_DataType<T>(argus.threshold);

--- a/projects/hipsparse/clients/include/testing_prune_csr2csr.hpp
+++ b/projects/hipsparse/clients/include/testing_prune_csr2csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_prune_csr2csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     size_t safe_size = 1;
 
     int    M                      = 1;
@@ -520,7 +520,7 @@ void testing_prune_csr2csr_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_prune_csr2csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                  M              = argus.M;
     int                  N              = argus.N;
     T                    threshold      = make_DataType<T>(argus.threshold);
@@ -557,12 +557,8 @@ void testing_prune_csr2csr(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz_A = 0;
-    if(!generate_csr_matrix(
-           filename, M, N, nnz_A, h_csr_row_ptr_A, h_csr_col_ind_A, h_csr_val_A, csr_idx_base_A))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, M, N, nnz_A, h_csr_row_ptr_A, h_csr_col_ind_A, h_csr_val_A, csr_idx_base_A));
 
     // Allocate device memory
     auto d_nnz_total_dev_host_ptr_managed

--- a/projects/hipsparse/clients/include/testing_prune_csr2csr_by_percentage.hpp
+++ b/projects/hipsparse/clients/include/testing_prune_csr2csr_by_percentage.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_prune_csr2csr_by_percentage_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     size_t safe_size = 1;
 
     int    M                      = 1;
@@ -616,7 +616,7 @@ void testing_prune_csr2csr_by_percentage_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_prune_csr2csr_by_percentage(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                  M              = argus.M;
     int                  N              = argus.N;
     T                    percentage     = make_DataType<T>(argus.percentage);
@@ -656,12 +656,8 @@ void testing_prune_csr2csr_by_percentage(Arguments argus)
 
     // Read or construct CSR matrix
     int nnz_A = 0;
-    if(!generate_csr_matrix(
-           filename, M, N, nnz_A, h_csr_row_ptr_A, h_csr_col_ind_A, h_csr_val_A, csr_idx_base_A))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, M, N, nnz_A, h_csr_row_ptr_A, h_csr_col_ind_A, h_csr_val_A, csr_idx_base_A));
 
     // Allocate device memory
     auto d_nnz_total_dev_host_ptr_managed

--- a/projects/hipsparse/clients/include/testing_prune_csr2csr_by_percentage.hpp
+++ b/projects/hipsparse/clients/include/testing_prune_csr2csr_by_percentage.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename T>
 void testing_prune_csr2csr_by_percentage_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     size_t safe_size = 1;
 
     int    M                      = 1;
@@ -616,7 +616,7 @@ void testing_prune_csr2csr_by_percentage_bad_arg(const Arguments& argus)
 template <typename T>
 void testing_prune_csr2csr_by_percentage(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION < 13000)
     int                  M              = argus.M;
     int                  N              = argus.N;
     T                    percentage     = make_DataType<T>(argus.percentage);

--- a/projects/hipsparse/clients/include/testing_sddmm_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_sddmm_coo.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_sddmm_coo_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
 
     int32_t              n         = 100;
     int32_t              m         = 100;
@@ -185,7 +185,7 @@ void testing_sddmm_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_sddmm_coo(Arguments argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -217,11 +217,8 @@ void testing_sddmm_coo(Arguments argus)
 
     // Read or construct CSR matrix
     I nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     std::vector<I> hrow_ind(nnz);
     // Convert to COO

--- a/projects/hipsparse/clients/include/testing_sddmm_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_sddmm_coo.hpp
@@ -43,7 +43,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_sddmm_coo_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
 
     int32_t              n         = 100;
     int32_t              m         = 100;
@@ -185,7 +185,7 @@ void testing_sddmm_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_sddmm_coo(Arguments argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;

--- a/projects/hipsparse/clients/include/testing_sddmm_coo_aos.hpp
+++ b/projects/hipsparse/clients/include/testing_sddmm_coo_aos.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_sddmm_coo_aos_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int32_t              n         = 100;
     int32_t              m         = 100;
     int32_t              k         = 100;
@@ -182,7 +182,7 @@ void testing_sddmm_coo_aos_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_sddmm_coo_aos(Arguments argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -214,11 +214,8 @@ void testing_sddmm_coo_aos(Arguments argus)
 
     // Read or construct CSR matrix
     I nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     std::vector<I> hrowcol_ind(nnz * 2);
     // Convert to COO_AOS

--- a/projects/hipsparse/clients/include/testing_sddmm_coo_aos.hpp
+++ b/projects/hipsparse/clients/include/testing_sddmm_coo_aos.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_sddmm_coo_aos_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int32_t              n         = 100;
     int32_t              m         = 100;
     int32_t              k         = 100;
@@ -182,7 +182,7 @@ void testing_sddmm_coo_aos_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_sddmm_coo_aos(Arguments argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;

--- a/projects/hipsparse/clients/include/testing_sddmm_csc.hpp
+++ b/projects/hipsparse/clients/include/testing_sddmm_csc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_sddmm_csc_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
 
     int32_t              n         = 100;
     int32_t              m         = 100;
@@ -188,7 +188,7 @@ template <typename I, typename J, typename T>
 void testing_sddmm_csc(Arguments argus)
 {
 // only csr format supported when using cusparse backend
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -221,11 +221,8 @@ void testing_sddmm_csc(Arguments argus)
 
     // Read or construct CSR matrix
     I nnz = 0;
-    if(!generate_csr_matrix(filename, n, m, nnz, hcsc_col_ptr, hcsc_row_ind, hcsc_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, n, m, nnz, hcsc_col_ptr, hcsc_row_ind, hcsc_val, idx_base));
 
     // Some matrix properties
     J A_m = (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k;

--- a/projects/hipsparse/clients/include/testing_sddmm_csc.hpp
+++ b/projects/hipsparse/clients/include/testing_sddmm_csc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_sddmm_csc_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
 
     int32_t              n         = 100;
     int32_t              m         = 100;
@@ -188,7 +188,7 @@ template <typename I, typename J, typename T>
 void testing_sddmm_csc(Arguments argus)
 {
 // only csr format supported when using cusparse backend
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;

--- a/projects/hipsparse/clients/include/testing_sddmm_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_sddmm_csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_sddmm_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
 
     int32_t              n         = 100;
     int32_t              m         = 100;
@@ -187,7 +187,7 @@ void testing_sddmm_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_sddmm_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;

--- a/projects/hipsparse/clients/include/testing_sddmm_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_sddmm_csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_sddmm_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
 
     int32_t              n         = 100;
     int32_t              m         = 100;
@@ -187,7 +187,7 @@ void testing_sddmm_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_sddmm_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -220,11 +220,8 @@ void testing_sddmm_csr(Arguments argus)
 
     // Read or construct CSR matrix
     I nnz = 0;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     // Some matrix properties
     J A_m = (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k;

--- a/projects/hipsparse/clients/include/testing_sparse_to_dense_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_sparse_to_dense_coo.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_sparse_to_dense_coo_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     int64_t safe_size = 100;
     int32_t m         = 10;
     int32_t n         = 10;
@@ -111,7 +111,7 @@ void testing_sparse_to_dense_coo_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSparseToDense(handle, matA, nullptr, alg, dbuf), "Error: matB is nullptr");
     // cuda returns success here
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSparseToDense(handle, matA, matB, alg, nullptr), "Error: dbuf is nullptr");
 #endif
@@ -125,7 +125,7 @@ void testing_sparse_to_dense_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_sparse_to_dense_coo(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     I                           m        = argus.M;
     I                           n        = argus.N;
     hipsparseOrder_t            order    = argus.orderA;

--- a/projects/hipsparse/clients/include/testing_sparse_to_dense_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_sparse_to_dense_coo.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_sparse_to_dense_coo_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     int64_t safe_size = 100;
     int32_t m         = 10;
     int32_t n         = 10;
@@ -111,7 +111,7 @@ void testing_sparse_to_dense_coo_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSparseToDense(handle, matA, nullptr, alg, dbuf), "Error: matB is nullptr");
     // cuda returns success here
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSparseToDense(handle, matA, matB, alg, nullptr), "Error: dbuf is nullptr");
 #endif
@@ -125,7 +125,7 @@ void testing_sparse_to_dense_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_sparse_to_dense_coo(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     I                           m        = argus.M;
     I                           n        = argus.N;
     hipsparseOrder_t            order    = argus.orderA;
@@ -150,11 +150,8 @@ void testing_sparse_to_dense_coo(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     I ld = (order == HIPSPARSE_ORDER_COL) ? m : n;
 

--- a/projects/hipsparse/clients/include/testing_sparse_to_dense_csc.hpp
+++ b/projects/hipsparse/clients/include/testing_sparse_to_dense_csc.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_sparse_to_dense_csc_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     int64_t safe_size = 100;
     int32_t m         = 10;
     int32_t n         = 10;
@@ -131,7 +131,7 @@ void testing_sparse_to_dense_csc_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_sparse_to_dense_csc(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     J                           m        = argus.M;
     J                           n        = argus.N;
     hipsparseOrder_t            order    = argus.orderA;

--- a/projects/hipsparse/clients/include/testing_sparse_to_dense_csc.hpp
+++ b/projects/hipsparse/clients/include/testing_sparse_to_dense_csc.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_sparse_to_dense_csc_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     int64_t safe_size = 100;
     int32_t m         = 10;
     int32_t n         = 10;
@@ -131,7 +131,7 @@ void testing_sparse_to_dense_csc_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_sparse_to_dense_csc(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     J                           m        = argus.M;
     J                           n        = argus.N;
     hipsparseOrder_t            order    = argus.orderA;
@@ -157,11 +157,8 @@ void testing_sparse_to_dense_csc(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     I ld = (order == HIPSPARSE_ORDER_COL) ? m : n;
 

--- a/projects/hipsparse/clients/include/testing_sparse_to_dense_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_sparse_to_dense_csr.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_sparse_to_dense_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     int64_t safe_size = 100;
     int32_t m         = 10;
     int32_t n         = 10;
@@ -131,7 +131,7 @@ void testing_sparse_to_dense_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_sparse_to_dense_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     J                           m        = argus.M;
     J                           n        = argus.N;
     hipsparseIndexBase_t        idx_base = argus.baseA;

--- a/projects/hipsparse/clients/include/testing_sparse_to_dense_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_sparse_to_dense_csr.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_sparse_to_dense_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     int64_t safe_size = 100;
     int32_t m         = 10;
     int32_t n         = 10;
@@ -131,7 +131,7 @@ void testing_sparse_to_dense_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_sparse_to_dense_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11020)
     J                           m        = argus.M;
     J                           n        = argus.N;
     hipsparseIndexBase_t        idx_base = argus.baseA;
@@ -157,11 +157,8 @@ void testing_sparse_to_dense_csr(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     I ld = (order == HIPSPARSE_ORDER_COL) ? m : n;
 

--- a/projects/hipsparse/clients/include/testing_spgemm_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spgemm_csr.hpp
@@ -39,7 +39,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spgemm_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -334,7 +334,7 @@ void testing_spgemm_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spgemm_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     J                    m        = argus.M;
     J                    k        = argus.K;
     T                    h_alpha  = make_DataType<T>(argus.alpha);
@@ -369,12 +369,8 @@ void testing_spgemm_csr(Arguments argus)
     srand(12345ULL);
 
     I nnz_A;
-    if(!generate_csr_matrix(
-           filename, m, k, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idxBaseA))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, m, k, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idxBaseA));
 
     // For sparse matrix B, use the transpose of A
     J n     = m;

--- a/projects/hipsparse/clients/include/testing_spgemm_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spgemm_csr.hpp
@@ -39,7 +39,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spgemm_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -334,7 +334,7 @@ void testing_spgemm_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spgemm_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     J                    m        = argus.M;
     J                    k        = argus.K;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_spgemmreuse_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spgemmreuse_csr.hpp
@@ -39,7 +39,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spgemmreuse_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -209,7 +209,7 @@ void testing_spgemmreuse_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spgemmreuse_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     J                    m        = argus.M;
     J                    k        = argus.K;
     T                    h_alpha  = make_DataType<T>(argus.alpha);
@@ -244,12 +244,8 @@ void testing_spgemmreuse_csr(Arguments argus)
     srand(12345ULL);
 
     I nnz_A;
-    if(!generate_csr_matrix(
-           filename, m, k, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idxBaseA))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(generate_csr_matrix(
+        filename, m, k, nnz_A, hcsr_row_ptr_A, hcsr_col_ind_A, hcsr_val_A, idxBaseA));
 
     // Sparse matrix B as the transpose of A
     J n     = m;

--- a/projects/hipsparse/clients/include/testing_spgemmreuse_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spgemmreuse_csr.hpp
@@ -39,7 +39,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spgemmreuse_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -209,7 +209,7 @@ void testing_spgemmreuse_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spgemmreuse_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     J                    m        = argus.M;
     J                    k        = argus.K;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_spmm_batched_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_batched_coo.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spmm_batched_coo_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -59,7 +59,7 @@ void testing_spmm_batched_coo_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxTypeI  = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if (CUDART_VERSION >= 11003)
+#if(CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_COO_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_COOMM_ALG1;
@@ -168,7 +168,7 @@ void testing_spmm_batched_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spmm_batched_coo(Arguments argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -184,7 +184,7 @@ void testing_spmm_batched_coo(Arguments argus)
     I batch_count_B = 10;
     I batch_count_C = 10;
 
-#if (CUDART_VERSION >= 11003)
+#if(CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_COO_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_COOMM_ALG1;
@@ -192,7 +192,7 @@ void testing_spmm_batched_coo(Arguments argus)
 
     std::string filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -366,7 +366,7 @@ void testing_spmm_batched_coo(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -378,14 +378,14 @@ void testing_spmm_batched_coo(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_batched_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_batched_coo.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spmm_batched_coo_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -59,7 +59,7 @@ void testing_spmm_batched_coo_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxTypeI  = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if(CUDART_VERSION >= 11003)
+#if (CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_COO_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_COOMM_ALG1;
@@ -168,7 +168,7 @@ void testing_spmm_batched_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spmm_batched_coo(Arguments argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -184,7 +184,7 @@ void testing_spmm_batched_coo(Arguments argus)
     I batch_count_B = 10;
     I batch_count_C = 10;
 
-#if(CUDART_VERSION >= 11003)
+#if (CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_COO_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_COOMM_ALG1;
@@ -192,7 +192,7 @@ void testing_spmm_batched_coo(Arguments argus)
 
     std::string filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -216,18 +216,15 @@ void testing_spmm_batched_coo(Arguments argus)
     srand(12345ULL);
 
     I nnz_A;
-    if(!generate_csr_matrix(filename,
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? k : m,
                             nnz_A,
                             hrow_ptr,
                             hcol_ind,
                             hval,
-                            idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+                            idx_base));
 
     std::vector<I> hrow_ind(nnz_A);
 
@@ -369,7 +366,7 @@ void testing_spmm_batched_coo(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -381,14 +378,14 @@ void testing_spmm_batched_coo(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_batched_csc.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_batched_csc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmm_batched_csc_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -60,7 +60,7 @@ void testing_spmm_batched_csc_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxTypeJ  = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if (CUDART_VERSION >= 11003)
+#if(CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -179,7 +179,7 @@ void testing_spmm_batched_csc_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmm_batched_csc(Arguments argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -195,7 +195,7 @@ void testing_spmm_batched_csc(Arguments argus)
     J batch_count_B = 3;
     J batch_count_C = 3;
 
-#if (CUDART_VERSION >= 11003)
+#if(CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -203,7 +203,7 @@ void testing_spmm_batched_csc(Arguments argus)
 
     std::string filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -364,7 +364,7 @@ void testing_spmm_batched_csc(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -376,14 +376,14 @@ void testing_spmm_batched_csc(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_batched_csc.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_batched_csc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmm_batched_csc_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -60,7 +60,7 @@ void testing_spmm_batched_csc_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxTypeJ  = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if(CUDART_VERSION >= 11003)
+#if (CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -179,7 +179,7 @@ void testing_spmm_batched_csc_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmm_batched_csc(Arguments argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -195,7 +195,7 @@ void testing_spmm_batched_csc(Arguments argus)
     J batch_count_B = 3;
     J batch_count_C = 3;
 
-#if(CUDART_VERSION >= 11003)
+#if (CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -203,7 +203,7 @@ void testing_spmm_batched_csc(Arguments argus)
 
     std::string filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -228,18 +228,15 @@ void testing_spmm_batched_csc(Arguments argus)
     srand(12345ULL);
 
     I nnz_A;
-    if(!generate_csr_matrix(filename,
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? k : m,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k,
                             nnz_A,
                             hcsc_col_ptr_temp,
                             hcsc_row_ind_temp,
                             hcsc_val_temp,
-                            idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+                            idx_base));
 
     // Some matrix properties
     J A_m = (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k;
@@ -367,7 +364,7 @@ void testing_spmm_batched_csc(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -379,14 +376,14 @@ void testing_spmm_batched_csc(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_batched_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_batched_csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmm_batched_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -60,7 +60,7 @@ void testing_spmm_batched_csr_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxTypeJ  = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if(CUDART_VERSION >= 11003)
+#if (CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -179,7 +179,7 @@ void testing_spmm_batched_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmm_batched_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -195,7 +195,7 @@ void testing_spmm_batched_csr(Arguments argus)
     J batch_count_B = 3;
     J batch_count_C = 3;
 
-#if(CUDART_VERSION >= 11003)
+#if (CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -203,7 +203,7 @@ void testing_spmm_batched_csr(Arguments argus)
 
     std::string filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -228,18 +228,15 @@ void testing_spmm_batched_csr(Arguments argus)
     srand(12345ULL);
 
     I nnz_A;
-    if(!generate_csr_matrix(filename,
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? k : m,
                             nnz_A,
                             hcsr_row_ptr_temp,
                             hcsr_col_ind_temp,
                             hcsr_val_temp,
-                            idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+                            idx_base));
 
     // Some matrix properties
     J A_m = (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k;
@@ -366,7 +363,7 @@ void testing_spmm_batched_csr(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -378,14 +375,14 @@ void testing_spmm_batched_csr(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_batched_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_batched_csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmm_batched_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -60,7 +60,7 @@ void testing_spmm_batched_csr_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxTypeJ  = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if (CUDART_VERSION >= 11003)
+#if(CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -179,7 +179,7 @@ void testing_spmm_batched_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmm_batched_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -195,7 +195,7 @@ void testing_spmm_batched_csr(Arguments argus)
     J batch_count_B = 3;
     J batch_count_C = 3;
 
-#if (CUDART_VERSION >= 11003)
+#if(CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -203,7 +203,7 @@ void testing_spmm_batched_csr(Arguments argus)
 
     std::string filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -363,7 +363,7 @@ void testing_spmm_batched_csr(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -375,14 +375,14 @@ void testing_spmm_batched_csr(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_coo.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spmm_coo_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int32_t              n         = 100;
     int32_t              m         = 100;
     int32_t              k         = 100;
@@ -61,7 +61,7 @@ void testing_spmm_coo_bad_arg(const Arguments& argus)
     //
     // !
     //
-#if (CUDART_VERSION >= 11003)
+#if(CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_COO_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -128,7 +128,7 @@ void testing_spmm_coo_bad_arg(const Arguments& argus)
             handle, transA, transB, &alpha, A, B, &beta, C, dataType, alg, nullptr),
         "Error: bsize is nullptr");
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     // SpMM_preprocess
     verify_hipsparse_status_invalid_handle(hipsparseSpMM_preprocess(
         nullptr, transA, transB, &alpha, A, B, &beta, C, dataType, alg, dbuf));
@@ -190,7 +190,7 @@ void testing_spmm_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spmm_coo(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -204,7 +204,7 @@ void testing_spmm_coo(Arguments argus)
     hipsparseSpMMAlg_t   alg      = argus.spmm_alg;
     std::string          filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -338,7 +338,7 @@ void testing_spmm_coo(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -350,14 +350,14 @@ void testing_spmm_coo(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_coo.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spmm_coo_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int32_t              n         = 100;
     int32_t              m         = 100;
     int32_t              k         = 100;
@@ -61,7 +61,7 @@ void testing_spmm_coo_bad_arg(const Arguments& argus)
     //
     // !
     //
-#if(CUDART_VERSION >= 11003)
+#if (CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_COO_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -128,7 +128,7 @@ void testing_spmm_coo_bad_arg(const Arguments& argus)
             handle, transA, transB, &alpha, A, B, &beta, C, dataType, alg, nullptr),
         "Error: bsize is nullptr");
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     // SpMM_preprocess
     verify_hipsparse_status_invalid_handle(hipsparseSpMM_preprocess(
         nullptr, transA, transB, &alpha, A, B, &beta, C, dataType, alg, dbuf));
@@ -190,7 +190,7 @@ void testing_spmm_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spmm_coo(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -204,7 +204,7 @@ void testing_spmm_coo(Arguments argus)
     hipsparseSpMMAlg_t   alg      = argus.spmm_alg;
     std::string          filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -228,18 +228,15 @@ void testing_spmm_coo(Arguments argus)
     srand(12345ULL);
 
     I nnz_A;
-    if(!generate_csr_matrix(filename,
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? k : m,
                             nnz_A,
                             hrow_ptr,
                             hcol_ind,
                             hval,
-                            idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+                            idx_base));
 
     std::vector<I> hrow_ind(nnz_A);
 
@@ -341,7 +338,7 @@ void testing_spmm_coo(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -353,14 +350,14 @@ void testing_spmm_coo(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_csc.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_csc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmm_csc_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -60,7 +60,7 @@ void testing_spmm_csc_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxTypeJ  = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if (CUDART_VERSION >= 11003)
+#if(CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -128,7 +128,7 @@ void testing_spmm_csc_bad_arg(const Arguments& argus)
             handle, transA, transB, &alpha, A, B, &beta, C, dataType, alg, nullptr),
         "Error: bsize is nullptr");
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     // SpMM_preprocess
     verify_hipsparse_status_invalid_handle(hipsparseSpMM_preprocess(
         nullptr, transA, transB, &alpha, A, B, &beta, C, dataType, alg, dbuf));
@@ -190,7 +190,7 @@ void testing_spmm_csc_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmm_csc(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11061)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11061)
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -204,7 +204,7 @@ void testing_spmm_csc(Arguments argus)
     hipsparseSpMMAlg_t   alg      = argus.spmm_alg;
     std::string          filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -329,7 +329,7 @@ void testing_spmm_csc(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -341,14 +341,14 @@ void testing_spmm_csc(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_csc.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_csc.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmm_csc_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -60,7 +60,7 @@ void testing_spmm_csc_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxTypeJ  = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if(CUDART_VERSION >= 11003)
+#if (CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -128,7 +128,7 @@ void testing_spmm_csc_bad_arg(const Arguments& argus)
             handle, transA, transB, &alpha, A, B, &beta, C, dataType, alg, nullptr),
         "Error: bsize is nullptr");
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     // SpMM_preprocess
     verify_hipsparse_status_invalid_handle(hipsparseSpMM_preprocess(
         nullptr, transA, transB, &alpha, A, B, &beta, C, dataType, alg, dbuf));
@@ -190,7 +190,7 @@ void testing_spmm_csc_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmm_csc(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11061)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11061)
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -204,7 +204,7 @@ void testing_spmm_csc(Arguments argus)
     hipsparseSpMMAlg_t   alg      = argus.spmm_alg;
     std::string          filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -229,18 +229,15 @@ void testing_spmm_csc(Arguments argus)
     srand(12345ULL);
 
     I nnz_A;
-    if(!generate_csr_matrix(filename,
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? k : m,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k,
                             nnz_A,
                             hcsc_col_ptr,
                             hcsc_row_ind,
                             hcsc_val,
-                            idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+                            idx_base));
 
     // Some matrix properties
     J A_m = (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k;
@@ -332,7 +329,7 @@ void testing_spmm_csc(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -344,14 +341,14 @@ void testing_spmm_csc(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmm_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -62,7 +62,7 @@ void testing_spmm_csr_bad_arg(const Arguments& argus)
     //
     // !
     //
-#if(CUDART_VERSION >= 11003)
+#if (CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -130,7 +130,7 @@ void testing_spmm_csr_bad_arg(const Arguments& argus)
             handle, transA, transB, &alpha, A, B, &beta, C, dataType, alg, nullptr),
         "Error: bsize is nullptr");
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     // SpMM_preprocess
     verify_hipsparse_status_invalid_handle(hipsparseSpMM_preprocess(
         nullptr, transA, transB, &alpha, A, B, &beta, C, dataType, alg, dbuf));
@@ -192,7 +192,7 @@ void testing_spmm_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmm_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -206,7 +206,7 @@ void testing_spmm_csr(Arguments argus)
     hipsparseSpMMAlg_t   alg      = argus.spmm_alg;
     std::string          filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -231,18 +231,15 @@ void testing_spmm_csr(Arguments argus)
     srand(12345ULL);
 
     I nnz_A;
-    if(!generate_csr_matrix(filename,
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k,
                             (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? k : m,
                             nnz_A,
                             hcsr_row_ptr,
                             hcsr_col_ind,
                             hcsr_val,
-                            idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+                            idx_base));
 
     // Some matrix properties
     J A_m = (transA == HIPSPARSE_OPERATION_NON_TRANSPOSE) ? m : k;
@@ -333,7 +330,7 @@ void testing_spmm_csr(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -345,14 +342,14 @@ void testing_spmm_csr(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmm_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spmm_csr.hpp
@@ -44,7 +44,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmm_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int32_t              m         = 100;
     int32_t              n         = 100;
     int32_t              k         = 100;
@@ -62,7 +62,7 @@ void testing_spmm_csr_bad_arg(const Arguments& argus)
     //
     // !
     //
-#if (CUDART_VERSION >= 11003)
+#if(CUDART_VERSION >= 11003)
     hipsparseSpMMAlg_t alg = HIPSPARSE_SPMM_CSR_ALG1;
 #else
     hipsparseSpMMAlg_t alg = HIPSPARSE_MM_ALG_DEFAULT;
@@ -130,7 +130,7 @@ void testing_spmm_csr_bad_arg(const Arguments& argus)
             handle, transA, transB, &alpha, A, B, &beta, C, dataType, alg, nullptr),
         "Error: bsize is nullptr");
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     // SpMM_preprocess
     verify_hipsparse_status_invalid_handle(hipsparseSpMM_preprocess(
         nullptr, transA, transB, &alpha, A, B, &beta, C, dataType, alg, dbuf));
@@ -192,7 +192,7 @@ void testing_spmm_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmm_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11000)
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -206,7 +206,7 @@ void testing_spmm_csr(Arguments argus)
     hipsparseSpMMAlg_t   alg      = argus.spmm_alg;
     std::string          filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC || orderB != HIPSPARSE_ORDER_COL)
     {
         return;
@@ -330,7 +330,7 @@ void testing_spmm_csr(Arguments argus)
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_bufferSize(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, &bufferSize));
 
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     //When using cusparse backend, cant pass nullptr for buffer to preprocess
     if(bufferSize == 0)
     {
@@ -342,14 +342,14 @@ void testing_spmm_csr(Arguments argus)
     CHECK_HIP_ERROR(hipMalloc(&buffer, bufferSize));
 
     // HIPSPARSE pointer mode host
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_HOST));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, &h_alpha, A, B, &h_beta, C1, typeT, alg, buffer));
 #endif
 
     // HIPSPARSE pointer mode device
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11021)
     CHECK_HIPSPARSE_ERROR(hipsparseSetPointerMode(handle, HIPSPARSE_POINTER_MODE_DEVICE));
     CHECK_HIPSPARSE_ERROR(hipsparseSpMM_preprocess(
         handle, transA, transB, d_alpha, A, B, d_beta, C2, typeT, alg, buffer));

--- a/projects/hipsparse/clients/include/testing_spmv_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_coo.hpp
@@ -42,8 +42,8 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spmv_coo_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
+     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -55,12 +55,12 @@ void testing_spmv_coo_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxType   = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #else
-#if(CUDART_VERSION >= 12000)
+#if (CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_COO_ALG1;
-#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -151,8 +151,8 @@ void testing_spmv_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spmv_coo(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
+     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     I                    m        = argus.M;
     I                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);
@@ -179,11 +179,8 @@ void testing_spmv_coo(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base));
 
     std::vector<I> hrow_ind(nnz);
 

--- a/projects/hipsparse/clients/include/testing_spmv_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_coo.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spmv_coo_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
+#if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
      || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     int64_t              m         = 100;
     int64_t              n         = 100;
@@ -55,12 +55,12 @@ void testing_spmv_coo_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxType   = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #else
-#if (CUDART_VERSION >= 12000)
+#if(CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_COO_ALG1;
-#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -151,7 +151,7 @@ void testing_spmv_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spmv_coo(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
+#if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
      || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     I                    m        = argus.M;
     I                    n        = argus.N;

--- a/projects/hipsparse/clients/include/testing_spmv_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_coo.hpp
@@ -43,7 +43,7 @@ template <typename I, typename T>
 void testing_spmv_coo_bad_arg(const Arguments& argus)
 {
 #if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -152,7 +152,7 @@ template <typename I, typename T>
 void testing_spmv_coo(Arguments argus)
 {
 #if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     I                    m        = argus.M;
     I                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_spmv_coo_aos.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_coo_aos.hpp
@@ -43,7 +43,7 @@ template <typename I, typename T>
 void testing_spmv_coo_aos_bad_arg(const Arguments& argus)
 {
 #if(!defined(CUDART_VERSION) || (CUDART_VERSION > 10010 && CUDART_VERSION < 12000) \
-     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1 && CUDART_VERSION < 12000))
+    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1 && CUDART_VERSION < 12000))
 
     int64_t              m         = 100;
     int64_t              n         = 100;

--- a/projects/hipsparse/clients/include/testing_spmv_coo_aos.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_coo_aos.hpp
@@ -42,8 +42,8 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spmv_coo_aos_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || (CUDART_VERSION > 10010 && CUDART_VERSION < 12000) \
-    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1 && CUDART_VERSION < 12000))
+#if (!defined(CUDART_VERSION) || (CUDART_VERSION > 10010 && CUDART_VERSION < 12000) \
+     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1 && CUDART_VERSION < 12000))
 
     int64_t              m         = 100;
     int64_t              n         = 100;
@@ -56,12 +56,12 @@ void testing_spmv_coo_aos_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxType   = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #else
-#if(CUDART_VERSION >= 12000)
+#if (CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_ALG_DEFAULT;
-#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -150,7 +150,7 @@ void testing_spmv_coo_aos_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spmv_coo_aos(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000))
+#if (!defined(CUDART_VERSION) || (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000))
     I                    m        = argus.M;
     I                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);
@@ -177,11 +177,8 @@ void testing_spmv_coo_aos(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base));
 
     std::vector<I> hind(2 * nnz);
 

--- a/projects/hipsparse/clients/include/testing_spmv_coo_aos.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_coo_aos.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spmv_coo_aos_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || (CUDART_VERSION > 10010 && CUDART_VERSION < 12000) \
+#if(!defined(CUDART_VERSION) || (CUDART_VERSION > 10010 && CUDART_VERSION < 12000) \
      || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1 && CUDART_VERSION < 12000))
 
     int64_t              m         = 100;
@@ -56,12 +56,12 @@ void testing_spmv_coo_aos_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxType   = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #else
-#if (CUDART_VERSION >= 12000)
+#if(CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_ALG_DEFAULT;
-#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -150,7 +150,7 @@ void testing_spmv_coo_aos_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spmv_coo_aos(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000))
+#if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000))
     I                    m        = argus.M;
     I                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_spmv_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_csr.hpp
@@ -42,8 +42,8 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmv_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
+     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -55,12 +55,12 @@ void testing_spmv_csr_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxType   = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #else
-#if(CUDART_VERSION >= 12000)
+#if (CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_ALG_DEFAULT;
-#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -175,8 +175,8 @@ void testing_spmv_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmv_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
+     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     J                    m        = argus.M;
     J                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);
@@ -204,11 +204,8 @@ void testing_spmv_csr(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcol_ind, hval, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcol_ind, hval, idx_base));
 
     std::vector<T> hx(n);
     std::vector<T> hy_1(m);

--- a/projects/hipsparse/clients/include/testing_spmv_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_csr.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmv_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
+#if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
      || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     int64_t              m         = 100;
     int64_t              n         = 100;
@@ -55,12 +55,12 @@ void testing_spmv_csr_bad_arg(const Arguments& argus)
     hipsparseIndexType_t idxType   = HIPSPARSE_INDEX_32I;
     hipDataType          dataType  = HIP_R_32F;
 
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #else
-#if (CUDART_VERSION >= 12000)
+#if(CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_ALG_DEFAULT;
-#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -175,7 +175,7 @@ void testing_spmv_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmv_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
+#if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
      || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     J                    m        = argus.M;
     J                    n        = argus.N;

--- a/projects/hipsparse/clients/include/testing_spmv_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_csr.hpp
@@ -43,7 +43,7 @@ template <typename I, typename J, typename T>
 void testing_spmv_csr_bad_arg(const Arguments& argus)
 {
 #if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -176,7 +176,7 @@ template <typename I, typename J, typename T>
 void testing_spmv_csr(Arguments argus)
 {
 #if(!defined(CUDART_VERSION) || CUDART_VERSION > 10010 \
-     || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
+    || (CUDART_VERSION == 10010 && CUDART_10_1_UPDATE_VERSION == 1))
     J                    m        = argus.M;
     J                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_spmv_sell.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_sell.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmv_sell_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION > 12011)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION > 12011)
     int64_t              m                       = 100;
     int64_t              n                       = 100;
     int64_t              nnz                     = 100;
@@ -57,12 +57,12 @@ void testing_spmv_sell_bad_arg(const Arguments& argus)
     hipsparseIndexType_t sellColInIdxType        = HIPSPARSE_INDEX_32I;
     hipDataType          dataType                = HIP_R_32F;
 
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #else
-#if(CUDART_VERSION >= 12000)
+#if (CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_ALG_DEFAULT;
-#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -188,7 +188,7 @@ void testing_spmv_sell_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmv_sell(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION > 12011)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION > 12011)
     J                    m          = argus.M;
     J                    n          = argus.N;
     J                    slice_size = argus.slice_size;
@@ -217,11 +217,8 @@ void testing_spmv_sell(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     I nslices = (m - 1) / slice_size + 1;
 

--- a/projects/hipsparse/clients/include/testing_spmv_sell.hpp
+++ b/projects/hipsparse/clients/include/testing_spmv_sell.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spmv_sell_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION > 12011)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION > 12011)
     int64_t              m                       = 100;
     int64_t              n                       = 100;
     int64_t              nnz                     = 100;
@@ -57,12 +57,12 @@ void testing_spmv_sell_bad_arg(const Arguments& argus)
     hipsparseIndexType_t sellColInIdxType        = HIPSPARSE_INDEX_32I;
     hipDataType          dataType                = HIP_R_32F;
 
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #else
-#if (CUDART_VERSION >= 12000)
+#if(CUDART_VERSION >= 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_SPMV_ALG_DEFAULT;
-#elif (CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
+#elif(CUDART_VERSION >= 10010 && CUDART_VERSION < 12000)
     hipsparseSpMVAlg_t alg = HIPSPARSE_MV_ALG_DEFAULT;
 #endif
 #endif
@@ -188,7 +188,7 @@ void testing_spmv_sell_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spmv_sell(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION > 12011)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION > 12011)
     J                    m          = argus.M;
     J                    n          = argus.N;
     J                    slice_size = argus.slice_size;

--- a/projects/hipsparse/clients/include/testing_spsm_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spsm_coo.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spsm_coo_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -181,7 +181,7 @@ void testing_spsm_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spsm_coo(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -196,7 +196,7 @@ void testing_spsm_coo(Arguments argus)
     hipsparseSpSMAlg_t   alg      = argus.spsm_alg;
     std::string          filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC)
     {
         return;

--- a/projects/hipsparse/clients/include/testing_spsm_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spsm_coo.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spsm_coo_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -181,7 +181,7 @@ void testing_spsm_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spsm_coo(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -196,7 +196,7 @@ void testing_spsm_coo(Arguments argus)
     hipsparseSpSMAlg_t   alg      = argus.spsm_alg;
     std::string          filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC)
     {
         return;
@@ -220,11 +220,8 @@ void testing_spsm_coo(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base));
 
     if(m != n)
     {

--- a/projects/hipsparse/clients/include/testing_spsm_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spsm_csr.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spsm_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -182,7 +182,7 @@ void testing_spsm_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spsm_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -197,7 +197,7 @@ void testing_spsm_csr(Arguments argus)
     hipsparseSpSMAlg_t   alg      = argus.spsm_alg;
     std::string          filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC)
     {
         return;
@@ -222,11 +222,8 @@ void testing_spsm_csr(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     if(m != n)
     {

--- a/projects/hipsparse/clients/include/testing_spsm_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spsm_csr.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spsm_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -182,7 +182,7 @@ void testing_spsm_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spsm_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -197,7 +197,7 @@ void testing_spsm_csr(Arguments argus)
     hipsparseSpSMAlg_t   alg      = argus.spsm_alg;
     std::string          filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC)
     {
         return;

--- a/projects/hipsparse/clients/include/testing_spsm_ex_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spsm_ex_coo.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spsm_ex_coo_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -178,7 +178,7 @@ void testing_spsm_ex_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spsm_ex_coo(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -193,7 +193,7 @@ void testing_spsm_ex_coo(Arguments argus)
     hipsparseSpSMAlg_t   alg      = argus.spsm_alg;
     std::string          filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC)
     {
         return;

--- a/projects/hipsparse/clients/include/testing_spsm_ex_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spsm_ex_coo.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spsm_ex_coo_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -178,7 +178,7 @@ void testing_spsm_ex_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spsm_ex_coo(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     I                    m        = argus.M;
     I                    n        = argus.N;
     I                    k        = argus.K;
@@ -193,7 +193,7 @@ void testing_spsm_ex_coo(Arguments argus)
     hipsparseSpSMAlg_t   alg      = argus.spsm_alg;
     std::string          filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC)
     {
         return;
@@ -217,11 +217,8 @@ void testing_spsm_ex_coo(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base));
 
     if(m != n)
     {

--- a/projects/hipsparse/clients/include/testing_spsm_ex_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spsm_ex_csr.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spsm_ex_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -179,7 +179,7 @@ void testing_spsm_ex_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spsm_ex_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -194,7 +194,7 @@ void testing_spsm_ex_csr(Arguments argus)
     hipsparseSpSMAlg_t   alg      = argus.spsm_alg;
     std::string          filename = argus.filename;
 
-#if (defined(CUDART_VERSION))
+#if(defined(CUDART_VERSION))
     if(orderB != orderC)
     {
         return;

--- a/projects/hipsparse/clients/include/testing_spsm_ex_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spsm_ex_csr.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spsm_ex_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              k         = 100;
@@ -179,7 +179,7 @@ void testing_spsm_ex_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spsm_ex_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11031)
     J                    m        = argus.M;
     J                    n        = argus.N;
     J                    k        = argus.K;
@@ -194,7 +194,7 @@ void testing_spsm_ex_csr(Arguments argus)
     hipsparseSpSMAlg_t   alg      = argus.spsm_alg;
     std::string          filename = argus.filename;
 
-#if(defined(CUDART_VERSION))
+#if (defined(CUDART_VERSION))
     if(orderB != orderC)
     {
         return;
@@ -219,11 +219,8 @@ void testing_spsm_ex_csr(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     if(m != n)
     {

--- a/projects/hipsparse/clients/include/testing_spsv_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spsv_coo.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spsv_coo_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -124,7 +124,7 @@ void testing_spsv_coo_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_analysis(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr, dbuf),
         "Error: y is nullptr");
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_analysis(handle, transA, &alpha, A, x, y, dataType, alg, descr, nullptr),
         "Error: dbuf is nullptr");
@@ -145,7 +145,7 @@ void testing_spsv_coo_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_solve(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr),
         "Error: y is nullptr");
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_solve(handle, transA, &alpha, A, x, y, dataType, alg, nullptr),
         "Error: descr is nullptr");
@@ -162,7 +162,7 @@ void testing_spsv_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spsv_coo(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
     I                    m        = argus.M;
     I                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);
@@ -190,11 +190,8 @@ void testing_spsv_coo(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hrow_ptr, hcol_ind, hval, idx_base));
 
     std::vector<I> hrow_ind(nnz);
 

--- a/projects/hipsparse/clients/include/testing_spsv_coo.hpp
+++ b/projects/hipsparse/clients/include/testing_spsv_coo.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename T>
 void testing_spsv_coo_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -124,7 +124,7 @@ void testing_spsv_coo_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_analysis(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr, dbuf),
         "Error: y is nullptr");
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_analysis(handle, transA, &alpha, A, x, y, dataType, alg, descr, nullptr),
         "Error: dbuf is nullptr");
@@ -145,7 +145,7 @@ void testing_spsv_coo_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_solve(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr),
         "Error: y is nullptr");
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_solve(handle, transA, &alpha, A, x, y, dataType, alg, nullptr),
         "Error: descr is nullptr");
@@ -162,7 +162,7 @@ void testing_spsv_coo_bad_arg(const Arguments& argus)
 template <typename I, typename T>
 void testing_spsv_coo(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
     I                    m        = argus.M;
     I                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/testing_spsv_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spsv_csr.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spsv_csr_bad_arg(const Arguments& argus)
 {
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -125,7 +125,7 @@ void testing_spsv_csr_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_analysis(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr, dbuf),
         "Error: y is nullptr");
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_analysis(handle, transA, &alpha, A, x, y, dataType, alg, descr, nullptr),
         "Error: dbuf is nullptr");
@@ -146,7 +146,7 @@ void testing_spsv_csr_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_solve(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr),
         "Error: y is nullptr");
-#if(!defined(CUDART_VERSION))
+#if (!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_solve(handle, transA, &alpha, A, x, y, dataType, alg, nullptr),
         "Error: descr is nullptr");
@@ -163,7 +163,7 @@ void testing_spsv_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spsv_csr(Arguments argus)
 {
-#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
+#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
     J                    m        = argus.M;
     J                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);
@@ -192,11 +192,8 @@ void testing_spsv_csr(Arguments argus)
     srand(12345ULL);
 
     I nnz;
-    if(!generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base))
-    {
-        fprintf(stderr, "Cannot open [read] %s\ncol", filename.c_str());
-        return;
-    }
+    CHECK_GENERATE_MATRIX_ERROR(
+        generate_csr_matrix(filename, m, n, nnz, hcsr_row_ptr, hcsr_col_ind, hcsr_val, idx_base));
 
     std::vector<T> hx(m);
     std::vector<T> hy_1(m);

--- a/projects/hipsparse/clients/include/testing_spsv_csr.hpp
+++ b/projects/hipsparse/clients/include/testing_spsv_csr.hpp
@@ -42,7 +42,7 @@ using namespace hipsparse_test;
 template <typename I, typename J, typename T>
 void testing_spsv_csr_bad_arg(const Arguments& argus)
 {
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     int64_t              m         = 100;
     int64_t              n         = 100;
     int64_t              nnz       = 100;
@@ -125,7 +125,7 @@ void testing_spsv_csr_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_analysis(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr, dbuf),
         "Error: y is nullptr");
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_analysis(handle, transA, &alpha, A, x, y, dataType, alg, descr, nullptr),
         "Error: dbuf is nullptr");
@@ -146,7 +146,7 @@ void testing_spsv_csr_bad_arg(const Arguments& argus)
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_solve(handle, transA, &alpha, A, x, nullptr, dataType, alg, descr),
         "Error: y is nullptr");
-#if (!defined(CUDART_VERSION))
+#if(!defined(CUDART_VERSION))
     verify_hipsparse_status_invalid_pointer(
         hipsparseSpSV_solve(handle, transA, &alpha, A, x, y, dataType, alg, nullptr),
         "Error: descr is nullptr");
@@ -163,7 +163,7 @@ void testing_spsv_csr_bad_arg(const Arguments& argus)
 template <typename I, typename J, typename T>
 void testing_spsv_csr(Arguments argus)
 {
-#if (!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
+#if(!defined(CUDART_VERSION) || CUDART_VERSION >= 11030)
     J                    m        = argus.M;
     J                    n        = argus.N;
     T                    h_alpha  = make_DataType<T>(argus.alpha);

--- a/projects/hipsparse/clients/include/utility.hpp
+++ b/projects/hipsparse/clients/include/utility.hpp
@@ -164,7 +164,7 @@ inline std::string get_filename(const std::string& matrix_filename)
 #define BSR_IND_R(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) * bsr_dim + (bj))
 #define BSR_IND_C(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) + (bj) * bsr_dim)
 
-#if (!defined(CUDART_VERSION) || (CUDART_VERSION >= 11003))
+#if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 11003))
 inline const char* hipsparseStatusToString(hipsparseStatus_t status)
 {
     switch(status)

--- a/projects/hipsparse/clients/include/utility.hpp
+++ b/projects/hipsparse/clients/include/utility.hpp
@@ -161,8 +161,8 @@ inline std::string get_filename(const std::string& matrix_filename)
 // BSR indexing macros
 #define BSR_IND(j, bi, bj, dir) \
     ((dir == HIPSPARSE_DIRECTION_ROW) ? BSR_IND_R(j, bi, bj) : BSR_IND_C(j, bi, bj))
-#define BSR_IND_R(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) * bsr_dim + (bj))
-#define BSR_IND_C(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) + (bj) * bsr_dim)
+#define BSR_IND_R(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi)*bsr_dim + (bj))
+#define BSR_IND_C(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) + (bj)*bsr_dim)
 
 #if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 11003))
 inline const char* hipsparseStatusToString(hipsparseStatus_t status)
@@ -232,15 +232,16 @@ inline const char* hipsparseStatusToString(hipsparseStatus_t status)
 #ifdef GOOGLE_TEST
 #define CHECK_GENERATE_MATRIX_ERROR2(ERROR) ASSERT_EQ(ERROR, true)
 #else
-#define CHECK_GENERATE_MATRIX_ERROR2(ERROR)                                                  \
-    do                                                                                       \
-    {                                                                                        \
-        auto error = ERROR;                                                                  \
-        if(error != true)                                                                    \
-        {                                                                                    \
-            fprintf(stderr, "Error encountered generating matrix data", __FILE__, __LINE__); \
-            exit(EXIT_FAILURE);                                                              \
-        }                                                                                    \
+#define CHECK_GENERATE_MATRIX_ERROR2(ERROR)                                                        \
+    do                                                                                             \
+    {                                                                                              \
+        auto error = ERROR;                                                                        \
+        if(error != true)                                                                          \
+        {                                                                                          \
+            fprintf(                                                                               \
+                stderr, "Error encountered generating matrix data (%s:%d)\n", __FILE__, __LINE__); \
+            exit(EXIT_FAILURE);                                                                    \
+        }                                                                                          \
     } while(0)
 #endif
 #define CHECK_GENERATE_MATRIX_ERROR(ERROR) CHECK_GENERATE_MATRIX_ERROR2(ERROR)

--- a/projects/hipsparse/clients/include/utility.hpp
+++ b/projects/hipsparse/clients/include/utility.hpp
@@ -161,10 +161,10 @@ inline std::string get_filename(const std::string& matrix_filename)
 // BSR indexing macros
 #define BSR_IND(j, bi, bj, dir) \
     ((dir == HIPSPARSE_DIRECTION_ROW) ? BSR_IND_R(j, bi, bj) : BSR_IND_C(j, bi, bj))
-#define BSR_IND_R(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi)*bsr_dim + (bj))
-#define BSR_IND_C(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) + (bj)*bsr_dim)
+#define BSR_IND_R(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) * bsr_dim + (bj))
+#define BSR_IND_C(j, bi, bj) (bsr_dim * bsr_dim * (j) + (bi) + (bj) * bsr_dim)
 
-#if(!defined(CUDART_VERSION) || (CUDART_VERSION >= 11003))
+#if (!defined(CUDART_VERSION) || (CUDART_VERSION >= 11003))
 inline const char* hipsparseStatusToString(hipsparseStatus_t status)
 {
     switch(status)
@@ -227,6 +227,23 @@ inline const char* hipsparseStatusToString(hipsparseStatus_t status)
     return "<undefined HIPSPARSE_STATUS value>";
 }
 #endif
+
+// CHECK_GENERATE_MATRIX_ERROR
+#ifdef GOOGLE_TEST
+#define CHECK_GENERATE_MATRIX_ERROR2(ERROR) ASSERT_EQ(ERROR, true)
+#else
+#define CHECK_GENERATE_MATRIX_ERROR2(ERROR)                                                  \
+    do                                                                                       \
+    {                                                                                        \
+        auto error = ERROR;                                                                  \
+        if(error != true)                                                                    \
+        {                                                                                    \
+            fprintf(stderr, "Error encountered generating matrix data", __FILE__, __LINE__); \
+            exit(EXIT_FAILURE);                                                              \
+        }                                                                                    \
+    } while(0)
+#endif
+#define CHECK_GENERATE_MATRIX_ERROR(ERROR) CHECK_GENERATE_MATRIX_ERROR2(ERROR)
 
 // CHECK_HIP_ERROR
 #ifdef GOOGLE_TEST
@@ -1245,6 +1262,11 @@ bool generate_csr_matrix(const std::string    filename,
             {
                 return true;
             }
+            else
+            {
+                fprintf(stderr, "Cannot open [read] %s\ncol", full_filename_path.c_str());
+                return false;
+            }
         }
         else if(extension == "mtx")
         {
@@ -1278,6 +1300,11 @@ bool generate_csr_matrix(const std::string    filename,
 
                     return true;
                 }
+            }
+            else
+            {
+                fprintf(stderr, "Cannot open [read] %s\ncol", full_filename_path.c_str());
+                return false;
             }
         }
     }


### PR DESCRIPTION
## Motivation

Currently if we encounter an error when calling `generate_csr_matrix` in the testing_xxx.hpp files, we simply return. This was fine when using the non-yaml file testing and would generate a googletest error, but now that we are using the yaml files, it doesn't. This PR adds a macro to check the return value of `generate_csr_matrix` and if it is a failure we generate a googletest error so the test is marked as failing.
