### PR TITLE
refactor(rocprim): replaced uses of the ROCPRIM_PRINT_ERROR_ONCE macro with __builtin_trap

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -8,6 +8,14 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 * Updated config system to pick better fallback configs for untuned GPUs.
 
+### Upcoming changes
+
+* Deprecated the `ROCPRIM_PRINT_ERROR_ONCE` macro.
+
+### Changed
+
+* Changed various APIs with undefined behaviors to abort with a trap instead of printing a runtime error with `ROCPRIM_PRINT_ERROR_ONCE` 
+
 ## rocPRIM 4.2.0 for ROCm 7.2
 
 ### Added

--- a/projects/rocprim/rocprim/include/rocprim/functional.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/functional.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/functional.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/functional.hpp
@@ -31,23 +31,10 @@ BEGIN_ROCPRIM_NAMESPACE
 /// \addtogroup utilsmodule_functional
 /// @{
 
-/// \brief Prints the supplied error message only once (using only one of the active threads).
-/// \note Currently, this is not defined for Navi devices.
-#if ROCPRIM_NAVI
-ROCPRIM_PRAGMA_MESSAGE("GPU printf warnings for invalid rocPRIM warp operations on Navi GPUs "
-                       "temporarily disabled, due to performance issues with printf.")
-    #define ROCPRIM_PRINT_ERROR_ONCE(message) \
-        {}
-#else
-    #define ROCPRIM_PRINT_ERROR_ONCE(message)                           \
-        {                                                               \
-            unsigned int idx = threadIdx.x + (blockIdx.x * blockDim.x); \
-            idx += threadIdx.y + (blockIdx.y * blockDim.y);             \
-            idx += threadIdx.z + (blockIdx.z * blockDim.z);             \
-            if(idx == 0)                                                \
-                printf("%s\n", #message);                               \
-        }
-#endif
+/// \brief Unused macro.
+/// \deprecated Will be removed in ROCm 9.0
+#define ROCPRIM_PRINT_ERROR_ONCE(message) \
+    {}
 
 /// \brief Returns the maximum of its arguments.
 template<class T>

--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -221,7 +221,7 @@ public:
 
         #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx9_4_generic__) || defined(__GFX12__)
         #pragma message "Texture cache iterator is not supported on gfx94x, gfx120x or gfx95x as the texture fetch functions in HIP are not available."
-        ROCPRIM_PRINT_ERROR_ONCE("WARNING: Usage of texture_cache_iterator on gfx94x, gfx120x or gfx95x devices is not supported and will not produce valid results.")
+        __builtin_trap();
         #else
         ROCPRIM_UNROLL
         for(unsigned int i = 0; i < multiple; i++)

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_reduce_dpp.hpp
@@ -125,12 +125,6 @@ public:
 
 #if !ROCPRIM_TARGET_SPIRV
             static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
-#else
-            if constexpr(VirtualWaveSize > 64)
-            {
-                ROCPRIM_PRINT_ERROR_ONCE("VirtualWaveSize > 64 is not supported");
-                return;
-            }
 #endif
         }
         // Read the result from the last lane of the logical warp

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2018-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/detail/warp_scan_dpp.hpp
@@ -120,12 +120,6 @@ public:
             }
 #if !ROCPRIM_TARGET_SPIRV
             static_assert(VirtualWaveSize <= 64, "VirtualWaveSize > 64 is not supported");
-#else
-            if constexpr(VirtualWaveSize > 64)
-            {
-                ROCPRIM_PRINT_ERROR_ONCE("VirtualWaveSize > 64 is not supported");
-                return;
-            }
 #endif
         }
     }

--- a/projects/rocprim/rocprim/include/rocprim/warp/warp_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/warp_reduce.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/warp/warp_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/warp_reduce.hpp
@@ -194,10 +194,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::reduce(input, output, storage, reduce_op);
@@ -212,9 +209,7 @@ public:
         typename std::enable_if<(FunctionWarpSize > arch::wavefront::max_size()), void>::type
     {
         (void)reduce_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs reduction across threads in a logical warp.
@@ -277,10 +272,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::reduce(input, output, valid_items, storage, reduce_op);
@@ -295,9 +287,7 @@ public:
         typename std::enable_if<(FunctionWarpSize > arch::wavefront::max_size()), void>::type
     {
         (void)reduce_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs head-segmented reduction across threads in a logical warp.
@@ -333,10 +323,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::head_segmented_reduce(input, output, flag, storage, reduce_op);
@@ -353,9 +340,7 @@ public:
         typename std::enable_if<(FunctionWarpSize > arch::wavefront::max_size()), void>::type
     {
         (void)reduce_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs tail-segmented reduction across threads in a logical warp.
@@ -391,10 +376,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::tail_segmented_reduce(input, output, flag, storage, reduce_op);
@@ -411,9 +393,7 @@ public:
         typename std::enable_if<(FunctionWarpSize > arch::wavefront::max_size()), void>::type
     {
         (void)reduce_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 };
 

--- a/projects/rocprim/rocprim/include/rocprim/warp/warp_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/warp_scan.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/warp/warp_scan.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/warp_scan.hpp
@@ -191,10 +191,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::inclusive_scan(input, output, storage, scan_op);
@@ -209,9 +206,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)scan_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size "
-                                 ". Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs seeded inclusive scan across threads in a logical warp.
@@ -280,9 +275,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::inclusive_scan(input, output, storage, scan_op, init);
@@ -297,9 +290,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)scan_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size "
-                                 ". Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs inclusive scan and reduction across threads in a logical warp.
@@ -366,9 +357,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::inclusive_scan(input, output, reduction, storage, scan_op);
@@ -383,9 +372,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)scan_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size "
-                                 ". Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs seeded inclusive scan and reduction across threads in a logical warp.
@@ -458,9 +445,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::inclusive_scan(input, output, reduction, storage, scan_op, init);
@@ -475,9 +460,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)scan_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size "
-                                 ". Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs exclusive scan across threads in a logical warp.
@@ -547,9 +530,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::exclusive_scan(input, output, init, storage, scan_op);
@@ -564,9 +545,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)scan_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size "
-                                 ". Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs exclusive scan and reduction across threads in a logical warp.
@@ -638,9 +617,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::exclusive_scan(input, output, init, reduction, storage, scan_op);
@@ -655,9 +632,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)scan_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size "
-                                 ". Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs exclusive scan without an initial value across threads in a logical warp
@@ -694,8 +669,7 @@ public:
                         BinaryFunction /*scan_op*/ = BinaryFunction())
         -> std::enable_if_t<(FunctionVirtualWaveSize > arch::wavefront::max_size())>
     {
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size."
-                                 " Aborting warp scan.");
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
     /// \endcond
 
