### PR TITLE
[MIOpen] Ported solver test to gtest

### DIFF
--- a/projects/miopen/test/gtest/solver.cpp
+++ b/projects/miopen/test/gtest/solver.cpp
@@ -44,27 +44,25 @@
 #include "random.hpp"
 #include "../get_handle.hpp"
 
-namespace miopen {
-namespace tests {
-
-class TrivialTestSolver final : public solver::conv::ConvSolver
+namespace {
+class TrivialTestSolver final : public miopen::solver::conv::ConvSolver
 {
 public:
     static const char* FileName() { return "TrivialTestSolver"; }
 
     const std::string& SolverDbId() const override { return GetSolverDbId<TrivialTestSolver>(); }
 
-    bool IsApplicable(const ExecutionContext&,
-                      const conv::ProblemDescription& problem) const override
+    bool IsApplicable(const miopen::ExecutionContext&,
+                      const miopen::conv::ProblemDescription& problem) const override
     {
         return problem.GetInWidth() == 1;
     }
 
-    solver::ConvSolution GetSolution(const ExecutionContext&,
-                                     const conv::ProblemDescription&) const override
+    miopen::solver::ConvSolution GetSolution(const miopen::ExecutionContext&,
+                                             const miopen::conv::ProblemDescription&) const override
     {
-        solver::ConvSolution ret;
-        solver::KernelInfo kernel;
+        miopen::solver::ConvSolution ret;
+        miopen::solver::KernelInfo kernel;
 
         kernel.kernel_file  = FileName();
         kernel.comp_options = " ";
@@ -74,7 +72,7 @@ public:
     }
 };
 
-struct TestConfig : solver::PerfConfigBase<TestConfig>
+struct TestConfig : miopen::solver::PerfConfigBase<TestConfig>
 {
     std::string str;
 
@@ -85,7 +83,7 @@ struct TestConfig : solver::PerfConfigBase<TestConfig>
     }
 };
 
-class SearchableTestSolver final : public solver::conv::ConvTunableSolver<TestConfig>
+class SearchableTestSolver final : public miopen::solver::conv::ConvTunableSolver<TestConfig>
 {
 public:
     static int searches_done() { return _serches_done; }
@@ -94,29 +92,30 @@ public:
 
     const std::string& SolverDbId() const override { return GetSolverDbId<SearchableTestSolver>(); }
 
-    bool IsApplicable(const ExecutionContext&, const conv::ProblemDescription&) const override
+    bool IsApplicable(const miopen::ExecutionContext&,
+                      const miopen::conv::ProblemDescription&) const override
     {
         return true;
     }
 
-    TestConfig GetDefaultPerformanceConfig(const ExecutionContext&,
-                                           const conv::ProblemDescription&) const override
+    TestConfig GetDefaultPerformanceConfig(const miopen::ExecutionContext&,
+                                           const miopen::conv::ProblemDescription&) const override
     {
         TestConfig config{};
         config.str = NoSearchFileName();
         return config;
     }
 
-    bool IsValidPerformanceConfig(const ExecutionContext&,
-                                  const conv::ProblemDescription&,
+    bool IsValidPerformanceConfig(const miopen::ExecutionContext&,
+                                  const miopen::conv::ProblemDescription&,
                                   const TestConfig&) const override
     {
         return true;
     }
 
-    TestConfig Search(const ExecutionContext&,
-                      const conv::ProblemDescription&,
-                      const AnyInvokeParams&) const override
+    TestConfig Search(const miopen::ExecutionContext&,
+                      const miopen::conv::ProblemDescription&,
+                      const miopen::AnyInvokeParams&) const override
     {
         TestConfig config;
         config.str = FileName();
@@ -124,13 +123,13 @@ public:
         return config;
     }
 
-    solver::ConvSolution GetSolution(const ExecutionContext&,
-                                     const conv::ProblemDescription&,
-                                     const TestConfig& config) const override
+    miopen::solver::ConvSolution GetSolution(const miopen::ExecutionContext&,
+                                             const miopen::conv::ProblemDescription&,
+                                             const TestConfig& config) const override
     {
 
-        solver::ConvSolution ret;
-        solver::KernelInfo kernel;
+        miopen::solver::ConvSolution ret;
+        miopen::solver::KernelInfo kernel;
 
         kernel.kernel_file  = config.str;
         kernel.comp_options = " ";
@@ -146,13 +145,13 @@ private:
 // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
 int SearchableTestSolver::_serches_done = 0;
 
-static solver::ConvSolution FindSolution(const ExecutionContext& ctx,
-                                         const conv::ProblemDescription& problem,
-                                         const fs::path& db_path)
+static miopen::solver::ConvSolution FindSolution(const miopen::ExecutionContext& ctx,
+                                                 const miopen::conv::ProblemDescription& problem,
+                                                 const miopen::fs::path& db_path)
 {
-    PlainTextDb db(DbKinds::PerfDb, db_path);
+    miopen::PlainTextDb db(miopen::DbKinds::PerfDb, db_path);
 
-    const auto solvers = solver::SolverContainer<TrivialTestSolver, SearchableTestSolver>{};
+    const auto solvers = miopen::solver::SolverContainer<TrivialTestSolver, SearchableTestSolver>{};
 
     return solvers.SearchForAllSolutions(ctx, problem, db, {}, 1).front();
 }
@@ -173,7 +172,8 @@ struct TestParams
 {
     std::string expected_kernel;
     std::vector<size_t> in;
-    std::function<void(ExecutionContext&)> context_filter = [](ExecutionContext&) {};
+    std::function<void(miopen::ExecutionContext&)> context_filter = [](miopen::ExecutionContext&) {
+    };
 };
 
 using TestCase =
@@ -183,20 +183,21 @@ using TestCase =
 auto GenCases()
 {
     return std::vector<TestCase>{std::make_tuple<std::vector<TestParams>, std::vector<TestParams>>(
-        {TestParams{TrivialTestSolver::FileName(), {1, 1, 1, 1}, [](ExecutionContext&) {}},
+        {TestParams{TrivialTestSolver::FileName(), {1, 1, 1, 1}, [](miopen::ExecutionContext&) {}},
          TestParams{TrivialTestSolver::FileName(),
                     {1, 1, 1, 1},
-                    [](ExecutionContext& c) { c.do_search = true; }},
+                    [](miopen::ExecutionContext& c) { c.do_search = true; }},
          TestParams{SearchableTestSolver::NoSearchFileName(),
                     {1, 1, 1, 2},
-                    [](ExecutionContext& c) { c.do_search = false; }},
+                    [](miopen::ExecutionContext& c) { c.do_search = false; }},
          TestParams{SearchableTestSolver::FileName(),
                     {1, 1, 1, 2},
-                    [](ExecutionContext& c) { c.do_search = true; }}},
-        {TestParams{SearchableTestSolver::FileName(), {1, 1, 1, 2}, [](ExecutionContext&) {}},
-         TestParams{SearchableTestSolver::FileName(), {1, 1, 1, 2}, [](ExecutionContext& c) {
-                        c.do_search = true;
-                    }}})};
+                    [](miopen::ExecutionContext& c) { c.do_search = true; }}},
+        {TestParams{
+             SearchableTestSolver::FileName(), {1, 1, 1, 2}, [](miopen::ExecutionContext&) {}},
+         TestParams{SearchableTestSolver::FileName(),
+                    {1, 1, 1, 2},
+                    [](miopen::ExecutionContext& c) { c.do_search = true; }}})};
 }
 
 auto GetCases()
