### PR TITLE
[hipDNN] BN fwd inference using MIOpen inverse variance API

### DIFF
--- a/dnn-providers/miopen-provider/docs/OperationSupport.md
+++ b/dnn-providers/miopen-provider/docs/OperationSupport.md
@@ -10,6 +10,7 @@ The following table lists all operations currently supported in hipDNN:
 
 | Operation | Datatypes | Layouts | Notes |
 |-----------|-----------|---------|-------|
+| Batchnorm Inference | FP16, BFP16, FP32 | NCHW, NHWC, NCDHW, NDHWC | MIOpen | Spatial mode only¹ |
 | Batchnorm Inference with Variance | FP16, BFP16, FP32 | NCHW, NHWC, NCDHW, NDHWC | Spatial mode only¹ |
 | Batchnorm Inference + DRelu + Backward | FP16, BFP16, FP32 | NCHW, NHWC, NCDHW, NDHWC | Fused graph³ |
 | Batchnorm Training  | FP16, BFP16, FP32 | NCHW, NHWC, NCDHW, NDHWC | Spatial mode only¹, No running stats⁴ |

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdInferencePlan.cpp
@@ -11,9 +11,7 @@ namespace miopen_legacy_plugin
 
 // We have made the intentional decision to hardcode the batchnorm mode to miopenBNSpatial
 // rather than making it configurable and adding extra complexity.
-
-// NOTE: BN inference temporarily disabled due to https://github.com/ROCm/rocm-libraries/issues/2459
-//const miopenBatchNormMode_t MIOPEN_BATCHNORM_MODE = miopenBNSpatial;
+const miopenBatchNormMode_t MIOPEN_BATCHNORM_MODE = miopenBNSpatial;
 
 BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
     const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& attributes,