@@ -737,8 +711,7 @@ public:
                         BinaryFunction /*scan_op*/ = BinaryFunction())
         -> std::enable_if_t<(FunctionVirtualWaveSize > arch::wavefront::max_size())>
     {
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size."
-                                 " Aborting warp scan.");
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
     /// \endcond
 
@@ -816,9 +789,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::scan(input, inclusive_output, exclusive_output, init, storage, scan_op);
@@ -833,9 +804,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)scan_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size "
-                                 ". Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Performs inclusive and exclusive scan operations, and reduction across
@@ -913,9 +882,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::scan(input,
@@ -936,9 +903,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)scan_op;
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp size "
-                                 ". Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Broadcasts value from one thread to all threads in logical warp.
@@ -950,6 +915,7 @@ public:
     /// \par Storage reusage
     /// Synchronization barrier should be placed before \p storage is reused
     /// or repurposed: \p __syncthreads() or \p rocprim::syncthreads().
+    /// \note Behavior is undefined if the virtual wave size exceeds the hardware-supported wave size.
     template<unsigned int FunctionVirtualWaveSize = VirtualWaveSize>
     ROCPRIM_DEVICE ROCPRIM_INLINE
     auto broadcast(T input, const unsigned int src_lane, storage_type& storage) ->
@@ -959,9 +925,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         return base_type::broadcast(input, src_lane, storage);
@@ -974,9 +938,7 @@ public:
     auto broadcast(T, const unsigned int, storage_type&) ->
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), T>::type
     {
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return T();
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Broadcasts value from one thread to all threads in logical warp.

--- a/projects/rocprim/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/warp/warp_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/warp_sort.hpp
@@ -144,10 +144,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::sort(thread_key, compare_function);
@@ -162,9 +159,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)compare_function; // disables unused parameter warning
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Warp sort for any data type.
@@ -190,10 +185,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::sort(thread_keys, compare_function);
@@ -211,9 +203,7 @@ public:
     {
         (void)thread_keys; // disables unused parameter warning
         (void)compare_function; // disables unused parameter warning
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Warp sort for any data type using temporary storage.
@@ -257,10 +247,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::sort(
@@ -277,9 +264,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)compare_function; // disables unused parameter warning
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Warp sort for any data type using temporary storage.
@@ -324,10 +309,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::sort(
@@ -348,9 +330,7 @@ public:
     {
         (void)thread_keys; // disables unused parameter warning
         (void)compare_function; // disables unused parameter warning
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Warp sort by key for any data type.
@@ -377,10 +357,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::sort(
@@ -397,9 +374,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)compare_function; // disables unused parameter warning
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Warp sort by key for any data type.
@@ -427,10 +402,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::sort(
@@ -452,9 +424,7 @@ public:
         (void)thread_keys; // disables unused parameter warning
         (void)thread_values; // disables unused parameter warning
         (void)compare_function; // disables unused parameter warning
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Warp sort by key for any data type using temporary storage.
@@ -500,10 +470,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::sort(
@@ -520,9 +487,7 @@ public:
         typename std::enable_if<(FunctionVirtualWaveSize > arch::wavefront::max_size()), void>::type
     {
         (void)compare_function; // disables unused parameter warning
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 
     /// \brief Warp sort by key for any data type using temporary storage.
@@ -569,10 +534,7 @@ public:
         {
             if(VirtualWaveSize > ::rocprim::arch::wavefront::size())
             {
-                ROCPRIM_PRINT_ERROR_ONCE(
-                    "Specified warp size exceeds current hardware supported warp "
-                    "size. Aborting warp sort.");
-                return;
+                __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
             }
         }
         base_type::sort(
@@ -595,9 +557,7 @@ public:
         (void)thread_keys; // disables unused parameter warning
         (void)thread_values; // disables unused parameter warning
         (void)compare_function; // disables unused parameter warning
-        ROCPRIM_PRINT_ERROR_ONCE("Specified warp size exceeds current hardware supported warp "
-                                 "size. Aborting warp sort.");
-        return;
+        __builtin_trap(); // behavior undefined if virtual wave size exceeds hardware limit
     }
 };
 


### PR DESCRIPTION
## Motivation

`ROCPRIM_PRINT_ERROR_ONCE` was used to indicate undefined behavior at runtime, but wasn't used on Navi GPUs due to performance issues

## Technical Details

- Deprecated the `ROCPRIM_PRINT_ERROR_ONCE` macro.
- Replaces all instances of `ROCPRIM_PRINT_ERROR_ONCE` with __builtin_trap.
  - Since it's undefined behavior, we terminate instead.
- Added __builtin_trap to functions that should have had a warning with `ROCPRIM_PRINT_ERROR_ONCE` but hadn't before.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
