### PR TITLE
Use more concise expression in compare_nan_sensitive in device_radix_sort

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -641,8 +641,8 @@ auto compare_nan_sensitive(const T& a, const T& b) ->
     auto b_bits = ::rocprim::detail::bit_cast<bit_key_type>(b_plus);
 
     // invert negatives, put 1 into sign bit for positives
-    a_bits ^= (sign_bit & a_bits) == 0 ? sign_bit : bit_key_type(-1);
-    b_bits ^= (sign_bit & b_bits) == 0 ? sign_bit : bit_key_type(-1);
+    a_bits ^= (sign_bit & a_bits ? bit_key_type(-1) : 0) | sign_bit;
+    b_bits ^= (sign_bit & b_bits ? bit_key_type(-1) : 0) | sign_bit;
 
     // sort numbers and NaNs according to their bit representation
     return a_bits > b_bits;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -629,6 +629,10 @@ auto compare_nan_sensitive(const T& a, const T& b) ->
     using bit_key_type             = decltype(sign_bit);
 
     // convert -0.0 to +0.0
+    // It was concerned that when the flags -fno-signed-zeros or -funsafe-math-optimizations
+    // (or -ffast-math which controls these two) is enabled then it is optimized away, but
+    // the compiler also seems to correctly model this and does not optimize away the addition
+    // when testing with the compile flags.
     const T zero{0};
     const T a_plus = a + zero;
     const T b_plus = b + zero;

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -628,12 +628,14 @@ auto compare_nan_sensitive(const T& a, const T& b) ->
     static constexpr auto sign_bit = ::rocprim::traits::get<T>().float_bit_mask().sign_bit;
     using bit_key_type             = decltype(sign_bit);
 
-    auto a_bits = ::rocprim::detail::bit_cast<bit_key_type>(a);
-    auto b_bits = ::rocprim::detail::bit_cast<bit_key_type>(b);
-
     // convert -0.0 to +0.0
-    a_bits = a_bits == sign_bit ? 0 : a_bits;
-    b_bits = b_bits == sign_bit ? 0 : b_bits;
+    const T zero{0};
+    const T a_plus = a + zero;
+    const T b_plus = b + zero;
+
+    auto a_bits = ::rocprim::detail::bit_cast<bit_key_type>(a_plus);
+    auto b_bits = ::rocprim::detail::bit_cast<bit_key_type>(b_plus);
+
     // invert negatives, put 1 into sign bit for positives
     a_bits ^= (sign_bit & a_bits) == 0 ? sign_bit : bit_key_type(-1);
     b_bits ^= (sign_bit & b_bits) == 0 ? sign_bit : bit_key_type(-1);


### PR DESCRIPTION
## Motivation

Device radix sort for its merge sort implementation has the following (simplified) snippet ([device/detail/device_radix_sort.hpp:534](https://github.com/ROCm/rocm-libraries/blob/43f5c62f93c939ddfc6d13579ae80105a43666d2/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp#L619-L643))

```cpp
bool compare_nan_sensitive(float a, float b) {
    auto a_bits = ::rocprim::detail::bit_cast<bit_key_type>(a);
    auto b_bits = ::rocprim::detail::bit_cast<bit_key_type>(b);

    // convert -0.0 to +0.0
    a_bits = a_bits == sign_bit ? 0 : a_bits;
    b_bits = b_bits == sign_bit ? 0 : b_bits;
    (...)
}
```

According to IEE754 floating point arithmetic this can be rewritten to:

```cpp
bool compare_nan_sensitive(float a, float b) {
    // convert -0.0 to +0.0
    const T zero{0};
    const T a_plus = a + zero;
    const T b_plus = b + zero;

    auto a_bits = ::rocprim::detail::bit_cast<bit_key_type>(a_plus);
    auto b_bits = ::rocprim::detail::bit_cast<bit_key_type>(b_plus);
    (...)
}
```

Which generates simpler assembly. [See on Compiler Explorer](https://godbolt.org/z/87EzK5GGe).

The result of addition of (positive) zero forces +0.0 when the input is -0.0 due to the rules of IEEE arithmetic (from IEE754-2008 [available on Sci-Hub](https://sci-hub.se/10.1109/ieeestd.2008.4610935)):
> When the sum of two operands with opposite signs (or the difference of two operands with like signs) is
exactly zero, the sign of that sum (or difference) shall be +0 in all rounding-direction attributes except
roundTowardNegative; under that attribute, the sign of an exact zero sum (or difference) shall be −0.
However, x+x = x−(−x) retains the same sign as x even when x is zero.

The default rounding mode is round toward even, and this utility is only used in device API where we have control over it, so in theory this optimization should be safe. The compiler also seems to correctly model this and does not optimize away the addition, by default. However if the flags `-fno-signed-zeros` or `-funsafe-math-optimizations` (or `-ffast-math` which controls these two) is enabled then it is optimized away, whereas the current code is not.
Compiling rocPRIM code with non-semantic preserving flags shouldn't be our concern in theory, but it can still bite is in practice.

## Technical Details

The proposed method doesn't raise compilation error or test failures with `-fno-signed-zeros`, `-funsafe-math-optimizations` or `-ffast-math`. 

There are indeed less instructions and code bytes with the changes:

<img width="1707" height="723" alt="image" src="https://github.com/user-attachments/assets/afdf42e9-e846-4df4-b0c8-f8bfbe8ef7ee" />

The benchmark result is as follows:

![device_radix_sort_90a](https://github.com/user-attachments/assets/1728f40b-889e-40c0-8896-280bb88c8258)
![device_radix_sort_908](https://github.com/user-attachments/assets/00bf058a-6566-4a76-90d4-f77ec8ebcde3)
![device_radix_sort_1201](https://github.com/user-attachments/assets/1e20c60b-84fc-403e-bb2a-ad5f636d7de0)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
