### PR TITLE
[hipblaslt][CMS] Opt Pack instructions out of verify_ascending_order

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1542,7 +1542,9 @@ def verify_packs_start_and_end_at_correct_indices(schedule_info: 'ScheduleInfo',
     """
     Ensure that the Packs start and end at the correct indices.
     """
-    assert not schedule_info.mfmaReorder, "MFMA reorder is not supported for pack validation."
+    if schedule_info.mfmaReorder:
+        printWarning("MFMA reorder is not supported for pack validation. Skipping pack validation.")
+        return True, ""
 
     if context["kernel"].get("UseMFMAF32XEmulation", False):
         printWarning("Pack validation is not supported for MFMA F32X emulation mode.")

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1613,7 +1613,7 @@ def verify_ascending_order(scheduleInfo, context: dict, code_path: int) -> tuple
     # TODO: Move this validation into each instructions's validation to allow for custom ordering.
     for k in scheduleInfo.optSchedule.keys():
         if k.startswith("Pack"):
-            # Packs have their own validation or ordering.
+            # Packs have their own validation for ordering.
             continue
         seq = schedule_get(k, code_path, scheduleInfo)
         for i in range(1, len(seq)):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1610,7 +1610,11 @@ def verify_ascending_order(scheduleInfo, context: dict, code_path: int) -> tuple
     instructions are non-decreasing. This rule is true for all groups of instructions,
     not just the 'GRIncA' instructions.
     """
+    # TODO: Move this validation into each instructions's validation to allow for custom ordering.
     for k in scheduleInfo.optSchedule.keys():
+        if k.startswith("Pack"):
+            # Packs have their own validation or ordering.
+            continue
         seq = schedule_get(k, code_path, scheduleInfo)
         for i in range(1, len(seq)):
             if seq[i] < seq[i - 1]:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -2652,7 +2652,6 @@ def _get_schedule_192x256x32_TF32(kernel, useLDSTr, TLDS):
         return False, None
 
     opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift, mfmaReorder=mfmaReorder)
-    opt1.disableValidation() # Disable validation as this schedule re-order pack instructions (Non-descending-order validator to be updated to allow this)
     return True, opt1
 
 @RegisterSchedule(
@@ -2791,5 +2790,4 @@ def _get_schedule_256x256x32_TF32(kernel, useLDSTr, TLDS):
         return False, None
 
     opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
-    opt1.disableValidation() # Disable validation as this schedule re-order pack instructions (Non-descending-order validator to be updated to allow this)
     return True, opt1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -580,11 +580,12 @@ class TestCustomScheduleBF16:
 
 
 class TestCustomScheduleTF32:
-    def test_schedule_192x256x32_TF32(self):
-        """Tests the 192x256x32 TF32 TN schedule."""
+    @pytest.mark.parametrize("transA, transB", [(True, False), (False, False)])
+    def test_schedule_192x256x32_TF32(self, transA, transB):
+        """Tests the 192x256x32 TF32 schedule."""        
         kernel = create_base_kernel()
         kernel["ProblemType"].update({
-            "TransposeA": True, "TransposeB": False
+            "TransposeA": transA, "TransposeB": transB
         })
         kernel.update({
             "UseF32XEmulation": True,
@@ -627,6 +628,32 @@ class TestCustomScheduleTF32:
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 72
+        assert kernel["UsePLRPack"]
+        valid, message = isValid(schedule_info, {"kernel": kernel})
+        assert valid, message
+
+    def test_schedule_256x256x32_TF32(self):
+        """Tests the 256x256x32 TF32 TN schedule."""
+        kernel = create_base_kernel()
+        kernel["ProblemType"].update({
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "UseF32XEmulation": True,
+            "ForceUnrollSubIter": True,
+            "MacroTile0": 256, "MacroTile1": 256, "DepthU": 32,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
+            "DirectToLds": True,
+            "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,
+            "MatrixInstruction": [16, 16, 32, 1], "MIWaveGroup": [2, 2],
+            "LDSTrInst": False, "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 8,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 192
         assert kernel["UsePLRPack"]
         valid, message = isValid(schedule_info, {"kernel": kernel})
         assert valid, message


### PR DESCRIPTION
## Motivation

`verify_ascending_order` is a validator pass which enforces that all instructions are issued in a non-descending order (i.e. [1,2,2,3] is valid but [2,1,2,3] is not). This is overly restrictive and we are starting to see schedules which attempt to make use of this for Pack instructions.

The validator for the Pack instructions itself keeps track of this order and accounts for it, so `verify_ascending_order` no longer needs to restrict schedules based on it.

## Technical Details

Skip this pass for Packs.

## Test Plan

Run existing and new tests.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
