### PR TITLE
[hipSPARSELt]Fix smart destroyer in hipsparselt example_prune_strip

### DIFF
--- a/projects/hipsparselt/clients/samples/example_prune_strip.cpp
+++ b/projects/hipsparselt/clients/samples/example_prune_strip.cpp
@@ -544,7 +544,7 @@ void run(int64_t              m,
             hipsparseLtDenseDescriptorInit(&handle, &matA, n, m, n, 16, type, HIPSPARSE_ORDER_COL));
     }
     SMART_DESTROYER<const hipsparseLtMatDescriptor_t, hipsparseStatus_t> smA(
-        &matC, hipsparseLtMatDescriptorDestroy);
+        &matA, hipsparseLtMatDescriptorDestroy);
 
     if(!sparse_b)
     {
@@ -565,7 +565,7 @@ void run(int64_t              m,
                                                 HIPSPARSELT_SPARSITY_50_PERCENT));
     }
     SMART_DESTROYER<const hipsparseLtMatDescriptor_t, hipsparseStatus_t> smB(
-        &matC, hipsparseLtMatDescriptorDestroy);
+        &matB, hipsparseLtMatDescriptorDestroy);
 
     auto tmp_m = (!sparse_b) ? m : n;
 
@@ -577,7 +577,7 @@ void run(int64_t              m,
     CHECK_HIPSPARSELT_ERROR(hipsparseLtDenseDescriptorInit(
         &handle, &matD, tmp_m, tmp_m, tmp_m, 16, type, HIPSPARSE_ORDER_COL));
     SMART_DESTROYER<const hipsparseLtMatDescriptor_t, hipsparseStatus_t> smD(
-        &matC, hipsparseLtMatDescriptorDestroy);
+        &matD, hipsparseLtMatDescriptorDestroy);
 
     CHECK_HIPSPARSELT_ERROR(hipsparseLtMatDescSetAttribute(
         &handle, &matA, HIPSPARSELT_MAT_NUM_BATCHES, &batch_count, sizeof(batch_count)));


### PR DESCRIPTION
Currently multiple smart destroyers are created to freeing up `matC` multiple times. Initialize the destroyers correctly by passing in the right matrix handles.

this is a clone of https://github.com/ROCm/rocm-libraries/pull/3457

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
