### PR TITLE
[origami] Update comments and a few variable names for clarity

### DIFF
--- a/shared/origami/include/origami/gemm.hpp
+++ b/shared/origami/include/origami/gemm.hpp
@@ -161,9 +161,11 @@ double compute_tile_latency(const problem_t& problem,
                             std::size_t splitting_factor);
 
 /**
- * @brief Computes the latency per K-complete MT wave.
- * A wave is defined as the time it takes for one CU to complete one
- * K-complete output tile
+ * @brief Computes the latency per K-complete macro-tile timestep.
+ * A timestep is defined as the time it takes for one set of concurrent
+ * K-complete output tiles to be computed on one or more CUs. Typically,
+ * this is simply the time it takes for one CU to complete one K-complete 
+ * output tile.
  *
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
@@ -179,9 +181,8 @@ double compute_timestep_latency(const problem_t& problem,
                                 std::size_t splitting_factor);
 
 /**
- * @brief Compute the total latency of a gemm based on the latency of one wave multiplied by the
- * number of waves A wave is defined as the time it takes for one CU to complete one K-complete
- * output tile.
+ * @brief Compute the total latency of a gemm based on the latency of one timestep multiplied by the
+ * number of timesteps. (@see compute_timestep_latency)
  *
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -305,7 +305,7 @@ struct config_t {
   dim3_t mt{0, 0, 0};
   dim3_t mi{0, 0, 0};
 
-  /// Occupancy (number of waves resident per CU).
+  /// Occupancy (number of wavefronts resident per CU).
   int occupancy = -1;
 
   /// Reorder workgroup id for L2 reuse.

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -82,7 +82,7 @@ double calculate_output_utilization(const problem_t& problem,
   return useful / launched;
 }
 
-// Computes the number of active compute units if there is only one wave and it is partial
+// Computes the number of active compute units if there is only one timestep and it is partial
 // Otherwise, returns hardware.N_CU
 std::tuple<size_t, size_t, size_t, size_t> compute_cu_occupancy(const problem_t& problem,
                                                                 const hardware_t& hardware,
@@ -94,15 +94,15 @@ std::tuple<size_t, size_t, size_t, size_t> compute_cu_occupancy(const problem_t&
   size_t num_mts = streamk::compute_number_of_output_tiles(
       config.mt.m, config.mt.n, problem.size.m, problem.size.n, problem.batch);
 
-  size_t num_wgs, num_active_cus, numWaves, splitFactor;
+  size_t num_wgs, num_active_cus, num_timesteps, split_factor;
 
   if (split)  // if it is given
   {
     split          = split > 1 ? split : 1;
     num_wgs        = num_mts * split;
     num_active_cus = num_wgs < hardware.N_CU ? num_wgs : hardware.N_CU;
-    numWaves       = math::safe_ceil_div(num_wgs, hardware.N_CU);
-    splitFactor    = split;
+    num_timesteps  = math::safe_ceil_div(num_wgs, hardware.N_CU);
+    split_factor   = split;
 
   } else  // as what StreamK predicts
   {
@@ -116,18 +116,17 @@ std::tuple<size_t, size_t, size_t, size_t> compute_cu_occupancy(const problem_t&
     // output variables
     num_active_cus = num_wgs < hardware.N_CU ? num_wgs : hardware.N_CU;
     // There are cases in which StreamK combines multiple output MTs and assigns to 1 WG.
-    // That means, we artifically observe one full wave, but that is not what actually happens
+    // That means, we artifically observe one full timesteps, but that is not what actually happens
     // under the hood. From a theoretical point of view, these distributions change all of the
     // computations in Origami. With current implementation, it is hard to capture that
     // behaviour analytically. So for now, if the num_wgs is less than the num_mts, we calculate
-    // numWaves based on the num_mts. Otherwise, we use num_wgs to compute numWaves.
-    numWaves    = num_wgs > num_mts ? math::safe_ceil_div(num_wgs, hardware.N_CU)
-                                    : math::safe_ceil_div(num_mts, hardware.N_CU);
-    splitFactor = math::safe_ceil_div(num_wgs, num_mts);
+    // num_timesteps based on the num_mts. Otherwise, we use num_wgs to compute num_timesteps.
+    num_timesteps = num_wgs > num_mts ? math::safe_ceil_div(num_wgs, hardware.N_CU)
+                                      : math::safe_ceil_div(num_mts, hardware.N_CU);
+    split_factor  = math::safe_ceil_div(num_wgs, num_mts);
   }
 
-
-  return std::make_tuple(num_wgs, num_active_cus, numWaves, splitFactor);
+  return std::make_tuple(num_wgs, num_active_cus, num_timesteps, split_factor);
 }
 
 /* ---------------------------------------------------------------------------------------- */
