### PR TITLE
Fix: Update CMake build system for CMake 4.x compatibility

### DIFF
--- a/projects/hipblaslt/deps/CMakeLists.txt
+++ b/projects/hipblaslt/deps/CMakeLists.txt
@@ -24,7 +24,7 @@
 # Helper cmake script to automate building dependencies for rocblaslt
 # This script can be invoked manually by the user with 'cmake -P'
 
-cmake_minimum_required(VERSION 3.22...3.25.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 
 list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../cmake )
 
@@ -64,13 +64,7 @@ if( BUILD_LAPACK )
   set( lapack_custom_target COMMAND cd ${LAPACK_BINARY_ROOT}$<SEMICOLON> ${CMAKE_COMMAND} --build . --target install )
 endif( )
 
-# POLICY CMP0037 - "Target names should not be reserved and should match a validity pattern"
-# Familiar target names like 'install' should be OK at the super-build level
-if( POLICY CMP0037 )
-  cmake_policy( SET CMP0037 OLD )
-endif( )
-
-add_custom_target( install
+add_custom_target( install_deps
   ${gtest_custom_target}
   ${lapack_custom_target}
   DEPENDS ${rocblaslt_dependencies}

--- a/projects/hipblaslt/install.sh
+++ b/projects/hipblaslt/install.sh
@@ -718,7 +718,7 @@ if [[ "${install_dependencies}" == true ]]; then
     mkdir -p ${build_dir}/deps && cd ${build_dir}/deps
     ${cmake_executable} -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_LAPACK=${build_lapack} ${root_path}/deps
     make -j$(nproc)
-    elevate_if_not_root make install
+    elevate_if_not_root make install_deps
   popd
 fi
 


### PR DESCRIPTION

## Motivation

Fix for https://github.com/ROCm/rocm-libraries/issues/2080

## Technical Details

This commit resolves a build failure with CMake 4.x and newer. The `deps/CMakeLists.txt` file used a deprecated CMake policy to allow a custom `install` target, which is no longer permitted.

The fix renames the custom target from `install` to `install_deps` and removes the deprecated policy. The `install.sh` script is also updated to call the new `install_deps` target. This ensures the dependency build process remains functional while complying with modern CMake standards.

The minimum required CMake version for the dependency build is set to 3.25.2 to align with the main project and avoid imposing unnecessary upgrade requirements.


## Test Plan

CI

