### PR TITLE
Deprecate duplicate operators and function in thread_operators hpp

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -16,6 +16,11 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 * Changed various APIs with undefined behaviors to abort with a trap instead of printing a runtime error with `ROCPRIM_PRINT_ERROR_ONCE` 
 
+### Removed
+
+* Removed unused `equality`, `inequality`, `sum`, `max`, `min` from thread_operator.hpp.
+* Removed duplicate `inequality_operator` from binary_op_warpper.hpp
+
 ## rocPRIM 4.2.0 for ROCm 7.2
 
 ### Added

--- a/projects/rocprim/rocprim/include/rocprim/detail/binary_op_wrappers.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/detail/binary_op_wrappers.hpp
@@ -103,30 +103,6 @@ private:
     BinaryFunction scan_op_;
 };
 
-
-template<class EqualityOp>
-struct inequality_wrapper
-{
-    using equality_op_type = EqualityOp;
-
-    ROCPRIM_HOST_DEVICE inline
-    inequality_wrapper() = default;
-
-    ROCPRIM_HOST_DEVICE inline
-    inequality_wrapper(equality_op_type equality_op)
-        : equality_op(equality_op)
-    {}
-
-    template<class T, class U>
-    ROCPRIM_DEVICE ROCPRIM_INLINE
-    bool operator()(const T &a, const U &b)
-    {
-        return !equality_op(a, b);
-    }
-
-    equality_op_type equality_op;
-};
-
 } // end of detail namespace
 
 END_ROCPRIM_NAMESPACE

