### PR TITLE
Exclude hipblaslt from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ exclude: |
     # ==========================================================================
     projects/composablekernel/.*|
     projects/hipblas/.*|
+    projects/hipblaslt/.*|
     projects/hipblas-common/.*|
     projects/hipcub/.*|
     projects/hipfft/.*|
@@ -46,12 +47,6 @@ exclude: |
     projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/.*_generated\.h|
     # Reference data
     projects/hipdnn/hipdnn_reference_data/.*|
-    # Large yaml files
-    projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/.*|
-    # Large (20k+ LOC) source files
-    projects/hipblaslt/tensilelite/Tensile/CustomKernels/.*|
-    # Generated test yaml files
-    projects/hipblaslt/tensilelite/Tensile/Tests/.*|
     # Generated files (see rocrand/tools/ _generator.cpp files)
     projects/rocrand/library/.*constants\.(cpp|h)|
     projects/rocrand/library/.*precomputed\.(cpp|h)


### PR DESCRIPTION
hipblaslt was not fully excluded from pre-commit. The proper path here would be to raise a PR that fully formats components, and then simultaneously turns on pre-commit linting/formatting for that section of code. This prevents "piecemeal" linting/formatting.

We should turn on these pre-commits soon (and then re-enable the noted exclusions).

