### PR TITLE
Template constructor of `RTCKernel` and make such objects own their own module if not given at construction

### DIFF
--- a/projects/rocfft/library/src/include/rtc_chirp_kernel.h
+++ b/projects/rocfft/library/src/include/rtc_chirp_kernel.h
@@ -37,11 +37,11 @@ struct RTCKernelChirp : public RTCKernel
     }
 
 protected:
-    RTCKernelChirp(const std::string&                       kernel_name,
-                   std::shared_future<hipModule_wrapper_t>& module,
-                   dim3                                     gridDim,
-                   dim3                                     blockDim)
-        : RTCKernel(kernel_name, module, gridDim, blockDim)
+    RTCKernelChirp(const std::string&       kernel_name,
+                   const std::vector<char>& code,
+                   dim3                     gridDim,
+                   dim3                     blockDim)
+        : RTCKernel(kernel_name, code, gridDim, blockDim)
     {
     }
 };

--- a/projects/rocfft/library/src/include/rtc_kernel.h
+++ b/projects/rocfft/library/src/include/rtc_kernel.h
@@ -28,6 +28,7 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -123,22 +124,25 @@ struct RTCKernel
 
     // take already-compiled code object and prepare to launch the
     // named kernel
-    RTCKernel(const std::string&                       kernel_name,
-              std::shared_future<hipModule_wrapper_t>& module,
-              dim3                                     gridDim  = {},
-              dim3                                     blockDim = {});
+    template <typename T>
+    RTCKernel(const std::string& kernel_name,
+              T&                 raw_code_or_module,
+              dim3               gridDim  = {},
+              dim3               blockDim = {});
 
     virtual ~RTCKernel()
     {
         kernel = nullptr;
 
 #ifndef ROCFFT_DEBUG_GENERATE_KERNEL_HARNESS
-        std::lock_guard<std::mutex> lock(active_modules_mutex);
-        // decrement refcount and remove the module from the map if it's no longer used
-        auto it = active_modules.find(rtc_module_key{kernel_name, deviceId});
-        it->second.refcount--;
-        if(it->second.refcount == 0)
-            active_modules.erase(it);
+        if(!owned_module)
+        {
+            std::lock_guard<std::mutex> lock(active_modules_mutex);
+            // decrement refcount and remove the module from the map if it's no longer used
+            auto it = active_modules.find(rtc_module_key{kernel_name, deviceId});
+            if(it != active_modules.end() && --it->second.refcount == 0)
+                active_modules.erase(it);
+        }
 #endif
     }
 
@@ -183,8 +187,10 @@ struct RTCKernel
     int         deviceId = 0;
 
 protected:
-    std::shared_future<hipModule_wrapper_t> module;
-    hipFunction_t                           kernel = nullptr;
+    // if not given a shared module at construction, this object
+    // creates (and owns) its own
+    std::optional<hipModule_wrapper_t> owned_module = std::nullopt;
+    hipFunction_t                      kernel       = nullptr;
 
 #ifndef ROCFFT_DEBUG_GENERATE_KERNEL_HARNESS
     struct RTCGenerator

--- a/projects/rocfft/library/src/include/rtc_stockham_kernel.h
+++ b/projects/rocfft/library/src/include/rtc_stockham_kernel.h
@@ -25,9 +25,9 @@
 
 struct RTCKernelStockham : public RTCKernel
 {
-    RTCKernelStockham(const std::string&                       kernel_name,
-                      std::shared_future<hipModule_wrapper_t>& module)
-        : RTCKernel(kernel_name, module)
+    template <typename T>
+    RTCKernelStockham(const std::string& kernel_name, T& code_or_module)
+        : RTCKernel(kernel_name, code_or_module)
         , hardcoded_dim(kernel_name.find("_dim") != std::string::npos)
     {
     }

--- a/projects/rocfft/library/src/include/rtc_twiddle_kernel.h
+++ b/projects/rocfft/library/src/include/rtc_twiddle_kernel.h
@@ -38,11 +38,11 @@ struct RTCKernelTwiddle : public RTCKernel
     }
 
 protected:
-    RTCKernelTwiddle(const std::string&                       kernel_name,
-                     std::shared_future<hipModule_wrapper_t>& module,
-                     dim3                                     gridDim,
-                     dim3                                     blockDim)
-        : RTCKernel(kernel_name, module, gridDim, blockDim)
+    RTCKernelTwiddle(const std::string&       kernel_name,
+                     const std::vector<char>& code,
+                     dim3                     gridDim,
+                     dim3                     blockDim)
+        : RTCKernel(kernel_name, code, gridDim, blockDim)
     {
     }
 };

--- a/projects/rocfft/library/src/rocfft_kernel_config_search.cpp
+++ b/projects/rocfft/library/src/rocfft_kernel_config_search.cpp
@@ -491,15 +491,9 @@ int main(int argc, char** argv)
                                                                   half_lds,
                                                                   direct_to_from_reg);
 
-                                auto code = compile_inprocess(kernel_src, device_prop.gcnArchName);
-                                hipModule_wrapper_t module;
-                                module.alloc(code.data());
-                                std::promise<hipModule_wrapper_t>       module_promise;
-                                std::shared_future<hipModule_wrapper_t> module_future
-                                    = module_promise.get_future();
-                                module_promise.set_value(std::move(module));
-
-                                RTCKernelStockham kernel(kernel_name, module_future);
+                                const auto code
+                                    = compile_inprocess(kernel_src, device_prop.gcnArchName);
+                                RTCKernelStockham kernel(kernel_name, code);
 
                                 float time = launch_kernel(
                                     kernel,
@@ -616,13 +610,8 @@ int main(int argc, char** argv)
                                               half_lds,
                                               direct_to_from_reg);
 
-            auto                code = compile_inprocess(kernel_src, device_prop.gcnArchName);
-            hipModule_wrapper_t module;
-            module.alloc(code.data());
-            std::promise<hipModule_wrapper_t>       module_promise;
-            std::shared_future<hipModule_wrapper_t> module_future = module_promise.get_future();
-            module_promise.set_value(std::move(module));
-            RTCKernelStockham kernel(kernel_name, module_future);
+            const auto        code = compile_inprocess(kernel_src, device_prop.gcnArchName);
+            RTCKernelStockham kernel(kernel_name, code);
 
             float time
                 = launch_kernel(kernel,

--- a/projects/rocfft/library/src/rtc_chirp_kernel.cpp
+++ b/projects/rocfft/library/src/rtc_chirp_kernel.cpp
@@ -30,11 +30,6 @@ RTCKernelChirp RTCKernelChirp::generate(const std::string& gpu_arch, rocfft_prec
         [=](const std::string& kernel_name) { return chirp_rtc(kernel_name, precision); }};
 
     auto code = RTCCache::cached_compile(kernel_name, gpu_arch, generator, generator_sum());
-    hipModule_wrapper_t module;
-    module.alloc(code.data());
-    std::promise<hipModule_wrapper_t>       module_promise;
-    std::shared_future<hipModule_wrapper_t> module_future = module_promise.get_future();
-    module_promise.set_value(std::move(module));
 
-    return RTCKernelChirp{kernel_name, module_future, {}, {}};
+    return RTCKernelChirp{kernel_name, code, {}, {}};
 }

--- a/projects/rocfft/library/src/rtc_kernel.cpp
+++ b/projects/rocfft/library/src/rtc_kernel.cpp
@@ -39,15 +39,14 @@ std::map<RTCKernel::rtc_module_key, RTCKernel::rtc_module_t> RTCKernel::active_m
 std::mutex                                                   RTCKernel::active_modules_mutex;
 #endif
 
-RTCKernel::RTCKernel(const std::string&                       kernel_name,
-                     std::shared_future<hipModule_wrapper_t>& module,
-                     dim3                                     gridDim,
-                     dim3                                     blockDim)
+template <typename T>
+RTCKernel::RTCKernel(const std::string& kernel_name, T& code_or_module, dim3 gridDim, dim3 blockDim)
     : gridDim(gridDim)
     , blockDim(blockDim)
     , kernel_name(kernel_name)