--- a/projects/rocprim/rocprim/include/rocprim/detail/binary_op_wrappers.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/detail/binary_op_wrappers.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
@@ -126,7 +126,7 @@ struct discontinuity_helper
         else
         {
             auto not_equal
-                = ::rocprim::detail::inequality_wrapper<CompareFunction>(CompareFunction());
+                = ::rocprim::inequality_wrapper<CompareFunction>(CompareFunction());
 
             constexpr unsigned int block_size      = BlockSize * ItemsPerThread;
             const InputType        block_successor = block_input[block_size];

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_run_length_encode.hpp
@@ -125,8 +125,7 @@ struct discontinuity_helper
         }
         else
         {
-            auto not_equal
-                = ::rocprim::inequality_wrapper<CompareFunction>(CompareFunction());
+            auto not_equal = ::rocprim::inequality_wrapper<CompareFunction>(CompareFunction());
 
             constexpr unsigned int block_size      = BlockSize * ItemsPerThread;
             const InputType        block_successor = block_input[block_size];

--- a/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_select.hpp
@@ -25,10 +25,9 @@
 #include <type_traits>
 
 #include "../config.hpp"
-#include "../detail/binary_op_wrappers.hpp"
 #include "../detail/various.hpp"
-
 #include "../iterator/transform_iterator.hpp"
+#include "../thread/thread_operators.hpp"
 
 #include "device_partition.hpp"
 
@@ -546,7 +545,7 @@ inline hipError_t unique(void*                     temporary_storage,
     rocprim::empty_type* const no_values = nullptr; // key only
 
     // Convert equality operator to inequality operator
-    auto inequality_op = detail::inequality_wrapper<EqualityOp>(equality_op);
+    auto inequality_op = inequality_wrapper<EqualityOp>(equality_op);
 
     using output_key_iterator_tuple = tuple<OutputIterator, ::rocprim::empty_type>;
     output_key_iterator_tuple output_tuple{output, ::rocprim::empty_type()};
@@ -649,7 +648,7 @@ inline hipError_t unique_by_key(void*                           temporary_storag
     const auto no_predicate = ::rocprim::empty_type{};
 
     // Convert equality operator to inequality operator
-    const auto inequality_op = detail::inequality_wrapper<EqualityOp>(equality_op);
+    const auto inequality_op = inequality_wrapper<EqualityOp>(equality_op);
 
     using output_key_iterator_tuple = tuple<OutputKeyIterator, ::rocprim::empty_type>;
     output_key_iterator_tuple output_key_tuple{keys_output, ::rocprim::empty_type()};

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_operators.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_operators.hpp
@@ -146,69 +146,6 @@ struct arg_min
 /// @}
 // end group thread_operators
 
-namespace detail
-{
-
-// CUB uses value_type of OutputIteratorT (if not void) as a type of intermediate results in scan and reduce,
-// for example:
-//
-// /// The output value type
-// typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-//     typename std::iterator_traits<InputIteratorT>::value_type,                                          // ... then the input iterator's value type,
-//     typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
-//
-// rocPRIM (as well as Thrust) uses result type of BinaryFunction instead (if not void):
-//
-// using input_type = typename std::iterator_traits<InputIterator>::value_type;
-// using result_type = typename ::rocprim::match_result_type<
-//     input_type, BinaryFunction
-// >::type;
-//
-// For short -> float using Sum()
-// CUB:     float Sum(float, float)
-// rocPRIM: short Sum(short, short)
-//
-// This wrapper allows to have compatibility with CUB in hipCUB.
-template<
-    class InputIteratorT,
-    class OutputIteratorT,
-    class BinaryFunction
->
-struct convert_result_type_wrapper
-{
-    using input_type = typename std::iterator_traits<InputIteratorT>::value_type;
-    using output_type = typename std::iterator_traits<OutputIteratorT>::value_type;
-    using result_type =
-        typename std::conditional<
-            std::is_void<output_type>::value, input_type, output_type
-        >::type;
-
-    convert_result_type_wrapper(BinaryFunction op) : op(op) {}
-
-    template<class T>
-    ROCPRIM_HOST_DEVICE inline
-    constexpr result_type operator()(const T &a, const T &b) const
-    {
-        return static_cast<result_type>(op(a, b));
-    }
-
-    BinaryFunction op;
-};
-
-template<
-    class InputIteratorT,
-    class OutputIteratorT,
-    class BinaryFunction
->
-inline
-convert_result_type_wrapper<InputIteratorT, OutputIteratorT, BinaryFunction>
-convert_result_type(BinaryFunction op)
-{
-    return convert_result_type_wrapper<InputIteratorT, OutputIteratorT, BinaryFunction>(op);
-}
-
-} // end detail namespace
-
 END_ROCPRIM_NAMESPACE
 
 #endif // ROCPRIM_THREAD_THREAD_OPERATORS_HPP_

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_operators.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_operators.hpp
@@ -92,42 +92,6 @@ struct inequality_wrapper
     }
 };
 
-/// \brief Functor that returns the sum of its arguments.
-struct sum
-{
-    /// \brief Invocation operator
-    template<class T>
-    ROCPRIM_HOST_DEVICE inline
-    constexpr T operator()(const T &a, const T &b) const
-    {
-        return a + b;
-    }
-};
-
-/// \brief Functor that returns the maximum of its arguments.
-struct max
-{
-    /// \brief Invocation operator
-    template<class T>
-    ROCPRIM_HOST_DEVICE inline
-    constexpr T operator()(const T &a, const T &b) const
-    {
-        return a < b ? b : a;
-    }
-};
-
-/// \brief Functor that returns the minimum of its arguments.
-struct min
-{
-    /// \brief Invocation operator
-    template<class T>
-    ROCPRIM_HOST_DEVICE inline
-    constexpr T operator()(const T &a, const T &b) const
-    {
-        return a < b ? a : b;
-    }
-};
-
 /// \brief Functor that returns the "arg max" of the given key-value pairs.
 ///
 /// The "arg max" of a key-value pair is defined as:

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_operators.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_operators.hpp
@@ -39,36 +39,6 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
-/// \defgroup thread_operators Thread Operators
-/// \ingroup threadmodule
-
-/// \addtogroup thread_operators
-/// @{
-
-/// \brief Functor that tests for equality.
-struct equality
-{
-    /// \brief Invocation operator
-    template<class T>
-    ROCPRIM_HOST_DEVICE inline
-    constexpr bool operator()(const T& a, const T& b) const
-    {
-        return a == b;
-    }
-};
-
-/// \brief Functor that tests for inequality.
-struct inequality
-{
-    /// \brief Invocation operator
-    template<class T>
-    ROCPRIM_HOST_DEVICE inline
-    constexpr bool operator()(const T& a, const T& b) const
-    {
-        return a != b;
-    }
-};
-
 /// \brief Functor that tests for inequality using a user-supplied equality comparator.
 template <class EqualityOp>
 struct inequality_wrapper

--- a/projects/rocprim/rocprim/include/rocprim/thread/thread_operators.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/thread/thread_operators.hpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * Modifications Copyright (c) 2017-2025, Advanced Micro Devices, Inc.  All rights reserved.
+ * Modifications Copyright (c) 2017-2026, Advanced Micro Devices, Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -39,6 +39,31 @@
 
 BEGIN_ROCPRIM_NAMESPACE
 
+/// \brief Functor that tests for equality.
+struct [[deprecated("Duplicate, use 'rocprim::equal_to' in functional.hpp instead.")]] equality
+{
+    /// \brief Invocation operator
+    template<class T>
+    ROCPRIM_HOST_DEVICE inline
+    constexpr bool operator()(const T& a, const T& b) const
+    {
+        return a == b;
+    }
+};
+
+/// \brief Functor that tests for inequality.
+struct [[deprecated(
+    "Duplicate, use 'rocprim::not_equal_to' in functional.hpp instead.")]] inequality
+{
+    /// \brief Invocation operator
+    template<class T>
+    ROCPRIM_HOST_DEVICE inline
+    constexpr bool operator()(const T& a, const T& b) const
+    {
+        return a != b;
+    }
+};
+
 /// \brief Functor that tests for inequality using a user-supplied equality comparator.
 template <class EqualityOp>
 struct inequality_wrapper
@@ -59,6 +84,42 @@ struct inequality_wrapper
     bool operator()(const T &a, const T &b)
     {
         return !op(a, b);
+    }
+};
+
+/// \brief Functor that returns the sum of its arguments.
+struct [[deprecated("Duplicate, use 'rocprim::plus' in functional.hpp instead.")]] sum
+{
+    /// \brief Invocation operator
+    template<class T>
+    ROCPRIM_HOST_DEVICE inline
+    constexpr T operator()(const T &a, const T &b) const
+    {
+        return a + b;
+    }
+};
+
+/// \brief Functor that returns the maximum of its arguments.
+struct [[deprecated("Duplicate, use 'rocprim::max' in functional.hpp instead.")]] max
+{
+    /// \brief Invocation operator
+    template<class T>
+    ROCPRIM_HOST_DEVICE inline
+    constexpr T operator()(const T &a, const T &b) const
+    {
+        return a < b ? b : a;
+    }
+};
+
+/// \brief Functor that returns the minimum of its arguments.
+struct [[deprecated("Duplicate, use 'rocprim::min' in functional.hpp instead.")]] min
+{
+    /// \brief Invocation operator
+    template<class T>
+    ROCPRIM_HOST_DEVICE inline
+    constexpr T operator()(const T &a, const T &b) const
+    {
+        return a < b ? a : b;
     }
 };
 


### PR DESCRIPTION
## Motivation

There is quite a lot of unnecessary code in thread_operators.hpp.

Most operators here have an equivalent in functional.hpp, these should be deprecated. Maybe the once that are not should be deprecated and moved to functional.hpp. The `convert_result_type_wrapper` is in the detail space and unused, so can probably be removed. `inequality_wrapper` is also defined in the detail space in `detail/binary_op_wrapper.hpp`, so I am not sure how to handle this one.

## Technical Details

In comparison with https://github.com/NVIDIA/cccl/blob/main/cub/cub/thread/thread_operators.cuh

The functionality of `inequality_wrapper` is the same under `thread_operators.hpp` and `binary_op_wrappers.hpp`, we kept the public one and removed the one in `detail`.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
