### PR TITLE
[MIOpen] Skip tests that require CK if CK is not built

### DIFF
--- a/projects/miopen/test/gtest/bad_fusion_plan.cpp
+++ b/projects/miopen/test/gtest/bad_fusion_plan.cpp
@@ -159,6 +159,7 @@ using namespace bad_fusion_plan;
 
 TEST(GPU_FusionPlan_FP16, GoodFusionPlan)
 {
+#if MIOPEN_USE_COMPOSABLEKERNEL
     GPU_FusionPlan_FP16<miopen::solver::fusion::ConvCKIgemmFwdBiasActivFused, half_float::half> obj(
         miopenTensorNHWC, miopenActivationRELU);
     if(obj.Skip())
@@ -167,6 +168,9 @@ TEST(GPU_FusionPlan_FP16, GoodFusionPlan)
     obj.AddBias();
     obj.AddActiv();
     ASSERT_TRUE(obj.Applicability());
+#else
+    GTEST_SKIP() << "Test requires CK";
+#endif
 }
 
 TEST(GPU_FusionPlan_FP16, BadOrderFusionPlan)
@@ -228,11 +232,15 @@ TEST(GPU_FusionPlan_FP16, BadMissingActivBiasFusionPlan)
 
 TEST(GPU_FusionPlan_FP16, BadEmptyFusionPlan)
 {
+#if MIOPEN_USE_COMPOSABLEKERNEL
     GPU_FusionPlan_FP16<miopen::solver::fusion::ConvCKIgemmFwdBiasActivFused, half_float::half> obj(
         miopenTensorNHWC, miopenActivationRELU);
     if(obj.Skip())
         GTEST_SKIP();
     EXPECT_ANY_THROW(obj.Applicability());
+#else
+    GTEST_SKIP() << "Test requires CK";
+#endif
 }
 
 TEST(GPU_FusionPlan_FP16, UnSupportedFusionPlanDuringSearchMode)

--- a/projects/miopen/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
+++ b/projects/miopen/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
@@ -215,6 +215,9 @@ public:
         {
             GTEST_SKIP() << "CBA graph Fusion not supported in this device";
         }
+#if !MIOPEN_USE_COMPOSABLEKERNEL
+        GTEST_SKIP() << "CBA graph Fusion requires CK";
+#endif
 
         prng::reset_seed();
     }

--- a/projects/miopen/test/gtest/kernel_tuning_net.cpp
+++ b/projects/miopen/test/gtest/kernel_tuning_net.cpp
@@ -199,7 +199,7 @@ class KernelTuningNetTest : public ::testing::TestWithParam<KernelTuningNetTestC
 protected:
     void TestParameterPredictionModel(std::string solver_nm)
     {
-#if MIOPEN_ENABLE_AI_KERNEL_TUNING
+#if MIOPEN_ENABLE_AI_KERNEL_TUNING && MIOPEN_USE_COMPOSABLEKERNEL
         auto test_case = GetParam();
 
         auto&& handle = get_handle();


### PR DESCRIPTION
## Motivation

Several unit tests were failing when run on therock on MI200.  These tests failed because they relied on CK, and CK is currently not built on some older targets by default (in therock).

## Technical Details

The fix is to skip the tests that require CK if CK is not built.

## Test Plan

Build without CK and then run the following tests on MI200:
- bin/miopen_gtest --gtest_filter="Smoke/GPU_ConvBiasResAddActivation_fwd_*"
- bin/miopen_gtest --gtest_filter="Smoke/GPU_KernelTuningNetTestConvHipIgemmGroup*"
- bin/miopen_gtest --gtest_filter="GPU_FusionPlan_FP16*"

The above tests cover all the failures that were seen.

## Test Result

All the tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