@@ -205,13 +206,9 @@ auto GetCases()
     return cases;
 }
 
-} // namespace tests
-} // namespace miopen
+} // namespace
 
-using namespace miopen;
-using namespace miopen::tests;
-
-class SolverTest : public ::testing::TestWithParam<TestCase>
+class GPU_SolverTest_NONE : public ::testing::TestWithParam<TestCase>
 {
 public:
     void SetUp() override { prng::reset_seed(); }
@@ -219,7 +216,7 @@ public:
     void Run()
     {
         auto [pre_check_param, post_check_param] = GetParam();
-        const TempFile db_path("miopen.tests.solver");
+        const miopen::TempFile db_path("miopen.tests.solver");
 
         for(auto const& param : pre_check_param)
         {
@@ -242,18 +239,19 @@ public:
 
 protected:
     void ConstructTest(
-        const fs::path& db_path,
+        const miopen::fs::path& db_path,
         const char* expected_kernel,
         const std::vector<size_t>& in,
-        const std::function<void(ExecutionContext&)>& context_filler = [](ExecutionContext&) {
-        }) const
+        const std::function<void(miopen::ExecutionContext&)>& context_filler =
+            [](miopen::ExecutionContext&) {}) const
     {
-        const auto problem = conv::ProblemDescription{TensorDescriptor{miopenFloat, in},
-                                                      TensorDescriptor{miopenFloat, in},
-                                                      TensorDescriptor{miopenFloat, in},
-                                                      ConvolutionDescriptor{},
-                                                      conv::Direction::Forward};
-        auto ctx           = ExecutionContext{};
+        const auto problem =
+            miopen::conv::ProblemDescription{miopen::TensorDescriptor{miopenFloat, in},
+                                             miopen::TensorDescriptor{miopenFloat, in},
+                                             miopen::TensorDescriptor{miopenFloat, in},
+                                             miopen::ConvolutionDescriptor{},
+                                             miopen::conv::Direction::Forward};
+        auto ctx = miopen::ExecutionContext{};
         ctx.SetStream(&get_handle());
         context_filler(ctx);
 
@@ -264,8 +262,9 @@ protected:
     }
 };
 
-TEST_P(SolverTest, GPU_TestSolver_None) { Run(); }
+TEST_P(GPU_SolverTest_NONE, TestSolver) { Run(); }
 
-INSTANTIATE_TEST_SUITE_P(Smoke, SolverTest, ::testing::ValuesIn(GetCases()), [](auto const&) {
-    return "SearchesDoneTest";
-});
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_SolverTest_NONE,
+                         ::testing::ValuesIn(GetCases()),
+                         [](auto const&) { return "SearchesDoneTest"; });

