### PR TITLE
[rocRoller] add gfx115x target support

### DIFF
--- a/shared/rocroller/GPUArchitectureGenerator/include/GPUArchitectureGenerator/GPUArchitectureGenerator_defs.hpp
+++ b/shared/rocroller/GPUArchitectureGenerator/include/GPUArchitectureGenerator/GPUArchitectureGenerator_defs.hpp
@@ -117,15 +117,25 @@ namespace GPUArchitectureGenerator
              {{"v_mfma_f32_32x32x16_bf16 a[0:15], v[32:35], v[36:39], a[0:15]"}, ""}},
 
             {rocRoller::GPUCapability::HasWMMA,
-             {{"v_wmma_f32_16x16x16_f16 v[0:7], v[32:35], v[36:39], v[0:7]"}, ""}},
+             {{"v_wmma_f32_16x16x16_f16 v[0:7], v[32:35], v[36:39], v[0:7]",
+               "v_wmma_f32_16x16x16_f16 v[0:7], v[32:39], v[40:47], v[0:7]"},
+              ""}},
             {rocRoller::GPUCapability::HasWMMA_F16_ACC,
-             {{"v_wmma_f16_16x16x16_f16 v[0:3], v[32:35], v[36:39], v[0:3]"}, ""}},
+             {{"v_wmma_f16_16x16x16_f16 v[0:3], v[32:35], v[36:39], v[0:3]",
+               "v_wmma_f16_16x16x16_f16 v[0:7], v[32:39], v[40:47], v[0:7]"},
+              ""}},
             {rocRoller::GPUCapability::HasWMMA_f32_16x16x16_f16,
-             {{"v_wmma_f32_16x16x16_f16 v[0:7], v[32:35], v[36:39], v[0:7]"}, ""}},
+             {{"v_wmma_f32_16x16x16_f16 v[0:7], v[32:35], v[36:39], v[0:7]",
+               "v_wmma_f32_16x16x16_f16 v[0:7], v[32:39], v[40:47], v[0:7]"},
+              ""}},
             {rocRoller::GPUCapability::HasWMMA_f16_16x16x16_f16,
-             {{"v_wmma_f16_16x16x16_f16 v[0:3], v[32:35], v[36:39], v[0:3]"}, ""}},
+             {{"v_wmma_f16_16x16x16_f16 v[0:3], v[32:35], v[36:39], v[0:3]",
+               "v_wmma_f16_16x16x16_f16 v[0:7], v[32:39], v[40:47], v[0:7]"},
+              ""}},
             {rocRoller::GPUCapability::HasWMMA_bf16_16x16x16_bf16,
-             {{"v_wmma_bf16_16x16x16_bf16 v[0:3], v[32:35], v[36:39], v[0:3]"}, ""}},
+             {{"v_wmma_bf16_16x16x16_bf16 v[0:3], v[32:35], v[36:39], v[0:3]",
+               "v_wmma_bf16_16x16x16_bf16 v[0:7], v[32:39], v[40:47], v[0:7]"},
+              ""}},
             {rocRoller::GPUCapability::HasWMMA_f32_16x16x16_f8,
              {{"v_wmma_f32_16x16x16_fp8_fp8 v[0:7], v[32:33], v[34:35], v[0:7]"}, ""}},
 
@@ -199,7 +209,8 @@ namespace GPUArchitectureGenerator
             {rocRoller::GPUCapability::HasPermLanes32, {{"v_permlane32_swap_b32 v4, v5"}, ""}},
             {rocRoller::GPUCapability::UnalignedSGPRs,
              {{"s_cmp_eq_u64 s[0:1], s[0:1], s[3:4]"}, ""}},
-            {rocRoller::GPUCapability::SeparateVscnt, {{"s_waitcnt_vscnt 0"}, ""}},
+            {rocRoller::GPUCapability::SeparateVscnt,
+             {{"s_waitcnt_vscnt 0", "s_waitcnt_vscnt null 0"}, ""}},
             {rocRoller::GPUCapability::HasSplitWaitCounters, {{"s_wait_kmcnt 0"}, ""}},
 
     };
@@ -345,6 +356,29 @@ namespace GPUArchitectureGenerator
         return retval;
     }
 
+    inline std::vector<rocRoller::GPUArchitectureTarget> gfx11ISAs()
+    {
+        std::vector<rocRoller::GPUArchitectureTarget> retval;
+        std::copy_if(rocRoller::SupportedArchitectures.begin(),
+                     rocRoller::SupportedArchitectures.end(),
+                     std::back_inserter(retval),
+                     [](rocRoller::GPUArchitectureTarget const& x) -> bool {
+                         return x.isRDNA3GPU() || x.isRDNA35GPU();
+                     });
+        return retval;
+    }
+
+    inline std::vector<rocRoller::GPUArchitectureTarget> gfx115XISAs()
+    {
+        std::vector<rocRoller::GPUArchitectureTarget> retval;
+        std::copy_if(
+            rocRoller::SupportedArchitectures.begin(),
+            rocRoller::SupportedArchitectures.end(),
+            std::back_inserter(retval),
+            [](rocRoller::GPUArchitectureTarget const& x) -> bool { return x.isRDNA35GPU(); });
+        return retval;
+    }
+
     inline std::vector<rocRoller::GPUArchitectureTarget> gfx120XISAs()
     {
         std::vector<rocRoller::GPUArchitectureTarget> retval;
@@ -421,9 +455,13 @@ namespace GPUArchitectureGenerator
                  return x.isCDNA2GPU() || x.isCDNA3GPU() || x.isCDNA35GPU() || x.isRDNA4GPU();
              }},
             {rocRoller::GPUCapability::WorkgroupIdxViaTTMP,
-             [](rocRoller::GPUArchitectureTarget x) -> bool { return x.isGFX12GPU(); }},
+             [](rocRoller::GPUArchitectureTarget x) -> bool {
+                 return x.isGFX11GPU() || x.isGFX12GPU();
+             }},
             {rocRoller::GPUCapability::HasBufferOutOfBoundsCheckOption,
-             [](rocRoller::GPUArchitectureTarget x) -> bool { return x.isGFX12GPU(); }},
+             [](rocRoller::GPUArchitectureTarget x) -> bool {
+                 return x.isGFX11GPU() || x.isGFX12GPU();
+             }},
 
     };
     // This is the way to add a set of instructions that have the same wait value and wait queues.
@@ -574,6 +612,154 @@ namespace GPUArchitectureGenerator
                  "scratch_store_dwordx2",
                  "scratch_store_dwordx3",
                  "scratch_store_dwordx4",
