### PR TITLE
[hipDNN] fix hipDNN data_sdk installed paths when using imported dependencies

### DIFF
--- a/projects/hipdnn/cmake/Dependencies.cmake
+++ b/projects/hipdnn/cmake/Dependencies.cmake
@@ -79,7 +79,7 @@ function(hipdnn_add_dependency_includes TARGET_NAME HEADER_LIB_TARGET_NAME)
         if(_dep_includes)
             foreach(_include IN LISTS _dep_includes)
                 message(VERBOSE "${TARGET_NAME} adding include from ${HEADER_LIB_TARGET_NAME}: ${_include}")
-                target_include_directories(${TARGET_NAME} SYSTEM INTERFACE ${_include})
+                target_include_directories(${TARGET_NAME} SYSTEM INTERFACE $<BUILD_INTERFACE:${_include}>)
             endforeach()
         endif()
 

--- a/projects/hipdnn/data_sdk/cmake/hipdnn_data_sdkConfig_imported.cmake.in
+++ b/projects/hipdnn/data_sdk/cmake/hipdnn_data_sdkConfig_imported.cmake.in
@@ -3,6 +3,41 @@
 
 @PACKAGE_INIT@
 
+# Extract and use include directories from dependency targets instead of linking
+# Function to add include directories and optional compile definitions from dependency targets
+# !!!! Note !!!! We are using this to force a headeronly consumption of 3rd party dependencies for hipdnn_data_sdk
+# Using regular linking will result in a non-header only consumption of these libraries due to the way they are configured when installing
+function(hipdnn_add_dependency_includes TARGET_NAME HEADER_LIB_TARGET_NAME)
+    # Parse optional arguments
+    set(options "")
+    set(oneValueArgs "")
+    set(multiValueArgs COMPILE_DEFINITIONS)
+    cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Validate required parameters
+    if(NOT TARGET ${TARGET_NAME})
+        message(FATAL_ERROR "hipdnn_add_dependency_includes: Target '${TARGET_NAME}' does not exist")
+        return()
+    endif()
+
+    if(NOT TARGET ${HEADER_LIB_TARGET_NAME})
+        message(FATAL_ERROR "hipdnn_add_dependency_includes: Header library target '${HEADER_LIB_TARGET_NAME}' does not exist")
+        return()
+    endif()
+
+    if(TARGET ${HEADER_LIB_TARGET_NAME})
+        get_target_property(_dep_includes ${HEADER_LIB_TARGET_NAME} INTERFACE_INCLUDE_DIRECTORIES)
+        if(_dep_includes)
+            message(VERBOSE "${TARGET_NAME} adding includes from ${HEADER_LIB_TARGET_NAME}: ${_dep_includes}")
+            target_include_directories(${TARGET_NAME} SYSTEM INTERFACE ${_dep_includes})
+        endif()
+
+        if(ARG_COMPILE_DEFINITIONS)
+            target_compile_definitions(${TARGET_NAME} INTERFACE ${ARG_COMPILE_DEFINITIONS})
+        endif()
+    endif()
+endfunction()
+
 # Find required dependencies
 find_package(Threads REQUIRED)
 
@@ -12,6 +47,9 @@ find_dependency(flatbuffers REQUIRED)
 find_dependency(spdlog REQUIRED)
 find_dependency(nlohmann_json REQUIRED)
 
+# fmt can potentially be embedded in spdlog, make this dependency quiet, and conditional include the path
+find_dependency(fmt QUIET)
+
 # Subdirectory path for hipDNN engine plugins (relative to lib)
 set(HIPDNN_PLUGIN_ENGINE_SUBDIR "@HIPDNN_PLUGIN_ENGINE_SUBDIR@")
 
@@ -20,6 +58,16 @@ set(HIPDNN_FULL_INSTALL_PLUGIN_ENGINE_DIR "@HIPDNN_FULL_INSTALL_PLUGIN_ENGINE_DI
 set(HIPDNN_RELATIVE_INSTALL_PLUGIN_ENGINE_DIR "@HIPDNN_RELATIVE_INSTALL_PLUGIN_ENGINE_DIR@")
 
 include("${CMAKE_CURRENT_LIST_DIR}/hipdnn_data_sdkTargets.cmake")
+
+hipdnn_add_dependency_includes(hipdnn_data_sdk flatbuffers::flatbuffers)
+hipdnn_add_dependency_includes(hipdnn_data_sdk spdlog::spdlog_header_only)
+hipdnn_add_dependency_includes(hipdnn_data_sdk nlohmann_json::nlohmann_json)
+if (fmt_FOUND)
+    message(STATUS "Found fmt: using system fmt")
+    hipdnn_add_dependency_includes(hipdnn_data_sdk fmt::fmt COMPILE_DEFINITIONS SPDLOG_FMT_EXTERNAL)
+else()
+    message(STATUS "Not found fmt: using bundled fmt from spdlog")
+endif()
 
 message(STATUS "hipDNN Data SDK: Engine plugin build directory is ${CMAKE_INSTALL_LIBDIR}/${HIPDNN_PLUGIN_ENGINE_SUBDIR}")
 message(STATUS "hipDNN Data SDK: Plugin absolute installation directory ${HIPDNN_FULL_INSTALL_PLUGIN_ENGINE_DIR}")


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/TheRock/issues/2807

## Technical Details

Issue was due to TheRock install propagating build paths for installed targets.
This fix removes the propagated build paths, and adds the proper include paths to the installed cmake config.

## Test Plan

Tests & build are passing correctly.
Adding a test to TheRock as a separate follow-up to emulate client consumption of hipDNN to prevent regressions.
Locally installing the artifacts, and using them to build samples from hipDNN.

## Test Result

Test & build are working.
Samples are now building and installing properly using artifacts generated with this change.