@@ -104,73 +102,66 @@ void BatchnormFwdInferencePlan::execute(
     [[maybe_unused]] void* workspace) const
 {
     // Hardcoded values from bn_driver in miopen
-    // auto alpha = static_cast<float>(1);
-    // auto beta = static_cast<float>(0);
-    // double epsilon = hipdnn_data_sdk::utilities::BATCHNORM_DEFAULT_EPSILON;
+    auto alpha = static_cast<float>(1);
+    auto beta = static_cast<float>(0);
 
-    // auto xBuffer = miopen_utils::findDeviceBuffer(
-    //     _inferenceParams.x().uid(), deviceBuffers, numDeviceBuffers);
-    // auto scaleBuffer = miopen_utils::findDeviceBuffer(
-    //     _inferenceParams.scale().uid(), deviceBuffers, numDeviceBuffers);
-    // auto biasBuffer = miopen_utils::findDeviceBuffer(
-    //     _inferenceParams.bias().uid(), deviceBuffers, numDeviceBuffers);
-    // auto estMeanBuffer = miopen_utils::findDeviceBuffer(
-    //     _inferenceParams.estMean().uid(), deviceBuffers, numDeviceBuffers);
-    // auto invVarianceBuffer = miopen_utils::findDeviceBuffer(
-    //     _inferenceParams.invVariance().uid(), deviceBuffers, numDeviceBuffers);
+    auto xBuffer = miopen_utils::findDeviceBuffer(
+        _inferenceParams.x().uid(), deviceBuffers, numDeviceBuffers);
+    auto scaleBuffer = miopen_utils::findDeviceBuffer(
+        _inferenceParams.scale().uid(), deviceBuffers, numDeviceBuffers);
+    auto biasBuffer = miopen_utils::findDeviceBuffer(
+        _inferenceParams.bias().uid(), deviceBuffers, numDeviceBuffers);
+    auto estMeanBuffer = miopen_utils::findDeviceBuffer(
+        _inferenceParams.estMean().uid(), deviceBuffers, numDeviceBuffers);
+    auto invVarianceBuffer = miopen_utils::findDeviceBuffer(
+        _inferenceParams.invVariance().uid(), deviceBuffers, numDeviceBuffers);
 
-    // if(_inferenceParams.optActivation().has_value() && _inferenceParams.activationOut().has_value())
-    // {
-    //     auto activationOutBuffer = miopen_utils::findDeviceBuffer(
-    //         _inferenceParams.activationOut()->uid(), deviceBuffers, numDeviceBuffers);
+    if(_inferenceParams.optActivation().has_value() && _inferenceParams.activationOut().has_value())
+    {
+        auto activationOutBuffer = miopen_utils::findDeviceBuffer(
+            _inferenceParams.activationOut()->uid(), deviceBuffers, numDeviceBuffers);
 
-    //     THROW_ON_MIOPEN_FAILURE(miopenBatchNormForwardInferenceActivation(
-    //         handle.miopenHandle,
-    //         MIOPEN_BATCHNORM_MODE,
-    //         &alpha,
-    //         &beta,
-    //         _inferenceParams.x().tensorDescriptor(),
-    //         xBuffer.ptr,
-    //         _inferenceParams.activationOut().value().tensorDescriptor(),
-    //         activationOutBuffer.ptr,
-    //         _inferenceParams.scale().tensorDescriptor(),
-    //         _inferenceParams.bias().tensorDescriptor(),
-    //         _inferenceParams.estMean().tensorDescriptor(),
-    //         _inferenceParams.invVariance().tensorDescriptor(),
-    //         scaleBuffer.ptr,
-    //         biasBuffer.ptr,
-    //         estMeanBuffer.ptr,
-    //         invVarianceBuffer.ptr,
-    //         epsilon,
-    //         _inferenceParams.optActivation().value().activationDescriptor()));
-    // }
-    // else
-    // {
-    //     auto yBuffer = miopen_utils::findDeviceBuffer(
-    //         _inferenceParams.y().uid(), deviceBuffers, numDeviceBuffers);
-    //     THROW_ON_MIOPEN_FAILURE(miopenBatchNormalizationForwardInference_V2(
-    //         handle.miopenHandle,
-    //         MIOPEN_BATCHNORM_MODE,
-    //         &alpha,
-    //         &beta,
-    //         _inferenceParams.x().tensorDescriptor(),
-    //         xBuffer.ptr,
-    //         _inferenceParams.y().tensorDescriptor(),
-    //         yBuffer.ptr,
-    //         _inferenceParams.scale().tensorDescriptor(),
-    //         _inferenceParams.bias().tensorDescriptor(),
-    //         _inferenceParams.estMean().tensorDescriptor(),
-    //         _inferenceParams.invVariance().tensorDescriptor(),
-    //         scaleBuffer.ptr,
-    //         biasBuffer.ptr,
-    //         estMeanBuffer.ptr,
-    //         invVarianceBuffer.ptr,
-    //         epsilon));
-    // }
-    throw hipdnn_plugin_sdk::HipdnnPluginException(
-        HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
-        "BatchnormFwdInferencePlan execution is currently disabled due to implementation issues "
-        "with the BatchnormInference op.");
+        THROW_ON_MIOPEN_FAILURE(miopenBatchNormForwardInferenceActivationInvVariance(
+            handle.miopenHandle,
+            MIOPEN_BATCHNORM_MODE,
+            &alpha,
+            &beta,
+            _inferenceParams.x().tensorDescriptor(),
+            xBuffer.ptr,
+            _inferenceParams.activationOut().value().tensorDescriptor(),
+            activationOutBuffer.ptr,
+            _inferenceParams.scale().tensorDescriptor(),
+            _inferenceParams.bias().tensorDescriptor(),
+            _inferenceParams.estMean().tensorDescriptor(),
+            _inferenceParams.invVariance().tensorDescriptor(),
+            scaleBuffer.ptr,
+            biasBuffer.ptr,
+            estMeanBuffer.ptr,
+            invVarianceBuffer.ptr,
+            _inferenceParams.optActivation().value().activationDescriptor()));
+    }
+    else
+    {
+        auto yBuffer = miopen_utils::findDeviceBuffer(
+            _inferenceParams.y().uid(), deviceBuffers, numDeviceBuffers);
+        THROW_ON_MIOPEN_FAILURE(miopenBatchNormalizationForwardInferenceInvVariance(
+            handle.miopenHandle,
+            MIOPEN_BATCHNORM_MODE,
+            &alpha,
+            &beta,
+            _inferenceParams.x().tensorDescriptor(),
+            xBuffer.ptr,
+            _inferenceParams.y().tensorDescriptor(),
+            yBuffer.ptr,
+            _inferenceParams.scale().tensorDescriptor(),
+            _inferenceParams.bias().tensorDescriptor(),
+            _inferenceParams.estMean().tensorDescriptor(),
+            _inferenceParams.invVariance().tensorDescriptor(),
+            scaleBuffer.ptr,
+            biasBuffer.ptr,
+            estMeanBuffer.ptr,
+            invVarianceBuffer.ptr));
+    }
 }
 
 }

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
@@ -423,13 +423,6 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
             }
         }
 
-        if(node.attributes_type()
-           == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes)
-        {
-            HIPDNN_LOG_WARN("Batchnorm inference support is temporarily disabled.");
-            return false;
-        }
-
         try
         {
             switch(node.attributes_type())

--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -20,8 +20,6 @@ using namespace hipdnn_test_sdk::utilities;
 using namespace miopen_legacy_plugin::test_utilities;
 using namespace test_bn_common;
 
-// Note: Tests temporarily disabled due to https://github.com/ROCm/rocm-libraries/issues/2459
-
 namespace
 {
 
@@ -115,7 +113,7 @@ using IntegrationGpuBatchnormForwardInferenceNdhwcFp16 = BatchnormForwardInferen
 
 } // namespace
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNchwFp32, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNchwFp32, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCHW);
 }
