### PR TITLE
[hipblasLT] SK use Tree reduction if < 2 split

### DIFF
--- a/projects/hipblaslt/CHANGELOG.md
+++ b/projects/hipblaslt/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for hipBLASLt is available at [rocm.docs.amd.com/projects/hipBLASLt](https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/index.html).
 
+## hipBLASLt 1.2.1 for ROCm 7.2.1
+
+### Resolved issues
+
+* Fix issue where users might encounter a `HIPBLAS_STATUS_INTERNAL_ERROR` with various sizes in CPX mode.
+
 ## hipBLASLt 1.2.0 for ROCm 7.2.0
 
 ### Added

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -2593,6 +2593,11 @@ namespace TensileLite
                     sk.grid      = tiles;
                 }
             }
+
+            if(sk.reduction == ReductionType::Parallel && sk.grid / tiles < 2)
+            {
+                throw std::runtime_error("hipblasLT Error: Cannot use Parallel reduction with StreamK kernel with splitting factor < 2\n");
+            }
         }
 
         if(debug)

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -2594,7 +2594,7 @@ namespace TensileLite
                 }
             }
 
-            if(sk.reduction == ReductionType::Parallel && sk.grid / tiles < 2)
+            if(sk.reduction == origami::reduction_t::parallel && sk.grid / tiles < 2)
             {
                 throw std::runtime_error("hipblasLT Error: Cannot use Parallel reduction with StreamK kernel with splitting factor < 2\n");
             }

--- a/shared/origami/src/origami/streamk.cpp
+++ b/shared/origami/src/origami/streamk.cpp
@@ -158,7 +158,7 @@ reduction_t select_reduction(const problem_t& problem,
       // For problems with large k and low number of tiles, use parallel reduction
       // TODO Benchmark to check if limits are correct
       constexpr int MinItersForParallel = 64;
-      constexpr int MaxTilesForParallel = 64;
+      const int MaxTilesForParallel = cu_count / 4;
       if (iters_per_tile >= MinItersForParallel && tiles <= MaxTilesForParallel)
         reduction_strategy = reduction_t::parallel;
     }


### PR DESCRIPTION
## Motivation

Cherry-pick of https://github.com/ROCm/rocm-libraries/commit/5b515cf1bca9959fb434c2414cf79b42fe25e93b from https://github.com/ROCm/rocm-libraries/pull/3403.

Reverted version bumps.


(from #3403)
If origami gives us Parallel reduction and sk.grid/tiles==1 then we will
launch post kernel call, this PR sets reduction strategy to Tree
reduction in this case.

## Technical Details

(from #3403)
After calling getSKReduction, this does a check to see if sk.grid/tiles
< 2, if so we ensure the reduction type is Tree reduction. Small change
to origami intended to keep `select_grid` behaviour the same.

## Test Plan

No testing aside from CI

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