-    , module(module)
 {
+    static_assert(std::is_same_v<T, std::shared_future<hipModule_wrapper_t>> /*    */
+                  || std::is_same_v<T, const std::vector<char>>);
 #ifndef ROCFFT_DEBUG_GENERATE_KERNEL_HARNESS
     // if we're only compiling, no need to actually load the code objects
     if(rocfft_getenv("ROCFFT_INTERNAL_COMPILE_ONLY") == "1")
@@ -57,9 +56,27 @@ RTCKernel::RTCKernel(const std::string&                       kernel_name,
     if(hipGetDevice(&deviceId) != hipSuccess)
         throw std::runtime_error("hipGetDevice failed");
 
-    if(hipModuleGetFunction(&kernel, module.get(), kernel_name.c_str()) != hipSuccess)
-        throw std::runtime_error("failed to get function " + kernel_name);
+    if constexpr(std::is_same_v<T, std::shared_future<hipModule_wrapper_t>>)
+    {
+        if(hipModuleGetFunction(&kernel, code_or_module.get(), kernel_name.c_str()) != hipSuccess)
+            throw std::runtime_error("failed to get function " + kernel_name);
+    }
+    else
+    {
+        // code_or_module is a const std::vector<char> object (due to static_assert above)
+        owned_module = hipModule_wrapper_t{};
+        owned_module->alloc(code_or_module.data());
+        if(hipModuleGetFunction(&kernel, *owned_module, kernel_name.c_str()) != hipSuccess)
+            throw std::runtime_error("failed to get function " + kernel_name);
+    }
 }
+
+// Explicit instantiations
+template RTCKernel::RTCKernel(const std::string&,
+                              std::shared_future<hipModule_wrapper_t>&,
+                              dim3,
+                              dim3);
+template RTCKernel::RTCKernel(const std::string&, const std::vector<char>&, dim3, dim3);
 
 #ifndef ROCFFT_DEBUG_GENERATE_KERNEL_HARNESS
 void RTCKernel::launch(DeviceCallIn& data, const hipDeviceProp_t& deviceProp)

--- a/projects/rocfft/library/src/rtc_test_harness_helper.cpp
+++ b/projects/rocfft/library/src/rtc_test_harness_helper.cpp
@@ -134,12 +134,5 @@ std::unique_ptr<RTCKernel> compile(const std::string& name, const std::string& s
         throw std::runtime_error("failed to get code");
     hiprtcDestroyProgram(&prog);
 
-    hipModule_wrapper_t module;
-    module.alloc(code.data());
-
-    std::promise<hipModule_wrapper_t>       module_promise;
-    std::shared_future<hipModule_wrapper_t> module_future = module_promise.get_future();
-    module_promise.set_value(std::move(module));
-
-    return std::make_unique<RTCKernel>(name, module_future);
+    return std::make_unique<RTCKernel>(name, const_cast<const std::vector<char>&>(code));
 }

--- a/projects/rocfft/library/src/rtc_twiddle_kernel.cpp
+++ b/projects/rocfft/library/src/rtc_twiddle_kernel.cpp
@@ -32,11 +32,6 @@ RTCKernelTwiddle RTCKernelTwiddle::generate(const std::string& gpu_arch,
         [=](const std::string& kernel_name) { return twiddle_rtc(kernel_name, type, precision); }};
 
     auto code = RTCCache::cached_compile(kernel_name, gpu_arch, generator, generator_sum());
-    hipModule_wrapper_t module;
-    module.alloc(code.data());
-    std::promise<hipModule_wrapper_t>       module_promise;
-    std::shared_future<hipModule_wrapper_t> module_future = module_promise.get_future();
-    module_promise.set_value(std::move(module));
 
-    return RTCKernelTwiddle{kernel_name, module_future, {}, {}};
+    return RTCKernelTwiddle{kernel_name, code, {}, {}};
 }


### PR DESCRIPTION
## Motivation

See comment about the destructor of `RTCKernel` objects in https://github.com/ROCm/rocm-libraries/pull/3572.

## Technical Details

Make `RTCKernel` constructible from either a `const std::vector<char>` object (raw code) or a `std::shared_future<hipModule_wrapper_t>` object (possibly shared with other `RTCKernel` objects). In the former case, the constructed `RTCKernel` builds its own module and owns it (optional member) without possibly sharing it.

## Test Plan

TBD

## Test Result

TBD

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
