### PR TITLE
[hipBLASlt] Exclude from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ exclude: |
     projects/composablekernel/.*|
     projects/hipblas/.*|
     projects/hipblas-common/.*|
+    projects/hipblaslt/.*|
     projects/hipcub/.*|
     projects/hipfft/.*|
     projects/hiprand/.*|


### PR DESCRIPTION
## Motivation

Exclude hipBLASlt from pre-commit due to the challenges of rebasing with formatting changes. If pre-commit fixes can't be applied, then there is no sense in running it on PRs. 

We can revisit adding hipBLASlt to pre-commit when there is less concurrent NPI work.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
