### PR TITLE
[fft-shared][array_validator] Fix incorrect use of '#pragma omp cancel for' 

### DIFF
--- a/projects/hipfft/shared/array_validator.cpp
+++ b/projects/hipfft/shared/array_validator.cpp
@@ -197,10 +197,10 @@ bool valid_length_stride_3d(const std::vector<size_t>& l,
     {
         if(!valid_length_stride_1d_multi(idx, l, s, verbose))
         {
+            invalid = true;
 #ifdef _OPENMP
 #pragma omp cancel for
 #endif
-            invalid = true;
         }
     }
     if(invalid)
@@ -236,10 +236,10 @@ bool valid_length_stride_4d(const std::vector<size_t>& l,
     {
         if(!valid_length_stride_1d_multi(idx0, l, s, verbose))
         {
+            invalid = true;
 #ifdef _OPENMP
 #pragma omp cancel for
 #endif
-            invalid = true;
         }
     }
     if(invalid)
@@ -324,10 +324,10 @@ bool valid_length_stride_4d(const std::vector<size_t>& l,
 
         if(!valid_length_stride_multi_multi(l0, s0, l1, s1))
         {
+            invalid = true;
 #ifdef _OPENMP
 #pragma omp cancel for
 #endif
-            invalid = true;
         }
     }
     if(invalid)
@@ -455,10 +455,10 @@ bool valid_length_stride_generald(const std::vector<size_t> l,
 
             if(!valid_length_stride_multi_multi(l0, s0, l1, s1))
             {
+                invalid = true;
 #ifdef _OPENMP
 #pragma omp cancel for
 #endif
-                invalid = true;
             }
         }
         if(invalid)

--- a/projects/rocfft/shared/array_validator.cpp
+++ b/projects/rocfft/shared/array_validator.cpp
@@ -197,10 +197,10 @@ bool valid_length_stride_3d(const std::vector<size_t>& l,
     {
         if(!valid_length_stride_1d_multi(idx, l, s, verbose))
         {
+            invalid = true;
 #ifdef _OPENMP
 #pragma omp cancel for
 #endif
-            invalid = true;
         }
     }
     if(invalid)
@@ -236,10 +236,10 @@ bool valid_length_stride_4d(const std::vector<size_t>& l,
     {
         if(!valid_length_stride_1d_multi(idx0, l, s, verbose))
         {
+            invalid = true;
 #ifdef _OPENMP
 #pragma omp cancel for
 #endif
-            invalid = true;
         }
     }
     if(invalid)
@@ -324,10 +324,10 @@ bool valid_length_stride_4d(const std::vector<size_t>& l,
 
         if(!valid_length_stride_multi_multi(l0, s0, l1, s1))
         {
+            invalid = true;
 #ifdef _OPENMP
 #pragma omp cancel for
 #endif
-            invalid = true;
         }
     }
     if(invalid)
@@ -455,10 +455,10 @@ bool valid_length_stride_generald(const std::vector<size_t> l,
 
             if(!valid_length_stride_multi_multi(l0, s0, l1, s1))
             {
+                invalid = true;
 #ifdef _OPENMP
 #pragma omp cancel for
 #endif
-                invalid = true;
             }
         }
         if(invalid)


### PR DESCRIPTION
## Motivation and details

The current usage is incorrect as it forces the interruption of the parallel loop _before_ the value to be returned was effectively updated by the thread finding a conflict when/if the `cancel` constructs are actually enabled (which is [not necessarily the default](https://www.openmp.org/spec-html/5.0/openmpse59.html)): without this suggested fix, tests may fail when/if the environment variable `OMP_CANCELLATION` is set to `true`.

## Test Plan

The [`valid_length_stride`](https://github.com/ROCm/rocm-libraries/blob/9b2657993554a1345e46c70a2898b88bc8b692cd/projects/rocfft/clients/tests/validate_length_stride.cpp#L124) tests were executed manually with the environment variable `OMP_CANCELLATION` defined and set to `true`.

## Test Result

All tests pass with the suggested changes (some fail otherwise).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