@@ -128,7 +126,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
                          IntegrationGpuBatchnormForwardInferenceNchwFp32,
                          testing::ValuesIn(getBnFwdInferenceFullTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNchwBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNchwBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCHW);
 }
@@ -141,7 +139,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
                          IntegrationGpuBatchnormForwardInferenceNchwBfp16,
                          testing::ValuesIn(getBnFwdInferenceFullTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNchwFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNchwFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCHW);
 }
@@ -154,7 +152,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
                          IntegrationGpuBatchnormForwardInferenceNchwFp16,
                          testing::ValuesIn(getBnFwdInferenceFullTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcFp32, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcFp32, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NHWC);
 }
@@ -167,7 +165,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
                          IntegrationGpuBatchnormForwardInferenceNhwcFp32,
                          testing::ValuesIn(getBnFwdInferenceFullTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NHWC);
 }
@@ -180,7 +178,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
                          IntegrationGpuBatchnormForwardInferenceNhwcBfp16,
                          testing::ValuesIn(getBnFwdInferenceFullTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NHWC);
 }
@@ -193,7 +191,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
                          IntegrationGpuBatchnormForwardInferenceNhwcFp16,
                          testing::ValuesIn(getBnFwdInferenceFullTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwFp32, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwFp32, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCDHW);
 }
@@ -202,7 +200,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          IntegrationGpuBatchnormForwardInferenceNcdhwFp32,
                          testing::ValuesIn(getBnFwdInference3dTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCDHW);
 }
@@ -211,7 +209,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          IntegrationGpuBatchnormForwardInferenceNcdhwBfp16,
                          testing::ValuesIn(getBnFwdInference3dTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCDHW);
 }
@@ -220,7 +218,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          IntegrationGpuBatchnormForwardInferenceNcdhwFp16,
                          testing::ValuesIn(getBnFwdInference3dTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcFp32, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcFp32, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NDHWC);
 }
@@ -229,7 +227,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          IntegrationGpuBatchnormForwardInferenceNdhwcFp32,
                          testing::ValuesIn(getBnFwdInference3dTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NDHWC);
 }
@@ -238,7 +236,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          IntegrationGpuBatchnormForwardInferenceNdhwcBfp16,
                          testing::ValuesIn(getBnFwdInference3dTestCases()));
 
-TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NDHWC);
 }

--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormFwdPlusActive.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormFwdPlusActive.cpp
@@ -176,7 +176,7 @@ using IntegrationGpuBatchnormFwdPlusActivNdhwcFp16
 
 } // namespace
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNchwFp32, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNchwFp32, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCHW);
 }
@@ -193,7 +193,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNchwBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNchwBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCHW);
 }
@@ -210,7 +210,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNchwFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNchwFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCHW);
 }
@@ -227,7 +227,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNhwcFp32, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNhwcFp32, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NHWC);
 }
@@ -244,7 +244,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNhwcBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNhwcBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NHWC);
 }
@@ -261,7 +261,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNhwcFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNhwcFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NHWC);
 }
@@ -279,7 +279,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
 
 //Ncdhw
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNcdhwFp32, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNcdhwFp32, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCDHW);
 }
@@ -290,7 +290,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNcdhwBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNcdhwBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCDHW);
 }
@@ -301,7 +301,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNcdhwFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNcdhwFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCDHW);
 }
@@ -313,7 +313,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
 
 //NDHWC
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNdhwcFp32, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNdhwcFp32, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NDHWC);
 }
@@ -324,7 +324,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNdhwcBfp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNdhwcBfp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NDHWC);
 }
@@ -335,7 +335,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
                      testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
 
-TEST_P(IntegrationGpuBatchnormFwdPlusActivNdhwcFp16, DISABLED_Correctness)
+TEST_P(IntegrationGpuBatchnormFwdPlusActivNdhwcFp16, Correctness)
 {
     runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NDHWC);
 }

--- a/projects/hipdnn/docs/Roadmap.md
+++ b/projects/hipdnn/docs/Roadmap.md
@@ -69,7 +69,6 @@ Plugins extend hipDNN's computational capabilities. See [Design.md](./Design.md#
 #### Near-Term Priorities
 
 - **Fusion Support**: Complete integration for Convolution fusions