+                 "scratch_store_short",
+                 "scratch_store_short_d16_hi",
+                  // clang-format on
+              },
+              0,
+              {rocRoller::GPUWaitQueueType::StoreQueue},
+              (1 << 12) - 1}}, // the offset is a `signed` 13-bit  (i.e., -4096..4095)
+            {gfx11ISAs(),
+             {{
+                  // clang-format off
+                 "buffer_load_b32",
+                 "buffer_load_b64",
+                 "buffer_load_b96",
+                 "buffer_load_b128",
+                 "buffer_load_sbyte",
+                 "buffer_load_sbyte_d16",
+                 "buffer_load_sbyte_d16_hi",
+                 "buffer_load_short_d16",
+                 "buffer_load_short_d16_hi",
+                 "buffer_load_sshort",
+                 "buffer_load_ubyte",
+                 "buffer_load_ubyte_d16",
+                 "buffer_load_ubyte_d16_hi",
+                 "buffer_load_ushort",
+                  // clang-format on
+              },
+              1,
+              {rocRoller::GPUWaitQueueType::LoadQueue},
+              (1 << 12) - 1}},
+            {gfx11ISAs(),
+             {{
+                  // clang-format off
+                 "buffer_store_byte",
+                 "buffer_store_byte_d16_hi",
+                 "buffer_store_b32",
+                 "buffer_store_b64",
+                 "buffer_store_b96",
+                 "buffer_store_b128",
+                 "buffer_store_short",
+                 "buffer_store_short_d16_hi",
+                  // clang-format on
+              },
+              1,
+              {rocRoller::GPUWaitQueueType::StoreQueue},
+              (1 << 12) - 1}},
+            // single-address LDS instructions
+            {gfx11ISAs(),
+             {{
+                  // clang-format off
+                 "ds_read_addtid_b32",
+                 "ds_read_b128",
+                 "ds_read_b32",
+                 "ds_read_b64",
+                 "ds_read_b96",
+                 "ds_read_i16",
+                 "ds_read_i8",
+                 "ds_read_i8_d16",
+                 "ds_read_i8_d16_hi",
+                 "ds_read_u16",
+                 "ds_read_u8",
+                 "ds_read_u16_d16",
+                 "ds_read_u16_d16_hi",
+                 "ds_read_u8_d16",
+                 "ds_read_u8_d16_hi",
+                 "ds_write_addtid_b32",
+                 "ds_write_b128",
+                 "ds_write_b16",
+                 "ds_write_b16_d16_hi",
+                 "ds_write_b32",
+                 "ds_write_b64",
+                 "ds_write_b8",
+                 "ds_write_b8_d16_hi",
+                 "ds_write_b96",
+                  // clang-format on
+              },
+              1,
+              {rocRoller::GPUWaitQueueType::DSQueue},
+              (1 << 16) - 1}},
+            // two-address LDS instructions
+            {gfx11ISAs(),
+             {{
+                  // clang-format off
+                 "ds_read2_b32",
+                 "ds_read2_b64",
+                 "ds_read2st64_b32",
+                 "ds_read2st64_b64",
+                 "ds_write2_b32",
+                 "ds_write2_b64",
+                 "ds_write2st64_b32",
+                 "ds_write2st64_b64",
+                  // clang-format on
+              },
+              1,
+              {rocRoller::GPUWaitQueueType::DSQueue},
+              (1 << 8) - 1}},
+            {gfx11ISAs(),
+             {{
+                  // clang-format off
+                 "global_load_b32",
+                 "global_load_b64",
+                 "global_load_b96",
+                 "global_load_b128",
+                 "global_load_sbyte",
+                 "global_load_sbyte_d16",
+                 "global_load_sbyte_d16_hi",
+                 "global_load_short_d16",
+                 "global_load_short_d16_hi",
+                 "global_load_sshort",
+                 "global_load_ubyte",
+                 "global_load_ubyte_d16",
+                 "global_load_ubyte_d16_hi",
+                 "global_load_ushort",
+                 "scratch_load_b32",
+                 "scratch_load_b64",
+                 "scratch_load_b96",
+                 "scratch_load_b128",
+                 "scratch_load_sbyte",
+                 "scratch_load_sbyte_d16",
+                 "scratch_load_sbyte_d16_hi",
+                 "scratch_load_short_d16",
+                 "scratch_load_short_d16_hi",
+                 "scratch_load_sshort",
+                 "scratch_load_ubyte",
+                 "scratch_load_ubyte_d16",
+                 "scratch_load_ubyte_d16_hi",
+                 "scratch_load_ushort",
+                  // clang-format on
+              },
+              0,
+              {rocRoller::GPUWaitQueueType::LoadQueue},
+              (1 << 12) - 1}}, // the offset is a `signed` 13-bit  (i.e., -4096..4095)
+            {gfx11ISAs(),
+             {{
+                  // clang-format off
+                 "global_store_byte",
+                 "global_store_byte_d16_hi",
+                 "global_store_b32",
+                 "global_store_b64",
+                 "global_store_b96",
+                 "global_store_b128",
+                 "global_store_short",
+                 "global_store_short_d16_hi",
+                 "scratch_store_byte",
+                 "scratch_store_byte_d16_hi",
+                 "scratch_store_b32",
+                 "scratch_store_b64",
+                 "scratch_store_b96",
+                 "scratch_store_b128",
                  "scratch_store_short",
                  "scratch_store_short_d16_hi",
                   // clang-format on
@@ -814,6 +1000,31 @@ namespace GPUArchitectureGenerator
                  rocRoller::GPUInstructionInfo("v_accvgpr_read_b32", 0, {}, 1),
                  rocRoller::GPUInstructionInfo("v_accvgpr_write", 0, {}, 2),
                  rocRoller::GPUInstructionInfo("v_accvgpr_write_b32", 0, {}, 2),
+             }},
+            {gfx11ISAs(),
+             {
+                 rocRoller::GPUInstructionInfo(
+                     "s_buffer_load_b32", 1, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_buffer_load_b64", 2, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_buffer_load_b128", 2, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_buffer_load_b256", 2, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_buffer_load_b512", 2, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_load_b32", 0, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_load_b64", 0, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_load_b128", 0, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_load_b256", 0, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_load_b512", 0, {rocRoller::GPUWaitQueueType::SMemQueue}),
+                 rocRoller::GPUInstructionInfo(
+                     "s_sendmsg", 1, {rocRoller::GPUWaitQueueType::SendMsgQueue}),
              }},
             {gfx12ISAs(),
              {
@@ -1066,6 +1277,13 @@ namespace GPUArchitectureGenerator
                                                /*implicitAccess*/ false,
                                                /*branch*/ false,
                                                (1 << 16) - 1),
+             }},
+            {gfx115XISAs(),
+             {
+                 rocRoller::GPUInstructionInfo("v_wmma_f32_16x16x16_f16", 0, {}, 16),
+                 rocRoller::GPUInstructionInfo("v_wmma_f32_16x16x16_bf16", 0, {}, 16),
+                 rocRoller::GPUInstructionInfo("v_wmma_f16_16x16x16_f16", 0, {}, 16),
+                 rocRoller::GPUInstructionInfo("v_wmma_bf16_16x16x16_bf16", 0, {}, 16),
              }},
             {gfx120XISAs(),
              {

--- a/shared/rocroller/GPUArchitectureGenerator/pregenerated/GPUArchitecture_def_gfx1150.yaml
+++ b/shared/rocroller/GPUArchitectureGenerator/pregenerated/GPUArchitecture_def_gfx1150.yaml
@@ -1,0 +1,12400 @@
+Architectures:
+  gfx1150:
+    Capabilities:
+      DefaultWavefrontSize: 32
+      HasBufferOutOfBoundsCheckOption: 0
+      HasWave32: 0
+      HasWave64: 0
+      MaxExpcnt: 7
+      MaxLdsSize: 65536
+      MaxLgkmcnt: 0
+      MaxVmcnt: 0
+      SupportedSource: 0
+      WorkgroupIdxViaTTMP: 0
+    ISAVersion:
+      ArchString: gfx1150
+      Sramecc: false
+      Xnack: false
+    InstructionInfos:
+      buffer_atomic_add:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_csub:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_csub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_csub_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_csub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_gl0_inv:
+        ImplicitAccess: false
+        Instruction: buffer_gl0_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_gl1_inv:
+        ImplicitAccess: false
+        Instruction: buffer_gl1_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_b128:
+        ImplicitAccess: false
+        Instruction: buffer_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b32:
+        ImplicitAccess: false
+        Instruction: buffer_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b64:
+        ImplicitAccess: false
+        Instruction: buffer_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b96:
+        ImplicitAccess: false
+        Instruction: buffer_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dword:
+        ImplicitAccess: false
+        Instruction: buffer_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_hi_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_hi_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_i16:
+        ImplicitAccess: false
+        Instruction: buffer_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_sbyte:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_short_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sshort:
+        ImplicitAccess: false
+        Instruction: buffer_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_u16:
+        ImplicitAccess: false
+        Instruction: buffer_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_ubyte:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ushort:
+        ImplicitAccess: false
+        Instruction: buffer_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_store_b128:
+        ImplicitAccess: false
+        Instruction: buffer_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b16:
+        ImplicitAccess: false
+        Instruction: buffer_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_b32:
+        ImplicitAccess: false
+        Instruction: buffer_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b64:
+        ImplicitAccess: false
+        Instruction: buffer_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b8:
+        ImplicitAccess: false
+        Instruction: buffer_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_b96:
+        ImplicitAccess: false
+        Instruction: buffer_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_byte:
+        ImplicitAccess: false
+        Instruction: buffer_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_d16_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dword:
+        ImplicitAccess: false
+        Instruction: buffer_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_hi_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_hi_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_short:
+        ImplicitAccess: false
+        Instruction: buffer_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      ds_add_f32:
+        ImplicitAccess: false
+        Instruction: ds_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_gs_reg_rtn:
+        ImplicitAccess: false
+        Instruction: ds_add_gs_reg_rtn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_u32:
+        ImplicitAccess: false
+        Instruction: ds_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_u64:
+        ImplicitAccess: false
+        Instruction: ds_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_b32:
+        ImplicitAccess: false
+        Instruction: ds_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_b64:
+        ImplicitAccess: false
+        Instruction: ds_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_and_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_and_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_append:
+        ImplicitAccess: false
+        Instruction: ds_append
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_bpermute_b32:
+        ImplicitAccess: false
+        Instruction: ds_bpermute_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_bvh_stack_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_bvh_stack_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_condxchg32_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_condxchg32_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_consume:
+        ImplicitAccess: false
+        Instruction: ds_consume
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_dec_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_dec_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_u32:
+        ImplicitAccess: false
+        Instruction: ds_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_u64:
+        ImplicitAccess: false
+        Instruction: ds_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_barrier:
+        ImplicitAccess: false
+        Instruction: ds_gws_barrier
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_init:
+        ImplicitAccess: false
+        Instruction: ds_gws_init
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_br:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_br
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_p:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_p
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_release_all:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_release_all
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_v:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_v
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_inc_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_inc_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_u32:
+        ImplicitAccess: false
+        Instruction: ds_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_u64:
+        ImplicitAccess: false
+        Instruction: ds_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_stride64_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_stride64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_stride64_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_stride64_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b128:
+        ImplicitAccess: false
+        Instruction: ds_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b96:
+        ImplicitAccess: false
+        Instruction: ds_load_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i16:
+        ImplicitAccess: false
+        Instruction: ds_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8:
+        ImplicitAccess: false
+        Instruction: ds_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_i8_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_i8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16:
+        ImplicitAccess: false
+        Instruction: ds_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_u16_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_u16_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8:
+        ImplicitAccess: false
+        Instruction: ds_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_u8_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_u8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_f32:
+        ImplicitAccess: false
+        Instruction: ds_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_f64:
+        ImplicitAccess: false
+        Instruction: ds_max_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_i32:
+        ImplicitAccess: false
+        Instruction: ds_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_i64:
+        ImplicitAccess: false
+        Instruction: ds_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_i32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_i64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_u32:
+        ImplicitAccess: false
+        Instruction: ds_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_u64:
+        ImplicitAccess: false
+        Instruction: ds_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_f32:
+        ImplicitAccess: false
+        Instruction: ds_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_f64:
+        ImplicitAccess: false
+        Instruction: ds_min_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_i32:
+        ImplicitAccess: false
+        Instruction: ds_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_i64:
+        ImplicitAccess: false
+        Instruction: ds_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_i32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_i64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_u32:
+        ImplicitAccess: false
+        Instruction: ds_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_u64:
+        ImplicitAccess: false
+        Instruction: ds_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_b32:
+        ImplicitAccess: false
+        Instruction: ds_mskor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_b64:
+        ImplicitAccess: false
+        Instruction: ds_mskor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_mskor_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_mskor_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_nop:
+        ImplicitAccess: false
+        Instruction: ds_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_b32:
+        ImplicitAccess: false
+        Instruction: ds_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_b64:
+        ImplicitAccess: false
+        Instruction: ds_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_or_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_or_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_ordered_count:
+        ImplicitAccess: false
+        Instruction: ds_ordered_count
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_permute_b32:
+        ImplicitAccess: false
+        Instruction: ds_permute_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_read2_b32:
+        ImplicitAccess: false
+        Instruction: ds_read2_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2_b64:
+        ImplicitAccess: false
+        Instruction: ds_read2_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2st64_b32:
+        ImplicitAccess: false
+        Instruction: ds_read2st64_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2st64_b64:
+        ImplicitAccess: false
+        Instruction: ds_read2st64_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_read_addtid_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b128:
+        ImplicitAccess: false
+        Instruction: ds_read_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b32:
+        ImplicitAccess: false
+        Instruction: ds_read_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b64:
+        ImplicitAccess: false
+        Instruction: ds_read_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b96:
+        ImplicitAccess: false
+        Instruction: ds_read_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i16:
+        ImplicitAccess: false
+        Instruction: ds_read_i16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8:
+        ImplicitAccess: false
+        Instruction: ds_read_i8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_i8_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_i8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16:
+        ImplicitAccess: false
+        Instruction: ds_read_u16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_u16_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_u16_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8:
+        ImplicitAccess: false
+        Instruction: ds_read_u8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_u8_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_u8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_rsub_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_rsub_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_rsub_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_u32:
+        ImplicitAccess: false
+        Instruction: ds_rsub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_u64:
+        ImplicitAccess: false
+        Instruction: ds_rsub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_stride64_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_stride64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_stride64_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_stride64_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b128:
+        ImplicitAccess: false
+        Instruction: ds_store_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b16:
+        ImplicitAccess: false
+        Instruction: ds_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_store_b16_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b8:
+        ImplicitAccess: false
+        Instruction: ds_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_store_b8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b96:
+        ImplicitAccess: false
+        Instruction: ds_store_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_stride64_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_stride64_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_stride64_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_stride64_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_gs_reg_rtn:
+        ImplicitAccess: false
+        Instruction: ds_sub_gs_reg_rtn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_sub_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_sub_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_u32:
+        ImplicitAccess: false
+        Instruction: ds_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_u64:
+        ImplicitAccess: false
+        Instruction: ds_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_swizzle_b32:
+        ImplicitAccess: false
+        Instruction: ds_swizzle_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrap_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrap_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_write2_b32:
+        ImplicitAccess: false
+        Instruction: ds_write2_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2_b64:
+        ImplicitAccess: false
+        Instruction: ds_write2_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2st64_b32:
+        ImplicitAccess: false
+        Instruction: ds_write2st64_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2st64_b64:
+        ImplicitAccess: false
+        Instruction: ds_write2st64_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_write_addtid_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b128:
+        ImplicitAccess: false
+        Instruction: ds_write_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b16:
+        ImplicitAccess: false
+        Instruction: ds_write_b16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_write_b16_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b32:
+        ImplicitAccess: false
+        Instruction: ds_write_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b64:
+        ImplicitAccess: false
+        Instruction: ds_write_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b8:
+        ImplicitAccess: false
+        Instruction: ds_write_b8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_write_b8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b96:
+        ImplicitAccess: false
+        Instruction: ds_write_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_wrxchg2_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2st64_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2st64_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2st64_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2st64_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_b32:
+        ImplicitAccess: false
+        Instruction: ds_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_b64:
+        ImplicitAccess: false
+        Instruction: ds_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_xor_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_xor_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      exp:
+        ImplicitAccess: false
+        Instruction: exp
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b128:
+        ImplicitAccess: false
+        Instruction: flat_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b32:
+        ImplicitAccess: false
+        Instruction: flat_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b64:
+        ImplicitAccess: false
+        Instruction: flat_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b96:
+        ImplicitAccess: false
+        Instruction: flat_load_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dword:
+        ImplicitAccess: false
+        Instruction: flat_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_i16:
+        ImplicitAccess: false
+        Instruction: flat_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_short_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_short_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_short_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sshort:
+        ImplicitAccess: false
+        Instruction: flat_load_sshort
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_u16:
+        ImplicitAccess: false
+        Instruction: flat_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ushort:
+        ImplicitAccess: false
+        Instruction: flat_load_ushort
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b128:
+        ImplicitAccess: false
+        Instruction: flat_store_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b16:
+        ImplicitAccess: false
+        Instruction: flat_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b32:
+        ImplicitAccess: false
+        Instruction: flat_store_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b64:
+        ImplicitAccess: false
+        Instruction: flat_store_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b8:
+        ImplicitAccess: false
+        Instruction: flat_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b96:
+        ImplicitAccess: false
+        Instruction: flat_store_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_byte:
+        ImplicitAccess: false
+        Instruction: flat_store_byte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_store_byte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: flat_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: flat_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dword:
+        ImplicitAccess: false
+        Instruction: flat_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_short:
+        ImplicitAccess: false
+        Instruction: flat_store_short
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_store_short_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add:
+        ImplicitAccess: false
+        Instruction: global_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and:
+        ImplicitAccess: false
+        Instruction: global_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_csub:
+        ImplicitAccess: false
+        Instruction: global_atomic_csub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_csub_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_csub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: global_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: global_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: global_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or:
+        ImplicitAccess: false
+        Instruction: global_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smax:
+        ImplicitAccess: false
+        Instruction: global_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smin:
+        ImplicitAccess: false
+        Instruction: global_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umax:
+        ImplicitAccess: false
+        Instruction: global_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umin:
+        ImplicitAccess: false
+        Instruction: global_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_load_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_b128:
+        ImplicitAccess: false
+        Instruction: global_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b32:
+        ImplicitAccess: false
+        Instruction: global_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b64:
+        ImplicitAccess: false
+        Instruction: global_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b96:
+        ImplicitAccess: false
+        Instruction: global_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: global_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dword:
+        ImplicitAccess: false
+        Instruction: global_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dword_addtid:
+        ImplicitAccess: false
+        Instruction: global_load_dword_addtid
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_i16:
+        ImplicitAccess: false
+        Instruction: global_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_i8:
+        ImplicitAccess: false
+        Instruction: global_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_load_lds_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: global_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: global_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: global_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: global_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: global_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_sbyte:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_short_d16:
+        ImplicitAccess: false
+        Instruction: global_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sshort:
+        ImplicitAccess: false
+        Instruction: global_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_u16:
+        ImplicitAccess: false
+        Instruction: global_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_u8:
+        ImplicitAccess: false
+        Instruction: global_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_ubyte:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ushort:
+        ImplicitAccess: false
+        Instruction: global_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_store_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_store_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b128:
+        ImplicitAccess: false
+        Instruction: global_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b16:
+        ImplicitAccess: false
+        Instruction: global_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b32:
+        ImplicitAccess: false
+        Instruction: global_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b64:
+        ImplicitAccess: false
+        Instruction: global_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b8:
+        ImplicitAccess: false
+        Instruction: global_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b96:
+        ImplicitAccess: false
+        Instruction: global_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_byte:
+        ImplicitAccess: false
+        Instruction: global_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: global_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: global_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dword:
+        ImplicitAccess: false
+        Instruction: global_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dword_addtid:
+        ImplicitAccess: false
+        Instruction: global_store_dword_addtid
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_short:
+        ImplicitAccess: false
+        Instruction: global_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      image_atomic_add:
+        ImplicitAccess: false
+        Instruction: image_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_and:
+        ImplicitAccess: false
+        Instruction: image_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: image_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_dec:
+        ImplicitAccess: false
+        Instruction: image_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_inc:
+        ImplicitAccess: false
+        Instruction: image_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_or:
+        ImplicitAccess: false
+        Instruction: image_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_smax:
+        ImplicitAccess: false
+        Instruction: image_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_smin:
+        ImplicitAccess: false
+        Instruction: image_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_sub:
+        ImplicitAccess: false
+        Instruction: image_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_swap:
+        ImplicitAccess: false
+        Instruction: image_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_umax:
+        ImplicitAccess: false
+        Instruction: image_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_umin:
+        ImplicitAccess: false
+        Instruction: image_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_xor:
+        ImplicitAccess: false
+        Instruction: image_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_bvh64_intersect_ray:
+        ImplicitAccess: false
+        Instruction: image_bvh64_intersect_ray
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_bvh_intersect_ray:
+        ImplicitAccess: false
+        Instruction: image_bvh_intersect_ray
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4:
+        ImplicitAccess: false
+        Instruction: image_gather4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_b:
+        ImplicitAccess: false
+        Instruction: image_gather4_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_b_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c:
+        ImplicitAccess: false
+        Instruction: image_gather4_c
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_b:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_b_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_l:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_lz:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_lz_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_l:
+        ImplicitAccess: false
+        Instruction: image_gather4_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_lz:
+        ImplicitAccess: false
+        Instruction: image_gather4_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_lz_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4h:
+        ImplicitAccess: false
+        Instruction: image_gather4h
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_get_lod:
+        ImplicitAccess: false
+        Instruction: image_get_lod
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_get_resinfo:
+        ImplicitAccess: false
+        Instruction: image_get_resinfo
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load:
+        ImplicitAccess: false
+        Instruction: image_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip:
+        ImplicitAccess: false
+        Instruction: image_load_mip
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip_pck:
+        ImplicitAccess: false
+        Instruction: image_load_mip_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip_pck_sgn:
+        ImplicitAccess: false
+        Instruction: image_load_mip_pck_sgn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_pck:
+        ImplicitAccess: false
+        Instruction: image_load_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_pck_sgn:
+        ImplicitAccess: false
+        Instruction: image_load_pck_sgn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_msaa_load:
+        ImplicitAccess: false
+        Instruction: image_msaa_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample:
+        ImplicitAccess: false
+        Instruction: image_sample
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b:
+        ImplicitAccess: false
+        Instruction: image_sample_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_b_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_o:
+        ImplicitAccess: false
+        Instruction: image_sample_b_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c:
+        ImplicitAccess: false
+        Instruction: image_sample_c
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_l:
+        ImplicitAccess: false
+        Instruction: image_sample_c_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_l_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_l_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_lz:
+        ImplicitAccess: false
+        Instruction: image_sample_c_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_lz_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d:
+        ImplicitAccess: false
+        Instruction: image_sample_d
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_o:
+        ImplicitAccess: false
+        Instruction: image_sample_d_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_l:
+        ImplicitAccess: false
+        Instruction: image_sample_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_l_o:
+        ImplicitAccess: false
+        Instruction: image_sample_l_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_lz:
+        ImplicitAccess: false
+        Instruction: image_sample_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_lz_o:
+        ImplicitAccess: false
+        Instruction: image_sample_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_o:
+        ImplicitAccess: false
+        Instruction: image_sample_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store:
+        ImplicitAccess: false
+        Instruction: image_store
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_mip:
+        ImplicitAccess: false
+        Instruction: image_store_mip
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_mip_pck:
+        ImplicitAccess: false
+        Instruction: image_store_mip_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_pck:
+        ImplicitAccess: false
+        Instruction: image_store_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      lds_direct_load:
+        ImplicitAccess: false
+        Instruction: lds_direct_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      lds_param_load:
+        ImplicitAccess: false
+        Instruction: lds_param_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_abs_i32:
+        ImplicitAccess: false
+        Instruction: s_abs_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_absdiff_i32:
+        ImplicitAccess: false
+        Instruction: s_absdiff_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_f16:
+        ImplicitAccess: false
+        Instruction: s_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_f32:
+        ImplicitAccess: false
+        Instruction: s_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_i32:
+        ImplicitAccess: false
+        Instruction: s_add_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_u32:
+        ImplicitAccess: false
+        Instruction: s_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_addc_u32:
+        ImplicitAccess: false
+        Instruction: s_addc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_addk_i32:
+        ImplicitAccess: false
+        Instruction: s_addk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_b32:
+        ImplicitAccess: false
+        Instruction: s_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_b64:
+        ImplicitAccess: false
+        Instruction: s_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not0_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not0_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not0_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not0_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn1_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn1_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ashr_i32:
+        ImplicitAccess: false
+        Instruction: s_ashr_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ashr_i64:
+        ImplicitAccess: false
+        Instruction: s_ashr_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_atc_probe:
+        ImplicitAccess: false
+        Instruction: s_atc_probe
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_atc_probe_buffer:
+        ImplicitAccess: false
+        Instruction: s_atc_probe_buffer
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_barrier:
+        ImplicitAccess: false
+        Instruction: s_barrier
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt0_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_bcnt0_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt0_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_bcnt0_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt1_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_bcnt1_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt1_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_bcnt1_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_i32:
+        ImplicitAccess: false
+        Instruction: s_bfe_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_i64:
+        ImplicitAccess: false
+        Instruction: s_bfe_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_u32:
+        ImplicitAccess: false
+        Instruction: s_bfe_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_u64:
+        ImplicitAccess: false
+        Instruction: s_bfe_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfm_b32:
+        ImplicitAccess: false
+        Instruction: s_bfm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfm_b64:
+        ImplicitAccess: false
+        Instruction: s_bfm_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp0_b32:
+        ImplicitAccess: false
+        Instruction: s_bitcmp0_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp0_b64:
+        ImplicitAccess: false
+        Instruction: s_bitcmp0_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp1_b32:
+        ImplicitAccess: false
+        Instruction: s_bitcmp1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp1_b64:
+        ImplicitAccess: false
+        Instruction: s_bitcmp1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitreplicate_b64_b32:
+        ImplicitAccess: false
+        Instruction: s_bitreplicate_b64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset0_b32:
+        ImplicitAccess: false
+        Instruction: s_bitset0_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset0_b64:
+        ImplicitAccess: false
+        Instruction: s_bitset0_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset1_b32:
+        ImplicitAccess: false
+        Instruction: s_bitset1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset1_b64:
+        ImplicitAccess: false
+        Instruction: s_bitset1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_branch:
+        ImplicitAccess: false
+        Instruction: s_branch
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_brev_b32:
+        ImplicitAccess: false
+        Instruction: s_brev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_brev_b64:
+        ImplicitAccess: false
+        Instruction: s_brev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_b128:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b256:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b256
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b32:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 1
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b512:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b512
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b64:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_dword:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx16:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx8:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_call_b64:
+        ImplicitAccess: false
+        Instruction: s_call_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys_and_user:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys_and_user
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys_or_user:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys_or_user
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbguser:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbguser
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_execnz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_execnz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_execz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_execz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_scc0:
+        ImplicitAccess: false
+        Instruction: s_cbranch_scc0
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_scc1:
+        ImplicitAccess: false
+        Instruction: s_cbranch_scc1
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_vccnz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_vccnz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_vccz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_vccz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ceil_f16:
+        ImplicitAccess: false
+        Instruction: s_ceil_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ceil_f32:
+        ImplicitAccess: false
+        Instruction: s_ceil_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clause:
+        ImplicitAccess: false
+        Instruction: s_clause
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cls_i32:
+        ImplicitAccess: false
+        Instruction: s_cls_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cls_i32_i64:
+        ImplicitAccess: false
+        Instruction: s_cls_i32_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clz_i32_u32:
+        ImplicitAccess: false
+        Instruction: s_clz_i32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clz_i32_u64:
+        ImplicitAccess: false
+        Instruction: s_clz_i32_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmov_b32:
+        ImplicitAccess: false
+        Instruction: s_cmov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmov_b64:
+        ImplicitAccess: false
+        Instruction: s_cmov_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmovk_i32:
+        ImplicitAccess: false
+        Instruction: s_cmovk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_u64:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_u64:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_neq_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_neq_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nge_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nge_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ngt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ngt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nle_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nle_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlg_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlg_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_o_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_o_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_u_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_u_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_eq_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_eq_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_ge_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_ge_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_gt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_gt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_le_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_le_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lg_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lg_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lg_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lg_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_code_end:
+        ImplicitAccess: false
+        Instruction: s_code_end
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cselect_b32:
+        ImplicitAccess: false
+        Instruction: s_cselect_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cselect_b64:
+        ImplicitAccess: false
+        Instruction: s_cselect_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ctz_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_ctz_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ctz_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_ctz_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f16_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_f16:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_i32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_u32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_hi_f32_f16:
+        ImplicitAccess: false
+        Instruction: s_cvt_hi_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_i32_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_pk_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_pk_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_u32_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_u32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_dcache_inv:
+        ImplicitAccess: false
+        Instruction: s_dcache_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_decperflevel:
+        ImplicitAccess: false
+        Instruction: s_decperflevel
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_delay_alu:
+        ImplicitAccess: false
+        Instruction: s_delay_alu
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_denorm_mode:
+        ImplicitAccess: false
+        Instruction: s_denorm_mode
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_endpgm:
+        ImplicitAccess: false
+        Instruction: s_endpgm
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues:
+        - FinalInstruction
+      s_endpgm_ordered_ps_done:
+        ImplicitAccess: false
+        Instruction: s_endpgm_ordered_ps_done
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_endpgm_saved:
+        ImplicitAccess: false
+        Instruction: s_endpgm_saved
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ff1_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_ff1_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ff1_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_ff1_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_i64:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_floor_f16:
+        ImplicitAccess: false
+        Instruction: s_floor_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_floor_f32:
+        ImplicitAccess: false
+        Instruction: s_floor_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: s_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmac_f16:
+        ImplicitAccess: false
+        Instruction: s_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmac_f32:
+        ImplicitAccess: false
+        Instruction: s_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: s_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_getpc_b64:
+        ImplicitAccess: false
+        Instruction: s_getpc_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_getreg_b32:
+        ImplicitAccess: false
+        Instruction: s_getreg_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_gl1_inv:
+        ImplicitAccess: false
+        Instruction: s_gl1_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_icache_inv:
+        ImplicitAccess: false
+        Instruction: s_icache_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_incperflevel:
+        ImplicitAccess: false
+        Instruction: s_incperflevel
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_inst_prefetch:
+        ImplicitAccess: false
+        Instruction: s_inst_prefetch
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_b128:
+        ImplicitAccess: false
+        Instruction: s_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b256:
+        ImplicitAccess: false
+        Instruction: s_load_b256
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b32:
+        ImplicitAccess: false
+        Instruction: s_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b512:
+        ImplicitAccess: false
+        Instruction: s_load_b512
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b64:
+        ImplicitAccess: false
+        Instruction: s_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_dword:
+        ImplicitAccess: false
+        Instruction: s_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx16:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx8:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl1_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl1_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl2_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl2_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl3_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl3_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl4_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl4_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl_b32:
+        ImplicitAccess: false
+        Instruction: s_lshl_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl_b64:
+        ImplicitAccess: false
+        Instruction: s_lshl_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshr_b32:
+        ImplicitAccess: false
+        Instruction: s_lshr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshr_b64:
+        ImplicitAccess: false
+        Instruction: s_lshr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_f16:
+        ImplicitAccess: false
+        Instruction: s_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_f32:
+        ImplicitAccess: false
+        Instruction: s_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_i32:
+        ImplicitAccess: false
+        Instruction: s_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_u32:
+        ImplicitAccess: false
+        Instruction: s_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_f16:
+        ImplicitAccess: false
+        Instruction: s_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_f32:
+        ImplicitAccess: false
+        Instruction: s_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_i32:
+        ImplicitAccess: false
+        Instruction: s_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_u32:
+        ImplicitAccess: false
+        Instruction: s_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mov_b32:
+        ImplicitAccess: false
+        Instruction: s_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mov_b64:
+        ImplicitAccess: false
+        Instruction: s_mov_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movk_i32:
+        ImplicitAccess: false
+        Instruction: s_movk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movreld_b32:
+        ImplicitAccess: false
+        Instruction: s_movreld_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movreld_b64:
+        ImplicitAccess: false
+        Instruction: s_movreld_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrels_b32:
+        ImplicitAccess: false
+        Instruction: s_movrels_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrels_b64:
+        ImplicitAccess: false
+        Instruction: s_movrels_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrelsd_2_b32:
+        ImplicitAccess: false
+        Instruction: s_movrelsd_2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_f16:
+        ImplicitAccess: false
+        Instruction: s_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_f32:
+        ImplicitAccess: false
+        Instruction: s_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_hi_i32:
+        ImplicitAccess: false
+        Instruction: s_mul_hi_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_hi_u32:
+        ImplicitAccess: false
+        Instruction: s_mul_hi_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_i32:
+        ImplicitAccess: false
+        Instruction: s_mul_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mulk_i32:
+        ImplicitAccess: false
+        Instruction: s_mulk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_b32:
+        ImplicitAccess: false
+        Instruction: s_nand_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_b64:
+        ImplicitAccess: false
+        Instruction: s_nand_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_nand_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_nand_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nop:
+        ImplicitAccess: false
+        Instruction: s_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_b32:
+        ImplicitAccess: false
+        Instruction: s_nor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_b64:
+        ImplicitAccess: false
+        Instruction: s_nor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_nor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_nor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_not_b32:
+        ImplicitAccess: false
+        Instruction: s_not_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_not_b64:
+        ImplicitAccess: false
+        Instruction: s_not_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_b32:
+        ImplicitAccess: false
+        Instruction: s_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_b64:
+        ImplicitAccess: false
+        Instruction: s_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not0_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not0_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not0_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not0_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_orn1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_orn1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_b32:
+        ImplicitAccess: false
+        Instruction: s_orn2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_b64:
+        ImplicitAccess: false
+        Instruction: s_orn2_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_orn2_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_orn2_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_hh_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_hh_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_hl_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_hl_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_lh_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_lh_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_ll_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_ll_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_quadmask_b32:
+        ImplicitAccess: false
+        Instruction: s_quadmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_quadmask_b64:
+        ImplicitAccess: false
+        Instruction: s_quadmask_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rfe_b64:
+        ImplicitAccess: false
+        Instruction: s_rfe_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rndne_f16:
+        ImplicitAccess: false
+        Instruction: s_rndne_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rndne_f32:
+        ImplicitAccess: false
+        Instruction: s_rndne_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_round_mode:
+        ImplicitAccess: false
+        Instruction: s_round_mode
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsg:
+        ImplicitAccess: false
+        Instruction: s_sendmsg
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 1
+        WaitQueues:
+        - SendMsgQueue
+      s_sendmsg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: s_sendmsg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: s_sendmsg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsghalt:
+        ImplicitAccess: false
+        Instruction: s_sendmsghalt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_set_inst_prefetch_distance:
+        ImplicitAccess: false
+        Instruction: s_set_inst_prefetch_distance
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sethalt:
+        ImplicitAccess: false
+        Instruction: s_sethalt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setkill:
+        ImplicitAccess: false
+        Instruction: s_setkill
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setpc_b64:
+        ImplicitAccess: false
+        Instruction: s_setpc_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setprio:
+        ImplicitAccess: false
+        Instruction: s_setprio
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setreg_b32:
+        ImplicitAccess: false
+        Instruction: s_setreg_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setreg_imm32_b32:
+        ImplicitAccess: false
+        Instruction: s_setreg_imm32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sext_i32_i16:
+        ImplicitAccess: false
+        Instruction: s_sext_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sext_i32_i8:
+        ImplicitAccess: false
+        Instruction: s_sext_i32_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sleep:
+        ImplicitAccess: false
+        Instruction: s_sleep
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_f16:
+        ImplicitAccess: false
+        Instruction: s_sub_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_f32:
+        ImplicitAccess: false
+        Instruction: s_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_i32:
+        ImplicitAccess: false
+        Instruction: s_sub_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_u32:
+        ImplicitAccess: false
+        Instruction: s_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_subb_u32:
+        ImplicitAccess: false
+        Instruction: s_subb_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_swappc_b64:
+        ImplicitAccess: false
+        Instruction: s_swappc_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trap:
+        ImplicitAccess: false
+        Instruction: s_trap
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trunc_f16:
+        ImplicitAccess: false
+        Instruction: s_trunc_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trunc_f32:
+        ImplicitAccess: false
+        Instruction: s_trunc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ttracedata:
+        ImplicitAccess: false
+        Instruction: s_ttracedata
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ttracedata_imm:
+        ImplicitAccess: false
+        Instruction: s_ttracedata_imm
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_version:
+        ImplicitAccess: false
+        Instruction: s_version
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wait_event:
+        ImplicitAccess: false
+        Instruction: s_wait_event
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wait_idle:
+        ImplicitAccess: false
+        Instruction: s_wait_idle
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_depctr:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_depctr
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_expcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_expcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_lgkmcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_lgkmcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_vmcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_vmcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_vscnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_vscnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wakeup:
+        ImplicitAccess: false
+        Instruction: s_wakeup
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wqm_b32:
+        ImplicitAccess: false
+        Instruction: s_wqm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wqm_b64:
+        ImplicitAccess: false
+        Instruction: s_wqm_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_b32:
+        ImplicitAccess: false
+        Instruction: s_xnor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_b64:
+        ImplicitAccess: false
+        Instruction: s_xnor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_xnor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_xnor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_b32:
+        ImplicitAccess: false
+        Instruction: s_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_b64:
+        ImplicitAccess: false
+        Instruction: s_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_xor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_xor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_b128:
+        ImplicitAccess: false
+        Instruction: scratch_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b32:
+        ImplicitAccess: false
+        Instruction: scratch_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b64:
+        ImplicitAccess: false
+        Instruction: scratch_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b96:
+        ImplicitAccess: false
+        Instruction: scratch_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dword:
+        ImplicitAccess: false
+        Instruction: scratch_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_i16:
+        ImplicitAccess: false
+        Instruction: scratch_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_sbyte:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_short_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sshort:
+        ImplicitAccess: false
+        Instruction: scratch_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_u16:
+        ImplicitAccess: false
+        Instruction: scratch_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_ubyte:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ushort:
+        ImplicitAccess: false
+        Instruction: scratch_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_store_b128:
+        ImplicitAccess: false
+        Instruction: scratch_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b16:
+        ImplicitAccess: false
+        Instruction: scratch_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_b32:
+        ImplicitAccess: false
+        Instruction: scratch_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b64:
+        ImplicitAccess: false
+        Instruction: scratch_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b8:
+        ImplicitAccess: false
+        Instruction: scratch_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_b96:
+        ImplicitAccess: false
+        Instruction: scratch_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_byte:
+        ImplicitAccess: false
+        Instruction: scratch_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: scratch_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: scratch_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dword:
+        ImplicitAccess: false
+        Instruction: scratch_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_short:
+        ImplicitAccess: false
+        Instruction: scratch_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      tbuffer_load_d16_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add3_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_add3_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add3_u32:
+        ImplicitAccess: false
+        Instruction: v_add3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_add_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_co_u32:
+        ImplicitAccess: false
+        Instruction: v_add_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f16:
+        ImplicitAccess: false
+        Instruction: v_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f32:
+        ImplicitAccess: false
+        Instruction: v_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f64:
+        ImplicitAccess: false
+        Instruction: v_add_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_lshl_u32:
+        ImplicitAccess: false
+        Instruction: v_add_lshl_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_i16:
+        ImplicitAccess: false
+        Instruction: v_add_nc_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_i32:
+        ImplicitAccess: false
+        Instruction: v_add_nc_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_u16:
+        ImplicitAccess: false
+        Instruction: v_add_nc_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_add_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_alignbit_b32:
+        ImplicitAccess: false
+        Instruction: v_alignbit_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_alignbyte_b32:
+        ImplicitAccess: false
+        Instruction: v_alignbyte_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_b16:
+        ImplicitAccess: false
+        Instruction: v_and_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_b32:
+        ImplicitAccess: false
+        Instruction: v_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_or_b32:
+        ImplicitAccess: false
+        Instruction: v_and_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i16:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i32:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i64:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bcnt_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_bcnt_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfe_i32:
+        ImplicitAccess: false
+        Instruction: v_bfe_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfe_u32:
+        ImplicitAccess: false
+        Instruction: v_bfe_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfi_b32:
+        ImplicitAccess: false
+        Instruction: v_bfi_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfm_b32:
+        ImplicitAccess: false
+        Instruction: v_bfm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfrev_b32:
+        ImplicitAccess: false
+        Instruction: v_bfrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f16:
+        ImplicitAccess: false
+        Instruction: v_ceil_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f32:
+        ImplicitAccess: false
+        Instruction: v_ceil_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f64:
+        ImplicitAccess: false
+        Instruction: v_ceil_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cls_i32:
+        ImplicitAccess: false
+        Instruction: v_cls_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_clz_i32_u32:
+        ImplicitAccess: false
+        Instruction: v_clz_i32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cndmask_b16:
+        ImplicitAccess: false
+        Instruction: v_cndmask_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cndmask_b32:
+        ImplicitAccess: false
+        Instruction: v_cndmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cos_f16:
+        ImplicitAccess: false
+        Instruction: v_cos_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cos_f32:
+        ImplicitAccess: false
+        Instruction: v_cos_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ctz_i32_b32:
+        ImplicitAccess: false
+        Instruction: v_ctz_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubeid_f32:
+        ImplicitAccess: false
+        Instruction: v_cubeid_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubema_f32:
+        ImplicitAccess: false
+        Instruction: v_cubema_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubesc_f32:
+        ImplicitAccess: false
+        Instruction: v_cubesc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubetc_f32:
+        ImplicitAccess: false
+        Instruction: v_cubetc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_i16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_u16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte0:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte0
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte1:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte1
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte2:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte3:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_floor_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_floor_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_flr_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_flr_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_i16:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_nearest_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_nearest_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_norm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_norm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_norm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_norm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_off_f32_i4:
+        ImplicitAccess: false
+        Instruction: v_cvt_off_f32_i4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_i16_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_i16_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u16_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u16_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u8_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u8_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pkrtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pkrtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_rpi_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_rpi_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_u16:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f16:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f32:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f64:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fmas_f32:
+        ImplicitAccess: false
+        Instruction: v_div_fmas_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fmas_f64:
+        ImplicitAccess: false
+        Instruction: v_div_fmas_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_scale_f32:
+        ImplicitAccess: false
+        Instruction: v_div_scale_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_scale_f64:
+        ImplicitAccess: false
+        Instruction: v_div_scale_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_bf16_bf16:
+        ImplicitAccess: false
+        Instruction: v_dot2_bf16_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f16_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f32_bf16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f32_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2acc_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2acc_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2c_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2c_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_i32_i8:
+        ImplicitAccess: false
+        Instruction: v_dot4_i32_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_i32_iu8:
+        ImplicitAccess: false
+        Instruction: v_dot4_i32_iu8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_u32_u8:
+        ImplicitAccess: false
+        Instruction: v_dot4_u32_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_i32_i4:
+        ImplicitAccess: false
+        Instruction: v_dot8_i32_i4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_i32_iu4:
+        ImplicitAccess: false
+        Instruction: v_dot8_i32_iu4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_u32_u4:
+        ImplicitAccess: false
+        Instruction: v_dot8_u32_u4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_add_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_add_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_dual_add_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_and_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_cndmask_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_cndmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_dot2acc_f32_bf16:
+        ImplicitAccess: false
+        Instruction: v_dual_dot2acc_f32_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_dot2acc_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dual_dot2acc_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmac_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_lshlrev_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_lshlrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_max_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_min_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mov_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mul_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_mul_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mul_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_sub_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_subrev_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_subrev_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_exp_f16:
+        ImplicitAccess: false
+        Instruction: v_exp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_exp_f32:
+        ImplicitAccess: false
+        Instruction: v_exp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbh_i32:
+        ImplicitAccess: false
+        Instruction: v_ffbh_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbh_u32:
+        ImplicitAccess: false
+        Instruction: v_ffbh_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbl_b32:
+        ImplicitAccess: false
+        Instruction: v_ffbl_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f16:
+        ImplicitAccess: false
+        Instruction: v_floor_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f32:
+        ImplicitAccess: false
+        Instruction: v_floor_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f64:
+        ImplicitAccess: false
+        Instruction: v_floor_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f64:
+        ImplicitAccess: false
+        Instruction: v_fma_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mix_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_mix_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mixhi_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_mixhi_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mixlo_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_mixlo_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmaak_f16:
+        ImplicitAccess: false
+        Instruction: v_fmaak_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: v_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_f16:
+        ImplicitAccess: false
+        Instruction: v_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmamk_f16:
+        ImplicitAccess: false
+        Instruction: v_fmamk_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: v_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f16:
+        ImplicitAccess: false
+        Instruction: v_fract_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f32:
+        ImplicitAccess: false
+        Instruction: v_fract_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f64:
+        ImplicitAccess: false
+        Instruction: v_fract_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i32_f64:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f16:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f32:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f64:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_new_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_new_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f16:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f32:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f64:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lerp_u8:
+        ImplicitAccess: false
+        Instruction: v_lerp_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_log_f16:
+        ImplicitAccess: false
+        Instruction: v_log_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_log_f32:
+        ImplicitAccess: false
+        Instruction: v_log_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshl_add_u32:
+        ImplicitAccess: false
+        Instruction: v_lshl_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshl_or_b32:
+        ImplicitAccess: false
+        Instruction: v_lshl_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b16:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b32:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b64:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b16:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b32:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b64:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i16:
+        ImplicitAccess: false
+        Instruction: v_mad_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i32_i16:
+        ImplicitAccess: false
+        Instruction: v_mad_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mad_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i64_i32:
+        ImplicitAccess: false
+        Instruction: v_mad_i64_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u16:
+        ImplicitAccess: false
+        Instruction: v_mad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u32_u16:
+        ImplicitAccess: false
+        Instruction: v_mad_u32_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mad_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u64_u32:
+        ImplicitAccess: false
+        Instruction: v_mad_u64_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_f16:
+        ImplicitAccess: false
+        Instruction: v_max3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_f32:
+        ImplicitAccess: false
+        Instruction: v_max3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_i16:
+        ImplicitAccess: false
+        Instruction: v_max3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_i32:
+        ImplicitAccess: false
+        Instruction: v_max3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_u16:
+        ImplicitAccess: false
+        Instruction: v_max3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_u32:
+        ImplicitAccess: false
+        Instruction: v_max3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f16:
+        ImplicitAccess: false
+        Instruction: v_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f32:
+        ImplicitAccess: false
+        Instruction: v_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f64:
+        ImplicitAccess: false
+        Instruction: v_max_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_i16:
+        ImplicitAccess: false
+        Instruction: v_max_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_i32:
+        ImplicitAccess: false
+        Instruction: v_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_u16:
+        ImplicitAccess: false
+        Instruction: v_max_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_u32:
+        ImplicitAccess: false
+        Instruction: v_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_f16:
+        ImplicitAccess: false
+        Instruction: v_maxmin_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_f32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_i32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_u32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mbcnt_hi_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_mbcnt_hi_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mbcnt_lo_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_mbcnt_lo_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_f16:
+        ImplicitAccess: false
+        Instruction: v_med3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_f32:
+        ImplicitAccess: false
+        Instruction: v_med3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_i16:
+        ImplicitAccess: false
+        Instruction: v_med3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_i32:
+        ImplicitAccess: false
+        Instruction: v_med3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_u16:
+        ImplicitAccess: false
+        Instruction: v_med3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_u32:
+        ImplicitAccess: false
+        Instruction: v_med3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_f16:
+        ImplicitAccess: false
+        Instruction: v_min3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_f32:
+        ImplicitAccess: false
+        Instruction: v_min3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_i16:
+        ImplicitAccess: false
+        Instruction: v_min3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_i32:
+        ImplicitAccess: false
+        Instruction: v_min3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_u16:
+        ImplicitAccess: false
+        Instruction: v_min3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_u32:
+        ImplicitAccess: false
+        Instruction: v_min3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f16:
+        ImplicitAccess: false
+        Instruction: v_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f32:
+        ImplicitAccess: false
+        Instruction: v_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f64:
+        ImplicitAccess: false
+        Instruction: v_min_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_i16:
+        ImplicitAccess: false
+        Instruction: v_min_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_i32:
+        ImplicitAccess: false
+        Instruction: v_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_u16:
+        ImplicitAccess: false
+        Instruction: v_min_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_u32:
+        ImplicitAccess: false
+        Instruction: v_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_f16:
+        ImplicitAccess: false
+        Instruction: v_minmax_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_f32:
+        ImplicitAccess: false
+        Instruction: v_minmax_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_i32:
+        ImplicitAccess: false
+        Instruction: v_minmax_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_u32:
+        ImplicitAccess: false
+        Instruction: v_minmax_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mov_b16:
+        ImplicitAccess: false
+        Instruction: v_mov_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mov_b32:
+        ImplicitAccess: false
+        Instruction: v_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movreld_b32:
+        ImplicitAccess: false
+        Instruction: v_movreld_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrels_b32:
+        ImplicitAccess: false
+        Instruction: v_movrels_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrelsd_2_b32:
+        ImplicitAccess: false
+        Instruction: v_movrelsd_2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrelsd_b32:
+        ImplicitAccess: false
+        Instruction: v_movrelsd_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mqsad_pk_u16_u8:
+        ImplicitAccess: false
+        Instruction: v_mqsad_pk_u16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mqsad_u32_u8:
+        ImplicitAccess: false
+        Instruction: v_mqsad_u32_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_msad_u8:
+        ImplicitAccess: false
+        Instruction: v_msad_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f16:
+        ImplicitAccess: false
+        Instruction: v_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f64:
+        ImplicitAccess: false
+        Instruction: v_mul_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_i32:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_u32:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mul_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_lo_u16:
+        ImplicitAccess: false
+        Instruction: v_mul_lo_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_lo_u32:
+        ImplicitAccess: false
+        Instruction: v_mul_lo_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mul_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mullit_f32:
+        ImplicitAccess: false
+        Instruction: v_mullit_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_nop:
+        ImplicitAccess: false
+        Instruction: v_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_not_b16:
+        ImplicitAccess: false
+        Instruction: v_not_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_not_b32:
+        ImplicitAccess: false
+        Instruction: v_not_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or3_b32:
+        ImplicitAccess: false
+        Instruction: v_or3_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or_b16:
+        ImplicitAccess: false
+        Instruction: v_or_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or_b32:
+        ImplicitAccess: false
+        Instruction: v_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pack_b32_f16:
+        ImplicitAccess: false
+        Instruction: v_pack_b32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_perm_b32:
+        ImplicitAccess: false
+        Instruction: v_perm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlane16_b32:
+        ImplicitAccess: false
+        Instruction: v_permlane16_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlane64_b32:
+        ImplicitAccess: false
+        Instruction: v_permlane64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlanex16_b32:
+        ImplicitAccess: false
+        Instruction: v_permlanex16_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pipeflush:
+        ImplicitAccess: false
+        Instruction: v_pipeflush
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_ashrrev_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_ashrrev_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_fma_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_fma_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_fmac_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_lshlrev_b16:
+        ImplicitAccess: false
+        Instruction: v_pk_lshlrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_lshrrev_b16:
+        ImplicitAccess: false
+        Instruction: v_pk_lshrrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mad_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_mad_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mad_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_mad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mul_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mul_lo_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_mul_lo_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_sub_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_sub_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_sub_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_sub_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_qsad_pk_u16_u8:
+        ImplicitAccess: false
+        Instruction: v_qsad_pk_u16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f16:
+        ImplicitAccess: false
+        Instruction: v_rcp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f32:
+        ImplicitAccess: false
+        Instruction: v_rcp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f64:
+        ImplicitAccess: false
+        Instruction: v_rcp_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_iflag_f32:
+        ImplicitAccess: false
+        Instruction: v_rcp_iflag_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_readfirstlane_b32:
+        ImplicitAccess: false
+        Instruction: v_readfirstlane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_readlane_b32:
+        ImplicitAccess: false
+        Instruction: v_readlane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f16:
+        ImplicitAccess: false
+        Instruction: v_rndne_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f32:
+        ImplicitAccess: false
+        Instruction: v_rndne_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f64:
+        ImplicitAccess: false
+        Instruction: v_rndne_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f16:
+        ImplicitAccess: false
+        Instruction: v_rsq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f32:
+        ImplicitAccess: false
+        Instruction: v_rsq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f64:
+        ImplicitAccess: false
+        Instruction: v_rsq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_hi_u8:
+        ImplicitAccess: false
+        Instruction: v_sad_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u16:
+        ImplicitAccess: false
+        Instruction: v_sad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u32:
+        ImplicitAccess: false
+        Instruction: v_sad_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u8:
+        ImplicitAccess: false
+        Instruction: v_sad_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sat_pk_u8_i16:
+        ImplicitAccess: false
+        Instruction: v_sat_pk_u8_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sin_f16:
+        ImplicitAccess: false
+        Instruction: v_sin_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sin_f32:
+        ImplicitAccess: false
+        Instruction: v_sin_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f16:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f32:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f64:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_co_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_f16:
+        ImplicitAccess: false
+        Instruction: v_sub_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_f32:
+        ImplicitAccess: false
+        Instruction: v_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_i16:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_i32:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_u16:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_co_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_f16:
+        ImplicitAccess: false
+        Instruction: v_subrev_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_f32:
+        ImplicitAccess: false
+        Instruction: v_subrev_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swap_b16:
+        ImplicitAccess: false
+        Instruction: v_swap_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swap_b32:
+        ImplicitAccess: false
+        Instruction: v_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swaprel_b32:
+        ImplicitAccess: false
+        Instruction: v_swaprel_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trig_preop_f64:
+        ImplicitAccess: false
+        Instruction: v_trig_preop_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f16:
+        ImplicitAccess: false
+        Instruction: v_trunc_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f32:
+        ImplicitAccess: false
+        Instruction: v_trunc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f64:
+        ImplicitAccess: false
+        Instruction: v_trunc_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_wmma_bf16_16x16x16_bf16:
+        ImplicitAccess: false
+        Instruction: v_wmma_bf16_16x16x16_bf16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f16_16x16x16_f16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f16_16x16x16_f16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f32_16x16x16_bf16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f32_16x16x16_bf16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f32_16x16x16_f16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f32_16x16x16_f16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_i32_16x16x16_iu4:
+        ImplicitAccess: false
+        Instruction: v_wmma_i32_16x16x16_iu4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_wmma_i32_16x16x16_iu8:
+        ImplicitAccess: false
+        Instruction: v_wmma_i32_16x16x16_iu8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_writelane_b32:
+        ImplicitAccess: false
+        Instruction: v_writelane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xad_u32:
+        ImplicitAccess: false
+        Instruction: v_xad_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xnor_b32:
+        ImplicitAccess: false
+        Instruction: v_xnor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor3_b32:
+        ImplicitAccess: false
+        Instruction: v_xor3_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_add_u32:
+        ImplicitAccess: false
+        Instruction: v_xor_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_b16:
+        ImplicitAccess: false
+        Instruction: v_xor_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_b32:
+        ImplicitAccess: false
+        Instruction: v_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []

--- a/shared/rocroller/GPUArchitectureGenerator/pregenerated/GPUArchitecture_def_gfx1151.yaml
+++ b/shared/rocroller/GPUArchitectureGenerator/pregenerated/GPUArchitecture_def_gfx1151.yaml
@@ -1,0 +1,12400 @@
+Architectures:
+  gfx1151:
+    Capabilities:
+      DefaultWavefrontSize: 32
+      HasBufferOutOfBoundsCheckOption: 0
+      HasWave32: 0
+      HasWave64: 0
+      MaxExpcnt: 7
+      MaxLdsSize: 65536
+      MaxLgkmcnt: 0
+      MaxVmcnt: 0
+      SupportedSource: 0
+      WorkgroupIdxViaTTMP: 0
+    ISAVersion:
+      ArchString: gfx1151
+      Sramecc: false
+      Xnack: false
+    InstructionInfos:
+      buffer_atomic_add:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_csub:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_csub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_csub_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_csub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_gl0_inv:
+        ImplicitAccess: false
+        Instruction: buffer_gl0_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_gl1_inv:
+        ImplicitAccess: false
+        Instruction: buffer_gl1_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_b128:
+        ImplicitAccess: false
+        Instruction: buffer_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b32:
+        ImplicitAccess: false
+        Instruction: buffer_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b64:
+        ImplicitAccess: false
+        Instruction: buffer_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b96:
+        ImplicitAccess: false
+        Instruction: buffer_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dword:
+        ImplicitAccess: false
+        Instruction: buffer_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_hi_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_hi_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_i16:
+        ImplicitAccess: false
+        Instruction: buffer_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_sbyte:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_short_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sshort:
+        ImplicitAccess: false
+        Instruction: buffer_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_u16:
+        ImplicitAccess: false
+        Instruction: buffer_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_ubyte:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ushort:
+        ImplicitAccess: false
+        Instruction: buffer_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_store_b128:
+        ImplicitAccess: false
+        Instruction: buffer_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b16:
+        ImplicitAccess: false
+        Instruction: buffer_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_b32:
+        ImplicitAccess: false
+        Instruction: buffer_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b64:
+        ImplicitAccess: false
+        Instruction: buffer_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b8:
+        ImplicitAccess: false
+        Instruction: buffer_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_b96:
+        ImplicitAccess: false
+        Instruction: buffer_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_byte:
+        ImplicitAccess: false
+        Instruction: buffer_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_d16_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dword:
+        ImplicitAccess: false
+        Instruction: buffer_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_hi_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_hi_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_short:
+        ImplicitAccess: false
+        Instruction: buffer_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      ds_add_f32:
+        ImplicitAccess: false
+        Instruction: ds_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_gs_reg_rtn:
+        ImplicitAccess: false
+        Instruction: ds_add_gs_reg_rtn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_u32:
+        ImplicitAccess: false
+        Instruction: ds_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_u64:
+        ImplicitAccess: false
+        Instruction: ds_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_b32:
+        ImplicitAccess: false
+        Instruction: ds_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_b64:
+        ImplicitAccess: false
+        Instruction: ds_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_and_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_and_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_append:
+        ImplicitAccess: false
+        Instruction: ds_append
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_bpermute_b32:
+        ImplicitAccess: false
+        Instruction: ds_bpermute_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_bvh_stack_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_bvh_stack_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_condxchg32_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_condxchg32_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_consume:
+        ImplicitAccess: false
+        Instruction: ds_consume
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_dec_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_dec_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_u32:
+        ImplicitAccess: false
+        Instruction: ds_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_u64:
+        ImplicitAccess: false
+        Instruction: ds_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_barrier:
+        ImplicitAccess: false
+        Instruction: ds_gws_barrier
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_init:
+        ImplicitAccess: false
+        Instruction: ds_gws_init
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_br:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_br
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_p:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_p
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_release_all:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_release_all
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_v:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_v
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_inc_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_inc_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_u32:
+        ImplicitAccess: false
+        Instruction: ds_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_u64:
+        ImplicitAccess: false
+        Instruction: ds_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_stride64_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_stride64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_stride64_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_stride64_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b128:
+        ImplicitAccess: false
+        Instruction: ds_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b96:
+        ImplicitAccess: false
+        Instruction: ds_load_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i16:
+        ImplicitAccess: false
+        Instruction: ds_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8:
+        ImplicitAccess: false
+        Instruction: ds_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_i8_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_i8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16:
+        ImplicitAccess: false
+        Instruction: ds_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_u16_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_u16_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8:
+        ImplicitAccess: false
+        Instruction: ds_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_u8_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_u8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_f32:
+        ImplicitAccess: false
+        Instruction: ds_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_f64:
+        ImplicitAccess: false
+        Instruction: ds_max_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_i32:
+        ImplicitAccess: false
+        Instruction: ds_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_i64:
+        ImplicitAccess: false
+        Instruction: ds_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_i32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_i64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_u32:
+        ImplicitAccess: false
+        Instruction: ds_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_u64:
+        ImplicitAccess: false
+        Instruction: ds_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_f32:
+        ImplicitAccess: false
+        Instruction: ds_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_f64:
+        ImplicitAccess: false
+        Instruction: ds_min_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_i32:
+        ImplicitAccess: false
+        Instruction: ds_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_i64:
+        ImplicitAccess: false
+        Instruction: ds_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_i32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_i64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_u32:
+        ImplicitAccess: false
+        Instruction: ds_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_u64:
+        ImplicitAccess: false
+        Instruction: ds_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_b32:
+        ImplicitAccess: false
+        Instruction: ds_mskor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_b64:
+        ImplicitAccess: false
+        Instruction: ds_mskor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_mskor_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_mskor_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_nop:
+        ImplicitAccess: false
+        Instruction: ds_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_b32:
+        ImplicitAccess: false
+        Instruction: ds_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_b64:
+        ImplicitAccess: false
+        Instruction: ds_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_or_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_or_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_ordered_count:
+        ImplicitAccess: false
+        Instruction: ds_ordered_count
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_permute_b32:
+        ImplicitAccess: false
+        Instruction: ds_permute_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_read2_b32:
+        ImplicitAccess: false
+        Instruction: ds_read2_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2_b64:
+        ImplicitAccess: false
+        Instruction: ds_read2_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2st64_b32:
+        ImplicitAccess: false
+        Instruction: ds_read2st64_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2st64_b64:
+        ImplicitAccess: false
+        Instruction: ds_read2st64_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_read_addtid_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b128:
+        ImplicitAccess: false
+        Instruction: ds_read_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b32:
+        ImplicitAccess: false
+        Instruction: ds_read_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b64:
+        ImplicitAccess: false
+        Instruction: ds_read_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b96:
+        ImplicitAccess: false
+        Instruction: ds_read_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i16:
+        ImplicitAccess: false
+        Instruction: ds_read_i16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8:
+        ImplicitAccess: false
+        Instruction: ds_read_i8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_i8_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_i8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16:
+        ImplicitAccess: false
+        Instruction: ds_read_u16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_u16_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_u16_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8:
+        ImplicitAccess: false
+        Instruction: ds_read_u8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_u8_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_u8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_rsub_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_rsub_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_rsub_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_u32:
+        ImplicitAccess: false
+        Instruction: ds_rsub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_u64:
+        ImplicitAccess: false
+        Instruction: ds_rsub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_stride64_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_stride64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_stride64_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_stride64_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b128:
+        ImplicitAccess: false
+        Instruction: ds_store_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b16:
+        ImplicitAccess: false
+        Instruction: ds_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_store_b16_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b8:
+        ImplicitAccess: false
+        Instruction: ds_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_store_b8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b96:
+        ImplicitAccess: false
+        Instruction: ds_store_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_stride64_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_stride64_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_stride64_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_stride64_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_gs_reg_rtn:
+        ImplicitAccess: false
+        Instruction: ds_sub_gs_reg_rtn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_sub_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_sub_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_u32:
+        ImplicitAccess: false
+        Instruction: ds_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_u64:
+        ImplicitAccess: false
+        Instruction: ds_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_swizzle_b32:
+        ImplicitAccess: false
+        Instruction: ds_swizzle_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrap_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrap_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_write2_b32:
+        ImplicitAccess: false
+        Instruction: ds_write2_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2_b64:
+        ImplicitAccess: false
+        Instruction: ds_write2_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2st64_b32:
+        ImplicitAccess: false
+        Instruction: ds_write2st64_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2st64_b64:
+        ImplicitAccess: false
+        Instruction: ds_write2st64_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_write_addtid_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b128:
+        ImplicitAccess: false
+        Instruction: ds_write_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b16:
+        ImplicitAccess: false
+        Instruction: ds_write_b16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_write_b16_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b32:
+        ImplicitAccess: false
+        Instruction: ds_write_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b64:
+        ImplicitAccess: false
+        Instruction: ds_write_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b8:
+        ImplicitAccess: false
+        Instruction: ds_write_b8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_write_b8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b96:
+        ImplicitAccess: false
+        Instruction: ds_write_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_wrxchg2_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2st64_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2st64_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2st64_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2st64_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_b32:
+        ImplicitAccess: false
+        Instruction: ds_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_b64:
+        ImplicitAccess: false
+        Instruction: ds_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_xor_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_xor_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      exp:
+        ImplicitAccess: false
+        Instruction: exp
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b128:
+        ImplicitAccess: false
+        Instruction: flat_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b32:
+        ImplicitAccess: false
+        Instruction: flat_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b64:
+        ImplicitAccess: false
+        Instruction: flat_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b96:
+        ImplicitAccess: false
+        Instruction: flat_load_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dword:
+        ImplicitAccess: false
+        Instruction: flat_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_i16:
+        ImplicitAccess: false
+        Instruction: flat_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_short_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_short_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_short_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sshort:
+        ImplicitAccess: false
+        Instruction: flat_load_sshort
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_u16:
+        ImplicitAccess: false
+        Instruction: flat_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ushort:
+        ImplicitAccess: false
+        Instruction: flat_load_ushort
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b128:
+        ImplicitAccess: false
+        Instruction: flat_store_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b16:
+        ImplicitAccess: false
+        Instruction: flat_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b32:
+        ImplicitAccess: false
+        Instruction: flat_store_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b64:
+        ImplicitAccess: false
+        Instruction: flat_store_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b8:
+        ImplicitAccess: false
+        Instruction: flat_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b96:
+        ImplicitAccess: false
+        Instruction: flat_store_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_byte:
+        ImplicitAccess: false
+        Instruction: flat_store_byte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_store_byte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: flat_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: flat_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dword:
+        ImplicitAccess: false
+        Instruction: flat_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_short:
+        ImplicitAccess: false
+        Instruction: flat_store_short
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_store_short_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add:
+        ImplicitAccess: false
+        Instruction: global_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and:
+        ImplicitAccess: false
+        Instruction: global_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_csub:
+        ImplicitAccess: false
+        Instruction: global_atomic_csub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_csub_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_csub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: global_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: global_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: global_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or:
+        ImplicitAccess: false
+        Instruction: global_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smax:
+        ImplicitAccess: false
+        Instruction: global_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smin:
+        ImplicitAccess: false
+        Instruction: global_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umax:
+        ImplicitAccess: false
+        Instruction: global_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umin:
+        ImplicitAccess: false
+        Instruction: global_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_load_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_b128:
+        ImplicitAccess: false
+        Instruction: global_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b32:
+        ImplicitAccess: false
+        Instruction: global_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b64:
+        ImplicitAccess: false
+        Instruction: global_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b96:
+        ImplicitAccess: false
+        Instruction: global_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: global_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dword:
+        ImplicitAccess: false
+        Instruction: global_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dword_addtid:
+        ImplicitAccess: false
+        Instruction: global_load_dword_addtid
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_i16:
+        ImplicitAccess: false
+        Instruction: global_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_i8:
+        ImplicitAccess: false
+        Instruction: global_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_load_lds_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: global_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: global_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: global_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: global_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: global_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_sbyte:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_short_d16:
+        ImplicitAccess: false
+        Instruction: global_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sshort:
+        ImplicitAccess: false
+        Instruction: global_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_u16:
+        ImplicitAccess: false
+        Instruction: global_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_u8:
+        ImplicitAccess: false
+        Instruction: global_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_ubyte:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ushort:
+        ImplicitAccess: false
+        Instruction: global_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_store_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_store_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b128:
+        ImplicitAccess: false
+        Instruction: global_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b16:
+        ImplicitAccess: false
+        Instruction: global_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b32:
+        ImplicitAccess: false
+        Instruction: global_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b64:
+        ImplicitAccess: false
+        Instruction: global_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b8:
+        ImplicitAccess: false
+        Instruction: global_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b96:
+        ImplicitAccess: false
+        Instruction: global_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_byte:
+        ImplicitAccess: false
+        Instruction: global_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: global_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: global_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dword:
+        ImplicitAccess: false
+        Instruction: global_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dword_addtid:
+        ImplicitAccess: false
+        Instruction: global_store_dword_addtid
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_short:
+        ImplicitAccess: false
+        Instruction: global_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      image_atomic_add:
+        ImplicitAccess: false
+        Instruction: image_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_and:
+        ImplicitAccess: false
+        Instruction: image_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: image_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_dec:
+        ImplicitAccess: false
+        Instruction: image_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_inc:
+        ImplicitAccess: false
+        Instruction: image_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_or:
+        ImplicitAccess: false
+        Instruction: image_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_smax:
+        ImplicitAccess: false
+        Instruction: image_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_smin:
+        ImplicitAccess: false
+        Instruction: image_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_sub:
+        ImplicitAccess: false
+        Instruction: image_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_swap:
+        ImplicitAccess: false
+        Instruction: image_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_umax:
+        ImplicitAccess: false
+        Instruction: image_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_umin:
+        ImplicitAccess: false
+        Instruction: image_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_xor:
+        ImplicitAccess: false
+        Instruction: image_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_bvh64_intersect_ray:
+        ImplicitAccess: false
+        Instruction: image_bvh64_intersect_ray
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_bvh_intersect_ray:
+        ImplicitAccess: false
+        Instruction: image_bvh_intersect_ray
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4:
+        ImplicitAccess: false
+        Instruction: image_gather4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_b:
+        ImplicitAccess: false
+        Instruction: image_gather4_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_b_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c:
+        ImplicitAccess: false
+        Instruction: image_gather4_c
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_b:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_b_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_l:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_lz:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_lz_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_l:
+        ImplicitAccess: false
+        Instruction: image_gather4_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_lz:
+        ImplicitAccess: false
+        Instruction: image_gather4_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_lz_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4h:
+        ImplicitAccess: false
+        Instruction: image_gather4h
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_get_lod:
+        ImplicitAccess: false
+        Instruction: image_get_lod
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_get_resinfo:
+        ImplicitAccess: false
+        Instruction: image_get_resinfo
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load:
+        ImplicitAccess: false
+        Instruction: image_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip:
+        ImplicitAccess: false
+        Instruction: image_load_mip
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip_pck:
+        ImplicitAccess: false
+        Instruction: image_load_mip_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip_pck_sgn:
+        ImplicitAccess: false
+        Instruction: image_load_mip_pck_sgn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_pck:
+        ImplicitAccess: false
+        Instruction: image_load_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_pck_sgn:
+        ImplicitAccess: false
+        Instruction: image_load_pck_sgn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_msaa_load:
+        ImplicitAccess: false
+        Instruction: image_msaa_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample:
+        ImplicitAccess: false
+        Instruction: image_sample
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b:
+        ImplicitAccess: false
+        Instruction: image_sample_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_b_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_o:
+        ImplicitAccess: false
+        Instruction: image_sample_b_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c:
+        ImplicitAccess: false
+        Instruction: image_sample_c
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_l:
+        ImplicitAccess: false
+        Instruction: image_sample_c_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_l_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_l_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_lz:
+        ImplicitAccess: false
+        Instruction: image_sample_c_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_lz_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d:
+        ImplicitAccess: false
+        Instruction: image_sample_d
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_o:
+        ImplicitAccess: false
+        Instruction: image_sample_d_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_l:
+        ImplicitAccess: false
+        Instruction: image_sample_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_l_o:
+        ImplicitAccess: false
+        Instruction: image_sample_l_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_lz:
+        ImplicitAccess: false
+        Instruction: image_sample_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_lz_o:
+        ImplicitAccess: false
+        Instruction: image_sample_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_o:
+        ImplicitAccess: false
+        Instruction: image_sample_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store:
+        ImplicitAccess: false
+        Instruction: image_store
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_mip:
+        ImplicitAccess: false
+        Instruction: image_store_mip
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_mip_pck:
+        ImplicitAccess: false
+        Instruction: image_store_mip_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_pck:
+        ImplicitAccess: false
+        Instruction: image_store_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      lds_direct_load:
+        ImplicitAccess: false
+        Instruction: lds_direct_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      lds_param_load:
+        ImplicitAccess: false
+        Instruction: lds_param_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_abs_i32:
+        ImplicitAccess: false
+        Instruction: s_abs_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_absdiff_i32:
+        ImplicitAccess: false
+        Instruction: s_absdiff_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_f16:
+        ImplicitAccess: false
+        Instruction: s_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_f32:
+        ImplicitAccess: false
+        Instruction: s_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_i32:
+        ImplicitAccess: false
+        Instruction: s_add_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_u32:
+        ImplicitAccess: false
+        Instruction: s_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_addc_u32:
+        ImplicitAccess: false
+        Instruction: s_addc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_addk_i32:
+        ImplicitAccess: false
+        Instruction: s_addk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_b32:
+        ImplicitAccess: false
+        Instruction: s_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_b64:
+        ImplicitAccess: false
+        Instruction: s_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not0_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not0_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not0_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not0_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn1_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn1_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ashr_i32:
+        ImplicitAccess: false
+        Instruction: s_ashr_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ashr_i64:
+        ImplicitAccess: false
+        Instruction: s_ashr_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_atc_probe:
+        ImplicitAccess: false
+        Instruction: s_atc_probe
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_atc_probe_buffer:
+        ImplicitAccess: false
+        Instruction: s_atc_probe_buffer
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_barrier:
+        ImplicitAccess: false
+        Instruction: s_barrier
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt0_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_bcnt0_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt0_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_bcnt0_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt1_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_bcnt1_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt1_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_bcnt1_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_i32:
+        ImplicitAccess: false
+        Instruction: s_bfe_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_i64:
+        ImplicitAccess: false
+        Instruction: s_bfe_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_u32:
+        ImplicitAccess: false
+        Instruction: s_bfe_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_u64:
+        ImplicitAccess: false
+        Instruction: s_bfe_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfm_b32:
+        ImplicitAccess: false
+        Instruction: s_bfm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfm_b64:
+        ImplicitAccess: false
+        Instruction: s_bfm_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp0_b32:
+        ImplicitAccess: false
+        Instruction: s_bitcmp0_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp0_b64:
+        ImplicitAccess: false
+        Instruction: s_bitcmp0_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp1_b32:
+        ImplicitAccess: false
+        Instruction: s_bitcmp1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp1_b64:
+        ImplicitAccess: false
+        Instruction: s_bitcmp1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitreplicate_b64_b32:
+        ImplicitAccess: false
+        Instruction: s_bitreplicate_b64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset0_b32:
+        ImplicitAccess: false
+        Instruction: s_bitset0_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset0_b64:
+        ImplicitAccess: false
+        Instruction: s_bitset0_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset1_b32:
+        ImplicitAccess: false
+        Instruction: s_bitset1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset1_b64:
+        ImplicitAccess: false
+        Instruction: s_bitset1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_branch:
+        ImplicitAccess: false
+        Instruction: s_branch
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_brev_b32:
+        ImplicitAccess: false
+        Instruction: s_brev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_brev_b64:
+        ImplicitAccess: false
+        Instruction: s_brev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_b128:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b256:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b256
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b32:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 1
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b512:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b512
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b64:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_dword:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx16:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx8:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_call_b64:
+        ImplicitAccess: false
+        Instruction: s_call_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys_and_user:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys_and_user
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys_or_user:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys_or_user
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbguser:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbguser
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_execnz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_execnz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_execz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_execz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_scc0:
+        ImplicitAccess: false
+        Instruction: s_cbranch_scc0
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_scc1:
+        ImplicitAccess: false
+        Instruction: s_cbranch_scc1
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_vccnz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_vccnz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_vccz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_vccz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ceil_f16:
+        ImplicitAccess: false
+        Instruction: s_ceil_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ceil_f32:
+        ImplicitAccess: false
+        Instruction: s_ceil_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clause:
+        ImplicitAccess: false
+        Instruction: s_clause
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cls_i32:
+        ImplicitAccess: false
+        Instruction: s_cls_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cls_i32_i64:
+        ImplicitAccess: false
+        Instruction: s_cls_i32_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clz_i32_u32:
+        ImplicitAccess: false
+        Instruction: s_clz_i32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clz_i32_u64:
+        ImplicitAccess: false
+        Instruction: s_clz_i32_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmov_b32:
+        ImplicitAccess: false
+        Instruction: s_cmov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmov_b64:
+        ImplicitAccess: false
+        Instruction: s_cmov_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmovk_i32:
+        ImplicitAccess: false
+        Instruction: s_cmovk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_u64:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_u64:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_neq_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_neq_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nge_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nge_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ngt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ngt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nle_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nle_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlg_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlg_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_o_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_o_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_u_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_u_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_eq_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_eq_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_ge_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_ge_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_gt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_gt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_le_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_le_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lg_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lg_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lg_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lg_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_code_end:
+        ImplicitAccess: false
+        Instruction: s_code_end
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cselect_b32:
+        ImplicitAccess: false
+        Instruction: s_cselect_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cselect_b64:
+        ImplicitAccess: false
+        Instruction: s_cselect_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ctz_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_ctz_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ctz_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_ctz_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f16_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_f16:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_i32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_u32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_hi_f32_f16:
+        ImplicitAccess: false
+        Instruction: s_cvt_hi_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_i32_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_pk_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_pk_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_u32_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_u32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_dcache_inv:
+        ImplicitAccess: false
+        Instruction: s_dcache_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_decperflevel:
+        ImplicitAccess: false
+        Instruction: s_decperflevel
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_delay_alu:
+        ImplicitAccess: false
+        Instruction: s_delay_alu
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_denorm_mode:
+        ImplicitAccess: false
+        Instruction: s_denorm_mode
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_endpgm:
+        ImplicitAccess: false
+        Instruction: s_endpgm
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues:
+        - FinalInstruction
+      s_endpgm_ordered_ps_done:
+        ImplicitAccess: false
+        Instruction: s_endpgm_ordered_ps_done
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_endpgm_saved:
+        ImplicitAccess: false
+        Instruction: s_endpgm_saved
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ff1_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_ff1_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ff1_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_ff1_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_i64:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_floor_f16:
+        ImplicitAccess: false
+        Instruction: s_floor_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_floor_f32:
+        ImplicitAccess: false
+        Instruction: s_floor_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: s_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmac_f16:
+        ImplicitAccess: false
+        Instruction: s_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmac_f32:
+        ImplicitAccess: false
+        Instruction: s_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: s_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_getpc_b64:
+        ImplicitAccess: false
+        Instruction: s_getpc_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_getreg_b32:
+        ImplicitAccess: false
+        Instruction: s_getreg_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_gl1_inv:
+        ImplicitAccess: false
+        Instruction: s_gl1_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_icache_inv:
+        ImplicitAccess: false
+        Instruction: s_icache_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_incperflevel:
+        ImplicitAccess: false
+        Instruction: s_incperflevel
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_inst_prefetch:
+        ImplicitAccess: false
+        Instruction: s_inst_prefetch
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_b128:
+        ImplicitAccess: false
+        Instruction: s_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b256:
+        ImplicitAccess: false
+        Instruction: s_load_b256
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b32:
+        ImplicitAccess: false
+        Instruction: s_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b512:
+        ImplicitAccess: false
+        Instruction: s_load_b512
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b64:
+        ImplicitAccess: false
+        Instruction: s_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_dword:
+        ImplicitAccess: false
+        Instruction: s_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx16:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx8:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl1_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl1_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl2_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl2_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl3_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl3_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl4_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl4_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl_b32:
+        ImplicitAccess: false
+        Instruction: s_lshl_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl_b64:
+        ImplicitAccess: false
+        Instruction: s_lshl_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshr_b32:
+        ImplicitAccess: false
+        Instruction: s_lshr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshr_b64:
+        ImplicitAccess: false
+        Instruction: s_lshr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_f16:
+        ImplicitAccess: false
+        Instruction: s_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_f32:
+        ImplicitAccess: false
+        Instruction: s_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_i32:
+        ImplicitAccess: false
+        Instruction: s_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_u32:
+        ImplicitAccess: false
+        Instruction: s_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_f16:
+        ImplicitAccess: false
+        Instruction: s_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_f32:
+        ImplicitAccess: false
+        Instruction: s_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_i32:
+        ImplicitAccess: false
+        Instruction: s_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_u32:
+        ImplicitAccess: false
+        Instruction: s_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mov_b32:
+        ImplicitAccess: false
+        Instruction: s_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mov_b64:
+        ImplicitAccess: false
+        Instruction: s_mov_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movk_i32:
+        ImplicitAccess: false
+        Instruction: s_movk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movreld_b32:
+        ImplicitAccess: false
+        Instruction: s_movreld_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movreld_b64:
+        ImplicitAccess: false
+        Instruction: s_movreld_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrels_b32:
+        ImplicitAccess: false
+        Instruction: s_movrels_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrels_b64:
+        ImplicitAccess: false
+        Instruction: s_movrels_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrelsd_2_b32:
+        ImplicitAccess: false
+        Instruction: s_movrelsd_2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_f16:
+        ImplicitAccess: false
+        Instruction: s_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_f32:
+        ImplicitAccess: false
+        Instruction: s_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_hi_i32:
+        ImplicitAccess: false
+        Instruction: s_mul_hi_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_hi_u32:
+        ImplicitAccess: false
+        Instruction: s_mul_hi_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_i32:
+        ImplicitAccess: false
+        Instruction: s_mul_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mulk_i32:
+        ImplicitAccess: false
+        Instruction: s_mulk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_b32:
+        ImplicitAccess: false
+        Instruction: s_nand_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_b64:
+        ImplicitAccess: false
+        Instruction: s_nand_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_nand_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_nand_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nop:
+        ImplicitAccess: false
+        Instruction: s_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_b32:
+        ImplicitAccess: false
+        Instruction: s_nor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_b64:
+        ImplicitAccess: false
+        Instruction: s_nor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_nor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_nor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_not_b32:
+        ImplicitAccess: false
+        Instruction: s_not_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_not_b64:
+        ImplicitAccess: false
+        Instruction: s_not_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_b32:
+        ImplicitAccess: false
+        Instruction: s_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_b64:
+        ImplicitAccess: false
+        Instruction: s_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not0_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not0_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not0_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not0_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_orn1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_orn1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_b32:
+        ImplicitAccess: false
+        Instruction: s_orn2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_b64:
+        ImplicitAccess: false
+        Instruction: s_orn2_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_orn2_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_orn2_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_hh_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_hh_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_hl_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_hl_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_lh_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_lh_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_ll_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_ll_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_quadmask_b32:
+        ImplicitAccess: false
+        Instruction: s_quadmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_quadmask_b64:
+        ImplicitAccess: false
+        Instruction: s_quadmask_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rfe_b64:
+        ImplicitAccess: false
+        Instruction: s_rfe_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rndne_f16:
+        ImplicitAccess: false
+        Instruction: s_rndne_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rndne_f32:
+        ImplicitAccess: false
+        Instruction: s_rndne_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_round_mode:
+        ImplicitAccess: false
+        Instruction: s_round_mode
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsg:
+        ImplicitAccess: false
+        Instruction: s_sendmsg
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 1
+        WaitQueues:
+        - SendMsgQueue
+      s_sendmsg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: s_sendmsg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: s_sendmsg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsghalt:
+        ImplicitAccess: false
+        Instruction: s_sendmsghalt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_set_inst_prefetch_distance:
+        ImplicitAccess: false
+        Instruction: s_set_inst_prefetch_distance
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sethalt:
+        ImplicitAccess: false
+        Instruction: s_sethalt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setkill:
+        ImplicitAccess: false
+        Instruction: s_setkill
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setpc_b64:
+        ImplicitAccess: false
+        Instruction: s_setpc_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setprio:
+        ImplicitAccess: false
+        Instruction: s_setprio
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setreg_b32:
+        ImplicitAccess: false
+        Instruction: s_setreg_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setreg_imm32_b32:
+        ImplicitAccess: false
+        Instruction: s_setreg_imm32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sext_i32_i16:
+        ImplicitAccess: false
+        Instruction: s_sext_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sext_i32_i8:
+        ImplicitAccess: false
+        Instruction: s_sext_i32_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sleep:
+        ImplicitAccess: false
+        Instruction: s_sleep
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_f16:
+        ImplicitAccess: false
+        Instruction: s_sub_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_f32:
+        ImplicitAccess: false
+        Instruction: s_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_i32:
+        ImplicitAccess: false
+        Instruction: s_sub_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_u32:
+        ImplicitAccess: false
+        Instruction: s_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_subb_u32:
+        ImplicitAccess: false
+        Instruction: s_subb_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_swappc_b64:
+        ImplicitAccess: false
+        Instruction: s_swappc_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trap:
+        ImplicitAccess: false
+        Instruction: s_trap
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trunc_f16:
+        ImplicitAccess: false
+        Instruction: s_trunc_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trunc_f32:
+        ImplicitAccess: false
+        Instruction: s_trunc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ttracedata:
+        ImplicitAccess: false
+        Instruction: s_ttracedata
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ttracedata_imm:
+        ImplicitAccess: false
+        Instruction: s_ttracedata_imm
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_version:
+        ImplicitAccess: false
+        Instruction: s_version
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wait_event:
+        ImplicitAccess: false
+        Instruction: s_wait_event
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wait_idle:
+        ImplicitAccess: false
+        Instruction: s_wait_idle
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_depctr:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_depctr
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_expcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_expcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_lgkmcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_lgkmcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_vmcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_vmcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_vscnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_vscnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wakeup:
+        ImplicitAccess: false
+        Instruction: s_wakeup
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wqm_b32:
+        ImplicitAccess: false
+        Instruction: s_wqm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wqm_b64:
+        ImplicitAccess: false
+        Instruction: s_wqm_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_b32:
+        ImplicitAccess: false
+        Instruction: s_xnor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_b64:
+        ImplicitAccess: false
+        Instruction: s_xnor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_xnor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_xnor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_b32:
+        ImplicitAccess: false
+        Instruction: s_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_b64:
+        ImplicitAccess: false
+        Instruction: s_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_xor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_xor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_b128:
+        ImplicitAccess: false
+        Instruction: scratch_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b32:
+        ImplicitAccess: false
+        Instruction: scratch_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b64:
+        ImplicitAccess: false
+        Instruction: scratch_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b96:
+        ImplicitAccess: false
+        Instruction: scratch_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dword:
+        ImplicitAccess: false
+        Instruction: scratch_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_i16:
+        ImplicitAccess: false
+        Instruction: scratch_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_sbyte:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_short_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sshort:
+        ImplicitAccess: false
+        Instruction: scratch_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_u16:
+        ImplicitAccess: false
+        Instruction: scratch_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_ubyte:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ushort:
+        ImplicitAccess: false
+        Instruction: scratch_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_store_b128:
+        ImplicitAccess: false
+        Instruction: scratch_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b16:
+        ImplicitAccess: false
+        Instruction: scratch_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_b32:
+        ImplicitAccess: false
+        Instruction: scratch_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b64:
+        ImplicitAccess: false
+        Instruction: scratch_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b8:
+        ImplicitAccess: false
+        Instruction: scratch_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_b96:
+        ImplicitAccess: false
+        Instruction: scratch_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_byte:
+        ImplicitAccess: false
+        Instruction: scratch_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: scratch_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: scratch_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dword:
+        ImplicitAccess: false
+        Instruction: scratch_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_short:
+        ImplicitAccess: false
+        Instruction: scratch_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      tbuffer_load_d16_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add3_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_add3_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add3_u32:
+        ImplicitAccess: false
+        Instruction: v_add3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_add_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_co_u32:
+        ImplicitAccess: false
+        Instruction: v_add_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f16:
+        ImplicitAccess: false
+        Instruction: v_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f32:
+        ImplicitAccess: false
+        Instruction: v_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f64:
+        ImplicitAccess: false
+        Instruction: v_add_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_lshl_u32:
+        ImplicitAccess: false
+        Instruction: v_add_lshl_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_i16:
+        ImplicitAccess: false
+        Instruction: v_add_nc_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_i32:
+        ImplicitAccess: false
+        Instruction: v_add_nc_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_u16:
+        ImplicitAccess: false
+        Instruction: v_add_nc_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_add_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_alignbit_b32:
+        ImplicitAccess: false
+        Instruction: v_alignbit_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_alignbyte_b32:
+        ImplicitAccess: false
+        Instruction: v_alignbyte_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_b16:
+        ImplicitAccess: false
+        Instruction: v_and_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_b32:
+        ImplicitAccess: false
+        Instruction: v_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_or_b32:
+        ImplicitAccess: false
+        Instruction: v_and_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i16:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i32:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i64:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bcnt_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_bcnt_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfe_i32:
+        ImplicitAccess: false
+        Instruction: v_bfe_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfe_u32:
+        ImplicitAccess: false
+        Instruction: v_bfe_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfi_b32:
+        ImplicitAccess: false
+        Instruction: v_bfi_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfm_b32:
+        ImplicitAccess: false
+        Instruction: v_bfm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfrev_b32:
+        ImplicitAccess: false
+        Instruction: v_bfrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f16:
+        ImplicitAccess: false
+        Instruction: v_ceil_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f32:
+        ImplicitAccess: false
+        Instruction: v_ceil_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f64:
+        ImplicitAccess: false
+        Instruction: v_ceil_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cls_i32:
+        ImplicitAccess: false
+        Instruction: v_cls_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_clz_i32_u32:
+        ImplicitAccess: false
+        Instruction: v_clz_i32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cndmask_b16:
+        ImplicitAccess: false
+        Instruction: v_cndmask_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cndmask_b32:
+        ImplicitAccess: false
+        Instruction: v_cndmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cos_f16:
+        ImplicitAccess: false
+        Instruction: v_cos_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cos_f32:
+        ImplicitAccess: false
+        Instruction: v_cos_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ctz_i32_b32:
+        ImplicitAccess: false
+        Instruction: v_ctz_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubeid_f32:
+        ImplicitAccess: false
+        Instruction: v_cubeid_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubema_f32:
+        ImplicitAccess: false
+        Instruction: v_cubema_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubesc_f32:
+        ImplicitAccess: false
+        Instruction: v_cubesc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubetc_f32:
+        ImplicitAccess: false
+        Instruction: v_cubetc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_i16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_u16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte0:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte0
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte1:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte1
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte2:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte3:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_floor_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_floor_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_flr_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_flr_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_i16:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_nearest_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_nearest_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_norm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_norm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_norm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_norm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_off_f32_i4:
+        ImplicitAccess: false
+        Instruction: v_cvt_off_f32_i4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_i16_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_i16_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u16_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u16_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u8_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u8_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pkrtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pkrtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_rpi_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_rpi_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_u16:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f16:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f32:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f64:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fmas_f32:
+        ImplicitAccess: false
+        Instruction: v_div_fmas_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fmas_f64:
+        ImplicitAccess: false
+        Instruction: v_div_fmas_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_scale_f32:
+        ImplicitAccess: false
+        Instruction: v_div_scale_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_scale_f64:
+        ImplicitAccess: false
+        Instruction: v_div_scale_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_bf16_bf16:
+        ImplicitAccess: false
+        Instruction: v_dot2_bf16_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f16_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f32_bf16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f32_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2acc_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2acc_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2c_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2c_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_i32_i8:
+        ImplicitAccess: false
+        Instruction: v_dot4_i32_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_i32_iu8:
+        ImplicitAccess: false
+        Instruction: v_dot4_i32_iu8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_u32_u8:
+        ImplicitAccess: false
+        Instruction: v_dot4_u32_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_i32_i4:
+        ImplicitAccess: false
+        Instruction: v_dot8_i32_i4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_i32_iu4:
+        ImplicitAccess: false
+        Instruction: v_dot8_i32_iu4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_u32_u4:
+        ImplicitAccess: false
+        Instruction: v_dot8_u32_u4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_add_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_add_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_dual_add_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_and_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_cndmask_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_cndmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_dot2acc_f32_bf16:
+        ImplicitAccess: false
+        Instruction: v_dual_dot2acc_f32_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_dot2acc_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dual_dot2acc_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmac_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_lshlrev_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_lshlrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_max_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_min_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mov_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mul_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_mul_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mul_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_sub_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_subrev_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_subrev_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_exp_f16:
+        ImplicitAccess: false
+        Instruction: v_exp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_exp_f32:
+        ImplicitAccess: false
+        Instruction: v_exp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbh_i32:
+        ImplicitAccess: false
+        Instruction: v_ffbh_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbh_u32:
+        ImplicitAccess: false
+        Instruction: v_ffbh_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbl_b32:
+        ImplicitAccess: false
+        Instruction: v_ffbl_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f16:
+        ImplicitAccess: false
+        Instruction: v_floor_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f32:
+        ImplicitAccess: false
+        Instruction: v_floor_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f64:
+        ImplicitAccess: false
+        Instruction: v_floor_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f64:
+        ImplicitAccess: false
+        Instruction: v_fma_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mix_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_mix_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mixhi_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_mixhi_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mixlo_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_mixlo_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmaak_f16:
+        ImplicitAccess: false
+        Instruction: v_fmaak_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: v_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_f16:
+        ImplicitAccess: false
+        Instruction: v_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmamk_f16:
+        ImplicitAccess: false
+        Instruction: v_fmamk_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: v_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f16:
+        ImplicitAccess: false
+        Instruction: v_fract_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f32:
+        ImplicitAccess: false
+        Instruction: v_fract_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f64:
+        ImplicitAccess: false
+        Instruction: v_fract_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i32_f64:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f16:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f32:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f64:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_new_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_new_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f16:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f32:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f64:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lerp_u8:
+        ImplicitAccess: false
+        Instruction: v_lerp_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_log_f16:
+        ImplicitAccess: false
+        Instruction: v_log_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_log_f32:
+        ImplicitAccess: false
+        Instruction: v_log_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshl_add_u32:
+        ImplicitAccess: false
+        Instruction: v_lshl_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshl_or_b32:
+        ImplicitAccess: false
+        Instruction: v_lshl_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b16:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b32:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b64:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b16:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b32:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b64:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i16:
+        ImplicitAccess: false
+        Instruction: v_mad_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i32_i16:
+        ImplicitAccess: false
+        Instruction: v_mad_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mad_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i64_i32:
+        ImplicitAccess: false
+        Instruction: v_mad_i64_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u16:
+        ImplicitAccess: false
+        Instruction: v_mad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u32_u16:
+        ImplicitAccess: false
+        Instruction: v_mad_u32_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mad_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u64_u32:
+        ImplicitAccess: false
+        Instruction: v_mad_u64_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_f16:
+        ImplicitAccess: false
+        Instruction: v_max3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_f32:
+        ImplicitAccess: false
+        Instruction: v_max3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_i16:
+        ImplicitAccess: false
+        Instruction: v_max3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_i32:
+        ImplicitAccess: false
+        Instruction: v_max3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_u16:
+        ImplicitAccess: false
+        Instruction: v_max3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_u32:
+        ImplicitAccess: false
+        Instruction: v_max3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f16:
+        ImplicitAccess: false
+        Instruction: v_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f32:
+        ImplicitAccess: false
+        Instruction: v_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f64:
+        ImplicitAccess: false
+        Instruction: v_max_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_i16:
+        ImplicitAccess: false
+        Instruction: v_max_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_i32:
+        ImplicitAccess: false
+        Instruction: v_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_u16:
+        ImplicitAccess: false
+        Instruction: v_max_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_u32:
+        ImplicitAccess: false
+        Instruction: v_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_f16:
+        ImplicitAccess: false
+        Instruction: v_maxmin_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_f32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_i32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_u32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mbcnt_hi_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_mbcnt_hi_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mbcnt_lo_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_mbcnt_lo_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_f16:
+        ImplicitAccess: false
+        Instruction: v_med3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_f32:
+        ImplicitAccess: false
+        Instruction: v_med3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_i16:
+        ImplicitAccess: false
+        Instruction: v_med3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_i32:
+        ImplicitAccess: false
+        Instruction: v_med3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_u16:
+        ImplicitAccess: false
+        Instruction: v_med3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_u32:
+        ImplicitAccess: false
+        Instruction: v_med3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_f16:
+        ImplicitAccess: false
+        Instruction: v_min3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_f32:
+        ImplicitAccess: false
+        Instruction: v_min3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_i16:
+        ImplicitAccess: false
+        Instruction: v_min3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_i32:
+        ImplicitAccess: false
+        Instruction: v_min3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_u16:
+        ImplicitAccess: false
+        Instruction: v_min3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_u32:
+        ImplicitAccess: false
+        Instruction: v_min3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f16:
+        ImplicitAccess: false
+        Instruction: v_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f32:
+        ImplicitAccess: false
+        Instruction: v_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f64:
+        ImplicitAccess: false
+        Instruction: v_min_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_i16:
+        ImplicitAccess: false
+        Instruction: v_min_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_i32:
+        ImplicitAccess: false
+        Instruction: v_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_u16:
+        ImplicitAccess: false
+        Instruction: v_min_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_u32:
+        ImplicitAccess: false
+        Instruction: v_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_f16:
+        ImplicitAccess: false
+        Instruction: v_minmax_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_f32:
+        ImplicitAccess: false
+        Instruction: v_minmax_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_i32:
+        ImplicitAccess: false
+        Instruction: v_minmax_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_u32:
+        ImplicitAccess: false
+        Instruction: v_minmax_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mov_b16:
+        ImplicitAccess: false
+        Instruction: v_mov_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mov_b32:
+        ImplicitAccess: false
+        Instruction: v_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movreld_b32:
+        ImplicitAccess: false
+        Instruction: v_movreld_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrels_b32:
+        ImplicitAccess: false
+        Instruction: v_movrels_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrelsd_2_b32:
+        ImplicitAccess: false
+        Instruction: v_movrelsd_2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrelsd_b32:
+        ImplicitAccess: false
+        Instruction: v_movrelsd_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mqsad_pk_u16_u8:
+        ImplicitAccess: false
+        Instruction: v_mqsad_pk_u16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mqsad_u32_u8:
+        ImplicitAccess: false
+        Instruction: v_mqsad_u32_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_msad_u8:
+        ImplicitAccess: false
+        Instruction: v_msad_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f16:
+        ImplicitAccess: false
+        Instruction: v_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f64:
+        ImplicitAccess: false
+        Instruction: v_mul_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_i32:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_u32:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mul_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_lo_u16:
+        ImplicitAccess: false
+        Instruction: v_mul_lo_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_lo_u32:
+        ImplicitAccess: false
+        Instruction: v_mul_lo_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mul_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mullit_f32:
+        ImplicitAccess: false
+        Instruction: v_mullit_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_nop:
+        ImplicitAccess: false
+        Instruction: v_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_not_b16:
+        ImplicitAccess: false
+        Instruction: v_not_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_not_b32:
+        ImplicitAccess: false
+        Instruction: v_not_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or3_b32:
+        ImplicitAccess: false
+        Instruction: v_or3_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or_b16:
+        ImplicitAccess: false
+        Instruction: v_or_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or_b32:
+        ImplicitAccess: false
+        Instruction: v_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pack_b32_f16:
+        ImplicitAccess: false
+        Instruction: v_pack_b32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_perm_b32:
+        ImplicitAccess: false
+        Instruction: v_perm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlane16_b32:
+        ImplicitAccess: false
+        Instruction: v_permlane16_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlane64_b32:
+        ImplicitAccess: false
+        Instruction: v_permlane64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlanex16_b32:
+        ImplicitAccess: false
+        Instruction: v_permlanex16_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pipeflush:
+        ImplicitAccess: false
+        Instruction: v_pipeflush
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_ashrrev_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_ashrrev_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_fma_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_fma_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_fmac_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_lshlrev_b16:
+        ImplicitAccess: false
+        Instruction: v_pk_lshlrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_lshrrev_b16:
+        ImplicitAccess: false
+        Instruction: v_pk_lshrrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mad_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_mad_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mad_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_mad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mul_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mul_lo_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_mul_lo_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_sub_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_sub_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_sub_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_sub_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_qsad_pk_u16_u8:
+        ImplicitAccess: false
+        Instruction: v_qsad_pk_u16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f16:
+        ImplicitAccess: false
+        Instruction: v_rcp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f32:
+        ImplicitAccess: false
+        Instruction: v_rcp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f64:
+        ImplicitAccess: false
+        Instruction: v_rcp_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_iflag_f32:
+        ImplicitAccess: false
+        Instruction: v_rcp_iflag_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_readfirstlane_b32:
+        ImplicitAccess: false
+        Instruction: v_readfirstlane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_readlane_b32:
+        ImplicitAccess: false
+        Instruction: v_readlane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f16:
+        ImplicitAccess: false
+        Instruction: v_rndne_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f32:
+        ImplicitAccess: false
+        Instruction: v_rndne_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f64:
+        ImplicitAccess: false
+        Instruction: v_rndne_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f16:
+        ImplicitAccess: false
+        Instruction: v_rsq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f32:
+        ImplicitAccess: false
+        Instruction: v_rsq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f64:
+        ImplicitAccess: false
+        Instruction: v_rsq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_hi_u8:
+        ImplicitAccess: false
+        Instruction: v_sad_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u16:
+        ImplicitAccess: false
+        Instruction: v_sad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u32:
+        ImplicitAccess: false
+        Instruction: v_sad_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u8:
+        ImplicitAccess: false
+        Instruction: v_sad_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sat_pk_u8_i16:
+        ImplicitAccess: false
+        Instruction: v_sat_pk_u8_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sin_f16:
+        ImplicitAccess: false
+        Instruction: v_sin_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sin_f32:
+        ImplicitAccess: false
+        Instruction: v_sin_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f16:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f32:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f64:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_co_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_f16:
+        ImplicitAccess: false
+        Instruction: v_sub_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_f32:
+        ImplicitAccess: false
+        Instruction: v_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_i16:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_i32:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_u16:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_co_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_f16:
+        ImplicitAccess: false
+        Instruction: v_subrev_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_f32:
+        ImplicitAccess: false
+        Instruction: v_subrev_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swap_b16:
+        ImplicitAccess: false
+        Instruction: v_swap_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swap_b32:
+        ImplicitAccess: false
+        Instruction: v_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swaprel_b32:
+        ImplicitAccess: false
+        Instruction: v_swaprel_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trig_preop_f64:
+        ImplicitAccess: false
+        Instruction: v_trig_preop_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f16:
+        ImplicitAccess: false
+        Instruction: v_trunc_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f32:
+        ImplicitAccess: false
+        Instruction: v_trunc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f64:
+        ImplicitAccess: false
+        Instruction: v_trunc_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_wmma_bf16_16x16x16_bf16:
+        ImplicitAccess: false
+        Instruction: v_wmma_bf16_16x16x16_bf16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f16_16x16x16_f16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f16_16x16x16_f16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f32_16x16x16_bf16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f32_16x16x16_bf16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f32_16x16x16_f16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f32_16x16x16_f16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_i32_16x16x16_iu4:
+        ImplicitAccess: false
+        Instruction: v_wmma_i32_16x16x16_iu4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_wmma_i32_16x16x16_iu8:
+        ImplicitAccess: false
+        Instruction: v_wmma_i32_16x16x16_iu8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_writelane_b32:
+        ImplicitAccess: false
+        Instruction: v_writelane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xad_u32:
+        ImplicitAccess: false
+        Instruction: v_xad_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xnor_b32:
+        ImplicitAccess: false
+        Instruction: v_xnor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor3_b32:
+        ImplicitAccess: false
+        Instruction: v_xor3_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_add_u32:
+        ImplicitAccess: false
+        Instruction: v_xor_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_b16:
+        ImplicitAccess: false
+        Instruction: v_xor_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_b32:
+        ImplicitAccess: false
+        Instruction: v_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []

--- a/shared/rocroller/GPUArchitectureGenerator/pregenerated/GPUArchitecture_def_gfx1152.yaml
+++ b/shared/rocroller/GPUArchitectureGenerator/pregenerated/GPUArchitecture_def_gfx1152.yaml
@@ -1,0 +1,12400 @@
+Architectures:
+  gfx1152:
+    Capabilities:
+      DefaultWavefrontSize: 32
+      HasBufferOutOfBoundsCheckOption: 0
+      HasWave32: 0
+      HasWave64: 0
+      MaxExpcnt: 7
+      MaxLdsSize: 65536
+      MaxLgkmcnt: 0
+      MaxVmcnt: 0
+      SupportedSource: 0
+      WorkgroupIdxViaTTMP: 0
+    ISAVersion:
+      ArchString: gfx1152
+      Sramecc: false
+      Xnack: false
+    InstructionInfos:
+      buffer_atomic_add:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_csub:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_csub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_csub_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_csub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_gl0_inv:
+        ImplicitAccess: false
+        Instruction: buffer_gl0_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_gl1_inv:
+        ImplicitAccess: false
+        Instruction: buffer_gl1_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_b128:
+        ImplicitAccess: false
+        Instruction: buffer_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b32:
+        ImplicitAccess: false
+        Instruction: buffer_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b64:
+        ImplicitAccess: false
+        Instruction: buffer_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b96:
+        ImplicitAccess: false
+        Instruction: buffer_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dword:
+        ImplicitAccess: false
+        Instruction: buffer_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_hi_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_hi_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_i16:
+        ImplicitAccess: false
+        Instruction: buffer_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_sbyte:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_short_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sshort:
+        ImplicitAccess: false
+        Instruction: buffer_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_u16:
+        ImplicitAccess: false
+        Instruction: buffer_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_ubyte:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ushort:
+        ImplicitAccess: false
+        Instruction: buffer_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_store_b128:
+        ImplicitAccess: false
+        Instruction: buffer_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b16:
+        ImplicitAccess: false
+        Instruction: buffer_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_b32:
+        ImplicitAccess: false
+        Instruction: buffer_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b64:
+        ImplicitAccess: false
+        Instruction: buffer_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b8:
+        ImplicitAccess: false
+        Instruction: buffer_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_b96:
+        ImplicitAccess: false
+        Instruction: buffer_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_byte:
+        ImplicitAccess: false
+        Instruction: buffer_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_d16_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dword:
+        ImplicitAccess: false
+        Instruction: buffer_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_hi_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_hi_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_short:
+        ImplicitAccess: false
+        Instruction: buffer_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      ds_add_f32:
+        ImplicitAccess: false
+        Instruction: ds_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_gs_reg_rtn:
+        ImplicitAccess: false
+        Instruction: ds_add_gs_reg_rtn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_u32:
+        ImplicitAccess: false
+        Instruction: ds_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_u64:
+        ImplicitAccess: false
+        Instruction: ds_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_b32:
+        ImplicitAccess: false
+        Instruction: ds_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_b64:
+        ImplicitAccess: false
+        Instruction: ds_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_and_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_and_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_append:
+        ImplicitAccess: false
+        Instruction: ds_append
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_bpermute_b32:
+        ImplicitAccess: false
+        Instruction: ds_bpermute_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_bvh_stack_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_bvh_stack_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_condxchg32_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_condxchg32_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_consume:
+        ImplicitAccess: false
+        Instruction: ds_consume
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_dec_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_dec_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_u32:
+        ImplicitAccess: false
+        Instruction: ds_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_u64:
+        ImplicitAccess: false
+        Instruction: ds_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_barrier:
+        ImplicitAccess: false
+        Instruction: ds_gws_barrier
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_init:
+        ImplicitAccess: false
+        Instruction: ds_gws_init
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_br:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_br
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_p:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_p
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_release_all:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_release_all
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_v:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_v
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_inc_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_inc_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_u32:
+        ImplicitAccess: false
+        Instruction: ds_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_u64:
+        ImplicitAccess: false
+        Instruction: ds_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_stride64_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_stride64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_stride64_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_stride64_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b128:
+        ImplicitAccess: false
+        Instruction: ds_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b96:
+        ImplicitAccess: false
+        Instruction: ds_load_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i16:
+        ImplicitAccess: false
+        Instruction: ds_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8:
+        ImplicitAccess: false
+        Instruction: ds_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_i8_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_i8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16:
+        ImplicitAccess: false
+        Instruction: ds_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_u16_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_u16_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8:
+        ImplicitAccess: false
+        Instruction: ds_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_u8_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_u8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_f32:
+        ImplicitAccess: false
+        Instruction: ds_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_f64:
+        ImplicitAccess: false
+        Instruction: ds_max_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_i32:
+        ImplicitAccess: false
+        Instruction: ds_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_i64:
+        ImplicitAccess: false
+        Instruction: ds_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_i32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_i64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_u32:
+        ImplicitAccess: false
+        Instruction: ds_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_u64:
+        ImplicitAccess: false
+        Instruction: ds_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_f32:
+        ImplicitAccess: false
+        Instruction: ds_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_f64:
+        ImplicitAccess: false
+        Instruction: ds_min_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_i32:
+        ImplicitAccess: false
+        Instruction: ds_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_i64:
+        ImplicitAccess: false
+        Instruction: ds_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_i32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_i64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_u32:
+        ImplicitAccess: false
+        Instruction: ds_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_u64:
+        ImplicitAccess: false
+        Instruction: ds_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_b32:
+        ImplicitAccess: false
+        Instruction: ds_mskor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_b64:
+        ImplicitAccess: false
+        Instruction: ds_mskor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_mskor_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_mskor_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_nop:
+        ImplicitAccess: false
+        Instruction: ds_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_b32:
+        ImplicitAccess: false
+        Instruction: ds_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_b64:
+        ImplicitAccess: false
+        Instruction: ds_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_or_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_or_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_ordered_count:
+        ImplicitAccess: false
+        Instruction: ds_ordered_count
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_permute_b32:
+        ImplicitAccess: false
+        Instruction: ds_permute_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_read2_b32:
+        ImplicitAccess: false
+        Instruction: ds_read2_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2_b64:
+        ImplicitAccess: false
+        Instruction: ds_read2_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2st64_b32:
+        ImplicitAccess: false
+        Instruction: ds_read2st64_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2st64_b64:
+        ImplicitAccess: false
+        Instruction: ds_read2st64_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_read_addtid_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b128:
+        ImplicitAccess: false
+        Instruction: ds_read_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b32:
+        ImplicitAccess: false
+        Instruction: ds_read_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b64:
+        ImplicitAccess: false
+        Instruction: ds_read_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b96:
+        ImplicitAccess: false
+        Instruction: ds_read_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i16:
+        ImplicitAccess: false
+        Instruction: ds_read_i16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8:
+        ImplicitAccess: false
+        Instruction: ds_read_i8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_i8_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_i8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16:
+        ImplicitAccess: false
+        Instruction: ds_read_u16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_u16_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_u16_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8:
+        ImplicitAccess: false
+        Instruction: ds_read_u8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_u8_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_u8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_rsub_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_rsub_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_rsub_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_u32:
+        ImplicitAccess: false
+        Instruction: ds_rsub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_u64:
+        ImplicitAccess: false
+        Instruction: ds_rsub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_stride64_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_stride64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_stride64_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_stride64_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b128:
+        ImplicitAccess: false
+        Instruction: ds_store_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b16:
+        ImplicitAccess: false
+        Instruction: ds_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_store_b16_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b8:
+        ImplicitAccess: false
+        Instruction: ds_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_store_b8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b96:
+        ImplicitAccess: false
+        Instruction: ds_store_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_stride64_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_stride64_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_stride64_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_stride64_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_gs_reg_rtn:
+        ImplicitAccess: false
+        Instruction: ds_sub_gs_reg_rtn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_sub_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_sub_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_u32:
+        ImplicitAccess: false
+        Instruction: ds_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_u64:
+        ImplicitAccess: false
+        Instruction: ds_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_swizzle_b32:
+        ImplicitAccess: false
+        Instruction: ds_swizzle_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrap_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrap_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_write2_b32:
+        ImplicitAccess: false
+        Instruction: ds_write2_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2_b64:
+        ImplicitAccess: false
+        Instruction: ds_write2_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2st64_b32:
+        ImplicitAccess: false
+        Instruction: ds_write2st64_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2st64_b64:
+        ImplicitAccess: false
+        Instruction: ds_write2st64_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_write_addtid_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b128:
+        ImplicitAccess: false
+        Instruction: ds_write_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b16:
+        ImplicitAccess: false
+        Instruction: ds_write_b16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_write_b16_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b32:
+        ImplicitAccess: false
+        Instruction: ds_write_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b64:
+        ImplicitAccess: false
+        Instruction: ds_write_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b8:
+        ImplicitAccess: false
+        Instruction: ds_write_b8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_write_b8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b96:
+        ImplicitAccess: false
+        Instruction: ds_write_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_wrxchg2_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2st64_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2st64_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2st64_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2st64_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_b32:
+        ImplicitAccess: false
+        Instruction: ds_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_b64:
+        ImplicitAccess: false
+        Instruction: ds_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_xor_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_xor_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      exp:
+        ImplicitAccess: false
+        Instruction: exp
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b128:
+        ImplicitAccess: false
+        Instruction: flat_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b32:
+        ImplicitAccess: false
+        Instruction: flat_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b64:
+        ImplicitAccess: false
+        Instruction: flat_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b96:
+        ImplicitAccess: false
+        Instruction: flat_load_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dword:
+        ImplicitAccess: false
+        Instruction: flat_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_i16:
+        ImplicitAccess: false
+        Instruction: flat_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_short_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_short_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_short_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sshort:
+        ImplicitAccess: false
+        Instruction: flat_load_sshort
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_u16:
+        ImplicitAccess: false
+        Instruction: flat_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ushort:
+        ImplicitAccess: false
+        Instruction: flat_load_ushort
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b128:
+        ImplicitAccess: false
+        Instruction: flat_store_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b16:
+        ImplicitAccess: false
+        Instruction: flat_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b32:
+        ImplicitAccess: false
+        Instruction: flat_store_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b64:
+        ImplicitAccess: false
+        Instruction: flat_store_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b8:
+        ImplicitAccess: false
+        Instruction: flat_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b96:
+        ImplicitAccess: false
+        Instruction: flat_store_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_byte:
+        ImplicitAccess: false
+        Instruction: flat_store_byte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_store_byte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: flat_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: flat_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dword:
+        ImplicitAccess: false
+        Instruction: flat_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_short:
+        ImplicitAccess: false
+        Instruction: flat_store_short
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_store_short_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add:
+        ImplicitAccess: false
+        Instruction: global_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and:
+        ImplicitAccess: false
+        Instruction: global_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_csub:
+        ImplicitAccess: false
+        Instruction: global_atomic_csub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_csub_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_csub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: global_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: global_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: global_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or:
+        ImplicitAccess: false
+        Instruction: global_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smax:
+        ImplicitAccess: false
+        Instruction: global_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smin:
+        ImplicitAccess: false
+        Instruction: global_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umax:
+        ImplicitAccess: false
+        Instruction: global_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umin:
+        ImplicitAccess: false
+        Instruction: global_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_load_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_b128:
+        ImplicitAccess: false
+        Instruction: global_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b32:
+        ImplicitAccess: false
+        Instruction: global_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b64:
+        ImplicitAccess: false
+        Instruction: global_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b96:
+        ImplicitAccess: false
+        Instruction: global_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: global_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dword:
+        ImplicitAccess: false
+        Instruction: global_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dword_addtid:
+        ImplicitAccess: false
+        Instruction: global_load_dword_addtid
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_i16:
+        ImplicitAccess: false
+        Instruction: global_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_i8:
+        ImplicitAccess: false
+        Instruction: global_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_load_lds_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: global_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: global_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: global_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: global_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: global_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_sbyte:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_short_d16:
+        ImplicitAccess: false
+        Instruction: global_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sshort:
+        ImplicitAccess: false
+        Instruction: global_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_u16:
+        ImplicitAccess: false
+        Instruction: global_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_u8:
+        ImplicitAccess: false
+        Instruction: global_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_ubyte:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ushort:
+        ImplicitAccess: false
+        Instruction: global_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_store_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_store_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b128:
+        ImplicitAccess: false
+        Instruction: global_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b16:
+        ImplicitAccess: false
+        Instruction: global_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b32:
+        ImplicitAccess: false
+        Instruction: global_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b64:
+        ImplicitAccess: false
+        Instruction: global_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b8:
+        ImplicitAccess: false
+        Instruction: global_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b96:
+        ImplicitAccess: false
+        Instruction: global_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_byte:
+        ImplicitAccess: false
+        Instruction: global_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: global_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: global_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dword:
+        ImplicitAccess: false
+        Instruction: global_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dword_addtid:
+        ImplicitAccess: false
+        Instruction: global_store_dword_addtid
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_short:
+        ImplicitAccess: false
+        Instruction: global_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      image_atomic_add:
+        ImplicitAccess: false
+        Instruction: image_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_and:
+        ImplicitAccess: false
+        Instruction: image_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: image_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_dec:
+        ImplicitAccess: false
+        Instruction: image_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_inc:
+        ImplicitAccess: false
+        Instruction: image_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_or:
+        ImplicitAccess: false
+        Instruction: image_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_smax:
+        ImplicitAccess: false
+        Instruction: image_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_smin:
+        ImplicitAccess: false
+        Instruction: image_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_sub:
+        ImplicitAccess: false
+        Instruction: image_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_swap:
+        ImplicitAccess: false
+        Instruction: image_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_umax:
+        ImplicitAccess: false
+        Instruction: image_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_umin:
+        ImplicitAccess: false
+        Instruction: image_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_xor:
+        ImplicitAccess: false
+        Instruction: image_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_bvh64_intersect_ray:
+        ImplicitAccess: false
+        Instruction: image_bvh64_intersect_ray
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_bvh_intersect_ray:
+        ImplicitAccess: false
+        Instruction: image_bvh_intersect_ray
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4:
+        ImplicitAccess: false
+        Instruction: image_gather4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_b:
+        ImplicitAccess: false
+        Instruction: image_gather4_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_b_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c:
+        ImplicitAccess: false
+        Instruction: image_gather4_c
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_b:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_b_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_l:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_lz:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_lz_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_l:
+        ImplicitAccess: false
+        Instruction: image_gather4_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_lz:
+        ImplicitAccess: false
+        Instruction: image_gather4_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_lz_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4h:
+        ImplicitAccess: false
+        Instruction: image_gather4h
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_get_lod:
+        ImplicitAccess: false
+        Instruction: image_get_lod
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_get_resinfo:
+        ImplicitAccess: false
+        Instruction: image_get_resinfo
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load:
+        ImplicitAccess: false
+        Instruction: image_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip:
+        ImplicitAccess: false
+        Instruction: image_load_mip
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip_pck:
+        ImplicitAccess: false
+        Instruction: image_load_mip_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip_pck_sgn:
+        ImplicitAccess: false
+        Instruction: image_load_mip_pck_sgn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_pck:
+        ImplicitAccess: false
+        Instruction: image_load_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_pck_sgn:
+        ImplicitAccess: false
+        Instruction: image_load_pck_sgn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_msaa_load:
+        ImplicitAccess: false
+        Instruction: image_msaa_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample:
+        ImplicitAccess: false
+        Instruction: image_sample
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b:
+        ImplicitAccess: false
+        Instruction: image_sample_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_b_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_o:
+        ImplicitAccess: false
+        Instruction: image_sample_b_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c:
+        ImplicitAccess: false
+        Instruction: image_sample_c
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_l:
+        ImplicitAccess: false
+        Instruction: image_sample_c_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_l_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_l_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_lz:
+        ImplicitAccess: false
+        Instruction: image_sample_c_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_lz_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d:
+        ImplicitAccess: false
+        Instruction: image_sample_d
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_o:
+        ImplicitAccess: false
+        Instruction: image_sample_d_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_l:
+        ImplicitAccess: false
+        Instruction: image_sample_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_l_o:
+        ImplicitAccess: false
+        Instruction: image_sample_l_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_lz:
+        ImplicitAccess: false
+        Instruction: image_sample_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_lz_o:
+        ImplicitAccess: false
+        Instruction: image_sample_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_o:
+        ImplicitAccess: false
+        Instruction: image_sample_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store:
+        ImplicitAccess: false
+        Instruction: image_store
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_mip:
+        ImplicitAccess: false
+        Instruction: image_store_mip
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_mip_pck:
+        ImplicitAccess: false
+        Instruction: image_store_mip_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_pck:
+        ImplicitAccess: false
+        Instruction: image_store_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      lds_direct_load:
+        ImplicitAccess: false
+        Instruction: lds_direct_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      lds_param_load:
+        ImplicitAccess: false
+        Instruction: lds_param_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_abs_i32:
+        ImplicitAccess: false
+        Instruction: s_abs_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_absdiff_i32:
+        ImplicitAccess: false
+        Instruction: s_absdiff_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_f16:
+        ImplicitAccess: false
+        Instruction: s_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_f32:
+        ImplicitAccess: false
+        Instruction: s_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_i32:
+        ImplicitAccess: false
+        Instruction: s_add_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_u32:
+        ImplicitAccess: false
+        Instruction: s_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_addc_u32:
+        ImplicitAccess: false
+        Instruction: s_addc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_addk_i32:
+        ImplicitAccess: false
+        Instruction: s_addk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_b32:
+        ImplicitAccess: false
+        Instruction: s_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_b64:
+        ImplicitAccess: false
+        Instruction: s_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not0_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not0_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not0_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not0_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn1_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn1_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ashr_i32:
+        ImplicitAccess: false
+        Instruction: s_ashr_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ashr_i64:
+        ImplicitAccess: false
+        Instruction: s_ashr_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_atc_probe:
+        ImplicitAccess: false
+        Instruction: s_atc_probe
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_atc_probe_buffer:
+        ImplicitAccess: false
+        Instruction: s_atc_probe_buffer
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_barrier:
+        ImplicitAccess: false
+        Instruction: s_barrier
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt0_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_bcnt0_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt0_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_bcnt0_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt1_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_bcnt1_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt1_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_bcnt1_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_i32:
+        ImplicitAccess: false
+        Instruction: s_bfe_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_i64:
+        ImplicitAccess: false
+        Instruction: s_bfe_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_u32:
+        ImplicitAccess: false
+        Instruction: s_bfe_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_u64:
+        ImplicitAccess: false
+        Instruction: s_bfe_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfm_b32:
+        ImplicitAccess: false
+        Instruction: s_bfm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfm_b64:
+        ImplicitAccess: false
+        Instruction: s_bfm_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp0_b32:
+        ImplicitAccess: false
+        Instruction: s_bitcmp0_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp0_b64:
+        ImplicitAccess: false
+        Instruction: s_bitcmp0_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp1_b32:
+        ImplicitAccess: false
+        Instruction: s_bitcmp1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp1_b64:
+        ImplicitAccess: false
+        Instruction: s_bitcmp1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitreplicate_b64_b32:
+        ImplicitAccess: false
+        Instruction: s_bitreplicate_b64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset0_b32:
+        ImplicitAccess: false
+        Instruction: s_bitset0_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset0_b64:
+        ImplicitAccess: false
+        Instruction: s_bitset0_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset1_b32:
+        ImplicitAccess: false
+        Instruction: s_bitset1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset1_b64:
+        ImplicitAccess: false
+        Instruction: s_bitset1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_branch:
+        ImplicitAccess: false
+        Instruction: s_branch
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_brev_b32:
+        ImplicitAccess: false
+        Instruction: s_brev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_brev_b64:
+        ImplicitAccess: false
+        Instruction: s_brev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_b128:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b256:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b256
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b32:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 1
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b512:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b512
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b64:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_dword:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx16:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx8:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_call_b64:
+        ImplicitAccess: false
+        Instruction: s_call_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys_and_user:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys_and_user
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys_or_user:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys_or_user
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbguser:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbguser
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_execnz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_execnz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_execz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_execz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_scc0:
+        ImplicitAccess: false
+        Instruction: s_cbranch_scc0
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_scc1:
+        ImplicitAccess: false
+        Instruction: s_cbranch_scc1
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_vccnz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_vccnz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_vccz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_vccz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ceil_f16:
+        ImplicitAccess: false
+        Instruction: s_ceil_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ceil_f32:
+        ImplicitAccess: false
+        Instruction: s_ceil_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clause:
+        ImplicitAccess: false
+        Instruction: s_clause
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cls_i32:
+        ImplicitAccess: false
+        Instruction: s_cls_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cls_i32_i64:
+        ImplicitAccess: false
+        Instruction: s_cls_i32_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clz_i32_u32:
+        ImplicitAccess: false
+        Instruction: s_clz_i32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clz_i32_u64:
+        ImplicitAccess: false
+        Instruction: s_clz_i32_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmov_b32:
+        ImplicitAccess: false
+        Instruction: s_cmov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmov_b64:
+        ImplicitAccess: false
+        Instruction: s_cmov_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmovk_i32:
+        ImplicitAccess: false
+        Instruction: s_cmovk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_u64:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_u64:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_neq_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_neq_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nge_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nge_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ngt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ngt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nle_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nle_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlg_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlg_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_o_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_o_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_u_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_u_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_eq_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_eq_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_ge_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_ge_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_gt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_gt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_le_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_le_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lg_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lg_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lg_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lg_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_code_end:
+        ImplicitAccess: false
+        Instruction: s_code_end
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cselect_b32:
+        ImplicitAccess: false
+        Instruction: s_cselect_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cselect_b64:
+        ImplicitAccess: false
+        Instruction: s_cselect_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ctz_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_ctz_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ctz_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_ctz_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f16_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_f16:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_i32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_u32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_hi_f32_f16:
+        ImplicitAccess: false
+        Instruction: s_cvt_hi_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_i32_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_pk_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_pk_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_u32_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_u32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_dcache_inv:
+        ImplicitAccess: false
+        Instruction: s_dcache_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_decperflevel:
+        ImplicitAccess: false
+        Instruction: s_decperflevel
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_delay_alu:
+        ImplicitAccess: false
+        Instruction: s_delay_alu
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_denorm_mode:
+        ImplicitAccess: false
+        Instruction: s_denorm_mode
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_endpgm:
+        ImplicitAccess: false
+        Instruction: s_endpgm
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues:
+        - FinalInstruction
+      s_endpgm_ordered_ps_done:
+        ImplicitAccess: false
+        Instruction: s_endpgm_ordered_ps_done
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_endpgm_saved:
+        ImplicitAccess: false
+        Instruction: s_endpgm_saved
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ff1_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_ff1_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ff1_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_ff1_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_i64:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_floor_f16:
+        ImplicitAccess: false
+        Instruction: s_floor_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_floor_f32:
+        ImplicitAccess: false
+        Instruction: s_floor_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: s_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmac_f16:
+        ImplicitAccess: false
+        Instruction: s_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmac_f32:
+        ImplicitAccess: false
+        Instruction: s_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: s_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_getpc_b64:
+        ImplicitAccess: false
+        Instruction: s_getpc_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_getreg_b32:
+        ImplicitAccess: false
+        Instruction: s_getreg_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_gl1_inv:
+        ImplicitAccess: false
+        Instruction: s_gl1_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_icache_inv:
+        ImplicitAccess: false
+        Instruction: s_icache_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_incperflevel:
+        ImplicitAccess: false
+        Instruction: s_incperflevel
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_inst_prefetch:
+        ImplicitAccess: false
+        Instruction: s_inst_prefetch
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_b128:
+        ImplicitAccess: false
+        Instruction: s_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b256:
+        ImplicitAccess: false
+        Instruction: s_load_b256
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b32:
+        ImplicitAccess: false
+        Instruction: s_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b512:
+        ImplicitAccess: false
+        Instruction: s_load_b512
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b64:
+        ImplicitAccess: false
+        Instruction: s_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_dword:
+        ImplicitAccess: false
+        Instruction: s_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx16:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx8:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl1_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl1_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl2_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl2_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl3_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl3_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl4_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl4_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl_b32:
+        ImplicitAccess: false
+        Instruction: s_lshl_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl_b64:
+        ImplicitAccess: false
+        Instruction: s_lshl_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshr_b32:
+        ImplicitAccess: false
+        Instruction: s_lshr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshr_b64:
+        ImplicitAccess: false
+        Instruction: s_lshr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_f16:
+        ImplicitAccess: false
+        Instruction: s_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_f32:
+        ImplicitAccess: false
+        Instruction: s_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_i32:
+        ImplicitAccess: false
+        Instruction: s_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_u32:
+        ImplicitAccess: false
+        Instruction: s_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_f16:
+        ImplicitAccess: false
+        Instruction: s_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_f32:
+        ImplicitAccess: false
+        Instruction: s_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_i32:
+        ImplicitAccess: false
+        Instruction: s_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_u32:
+        ImplicitAccess: false
+        Instruction: s_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mov_b32:
+        ImplicitAccess: false
+        Instruction: s_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mov_b64:
+        ImplicitAccess: false
+        Instruction: s_mov_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movk_i32:
+        ImplicitAccess: false
+        Instruction: s_movk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movreld_b32:
+        ImplicitAccess: false
+        Instruction: s_movreld_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movreld_b64:
+        ImplicitAccess: false
+        Instruction: s_movreld_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrels_b32:
+        ImplicitAccess: false
+        Instruction: s_movrels_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrels_b64:
+        ImplicitAccess: false
+        Instruction: s_movrels_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrelsd_2_b32:
+        ImplicitAccess: false
+        Instruction: s_movrelsd_2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_f16:
+        ImplicitAccess: false
+        Instruction: s_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_f32:
+        ImplicitAccess: false
+        Instruction: s_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_hi_i32:
+        ImplicitAccess: false
+        Instruction: s_mul_hi_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_hi_u32:
+        ImplicitAccess: false
+        Instruction: s_mul_hi_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_i32:
+        ImplicitAccess: false
+        Instruction: s_mul_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mulk_i32:
+        ImplicitAccess: false
+        Instruction: s_mulk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_b32:
+        ImplicitAccess: false
+        Instruction: s_nand_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_b64:
+        ImplicitAccess: false
+        Instruction: s_nand_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_nand_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_nand_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nop:
+        ImplicitAccess: false
+        Instruction: s_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_b32:
+        ImplicitAccess: false
+        Instruction: s_nor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_b64:
+        ImplicitAccess: false
+        Instruction: s_nor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_nor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_nor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_not_b32:
+        ImplicitAccess: false
+        Instruction: s_not_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_not_b64:
+        ImplicitAccess: false
+        Instruction: s_not_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_b32:
+        ImplicitAccess: false
+        Instruction: s_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_b64:
+        ImplicitAccess: false
+        Instruction: s_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not0_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not0_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not0_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not0_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_orn1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_orn1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_b32:
+        ImplicitAccess: false
+        Instruction: s_orn2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_b64:
+        ImplicitAccess: false
+        Instruction: s_orn2_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_orn2_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_orn2_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_hh_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_hh_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_hl_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_hl_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_lh_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_lh_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_ll_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_ll_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_quadmask_b32:
+        ImplicitAccess: false
+        Instruction: s_quadmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_quadmask_b64:
+        ImplicitAccess: false
+        Instruction: s_quadmask_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rfe_b64:
+        ImplicitAccess: false
+        Instruction: s_rfe_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rndne_f16:
+        ImplicitAccess: false
+        Instruction: s_rndne_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rndne_f32:
+        ImplicitAccess: false
+        Instruction: s_rndne_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_round_mode:
+        ImplicitAccess: false
+        Instruction: s_round_mode
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsg:
+        ImplicitAccess: false
+        Instruction: s_sendmsg
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 1
+        WaitQueues:
+        - SendMsgQueue
+      s_sendmsg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: s_sendmsg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: s_sendmsg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsghalt:
+        ImplicitAccess: false
+        Instruction: s_sendmsghalt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_set_inst_prefetch_distance:
+        ImplicitAccess: false
+        Instruction: s_set_inst_prefetch_distance
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sethalt:
+        ImplicitAccess: false
+        Instruction: s_sethalt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setkill:
+        ImplicitAccess: false
+        Instruction: s_setkill
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setpc_b64:
+        ImplicitAccess: false
+        Instruction: s_setpc_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setprio:
+        ImplicitAccess: false
+        Instruction: s_setprio
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setreg_b32:
+        ImplicitAccess: false
+        Instruction: s_setreg_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setreg_imm32_b32:
+        ImplicitAccess: false
+        Instruction: s_setreg_imm32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sext_i32_i16:
+        ImplicitAccess: false
+        Instruction: s_sext_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sext_i32_i8:
+        ImplicitAccess: false
+        Instruction: s_sext_i32_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sleep:
+        ImplicitAccess: false
+        Instruction: s_sleep
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_f16:
+        ImplicitAccess: false
+        Instruction: s_sub_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_f32:
+        ImplicitAccess: false
+        Instruction: s_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_i32:
+        ImplicitAccess: false
+        Instruction: s_sub_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_u32:
+        ImplicitAccess: false
+        Instruction: s_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_subb_u32:
+        ImplicitAccess: false
+        Instruction: s_subb_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_swappc_b64:
+        ImplicitAccess: false
+        Instruction: s_swappc_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trap:
+        ImplicitAccess: false
+        Instruction: s_trap
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trunc_f16:
+        ImplicitAccess: false
+        Instruction: s_trunc_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trunc_f32:
+        ImplicitAccess: false
+        Instruction: s_trunc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ttracedata:
+        ImplicitAccess: false
+        Instruction: s_ttracedata
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ttracedata_imm:
+        ImplicitAccess: false
+        Instruction: s_ttracedata_imm
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_version:
+        ImplicitAccess: false
+        Instruction: s_version
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wait_event:
+        ImplicitAccess: false
+        Instruction: s_wait_event
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wait_idle:
+        ImplicitAccess: false
+        Instruction: s_wait_idle
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_depctr:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_depctr
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_expcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_expcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_lgkmcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_lgkmcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_vmcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_vmcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_vscnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_vscnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wakeup:
+        ImplicitAccess: false
+        Instruction: s_wakeup
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wqm_b32:
+        ImplicitAccess: false
+        Instruction: s_wqm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wqm_b64:
+        ImplicitAccess: false
+        Instruction: s_wqm_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_b32:
+        ImplicitAccess: false
+        Instruction: s_xnor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_b64:
+        ImplicitAccess: false
+        Instruction: s_xnor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_xnor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_xnor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_b32:
+        ImplicitAccess: false
+        Instruction: s_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_b64:
+        ImplicitAccess: false
+        Instruction: s_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_xor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_xor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_b128:
+        ImplicitAccess: false
+        Instruction: scratch_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b32:
+        ImplicitAccess: false
+        Instruction: scratch_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b64:
+        ImplicitAccess: false
+        Instruction: scratch_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b96:
+        ImplicitAccess: false
+        Instruction: scratch_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dword:
+        ImplicitAccess: false
+        Instruction: scratch_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_i16:
+        ImplicitAccess: false
+        Instruction: scratch_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_sbyte:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_short_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sshort:
+        ImplicitAccess: false
+        Instruction: scratch_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_u16:
+        ImplicitAccess: false
+        Instruction: scratch_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_ubyte:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ushort:
+        ImplicitAccess: false
+        Instruction: scratch_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_store_b128:
+        ImplicitAccess: false
+        Instruction: scratch_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b16:
+        ImplicitAccess: false
+        Instruction: scratch_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_b32:
+        ImplicitAccess: false
+        Instruction: scratch_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b64:
+        ImplicitAccess: false
+        Instruction: scratch_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b8:
+        ImplicitAccess: false
+        Instruction: scratch_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_b96:
+        ImplicitAccess: false
+        Instruction: scratch_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_byte:
+        ImplicitAccess: false
+        Instruction: scratch_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: scratch_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: scratch_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dword:
+        ImplicitAccess: false
+        Instruction: scratch_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_short:
+        ImplicitAccess: false
+        Instruction: scratch_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      tbuffer_load_d16_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add3_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_add3_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add3_u32:
+        ImplicitAccess: false
+        Instruction: v_add3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_add_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_co_u32:
+        ImplicitAccess: false
+        Instruction: v_add_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f16:
+        ImplicitAccess: false
+        Instruction: v_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f32:
+        ImplicitAccess: false
+        Instruction: v_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f64:
+        ImplicitAccess: false
+        Instruction: v_add_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_lshl_u32:
+        ImplicitAccess: false
+        Instruction: v_add_lshl_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_i16:
+        ImplicitAccess: false
+        Instruction: v_add_nc_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_i32:
+        ImplicitAccess: false
+        Instruction: v_add_nc_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_u16:
+        ImplicitAccess: false
+        Instruction: v_add_nc_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_add_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_alignbit_b32:
+        ImplicitAccess: false
+        Instruction: v_alignbit_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_alignbyte_b32:
+        ImplicitAccess: false
+        Instruction: v_alignbyte_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_b16:
+        ImplicitAccess: false
+        Instruction: v_and_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_b32:
+        ImplicitAccess: false
+        Instruction: v_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_or_b32:
+        ImplicitAccess: false
+        Instruction: v_and_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i16:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i32:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i64:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bcnt_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_bcnt_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfe_i32:
+        ImplicitAccess: false
+        Instruction: v_bfe_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfe_u32:
+        ImplicitAccess: false
+        Instruction: v_bfe_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfi_b32:
+        ImplicitAccess: false
+        Instruction: v_bfi_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfm_b32:
+        ImplicitAccess: false
+        Instruction: v_bfm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfrev_b32:
+        ImplicitAccess: false
+        Instruction: v_bfrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f16:
+        ImplicitAccess: false
+        Instruction: v_ceil_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f32:
+        ImplicitAccess: false
+        Instruction: v_ceil_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f64:
+        ImplicitAccess: false
+        Instruction: v_ceil_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cls_i32:
+        ImplicitAccess: false
+        Instruction: v_cls_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_clz_i32_u32:
+        ImplicitAccess: false
+        Instruction: v_clz_i32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cndmask_b16:
+        ImplicitAccess: false
+        Instruction: v_cndmask_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cndmask_b32:
+        ImplicitAccess: false
+        Instruction: v_cndmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cos_f16:
+        ImplicitAccess: false
+        Instruction: v_cos_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cos_f32:
+        ImplicitAccess: false
+        Instruction: v_cos_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ctz_i32_b32:
+        ImplicitAccess: false
+        Instruction: v_ctz_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubeid_f32:
+        ImplicitAccess: false
+        Instruction: v_cubeid_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubema_f32:
+        ImplicitAccess: false
+        Instruction: v_cubema_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubesc_f32:
+        ImplicitAccess: false
+        Instruction: v_cubesc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubetc_f32:
+        ImplicitAccess: false
+        Instruction: v_cubetc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_i16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_u16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte0:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte0
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte1:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte1
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte2:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte3:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_floor_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_floor_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_flr_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_flr_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_i16:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_nearest_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_nearest_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_norm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_norm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_norm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_norm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_off_f32_i4:
+        ImplicitAccess: false
+        Instruction: v_cvt_off_f32_i4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_i16_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_i16_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u16_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u16_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u8_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u8_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pkrtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pkrtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_rpi_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_rpi_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_u16:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f16:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f32:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f64:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fmas_f32:
+        ImplicitAccess: false
+        Instruction: v_div_fmas_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fmas_f64:
+        ImplicitAccess: false
+        Instruction: v_div_fmas_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_scale_f32:
+        ImplicitAccess: false
+        Instruction: v_div_scale_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_scale_f64:
+        ImplicitAccess: false
+        Instruction: v_div_scale_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_bf16_bf16:
+        ImplicitAccess: false
+        Instruction: v_dot2_bf16_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f16_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f32_bf16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f32_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2acc_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2acc_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2c_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2c_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_i32_i8:
+        ImplicitAccess: false
+        Instruction: v_dot4_i32_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_i32_iu8:
+        ImplicitAccess: false
+        Instruction: v_dot4_i32_iu8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_u32_u8:
+        ImplicitAccess: false
+        Instruction: v_dot4_u32_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_i32_i4:
+        ImplicitAccess: false
+        Instruction: v_dot8_i32_i4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_i32_iu4:
+        ImplicitAccess: false
+        Instruction: v_dot8_i32_iu4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_u32_u4:
+        ImplicitAccess: false
+        Instruction: v_dot8_u32_u4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_add_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_add_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_dual_add_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_and_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_cndmask_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_cndmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_dot2acc_f32_bf16:
+        ImplicitAccess: false
+        Instruction: v_dual_dot2acc_f32_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_dot2acc_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dual_dot2acc_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmac_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_lshlrev_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_lshlrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_max_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_min_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mov_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mul_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_mul_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mul_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_sub_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_subrev_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_subrev_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_exp_f16:
+        ImplicitAccess: false
+        Instruction: v_exp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_exp_f32:
+        ImplicitAccess: false
+        Instruction: v_exp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbh_i32:
+        ImplicitAccess: false
+        Instruction: v_ffbh_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbh_u32:
+        ImplicitAccess: false
+        Instruction: v_ffbh_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbl_b32:
+        ImplicitAccess: false
+        Instruction: v_ffbl_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f16:
+        ImplicitAccess: false
+        Instruction: v_floor_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f32:
+        ImplicitAccess: false
+        Instruction: v_floor_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f64:
+        ImplicitAccess: false
+        Instruction: v_floor_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f64:
+        ImplicitAccess: false
+        Instruction: v_fma_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mix_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_mix_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mixhi_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_mixhi_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mixlo_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_mixlo_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmaak_f16:
+        ImplicitAccess: false
+        Instruction: v_fmaak_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: v_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_f16:
+        ImplicitAccess: false
+        Instruction: v_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmamk_f16:
+        ImplicitAccess: false
+        Instruction: v_fmamk_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: v_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f16:
+        ImplicitAccess: false
+        Instruction: v_fract_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f32:
+        ImplicitAccess: false
+        Instruction: v_fract_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f64:
+        ImplicitAccess: false
+        Instruction: v_fract_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i32_f64:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f16:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f32:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f64:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_new_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_new_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f16:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f32:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f64:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lerp_u8:
+        ImplicitAccess: false
+        Instruction: v_lerp_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_log_f16:
+        ImplicitAccess: false
+        Instruction: v_log_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_log_f32:
+        ImplicitAccess: false
+        Instruction: v_log_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshl_add_u32:
+        ImplicitAccess: false
+        Instruction: v_lshl_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshl_or_b32:
+        ImplicitAccess: false
+        Instruction: v_lshl_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b16:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b32:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b64:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b16:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b32:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b64:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i16:
+        ImplicitAccess: false
+        Instruction: v_mad_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i32_i16:
+        ImplicitAccess: false
+        Instruction: v_mad_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mad_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i64_i32:
+        ImplicitAccess: false
+        Instruction: v_mad_i64_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u16:
+        ImplicitAccess: false
+        Instruction: v_mad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u32_u16:
+        ImplicitAccess: false
+        Instruction: v_mad_u32_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mad_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u64_u32:
+        ImplicitAccess: false
+        Instruction: v_mad_u64_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_f16:
+        ImplicitAccess: false
+        Instruction: v_max3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_f32:
+        ImplicitAccess: false
+        Instruction: v_max3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_i16:
+        ImplicitAccess: false
+        Instruction: v_max3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_i32:
+        ImplicitAccess: false
+        Instruction: v_max3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_u16:
+        ImplicitAccess: false
+        Instruction: v_max3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_u32:
+        ImplicitAccess: false
+        Instruction: v_max3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f16:
+        ImplicitAccess: false
+        Instruction: v_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f32:
+        ImplicitAccess: false
+        Instruction: v_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f64:
+        ImplicitAccess: false
+        Instruction: v_max_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_i16:
+        ImplicitAccess: false
+        Instruction: v_max_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_i32:
+        ImplicitAccess: false
+        Instruction: v_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_u16:
+        ImplicitAccess: false
+        Instruction: v_max_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_u32:
+        ImplicitAccess: false
+        Instruction: v_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_f16:
+        ImplicitAccess: false
+        Instruction: v_maxmin_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_f32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_i32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_u32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mbcnt_hi_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_mbcnt_hi_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mbcnt_lo_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_mbcnt_lo_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_f16:
+        ImplicitAccess: false
+        Instruction: v_med3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_f32:
+        ImplicitAccess: false
+        Instruction: v_med3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_i16:
+        ImplicitAccess: false
+        Instruction: v_med3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_i32:
+        ImplicitAccess: false
+        Instruction: v_med3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_u16:
+        ImplicitAccess: false
+        Instruction: v_med3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_u32:
+        ImplicitAccess: false
+        Instruction: v_med3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_f16:
+        ImplicitAccess: false
+        Instruction: v_min3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_f32:
+        ImplicitAccess: false
+        Instruction: v_min3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_i16:
+        ImplicitAccess: false
+        Instruction: v_min3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_i32:
+        ImplicitAccess: false
+        Instruction: v_min3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_u16:
+        ImplicitAccess: false
+        Instruction: v_min3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_u32:
+        ImplicitAccess: false
+        Instruction: v_min3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f16:
+        ImplicitAccess: false
+        Instruction: v_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f32:
+        ImplicitAccess: false
+        Instruction: v_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f64:
+        ImplicitAccess: false
+        Instruction: v_min_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_i16:
+        ImplicitAccess: false
+        Instruction: v_min_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_i32:
+        ImplicitAccess: false
+        Instruction: v_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_u16:
+        ImplicitAccess: false
+        Instruction: v_min_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_u32:
+        ImplicitAccess: false
+        Instruction: v_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_f16:
+        ImplicitAccess: false
+        Instruction: v_minmax_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_f32:
+        ImplicitAccess: false
+        Instruction: v_minmax_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_i32:
+        ImplicitAccess: false
+        Instruction: v_minmax_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_u32:
+        ImplicitAccess: false
+        Instruction: v_minmax_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mov_b16:
+        ImplicitAccess: false
+        Instruction: v_mov_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mov_b32:
+        ImplicitAccess: false
+        Instruction: v_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movreld_b32:
+        ImplicitAccess: false
+        Instruction: v_movreld_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrels_b32:
+        ImplicitAccess: false
+        Instruction: v_movrels_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrelsd_2_b32:
+        ImplicitAccess: false
+        Instruction: v_movrelsd_2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrelsd_b32:
+        ImplicitAccess: false
+        Instruction: v_movrelsd_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mqsad_pk_u16_u8:
+        ImplicitAccess: false
+        Instruction: v_mqsad_pk_u16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mqsad_u32_u8:
+        ImplicitAccess: false
+        Instruction: v_mqsad_u32_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_msad_u8:
+        ImplicitAccess: false
+        Instruction: v_msad_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f16:
+        ImplicitAccess: false
+        Instruction: v_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f64:
+        ImplicitAccess: false
+        Instruction: v_mul_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_i32:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_u32:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mul_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_lo_u16:
+        ImplicitAccess: false
+        Instruction: v_mul_lo_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_lo_u32:
+        ImplicitAccess: false
+        Instruction: v_mul_lo_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mul_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mullit_f32:
+        ImplicitAccess: false
+        Instruction: v_mullit_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_nop:
+        ImplicitAccess: false
+        Instruction: v_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_not_b16:
+        ImplicitAccess: false
+        Instruction: v_not_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_not_b32:
+        ImplicitAccess: false
+        Instruction: v_not_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or3_b32:
+        ImplicitAccess: false
+        Instruction: v_or3_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or_b16:
+        ImplicitAccess: false
+        Instruction: v_or_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or_b32:
+        ImplicitAccess: false
+        Instruction: v_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pack_b32_f16:
+        ImplicitAccess: false
+        Instruction: v_pack_b32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_perm_b32:
+        ImplicitAccess: false
+        Instruction: v_perm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlane16_b32:
+        ImplicitAccess: false
+        Instruction: v_permlane16_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlane64_b32:
+        ImplicitAccess: false
+        Instruction: v_permlane64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlanex16_b32:
+        ImplicitAccess: false
+        Instruction: v_permlanex16_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pipeflush:
+        ImplicitAccess: false
+        Instruction: v_pipeflush
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_ashrrev_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_ashrrev_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_fma_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_fma_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_fmac_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_lshlrev_b16:
+        ImplicitAccess: false
+        Instruction: v_pk_lshlrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_lshrrev_b16:
+        ImplicitAccess: false
+        Instruction: v_pk_lshrrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mad_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_mad_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mad_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_mad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mul_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mul_lo_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_mul_lo_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_sub_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_sub_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_sub_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_sub_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_qsad_pk_u16_u8:
+        ImplicitAccess: false
+        Instruction: v_qsad_pk_u16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f16:
+        ImplicitAccess: false
+        Instruction: v_rcp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f32:
+        ImplicitAccess: false
+        Instruction: v_rcp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f64:
+        ImplicitAccess: false
+        Instruction: v_rcp_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_iflag_f32:
+        ImplicitAccess: false
+        Instruction: v_rcp_iflag_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_readfirstlane_b32:
+        ImplicitAccess: false
+        Instruction: v_readfirstlane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_readlane_b32:
+        ImplicitAccess: false
+        Instruction: v_readlane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f16:
+        ImplicitAccess: false
+        Instruction: v_rndne_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f32:
+        ImplicitAccess: false
+        Instruction: v_rndne_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f64:
+        ImplicitAccess: false
+        Instruction: v_rndne_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f16:
+        ImplicitAccess: false
+        Instruction: v_rsq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f32:
+        ImplicitAccess: false
+        Instruction: v_rsq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f64:
+        ImplicitAccess: false
+        Instruction: v_rsq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_hi_u8:
+        ImplicitAccess: false
+        Instruction: v_sad_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u16:
+        ImplicitAccess: false
+        Instruction: v_sad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u32:
+        ImplicitAccess: false
+        Instruction: v_sad_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u8:
+        ImplicitAccess: false
+        Instruction: v_sad_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sat_pk_u8_i16:
+        ImplicitAccess: false
+        Instruction: v_sat_pk_u8_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sin_f16:
+        ImplicitAccess: false
+        Instruction: v_sin_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sin_f32:
+        ImplicitAccess: false
+        Instruction: v_sin_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f16:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f32:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f64:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_co_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_f16:
+        ImplicitAccess: false
+        Instruction: v_sub_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_f32:
+        ImplicitAccess: false
+        Instruction: v_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_i16:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_i32:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_u16:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_co_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_f16:
+        ImplicitAccess: false
+        Instruction: v_subrev_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_f32:
+        ImplicitAccess: false
+        Instruction: v_subrev_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swap_b16:
+        ImplicitAccess: false
+        Instruction: v_swap_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swap_b32:
+        ImplicitAccess: false
+        Instruction: v_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swaprel_b32:
+        ImplicitAccess: false
+        Instruction: v_swaprel_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trig_preop_f64:
+        ImplicitAccess: false
+        Instruction: v_trig_preop_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f16:
+        ImplicitAccess: false
+        Instruction: v_trunc_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f32:
+        ImplicitAccess: false
+        Instruction: v_trunc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f64:
+        ImplicitAccess: false
+        Instruction: v_trunc_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_wmma_bf16_16x16x16_bf16:
+        ImplicitAccess: false
+        Instruction: v_wmma_bf16_16x16x16_bf16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f16_16x16x16_f16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f16_16x16x16_f16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f32_16x16x16_bf16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f32_16x16x16_bf16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f32_16x16x16_f16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f32_16x16x16_f16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_i32_16x16x16_iu4:
+        ImplicitAccess: false
+        Instruction: v_wmma_i32_16x16x16_iu4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_wmma_i32_16x16x16_iu8:
+        ImplicitAccess: false
+        Instruction: v_wmma_i32_16x16x16_iu8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_writelane_b32:
+        ImplicitAccess: false
+        Instruction: v_writelane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xad_u32:
+        ImplicitAccess: false
+        Instruction: v_xad_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xnor_b32:
+        ImplicitAccess: false
+        Instruction: v_xnor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor3_b32:
+        ImplicitAccess: false
+        Instruction: v_xor3_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_add_u32:
+        ImplicitAccess: false
+        Instruction: v_xor_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_b16:
+        ImplicitAccess: false
+        Instruction: v_xor_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_b32:
+        ImplicitAccess: false
+        Instruction: v_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []

--- a/shared/rocroller/GPUArchitectureGenerator/pregenerated/GPUArchitecture_def_gfx1153.yaml
+++ b/shared/rocroller/GPUArchitectureGenerator/pregenerated/GPUArchitecture_def_gfx1153.yaml
@@ -1,0 +1,12400 @@
+Architectures:
+  gfx1153:
+    Capabilities:
+      DefaultWavefrontSize: 32
+      HasBufferOutOfBoundsCheckOption: 0
+      HasWave32: 0
+      HasWave64: 0
+      MaxExpcnt: 7
+      MaxLdsSize: 65536
+      MaxLgkmcnt: 0
+      MaxVmcnt: 0
+      SupportedSource: 0
+      WorkgroupIdxViaTTMP: 0
+    ISAVersion:
+      ArchString: gfx1153
+      Sramecc: false
+      Xnack: false
+    InstructionInfos:
+      buffer_atomic_add:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_csub:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_csub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_csub_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_csub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umax:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umin:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: buffer_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_gl0_inv:
+        ImplicitAccess: false
+        Instruction: buffer_gl0_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_gl1_inv:
+        ImplicitAccess: false
+        Instruction: buffer_gl1_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_b128:
+        ImplicitAccess: false
+        Instruction: buffer_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b32:
+        ImplicitAccess: false
+        Instruction: buffer_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b64:
+        ImplicitAccess: false
+        Instruction: buffer_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_b96:
+        ImplicitAccess: false
+        Instruction: buffer_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dword:
+        ImplicitAccess: false
+        Instruction: buffer_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: buffer_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_hi_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_hi_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_load_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_i16:
+        ImplicitAccess: false
+        Instruction: buffer_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_sbyte:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_short_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_sshort:
+        ImplicitAccess: false
+        Instruction: buffer_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_u16:
+        ImplicitAccess: false
+        Instruction: buffer_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_u8:
+        ImplicitAccess: false
+        Instruction: buffer_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_load_ubyte:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_load_ushort:
+        ImplicitAccess: false
+        Instruction: buffer_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - LoadQueue
+      buffer_store_b128:
+        ImplicitAccess: false
+        Instruction: buffer_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b16:
+        ImplicitAccess: false
+        Instruction: buffer_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_b32:
+        ImplicitAccess: false
+        Instruction: buffer_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b64:
+        ImplicitAccess: false
+        Instruction: buffer_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_b8:
+        ImplicitAccess: false
+        Instruction: buffer_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_b96:
+        ImplicitAccess: false
+        Instruction: buffer_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_byte:
+        ImplicitAccess: false
+        Instruction: buffer_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_d16_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_d16_hi_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_d16_hi_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dword:
+        ImplicitAccess: false
+        Instruction: buffer_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: buffer_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_hi_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_hi_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_x:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xy:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xyz:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_format_xyzw:
+        ImplicitAccess: false
+        Instruction: buffer_store_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      buffer_store_short:
+        ImplicitAccess: false
+        Instruction: buffer_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      buffer_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: buffer_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 1
+        WaitQueues:
+        - StoreQueue
+      ds_add_f32:
+        ImplicitAccess: false
+        Instruction: ds_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_gs_reg_rtn:
+        ImplicitAccess: false
+        Instruction: ds_add_gs_reg_rtn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_add_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_u32:
+        ImplicitAccess: false
+        Instruction: ds_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_add_u64:
+        ImplicitAccess: false
+        Instruction: ds_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_b32:
+        ImplicitAccess: false
+        Instruction: ds_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_b64:
+        ImplicitAccess: false
+        Instruction: ds_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_and_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_and_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_and_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_append:
+        ImplicitAccess: false
+        Instruction: ds_append
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_bpermute_b32:
+        ImplicitAccess: false
+        Instruction: ds_bpermute_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_bvh_stack_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_bvh_stack_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpst_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpst_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_cmpstore_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_cmpstore_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_condxchg32_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_condxchg32_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_consume:
+        ImplicitAccess: false
+        Instruction: ds_consume
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_dec_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_dec_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_u32:
+        ImplicitAccess: false
+        Instruction: ds_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_dec_u64:
+        ImplicitAccess: false
+        Instruction: ds_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_barrier:
+        ImplicitAccess: false
+        Instruction: ds_gws_barrier
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_init:
+        ImplicitAccess: false
+        Instruction: ds_gws_init
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_br:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_br
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_p:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_p
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_release_all:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_release_all
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_gws_sema_v:
+        ImplicitAccess: false
+        Instruction: ds_gws_sema_v
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_inc_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_inc_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_u32:
+        ImplicitAccess: false
+        Instruction: ds_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_inc_u64:
+        ImplicitAccess: false
+        Instruction: ds_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_stride64_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_stride64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_2addr_stride64_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_2addr_stride64_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b128:
+        ImplicitAccess: false
+        Instruction: ds_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b32:
+        ImplicitAccess: false
+        Instruction: ds_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b64:
+        ImplicitAccess: false
+        Instruction: ds_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_b96:
+        ImplicitAccess: false
+        Instruction: ds_load_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i16:
+        ImplicitAccess: false
+        Instruction: ds_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8:
+        ImplicitAccess: false
+        Instruction: ds_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_i8_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_i8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_i8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16:
+        ImplicitAccess: false
+        Instruction: ds_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_u16_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_u16_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8:
+        ImplicitAccess: false
+        Instruction: ds_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8_d16:
+        ImplicitAccess: false
+        Instruction: ds_load_u8_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_load_u8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_load_u8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_f32:
+        ImplicitAccess: false
+        Instruction: ds_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_f64:
+        ImplicitAccess: false
+        Instruction: ds_max_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_i32:
+        ImplicitAccess: false
+        Instruction: ds_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_i64:
+        ImplicitAccess: false
+        Instruction: ds_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_i32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_i64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_max_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_u32:
+        ImplicitAccess: false
+        Instruction: ds_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_max_u64:
+        ImplicitAccess: false
+        Instruction: ds_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_f32:
+        ImplicitAccess: false
+        Instruction: ds_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_f64:
+        ImplicitAccess: false
+        Instruction: ds_min_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_i32:
+        ImplicitAccess: false
+        Instruction: ds_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_i64:
+        ImplicitAccess: false
+        Instruction: ds_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_f32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_f64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_i32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_i64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_min_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_u32:
+        ImplicitAccess: false
+        Instruction: ds_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_min_u64:
+        ImplicitAccess: false
+        Instruction: ds_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_b32:
+        ImplicitAccess: false
+        Instruction: ds_mskor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_b64:
+        ImplicitAccess: false
+        Instruction: ds_mskor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_mskor_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_mskor_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_mskor_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_nop:
+        ImplicitAccess: false
+        Instruction: ds_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_b32:
+        ImplicitAccess: false
+        Instruction: ds_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_b64:
+        ImplicitAccess: false
+        Instruction: ds_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_or_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_or_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_or_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_ordered_count:
+        ImplicitAccess: false
+        Instruction: ds_ordered_count
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_permute_b32:
+        ImplicitAccess: false
+        Instruction: ds_permute_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_read2_b32:
+        ImplicitAccess: false
+        Instruction: ds_read2_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2_b64:
+        ImplicitAccess: false
+        Instruction: ds_read2_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2st64_b32:
+        ImplicitAccess: false
+        Instruction: ds_read2st64_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read2st64_b64:
+        ImplicitAccess: false
+        Instruction: ds_read2st64_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_read_addtid_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b128:
+        ImplicitAccess: false
+        Instruction: ds_read_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b32:
+        ImplicitAccess: false
+        Instruction: ds_read_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b64:
+        ImplicitAccess: false
+        Instruction: ds_read_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_b96:
+        ImplicitAccess: false
+        Instruction: ds_read_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i16:
+        ImplicitAccess: false
+        Instruction: ds_read_i16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8:
+        ImplicitAccess: false
+        Instruction: ds_read_i8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_i8_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_i8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_i8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16:
+        ImplicitAccess: false
+        Instruction: ds_read_u16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_u16_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_u16_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8:
+        ImplicitAccess: false
+        Instruction: ds_read_u8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8_d16:
+        ImplicitAccess: false
+        Instruction: ds_read_u8_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_read_u8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_read_u8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_rsub_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_rsub_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_rsub_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_u32:
+        ImplicitAccess: false
+        Instruction: ds_rsub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_rsub_u64:
+        ImplicitAccess: false
+        Instruction: ds_rsub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_stride64_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_stride64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_2addr_stride64_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_2addr_stride64_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b128:
+        ImplicitAccess: false
+        Instruction: ds_store_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b16:
+        ImplicitAccess: false
+        Instruction: ds_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_store_b16_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b32:
+        ImplicitAccess: false
+        Instruction: ds_store_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b64:
+        ImplicitAccess: false
+        Instruction: ds_store_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b8:
+        ImplicitAccess: false
+        Instruction: ds_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_store_b8_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_store_b96:
+        ImplicitAccess: false
+        Instruction: ds_store_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_stride64_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_stride64_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_2addr_stride64_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_2addr_stride64_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_storexchg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_storexchg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_gs_reg_rtn:
+        ImplicitAccess: false
+        Instruction: ds_sub_gs_reg_rtn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_rtn_u32:
+        ImplicitAccess: false
+        Instruction: ds_sub_rtn_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_rtn_u64:
+        ImplicitAccess: false
+        Instruction: ds_sub_rtn_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_u32:
+        ImplicitAccess: false
+        Instruction: ds_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_sub_u64:
+        ImplicitAccess: false
+        Instruction: ds_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_swizzle_b32:
+        ImplicitAccess: false
+        Instruction: ds_swizzle_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrap_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrap_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_write2_b32:
+        ImplicitAccess: false
+        Instruction: ds_write2_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2_b64:
+        ImplicitAccess: false
+        Instruction: ds_write2_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2st64_b32:
+        ImplicitAccess: false
+        Instruction: ds_write2st64_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write2st64_b64:
+        ImplicitAccess: false
+        Instruction: ds_write2st64_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 255
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_addtid_b32:
+        ImplicitAccess: false
+        Instruction: ds_write_addtid_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b128:
+        ImplicitAccess: false
+        Instruction: ds_write_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b16:
+        ImplicitAccess: false
+        Instruction: ds_write_b16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b16_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_write_b16_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b32:
+        ImplicitAccess: false
+        Instruction: ds_write_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b64:
+        ImplicitAccess: false
+        Instruction: ds_write_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b8:
+        ImplicitAccess: false
+        Instruction: ds_write_b8
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b8_d16_hi:
+        ImplicitAccess: false
+        Instruction: ds_write_b8_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_write_b96:
+        ImplicitAccess: false
+        Instruction: ds_write_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 65535
+        WaitCount: 1
+        WaitQueues:
+        - DSQueue
+      ds_wrxchg2_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2st64_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2st64_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg2st64_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg2st64_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_wrxchg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_wrxchg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_b32:
+        ImplicitAccess: false
+        Instruction: ds_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_b64:
+        ImplicitAccess: false
+        Instruction: ds_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_rtn_b32:
+        ImplicitAccess: false
+        Instruction: ds_xor_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      ds_xor_rtn_b64:
+        ImplicitAccess: false
+        Instruction: ds_xor_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      exp:
+        ImplicitAccess: false
+        Instruction: exp
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umax:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umin:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: flat_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b128:
+        ImplicitAccess: false
+        Instruction: flat_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b32:
+        ImplicitAccess: false
+        Instruction: flat_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b64:
+        ImplicitAccess: false
+        Instruction: flat_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_b96:
+        ImplicitAccess: false
+        Instruction: flat_load_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dword:
+        ImplicitAccess: false
+        Instruction: flat_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: flat_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_i16:
+        ImplicitAccess: false
+        Instruction: flat_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_i8:
+        ImplicitAccess: false
+        Instruction: flat_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_short_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_short_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_short_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_sshort:
+        ImplicitAccess: false
+        Instruction: flat_load_sshort
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_u16:
+        ImplicitAccess: false
+        Instruction: flat_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_u8:
+        ImplicitAccess: false
+        Instruction: flat_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte_d16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_load_ushort:
+        ImplicitAccess: false
+        Instruction: flat_load_ushort
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b128:
+        ImplicitAccess: false
+        Instruction: flat_store_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b16:
+        ImplicitAccess: false
+        Instruction: flat_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b32:
+        ImplicitAccess: false
+        Instruction: flat_store_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b64:
+        ImplicitAccess: false
+        Instruction: flat_store_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b8:
+        ImplicitAccess: false
+        Instruction: flat_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_b96:
+        ImplicitAccess: false
+        Instruction: flat_store_b96
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_byte:
+        ImplicitAccess: false
+        Instruction: flat_store_byte
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_store_byte_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: flat_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: flat_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dword:
+        ImplicitAccess: false
+        Instruction: flat_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: flat_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_short:
+        ImplicitAccess: false
+        Instruction: flat_store_short
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      flat_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: flat_store_short_d16_hi
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add:
+        ImplicitAccess: false
+        Instruction: global_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_add_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_add_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and:
+        ImplicitAccess: false
+        Instruction: global_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_and_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_and_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_cmpswap_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_cmpswap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_csub:
+        ImplicitAccess: false
+        Instruction: global_atomic_csub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_csub_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_csub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_dec_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_dec_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fcmpswap:
+        ImplicitAccess: false
+        Instruction: global_atomic_fcmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fmax:
+        ImplicitAccess: false
+        Instruction: global_atomic_fmax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_fmin:
+        ImplicitAccess: false
+        Instruction: global_atomic_fmin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_inc_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_inc_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_i32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_i64:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_max_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_max_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_f32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_i32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_i64:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_min_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_min_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or:
+        ImplicitAccess: false
+        Instruction: global_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_or_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_or_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smax:
+        ImplicitAccess: false
+        Instruction: global_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smax_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_smax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smin:
+        ImplicitAccess: false
+        Instruction: global_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_smin_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_smin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_u32:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_u64:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_sub_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_sub_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_swap_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_swap_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umax:
+        ImplicitAccess: false
+        Instruction: global_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umax_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_umax_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umin:
+        ImplicitAccess: false
+        Instruction: global_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_umin_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_umin_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_b32:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_b64:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_atomic_xor_x2:
+        ImplicitAccess: false
+        Instruction: global_atomic_xor_x2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_load_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_b128:
+        ImplicitAccess: false
+        Instruction: global_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b32:
+        ImplicitAccess: false
+        Instruction: global_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b64:
+        ImplicitAccess: false
+        Instruction: global_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_b96:
+        ImplicitAccess: false
+        Instruction: global_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: global_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: global_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dword:
+        ImplicitAccess: false
+        Instruction: global_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dword_addtid:
+        ImplicitAccess: false
+        Instruction: global_load_dword_addtid
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: global_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_i16:
+        ImplicitAccess: false
+        Instruction: global_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_i8:
+        ImplicitAccess: false
+        Instruction: global_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_load_lds_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: global_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: global_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: global_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: global_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: global_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_sbyte:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_short_d16:
+        ImplicitAccess: false
+        Instruction: global_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_sshort:
+        ImplicitAccess: false
+        Instruction: global_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_u16:
+        ImplicitAccess: false
+        Instruction: global_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_u8:
+        ImplicitAccess: false
+        Instruction: global_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_load_ubyte:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_load_ushort:
+        ImplicitAccess: false
+        Instruction: global_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      global_store_addtid_b32:
+        ImplicitAccess: false
+        Instruction: global_store_addtid_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b128:
+        ImplicitAccess: false
+        Instruction: global_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b16:
+        ImplicitAccess: false
+        Instruction: global_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b32:
+        ImplicitAccess: false
+        Instruction: global_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b64:
+        ImplicitAccess: false
+        Instruction: global_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_b8:
+        ImplicitAccess: false
+        Instruction: global_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_b96:
+        ImplicitAccess: false
+        Instruction: global_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_byte:
+        ImplicitAccess: false
+        Instruction: global_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: global_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: global_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dword:
+        ImplicitAccess: false
+        Instruction: global_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dword_addtid:
+        ImplicitAccess: false
+        Instruction: global_store_dword_addtid
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: global_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      global_store_short:
+        ImplicitAccess: false
+        Instruction: global_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      global_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: global_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      image_atomic_add:
+        ImplicitAccess: false
+        Instruction: image_atomic_add
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_and:
+        ImplicitAccess: false
+        Instruction: image_atomic_and
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_cmpswap:
+        ImplicitAccess: false
+        Instruction: image_atomic_cmpswap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_dec:
+        ImplicitAccess: false
+        Instruction: image_atomic_dec
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_inc:
+        ImplicitAccess: false
+        Instruction: image_atomic_inc
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_or:
+        ImplicitAccess: false
+        Instruction: image_atomic_or
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_smax:
+        ImplicitAccess: false
+        Instruction: image_atomic_smax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_smin:
+        ImplicitAccess: false
+        Instruction: image_atomic_smin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_sub:
+        ImplicitAccess: false
+        Instruction: image_atomic_sub
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_swap:
+        ImplicitAccess: false
+        Instruction: image_atomic_swap
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_umax:
+        ImplicitAccess: false
+        Instruction: image_atomic_umax
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_umin:
+        ImplicitAccess: false
+        Instruction: image_atomic_umin
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_atomic_xor:
+        ImplicitAccess: false
+        Instruction: image_atomic_xor
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_bvh64_intersect_ray:
+        ImplicitAccess: false
+        Instruction: image_bvh64_intersect_ray
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_bvh_intersect_ray:
+        ImplicitAccess: false
+        Instruction: image_bvh_intersect_ray
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4:
+        ImplicitAccess: false
+        Instruction: image_gather4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_b:
+        ImplicitAccess: false
+        Instruction: image_gather4_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_b_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c:
+        ImplicitAccess: false
+        Instruction: image_gather4_c
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_b:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_b_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_l:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_lz:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_c_lz_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_c_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_cl:
+        ImplicitAccess: false
+        Instruction: image_gather4_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_l:
+        ImplicitAccess: false
+        Instruction: image_gather4_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_lz:
+        ImplicitAccess: false
+        Instruction: image_gather4_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_lz_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4_o:
+        ImplicitAccess: false
+        Instruction: image_gather4_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_gather4h:
+        ImplicitAccess: false
+        Instruction: image_gather4h
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_get_lod:
+        ImplicitAccess: false
+        Instruction: image_get_lod
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_get_resinfo:
+        ImplicitAccess: false
+        Instruction: image_get_resinfo
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load:
+        ImplicitAccess: false
+        Instruction: image_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip:
+        ImplicitAccess: false
+        Instruction: image_load_mip
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip_pck:
+        ImplicitAccess: false
+        Instruction: image_load_mip_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_mip_pck_sgn:
+        ImplicitAccess: false
+        Instruction: image_load_mip_pck_sgn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_pck:
+        ImplicitAccess: false
+        Instruction: image_load_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_load_pck_sgn:
+        ImplicitAccess: false
+        Instruction: image_load_pck_sgn
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_msaa_load:
+        ImplicitAccess: false
+        Instruction: image_msaa_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample:
+        ImplicitAccess: false
+        Instruction: image_sample
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b:
+        ImplicitAccess: false
+        Instruction: image_sample_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_b_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_b_o:
+        ImplicitAccess: false
+        Instruction: image_sample_b_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c:
+        ImplicitAccess: false
+        Instruction: image_sample_c
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_b_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_b_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_cl_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_cl_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_d_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_c_d_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_l:
+        ImplicitAccess: false
+        Instruction: image_sample_c_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_l_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_l_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_lz:
+        ImplicitAccess: false
+        Instruction: image_sample_c_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_lz_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_c_o:
+        ImplicitAccess: false
+        Instruction: image_sample_c_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d:
+        ImplicitAccess: false
+        Instruction: image_sample_d
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_o:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_cl_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_cl_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_o:
+        ImplicitAccess: false
+        Instruction: image_sample_d_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_d_o_g16:
+        ImplicitAccess: false
+        Instruction: image_sample_d_o_g16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_l:
+        ImplicitAccess: false
+        Instruction: image_sample_l
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_l_o:
+        ImplicitAccess: false
+        Instruction: image_sample_l_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_lz:
+        ImplicitAccess: false
+        Instruction: image_sample_lz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_lz_o:
+        ImplicitAccess: false
+        Instruction: image_sample_lz_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_sample_o:
+        ImplicitAccess: false
+        Instruction: image_sample_o
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store:
+        ImplicitAccess: false
+        Instruction: image_store
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_mip:
+        ImplicitAccess: false
+        Instruction: image_store_mip
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_mip_pck:
+        ImplicitAccess: false
+        Instruction: image_store_mip_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      image_store_pck:
+        ImplicitAccess: false
+        Instruction: image_store_pck
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      lds_direct_load:
+        ImplicitAccess: false
+        Instruction: lds_direct_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      lds_param_load:
+        ImplicitAccess: false
+        Instruction: lds_param_load
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_abs_i32:
+        ImplicitAccess: false
+        Instruction: s_abs_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_absdiff_i32:
+        ImplicitAccess: false
+        Instruction: s_absdiff_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_f16:
+        ImplicitAccess: false
+        Instruction: s_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_f32:
+        ImplicitAccess: false
+        Instruction: s_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_i32:
+        ImplicitAccess: false
+        Instruction: s_add_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_add_u32:
+        ImplicitAccess: false
+        Instruction: s_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_addc_u32:
+        ImplicitAccess: false
+        Instruction: s_addc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_addk_i32:
+        ImplicitAccess: false
+        Instruction: s_addk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_b32:
+        ImplicitAccess: false
+        Instruction: s_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_b64:
+        ImplicitAccess: false
+        Instruction: s_and_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not0_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not0_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not0_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not0_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not0_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_not1_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_not1_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_not1_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_and_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_and_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_and_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn1_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn1_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn1_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_wrexec_b32:
+        ImplicitAccess: false
+        Instruction: s_andn2_wrexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_andn2_wrexec_b64:
+        ImplicitAccess: false
+        Instruction: s_andn2_wrexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ashr_i32:
+        ImplicitAccess: false
+        Instruction: s_ashr_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ashr_i64:
+        ImplicitAccess: false
+        Instruction: s_ashr_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_atc_probe:
+        ImplicitAccess: false
+        Instruction: s_atc_probe
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_atc_probe_buffer:
+        ImplicitAccess: false
+        Instruction: s_atc_probe_buffer
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_barrier:
+        ImplicitAccess: false
+        Instruction: s_barrier
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt0_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_bcnt0_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt0_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_bcnt0_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt1_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_bcnt1_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bcnt1_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_bcnt1_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_i32:
+        ImplicitAccess: false
+        Instruction: s_bfe_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_i64:
+        ImplicitAccess: false
+        Instruction: s_bfe_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_u32:
+        ImplicitAccess: false
+        Instruction: s_bfe_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfe_u64:
+        ImplicitAccess: false
+        Instruction: s_bfe_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfm_b32:
+        ImplicitAccess: false
+        Instruction: s_bfm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bfm_b64:
+        ImplicitAccess: false
+        Instruction: s_bfm_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp0_b32:
+        ImplicitAccess: false
+        Instruction: s_bitcmp0_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp0_b64:
+        ImplicitAccess: false
+        Instruction: s_bitcmp0_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp1_b32:
+        ImplicitAccess: false
+        Instruction: s_bitcmp1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitcmp1_b64:
+        ImplicitAccess: false
+        Instruction: s_bitcmp1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitreplicate_b64_b32:
+        ImplicitAccess: false
+        Instruction: s_bitreplicate_b64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset0_b32:
+        ImplicitAccess: false
+        Instruction: s_bitset0_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset0_b64:
+        ImplicitAccess: false
+        Instruction: s_bitset0_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset1_b32:
+        ImplicitAccess: false
+        Instruction: s_bitset1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_bitset1_b64:
+        ImplicitAccess: false
+        Instruction: s_bitset1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_branch:
+        ImplicitAccess: false
+        Instruction: s_branch
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_brev_b32:
+        ImplicitAccess: false
+        Instruction: s_brev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_brev_b64:
+        ImplicitAccess: false
+        Instruction: s_brev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_b128:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b256:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b256
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b32:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 1
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b512:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b512
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_b64:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 2
+        WaitQueues:
+        - SMemQueue
+      s_buffer_load_dword:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx16:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_buffer_load_dwordx8:
+        ImplicitAccess: false
+        Instruction: s_buffer_load_dwordx8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_call_b64:
+        ImplicitAccess: false
+        Instruction: s_call_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys_and_user:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys_and_user
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbgsys_or_user:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbgsys_or_user
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_cdbguser:
+        ImplicitAccess: false
+        Instruction: s_cbranch_cdbguser
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_execnz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_execnz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_execz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_execz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_scc0:
+        ImplicitAccess: false
+        Instruction: s_cbranch_scc0
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_scc1:
+        ImplicitAccess: false
+        Instruction: s_cbranch_scc1
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_vccnz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_vccnz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cbranch_vccz:
+        ImplicitAccess: false
+        Instruction: s_cbranch_vccz
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ceil_f16:
+        ImplicitAccess: false
+        Instruction: s_ceil_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ceil_f32:
+        ImplicitAccess: false
+        Instruction: s_ceil_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clause:
+        ImplicitAccess: false
+        Instruction: s_clause
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cls_i32:
+        ImplicitAccess: false
+        Instruction: s_cls_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cls_i32_i64:
+        ImplicitAccess: false
+        Instruction: s_cls_i32_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clz_i32_u32:
+        ImplicitAccess: false
+        Instruction: s_clz_i32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_clz_i32_u64:
+        ImplicitAccess: false
+        Instruction: s_clz_i32_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmov_b32:
+        ImplicitAccess: false
+        Instruction: s_cmov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmov_b64:
+        ImplicitAccess: false
+        Instruction: s_cmov_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmovk_i32:
+        ImplicitAccess: false
+        Instruction: s_cmovk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_eq_u64:
+        ImplicitAccess: false
+        Instruction: s_cmp_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ge_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_gt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_le_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lg_u64:
+        ImplicitAccess: false
+        Instruction: s_cmp_lg_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_lt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmp_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_neq_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_neq_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nge_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nge_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ngt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_ngt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nle_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nle_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlg_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlg_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlt_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_nlt_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_o_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_o_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_u_f16:
+        ImplicitAccess: false
+        Instruction: s_cmp_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmp_u_f32:
+        ImplicitAccess: false
+        Instruction: s_cmp_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_eq_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_eq_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_ge_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_ge_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_gt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_gt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_le_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_le_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lg_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lg_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lg_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lg_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lt_i32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cmpk_lt_u32:
+        ImplicitAccess: false
+        Instruction: s_cmpk_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_code_end:
+        ImplicitAccess: false
+        Instruction: s_code_end
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cselect_b32:
+        ImplicitAccess: false
+        Instruction: s_cselect_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cselect_b64:
+        ImplicitAccess: false
+        Instruction: s_cselect_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ctz_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_ctz_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ctz_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_ctz_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f16_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_f16:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_i32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_f32_u32:
+        ImplicitAccess: false
+        Instruction: s_cvt_f32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_hi_f32_f16:
+        ImplicitAccess: false
+        Instruction: s_cvt_hi_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_i32_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_pk_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_pk_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_cvt_u32_f32:
+        ImplicitAccess: false
+        Instruction: s_cvt_u32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_dcache_inv:
+        ImplicitAccess: false
+        Instruction: s_dcache_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_decperflevel:
+        ImplicitAccess: false
+        Instruction: s_decperflevel
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_delay_alu:
+        ImplicitAccess: false
+        Instruction: s_delay_alu
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_denorm_mode:
+        ImplicitAccess: false
+        Instruction: s_denorm_mode
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_endpgm:
+        ImplicitAccess: false
+        Instruction: s_endpgm
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues:
+        - FinalInstruction
+      s_endpgm_ordered_ps_done:
+        ImplicitAccess: false
+        Instruction: s_endpgm_ordered_ps_done
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_endpgm_saved:
+        ImplicitAccess: false
+        Instruction: s_endpgm_saved
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ff1_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_ff1_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ff1_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_ff1_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_b32:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_b64:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_flbit_i32_i64:
+        ImplicitAccess: false
+        Instruction: s_flbit_i32_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_floor_f16:
+        ImplicitAccess: false
+        Instruction: s_floor_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_floor_f32:
+        ImplicitAccess: false
+        Instruction: s_floor_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: s_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmac_f16:
+        ImplicitAccess: false
+        Instruction: s_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmac_f32:
+        ImplicitAccess: false
+        Instruction: s_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: s_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_getpc_b64:
+        ImplicitAccess: false
+        Instruction: s_getpc_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_getreg_b32:
+        ImplicitAccess: false
+        Instruction: s_getreg_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_gl1_inv:
+        ImplicitAccess: false
+        Instruction: s_gl1_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_icache_inv:
+        ImplicitAccess: false
+        Instruction: s_icache_inv
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_incperflevel:
+        ImplicitAccess: false
+        Instruction: s_incperflevel
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_inst_prefetch:
+        ImplicitAccess: false
+        Instruction: s_inst_prefetch
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_b128:
+        ImplicitAccess: false
+        Instruction: s_load_b128
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b256:
+        ImplicitAccess: false
+        Instruction: s_load_b256
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b32:
+        ImplicitAccess: false
+        Instruction: s_load_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b512:
+        ImplicitAccess: false
+        Instruction: s_load_b512
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_b64:
+        ImplicitAccess: false
+        Instruction: s_load_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues:
+        - SMemQueue
+      s_load_dword:
+        ImplicitAccess: false
+        Instruction: s_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx16:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_load_dwordx8:
+        ImplicitAccess: false
+        Instruction: s_load_dwordx8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl1_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl1_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl2_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl2_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl3_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl3_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl4_add_u32:
+        ImplicitAccess: false
+        Instruction: s_lshl4_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl_b32:
+        ImplicitAccess: false
+        Instruction: s_lshl_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshl_b64:
+        ImplicitAccess: false
+        Instruction: s_lshl_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshr_b32:
+        ImplicitAccess: false
+        Instruction: s_lshr_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_lshr_b64:
+        ImplicitAccess: false
+        Instruction: s_lshr_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_f16:
+        ImplicitAccess: false
+        Instruction: s_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_f32:
+        ImplicitAccess: false
+        Instruction: s_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_i32:
+        ImplicitAccess: false
+        Instruction: s_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_max_u32:
+        ImplicitAccess: false
+        Instruction: s_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_f16:
+        ImplicitAccess: false
+        Instruction: s_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_f32:
+        ImplicitAccess: false
+        Instruction: s_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_i32:
+        ImplicitAccess: false
+        Instruction: s_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_min_u32:
+        ImplicitAccess: false
+        Instruction: s_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mov_b32:
+        ImplicitAccess: false
+        Instruction: s_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mov_b64:
+        ImplicitAccess: false
+        Instruction: s_mov_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movk_i32:
+        ImplicitAccess: false
+        Instruction: s_movk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movreld_b32:
+        ImplicitAccess: false
+        Instruction: s_movreld_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movreld_b64:
+        ImplicitAccess: false
+        Instruction: s_movreld_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrels_b32:
+        ImplicitAccess: false
+        Instruction: s_movrels_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrels_b64:
+        ImplicitAccess: false
+        Instruction: s_movrels_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_movrelsd_2_b32:
+        ImplicitAccess: false
+        Instruction: s_movrelsd_2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_f16:
+        ImplicitAccess: false
+        Instruction: s_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_f32:
+        ImplicitAccess: false
+        Instruction: s_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_hi_i32:
+        ImplicitAccess: false
+        Instruction: s_mul_hi_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_hi_u32:
+        ImplicitAccess: false
+        Instruction: s_mul_hi_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mul_i32:
+        ImplicitAccess: false
+        Instruction: s_mul_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_mulk_i32:
+        ImplicitAccess: false
+        Instruction: s_mulk_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_b32:
+        ImplicitAccess: false
+        Instruction: s_nand_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_b64:
+        ImplicitAccess: false
+        Instruction: s_nand_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_nand_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nand_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_nand_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nop:
+        ImplicitAccess: false
+        Instruction: s_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_b32:
+        ImplicitAccess: false
+        Instruction: s_nor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_b64:
+        ImplicitAccess: false
+        Instruction: s_nor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_nor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_nor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_nor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_not_b32:
+        ImplicitAccess: false
+        Instruction: s_not_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_not_b64:
+        ImplicitAccess: false
+        Instruction: s_not_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_b32:
+        ImplicitAccess: false
+        Instruction: s_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_b64:
+        ImplicitAccess: false
+        Instruction: s_or_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not0_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not0_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not0_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not0_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not1_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not1_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_not1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_not1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_not1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_or_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_or_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_or_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn1_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_orn1_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn1_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_orn1_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_b32:
+        ImplicitAccess: false
+        Instruction: s_orn2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_b64:
+        ImplicitAccess: false
+        Instruction: s_orn2_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_orn2_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_orn2_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_orn2_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_hh_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_hh_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_hl_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_hl_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_lh_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_lh_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_pack_ll_b32_b16:
+        ImplicitAccess: false
+        Instruction: s_pack_ll_b32_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_quadmask_b32:
+        ImplicitAccess: false
+        Instruction: s_quadmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_quadmask_b64:
+        ImplicitAccess: false
+        Instruction: s_quadmask_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rfe_b64:
+        ImplicitAccess: false
+        Instruction: s_rfe_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rndne_f16:
+        ImplicitAccess: false
+        Instruction: s_rndne_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_rndne_f32:
+        ImplicitAccess: false
+        Instruction: s_rndne_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_round_mode:
+        ImplicitAccess: false
+        Instruction: s_round_mode
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsg:
+        ImplicitAccess: false
+        Instruction: s_sendmsg
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: 1
+        WaitQueues:
+        - SendMsgQueue
+      s_sendmsg_rtn_b32:
+        ImplicitAccess: false
+        Instruction: s_sendmsg_rtn_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsg_rtn_b64:
+        ImplicitAccess: false
+        Instruction: s_sendmsg_rtn_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sendmsghalt:
+        ImplicitAccess: false
+        Instruction: s_sendmsghalt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_set_inst_prefetch_distance:
+        ImplicitAccess: false
+        Instruction: s_set_inst_prefetch_distance
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sethalt:
+        ImplicitAccess: false
+        Instruction: s_sethalt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setkill:
+        ImplicitAccess: false
+        Instruction: s_setkill
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setpc_b64:
+        ImplicitAccess: false
+        Instruction: s_setpc_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setprio:
+        ImplicitAccess: false
+        Instruction: s_setprio
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setreg_b32:
+        ImplicitAccess: false
+        Instruction: s_setreg_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_setreg_imm32_b32:
+        ImplicitAccess: false
+        Instruction: s_setreg_imm32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sext_i32_i16:
+        ImplicitAccess: false
+        Instruction: s_sext_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sext_i32_i8:
+        ImplicitAccess: false
+        Instruction: s_sext_i32_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sleep:
+        ImplicitAccess: false
+        Instruction: s_sleep
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_f16:
+        ImplicitAccess: false
+        Instruction: s_sub_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_f32:
+        ImplicitAccess: false
+        Instruction: s_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_i32:
+        ImplicitAccess: false
+        Instruction: s_sub_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_sub_u32:
+        ImplicitAccess: false
+        Instruction: s_sub_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_subb_u32:
+        ImplicitAccess: false
+        Instruction: s_subb_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_swappc_b64:
+        ImplicitAccess: false
+        Instruction: s_swappc_b64
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trap:
+        ImplicitAccess: false
+        Instruction: s_trap
+        IsBranch: true
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trunc_f16:
+        ImplicitAccess: false
+        Instruction: s_trunc_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_trunc_f32:
+        ImplicitAccess: false
+        Instruction: s_trunc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ttracedata:
+        ImplicitAccess: false
+        Instruction: s_ttracedata
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_ttracedata_imm:
+        ImplicitAccess: false
+        Instruction: s_ttracedata_imm
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_version:
+        ImplicitAccess: false
+        Instruction: s_version
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wait_event:
+        ImplicitAccess: false
+        Instruction: s_wait_event
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wait_idle:
+        ImplicitAccess: false
+        Instruction: s_wait_idle
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_depctr:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_depctr
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_expcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_expcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_lgkmcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_lgkmcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_vmcnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_vmcnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_waitcnt_vscnt:
+        ImplicitAccess: false
+        Instruction: s_waitcnt_vscnt
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wakeup:
+        ImplicitAccess: false
+        Instruction: s_wakeup
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wqm_b32:
+        ImplicitAccess: false
+        Instruction: s_wqm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_wqm_b64:
+        ImplicitAccess: false
+        Instruction: s_wqm_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_b32:
+        ImplicitAccess: false
+        Instruction: s_xnor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_b64:
+        ImplicitAccess: false
+        Instruction: s_xnor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_xnor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xnor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_xnor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_b32:
+        ImplicitAccess: false
+        Instruction: s_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_b64:
+        ImplicitAccess: false
+        Instruction: s_xor_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_saveexec_b32:
+        ImplicitAccess: false
+        Instruction: s_xor_saveexec_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      s_xor_saveexec_b64:
+        ImplicitAccess: false
+        Instruction: s_xor_saveexec_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_b128:
+        ImplicitAccess: false
+        Instruction: scratch_load_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b32:
+        ImplicitAccess: false
+        Instruction: scratch_load_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b64:
+        ImplicitAccess: false
+        Instruction: scratch_load_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_b96:
+        ImplicitAccess: false
+        Instruction: scratch_load_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_d16_b16:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_hi_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_d16_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_d16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dword:
+        ImplicitAccess: false
+        Instruction: scratch_load_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx2:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx3:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_dwordx4:
+        ImplicitAccess: false
+        Instruction: scratch_load_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_i16:
+        ImplicitAccess: false
+        Instruction: scratch_load_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_b32:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_i16:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_i8:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_u16:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_lds_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_lds_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_sbyte:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sbyte_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sbyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_sbyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_short_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_short_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_sshort:
+        ImplicitAccess: false
+        Instruction: scratch_load_sshort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_u16:
+        ImplicitAccess: false
+        Instruction: scratch_load_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_u8:
+        ImplicitAccess: false
+        Instruction: scratch_load_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_load_ubyte:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ubyte_d16:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte_d16
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ubyte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_load_ubyte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_load_ushort:
+        ImplicitAccess: false
+        Instruction: scratch_load_ushort
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - LoadQueue
+      scratch_store_b128:
+        ImplicitAccess: false
+        Instruction: scratch_store_b128
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b16:
+        ImplicitAccess: false
+        Instruction: scratch_store_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_b32:
+        ImplicitAccess: false
+        Instruction: scratch_store_b32
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b64:
+        ImplicitAccess: false
+        Instruction: scratch_store_b64
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_b8:
+        ImplicitAccess: false
+        Instruction: scratch_store_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_b96:
+        ImplicitAccess: false
+        Instruction: scratch_store_b96
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_byte:
+        ImplicitAccess: false
+        Instruction: scratch_store_byte
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_byte_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_store_byte_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_d16_hi_b16:
+        ImplicitAccess: false
+        Instruction: scratch_store_d16_hi_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_d16_hi_b8:
+        ImplicitAccess: false
+        Instruction: scratch_store_d16_hi_b8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dword:
+        ImplicitAccess: false
+        Instruction: scratch_store_dword
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx2:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx3:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_dwordx4:
+        ImplicitAccess: false
+        Instruction: scratch_store_dwordx4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      scratch_store_short:
+        ImplicitAccess: false
+        Instruction: scratch_store_short
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      scratch_store_short_d16_hi:
+        ImplicitAccess: false
+        Instruction: scratch_store_short_d16_hi
+        IsBranch: false
+        Latency: -1
+        MaxLiteral: 4095
+        WaitCount: 0
+        WaitQueues:
+        - StoreQueue
+      tbuffer_load_d16_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_load_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_load_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_d16_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_d16_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_d16_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_d16_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_x:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_x
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xy:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xy
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xyz:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xyz
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      tbuffer_store_format_xyzw:
+        ImplicitAccess: false
+        Instruction: tbuffer_store_format_xyzw
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add3_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_add3_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add3_u32:
+        ImplicitAccess: false
+        Instruction: v_add3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_add_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_co_u32:
+        ImplicitAccess: false
+        Instruction: v_add_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f16:
+        ImplicitAccess: false
+        Instruction: v_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f32:
+        ImplicitAccess: false
+        Instruction: v_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_f64:
+        ImplicitAccess: false
+        Instruction: v_add_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_lshl_u32:
+        ImplicitAccess: false
+        Instruction: v_add_lshl_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_i16:
+        ImplicitAccess: false
+        Instruction: v_add_nc_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_i32:
+        ImplicitAccess: false
+        Instruction: v_add_nc_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_u16:
+        ImplicitAccess: false
+        Instruction: v_add_nc_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_add_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_add_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_alignbit_b32:
+        ImplicitAccess: false
+        Instruction: v_alignbit_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_alignbyte_b32:
+        ImplicitAccess: false
+        Instruction: v_alignbyte_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_b16:
+        ImplicitAccess: false
+        Instruction: v_and_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_b32:
+        ImplicitAccess: false
+        Instruction: v_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_and_or_b32:
+        ImplicitAccess: false
+        Instruction: v_and_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i16:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i32:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ashrrev_i64:
+        ImplicitAccess: false
+        Instruction: v_ashrrev_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bcnt_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_bcnt_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfe_i32:
+        ImplicitAccess: false
+        Instruction: v_bfe_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfe_u32:
+        ImplicitAccess: false
+        Instruction: v_bfe_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfi_b32:
+        ImplicitAccess: false
+        Instruction: v_bfi_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfm_b32:
+        ImplicitAccess: false
+        Instruction: v_bfm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_bfrev_b32:
+        ImplicitAccess: false
+        Instruction: v_bfrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f16:
+        ImplicitAccess: false
+        Instruction: v_ceil_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f32:
+        ImplicitAccess: false
+        Instruction: v_ceil_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ceil_f64:
+        ImplicitAccess: false
+        Instruction: v_ceil_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cls_i32:
+        ImplicitAccess: false
+        Instruction: v_cls_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_clz_i32_u32:
+        ImplicitAccess: false
+        Instruction: v_clz_i32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_class_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_class_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_eq_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_f_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_f_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ge_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ge_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_gt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_gt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_le_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_le_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_lt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_lt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ne_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ne_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_neq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_neq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_ngt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_ngt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nle_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nle_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_nlt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_nlt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_o_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_o_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_t_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_t_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_i32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_i64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_u32:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_tru_u64:
+        ImplicitAccess: false
+        Instruction: v_cmp_tru_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f16:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f32:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmp_u_f64:
+        ImplicitAccess: false
+        Instruction: v_cmp_u_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_class_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_class_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_eq_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_eq_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_f_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_f_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ge_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ge_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_gt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_gt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_le_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_le_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_lt_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_lt_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ne_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ne_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_neq_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_neq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nge_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nge_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_ngt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_ngt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nle_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nle_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlg_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlg_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_nlt_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_nlt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_o_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_o_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_t_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_t_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_i32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_i64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_i64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_u32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_tru_u64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_tru_u64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f16:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f32:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cmpx_u_f64:
+        ImplicitAccess: false
+        Instruction: v_cmpx_u_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cndmask_b16:
+        ImplicitAccess: false
+        Instruction: v_cndmask_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cndmask_b32:
+        ImplicitAccess: false
+        Instruction: v_cndmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cos_f16:
+        ImplicitAccess: false
+        Instruction: v_cos_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cos_f32:
+        ImplicitAccess: false
+        Instruction: v_cos_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ctz_i32_b32:
+        ImplicitAccess: false
+        Instruction: v_ctz_i32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubeid_f32:
+        ImplicitAccess: false
+        Instruction: v_cubeid_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubema_f32:
+        ImplicitAccess: false
+        Instruction: v_cubema_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubesc_f32:
+        ImplicitAccess: false
+        Instruction: v_cubesc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cubetc_f32:
+        ImplicitAccess: false
+        Instruction: v_cubetc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_i16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f16_u16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f16_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte0:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte0
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte1:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte1
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte2:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte2
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f32_ubyte3:
+        ImplicitAccess: false
+        Instruction: v_cvt_f32_ubyte3
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_f64_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_f64_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_floor_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_floor_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_flr_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_flr_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_i32_i16:
+        ImplicitAccess: false
+        Instruction: v_cvt_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_nearest_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_nearest_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_norm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_norm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_norm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_norm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_off_f32_i4:
+        ImplicitAccess: false
+        Instruction: v_cvt_off_f32_i4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_i16_i32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_i16_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_norm_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_norm_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u16_u32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u16_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pk_u8_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pk_u8_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_i16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_i16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pknorm_u16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pknorm_u16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_pkrtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_pkrtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_rpi_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_rpi_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u16_f16:
+        ImplicitAccess: false
+        Instruction: v_cvt_u16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_f32:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_f64:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_cvt_u32_u16:
+        ImplicitAccess: false
+        Instruction: v_cvt_u32_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f16:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f32:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fixup_f64:
+        ImplicitAccess: false
+        Instruction: v_div_fixup_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fmas_f32:
+        ImplicitAccess: false
+        Instruction: v_div_fmas_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_fmas_f64:
+        ImplicitAccess: false
+        Instruction: v_div_fmas_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_scale_f32:
+        ImplicitAccess: false
+        Instruction: v_div_scale_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_div_scale_f64:
+        ImplicitAccess: false
+        Instruction: v_div_scale_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_bf16_bf16:
+        ImplicitAccess: false
+        Instruction: v_dot2_bf16_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f16_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f32_bf16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f32_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2acc_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2acc_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot2c_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dot2c_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_i32_i8:
+        ImplicitAccess: false
+        Instruction: v_dot4_i32_i8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_i32_iu8:
+        ImplicitAccess: false
+        Instruction: v_dot4_i32_iu8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot4_u32_u8:
+        ImplicitAccess: false
+        Instruction: v_dot4_u32_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_i32_i4:
+        ImplicitAccess: false
+        Instruction: v_dot8_i32_i4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_i32_iu4:
+        ImplicitAccess: false
+        Instruction: v_dot8_i32_iu4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dot8_u32_u4:
+        ImplicitAccess: false
+        Instruction: v_dot8_u32_u4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_add_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_add_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_add_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_dual_add_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_and_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_and_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_cndmask_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_cndmask_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_dot2acc_f32_bf16:
+        ImplicitAccess: false
+        Instruction: v_dual_dot2acc_f32_bf16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_dot2acc_f32_f16:
+        ImplicitAccess: false
+        Instruction: v_dual_dot2acc_f32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmac_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_lshlrev_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_lshlrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_max_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_min_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mov_b32:
+        ImplicitAccess: false
+        Instruction: v_dual_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mul_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_mul_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_mul_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_sub_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_dual_subrev_f32:
+        ImplicitAccess: false
+        Instruction: v_dual_subrev_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_exp_f16:
+        ImplicitAccess: false
+        Instruction: v_exp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_exp_f32:
+        ImplicitAccess: false
+        Instruction: v_exp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbh_i32:
+        ImplicitAccess: false
+        Instruction: v_ffbh_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbh_u32:
+        ImplicitAccess: false
+        Instruction: v_ffbh_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ffbl_b32:
+        ImplicitAccess: false
+        Instruction: v_ffbl_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f16:
+        ImplicitAccess: false
+        Instruction: v_floor_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f32:
+        ImplicitAccess: false
+        Instruction: v_floor_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_floor_f64:
+        ImplicitAccess: false
+        Instruction: v_floor_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_f64:
+        ImplicitAccess: false
+        Instruction: v_fma_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mix_f32:
+        ImplicitAccess: false
+        Instruction: v_fma_mix_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mixhi_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_mixhi_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fma_mixlo_f16:
+        ImplicitAccess: false
+        Instruction: v_fma_mixlo_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmaak_f16:
+        ImplicitAccess: false
+        Instruction: v_fmaak_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmaak_f32:
+        ImplicitAccess: false
+        Instruction: v_fmaak_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_f16:
+        ImplicitAccess: false
+        Instruction: v_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmac_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_fmac_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmamk_f16:
+        ImplicitAccess: false
+        Instruction: v_fmamk_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fmamk_f32:
+        ImplicitAccess: false
+        Instruction: v_fmamk_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f16:
+        ImplicitAccess: false
+        Instruction: v_fract_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f32:
+        ImplicitAccess: false
+        Instruction: v_fract_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_fract_f64:
+        ImplicitAccess: false
+        Instruction: v_fract_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i16_f16:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i16_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i32_f32:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i32_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_exp_i32_f64:
+        ImplicitAccess: false
+        Instruction: v_frexp_exp_i32_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f16:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f32:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_frexp_mant_f64:
+        ImplicitAccess: false
+        Instruction: v_frexp_mant_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p10_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p10_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_new_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_new_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_interp_p2_rtz_f16_f32:
+        ImplicitAccess: false
+        Instruction: v_interp_p2_rtz_f16_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f16:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f32:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_ldexp_f64:
+        ImplicitAccess: false
+        Instruction: v_ldexp_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lerp_u8:
+        ImplicitAccess: false
+        Instruction: v_lerp_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_log_f16:
+        ImplicitAccess: false
+        Instruction: v_log_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_log_f32:
+        ImplicitAccess: false
+        Instruction: v_log_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshl_add_u32:
+        ImplicitAccess: false
+        Instruction: v_lshl_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshl_or_b32:
+        ImplicitAccess: false
+        Instruction: v_lshl_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b16:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b32:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshlrev_b64:
+        ImplicitAccess: false
+        Instruction: v_lshlrev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b16:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b32:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_lshrrev_b64:
+        ImplicitAccess: false
+        Instruction: v_lshrrev_b64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i16:
+        ImplicitAccess: false
+        Instruction: v_mad_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i32_i16:
+        ImplicitAccess: false
+        Instruction: v_mad_i32_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mad_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_i64_i32:
+        ImplicitAccess: false
+        Instruction: v_mad_i64_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u16:
+        ImplicitAccess: false
+        Instruction: v_mad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u32_u16:
+        ImplicitAccess: false
+        Instruction: v_mad_u32_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mad_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mad_u64_u32:
+        ImplicitAccess: false
+        Instruction: v_mad_u64_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_f16:
+        ImplicitAccess: false
+        Instruction: v_max3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_f32:
+        ImplicitAccess: false
+        Instruction: v_max3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_i16:
+        ImplicitAccess: false
+        Instruction: v_max3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_i32:
+        ImplicitAccess: false
+        Instruction: v_max3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_u16:
+        ImplicitAccess: false
+        Instruction: v_max3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max3_u32:
+        ImplicitAccess: false
+        Instruction: v_max3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f16:
+        ImplicitAccess: false
+        Instruction: v_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f32:
+        ImplicitAccess: false
+        Instruction: v_max_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_f64:
+        ImplicitAccess: false
+        Instruction: v_max_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_i16:
+        ImplicitAccess: false
+        Instruction: v_max_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_i32:
+        ImplicitAccess: false
+        Instruction: v_max_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_u16:
+        ImplicitAccess: false
+        Instruction: v_max_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_max_u32:
+        ImplicitAccess: false
+        Instruction: v_max_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_f16:
+        ImplicitAccess: false
+        Instruction: v_maxmin_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_f32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_i32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_maxmin_u32:
+        ImplicitAccess: false
+        Instruction: v_maxmin_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mbcnt_hi_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_mbcnt_hi_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mbcnt_lo_u32_b32:
+        ImplicitAccess: false
+        Instruction: v_mbcnt_lo_u32_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_f16:
+        ImplicitAccess: false
+        Instruction: v_med3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_f32:
+        ImplicitAccess: false
+        Instruction: v_med3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_i16:
+        ImplicitAccess: false
+        Instruction: v_med3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_i32:
+        ImplicitAccess: false
+        Instruction: v_med3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_u16:
+        ImplicitAccess: false
+        Instruction: v_med3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_med3_u32:
+        ImplicitAccess: false
+        Instruction: v_med3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_f16:
+        ImplicitAccess: false
+        Instruction: v_min3_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_f32:
+        ImplicitAccess: false
+        Instruction: v_min3_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_i16:
+        ImplicitAccess: false
+        Instruction: v_min3_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_i32:
+        ImplicitAccess: false
+        Instruction: v_min3_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_u16:
+        ImplicitAccess: false
+        Instruction: v_min3_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min3_u32:
+        ImplicitAccess: false
+        Instruction: v_min3_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f16:
+        ImplicitAccess: false
+        Instruction: v_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f32:
+        ImplicitAccess: false
+        Instruction: v_min_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_f64:
+        ImplicitAccess: false
+        Instruction: v_min_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_i16:
+        ImplicitAccess: false
+        Instruction: v_min_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_i32:
+        ImplicitAccess: false
+        Instruction: v_min_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_u16:
+        ImplicitAccess: false
+        Instruction: v_min_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_min_u32:
+        ImplicitAccess: false
+        Instruction: v_min_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_f16:
+        ImplicitAccess: false
+        Instruction: v_minmax_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_f32:
+        ImplicitAccess: false
+        Instruction: v_minmax_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_i32:
+        ImplicitAccess: false
+        Instruction: v_minmax_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_minmax_u32:
+        ImplicitAccess: false
+        Instruction: v_minmax_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mov_b16:
+        ImplicitAccess: false
+        Instruction: v_mov_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mov_b32:
+        ImplicitAccess: false
+        Instruction: v_mov_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movreld_b32:
+        ImplicitAccess: false
+        Instruction: v_movreld_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrels_b32:
+        ImplicitAccess: false
+        Instruction: v_movrels_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrelsd_2_b32:
+        ImplicitAccess: false
+        Instruction: v_movrelsd_2_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_movrelsd_b32:
+        ImplicitAccess: false
+        Instruction: v_movrelsd_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mqsad_pk_u16_u8:
+        ImplicitAccess: false
+        Instruction: v_mqsad_pk_u16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mqsad_u32_u8:
+        ImplicitAccess: false
+        Instruction: v_mqsad_u32_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_msad_u8:
+        ImplicitAccess: false
+        Instruction: v_msad_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_dx9_zero_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_dx9_zero_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f16:
+        ImplicitAccess: false
+        Instruction: v_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_f64:
+        ImplicitAccess: false
+        Instruction: v_mul_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_i32:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_u32:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_hi_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mul_hi_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_i32_i24:
+        ImplicitAccess: false
+        Instruction: v_mul_i32_i24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_legacy_f32:
+        ImplicitAccess: false
+        Instruction: v_mul_legacy_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_lo_u16:
+        ImplicitAccess: false
+        Instruction: v_mul_lo_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_lo_u32:
+        ImplicitAccess: false
+        Instruction: v_mul_lo_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mul_u32_u24:
+        ImplicitAccess: false
+        Instruction: v_mul_u32_u24
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_mullit_f32:
+        ImplicitAccess: false
+        Instruction: v_mullit_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_nop:
+        ImplicitAccess: false
+        Instruction: v_nop
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_not_b16:
+        ImplicitAccess: false
+        Instruction: v_not_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_not_b32:
+        ImplicitAccess: false
+        Instruction: v_not_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or3_b32:
+        ImplicitAccess: false
+        Instruction: v_or3_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or_b16:
+        ImplicitAccess: false
+        Instruction: v_or_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_or_b32:
+        ImplicitAccess: false
+        Instruction: v_or_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pack_b32_f16:
+        ImplicitAccess: false
+        Instruction: v_pack_b32_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_perm_b32:
+        ImplicitAccess: false
+        Instruction: v_perm_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlane16_b32:
+        ImplicitAccess: false
+        Instruction: v_permlane16_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlane64_b32:
+        ImplicitAccess: false
+        Instruction: v_permlane64_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_permlanex16_b32:
+        ImplicitAccess: false
+        Instruction: v_permlanex16_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pipeflush:
+        ImplicitAccess: false
+        Instruction: v_pipeflush
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_add_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_add_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_ashrrev_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_ashrrev_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_fma_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_fma_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_fmac_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_fmac_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_lshlrev_b16:
+        ImplicitAccess: false
+        Instruction: v_pk_lshlrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_lshrrev_b16:
+        ImplicitAccess: false
+        Instruction: v_pk_lshrrev_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mad_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_mad_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mad_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_mad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_max_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_max_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_min_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_min_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mul_f16:
+        ImplicitAccess: false
+        Instruction: v_pk_mul_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_mul_lo_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_mul_lo_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_sub_i16:
+        ImplicitAccess: false
+        Instruction: v_pk_sub_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_pk_sub_u16:
+        ImplicitAccess: false
+        Instruction: v_pk_sub_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_qsad_pk_u16_u8:
+        ImplicitAccess: false
+        Instruction: v_qsad_pk_u16_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f16:
+        ImplicitAccess: false
+        Instruction: v_rcp_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f32:
+        ImplicitAccess: false
+        Instruction: v_rcp_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_f64:
+        ImplicitAccess: false
+        Instruction: v_rcp_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rcp_iflag_f32:
+        ImplicitAccess: false
+        Instruction: v_rcp_iflag_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_readfirstlane_b32:
+        ImplicitAccess: false
+        Instruction: v_readfirstlane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_readlane_b32:
+        ImplicitAccess: false
+        Instruction: v_readlane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f16:
+        ImplicitAccess: false
+        Instruction: v_rndne_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f32:
+        ImplicitAccess: false
+        Instruction: v_rndne_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rndne_f64:
+        ImplicitAccess: false
+        Instruction: v_rndne_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f16:
+        ImplicitAccess: false
+        Instruction: v_rsq_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f32:
+        ImplicitAccess: false
+        Instruction: v_rsq_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_rsq_f64:
+        ImplicitAccess: false
+        Instruction: v_rsq_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_hi_u8:
+        ImplicitAccess: false
+        Instruction: v_sad_hi_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u16:
+        ImplicitAccess: false
+        Instruction: v_sad_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u32:
+        ImplicitAccess: false
+        Instruction: v_sad_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sad_u8:
+        ImplicitAccess: false
+        Instruction: v_sad_u8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sat_pk_u8_i16:
+        ImplicitAccess: false
+        Instruction: v_sat_pk_u8_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sin_f16:
+        ImplicitAccess: false
+        Instruction: v_sin_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sin_f32:
+        ImplicitAccess: false
+        Instruction: v_sin_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f16:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f32:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sqrt_f64:
+        ImplicitAccess: false
+        Instruction: v_sqrt_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_co_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_f16:
+        ImplicitAccess: false
+        Instruction: v_sub_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_f32:
+        ImplicitAccess: false
+        Instruction: v_sub_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_i16:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_i16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_i32:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_i32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_u16:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_u16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_sub_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_sub_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_co_ci_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_co_ci_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_co_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_co_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_f16:
+        ImplicitAccess: false
+        Instruction: v_subrev_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_f32:
+        ImplicitAccess: false
+        Instruction: v_subrev_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_subrev_nc_u32:
+        ImplicitAccess: false
+        Instruction: v_subrev_nc_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swap_b16:
+        ImplicitAccess: false
+        Instruction: v_swap_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swap_b32:
+        ImplicitAccess: false
+        Instruction: v_swap_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_swaprel_b32:
+        ImplicitAccess: false
+        Instruction: v_swaprel_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trig_preop_f64:
+        ImplicitAccess: false
+        Instruction: v_trig_preop_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f16:
+        ImplicitAccess: false
+        Instruction: v_trunc_f16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f32:
+        ImplicitAccess: false
+        Instruction: v_trunc_f32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_trunc_f64:
+        ImplicitAccess: false
+        Instruction: v_trunc_f64
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_wmma_bf16_16x16x16_bf16:
+        ImplicitAccess: false
+        Instruction: v_wmma_bf16_16x16x16_bf16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f16_16x16x16_f16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f16_16x16x16_f16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f32_16x16x16_bf16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f32_16x16x16_bf16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_f32_16x16x16_f16:
+        ImplicitAccess: false
+        Instruction: v_wmma_f32_16x16x16_f16
+        IsBranch: false
+        Latency: 16
+        MaxLiteral: 0
+        WaitCount: 0
+        WaitQueues: []
+      v_wmma_i32_16x16x16_iu4:
+        ImplicitAccess: false
+        Instruction: v_wmma_i32_16x16x16_iu4
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_wmma_i32_16x16x16_iu8:
+        ImplicitAccess: false
+        Instruction: v_wmma_i32_16x16x16_iu8
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_writelane_b32:
+        ImplicitAccess: false
+        Instruction: v_writelane_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xad_u32:
+        ImplicitAccess: false
+        Instruction: v_xad_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xnor_b32:
+        ImplicitAccess: false
+        Instruction: v_xnor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor3_b32:
+        ImplicitAccess: false
+        Instruction: v_xor3_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_add_u32:
+        ImplicitAccess: false
+        Instruction: v_xor_add_u32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_b16:
+        ImplicitAccess: false
+        Instruction: v_xor_b16
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []
+      v_xor_b32:
+        ImplicitAccess: false
+        Instruction: v_xor_b32
+        IsBranch: false
+        Latency: 0
+        MaxLiteral: 0
+        WaitCount: -1
+        WaitQueues: []

--- a/shared/rocroller/lib/include/rocRoller/CodeGen/MemoryInstructions_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/CodeGen/MemoryInstructions_impl.hpp
@@ -243,10 +243,13 @@ namespace rocRoller
         AssertFatal(numBytes > 0 && (numBytes < m_wordSize || numBytes % m_wordSize == 0),
                     "Invalid number of bytes");
 
-        auto ctx = m_context.lock();
-        co_yield addLargerOffset2Addr(offset, addr, "global_load_dword");
+        auto        ctx = m_context.lock();
+        const auto& gpu = ctx->targetArchitecture().target();
+        co_yield addLargerOffset2Addr(
+            offset, addr, gpu.isGFX11GPU() ? "global_load_b32" : "global_load_dword");
 
-        co_yield addLargerOffset2Addr(offset, addr, "flat_load_dword");
+        co_yield addLargerOffset2Addr(
+            offset, addr, gpu.isGFX11GPU() ? "flat_load_b32" : "flat_load_dword");
 
         if(numBytes < m_wordSize)
         {
@@ -289,13 +292,18 @@ namespace rocRoller
             {
                 auto width = chooseWidth(
                     numWords - count, potentialWords, ctx->kernelOptions()->loadGlobalWidth);
-                auto offsetModifier = genOffsetModifier(offset + count * m_wordSize);
-                co_yield_(Instruction(
-                    concatenate("global_load_dword", width == 1 ? "" : "x" + std::to_string(width)),
-                    {dest->subset(Generated(iota(count, count + width)))},
-                    {addr},
-                    {"off", offsetModifier},
-                    "Load value"));
+                auto        offsetModifier = genOffsetModifier(offset + count * m_wordSize);
+                std::string opString;
+                if(gpu.isGFX11GPU())
+                    opString = "global_load_b" + std::to_string(width * 32);
+                else
+                    opString
+                        = "global_load_dword" + (width == 1 ? "" : "x" + std::to_string(width));
+                co_yield_(Instruction(opString,
+                                      {dest->subset(Generated(iota(count, count + width)))},
+                                      {addr},
+                                      {"off", offsetModifier},
+                                      "Load value"));
                 count += width;
             }
         }
@@ -314,10 +322,13 @@ namespace rocRoller
         AssertFatal(numBytes > 0 && (numBytes < m_wordSize || numBytes % m_wordSize == 0),
                     "Invalid number of bytes");
 
-        auto ctx = m_context.lock();
-        co_yield addLargerOffset2Addr(offset, addr, "global_store_dword");
+        auto        ctx = m_context.lock();
+        const auto& gpu = ctx->targetArchitecture().target();
+        co_yield addLargerOffset2Addr(
+            offset, addr, gpu.isGFX11GPU() ? "global_store_b32" : "global_store_dword");
 
-        co_yield addLargerOffset2Addr(offset, addr, "flat_store_dword");
+        co_yield addLargerOffset2Addr(
+            offset, addr, gpu.isGFX11GPU() ? "flat_store_b32" : "flat_store_dword");
 
         if(numBytes < m_wordSize)
         {
@@ -361,9 +372,18 @@ namespace rocRoller
                 auto width = chooseWidth(
                     numWords - count, potentialWords, ctx->kernelOptions()->storeGlobalWidth);
                 // Find the largest store instruction that can be used
-                auto offsetModifier = genOffsetModifier(offset + count * m_wordSize);
-                co_yield_(Instruction(concatenate("global_store_dword",
-                                                  width == 1 ? "" : "x" + std::to_string(width)),
+                auto        offsetModifier     = genOffsetModifier(offset + count * m_wordSize);
+                std::string instruction_string = "";
+                if(gpu.isGFX11GPU())
+                {
+                    instruction_string = concatenate("global_store_b", std::to_string(width * 32));
+                }
+                else
+                {
+                    instruction_string = concatenate("global_store_dword",
+                                                     width == 1 ? "" : "x" + std::to_string(width));
+                }
+                co_yield_(Instruction(instruction_string,
                                       {},
                                       {addr, data->subset(Generated(iota(count, count + width)))},
                                       {"off", offsetModifier},
@@ -388,17 +408,26 @@ namespace rocRoller
 
         auto offsetLiteral = Register::Value::Literal(offset);
 
-        std::string instruction_string
-            = concatenate("s_load_dword",
-                          (numBytes > 4 ? "x" : ""),
-                          (numBytes > 4 ? std::to_string(numBytes / 4) : ""));
+        auto        ctx                = m_context.lock();
+        const auto& gpu                = ctx->targetArchitecture().target();
+        std::string instruction_string = "";
+        if(gpu.isGFX11GPU())
+        {
+            instruction_string
+                = concatenate("s_load_b", (numBytes > 4 ? std::to_string(numBytes * 8) : "32"));
+        }
+        else
+        {
+            instruction_string = concatenate("s_load_dword",
+                                             (numBytes > 4 ? "x" : ""),
+                                             (numBytes > 4 ? std::to_string(numBytes / 4) : ""));
+        }
 
         std::string modifier = glc ? "glc" : "";
 
         co_yield_(Instruction(
             instruction_string, {dest}, {base, offsetLiteral}, {modifier}, "Load scalar value"));
 
-        auto ctx = m_context.lock();
         if(ctx->kernelOptions()->alwaysWaitAfterLoad)
             co_yield Instruction::Wait(
                 WaitCount::Zero(ctx->targetArchitecture(), "DEBUG: Wait after load"));
@@ -415,17 +444,25 @@ namespace rocRoller
 
         auto offsetLiteral = Register::Value::Literal(offset);
 
-        std::string instruction_string
-            = concatenate("s_store_dword",
-                          (numBytes > 4 ? "x" : ""),
-                          (numBytes > 4 ? std::to_string(numBytes / 4) : ""));
-
+        auto        ctx                = m_context.lock();
+        const auto& gpu                = ctx->targetArchitecture().target();
+        std::string instruction_string = "";
+        if(gpu.isGFX11GPU())
+        {
+            instruction_string
+                = concatenate("s_store_b", (numBytes > 4 ? std::to_string(numBytes * 8) : "32"));
+        }
+        else
+        {
+            instruction_string = concatenate("s_store_dword",
+                                             (numBytes > 4 ? "x" : ""),
+                                             (numBytes > 4 ? std::to_string(numBytes / 4) : ""));
+        }
         std::string modifier = glc ? "glc" : "";
 
         co_yield_(Instruction(
             instruction_string, {}, {data, addr, offsetLiteral}, {modifier}, "Store scalar value"));
 
-        auto ctx = m_context.lock();
         if(ctx->kernelOptions()->alwaysWaitAfterStore)
             co_yield Instruction::Wait(
                 WaitCount::Zero(ctx->targetArchitecture(), "DEBUG: Wait after store"));
@@ -606,8 +643,11 @@ namespace rocRoller
                     "Operation doesn't support hi argument for sizes of "
                         + std::to_string(numBytes));
 
-        auto ctx = m_context.lock();
-        co_yield addLargerOffset2Addr(offset, addr, "buffer_load_dword");
+        auto        ctx     = m_context.lock();
+        const auto& gpu     = ctx->targetArchitecture().target();
+        std::string opStart = "buffer_load_";
+
+        co_yield addLargerOffset2Addr(offset, addr, opStart + (gpu.isGFX11GPU() ? "b32" : "dword"));
 
         std::string offsetModifier = "", glc = "", slc = "", lds = "";
         if(buffOpts.offen || offset == 0)
@@ -641,22 +681,22 @@ namespace rocRoller
                 {
                     AssertFatal(m_context.lock()->targetArchitecture().HasCapability(
                         GPUCapability::HasMFMA_fp8));
-                    opEnd += "ubyte_d16_hi";
+                    opEnd += gpu.isGFX11GPU() ? "d16_hi_u8" : "ubyte_d16_hi";
                 }
                 else
-                    opEnd += "ubyte";
+                    opEnd += gpu.isGFX11GPU() ? "u8" : "ubyte";
             }
             else if(numBytes == 2)
             {
                 if(high)
-                    opEnd += "short_d16_hi";
+                    opEnd += gpu.isGFX11GPU() ? "d16_hi_b16" : "short_d16_hi";
                 else
-                    opEnd += "ushort";
+                    opEnd += gpu.isGFX11GPU() ? "u16" : "ushort";
             }
-            const auto& gpu = ctx->targetArchitecture().target();
-            const auto  soffset
-                = gpu.isGFX12GPU() ? Register::Value::NullLiteral() : Register::Value::Literal(0);
-            co_yield_(Instruction("buffer_load_" + opEnd,
+            const auto soffset = gpu.isGFX11GPU() || gpu.isGFX12GPU()
+                                     ? Register::Value::NullLiteral()
+                                     : Register::Value::Literal(0);
+            co_yield_(Instruction(opStart + opEnd,
                                   {dest},
                                   {addr, sgprSrd, soffset},
                                   {"offen", offsetModifier, glc, slc, lds},
@@ -672,15 +712,24 @@ namespace rocRoller
             {
                 auto width = chooseWidth(
                     numWords - count, potentialWords, ctx->kernelOptions()->loadGlobalWidth);
-                auto       offsetModifier = genOffsetModifier(offset + count * m_wordSize);
-                const auto soffset        = gpu.isGFX12GPU() ? Register::Value::NullLiteral()
-                                                             : Register::Value::Literal(0);
-                co_yield_(Instruction(
-                    concatenate("buffer_load_dword", width == 1 ? "" : "x" + std::to_string(width)),
-                    {dest->subset(Generated(iota(count, count + width)))},
-                    {addr, sgprSrd, soffset},
-                    {"offen", offsetModifier, glc, slc, lds},
-                    "Load value"));
+                auto        offsetModifier = genOffsetModifier(offset + count * m_wordSize);
+                const auto  soffset        = gpu.isGFX11GPU() || gpu.isGFX12GPU()
+                                                 ? Register::Value::NullLiteral()
+                                                 : Register::Value::Literal(0);
+                std::string opFull;
+                if(gpu.isGFX11GPU())
+                {
+                    opFull = concatenate(opStart, "b", std::to_string(width * 32));
+                }
+                else
+                {
+                    opFull = concatenate(opStart, width == 1 ? "" : "x" + std::to_string(width));
+                }
+                co_yield_(Instruction(opFull,
+                                      {dest->subset(Generated(iota(count, count + width)))},
+                                      {addr, sgprSrd, soffset},
+                                      {"offen", offsetModifier, glc, slc, lds},
+                                      "Load value"));
                 count += width;
             }
         }
@@ -784,8 +833,10 @@ namespace rocRoller
                         && ((numBytes < m_wordSize && numBytes != 3) || numBytes % m_wordSize == 0),
                     "Invalid number of bytes");
 
-        auto ctx = m_context.lock();
-        co_yield addLargerOffset2Addr(offset, addr, "buffer_store_dword");
+        auto        ctx     = m_context.lock();
+        const auto& gpu     = ctx->targetArchitecture().target();
+        std::string opStart = "buffer_store_";
+        co_yield addLargerOffset2Addr(offset, addr, opStart + (gpu.isGFX11GPU() ? "b32" : "dword"));
 
         std::string offsetModifier = "", glc = "", slc = "", sc1 = "", lds = "";
         if(buffOpts.offen || offset == 0)
@@ -830,24 +881,29 @@ namespace rocRoller
             AssertFatal(numBytes <= 2);
             if(numBytes == 1)
             {
-                opEnd += "byte";
                 if(high)
                 {
                     AssertFatal(m_context.lock()->targetArchitecture().HasCapability(
                         GPUCapability::HasMFMA_fp8));
-                    opEnd += "_d16_hi";
+                    opEnd += gpu.isGFX11GPU() ? "d16_hi_b8" : "byte_d16_hi";
+                }
+                else
+                {
+                    opEnd += gpu.isGFX11GPU() ? "b8" : "byte";
                 }
             }
             else if(numBytes == 2)
             {
-                opEnd += "short";
                 if(high)
-                    opEnd += "_d16_hi";
+                    opEnd += gpu.isGFX11GPU() ? "d16_hi_b16" : "short_d16_hi";
+                else
+                    opEnd += gpu.isGFX11GPU() ? "b16" : "short";
             }
-            const auto& gpu = ctx->targetArchitecture().target();
-            const auto  soffset
-                = gpu.isGFX12GPU() ? Register::Value::NullLiteral() : Register::Value::Literal(0);
-            co_yield_(Instruction("buffer_store_" + opEnd,
+            const auto& gpu     = ctx->targetArchitecture().target();
+            const auto  soffset = gpu.isGFX11GPU() || gpu.isGFX12GPU()
+                                      ? Register::Value::NullLiteral()
+                                      : Register::Value::Literal(0);
+            co_yield_(Instruction(opStart + opEnd,
                                   {},
                                   {data, addr, sgprSrd, soffset},
                                   {"offen", offsetModifier, glc, slc, sc1, lds},
@@ -879,10 +935,15 @@ namespace rocRoller
                 {
                     dataSubset = data->subset(Generated(iota(count, count + width)));
                 }
-                const auto soffset = gpu.isGFX12GPU() ? Register::Value::NullLiteral()
-                                                      : Register::Value::Literal(0);
-                co_yield_(Instruction(concatenate("buffer_store_dword",
-                                                  width == 1 ? "" : "x" + std::to_string(width)),
+                const auto  soffset = gpu.isGFX11GPU() || gpu.isGFX12GPU()
+                                          ? Register::Value::NullLiteral()
+                                          : Register::Value::Literal(0);
+                std::string opFull;
+                if(gpu.isGFX11GPU())
+                    opFull = concatenate(opStart, "b", std::to_string(width * 32));
+                else
+                    opFull = concatenate(opStart, width == 1 ? "" : "x" + std::to_string(width));
+                co_yield_(Instruction(opFull,
                                       {},
                                       {dataSubset, addr, sgprSrd, soffset},
                                       {"offen", offsetModifier, glc, slc, sc1, lds},

--- a/shared/rocroller/lib/include/rocRoller/CodeGen/WaitCount.hpp
+++ b/shared/rocroller/lib/include/rocRoller/CodeGen/WaitCount.hpp
@@ -147,6 +147,7 @@ namespace rocRoller
 
         bool m_isSplitCounter = false;
         bool m_hasVSCnt       = false;
+        bool m_vsCntHasDest   = false;
         bool m_hasEXPCnt      = false;
     };
 

--- a/shared/rocroller/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp
+++ b/shared/rocroller/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp
@@ -65,6 +65,10 @@ namespace rocRoller
         GFX1011,
         GFX1012,
         GFX1030,
+        GFX1150,
+        GFX1151,
+        GFX1152,
+        GFX1153,
         GFX1200,
         GFX1201,
 
@@ -137,6 +141,12 @@ namespace rocRoller
             return false;
         }
 
+        constexpr bool isRDNA35GPU() const
+        {
+            return gfx == GPUArchitectureGFX::GFX1150 || gfx == GPUArchitectureGFX::GFX1151
+                   || gfx == GPUArchitectureGFX::GFX1152 || gfx == GPUArchitectureGFX::GFX1153;
+        }
+
         constexpr bool isRDNA4GPU() const
         {
             return gfx == GPUArchitectureGFX::GFX1200 || gfx == GPUArchitectureGFX::GFX1201;
@@ -144,7 +154,7 @@ namespace rocRoller
 
         constexpr bool isRDNAGPU() const
         {
-            return isRDNA1GPU() || isRDNA2GPU() || isRDNA3GPU() || isRDNA4GPU();
+            return isRDNA1GPU() || isRDNA2GPU() || isRDNA3GPU() || isRDNA35GPU() || isRDNA4GPU();
         }
 
         constexpr bool isCDNAGPU() const
@@ -160,6 +170,11 @@ namespace rocRoller
         constexpr bool isGFX10GPU() const
         {
             return isRDNA1GPU() || isRDNA2GPU();
+        }
+
+        constexpr bool isGFX11GPU() const
+        {
+            return isRDNA3GPU() || isRDNA35GPU();
         }
 
         constexpr bool isGFX12GPU() const
@@ -203,7 +218,7 @@ namespace rocRoller
         return target.name();
     }
 
-    constexpr std::array<rocRoller::GPUArchitectureTarget, 16> SupportedArchitectures
+    constexpr std::array<rocRoller::GPUArchitectureTarget, 20> SupportedArchitectures
         = {GPUArchitectureTarget{GPUArchitectureGFX::GFX908},
            GPUArchitectureTarget{GPUArchitectureGFX::GFX908, {.xnack = true}},
            GPUArchitectureTarget{GPUArchitectureGFX::GFX908, {.sramecc = true}},
@@ -218,6 +233,10 @@ namespace rocRoller
            GPUArchitectureTarget{GPUArchitectureGFX::GFX1012},
            GPUArchitectureTarget{GPUArchitectureGFX::GFX1012, {.xnack = true}},
            GPUArchitectureTarget{GPUArchitectureGFX::GFX1030},
+           GPUArchitectureTarget{GPUArchitectureGFX::GFX1150},
+           GPUArchitectureTarget{GPUArchitectureGFX::GFX1151},
+           GPUArchitectureTarget{GPUArchitectureGFX::GFX1152},
+           GPUArchitectureTarget{GPUArchitectureGFX::GFX1153},
            GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
            GPUArchitectureTarget{GPUArchitectureGFX::GFX1201}};
 }

--- a/shared/rocroller/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget_impl.hpp
@@ -63,6 +63,14 @@ namespace rocRoller
             return "gfx1012";
         case GPUArchitectureGFX::GFX1030:
             return "gfx1030";
+        case GPUArchitectureGFX::GFX1150:
+            return "gfx1150";
+        case GPUArchitectureGFX::GFX1151:
+            return "gfx1151";
+        case GPUArchitectureGFX::GFX1152:
+            return "gfx1152";
+        case GPUArchitectureGFX::GFX1153:
+            return "gfx1153";
         case GPUArchitectureGFX::GFX1200:
             return "gfx1200";
         case GPUArchitectureGFX::GFX1201:
@@ -93,6 +101,11 @@ namespace rocRoller
             return "AMD RDNA 1";
         case GPUArchitectureGFX::GFX1030:
             return "AMD RDNA 2";
+        case GPUArchitectureGFX::GFX1150:
+        case GPUArchitectureGFX::GFX1151:
+        case GPUArchitectureGFX::GFX1152:
+        case GPUArchitectureGFX::GFX1153:
+            return "AMD RDNA 3.5";
         case GPUArchitectureGFX::GFX1200:
         case GPUArchitectureGFX::GFX1201:
             return "AMD RDNA 4";

--- a/shared/rocroller/lib/source/CodeGen/WaitCount.cpp
+++ b/shared/rocroller/lib/source/CodeGen/WaitCount.cpp
@@ -37,6 +37,7 @@ namespace rocRoller
     {
         m_isSplitCounter = arch.HasCapability(GPUCapability::HasSplitWaitCounters);
         m_hasVSCnt       = arch.HasCapability(GPUCapability::SeparateVscnt);
+        m_vsCntHasDest   = arch.target().isGFX11GPU();
         m_hasEXPCnt      = arch.HasCapability(GPUCapability::HasExpcnt);
         if(message.length() > 0)
         {
@@ -59,6 +60,7 @@ namespace rocRoller
         , m_expcnt(expcnt)
         , m_isSplitCounter(arch.HasCapability(GPUCapability::HasSplitWaitCounters))
         , m_hasVSCnt(arch.HasCapability(GPUCapability::SeparateVscnt))
+        , m_vsCntHasDest(arch.target().isGFX11GPU())
         , m_hasEXPCnt(arch.HasCapability(GPUCapability::HasExpcnt))
     {
     }
@@ -449,7 +451,7 @@ namespace rocRoller
         {
             AssertFatal(m_hasVSCnt, "VSCnt is not a valid counter in target architecture");
 
-            os << "s_waitcnt_vscnt " << m_vscnt;
+            os << "s_waitcnt_vscnt " << (m_vsCntHasDest ? "null " : "") << m_vscnt;
 
             if(commentIter != m_comments.end())
             {

--- a/shared/rocroller/test/catch/ConvertPropagationTest.cpp
+++ b/shared/rocroller/test/catch/ConvertPropagationTest.cpp
@@ -282,6 +282,8 @@ namespace ExpressionTest
             auto const& arch = context->targetArchitecture().target();
             if(arch.isGFX12GPU())
                 SKIP("Instruction not supported on gfx12");
+            if(arch.isGFX11GPU())
+                SKIP("Instruction not supported on gfx11");
 
             auto expr = [&](Expression::ExpressionPtr a,
                             Expression::ExpressionPtr b,
@@ -348,6 +350,8 @@ namespace ExpressionTest
             auto const& arch    = context->targetArchitecture().target();
             if(arch.isGFX12GPU())
                 SKIP("Instruction not supported on gfx12");
+            if(arch.isGFX11GPU())
+                SKIP("Instruction not supported on gfx11");
 
             auto typeResult = DataType::Int32;
 

--- a/shared/rocroller/test/catch/WMMAHazardObserverTest.cpp
+++ b/shared/rocroller/test/catch/WMMAHazardObserverTest.cpp
@@ -53,9 +53,14 @@ namespace WMMAObserverTests
         }
     };
 
-    TEST_CASE("RAW hazards on GFX1200/GFX1201", "[codegen]")
+    TEST_CASE("RAW hazards on GFX115x/GFX120x", "[codegen]")
     {
-        auto target = GENERATE(GPUArchitectureGFX::GFX1200, GPUArchitectureGFX::GFX1201);
+        auto             target = GENERATE(GPUArchitectureGFX::GFX1150,
+                               GPUArchitectureGFX::GFX1151,
+                               GPUArchitectureGFX::GFX1152,
+                               GPUArchitectureGFX::GFX1153,
+                               GPUArchitectureGFX::GFX1200,
+                               GPUArchitectureGFX::GFX1201);
         WMMAObserverTest t{target};
 
         { // A/B is previous D
@@ -175,9 +180,14 @@ namespace WMMAObserverTests
         }
     }
 
-    TEST_CASE("WAR/WAW hazards on GFX1200/GFX1201", "[codegen]")
+    TEST_CASE("WAR/WAW hazards on GFX115x/GFX120x", "[codegen]")
     {
-        auto target = GENERATE(GPUArchitectureGFX::GFX1200, GPUArchitectureGFX::GFX1201);
+        auto             target = GENERATE(GPUArchitectureGFX::GFX1150,
+                               GPUArchitectureGFX::GFX1151,
+                               GPUArchitectureGFX::GFX1152,
+                               GPUArchitectureGFX::GFX1153,
+                               GPUArchitectureGFX::GFX1200,
+                               GPUArchitectureGFX::GFX1201);
         WMMAObserverTest t{target};
 
         const auto v0 = t.createRegisters(Register::Type::Vector, DataType::Half, 4);

--- a/shared/rocroller/test/catch/WMMAObserverUnitTest.cpp
+++ b/shared/rocroller/test/catch/WMMAObserverUnitTest.cpp
@@ -43,9 +43,14 @@ namespace WMMAObserverUnitTests
             : TestContext(TestContext::ForTarget({gfx})){};
     };
 
-    TEST_CASE("Unit test observer regarding WMMA hazards on GFX1200/1201", "[observer]")
+    TEST_CASE("Unit test observer regarding WMMA hazards on GFX115x/120x", "[observer]")
     {
-        auto target = GENERATE(GPUArchitectureGFX::GFX1200, GPUArchitectureGFX::GFX1201);
+        auto                 target = GENERATE(GPUArchitectureGFX::GFX1150,
+                               GPUArchitectureGFX::GFX1151,
+                               GPUArchitectureGFX::GFX1152,
+                               GPUArchitectureGFX::GFX1153,
+                               GPUArchitectureGFX::GFX1200,
+                               GPUArchitectureGFX::GFX1201);
         WMMAObserverUnitTest t{target};
         std::string          opCode{"v_wmma_f32_16x16x16_f16"};
         auto                 ctx = t.get();

--- a/shared/rocroller/test/unit/CMakeLists.txt
+++ b/shared/rocroller/test/unit/CMakeLists.txt
@@ -97,7 +97,7 @@ target_sources(rocroller-tests
         "${CMAKE_CURRENT_SOURCE_DIR}/MFMAHazardObserverTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MFMAUnitObserverTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MatrixMultiplyTestGFX9.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/MatrixMultiplyTestGFX120X.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/MatrixMultiplyTestRDNAGPU.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MemoryInstructionsTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MetaObserverTest.cpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MixedArithmeticTest.cpp"

--- a/shared/rocroller/test/unit/CopyGeneratorTest.cpp
+++ b/shared/rocroller/test/unit/CopyGeneratorTest.cpp
@@ -62,6 +62,14 @@ namespace CopyGeneratorTest
         }
     };
 
+    class CopyGenerator1150Test : public GenericContextFixture
+    {
+        GPUArchitectureTarget targetArchitecture() override
+        {
+            return {GPUArchitectureGFX::GFX1150};
+        }
+    };
+
     class CopyGenerator1200Test : public GenericContextFixture
     {
         GPUArchitectureTarget targetArchitecture() override
@@ -158,6 +166,12 @@ namespace CopyGeneratorTest
     }
 
     TEST_F(CopyGenerator94xTest, ensureTypeCommutative)
+    {
+        testEnsureTypeCommutative(m_context);
+        EXPECT_EQ(NormalizedSource("v_mov_b32 v1, 65536"), NormalizedSource(output()));
+    }
+
+    TEST_F(CopyGenerator1150Test, ensureTypeCommutative)
     {
         testEnsureTypeCommutative(m_context);
         EXPECT_EQ(NormalizedSource("v_mov_b32 v1, 65536"), NormalizedSource(output()));
@@ -655,6 +669,30 @@ namespace CopyGeneratorTest
             HasHipSuccess(0));
 
         EXPECT_EQ(std::memcmp(resultValue, expectedValue, size), 0);
+    }
+
+    TEST_F(CopyGenerator1150Test, NoAccVGPR)
+    {
+        auto literal = Register::Value::Literal(1);
+        auto vgpr
+            = std::make_shared<Register::Value>(m_context,
+                                                Register::Type::Vector,
+                                                DataType::Int32,
+                                                1,
+                                                Register::AllocationOptions::FullyContiguous());
+        auto accVGPR
+            = std::make_shared<Register::Value>(m_context,
+                                                Register::Type::Accumulator,
+                                                DataType::Int32,
+                                                1,
+                                                Register::AllocationOptions::FullyContiguous());
+
+        EXPECT_THROW({ m_context->schedule(m_context->copier()->copy(accVGPR, literal)); },
+                     FatalError);
+        EXPECT_THROW({ m_context->schedule(m_context->copier()->copy(accVGPR, vgpr)); },
+                     FatalError);
+        EXPECT_THROW({ m_context->schedule(m_context->copier()->copy(vgpr, accVGPR)); },
+                     FatalError);
     }
 
     TEST_F(CopyGenerator1200Test, NoAccVGPR)

--- a/shared/rocroller/test/unit/EnumToStringTest.cpp
+++ b/shared/rocroller/test/unit/EnumToStringTest.cpp
@@ -165,6 +165,10 @@ TEST(EnumToStringTest, ALL)
         {GPUArchitectureGFX::GFX942, "gfx942"},
         {GPUArchitectureGFX::GFX1012, "gfx1012"},
         {GPUArchitectureGFX::GFX1030, "gfx1030"},
+        {GPUArchitectureGFX::GFX1150, "gfx1150"},
+        {GPUArchitectureGFX::GFX1151, "gfx1151"},
+        {GPUArchitectureGFX::GFX1152, "gfx1152"},
+        {GPUArchitectureGFX::GFX1153, "gfx1153"},
         {GPUArchitectureGFX::GFX1200, "gfx1200"},
         {GPUArchitectureGFX::GFX1201, "gfx1201"},
     });

--- a/shared/rocroller/test/unit/GPUArchitectureTest.cpp
+++ b/shared/rocroller/test/unit/GPUArchitectureTest.cpp
@@ -168,12 +168,36 @@ TEST_F(GPUArchitectureTest, WaveFrontSize)
                   {GPUArchitectureGFX::GFX1030}, GPUCapability::DefaultWavefrontSize),
               32);
 
+    EXPECT_EQ(GPUArchitectureLibrary::getInstance()->HasCapability({GPUArchitectureGFX::GFX1150},
+                                                                   GPUCapability::HasWave32),
+              true);
+    EXPECT_EQ(GPUArchitectureLibrary::getInstance()->HasCapability({GPUArchitectureGFX::GFX1151},
+                                                                   GPUCapability::HasWave32),
+              true);
+    EXPECT_EQ(GPUArchitectureLibrary::getInstance()->HasCapability({GPUArchitectureGFX::GFX1152},
+                                                                   GPUCapability::HasWave32),
+              true);
+    EXPECT_EQ(GPUArchitectureLibrary::getInstance()->HasCapability({GPUArchitectureGFX::GFX1153},
+                                                                   GPUCapability::HasWave32),
+              true);
     EXPECT_EQ(GPUArchitectureLibrary::getInstance()->HasCapability({GPUArchitectureGFX::GFX1200},
                                                                    GPUCapability::HasWave32),
               true);
     EXPECT_EQ(GPUArchitectureLibrary::getInstance()->HasCapability({GPUArchitectureGFX::GFX1201},
                                                                    GPUCapability::HasWave32),
               true);
+    EXPECT_EQ(GPUArchitectureLibrary::getInstance()->GetCapability(
+                  {GPUArchitectureGFX::GFX1150}, GPUCapability::DefaultWavefrontSize),
+              32);
+    EXPECT_EQ(GPUArchitectureLibrary::getInstance()->GetCapability(
+                  {GPUArchitectureGFX::GFX1151}, GPUCapability::DefaultWavefrontSize),
+              32);
+    EXPECT_EQ(GPUArchitectureLibrary::getInstance()->GetCapability(
+                  {GPUArchitectureGFX::GFX1152}, GPUCapability::DefaultWavefrontSize),
+              32);
+    EXPECT_EQ(GPUArchitectureLibrary::getInstance()->GetCapability(
+                  {GPUArchitectureGFX::GFX1153}, GPUCapability::DefaultWavefrontSize),
+              32);
     EXPECT_EQ(GPUArchitectureLibrary::getInstance()->GetCapability(
                   {GPUArchitectureGFX::GFX1200}, GPUCapability::DefaultWavefrontSize),
               32);

--- a/shared/rocroller/test/unit/MatrixMultiplyTestRDNAGPU.cpp
+++ b/shared/rocroller/test/unit/MatrixMultiplyTestRDNAGPU.cpp
@@ -32,7 +32,7 @@ namespace MatrixMultiplyTest
     namespace SolutionParams = rocRoller::Parameters::Solution;
 
     // Params are: (AB type, waveK), (transA, transB), loadPathAB
-    class WMMATestGFX120X
+    class WMMATestRDNAGPU
         : public BaseMatrixMultiplyContextFixture<std::tuple<std::pair<rocRoller::DataType, int>,
                                                              std::pair<std::string, std::string>,
                                                              SolutionParams::LoadPath>>
@@ -40,7 +40,7 @@ namespace MatrixMultiplyTest
     };
 
     // Params are: (AB type, waveK), (transA, transB), loadPathAB
-    class F16AccWMMATestGFX120X
+    class F16AccWMMATestRDNAGPU
         : public BaseMatrixMultiplyContextFixture<std::tuple<std::pair<rocRoller::DataType, int>,
                                                              std::pair<std::string, std::string>,
                                                              SolutionParams::LoadPath>>
@@ -48,7 +48,7 @@ namespace MatrixMultiplyTest
     };
 
     // Params are: A type, B type, waveK, (transA, transB), loadPathAB
-    class MixedWMMATestGFX120X
+    class MixedWMMATestRDNAGPU
         : public BaseMatrixMultiplyContextFixture<std::tuple<rocRoller::DataType,
                                                              rocRoller::DataType,
                                                              int,
@@ -58,12 +58,12 @@ namespace MatrixMultiplyTest
     };
 
     // Params: waveK, laodPathAB
-    class ABCWMMATestGFX120X
+    class ABCWMMATestRDNAGPU
         : public BaseMatrixMultiplyContextFixture<std::tuple<int, SolutionParams::LoadPath>>
     {
     };
 
-    TEST_P(WMMATestGFX120X, GPU_MatrixMultiplyMacroTileWMMA)
+    TEST_P(WMMATestRDNAGPU, GPU_MatrixMultiplyMacroTileWMMA)
     {
         const auto [typeAndWaveK, transOp, loadPathB] = std::get<1>(GetParam());
         const auto [typeAB, waveK]                    = typeAndWaveK;
@@ -95,7 +95,7 @@ namespace MatrixMultiplyTest
         EXPECT_EQ(countSubstring(generatedCode, wmmaMnemonic), numWMMAs);
     }
 
-    TEST_P(F16AccWMMATestGFX120X, GPU_MatrixMultiplyMacroTileWMMA)
+    TEST_P(F16AccWMMATestRDNAGPU, GPU_MatrixMultiplyMacroTileWMMA)
     {
         const auto [typeAndWaveK, transOp, loadPathB] = std::get<1>(GetParam());
         const auto [dataType, waveK]                  = typeAndWaveK;
@@ -140,7 +140,7 @@ namespace MatrixMultiplyTest
         EXPECT_EQ(countSubstring(generatedCode, wmmaMnemonic), numWMMAs);
     }
 
-    TEST_P(WMMATestGFX120X, GPU_MatrixMultiplyABWMMA)
+    TEST_P(WMMATestRDNAGPU, GPU_MatrixMultiplyABWMMA)
     {
         const auto [typeAndWaveK, transOp, loadPathAB] = std::get<1>(GetParam());
         const auto [typeAB, waveK]                     = typeAndWaveK;
@@ -173,7 +173,7 @@ namespace MatrixMultiplyTest
         EXPECT_EQ(countSubstring(generatedCode, wmmaMnemonic), numWMMAs);
     }
 
-    TEST_P(F16AccWMMATestGFX120X, GPU_MatrixMultiplyABWMMA)
+    TEST_P(F16AccWMMATestRDNAGPU, GPU_MatrixMultiplyABWMMA)
     {
         const auto [typeAndWaveK, transOp, loadPathAB] = std::get<1>(GetParam());
         const auto [typeAB, waveK]                     = typeAndWaveK;
@@ -218,7 +218,7 @@ namespace MatrixMultiplyTest
         EXPECT_EQ(countSubstring(generatedCode, wmmaMnemonic), numWMMAs);
     }
 
-    TEST_P(MixedWMMATestGFX120X, GPU_MatrixMultiplyMacroTileMixedWMMA)
+    TEST_P(MixedWMMATestRDNAGPU, GPU_MatrixMultiplyMacroTileMixedWMMA)
     {
         const auto [typeA, typeB, waveK, transOp, loadPathB] = std::get<1>(GetParam());
         const auto [transA, transB]                          = transOp;
@@ -266,7 +266,7 @@ namespace MatrixMultiplyTest
         EXPECT_EQ(countSubstring(generatedCode, wmmaMnemonic), numWMMAs);
     }
 
-    TEST_P(MixedWMMATestGFX120X, GPU_MatrixMultiplyABMixedWMMA)
+    TEST_P(MixedWMMATestRDNAGPU, GPU_MatrixMultiplyABMixedWMMA)
     {
         const auto [typeA, typeB, waveK, transOp, loadPathAB] = std::get<1>(GetParam());
         const auto [transA, transB]                           = transOp;
@@ -316,7 +316,7 @@ namespace MatrixMultiplyTest
         EXPECT_EQ(countSubstring(generatedCode, wmmaMnemonic), numWMMAs);
     }
 
-    TEST_P(ABCWMMATestGFX120X, GPU_MatrixMultiplyABCF16AccWMMAFP16)
+    TEST_P(ABCWMMATestRDNAGPU, GPU_MatrixMultiplyABCF16AccWMMAFP16)
     {
         const auto [waveK, loadPathAB] = std::get<1>(GetParam());
         REQUIRE_ARCH_CAP(GPUCapability::HasWMMA_F16_ACC);
@@ -337,7 +337,7 @@ namespace MatrixMultiplyTest
         EXPECT_EQ(countSubstring(generatedCode, wmmaMnemonic), numWMMAs);
     }
 
-    TEST_P(ABCWMMATestGFX120X, GPU_MatrixMultiplyABCF16AccWMMABFloat16)
+    TEST_P(ABCWMMATestRDNAGPU, GPU_MatrixMultiplyABCF16AccWMMABFloat16)
     {
         const auto [waveK, loadPathAB] = std::get<1>(GetParam());
         REQUIRE_ARCH_CAP(GPUCapability::HasWMMA_F16_ACC);
@@ -359,10 +359,14 @@ namespace MatrixMultiplyTest
     }
 
     INSTANTIATE_TEST_SUITE_P(
-        MatrixMultiply120X,
-        WMMATestGFX120X,
+        MatrixMultiplyRDNAGPU,
+        WMMATestRDNAGPU,
         ::testing::Combine(
-            ::testing::Values(GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
+            ::testing::Values(GPUArchitectureTarget{GPUArchitectureGFX::GFX1150},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1151},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1152},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1153},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
                               GPUArchitectureTarget{GPUArchitectureGFX::GFX1201}),
             ::testing::Combine(
                 ::testing::Values(std::make_pair(rocRoller::DataType::Half, /*waveK*/ 16),
@@ -374,10 +378,14 @@ namespace MatrixMultiplyTest
                 ::testing::Values(SolutionParams::LoadPath::BufferToLDSViaVGPR))));
 
     INSTANTIATE_TEST_SUITE_P(
-        MatrixMultiply120X,
-        F16AccWMMATestGFX120X,
+        MatrixMultiplyRDNAGPU,
+        F16AccWMMATestRDNAGPU,
         ::testing::Combine(
-            ::testing::Values(GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
+            ::testing::Values(GPUArchitectureTarget{GPUArchitectureGFX::GFX1150},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1151},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1152},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1153},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
                               GPUArchitectureTarget{GPUArchitectureGFX::GFX1201}),
             ::testing::Combine(
                 ::testing::Values(std::make_pair(rocRoller::DataType::Half, /*waveK*/ 16),
@@ -389,8 +397,8 @@ namespace MatrixMultiplyTest
                 ::testing::Values(SolutionParams::LoadPath::BufferToLDSViaVGPR))));
 
     INSTANTIATE_TEST_SUITE_P(
-        MatrixMultiply120X,
-        MixedWMMATestGFX120X,
+        MatrixMultiplyRDNAGPU,
+        MixedWMMATestRDNAGPU,
         ::testing::Combine(
             ::testing::Values(GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
                               GPUArchitectureTarget{GPUArchitectureGFX::GFX1201}),
@@ -405,19 +413,27 @@ namespace MatrixMultiplyTest
                 ::testing::Values(SolutionParams::LoadPath::BufferToLDSViaVGPR))));
 
     INSTANTIATE_TEST_SUITE_P(
-        MatrixMultiplyABC120X,
-        ABCWMMATestGFX120X,
+        MatrixMultiplyABCRDNAGPU,
+        ABCWMMATestRDNAGPU,
         ::testing::Combine(
-            ::testing::Values(GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
+            ::testing::Values(GPUArchitectureTarget{GPUArchitectureGFX::GFX1150},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1151},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1152},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1153},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
                               GPUArchitectureTarget{GPUArchitectureGFX::GFX1201}),
             ::testing::Combine(::testing::Values(/*waveK*/ 16),
                                ::testing::Values(SolutionParams::LoadPath::BufferToVGPR))));
 
     INSTANTIATE_TEST_SUITE_P(
-        MatrixMultiplyABCWMMA120X,
-        ABCWMMATestGFX120X,
+        MatrixMultiplyABCWMMARDNAGPU,
+        ABCWMMATestRDNAGPU,
         ::testing::Combine(
-            ::testing::Values(GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
+            ::testing::Values(GPUArchitectureTarget{GPUArchitectureGFX::GFX1150},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1151},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1152},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1153},
+                              GPUArchitectureTarget{GPUArchitectureGFX::GFX1200},
                               GPUArchitectureTarget{GPUArchitectureGFX::GFX1201}),
             ::testing::Combine(::testing::Values(/*waveK*/ 16),
                                ::testing::Values(SolutionParams::LoadPath::BufferToVGPR))));


### PR DESCRIPTION
## Motivation

- Add gfx115x targets to supported list to allow dependent components to build with these parameters
- Attempt to implement basic functionality (matching current gfx12 state)

## Technical Details

- Add gfx115x targets and related checks
- Define assembly instructions for gfx115x (to match gfx12 capability)
- Generate GPU architecture YAML files for the new targets

## Test Plan

- Run TheRock CI tests for rocroller on target boards.
- Add gfx115x unit tests wherever gfx12xx unit tests exist, and run on machines equipped with gfx115x hardware.

## Test Result

TheRock CI tests are passing on gfx115x hardware.

Some of the new gfx115x tests pass. However, WMMA tests have some failures due to a difference in the `v_wmma_*` instructions between RDNA4 versus RDNA3.5 (2nd and 3rd options use half the registers on RDNA3.5). As of now, I don't know how to fix this.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests
- [ ] Fix gfx115x WMMA tests 