### PR TITLE
[rocfft-test] remove dependency on boost tokenizer by using CLI11 instead

### DIFF
--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -395,8 +395,11 @@ int main(int argc, char* argv[])
         ->check(CLI::NonNegativeNumber);
     app.add_option("--mp_launch",
                    mp_launch,
-                   "Command line prefix to launch multi-process transforms, e.g. \"mpirun --np 4 "
-                   "/path/to/hipfft_mpi_worker\"")
+                   "Command line prefix to launch multi-process transforms, e.g. \n"
+                   "\"mpirun --np 4 /path/to/hipfft_mpi_worker\"\n"
+                   "NOTE: embedded quotes must be used for all command arguments that contain "
+                   "space character(s). For instance,\n"
+                   "\"mpirun --np 4 \\\"/path with spaces/to/hipfft_mpi_worker\\\"\"")
         ->default_val("")
         ->each([&](const std::string&) {
             if(mp_lib == fft_params::fft_mp_lib_none)

--- a/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
+++ b/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
@@ -30,6 +30,7 @@
 
 #include "../hipfft_params.h"
 
+#include "../../shared/CLI11.hpp"
 #include "../../shared/accuracy_test.h"
 #include "../../shared/fftw_transform.h"
 #include "../../shared/gpubuf.h"
@@ -39,6 +40,38 @@
 #include "../../shared/subprocess.h"
 
 extern std::string mp_launch;
+struct user_mp_launch_command
+{
+    std::string              exe;
+    std::vector<std::string> user_mp_argv;
+};
+static user_mp_launch_command get_mp_launch_command()
+{
+    user_mp_launch_command ret;
+    try
+    {
+        CLI::App command_splitter;
+        command_splitter.allow_extras();
+        command_splitter.parse(mp_launch, /*program_name_included = */ true);
+        ret.exe          = command_splitter.get_name();
+        ret.user_mp_argv = command_splitter.remaining();
+    }
+    catch(const CLI::Error& e)
+    {
+        if(verbose)
+        {
+            if(!mp_launch.empty())
+                std::cout << "CLI11 failed to parse the command " << mp_launch << "\n";
+            std::cout << "CLI11 exception name: " << e.get_name() << "\n"
+                      << "CLI11 exception info: " << e.what() << "\n"
+                      << "CLI11 error code:" << e.get_exit_code() << std::endl;
+        }
+        // returned empty struct
+        ret.exe.clear();
+        ret.user_mp_argv.clear();
+    }
+    return ret;
+}
 
 extern last_cpu_fft_cache last_cpu_fft_data;
 
@@ -137,22 +170,14 @@ TEST_P(accuracy_test, vs_fftw)
     }
     case fft_params::fft_mp_lib_mpi:
     {
-        // split launcher into tokens since the first one is the exe
-        // and the remainder is the start of its argv
-        boost::escaped_list_separator<char>                   sep('\\', ' ', '\"');
-        boost::tokenizer<boost::escaped_list_separator<char>> tokenizer(mp_launch, sep);
-        std::string                                           exe;
-        std::vector<std::string>                              argv;
-        for(auto t : tokenizer)
-        {
-            if(t.empty())
-                continue;
+        // Multi-proc FFT.
+        static const auto mp_launch_command = get_mp_launch_command();
 
-            if(exe.empty())
-                exe = t;
-            else
-                argv.push_back(t);
-        }
+        if(mp_launch_command.exe.empty())
+            GTEST_FAIL() << "Cannot proceed due to empty multi-process executable: omitted "
+                            "\"--mp_launch\" option or invalid value thereof.";
+        auto argv = mp_launch_command.user_mp_argv;
+
         // append test token and ask for accuracy test
         argv.push_back("--token");
         argv.push_back(params.token());
@@ -160,7 +185,7 @@ TEST_P(accuracy_test, vs_fftw)
 
         // throws an exception if launch fails or if subprocess
         // returns nonzero exit code
-        execute_subprocess(exe, argv, {});
+        execute_subprocess(mp_launch_command.exe, argv, {});
         break;
     }
     default:

--- a/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
+++ b/projects/hipfft/clients/tests/hipfft_accuracy_test.cpp
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <boost/tokenizer.hpp>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>
 #include <math.h>

--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -421,8 +421,11 @@ int main(int argc, char* argv[])
         ->check(CLI::NonNegativeNumber);
     app.add_option("--mp_launch",
                    mp_launch,
-                   "Command line prefix to launch multi-process transforms, e.g. \"mpirun --np 4 "
-                   "/path/to/rocfft_mpi_worker\"")
+                   "Command line prefix to launch multi-process transforms, e.g. \n"
+                   "\"mpirun --np 4 /path/to/rocfft_mpi_worker\"\n"
+                   "NOTE: embedded quotes must be used for all command arguments that contain "
+                   "space character(s). For instance,\n"
+                   "\"mpirun --np 4 \\\"/path with spaces/to/rocfft_mpi_worker\\\"\"")
         ->default_val("")
         ->each([&](const std::string&) {
             if(mp_lib == fft_params::fft_mp_lib_none)

--- a/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
+++ b/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
@@ -43,12 +43,28 @@ struct user_mp_launch_command
 static user_mp_launch_command get_mp_launch_command()
 {
     user_mp_launch_command ret;
-    CLI::App               command_splitter;
-    command_splitter.allow_extras();
-    command_splitter.parse(mp_launch);
-    ret.user_mp_argv = command_splitter.remaining();
-    ret.exe          = ret.user_mp_argv.front();
-    ret.user_mp_argv.erase(ret.user_mp_argv.begin());
+    try
+    {
+        CLI::App command_splitter;
+        command_splitter.allow_extras();
+        command_splitter.parse(mp_launch, /*program_name_included = */ true);
+        ret.exe          = command_splitter.get_name();
+        ret.user_mp_argv = command_splitter.remaining();
+    }
+    catch(const CLI::Error& e)
+    {
+        if(verbose)
+        {
+            if(!mp_launch.empty())
+                std::cout << "CLI11 failed to parse the command " << mp_launch << "\n";
+            std::cout << "CLI11 exception name: " << e.get_name() << "\n"
+                      << "CLI11 exception info: " << e.what() << "\n"
+                      << "CLI11 error code:" << e.get_exit_code() << std::endl;
+        }
+        // returned empty struct
+        ret.exe.clear();
+        ret.user_mp_argv.clear();
+    }
     return ret;
 }
 
@@ -127,8 +143,8 @@ TEST_P(accuracy_test, vs_fftw)
         static const auto mp_launch_command = get_mp_launch_command();
 
         if(mp_launch_command.exe.empty())
-            GTEST_FAIL() << "Required multi-process executable to launch was omitted "
-                            "(\"--mp_launch\" option)";
+            GTEST_FAIL() << "Cannot proceed due to empty multi-process executable: omitted "
+                            "\"--mp_launch\" option or invalid value thereof.";
         auto argv = mp_launch_command.user_mp_argv;
 
         // append test token and ask for accuracy test

--- a/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
+++ b/projects/rocfft/clients/tests/rocfft_accuracy_test.cpp
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <boost/tokenizer.hpp>
 #include <gtest/gtest.h>
 #include <math.h>
 #include <stdexcept>
@@ -27,6 +26,7 @@
 
 #include "../../shared/rocfft_accuracy_test.h"
 
+#include "../../shared/CLI11.hpp"
 #include "../../shared/client_except.h"
 #include "../../shared/fftw_transform.h"
 #include "../../shared/gpubuf.h"
@@ -35,6 +35,22 @@
 #include "rocfft/rocfft.h"
 
 extern std::string mp_launch;
+struct user_mp_launch_command
+{
+    std::string              exe;
+    std::vector<std::string> user_mp_argv;
+};
+static user_mp_launch_command get_mp_launch_command()
+{
+    user_mp_launch_command ret;
+    CLI::App               command_splitter;
+    command_splitter.allow_extras();
+    command_splitter.parse(mp_launch);
+    ret.user_mp_argv = command_splitter.remaining();
+    ret.exe          = ret.user_mp_argv.front();
+    ret.user_mp_argv.erase(ret.user_mp_argv.begin());
+    return ret;
+}
 
 extern last_cpu_fft_cache last_cpu_fft_data;
 
@@ -108,22 +124,13 @@ TEST_P(accuracy_test, vs_fftw)
     case fft_params::fft_mp_lib_mpi:
     {
         // Multi-proc FFT.
-        // Split launcher into tokens since the first one is the exe
-        // and the remainder is the start of its argv
-        boost::escaped_list_separator<char>                   sep('\\', ' ', '\"');
-        boost::tokenizer<boost::escaped_list_separator<char>> tokenizer(mp_launch, sep);
-        std::string                                           exe;
-        std::vector<std::string>                              argv;
-        for(auto t : tokenizer)
-        {
-            if(t.empty())
-                continue;
+        static const auto mp_launch_command = get_mp_launch_command();
 
-            if(exe.empty())
-                exe = t;
-            else
-                argv.push_back(t);
-        }
+        if(mp_launch_command.exe.empty())
+            GTEST_FAIL() << "Required multi-process executable to launch was omitted "
+                            "(\"--mp_launch\" option)";
+        auto argv = mp_launch_command.user_mp_argv;
+
         // append test token and ask for accuracy test
         argv.push_back("--token");
         argv.push_back(testcase_token);
@@ -131,7 +138,7 @@ TEST_P(accuracy_test, vs_fftw)
 
         // throws an exception if launch fails or if subprocess
         // returns nonzero exit code
-        execute_subprocess(exe, argv, {});
+        execute_subprocess(mp_launch_command.exe, argv, {});
         break;
     }
     default:


### PR DESCRIPTION
## Motivation

Alternative approach to #3591.

## Technical Details

Keep the user-provided mpi launch command as a `std::string` option to rocfft-test and use an internal `CLI::App` object to parse it thereafter to extract the command's `argv` from it.

## Test Plan

Multi-processes and/or multi-device tests cover the changes.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
