### PR TITLE
Remove stray comma in Windows prerequisites installer script.

### DIFF
--- a/projects/hipdnn/scripts/windows/windows_build_setup.ps1
+++ b/projects/hipdnn/scripts/windows/windows_build_setup.ps1
@@ -10,7 +10,7 @@ param(
     [switch]$SkipPrerequisites = $false,
     [switch]$SkipWindowsConfig = $false,
     [switch]$SkipToolchainDownload = $false,
-    [switch]$SkipEnvironmentVariables = $false,
+    [switch]$SkipEnvironmentVariables = $false
 )
 
 # Script configuration


### PR DESCRIPTION
## Motivation

The script fails to run out of the box:

```
PS C:\Users\bhargrea\github\TheRock\rocm-libraries\projects\hipdnn\scripts\windows> .\windows_build_setup.ps1
At C:\Users\bhargrea\github\TheRock\rocm-libraries\projects\hipdnn\scripts\windows\windows_build_setup.ps1:13 char:48
+     [switch]$SkipEnvironmentVariables = $false,
+                                                ~
Missing expression after ','.
    + CategoryInfo          : ParserError: (:) [], ParseException
    + FullyQualifiedErrorId : MissingExpressionAfterToken
```

## Technical Details

It's a powershell script for installing the prerequisites on Windows for building hipdnn.

## Test Plan

Run the script after fixing the typo

## Test Result

It runs fine after fixing it:

```
PS C:\Users\bhargrea\github\TheRock\rocm-libraries\projects\hipdnn\scripts\windows> .\windows_build_setup.ps1

===================================================
  hipDNN Windows Build Setup Script
===================================================
Configuration:
  Clang Path: C:\dist\clang
  TheRock Path: C:\dist\therock
  Project Path: C:\projects\hipdnn
  GPU Target: gfx1103
===================================================
```

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