-- **Batchnorm Inference**: Re-enable support after resolving [known issues](https://github.com/ROCm/rocm-libraries/issues/2459)
 - **Batchnorm Running Stats**: Add support for running statistics in Batchnorm operations
 - **Code Refactoring**: Extract common MIOpen plugin code into reusable Plugin SDK and Test SDK components
 

--- a/projects/hipdnn/samples/CMakeLists.txt
+++ b/projects/hipdnn/samples/CMakeLists.txt
@@ -35,8 +35,7 @@ function(add_hipdnn_sample NAME SOURCE)
     target_link_libraries(${NAME} PRIVATE hip::host Threads::Threads hipdnn_frontend hipdnn_test_sdk)
 endfunction()
 
-# Temporarily disabled bn_inference due to https://github.com/ROCm/rocm-libraries/issues/2459
-# add_hipdnn_sample(bn_inference batchnorm/BnInference.cpp)
+add_hipdnn_sample(bn_inference batchnorm/BnInference.cpp)
 add_hipdnn_sample(bn_inference_with_variance batchnorm/BnInferenceWithVariance.cpp)
 add_hipdnn_sample(bn_training batchnorm/BnTraining.cpp)
 add_hipdnn_sample(fused_bn_training_activ batchnorm/FusedBnTrainingActiv.cpp)
@@ -87,7 +86,7 @@ add_hipdnn_sample_test(fused_conv_fprop_activ)
 add_hipdnn_sample_test(fused_conv_fprop_bias_activ)
 
 # Register batchnorm samples as tests
-# Note: bn_inference is currently disabled per issue #2459
+add_hipdnn_sample_test(bn_inference)
 add_hipdnn_sample_test(bn_inference_with_variance)
 add_hipdnn_sample_test(bn_training)
 add_hipdnn_sample_test(fused_bn_training_activ)

--- a/projects/hipdnn/samples/batchnorm/BnInference.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInference.cpp
@@ -17,8 +17,6 @@
 using namespace hipdnn_frontend;
 using namespace hipdnn_data_sdk;
 
-// Note: Sample temporarily disabled due to https://github.com/ROCm/rocm-libraries/issues/2459
-
 template <typename InputType, typename IntermediateType>
 bool SampleRunner::operator()(const TensorLayout& layout)
 {
@@ -39,10 +37,10 @@ bool SampleRunner::operator()(const TensorLayout& layout)
         .set_compute_data_type(hipdnn_frontend::DataType::FLOAT);
 
     auto x = createTensor({n, c, h, w}, inputType, layout);
-    auto scale = createTensor({1, c, 1, 1}, intermediateType);
-    auto bias = createTensor({1, c, 1, 1}, intermediateType);
-    auto mean = createTensor({1, c, 1, 1}, intermediateType);
-    auto invVariance = createTensor({1, c, 1, 1}, intermediateType);
+    auto scale = createTensor({1, c, 1, 1}, intermediateType, layout);
+    auto bias = createTensor({1, c, 1, 1}, intermediateType, layout);
+    auto mean = createTensor({1, c, 1, 1}, intermediateType, layout);
+    auto invVariance = createTensor({1, c, 1, 1}, intermediateType, layout);
 
     auto bnAttributes = graph::BatchnormInferenceAttributes();
     bnAttributes.set_name("bn_inference_node");
@@ -92,7 +90,6 @@ bool SampleRunner::operator()(const TensorLayout& layout)
         utilities::Tensor<InputType> yRefTensor(y->get_dim(), layout);
 
         auto tolerance = hipdnn_test_sdk::utilities::batchnorm::getToleranceInference<InputType>();
-        double epsilon = utilities::BATCHNORM_DEFAULT_EPSILON;
 
         hipdnn_test_sdk::utilities::CpuFpReferenceBatchnorm::fwdInference(
             xTensor, scaleTensor, biasTensor, meanTensor, invVarianceTensor, yRefTensor);


### PR DESCRIPTION
## Motivation

Re-enable the Batchnorm Forward Inference interface by using the new MIOpen APIs added by https://github.com/ROCm/rocm-libraries/pull/3511 which is a dependency for this work to be merged.

This interface was previously disabled in https://github.com/ROCm/rocm-libraries/pull/2492/ and tests & samples disabled. The tests and samples are reinstated as part of this PR.

Closes https://github.com/ROCm/rocm-libraries/issues/2459

## Technical details

The BN inference samples needed modifications to pass the layout to scale/bias/mean/invVariance tensors such that the tensors have compatible layouts for the NHCW case to allow the BN inference plan to be applicable. 

## Test Plan

Built against an MIOpen library with new APIs and executed re-enabled tests with
```sh
$ ./bin/miopen_plugin_integration_test --gtest_filter=*IntegrationGpuBatchnormForwardInference* 
$ ./bin/miopen_plugin_integration_test --gtest_filter=*IntegrationGpuBatchnormFwdPlusActiv*
```

As well as the re-enabled sample
```sh
 ./bn_inference --verify-cpu
```

## Test Result

On gfx90a both re-enabled tests and sample pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
