### PR TITLE
Add NHWC support to Softmax

### DIFF
--- a/projects/miopen/driver/mloSoftmaxHost.hpp
+++ b/projects/miopen/driver/mloSoftmaxHost.hpp
@@ -1,26 +1,5 @@
-/**********************************************************************
-Copyright (c)2017 Advanced Micro Devices, Inc. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted
-provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list of conditions and
-the following disclaimer.
-Redistributions in binary form must reproduce the above copyright notice, this list of conditions
-and the following disclaimer in the documentation and/or
- other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
-SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-********************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #ifndef MLO_SOFTMAXHOST_H_
 #define MLO_SOFTMAXHOST_H_
@@ -60,8 +39,6 @@ int mloSoftmaxForwardRunHost(miopenTensorDescriptor_t inputTensor,
     miopenGet4dTensorDescriptorLengths(inputTensor, &n, &c, &h, &w);
     miopenGet4dTensorDescriptorStrides(inputTensor, &in_nstr, &in_cstr, &in_hstr, &in_wstr);
     miopenGet4dTensorDescriptorStrides(outputTensor, &out_nstr, &out_cstr, &out_hstr, &out_wstr);
-    (void)in_wstr;
-    (void)out_wstr;
 
     Tcheck max_val = (sizeof(Tgpu) == 4) ? 3.402823466e+38f : 65504.;
     std::vector<Tcheck> channel_max((mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? n : n * h * w),
@@ -81,7 +58,7 @@ int mloSoftmaxForwardRunHost(miopenTensorDescriptor_t inputTensor,
                         for(int s1 = 0; s1 < w; s1++)
                         {
                             results[(i * c + j) * h * w + s0 * w + s1] = static_cast<Tcheck>(
-                                in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1]);
+                                in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr]);
                         }
             }
             else
@@ -90,10 +67,10 @@ int mloSoftmaxForwardRunHost(miopenTensorDescriptor_t inputTensor,
                     for(int s0 = 0; s0 < h; s0++)
                         for(int s1 = 0; s1 < w; s1++)
                         {
-                            channel_max[i] =
-                                std::max(static_cast<Tcheck>(
-                                             in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1]),
-                                         channel_max[i]);
+                            channel_max[i] = std::max(
+                                static_cast<Tcheck>(
+                                    in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr]),
+                                channel_max[i]);
                         }
 
                 for(int j = 0; j < c; j++)
@@ -102,7 +79,7 @@ int mloSoftmaxForwardRunHost(miopenTensorDescriptor_t inputTensor,
                         {
                             results[(i * c + j) * h * w + s0 * w + s1] =
                                 static_cast<Tcheck>(
-                                    in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1]) -
+                                    in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr]) -
                                 channel_max[i];
                         }
             }
@@ -126,10 +103,11 @@ int mloSoftmaxForwardRunHost(miopenTensorDescriptor_t inputTensor,
                     for(int s0 = 0; s0 < h; s0++)
                         for(int s1 = 0; s1 < w; s1++)
                         {
-                            outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1] =
+                            outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1 * out_wstr] =
                                 alpha *
                                     (results[(i * c + j) * h * w + s0 * w + s1] - channel_max[i]) +
-                                beta * outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1];
+                                beta * outhost[i * out_nstr + j * out_cstr + s0 * out_hstr +
+                                               s1 * out_wstr];
                         }
             }
             else
@@ -148,10 +126,11 @@ int mloSoftmaxForwardRunHost(miopenTensorDescriptor_t inputTensor,
                     for(int s0 = 0; s0 < h; s0++)
                         for(int s1 = 0; s1 < w; s1++)
                         {
-                            outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1] =
+                            outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1 * out_wstr] =
                                 alpha *
                                     (results[(i * c + j) * h * w + s0 * w + s1] / channel_max[i]) +
-                                beta * outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1];
+                                beta * outhost[i * out_nstr + j * out_cstr + s0 * out_hstr +
+                                               s1 * out_wstr];
                         }
             }
         }
@@ -168,24 +147,24 @@ int mloSoftmaxForwardRunHost(miopenTensorDescriptor_t inputTensor,
                         for(int j = 0; j < c; j++)
                         {
                             results[(i * c + j) * h * w + s0 * w + s1] = static_cast<Tcheck>(
-                                in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1]);
+                                in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr]);
                         }
                     }
                     else
                     {
                         for(int j = 0; j < c; j++)
                         {
-                            channel_max[i * h * w + s0 * w + s1] =
-                                std::max(static_cast<Tcheck>(
-                                             in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1]),
-                                         channel_max[i * h * w + s0 * w + s1]);
+                            channel_max[i * h * w + s0 * w + s1] = std::max(
+                                static_cast<Tcheck>(
+                                    in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr]),
+                                channel_max[i * h * w + s0 * w + s1]);
                         }
 
                         for(int j = 0; j < c; j++)
                         {
                             results[(i * c + j) * h * w + s0 * w + s1] =
                                 static_cast<Tcheck>(
-                                    in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1]) -
+                                    in[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr]) -
                                 channel_max[i * h * w + s0 * w + s1];
                         }
                     }
@@ -206,10 +185,11 @@ int mloSoftmaxForwardRunHost(miopenTensorDescriptor_t inputTensor,
 
                         for(int j = 0; j < c; j++)
                         {
-                            outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1] =
+                            outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1 * out_wstr] =
                                 alpha * (results[(i * c + j) * h * w + s0 * w + s1] -
                                          channel_max[i * h * w + s0 * w + s1]) +
-                                beta * outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1];
+                                beta * outhost[i * out_nstr + j * out_cstr + s0 * out_hstr +
+                                               s1 * out_wstr];
                         }
                     }
                     else
@@ -225,10 +205,11 @@ int mloSoftmaxForwardRunHost(miopenTensorDescriptor_t inputTensor,
 
                         for(int j = 0; j < c; j++)
                         {
-                            outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1] =
+                            outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1 * out_wstr] =
                                 alpha * (results[(i * c + j) * h * w + s0 * w + s1] /
                                          channel_max[i * h * w + s0 * w + s1]) +
-                                beta * outhost[i * out_nstr + j * out_cstr + s0 * out_hstr + s1];
+                                beta * outhost[i * out_nstr + j * out_cstr + s0 * out_hstr +
+                                               s1 * out_wstr];
                         }
                     }
                 }
@@ -255,8 +236,6 @@ int mloSoftmaxBackwardRunHost(miopenTensorDescriptor_t dInputTensor,
     miopenGet4dTensorDescriptorLengths(dOutputTensor, &n, &c, &h, &w);
     miopenGet4dTensorDescriptorStrides(dInputTensor, &in_nstr, &in_cstr, &in_hstr, &in_wstr);
     miopenGet4dTensorDescriptorStrides(dOutputTensor, &out_nstr, &out_cstr, &out_hstr, &out_wstr);
-    (void)in_wstr;
-    (void)out_wstr;
 
     std::vector<Tcheck> channel_dot((mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? n : n * h * w),
                                     static_cast<Tcheck>(0.0));
@@ -275,15 +254,15 @@ int mloSoftmaxBackwardRunHost(miopenTensorDescriptor_t dInputTensor,
                         if(algo == MIOPEN_SOFTMAX_LOG)
                         {
                             channel_dot[i] += static_cast<Tcheck>(
-                                dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]);
+                                dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1 * out_wstr]);
                         }
                         else
                         {
                             channel_dot[i] +=
-                                static_cast<Tcheck>(
-                                    out[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]) *
-                                static_cast<Tcheck>(
-                                    dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]);
+                                static_cast<Tcheck>(out[i * out_nstr + j * out_cstr +
+                                                        s0 * out_hstr + s1 * out_wstr]) *
+                                static_cast<Tcheck>(dout[i * out_nstr + j * out_cstr +
+                                                         s0 * out_hstr + s1 * out_wstr]);
                         }
                     }
 
@@ -294,24 +273,24 @@ int mloSoftmaxBackwardRunHost(miopenTensorDescriptor_t dInputTensor,
                         if(algo == MIOPEN_SOFTMAX_LOG)
                         {
                             results[(i * c + j) * h * w + s0 * w + s1] =
-                                static_cast<Tcheck>(
-                                    dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]) -
-                                channel_dot[i] *
-                                    std::exp(out[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]);
+                                static_cast<Tcheck>(dout[i * out_nstr + j * out_cstr +
+                                                         s0 * out_hstr + s1 * out_wstr]) -
+                                channel_dot[i] * std::exp(out[i * out_nstr + j * out_cstr +
+                                                              s0 * out_hstr + s1 * out_wstr]);
                         }
                         else
                         {
                             results[(i * c + j) * h * w + s0 * w + s1] =
-                                static_cast<Tcheck>(
-                                    dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]) -
+                                static_cast<Tcheck>(dout[i * out_nstr + j * out_cstr +
+                                                         s0 * out_hstr + s1 * out_wstr]) -
                                 channel_dot[i];
 
                             results[(i * c + j) * h * w + s0 * w + s1] *= static_cast<Tcheck>(
-                                out[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]);
+                                out[i * out_nstr + j * out_cstr + s0 * out_hstr + s1 * out_wstr]);
                         }
-                        dinhost[i * in_nstr + j * in_cstr + s0 * in_hstr + s1] =
+                        dinhost[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr] =
                             alpha * results[(i * c + j) * h * w + s0 * w + s1] +
-                            beta * dinhost[i * in_nstr + j * in_cstr + s0 * in_hstr + s1];
+                            beta * dinhost[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr];
                     }
         }
         else
@@ -324,15 +303,15 @@ int mloSoftmaxBackwardRunHost(miopenTensorDescriptor_t dInputTensor,
                         if(algo == MIOPEN_SOFTMAX_LOG)
                         {
                             channel_dot[i * h * w + s0 * w + s1] += static_cast<Tcheck>(
-                                dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]);
+                                dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1 * out_wstr]);
                         }
                         else
                         {
                             channel_dot[i * h * w + s0 * w + s1] +=
-                                static_cast<Tcheck>(
-                                    out[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]) *
-                                static_cast<Tcheck>(
-                                    dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]);
+                                static_cast<Tcheck>(out[i * out_nstr + j * out_cstr +
+                                                        s0 * out_hstr + s1 * out_wstr]) *
+                                static_cast<Tcheck>(dout[i * out_nstr + j * out_cstr +
+                                                         s0 * out_hstr + s1 * out_wstr]);
                         }
                     }
 
@@ -341,24 +320,25 @@ int mloSoftmaxBackwardRunHost(miopenTensorDescriptor_t dInputTensor,
                         if(algo == MIOPEN_SOFTMAX_LOG)
                         {
                             results[(i * c + j) * h * w + s0 * w + s1] =
-                                static_cast<Tcheck>(
-                                    dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]) -
+                                static_cast<Tcheck>(dout[i * out_nstr + j * out_cstr +
+                                                         s0 * out_hstr + s1 * out_wstr]) -
                                 channel_dot[i * h * w + s0 * w + s1] *
-                                    std::exp(out[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]);
+                                    std::exp(out[i * out_nstr + j * out_cstr + s0 * out_hstr +
+                                                 s1 * out_wstr]);
                         }
                         else
                         {
                             results[(i * c + j) * h * w + s0 * w + s1] =
-                                static_cast<Tcheck>(
-                                    dout[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]) -
+                                static_cast<Tcheck>(dout[i * out_nstr + j * out_cstr +
+                                                         s0 * out_hstr + s1 * out_wstr]) -
                                 channel_dot[i * h * w + s0 * w + s1];
 
                             results[(i * c + j) * h * w + s0 * w + s1] *= static_cast<Tcheck>(
-                                out[i * out_nstr + j * out_cstr + s0 * out_hstr + s1]);
+                                out[i * out_nstr + j * out_cstr + s0 * out_hstr + s1 * out_wstr]);
                         }
-                        dinhost[i * in_nstr + j * in_cstr + s0 * in_hstr + s1] =
+                        dinhost[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr] =
                             alpha * results[(i * c + j) * h * w + s0 * w + s1] +
-                            beta * dinhost[i * in_nstr + j * in_cstr + s0 * in_hstr + s1];
+                            beta * dinhost[i * in_nstr + j * in_cstr + s0 * in_hstr + s1 * in_wstr];
                     }
                 }
         }

--- a/projects/miopen/driver/softmax_driver.hpp
+++ b/projects/miopen/driver/softmax_driver.hpp
@@ -192,8 +192,7 @@ void SoftmaxDriver<Tgpu, Tref>::ValidateLayout()
     }
     else if(layout_value != "NCHW" && layout_value != "NHWC")
     {
-        std::cerr << "Invalid layout parameter value: " << layout_value << std::endl;
-        exit(EXIT_FAILURE); // NOLINT (concurrency-mt-unsafe)
+        MIOPEN_THROW(miopenStatusInvalidValue, "Invalid layout parameter value: " + layout_value);
     }
 }
 

--- a/projects/miopen/driver/softmax_driver.hpp
+++ b/projects/miopen/driver/softmax_driver.hpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 #ifndef GUARD_MIOPEN_SOFTMAX_DRIVER_HPP
 #define GUARD_MIOPEN_SOFTMAX_DRIVER_HPP
 
@@ -39,11 +16,9 @@
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>
 
-#include <algorithm>
 #include <cfloat>
 #include <cstdlib>
 #include <memory>
-#include <numeric>
 #include <vector>
 
 template <typename Tgpu, typename Tref>
@@ -67,6 +42,7 @@ public:
 
     int GetandSetData() override;
     std::vector<int> GetInputTensorLengthsFromCmdLine();
+    void ValidateLayout();
 
     int AllocateBuffersAndCopy() override;
 
@@ -134,12 +110,29 @@ template <typename Tgpu, typename Tref>
 int SoftmaxDriver<Tgpu, Tref>::GetandSetData()
 {
     std::vector<int> in_len = GetInputTensorLengthsFromCmdLine();
+    ValidateLayout();
 
-    SetTensor4d(inputTensor, in_len, data_type);
-    SetTensor4d(outputTensor, in_len, data_type);
+    if(SetTensorNd(inputTensor, in_len, inflags.GetValueStr("layout"), data_type) !=
+       miopenStatusSuccess)
+    {
+        MIOPEN_THROW("Error setting input tensor.");
+    }
+    if(SetTensorNd(outputTensor, in_len, inflags.GetValueStr("layout"), data_type) !=
+       miopenStatusSuccess)
+    {
+        MIOPEN_THROW("Error setting output tensor.");
+    }
 
-    SetTensor4d(dInputTensor, in_len, data_type);
-    SetTensor4d(dOutputTensor, in_len, data_type);
+    if(SetTensorNd(dInputTensor, in_len, inflags.GetValueStr("layout"), data_type) !=
+       miopenStatusSuccess)
+    {
+        MIOPEN_THROW("Error setting dinput tensor.");
+    }
+    if(SetTensorNd(dOutputTensor, in_len, inflags.GetValueStr("layout"), data_type) !=
+       miopenStatusSuccess)
+    {
+        MIOPEN_THROW("Error setting doutput tensor.");
+    }
 
     alpha = static_cast<float>(inflags.GetValueDouble("alpha"));
     beta  = static_cast<float>(inflags.GetValueDouble("beta"));
@@ -152,6 +145,8 @@ template <typename Tgpu, typename Tref>
 int SoftmaxDriver<Tgpu, Tref>::AddCmdLineArgs()
 {
     inflags.AddInputFlag("forw", 'F', "0", "Run only Forward Softmax (Default=0)", "int");
+    inflags.AddInputFlag(
+        "layout", 'L', "", "Tensor layout: [NCHW, NHWC] (Default=NCHW)", "string", true);
     inflags.AddInputFlag("batchsize", 'n', "100", "Mini-batch size (Default=100)", "int");
     inflags.AddInputFlag("in_channels", 'c', "3", "Number of Input Channels (Default=3)", "int");
     inflags.AddInputFlag("in_h", 'H', "32", "Input Height (Default=32)", "int");
@@ -185,6 +180,21 @@ std::vector<int> SoftmaxDriver<Tgpu, Tref>::GetInputTensorLengthsFromCmdLine()
     isForward = inflags.GetValueInt("forw") == 1;
 
     return std::vector<int>({in_n, in_c, in_h, in_w});
+}
+
+template <typename Tgpu, typename Tref>
+void SoftmaxDriver<Tgpu, Tref>::ValidateLayout()
+{
+    auto layout_value = inflags.GetValueStr("layout");
+    if(layout_value.empty())
+    {
+        inflags.SetValue("layout", "NCHW");
+    }
+    else if(layout_value != "NCHW" && layout_value != "NHWC")
+    {
+        std::cerr << "Invalid layout parameter value: " << layout_value << std::endl;
+        exit(EXIT_FAILURE); // NOLINT (concurrency-mt-unsafe)
+    }
 }
 
 template <typename Tgpu, typename Tref>

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2025 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 #ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
@@ -119,11 +96,11 @@ __device__ void loop(const unsigned int lid, LAMBDA&& lambda)
     }
 }
 
-template <bool IS_PACKED>
+template <bool IS_CONTIGUOUS>
 __forceinline__ __device__ int get_index(int n, int i, int s, int s0, int s1, const int offset)
 {
     auto idx = offset;
-    if constexpr(IS_PACKED)
+    if constexpr(IS_CONTIGUOUS)
     {
         idx += (n * VECTOR_SIZE + i) * SPATIAL_DIM + s;
     }
@@ -132,35 +109,35 @@ __forceinline__ __device__ int get_index(int n, int i, int s, int s0, int s1, co
         auto i0 = i / (HEIGHT * WIDTH);
         auto i1 = (i % (HEIGHT * WIDTH)) / WIDTH;
         auto i2 = (i % (HEIGHT * WIDTH)) % WIDTH;
-        idx += n * N_STRIDE + i0 * C_STRIDE + i1 * H_STRIDE + i2;
+        idx += n * N_STRIDE + i0 * C_STRIDE + i1 * H_STRIDE + i2 * W_STRIDE;
     }
     else
     {
-        idx += n * N_STRIDE + i * C_STRIDE + s0 * H_STRIDE + s1;
+        idx += n * N_STRIDE + i * C_STRIDE + s0 * H_STRIDE + s1 * W_STRIDE;
     }
     return idx;
 }
 
 __forceinline__ __device__ int get_x_index(int n, int i, int s, int s0, int s1, const int x_offset)
 {
-    return get_index<IS_INPUT_PACKED>(n, i, s, s0, s1, x_offset);
+    return get_index<IS_INPUT_CONTIGUOUS>(n, i, s, s0, s1, x_offset);
 }
 
 __forceinline__ __device__ int get_y_index(int n, int i, int s, int s0, int s1, const int y_offset)
 {
-    return get_index<IS_OUTPUT_PACKED>(n, i, s, s0, s1, y_offset);
+    return get_index<IS_OUTPUT_CONTIGUOUS>(n, i, s, s0, s1, y_offset);
 }
 
 __forceinline__ __device__ int
 get_dx_index(int n, int i, int s, int s0, int s1, const int dx_offset)
 {
-    return get_index<IS_DINPUT_PACKED>(n, i, s, s0, s1, dx_offset);
+    return get_index<IS_DINPUT_CONTIGUOUS>(n, i, s, s0, s1, dx_offset);
 }
 
 __forceinline__ __device__ int
 get_dy_index(int n, int i, int s, int s0, int s1, const int dy_offset)
 {
-    return get_index<IS_DOUTPUT_PACKED>(n, i, s, s0, s1, dy_offset);
+    return get_index<IS_DOUTPUT_CONTIGUOUS>(n, i, s, s0, s1, dy_offset);
 }
 
 template <typename TI, typename TO>
@@ -280,7 +257,8 @@ __forceinline__ __device__ void softmaxfwd(const TI* __restrict__ x,
                     value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
                 }
 
-                value = value * FLOAT_ACCUM(alpha) + CVT_FLOAT2ACCUM(y[y_idx]) * FLOAT_ACCUM(beta);
+                value = value * CVT_FP32_2ACCUM(alpha) +
+                        CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
                 y[y_idx] = CVT_ACCUM2FLOAT(value);
             });
         }
@@ -407,8 +385,8 @@ __forceinline__ __device__ void softmaxfwd(const TI* __restrict__ x,
                     values[v_idx] *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
                 }
 
-                values[v_idx] = values[v_idx] * FLOAT_ACCUM(alpha) +
-                                CVT_FLOAT2ACCUM(y[y_idx]) * FLOAT_ACCUM(beta);
+                values[v_idx] = values[v_idx] * CVT_FP32_2ACCUM(alpha) +
+                                CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
 
                 y[y_idx] = CVT_ACCUM2FLOAT(values[v_idx]);
             }
@@ -476,8 +454,8 @@ __forceinline__ __device__ void softmaxbwd(const TI* __restrict__ y,
                 {
                     value = (value - channel_dot) * CVT_FLOAT2ACCUM(y[y_idx]);
                 }
-                value =
-                    value * FLOAT_ACCUM(alpha) + CVT_FLOAT2ACCUM(dx[dx_idx]) * FLOAT_ACCUM(beta);
+                value = value * CVT_FP32_2ACCUM(alpha) +
+                        CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
                 dx[dx_idx] = CVT_ACCUM2FLOAT(value);
             });
         }
@@ -544,8 +522,8 @@ __forceinline__ __device__ void softmaxbwd(const TI* __restrict__ y,
                     dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
                 }
 
-                auto value = dy_values[index] * FLOAT_ACCUM(alpha) +
-                             CVT_FLOAT2ACCUM(dx[dx_idx]) * FLOAT_ACCUM(beta);
+                auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                             CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
                 dx[dx_idx] = CVT_ACCUM2FLOAT(value);
             }
             ++index;

--- a/projects/miopen/src/softmax/problem_description.cpp
+++ b/projects/miopen/src/softmax/problem_description.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/datatype.hpp>
 #include <miopen/softmax/problem_description.hpp>
@@ -51,15 +28,8 @@ NetworkConfig ProblemDescription::MakeNetworkConfig() const
     ss << "mode" << static_cast<int>(mode);
 
     auto printStrides = [&ss](std::string_view name, const miopen::TensorDescriptor& d) {
-        if(d.IsPacked())
-        {
-            ss << name << "pk1";
-        }
-        else
-        {
-            const auto [n, c, h, w] = tien<4>(d.GetStrides());
-            ss << name << "pk0strides" << n << "x" << c << "x" << h << "x" << w;
-        }
+        const auto [n, c, h, w] = tien<4>(d.GetStrides());
+        ss << name << "strides" << n << "x" << c << "x" << h << "x" << w;
     };
 
     if(isForward)

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/env.hpp>
 #include <miopen/softmax/solvers.hpp>
@@ -171,10 +148,10 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
                               {"NUM_BATCH", num_batch},
                               {"BATCH_SIZE", batch_size},
                               {"U_BATCH_SIZE", u_batch_size},
-                              {"IS_INPUT_PACKED", problem.GetXDesc().IsPacked()},
-                              {"IS_OUTPUT_PACKED", problem.GetYDesc().IsPacked()},
-                              {"IS_DINPUT_PACKED", problem.GetdXDesc().IsPacked()},
-                              {"IS_DOUTPUT_PACKED", problem.GetdYDesc().IsPacked()}};
+                              {"IS_INPUT_CONTIGUOUS", problem.GetXDesc().IsContiguous()},
+                              {"IS_OUTPUT_CONTIGUOUS", problem.GetYDesc().IsContiguous()},
+                              {"IS_DINPUT_CONTIGUOUS", problem.GetdXDesc().IsContiguous()},
+                              {"IS_DOUTPUT_CONTIGUOUS", problem.GetdYDesc().IsContiguous()}};
 
     kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
 

--- a/projects/miopen/test/gtest/soft_max.cpp
+++ b/projects/miopen/test/gtest/soft_max.cpp
@@ -1,30 +1,8 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2025 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include "get_handle.hpp"
+#include "miopen/miopen.h"
 #include "verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/softmax.hpp>
@@ -50,6 +28,7 @@ struct TestCase
     std::vector<float> scale;
     miopenSoftmaxAlgorithm_t algo;
     miopenSoftmaxMode_t mode;
+    miopenTensorLayout_t layout;
 };
 
 std::string PrintToString(const TestCase& test_case)
@@ -73,7 +52,8 @@ std::string PrintToString(const TestCase& test_case)
     {
         ss << test_case.scale[test_case.scale.size() - 1];
     }
-    ss << "}, algo = " << test_case.algo << ", mode = " << test_case.mode << "}";
+    ss << "}, algo = " << test_case.algo << ", mode = " << test_case.mode
+       << ", layout = " << (test_case.layout == miopenTensorNCHW ? "NCHW" : "NHWC") << "}";
     return ss.str();
 }
 
@@ -82,6 +62,7 @@ void AddTestCasesForDifferentScales(std::vector<TestCase>& test_cases,
                                     const std::vector<size_t>& in_dim,
                                     int algo,
                                     int mode,
+                                    miopenTensorLayout_t layout,
                                     const std::vector<std::vector<float>>& scales)
 {
     // Result does not fit in data type
@@ -98,6 +79,7 @@ void AddTestCasesForDifferentScales(std::vector<TestCase>& test_cases,
         test_case.in_dim = in_dim;
         test_case.algo   = static_cast<miopenSoftmaxAlgorithm_t>(algo);
         test_case.mode   = static_cast<miopenSoftmaxMode_t>(mode);
+        test_case.layout = layout;
         test_case.scale  = scale;
     }
 }
@@ -109,18 +91,25 @@ std::vector<TestCase> GenCases()
 
     std::set<std::vector<size_t>> in_dim_set = get_inputs<size_t>(batch_factor);
 
-    std::vector<int> algos                 = {0, 1, 2};
-    std::vector<int> modes                 = {0, 1};
-    std::vector<std::vector<float>> scales = {{1.0f, 0.0f}, {0.5f, 0.5f}};
+    std::vector<int> algos                    = {0, 1, 2};
+    std::vector<int> modes                    = {0, 1};
+    std::vector<std::vector<float>> scales    = {{1.0f, 0.0f}, {0.5f, 0.5f}};
+    std::vector<miopenTensorLayout_t> layouts = {miopenTensorNCHW, miopenTensorNHWC};
 
     std::vector<TestCase> test_cases;
 
     for(const auto& in_dim : in_dim_set)
+    {
         for(const int algo : algos)
+        {
             for(const int mode : modes)
             {
-                AddTestCasesForDifferentScales<T>(test_cases, in_dim, algo, mode, scales);
+                for(const miopenTensorLayout_t layout : layouts)
+                    AddTestCasesForDifferentScales<T>(
+                        test_cases, in_dim, algo, mode, layout, scales);
             }
+        }
+    }
 
     return test_cases;
 }
@@ -146,8 +135,9 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
         uint64_t max_value =
             miopen_type<T>{} == miopenHalf ? (test_case.algo == MIOPEN_SOFTMAX_LOG ? 3 : 5) : 17;
 
-        input            = tensor<T>{test_case.in_dim}.generate(tensor_elem_gen_integer{max_value});
-        size_t total_mem = 2 * input.desc.GetNumBytes(); // estimate based on backward pass
+        input = tensor<T>{test_case.layout, test_case.in_dim}.generate(
+            tensor_elem_gen_integer{max_value});
+        size_t total_mem  = 2 * input.desc.GetNumBytes(); // estimate based on backward pass
         size_t device_mem = get_handle().GetGlobalMemorySize();
         if(total_mem >= device_mem)
         {
@@ -158,7 +148,8 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
             GTEST_SKIP();
         }
 
-        output = tensor<T>{test_case.in_dim}.generate(tensor_elem_gen_integer{max_value});
+        output = tensor<T>{test_case.layout, test_case.in_dim}.generate(
+            tensor_elem_gen_integer{max_value});
 
         std::vector<T> tensorCpuDataForward = GetForwardCpu();
         std::vector<T> tensorGpuDataForward = GetForwardGpu();
@@ -166,12 +157,15 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
         // check forward results
         CompareResults(tensorGpuDataForward, tensorCpuDataForward, true);
 
-        dout   = tensor<T>{test_case.in_dim}.generate([&](int n, int c, int h, int w) {
-            T x      = input(n, c, h, w);
-            double y = (877 * n + 547 * c + 701 * h + 1049 * w + static_cast<int>(769 * x)) % 2503;
-            return ((x * y) / 1301.0);
-        });
-        dinput = tensor<T>{test_case.in_dim}.generate(tensor_elem_gen_integer{max_value});
+        dout =
+            tensor<T>{test_case.layout, test_case.in_dim}.generate([&](int n, int c, int h, int w) {
+                T x = input(n, c, h, w);
+                double y =
+                    (877 * n + 547 * c + 701 * h + 1049 * w + static_cast<int>(769 * x)) % 2503;
+                return ((x * y) / 1301.0);
+            });
+        dinput = tensor<T>{test_case.layout, test_case.in_dim}.generate(
+            tensor_elem_gen_integer{max_value});
 
         std::vector<T> tensorCpuDataBackward = GetBackwardCpu();
         std::vector<T> tensorGpuDataBackward = GetBackwardGpu();
@@ -189,12 +183,11 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
         int in_n, in_c, in_h, in_w;
         std::tie(in_n, in_c, in_h, in_w) = miopen::tien<4>(input.desc.GetLengths());
 
-        int in_nstr, in_cstr, in_hstr;
-        std::tie(in_nstr, in_cstr, in_hstr, std::ignore) = miopen::tien<4>(input.desc.GetStrides());
+        int in_nstr, in_cstr, in_hstr, in_wstr;
+        std::tie(in_nstr, in_cstr, in_hstr, in_wstr) = miopen::tien<4>(input.desc.GetStrides());
 
-        int out_nstr, out_cstr, out_hstr;
-        std::tie(out_nstr, out_cstr, out_hstr, std::ignore) =
-            miopen::tien<4>(out.desc.GetStrides());
+        int out_nstr, out_cstr, out_hstr, out_wstr;
+        std::tie(out_nstr, out_cstr, out_hstr, out_wstr) = miopen::tien<4>(out.desc.GetStrides());
 
         float alpha = test_case.scale[0];
         float beta  = test_case.scale[1];
@@ -206,20 +199,24 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
                 {
                     double sum = 0;
                     miopen::ford(in_c, in_h, in_w)([&](int w, int i, int j) {
-                        sum += std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j]);
+                        sum +=
+                            std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr]);
                     });
                     miopen::ford(in_c, in_h, in_w)([&](int w, int i, int j) {
-                        out[o * out_nstr + w * out_cstr + i * out_hstr + j] =
-                            alpha * (std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j]) /
-                                     sum) +
-                            beta * out[o * out_nstr + w * out_cstr + i * out_hstr + j];
+                        out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr] =
+                            alpha *
+                                (std::exp(
+                                     input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr]) /
+                                 sum) +
+                            beta * out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr];
                     });
                 }
                 else
                 {
                     T max_c = std::numeric_limits<T>::lowest();
                     miopen::ford(in_c, in_h, in_w)([&](int w, int i, int j) {
-                        max_c = std::max(max_c, input[o * in_nstr + w * in_cstr + i * in_hstr + j]);
+                        max_c = std::max(
+                            max_c, input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr]);
                     });
 
                     if(test_case.algo == MIOPEN_SOFTMAX_LOG)
@@ -230,33 +227,39 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
                         double sum     = neg_inf;
                         miopen::ford(in_c, in_h, in_w)([&](int w, int i, int j) {
                             sum = logaddexp(
-                                double(input[o * in_nstr + w * in_cstr + i * in_hstr + j] - max_c),
+                                double(
+                                    input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr] -
+                                    max_c),
                                 sum,
                                 neg_inf);
                         });
 
                         miopen::ford(in_c, in_h, in_w)([&](int w, int i, int j) {
-                            out[o * out_nstr + w * out_cstr + i * out_hstr + j] =
-                                alpha * (input[o * in_nstr + w * in_cstr + i * in_hstr + j] -
-                                         max_c - sum) +
-                                beta * out[o * out_nstr + w * out_cstr + i * out_hstr + j];
+                            out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr] =
+                                alpha *
+                                    (input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr] -
+                                     max_c - sum) +
+                                beta *
+                                    out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr];
                         });
                     }
                     else
                     {
                         double sum = 0;
                         miopen::ford(in_c, in_h, in_w)([&](int w, int i, int j) {
-                            sum += std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j] -
-                                            max_c);
+                            sum += std::exp(
+                                input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr] -
+                                max_c);
                         });
 
                         miopen::ford(in_c, in_h, in_w)([&](int w, int i, int j) {
-                            out[o * out_nstr + w * out_cstr + i * out_hstr + j] =
-                                alpha *
-                                    (std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j] -
-                                              max_c) /
-                                     sum) +
-                                beta * out[o * out_nstr + w * out_cstr + i * out_hstr + j];
+                            out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr] =
+                                alpha * (std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr +
+                                                        j * in_wstr] -
+                                                  max_c) /
+                                         sum) +
+                                beta *
+                                    out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr];
                         });
                     }
                 }
@@ -269,20 +272,24 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
                 {
                     double sum = 0;
                     miopen::ford(in_c)([&](int w) {
-                        sum += std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j]);
+                        sum +=
+                            std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr]);
                     });
                     miopen::ford(in_c)([&](int w) {
-                        out[o * out_nstr + w * out_cstr + i * out_hstr + j] =
-                            alpha * (std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j]) /
-                                     sum) +
-                            beta * out[o * out_nstr + w * out_cstr + i * out_hstr + j];
+                        out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr] =
+                            alpha *
+                                (std::exp(
+                                     input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr]) /
+                                 sum) +
+                            beta * out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr];
                     });
                 }
                 else
                 {
                     T max_c = std::numeric_limits<T>::lowest();
                     miopen::ford(in_c)([&](int w) {
-                        max_c = std::max(max_c, input[o * in_nstr + w * in_cstr + i * in_hstr + j]);
+                        max_c = std::max(
+                            max_c, input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr]);
                     });
 
                     if(test_case.algo == MIOPEN_SOFTMAX_LOG)
@@ -293,33 +300,39 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
                         double sum     = neg_inf;
                         miopen::ford(in_c)([&](int w) {
                             sum = logaddexp(
-                                double(input[o * in_nstr + w * in_cstr + i * in_hstr + j] - max_c),
+                                double(
+                                    input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr] -
+                                    max_c),
                                 sum,
                                 neg_inf);
                         });
 
                         miopen::ford(in_c)([&](int w) {
-                            out[o * out_nstr + w * out_cstr + i * out_hstr + j] =
-                                alpha * (input[o * in_nstr + w * in_cstr + i * in_hstr + j] -
-                                         max_c - sum) +
-                                beta * out[o * out_nstr + w * out_cstr + i * out_hstr + j];
+                            out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr] =
+                                alpha *
+                                    (input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr] -
+                                     max_c - sum) +
+                                beta *
+                                    out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr];
                         });
                     }
                     else
                     {
                         double sum = 0;
                         miopen::ford(in_c)([&](int w) {
-                            sum += std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j] -
-                                            max_c);
+                            sum += std::exp(
+                                input[o * in_nstr + w * in_cstr + i * in_hstr + j * in_wstr] -
+                                max_c);
                         });
 
                         miopen::ford(in_c)([&](int w) {
-                            out[o * out_nstr + w * out_cstr + i * out_hstr + j] =
-                                alpha *
-                                    (std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr + j] -
-                                              max_c) /
-                                     sum) +
-                                beta * out[o * out_nstr + w * out_cstr + i * out_hstr + j];
+                            out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr] =
+                                alpha * (std::exp(input[o * in_nstr + w * in_cstr + i * in_hstr +
+                                                        j * in_wstr] -
+                                                  max_c) /
+                                         sum) +
+                                beta *
+                                    out[o * out_nstr + w * out_cstr + i * out_hstr + j * out_wstr];
                         });
                     }
                 }
@@ -358,12 +371,11 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
         int in_n, in_c, in_h, in_w;
         std::tie(in_n, in_c, in_h, in_w) = miopen::tien<4>(din.desc.GetLengths());
 
-        int in_nstr, in_cstr, in_hstr;
-        std::tie(in_nstr, in_cstr, in_hstr, std::ignore) = miopen::tien<4>(din.desc.GetStrides());
+        int in_nstr, in_cstr, in_hstr, in_wstr;
+        std::tie(in_nstr, in_cstr, in_hstr, in_wstr) = miopen::tien<4>(din.desc.GetStrides());
 
-        int out_nstr, out_cstr, out_hstr;
-        std::tie(out_nstr, out_cstr, out_hstr, std::ignore) =
-            miopen::tien<4>(dout.desc.GetStrides());
+        int out_nstr, out_cstr, out_hstr, out_wstr;
+        std::tie(out_nstr, out_cstr, out_hstr, out_wstr) = miopen::tien<4>(dout.desc.GetStrides());
 
         float alpha = test_case.scale[0];
         float beta  = test_case.scale[1];
@@ -375,30 +387,33 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
                 miopen::ford(in_c, in_h, in_w)([&](int c, int i, int j) {
                     if(test_case.algo == MIOPEN_SOFTMAX_LOG)
                     {
-                        sum += dout[o * out_nstr + c * out_cstr + i * out_hstr + j];
+                        sum += dout[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr];
                     }
                     else
                     {
-                        sum += output[o * out_nstr + c * out_cstr + i * out_hstr + j] *
-                               dout[o * out_nstr + c * out_cstr + i * out_hstr + j];
+                        sum += output[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr] *
+                               dout[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr];
                     }
                 });
 
                 miopen::ford(in_c, in_h, in_w)([&](int c, int i, int j) {
                     if(test_case.algo == MIOPEN_SOFTMAX_LOG)
                     {
-                        din[o * in_nstr + c * in_cstr + i * in_hstr + j] =
-                            T(alpha * (dout[o * out_nstr + c * out_cstr + i * out_hstr + j] -
-                                       sum * std::exp(output[o * out_nstr + c * out_cstr +
-                                                             i * out_hstr + j])) +
-                              beta * din[o * in_nstr + c * in_cstr + i * in_hstr + j]);
+                        din[o * in_nstr + c * in_cstr + i * in_hstr + j * in_wstr] =
+                            T(alpha *
+                                  (dout[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr] -
+                                   sum * std::exp(output[o * out_nstr + c * out_cstr +
+                                                         i * out_hstr + j * out_wstr])) +
+                              beta * din[o * in_nstr + c * in_cstr + i * in_hstr + j * in_wstr]);
                     }
                     else
                     {
-                        din[o * in_nstr + c * in_cstr + i * in_hstr + j] =
-                            alpha * (output[o * out_nstr + c * out_cstr + i * out_hstr + j] *
-                                     (dout[o * out_nstr + c * out_cstr + i * out_hstr + j] - sum)) +
-                            beta * din[o * in_nstr + c * in_cstr + i * in_hstr + j];
+                        din[o * in_nstr + c * in_cstr + i * in_hstr + j * in_wstr] =
+                            alpha *
+                                (output[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr] *
+                                 (dout[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr] -
+                                  sum)) +
+                            beta * din[o * in_nstr + c * in_cstr + i * in_hstr + j * in_wstr];
                     }
                 });
             });
@@ -410,32 +425,33 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
                 miopen::ford(in_c)([&](int c) {
                     if(test_case.algo == MIOPEN_SOFTMAX_LOG)
                     {
-                        sum += dout[o * out_nstr + c * out_cstr + i * out_hstr + j];
+                        sum += dout[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr];
                     }
                     else
                     {
-                        sum += output[o * out_nstr + c * out_cstr + i * out_hstr + j] *
-                               dout[o * out_nstr + c * out_cstr + i * out_hstr + j];
+                        sum += output[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr] *
+                               dout[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr];
                     }
                 });
 
                 miopen::ford(in_c)([&](int c) {
                     if(test_case.algo == MIOPEN_SOFTMAX_LOG)
                     {
-                        din[o * in_nstr + c * in_cstr + i * in_hstr + j] =
+                        din[o * in_nstr + c * in_cstr + i * in_hstr + j * in_wstr] =
                             alpha *
-                                (dout[o * out_nstr + c * out_cstr + i * out_hstr + j] -
-                                 sum *
-                                     std::exp(
-                                         output[o * out_nstr + c * out_cstr + i * out_hstr + j])) +
-                            beta * din[o * in_nstr + c * in_cstr + i * in_hstr + j];
+                                (dout[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr] -
+                                 sum * std::exp(output[o * out_nstr + c * out_cstr + i * out_hstr +
+                                                       j * out_wstr])) +
+                            beta * din[o * in_nstr + c * in_cstr + i * in_hstr + j * in_wstr];
                     }
                     else
                     {
-                        din[o * in_nstr + c * in_cstr + i * in_hstr + j] =
-                            alpha * (output[o * out_nstr + c * out_cstr + i * out_hstr + j] *
-                                     (dout[o * out_nstr + c * out_cstr + i * out_hstr + j] - sum)) +
-                            beta * din[o * in_nstr + c * in_cstr + i * in_hstr + j];
+                        din[o * in_nstr + c * in_cstr + i * in_hstr + j * in_wstr] =
+                            alpha *
+                                (output[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr] *
+                                 (dout[o * out_nstr + c * out_cstr + i * out_hstr + j * out_wstr] -
+                                  sum)) +
+                            beta * din[o * in_nstr + c * in_cstr + i * in_hstr + j * in_wstr];
                     }
                 });
             });
@@ -489,6 +505,7 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
         ASSERT_LE(error, threshold)
             << "Tensor Dims: " << test_case.in_dim[0] << ", " << test_case.in_dim[1] << ", "
             << test_case.in_dim[2] << ", " << test_case.in_dim[3] << ", "
+            << "Layout: " << (test_case.layout == miopenTensorNCHW ? "NCHW" : "NHWC") << ", "
             << "Alpha / Beta: " << test_case.scale[0] << ", " << test_case.scale[1]
             << ". Algo: " << test_case.algo << ". Mode: " << test_case.mode
             << ". Direction: " << (isForward ? "Forward" : "Backward") << std::endl;

--- a/projects/miopen/test/gtest/soft_max.cpp
+++ b/projects/miopen/test/gtest/soft_max.cpp
@@ -180,14 +180,12 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
 
         auto out = output;
 
-        int in_n, in_c, in_h, in_w;
-        std::tie(in_n, in_c, in_h, in_w) = miopen::tien<4>(input.desc.GetLengths());
+        const auto [in_n, in_c, in_h, in_w] = miopen::tien<4>(input.desc.GetLengths());
 
-        int in_nstr, in_cstr, in_hstr, in_wstr;
-        std::tie(in_nstr, in_cstr, in_hstr, in_wstr) = miopen::tien<4>(input.desc.GetStrides());
+        const auto [in_nstr, in_cstr, in_hstr, in_wstr] = miopen::tien<4>(input.desc.GetStrides());
 
-        int out_nstr, out_cstr, out_hstr, out_wstr;
-        std::tie(out_nstr, out_cstr, out_hstr, out_wstr) = miopen::tien<4>(out.desc.GetStrides());
+        const auto [out_nstr, out_cstr, out_hstr, out_wstr] =
+            miopen::tien<4>(out.desc.GetStrides());
 
         float alpha = test_case.scale[0];
         float beta  = test_case.scale[1];
@@ -368,14 +366,12 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
 
         auto din = dinput;
 
-        int in_n, in_c, in_h, in_w;
-        std::tie(in_n, in_c, in_h, in_w) = miopen::tien<4>(din.desc.GetLengths());
+        const auto [in_n, in_c, in_h, in_w] = miopen::tien<4>(din.desc.GetLengths());
 
-        int in_nstr, in_cstr, in_hstr, in_wstr;
-        std::tie(in_nstr, in_cstr, in_hstr, in_wstr) = miopen::tien<4>(din.desc.GetStrides());
+        const auto [in_nstr, in_cstr, in_hstr, in_wstr] = miopen::tien<4>(din.desc.GetStrides());
 
-        int out_nstr, out_cstr, out_hstr, out_wstr;
-        std::tie(out_nstr, out_cstr, out_hstr, out_wstr) = miopen::tien<4>(dout.desc.GetStrides());
+        const auto [out_nstr, out_cstr, out_hstr, out_wstr] =
+            miopen::tien<4>(dout.desc.GetStrides());
 
         float alpha = test_case.scale[0];
         float beta  = test_case.scale[1];


### PR DESCRIPTION
## Motivation

This PR adds support for the NHWC layout to softmax.

## Technical Details

- Add support for NHWC to the HIP kernel and CPU reference implementations.
- Add new softmax tests to cover NHWC.
- Add layout flag to the softmax MIOpenDriver.

## Test Plan

Build and run the test target `test_soft_max`.

## Test Result

Both new and existing softmax tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