--- a/projects/miopen/test/gtest/solver.cpp
+++ b/projects/miopen/test/gtest/solver.cpp
@@ -208,7 +208,7 @@ auto GetCases()
 
 } // namespace
 
-class GPU_SolverTest_NONE : public ::testing::TestWithParam<TestCase>
+class CPU_SolverTest_NONE : public ::testing::TestWithParam<TestCase>
 {
 public:
     void SetUp() override { prng::reset_seed(); }
@@ -262,9 +262,9 @@ protected:
     }
 };
 
-TEST_P(GPU_SolverTest_NONE, TestSolver) { Run(); }
+TEST_P(CPU_SolverTest_NONE, TestSolver) { Run(); }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_SolverTest_NONE,
+                         CPU_SolverTest_NONE,
                          ::testing::ValuesIn(GetCases()),
                          [](auto const&) { return "SearchesDoneTest"; });

--- a/projects/miopen/test/gtest/solver.cpp
+++ b/projects/miopen/test/gtest/solver.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,8 @@
  *
  *******************************************************************************/
 
+#include <gtest/gtest.h>
+
 #include <miopen/convolution.hpp>
 #include <miopen/db.hpp>
 #include <miopen/find_solution.hpp>
@@ -35,10 +37,12 @@
 #include <cstdlib>
 #include <functional>
 #include <sstream>
+#include <string_view>
 #include <typeinfo>
+#include <utility>
 
-#include "get_handle.hpp"
-#include "test.hpp"
+#include "random.hpp"
+#include "../get_handle.hpp"
 
 namespace miopen {
 namespace tests {
@@ -165,52 +169,91 @@ public:
     }
 };
 
