### PR TITLE
Update composable_kernel hash to latest develop

### DIFF
--- a/projects/miopen/requirements.txt
+++ b/projects/miopen/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.22
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@38c52448b1a4996b3e0e435a877d02441098b1dd
-ROCm/composable_kernel@355ce9230d9c4f2e74776e879f2bee71a26bae4a -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@4670df5ca606e6e3ee07a085ea61016489bf91ad -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0

--- a/projects/miopen/requirements.txt
+++ b/projects/miopen/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.22
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@38c52448b1a4996b3e0e435a877d02441098b1dd
-ROCm/composable_kernel@9bd67c2cf2fe8e4479a433bcd6d467e2ea9aedb4 -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@1da340031c98bfde0f142bf34493d087490ec70d -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0

--- a/projects/miopen/requirements.txt
+++ b/projects/miopen/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.22
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@38c52448b1a4996b3e0e435a877d02441098b1dd
-ROCm/composable_kernel@1da340031c98bfde0f142bf34493d087490ec70d -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@355ce9230d9c4f2e74776e879f2bee71a26bae4a -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0


### PR DESCRIPTION
Update hash of requirements.txt in MIOpen to latest develop branch for composable_kernel repo.

## Motivation

Required to enable MIOpen to compile using CK on TheRock on Windows since only latest composable_kernel develop branch has all the relevant fixes in it.

## Technical Details

Simple hash bump on requirements.txt

## Test Plan

Looking for a normal CI pass

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