@@ -176,7 +175,7 @@ static inline double compute_cvt_overhead_x1(const problem_t& problem,
   // v_cvt_pk_bf16_f32  (convert/pack fp32 to bf16)
   // ds_write_b64
   // That is, the extra instructions that we need to account for are the two cvt_pk ops
-  // per wave tile
+  // per wavefront tile
 
   // However, these extra ops should not be added up to the overal tile latency becuase
   // they can be run in parallel to Matix and Memory operations (given they are not dependent).
@@ -198,7 +197,7 @@ static inline double compute_cvt_overhead_x1(const problem_t& problem,
   const auto a_bytes = data_type_to_bytes(problem.a_dtype);
   const auto b_bytes = data_type_to_bytes(problem.b_dtype);
 
-  // TODO: Use kernel's actual wavetiles.
+  // TODO: Use kernel's actual wavetiles (wavefront's tile size).
   const double wave_tile_m = MT_M / 2.0;
   const double wave_tile_n = MT_N / 2.0;
   const double wave_tile_k = MT_K / MI_K;
@@ -243,8 +242,8 @@ static inline double compute_cvt_overhead_x1(const problem_t& problem,
 static inline double compute_cvt_overhead(const problem_t& problem,
                                           const hardware_t& hardware,
                                           const config_t& config) {
-  // Wave tile sizes
-  // TODO: Use kernel's actual wavetiles.
+  // Wavefront tile sizes
+  // TODO: Use kernel's actual wavetiles (wavefront's tile size).
   const double wave_tile_m = config.mt.m / 2.0;
   const double wave_tile_n = config.mt.n / 2.0;
   const double wave_tile_k = config.mt.k / config.mi.k;
@@ -392,8 +391,8 @@ double estimate_l2_hit(const problem_t& problem,
   l2_tile_n = std::max(std::min(workgroups_n, l2_tile_n), static_cast<size_t>(1));
 
   // Calculate memory footprint in bytes.
-  const auto a_bytes     = data_type_to_bytes(problem.a_dtype);
-  const auto b_bytes     = data_type_to_bytes(problem.b_dtype);
+  const auto a_bytes       = data_type_to_bytes(problem.a_dtype);
+  const auto b_bytes       = data_type_to_bytes(problem.b_dtype);
   auto calculate_footprint = [&](auto tile_m, auto tile_n) {
     auto a_footprint = tile_m * config.mt.mk() * a_bytes;
     auto b_footprint = tile_n * config.mt.nk() * b_bytes;
@@ -484,7 +483,6 @@ double estimate_mall_hit(const problem_t& problem,
   const long long cached_reads = total_reads - total_uncached_reads;
 
   double mall_hit_rate = static_cast<double>(cached_reads) / static_cast<double>(total_reads);
-
 
   // Clamp the final result to the valid [0, 1] range.
   return std::max(0.0, std::min(mall_hit_rate, 1.0));
@@ -606,10 +604,10 @@ double compute_memory_latency(const problem_t& problem,
     MT_K_rounded_128bytes = MT_K;
   }
 
-  size_t Ld_A_value  = MT_M_rounded_128bytes * MT_K_rounded_128bytes;
-  size_t Ld_B_value  = MT_N_rounded_128bytes * MT_K_rounded_128bytes;
-  auto Ld_CU_bytes = (Ld_A_value * a_bytes)     // A Bytes
-                       + (Ld_B_value * b_bytes);  // B Bytes
+  size_t Ld_A_value = MT_M_rounded_128bytes * MT_K_rounded_128bytes;
+  size_t Ld_B_value = MT_N_rounded_128bytes * MT_K_rounded_128bytes;
+  auto Ld_CU_bytes  = (Ld_A_value * a_bytes)    // A Bytes
+                     + (Ld_B_value * b_bytes);  // B Bytes
 
   // Logic for block scaled datatypes (Assuming BS=32 and 8-bit scales)
   // TODO This is technically wrong, need separate flag to enable MX so we can differentiate FP8
@@ -678,7 +676,6 @@ double compute_memory_latency(const problem_t& problem,
   // 12) pick the worst‐case bound
   double L_mem = std::max({L_mem_mem1, L_mem_mem2, L_mem_MEM});
 
-
   return L_mem;
 }
 
@@ -698,8 +695,8 @@ double compute_tile_latency(const problem_t& problem,
   const size_t MT_N = config.mt.n;
   const size_t MT_K = config.mt.k;
 
-  const auto a_bits    = datatype_to_bits(problem.a_dtype);
-  const auto b_bits    = datatype_to_bits(problem.b_dtype);
+  const auto a_bits  = datatype_to_bits(problem.a_dtype);
+  const auto b_bits  = datatype_to_bits(problem.b_dtype);
   const auto d_bytes = data_type_to_bytes(problem.d_dtype);
 
   // 1) Compute per-tile latencies
@@ -808,25 +805,20 @@ double compute_tile_latency(const problem_t& problem,
       (500 * static_cast<double>(
                  num_iter));  // 7 instructions (each with 4 cycles) at the end of the loop
 
-
   return L_tile_total;
 }
 
-// Computes the latency per K-complete MT wave
-// A wave is defined as : The time it takes for one CU to complete one K-complete output tile
 double compute_timestep_latency(const problem_t& problem,
                                 const hardware_t& hardware,
                                 const config_t& config,
                                 size_t num_active_cus,
                                 size_t splitting_factor) {
-  // Assume latency of a wave is latency of a single k-complete output tile.
+  // Assume latency of a timestep is latency of a single K-complete output tile computed on one CU.
   double L_wave = compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor);
 
   return L_wave;
 }
 
-// Compute the total latency of a gemm based on the latency of one wave multiplied by the number of
-// waves A wave is defined as : The time it takes for one CU to complete one K-complete output tile
 double compute_total_latency(const problem_t& problem,
                              const hardware_t& hardware,
                              const config_t& config,
@@ -852,7 +844,6 @@ double compute_total_latency(const problem_t& problem,
   const int a_bits  = datatype_to_bits(problem.a_dtype);
   const int b_bits  = datatype_to_bits(problem.b_dtype);
   const int a_bytes = data_type_to_bytes(problem.a_dtype);
-
 
   // 0) Short-circuit
   // We don't need to compute latency for all MTs. With this, we can shortcut.
@@ -895,16 +886,15 @@ double compute_total_latency(const problem_t& problem,
   config_with_default_wgm.workgroup_mapping = std::max(defaultWGM, 1);
 
   // 1-2) Find CU occupancy
-  auto [num_wgs, num_active_cus, numWaves, splitting_factor] = compute_cu_occupancy(
+  auto [num_wgs, num_active_cus, num_timesteps, splitting_factor] = compute_cu_occupancy(
       problem, hardware, config_with_default_wgm, grid_selection_t::k_split_aware, max_cus);
 
-  // 2) Compute latency of a wave
-  // Compute latency of a wave
-  double L_wave = compute_timestep_latency(
+  // 2) Compute latency of a timestep
+  double L_timestep = compute_timestep_latency(
       problem, hardware, config_with_default_wgm, num_active_cus, splitting_factor);
 
-  // Compute latency for all waves and return it as the latency for the MT/problem
-  double total_latency = L_wave * numWaves;
+  // Compute latency for all timesteps and return it as the latency for the MT/problem
+  double total_latency = L_timestep * num_timesteps;
 
   // 3) Customized heuristics
   // TODO These are quantifying effects that don't work in the current math.
@@ -955,7 +945,6 @@ double compute_total_latency(const problem_t& problem,
       }
     }
   }
-
 
   return total_latency;
 }

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -814,9 +814,9 @@ double compute_timestep_latency(const problem_t& problem,
                                 size_t num_active_cus,
                                 size_t splitting_factor) {
   // Assume latency of a timestep is latency of a single K-complete output tile computed on one CU.
-  double L_wave = compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor);
+  double L_timestep = compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor);
 
-  return L_wave;
+  return L_timestep;
 }
 
 double compute_total_latency(const problem_t& problem,

--- a/shared/origami/src/origami/origami.cpp
+++ b/shared/origami/src/origami/origami.cpp
@@ -66,10 +66,10 @@ std::tuple<int, int> select_workgroup_mapping(const problem_t& problem,
   size_t numMT_N = math::safe_ceil_div(N, MT_N);
   size_t numMTs  = numMT_M * numMT_N;
 
-  // What SK does -- we already have skGrid so just compute numWaves and splitFactor
-  auto numWaves    = skGrid > numMTs ? math::safe_ceil_div(skGrid, hardware.N_CU)
-                                     : math::safe_ceil_div(numMTs, hardware.N_CU);
-  auto splitFactor = math::safe_ceil_div(skGrid, numMTs);
+  // What SK does -- we already have skGrid so just compute num_timesteps and split_factor
+  auto num_timesteps = skGrid > numMTs ? math::safe_ceil_div(skGrid, hardware.N_CU)
+                                       : math::safe_ceil_div(numMTs, hardware.N_CU);
+  auto split_factor  = math::safe_ceil_div(skGrid, numMTs);
 
   // -------------------
   // NonTemporal Cases
@@ -104,8 +104,8 @@ std::tuple<int, int> select_workgroup_mapping(const problem_t& problem,
     // else use the default (num_xcd)
   }
 
-  // If we are lucky that the splitFactor is a multiple of NUM_XCD -> no mapping
-  if ((splitFactor % hardware.NUM_XCD == 0) && !isWGMXCCset) {
+  // If we are lucky that the split_factor is a multiple of NUM_XCD -> no mapping
+  if ((split_factor % hardware.NUM_XCD == 0) && !isWGMXCCset) {
     out_wgmxcc  = 1;
     isWGMXCCset = true;
   }
@@ -116,11 +116,11 @@ std::tuple<int, int> select_workgroup_mapping(const problem_t& problem,
     isWGMXCCset = true;
   }
 
-  // For sizes that we have more than 2 waves of computations, we skip xcc mapping as MALL is
+  // For sizes that we have more than 2 timesteps of computations, we skip xcc mapping as MALL is
   // more important -- matrix should not be skinny
   // To avoid regressions, it's set to default, but it should actually be 1!
   bool MallIsImportant =
-      (splitFactor == 1 && batch == 1 && numMTs > 2 * hardware.N_CU && numMT_M > 8 && numMT_N > 8);
+      (split_factor == 1 && batch == 1 && numMTs > 2 * hardware.N_CU && numMT_M > 8 && numMT_N > 8);
   if (MallIsImportant && !isWGMXCCset) {
     out_wgmxcc  = defaultWGMXCC;
     isWGMXCCset = true;
@@ -158,7 +158,7 @@ std::tuple<int, int> select_workgroup_mapping(const problem_t& problem,
   }
 
   if (!isWGMset) {
-    size_t numWGs = numWaves * splitFactor * numMTs;
+    size_t numWGs = num_timesteps * split_factor * numMTs;
     size_t q      = numWGs / hardware.NUM_XCD;
     size_t r      = numWGs % hardware.NUM_XCD;
 
@@ -173,14 +173,14 @@ std::tuple<int, int> select_workgroup_mapping(const problem_t& problem,
       auto numXCD        = std::min(hardware.NUM_XCD, numWGs);
 
       // Compute unique loads per L2 tile
-      for (uint32_t x = 0; x < numWaves * numXCD; ++x) {
+      for (uint32_t x = 0; x < num_timesteps * numXCD; ++x) {
         // Range of "output tiles" that this xcd takes.
         auto xccStart = q * x + (x < r ? x : r);
         auto xccEnd   = xccStart + q - 1 + (x < r ? 1 : 0);
         // xccStart and xccEnd are supposed to be tile IDs
         // In case of splitting, they are WG IDs. Modify to get tile IDs
-        xccStart /= splitFactor;
-        xccEnd /= splitFactor;
+        xccStart /= split_factor;
+        xccEnd /= split_factor;
 
         auto slabStart = xccStart / slabTiles;
         auto slabEnd   = xccEnd / slabTiles;
@@ -226,8 +226,7 @@ std::tuple<int, int> select_workgroup_mapping(const problem_t& problem,
         bestWGM = wgm;
       }
 
-      if (get_runtime_options(config).debug_enabled) {
-      }
+      if (get_runtime_options(config).debug_enabled) {}
     }
 
     out_wgm = bestWGM;

--- a/shared/origami/tests/test_gemm.cpp
+++ b/shared/origami/tests/test_gemm.cpp
@@ -154,16 +154,16 @@ TEST_CASE("GEMM: compute_tile_latency", "[gemm]") {
 
 TEST_CASE("GEMM: compute_timestep_latency", "[gemm]") {
   for (int gpu_arch : test_architectures) {
-    DYNAMIC_SECTION("gfx" << gpu_arch << " - wave latency equals tile latency") {
+    DYNAMIC_SECTION("gfx" << gpu_arch << " - timestep latency equals tile latency") {
       auto hardware = make_hardware(gpu_arch);
       auto problem =
           make_problem(4096, 4096, 1024, origami::transpose_t::T, origami::transpose_t::N, 2);
       auto config = make_config(128, 128, 64, 32, 32, 8, 8);
 
       auto tile_latency = origami::compute_tile_latency(problem, hardware, config, 304, 4);
-      auto wave_latency = origami::compute_timestep_latency(problem, hardware, config, 304, 4);
+      auto timestep_latency = origami::compute_timestep_latency(problem, hardware, config, 304, 4);
 
-      REQUIRE(wave_latency == Approx(tile_latency));
+      REQUIRE(timestep_latency == Approx(tile_latency));
     }
   }
 }


### PR DESCRIPTION
## Motivation

Based on the conversation, its important to clarify wave and wavefront and separately a "timestep". Make sure that is being respected throughout the code for clarity.

## Technical Details

- `wave` / `wavefront` : 32 or 64 threads running in a lockstep SIMD fashion.
- `timestep` : A timestep is defined as the time it takes for one set of concurrent K-complete output tiles to be computed on one or more CUs. Typically, this is simply the time it takes for one CU to complete one K-complete output tile. Typically it is also referred to as a "wave" of work (which is what makes it confusing.) This PR changes it to a timestep of work being completed.

## Test Plan

Ran origami-tests locally and they pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