-class SolverTest
+struct TestParams
+{
+    std::string expected_kernel;
+    std::vector<size_t> in;
+    std::function<void(ExecutionContext&)> context_filter = [](ExecutionContext&) {};
+};
+
+using TestCase = std::tuple<std::vector<TestParams>, std::vector<TestParams>>; // pre-check parameters and post-check parameters
+
+auto GenCases()
+{
+    return std::vector<TestCase>{std::make_tuple<std::vector<TestParams>, std::vector<TestParams>>(
+        {
+            TestParams{TrivialTestSolver::FileName(),
+                      {1, 1, 1, 1},
+                      [](ExecutionContext&) {}},
+            TestParams{TrivialTestSolver::FileName(),
+                      {1, 1, 1, 1},
+                      [](ExecutionContext& c) { c.do_search = true; }},
+            TestParams{SearchableTestSolver::NoSearchFileName(),
+                      {1, 1, 1, 2},
+                      [](ExecutionContext& c) { c.do_search = false; }},
+            TestParams{ SearchableTestSolver::FileName(),
+                      {1, 1, 1, 2},
+                      [](ExecutionContext& c) { c.do_search = true; }}
+        },
+        {
+            TestParams{SearchableTestSolver::FileName(), {1, 1, 1, 2}, [](ExecutionContext&) {}},
+            TestParams{SearchableTestSolver::FileName(),
+                      {1, 1, 1, 2},
+                      [](ExecutionContext& c) { c.do_search = true; }}
+        }
+    )};
+}
+
+auto GetCases()
+{
+    static auto cases = GenCases();
+    return cases;
+}
+
+} // namespace tests
+} // namespace miopen
+
+using namespace miopen;
+using namespace miopen::tests;
+
+class SolverTest : public ::testing::TestWithParam<TestCase>
 {
 public:
-    void Run() const
+    void SetUp() override
     {
+        prng::reset_seed();
+    }
+
+    void Run()
+    {
+        auto [pre_check_param, post_check_param] = GetParam();
         const TempFile db_path("miopen.tests.solver");
 
-        ConstructTest(db_path, TrivialTestSolver::FileName(), {1, 1, 1, 1});
-
-        ConstructTest(db_path,
-                      TrivialTestSolver::FileName(),
-                      {1, 1, 1, 1},
-                      [](ExecutionContext& c) { c.do_search = true; });
-
-        ConstructTest(db_path,
-                      SearchableTestSolver::NoSearchFileName(),
-                      {1, 1, 1, 2},
-                      [](ExecutionContext& c) { c.do_search = false; });
-
-        ConstructTest(db_path,
-                      SearchableTestSolver::FileName(),
-                      {1, 1, 1, 2},
-                      [](ExecutionContext& c) { c.do_search = true; });
+        for(auto const& param : pre_check_param)
+        {
+            ConstructTest(db_path, param.expected_kernel.c_str(), param.in, param.context_filter);
+        }
 
         const auto& searchable_solver = StaticContainer<const SearchableTestSolver>::Instance();
         const auto searches           = SearchableTestSolver::searches_done();
 
         // Should read in both cases: result is already in DB, solver is searchable.
-        ConstructTest(
-            db_path, SearchableTestSolver::FileName(), {1, 1, 1, 2}, [](ExecutionContext&) {});
 
-        ConstructTest(db_path,
-                      SearchableTestSolver::FileName(),
-                      {1, 1, 1, 2},
-                      [](ExecutionContext& c) { c.do_search = true; });
+        for(auto const& param : post_check_param)
+        {
+            ConstructTest(db_path, param.expected_kernel.c_str(), param.in, param.context_filter);
+        }
 
         // Checking no more searches were done.
-        EXPECT_EQUAL(searches, searchable_solver.searches_done());
+        EXPECT_EQ(searches, searchable_solver.searches_done());
     }
 
-private:
-    static void ConstructTest(
+protected:
+    void ConstructTest(
         const fs::path& db_path,
         const char* expected_kernel,
-        const std::initializer_list<size_t>& in,
-        const std::function<void(ExecutionContext&)>& context_filler = [](ExecutionContext&) {})
+        const std::vector<size_t>& in,
+        const std::function<void(ExecutionContext&)>& context_filler = [](ExecutionContext&) {}) const
     {
         const auto problem = conv::ProblemDescription{TensorDescriptor{miopenFloat, in},
                                                       TensorDescriptor{miopenFloat, in},
@@ -223,12 +266,11 @@ private:
 
         const auto sol = FindSolution(ctx, problem, db_path);
 
-        EXPECT_OP(sol.construction_params.size(), >, 0);
-        EXPECT_EQUAL(sol.construction_params[0].kernel_file, expected_kernel);
+        EXPECT_TRUE(sol.construction_params.size() > 0);
+        EXPECT_EQ(sol.construction_params[0].kernel_file, expected_kernel);
     }
 };
 
-} // namespace tests
-} // namespace miopen
+TEST_P(SolverTest, GPU_TestSolver_None) { Run(); }
 
-int main() { miopen::tests::SolverTest().Run(); }
+INSTANTIATE_TEST_SUITE_P(Smoke, SolverTest, ::testing::ValuesIn(GetCases()));

--- a/projects/miopen/test/gtest/solver.cpp
+++ b/projects/miopen/test/gtest/solver.cpp
@@ -1,45 +1,11 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2025 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 
-#include <miopen/convolution.hpp>
-#include <miopen/db.hpp>
 #include <miopen/find_solution.hpp>
-#include <miopen/invoke_params.hpp>
-#include <miopen/mlo_internal.hpp>
 #include <miopen/conv/solvers.hpp>
 #include <miopen/temp_file.hpp>
-
-#include <cstdlib>
-#include <functional>
-#include <sstream>
-#include <string_view>
-#include <typeinfo>
-#include <utility>
 
 #include "random.hpp"
 #include "../get_handle.hpp"

