### PR TITLE
[Tensilelite] Sparse related changes

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
@@ -333,6 +333,7 @@ defaultBenchmarkCommonParameters = [
     {"LdsBlockSizePerPadB": [-1]},
     {"LdsBlockSizePerPadMetadata": [0]},
     {"TransposeLDS": [-1]},
+    {"TransposeLDSMetadata": [-1]},
     {"MaxOccupancy": [40]},
     {"MaxLDS": [-1]},
     {"VectorWidthA": [-1]},

--- a/projects/hipblaslt/tensilelite/Tensile/Common/RequiredParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/RequiredParameters.py
@@ -95,6 +95,7 @@ def getRequiredParametersMin() -> set:
         'SwapGlobalReadOrder',
         'TailloopInNll',
         'TransposeLDS',
+        'TransposeLDSMetadata',
         'UnrollLoopSwapGlobalReadOrder',
         'Use64bShadowLimit',
         'UseInstOffsetForGRO',

--- a/projects/hipblaslt/tensilelite/Tensile/Common/RequiredParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/RequiredParameters.py
@@ -43,6 +43,7 @@ def getRequiredParametersMin() -> set:
         'ConvertAfterDS',
         'DirectToVgprA',
         'DirectToVgprB',
+        'DirectToVgprSparseMetadata',
         'DirectToLdsA',
         'DirectToLdsB',
         'ExpandPointerSwap',

--- a/projects/hipblaslt/tensilelite/Tensile/Common/ValidParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/ValidParameters.py
@@ -818,6 +818,7 @@ validParameters = { # we need to make sure this matches develop
     # 1  : keep LDS layout same as global fetch dimension for both A and B for NN,TN,TT, but NT would be rejected
     # 2  : coalesced dimension of lds is unroll dimension for both A and B
     "TransposeLDS": [-1, 1, 0, 2],
+    "TransposeLDSMetadata": [-1, 1, 0],
     # add gls or slc after global memory read/writes to change caching, not caching the writes is promising and improved performance a tiny bit
     # 0: none, 1: glc, 2: slc, 3: glc slc
     # For gfx942, sets sc0/sc1/nt bits

--- a/projects/hipblaslt/tensilelite/Tensile/Components/GSU.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/GSU.py
@@ -355,8 +355,9 @@ class GSUOn(GSU):
             if divider != 1:
                 depthUDiv = depthU // divider
                 gsuOffsetStr = "gsuOffset = DepthU/%s*bpeGR*GSUSumIdx"%(divider)
-        gsucLabel    = Label(label=writer.labels.getNameInc("GSUC_A" if tP["isA"] else "GSUC_B"), comment="")
-        gsucLabelEnd = Label(label=writer.labels.getNameInc("GSUC_A_End" if tP["isA"] else "GSUC_B_End"), comment="")
+        gsucLabelStr = "GSUC_%s"%( "A" if tP["isA"] else "B" if tP["isB"] else "M" )
+        gsucLabel    = Label(label=writer.labels.getNameInc(gsucLabelStr), comment="")
+        gsucLabelEnd = Label(label=writer.labels.getNameInc("%s_End"%(gsucLabelStr)), comment="")
         module.add(SAndB32(dst=sgpr(stmp), src0=sgpr("GSU"), src1=hex(0x8000), comment="SCC = (GSUC == 1) ?"))
         module.add(SCBranchSCC1(labelName=gsucLabel.getLabelName(), comment="branch if GSUC == 1"))
         gsuOffsetStr = "gsuOffset = DepthU*GSUSumIdx"

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -299,7 +299,7 @@ class LocalReadMFMA(LocalRead):
         valufIdx = 0
         if enableLDSTr:
             numberMTilesPerWave = kernel["MIWaveTile"][tile01]
-            numOffsetsPerLoad = 2
+            numOffsetsPerLoad = 2 * blocksPerTGroupSMFMA
             highBits = 0
             totalLoads = numberMTilesPerWave * numOffsetsPerLoad
             for tIdx in range(0, numberMTilesPerWave):
@@ -315,15 +315,17 @@ class LocalReadMFMA(LocalRead):
                     return offset_val
 
                 for oIdx in range(0,numOffsetsPerLoad):
+                    if blocksPerTGroupSMFMA > 1 and oIdx % blocksPerTGroupSMFMA == 0:
+                        offset_val += (kernel["MacroTile%s"%tc] * blockOffsetSMFMA) * tP["bpeDS"] * (oIdx // blocksPerTGroupSMFMA)
 
                     offset, srcAddr = self.cal_offset_srcAddr(maxLDSConstOffset, tc, offset_val)
                     offset = applyPad(offset)
                     ds = DSModifiers(na=1, offset=offset)
-                    destVgpr = vgpr("Valu%s_X%u_I%u+%u+%u"%(tc,bufferIdx,iui, 4*tIdx, oIdx * 2), 2)
+                    destVgpr = vgpr("Valu%s_X%u_I%u+%u+%u"%(tc,bufferIdx,iui, 4*tIdx*blocksPerTGroupSMFMA, oIdx * 2), 2)
                     localReadCode = Module("LocalRead%s Valu%u"%(tc,valuiIdx))
                     localReadCode.add(LocalReadX(dst=destVgpr, src=srcAddr, ds=ds, comment=comment))
                     if perpStride == 1:
-                        offset_val += UnrollStride*inputPerThread
+                        offset_val += (UnrollStride*inputPerThread) // (blocksPerTGroupSMFMA if writer.states.inTailLoop else 1)
                     else:
                         permBlock = kernel["MatrixInstK"]
                         perpStrideInv = permBlock // perpStride

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -4821,9 +4821,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
         vgprIdx = self.states.b.startVgprValu \
             + max(self.states.b.numVgprValu + numVgprValuPackB, self.states.b.numVgprG2LAllocated)
 
-    if ((tensorParametersA["bpe"] < 4 and not kernel["UnrollMajorLDSA"]) or                                 \
-        (tensorParametersB["bpe"] < 4 and not kernel["UnrollMajorLDSB"]) or                                 \
-        (not kernel["UnrollMajorLDSMetadata"] and kernel["MIInputPerThreadMetadata"] == 4))                \
+    if ((tensorParametersA["bpe"] < 4 and not kernel["UnrollMajorLDSA"]) or                                                      \
+        (tensorParametersB["bpe"] < 4 and not kernel["UnrollMajorLDSB"]) or                                                      \
+        (kernel["ProblemType"]["Sparse"] and not kernel["UnrollMajorLDSMetadata"] and kernel["MIInputPerThreadMetadata"] == 4))  \
         and (kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat()):
       self.states.a.startVgprValuPackTemp = vgprIdx
       self.states.b.startVgprValuPackTemp = vgprIdx

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -3479,9 +3479,11 @@ class KernelWriterAssembly(KernelWriter):
           # The sizeL of a structure sparsity 2:4 matrix is half of the dense matrix.
           if (idx in kernel["ProblemType"]["IndicesSummation"]) and     \
              ((tP["isA"] and kernel["ProblemType"]["Sparse"] == 1) or   \
-             (tP["isB"] and kernel["ProblemType"]["Sparse"] == 2)) :
-            module.add(SLShiftRightB32(dst=sgpr(stmp), src=size, shiftHex=0x1, comment="(size/2)"))
-            module.add(SSubU32(dst=sgpr(stmp), src0=sgpr(stmp), src1=0x1, comment="(size/2-1)"))
+             (tP["isB"] and kernel["ProblemType"]["Sparse"] == 2) or    \
+             tP["isM"]) :
+            divider = 8 if tP["isM"] else 2
+            module.add(SLShiftRightB32(dst=sgpr(stmp), src=size, shiftHex=hex(int(log(divider,2))), comment="(size/%u)"%divider))
+            module.add(SSubU32(dst=sgpr(stmp), src0=sgpr(stmp), src1=0x1, comment="(size/%u-1)"%divider))
           else:
             if tP["isSwizzled"]:
               if idx in kernel["ProblemType"]["IndicesSummation"]:

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -922,9 +922,9 @@ class KernelWriterAssembly(KernelWriter):
     if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
       moduleVgprMacro.add(RegSet("v", "vgprG2LMetadata", "vgprBase", self.states.m.startVgprG2L - self.states.startVgpr))
 
-    if ((tPA["bpe"] < 4 and not kernel["UnrollMajorLDSA"]) or                                              \
-        (tPB["bpe"] < 4 and not kernel["UnrollMajorLDSB"]) or                                              \
-        (not kernel["UnrollMajorLDSMetadata"] and kernel["MIInputPerThreadMetadata"] == 4))                \
+    if ((tPA["bpe"] < 4 and not kernel["UnrollMajorLDSA"]) or                                                                    \
+        (tPB["bpe"] < 4 and not kernel["UnrollMajorLDSB"]) or                                                                    \
+        (kernel["ProblemType"]["Sparse"] and not kernel["UnrollMajorLDSMetadata"] and kernel["MIInputPerThreadMetadata"] == 4))  \
         and (kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat()):
       moduleVgprMacro.add(RegSet("v", "vgprPackTemp", "vgprBase", self.states.a.startVgprValuPackTemp - self.states.startVgpr))
 
@@ -4844,7 +4844,7 @@ class KernelWriterAssembly(KernelWriter):
     numVgprPackTemp = 0
     if ((tensorParametersA["bpe"] < 4 and not kernel["UnrollMajorLDSA"])                                   \
         or (tensorParametersB["bpe"] < 4 and not kernel["UnrollMajorLDSB"])                                \
-        or (not kernel["UnrollMajorLDSMetadata"] and kernel["MIInputPerThreadMetadata"] == 4))             \
+        or (kernel["ProblemType"]["Sparse"] and not kernel["UnrollMajorLDSMetadata"] and kernel["MIInputPerThreadMetadata"] == 4))             \
         and (kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat()):
       numVgprPackTemp = 1
     numVgprCvtTemp = 0

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1381,8 +1381,11 @@ class Solution(collections.abc.Mapping):
       else:
         state["VectorWidthB"] = 1
 
-    if state["ProblemType"]["Sparse"] and not state["DirectToVgprSparseMetadata"]:
-      state["VectorWidthMetadata"] = state["VectorWidthA"] if state["ProblemType"]["Sparse"] == 1 else state["VectorWidthB"]
+    if state["ProblemType"]["Sparse"]:
+      if not state["DirectToVgprSparseMetadata"]:
+        state["VectorWidthMetadata"] = state["VectorWidthA"] if state["ProblemType"]["Sparse"] == 1 else state["VectorWidthB"]
+      # ON/OFF the sourceswap according to the sparse type automatically
+      state["SourceSwap"] = 0 if state["ProblemType"]["Sparse"] == 1 else 1
 
     numBytes = state["ProblemType"]["DataType"].numBytes()
     isa = tuple(state["ISA"])
@@ -3128,14 +3131,6 @@ class Solution(collections.abc.Mapping):
       if state["EnableMatrixInstruction"] and state["MIArchVgpr"]:
         reject(state, printRejectionReason, "Sparse A kernel does not support MIArchVgpr yet.")
         return
-      # Not Support Feature
-      if state["ProblemType"]["Sparse"] == 1 and state["SourceSwap"] :
-        reject(state, printRejectionReason, "Sparse A kernel cannot support SourceSwap.")
-        return
-      else:
-        if state["ProblemType"]["Sparse"] == 2 and not state["SourceSwap"]:
-          reject(state, printRejectionReason, "Sparse B kernel must enable SourceSwap.")
-          return
       state["AssertSummationElementMultiple"] = 8
 
     # check if need to use lds init Acc vgprs

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -2559,11 +2559,17 @@ class Solution(collections.abc.Mapping):
     # LDS
     ########################################
 
-    state["TransposeLDSMetadata"] = False if state["ProblemType"]["Sparse"] == 2 else True
-    state["UnrollMajorLDSMetadata"] = False if state["ProblemType"]["Sparse"] == 2 else True
+    if state["ProblemType"]["Sparse"]:
+      transposeLDSMetadata = int(state["TransposeLDSMetadata"])
+      if transposeLDSMetadata == -1:
+        state["TransposeLDSMetadata"] = int(not state["ProblemType"]["TLUMetadata"])
+      else:
+        state["TransposeLDSMetadata"] = int(transposeLDSMetadata)
 
-    if state["ProblemType"]["Sparse"] and not state["DirectToVgprSparseMetadata"]:
-      state["UnrollMajorLDSMetadata"] = state["TransposeLDSMetadata"] and (not state["ProblemType"]["TLUMetadata"])
+      state["UnrollMajorLDSMetadata"] = False if state["ProblemType"]["Sparse"] == 2 else True
+
+      if not state["DirectToVgprSparseMetadata"]:
+        state["UnrollMajorLDSMetadata"] = state["TransposeLDSMetadata"]
 
     # Determine if we can load directly-to-LDS.
     # Transpose requires a trip through registers to perform the transpose so can't use DirectToLdsA

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_ldstr.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_ldstr.yaml
@@ -1,0 +1,303 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported yet
+GlobalParameters:
+  MinimumRequiredVersion: 5.0.0
+  SleepPercent: 50
+  NumElementsToValidate: -1
+  #DataInitTypeBeta: 0
+  #DataInitTypeAlpha: 1
+  #DataInitTypeA: 8
+  #DataInitTypeB: 8
+  #DataInitTypeBias: 0
+  NewClient: 2
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  #Device: 0
+  PruneSparseMode: 0
+  MaxLDS: 163840
+  DeviceLDS: 163840
+  PrintSolutionRejectionReason: 1
+BenchmarkProblems:
+  #######################################
+  # NT - standard
+  #######################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      UseBias: 3
+      Batched: True
+      Activation: True
+      ActivationType: all
+      UseScaleAlphaVec: 3
+      #ActivationHPA: True
+      Sparse: 1
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 64, 1, 1, 1, 1, 1, 1 ]
+          - [16, 16, 64, 1, 1, 1, 1, 2, 2 ]
+          - [16, 16, 64, 1, 1, 1, 3, 2, 2 ]
+          - [16, 16, 64, 1, 1, 2, 1, 1, 4 ]
+          - [16, 16, 64, 1, 1, 8, 6, 1, 1 ]
+          - [16, 16, 64, 1, 1, 8, 8, 2, 2 ]
+          - [16, 16, 64, 1, 1, 7, 2, 2, 2 ]
+          - [16, 16, 64, 1, 1, 5, 9, 1, 4 ] # LDS 128K B
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [0,1,2]
+        - ClusterLocalRead: [0,1]
+        - DepthU: [64,128]
+        #- LocalReadVectorWidth: [8] #
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]       #
+        - TransposeLDS: [-1]
+        - LdsPadA: [0,-1]
+        - LdsPadB: [0,-1]
+        - LdsPadMetadata: [0,-1]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - SourceSwap: [0]
+        - StoreRemapVectorWidth: [-1]
+        - LDSTrInst: [1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [8, 8, 1, 32] # classic format
+          - Exact: [8, 8, 1, 64] # classic format
+          - Exact: [8, 8, 1, 128] # classic format
+          - Exact: [8, 8, 1, 256] # classic format
+          - Exact: [256, 256, 1, 32] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
+          - Exact: [256, 256, 1, 128] # classic format
+          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [1024, 1024, 1, 1024] # classic format
+        - BiasTypeArgs: ['s']
+        - FactorDimArgs: [0]
+        - ActivationArgs:
+          - [Enum: none]
+
+  #######################################
+  # NT - standard
+  #######################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      UseBias: 3
+      Batched: True
+      Activation: True
+      ActivationType: all
+      UseScaleAlphaVec: 3
+      #ActivationHPA: True
+      Sparse: 2
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 64, 1, 1, 1, 1, 1, 1 ]
+          - [16, 16, 64, 1, 1, 1, 1, 2, 2 ]
+          - [16, 16, 64, 1, 1, 1, 3, 2, 2 ]
+          - [16, 16, 64, 1, 1, 2, 1, 1, 4 ]
+          - [16, 16, 64, 1, 1, 8, 6, 1, 1 ]
+          - [16, 16, 64, 1, 1, 8, 8, 2, 2 ]
+          - [16, 16, 64, 1, 1, 7, 2, 2, 2 ]
+          - [16, 16, 64, 1, 1, 5, 9, 1, 4 ] # LDS 128K B
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [0,1,2]
+        - ClusterLocalRead: [0,1]
+        - DepthU: [64,128]
+        #- LocalReadVectorWidth: [8] #
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]       #
+        - TransposeLDS: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - LdsPadMetadata: [-1]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - SourceSwap: [1]
+        - LDSTrInst: [0,1]        
+        - StoreRemapVectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [8, 8, 1, 32] # classic format
+          - Exact: [8, 8, 1, 64] # classic format
+          - Exact: [8, 8, 1, 128] # classic format
+          - Exact: [8, 8, 1, 256] # classic format
+          - Exact: [256, 256, 1, 32] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
+          - Exact: [256, 256, 1, 128] # classic format
+          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [1024, 1024, 1, 1024] # classic format
+        - BiasTypeArgs: ['s']
+        - FactorDimArgs: [1]
+        - ActivationArgs:
+          - [Enum: none]
+
+  #######################################
+  # NT - standard
+  #######################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: f8
+      DestDataType: s
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      UseBias: 3
+      Batched: True
+      Activation: True
+      ActivationType: all
+      UseScaleAlphaVec: 3
+      #ActivationHPA: True
+      Sparse: 1
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 128, 1, 1, 1, 1, 1, 1 ]
+          - [16, 16, 128, 1, 1, 1, 1, 2, 2 ]
+          - [16, 16, 128, 1, 1, 1, 3, 2, 2 ]
+          - [16, 16, 128, 1, 1, 2, 2, 2, 2 ]
+          - [16, 16, 128, 1, 1, 2, 1, 1, 4 ]
+          - [16, 16, 128, 1, 1, 8, 8, 2, 2 ]
+          - [16, 16, 128, 1, 1, 7, 2, 2, 2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [0,1,2]
+        - ClusterLocalRead: [1]
+        - DepthU: [128,256]
+        #- LocalReadVectorWidth: [8] #
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]       #
+        - TransposeLDS: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - LdsPadMetadata: [-1]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - GlobalSplitUAlgorithm: [MultipleBuffer, MultipleBufferSingleKernel]
+        - SourceSwap: [0]
+        - StoreRemapVectorWidth: [-1]
+        - LDSTrInst: [0,1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 384] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
+          - Exact: [256, 256, 1, 128] # classic format
+          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 384] # classic format
+          - Exact: [1024, 1024, 1, 1024] # classic format          
+        - BiasTypeArgs: ['s']
+        - FactorDimArgs: [0]
+        - ActivationArgs:
+          - [Enum: none]
+
+  #######################################
+  # NT - standard
+  #######################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: f8
+      DestDataType: s
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      UseBias: 3
+      Batched: True
+      Activation: True
+      ActivationType: all
+      UseScaleAlphaVec: 3
+      #ActivationHPA: True
+      Sparse: 2
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 128, 1, 1, 1, 1, 1, 1 ]
+          - [16, 16, 128, 1, 1, 1, 1, 2, 2 ]
+          - [16, 16, 128, 1, 1, 1, 3, 2, 2 ]
+          - [16, 16, 128, 1, 1, 2, 2, 2, 2 ]
+          - [16, 16, 128, 1, 1, 2, 1, 1, 4 ]
+          - [16, 16, 128, 1, 1, 8, 8, 2, 2 ]
+          - [16, 16, 128, 1, 1, 7, 2, 2, 2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [0,1,2]
+        - ClusterLocalRead: [1]
+        - DepthU: [128,256]
+        #- LocalReadVectorWidth: [8] #
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]       #
+        - TransposeLDS: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - LdsPadMetadata: [-1]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - GlobalSplitUAlgorithm: [MultipleBuffer, MultipleBufferSingleKernel]
+        - SourceSwap: [1]
+        - StoreRemapVectorWidth: [-1]
+        - LDSTrInst: [0,1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [16, 16, 1, 256] # classic format
+          - Exact: [16, 16, 1, 384] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
+          - Exact: [256, 256, 1, 128] # classic format
+          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 384] # classic format
+          - Exact: [1024, 1024, 1, 1024] # classic format          
+        - BiasTypeArgs: ['s']
+        - FactorDimArgs: [1]
+        - ActivationArgs:
+          - [Enum: none]          

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_TensileLibLogicToYaml.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_TensileLibLogicToYaml.py
@@ -307,7 +307,7 @@ VALID_LIBLOGIC_FILE_CONTENT = """
     ThreadTileA: 12
     ThreadTileB: 3
     TransposeLDS: 2
-    TransposeLDSMetadata: true
+    TransposeLDSMetadata: 1
     ULSGRODoubleG2L: 0
     UnrollLoopSwapGlobalReadOrder: 0
     UnrollMajorLDSA: 1
@@ -433,6 +433,7 @@ BenchmarkProblems:
     - StreamKXCCMapping: [8]
     - ThreadTile: [[1, 1]]
     - TransposeLDS: [2]
+    - TransposeLDSMetadata: [1]
     - UseCustomMainLoopSchedule: [0]
     - UseSgprForGRO: [1]
     - VectorWidthA: [1]


### PR DESCRIPTION
## Motivation
1. Supported TransposeLDSMetadata = -1
2. Configure SourceSwap automatically.
3. Fix GSUC for sparse metadata.
4. Add DirectToVgprSparseMetadata (DTVSM) to the kernel name.
5. Support LDSTrInst for sparse kernel's A/B matrix.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
