### PR TITLE
[hipblaslt] Fix tensilelite-client seg fault when selection-only is on

### DIFF
--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -740,7 +740,7 @@ int main(int argc, const char* argv[])
         std::cout << ss.str();
     }
 
-    while(listeners.needMoreBenchmarkRuns())
+    while(listeners.needMoreBenchmarkRuns() && runKernels)
     {
         listeners.preBenchmarkRun();
         const auto flushGridSize = flush_grid_size();
@@ -775,7 +775,7 @@ int main(int argc, const char* argv[])
                         throw std::runtime_error("Could not find a solution");
 
                     listeners.preSolution(solution.get());
-                    if(solutionIterator->runCurrentSolution() && runKernels)
+                    if(solutionIterator->runCurrentSolution())
                     {
                         try
                         {


### PR DESCRIPTION
## Motivation

We observed that tensilelite-client crashes in one of our case studies due to segmentation fault. 

## The fix

Our fix disables the entire benchmark loop when selection-only is set. It is expected to fix this problem plus speeding up the non-benchmarking mode by removing the unnecessary argument setups.

## The cause of the problem

The problem is coming from here
https://github.com/ROCm/rocm-libraries/blob/21c5202733765a28e007f294ba711c6dbb654e09/projects/hipblaslt/tensilelite/client/main.cpp#L749

When selection-only is set, initialization of benchmarkTimer is skipped, therefore calling its method will fail.
https://github.com/ROCm/rocm-libraries/blob/21c5202733765a28e007f294ba711c6dbb654e09/projects/hipblaslt/tensilelite/client/main.cpp#L696-L705

## To reproduce
To reproduce, visit the link below and download our library & config files, put it under `[**YOUR_PATH**]`

https://amdcloud-my.sharepoint.com/:f:/g/personal/wkong_amd_com/IgCYKUYXIowRRrJQIM-gdrwQAQAbGRei1MJAwpCSvuaJDAU?e=hlr68K

Those files are generated under my setup so you need to change the following path:
- Open `[**YOUR_PATH**]/CaseStudy_P80-36864-2048_pBest_20260108_091218/1_BenchmarkProblems/Cijk_Alik_Bljk_BBS_BH_UserArgs_00/00_Final/build/run.sh`
- Change `/workspace/repo/Task_Tuning_Driver/rocm-libraries/projects/hipblaslt/tensilelite/build_tmp/tensilelite/client/tensilelite-client` ------> the abs path of your tensilelite-client
- Change `/workspace/repo/Task_Tuning_Driver/ClusterTuningPortal/tools/formo_tuning/Experiment/CaseStudy_P80-36864-2048_pBest_20260108_091218/1_BenchmarkProblems/Cijk_Alik_Bljk_BBS_BH_UserArgs_00/00_Final/build/../source/ClientParameters.ini` ------> `[**YOUR_PATH**]/CaseStudy_P80-36864-2048_pBest_20260108_091218/1_BenchmarkProblems/Cijk_Alik_Bljk_BBS_BH_UserArgs_00/00_Final/build/../source/ClientParameters.ini`

Then you may reproduce the error by running
```shell
cd [**YOUR_PATH**]/CaseStudy_P80-36864-2048_pBest_20260108_091218/1_BenchmarkProblems/Cijk_Alik_Bljk_BBS_BH_UserArgs_00/00_Final/build
./run.sh
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