--- a/projects/miopen/test/gtest/solver.cpp
+++ b/projects/miopen/test/gtest/solver.cpp
@@ -176,32 +176,27 @@ struct TestParams
     std::function<void(ExecutionContext&)> context_filter = [](ExecutionContext&) {};
 };
 
-using TestCase = std::tuple<std::vector<TestParams>, std::vector<TestParams>>; // pre-check parameters and post-check parameters
+using TestCase =
+    std::tuple<std::vector<TestParams>,
+               std::vector<TestParams>>; // pre-check parameters and post-check parameters
 
 auto GenCases()
 {
     return std::vector<TestCase>{std::make_tuple<std::vector<TestParams>, std::vector<TestParams>>(
-        {
-            TestParams{TrivialTestSolver::FileName(),
-                      {1, 1, 1, 1},
-                      [](ExecutionContext&) {}},
-            TestParams{TrivialTestSolver::FileName(),
-                      {1, 1, 1, 1},
-                      [](ExecutionContext& c) { c.do_search = true; }},
-            TestParams{SearchableTestSolver::NoSearchFileName(),
-                      {1, 1, 1, 2},
-                      [](ExecutionContext& c) { c.do_search = false; }},
-            TestParams{ SearchableTestSolver::FileName(),
-                      {1, 1, 1, 2},
-                      [](ExecutionContext& c) { c.do_search = true; }}
-        },
-        {
-            TestParams{SearchableTestSolver::FileName(), {1, 1, 1, 2}, [](ExecutionContext&) {}},
-            TestParams{SearchableTestSolver::FileName(),
-                      {1, 1, 1, 2},
-                      [](ExecutionContext& c) { c.do_search = true; }}
-        }
-    )};
+        {TestParams{TrivialTestSolver::FileName(), {1, 1, 1, 1}, [](ExecutionContext&) {}},
+         TestParams{TrivialTestSolver::FileName(),
+                    {1, 1, 1, 1},
+                    [](ExecutionContext& c) { c.do_search = true; }},
+         TestParams{SearchableTestSolver::NoSearchFileName(),
+                    {1, 1, 1, 2},
+                    [](ExecutionContext& c) { c.do_search = false; }},
+         TestParams{SearchableTestSolver::FileName(),
+                    {1, 1, 1, 2},
+                    [](ExecutionContext& c) { c.do_search = true; }}},
+        {TestParams{SearchableTestSolver::FileName(), {1, 1, 1, 2}, [](ExecutionContext&) {}},
+         TestParams{SearchableTestSolver::FileName(), {1, 1, 1, 2}, [](ExecutionContext& c) {
+                        c.do_search = true;
+                    }}})};
 }
 
 auto GetCases()
@@ -219,10 +214,7 @@ using namespace miopen::tests;
 class SolverTest : public ::testing::TestWithParam<TestCase>
 {
 public:
-    void SetUp() override
-    {
-        prng::reset_seed();
-    }
+    void SetUp() override { prng::reset_seed(); }
 
     void Run()
     {
@@ -253,7 +245,8 @@ protected:
         const fs::path& db_path,
         const char* expected_kernel,
         const std::vector<size_t>& in,
-        const std::function<void(ExecutionContext&)>& context_filler = [](ExecutionContext&) {}) const
+        const std::function<void(ExecutionContext&)>& context_filler = [](ExecutionContext&) {
+        }) const
     {
         const auto problem = conv::ProblemDescription{TensorDescriptor{miopenFloat, in},
                                                       TensorDescriptor{miopenFloat, in},
@@ -273,4 +266,6 @@ protected:
 
 TEST_P(SolverTest, GPU_TestSolver_None) { Run(); }
 
-INSTANTIATE_TEST_SUITE_P(Smoke, SolverTest, ::testing::ValuesIn(GetCases()));
+INSTANTIATE_TEST_SUITE_P(Smoke, SolverTest, ::testing::ValuesIn(GetCases()), [](auto const&) {
+    return "SearchesDoneTest";
+});


### PR DESCRIPTION
## Motivation

Porting tests from CTest to GTest, in this case, `solver.cpp`

## Technical Details

Pretty straightforward port, although I had to get creative in order to conform to `INSTANTIATE_TEST_SUITE_P` pattern and naming conventions

## Test Plan

Running locally, using the CI launched by this PR

## Test Result

See CI actions launched by this PR

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
