### PR TITLE
[hipblaslt] Fix comments for build option HIPBLASLT_ENABLE_LLVM

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -75,7 +75,7 @@ if(HIPBLASLT_ENABLE_HOST OR TENSILELITE_ENABLE_HOST)
     option(HIPBLASLT_ENABLE_LAZY_LOAD "Enable lazy loading of runtime code oject files to reduce ram usage." ON)
     option(HIPBLASLT_ENABLE_MSGPACK "Use msgpack for parsing configuration files." ON)
     option(HIPBLASLT_ENABLE_OPENMP "Use OpenMP to improve performance." ON)
-    option(HIPBLASLT_ENABLE_LLVM "Use msgpack for parsing configuration files." OFF)
+    option(HIPBLASLT_ENABLE_LLVM "Use LLVM for parsing configuration files." OFF)
 endif()
 
 if(HIPBLASLT_ENABLE_HOST)

--- a/projects/hipblaslt/README.md
+++ b/projects/hipblaslt/README.md
@@ -144,7 +144,7 @@ Refer to the available build options using `./install.sh --help`:
 
 * `HIPBLASLT_ENABLE_BLIS`: Enable BLIS support (default `ON`)
 * `HIPBLASLT_ENABLE_HIP`: Use the HIP runtime (default `ON`)
-* `HIPBLASLT_ENABLE_LLVM`: Use msgpack for parsing configuration files (default `OFF`)
+* `HIPBLASLT_ENABLE_LLVM`: Use LLVM for parsing configuration files (default `OFF`)
 * `HIPBLASLT_ENABLE_MSGPACK` Use msgpack for parsing configuration files (default `ON`)
 * `HIPBLASLT_ENABLE_OPENMP`: "Use OpenMP to improve performance (default `ON`)
 * `HIPBLASLT_ENABLE_ROCROLLER:` Use RocRoller library (default `OFF`)


### PR DESCRIPTION
## Motivation

Previous comments for build option HIPBLASLT_ENABLE_LLVM in readme and CMakeLists.txt are wrong. Change them properly.

## Technical Details

This PR does not change the functionality of the code. Testing is not needed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
