### PR TITLE
[CI] Use fractional runners for linux tests

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -145,6 +145,6 @@ jobs:
     with:
       project_to_test: ${{ inputs.project_to_test }}
       amdgpu_families: "gfx94X-dcgpu"
-      test_runs_on: "linux-mi325-1gpu-ossci-rocm"
+      test_runs_on: "linux-mi325-1gpu-ossci-rocm-frac"
       platform: "linux"
       test_type: ${{ inputs.test_type }}


### PR DESCRIPTION
## Motivation

On this rocm-libraries PR To the 7.2 branch (https://github.com/ROCm/rocm-libraries/pull/3403) I was seeing an issue where linux tests are timing out waiting for a runner: 
https://github.com/ROCm/rocm-libraries/actions/runs/20318068285/attempts/1?pr=3403
https://github.com/ROCm/rocm-libraries/actions/runs/20318068285/attempts/2?pr=3403
  
It looks like the runner group was replaced with the fractional runner

## Technical Details

Updating the runner to use the frac runner instead. 

## Test Plan

CI

## Test Result


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
