### PR TITLE
[rocBLAS] fix bench when not using ROCBLAS_BENCH_STREAM_SYNC

### DIFF
--- a/projects/rocblas/clients/include/blas1/testing_dot_strided_batched.hpp
+++ b/projects/rocblas/clients/include/blas1/testing_dot_strided_batched.hpp
@@ -371,7 +371,7 @@ void testing_dot_strided_batched(const Arguments& arg)
 
         hipStream_t stream;
         CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
-        gpu_time_used = get_time_us_sync(stream); // in microseconds
+
         for(int iter = 0; iter < total_calls; iter++)
         {
             if(iter == number_cold_calls)

--- a/projects/rocblas/clients/include/blas2/testing_tbsv_batched.hpp
+++ b/projects/rocblas/clients/include/blas2/testing_tbsv_batched.hpp
@@ -275,7 +275,6 @@ void testing_tbsv_batched(const Arguments& arg)
 
         hipStream_t stream;
         CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
-        gpu_time_used = get_time_us_sync(stream); // in microseconds
 
         for(int iter = 0; iter < total_calls; iter++)
         {

--- a/projects/rocblas/clients/include/blas2/testing_tpmv_batched.hpp
+++ b/projects/rocblas/clients/include/blas2/testing_tpmv_batched.hpp
@@ -235,7 +235,6 @@ void testing_tpmv_batched(const Arguments& arg)
 
         hipStream_t stream;
         CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
-        gpu_time_used = get_time_us_sync(stream); // in microseconds
 
         for(int iter = 0; iter < total_calls; iter++)
         {

--- a/projects/rocblas/clients/include/blas2/testing_tpsv_batched.hpp
+++ b/projects/rocblas/clients/include/blas2/testing_tpsv_batched.hpp
@@ -239,7 +239,6 @@ void testing_tpsv_batched(const Arguments& arg)
 
         hipStream_t stream;
         CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
-        gpu_time_used = get_time_us_sync(stream); // in microseconds
 
         for(int iter = 0; iter < total_calls; iter++)
         {

--- a/projects/rocblas/clients/include/blas2/testing_trmv_batched.hpp
+++ b/projects/rocblas/clients/include/blas2/testing_trmv_batched.hpp
@@ -234,7 +234,6 @@ void testing_trmv_batched(const Arguments& arg)
 
         hipStream_t stream;
         CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
-        gpu_time_used = get_time_us_sync(stream); // in microseconds
 
         for(int iter = 0; iter < total_calls; iter++)
         {

--- a/projects/rocblas/clients/include/blas2/testing_trsv_batched.hpp
+++ b/projects/rocblas/clients/include/blas2/testing_trsv_batched.hpp
@@ -337,7 +337,6 @@ void testing_trsv_batched(const Arguments& arg)
 
         hipStream_t stream;
         CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
-        gpu_time_used = get_time_us_sync(stream); // in microseconds
 
         for(int iter = 0; iter < total_calls; iter++)
         {

--- a/projects/rocblas/clients/include/blas3/testing_trsm_batched.hpp
+++ b/projects/rocblas/clients/include/blas3/testing_trsm_batched.hpp
@@ -745,7 +745,6 @@ void testing_trsm_batched(const Arguments& arg)
 
         hipStream_t stream;
         CHECK_ROCBLAS_ERROR(rocblas_get_stream(handle, &stream));
-        gpu_time_used = get_time_us_sync(stream); // in microseconds
 
         for(int i = 0; i < total_calls; i++)
         {

--- a/projects/rocblas/clients/include/client_utility.hpp
+++ b/projects/rocblas/clients/include/client_utility.hpp
@@ -173,7 +173,7 @@ void set_device(rocblas_int device_id);
 /*! \brief  CPU Timer(in microsecond): synchronize with the default device and return wall time */
 double get_time_us_sync_device();
 
-/*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and return wall time */
+/*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and return wall time. Must be called in matching pairs (start, stop) */
 double get_time_us_sync(hipStream_t stream);
 
 /*! \brief  CPU Timer(in microsecond): no GPU synchronization and return wall time */


### PR DESCRIPTION
## Motivation

fix bench output of perf, time reported was wrong without env ROCBLAS_BENCH_STREAM_SYNC=1

## Test Plan

Pass existing test set.  New PR for additional perf testing in CI.
