### PR TITLE
[hipDNN] Add FP8_E8M0 data type support

### DIFF
--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
@@ -26,11 +26,12 @@ enum class DataType : int8_t {
   UINT8 = 5,
   INT32 = 6,
   INT8 = 7,
+  FP8_E4M3 = 8,
   MIN = UNSET,
-  MAX = INT8
+  MAX = FP8_E4M3
 };
 
-inline const DataType (&EnumValuesDataType())[8] {
+inline const DataType (&EnumValuesDataType())[9] {
   static const DataType values[] = {
     DataType::UNSET,
     DataType::FLOAT,
@@ -39,13 +40,14 @@ inline const DataType (&EnumValuesDataType())[8] {
     DataType::DOUBLE,
     DataType::UINT8,
     DataType::INT32,
-    DataType::INT8
+    DataType::INT8,
+    DataType::FP8_E4M3
   };
   return values;
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[9] = {
+  static const char * const names[10] = {
     "UNSET",
     "FLOAT",
     "HALF",
@@ -54,13 +56,14 @@ inline const char * const *EnumNamesDataType() {
     "UINT8",
     "INT32",
     "INT8",
+    "FP8_E4M3",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameDataType(DataType e) {
-  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT8)) return "";
+  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::FP8_E4M3)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDataType()[index];
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
@@ -25,11 +25,12 @@ enum class DataType : int8_t {
   DOUBLE = 4,
   UINT8 = 5,
   INT32 = 6,
+  INT8 = 7,
   MIN = UNSET,
-  MAX = INT32
+  MAX = INT8
 };
 
-inline const DataType (&EnumValuesDataType())[7] {
+inline const DataType (&EnumValuesDataType())[8] {
   static const DataType values[] = {
     DataType::UNSET,
     DataType::FLOAT,
@@ -37,13 +38,14 @@ inline const DataType (&EnumValuesDataType())[7] {
     DataType::BFLOAT16,
     DataType::DOUBLE,
     DataType::UINT8,
-    DataType::INT32
+    DataType::INT32,
+    DataType::INT8
   };
   return values;
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[8] = {
+  static const char * const names[9] = {
     "UNSET",
     "FLOAT",
     "HALF",
@@ -51,13 +53,14 @@ inline const char * const *EnumNamesDataType() {
     "DOUBLE",
     "UINT8",
     "INT32",
+    "INT8",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameDataType(DataType e) {
-  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT32)) return "";
+  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::INT8)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDataType()[index];
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
@@ -27,11 +27,12 @@ enum class DataType : int8_t {
   INT32 = 6,
   INT8 = 7,
   FP8_E4M3 = 8,
+  FP8_E5M2 = 9,
   MIN = UNSET,
-  MAX = FP8_E4M3
+  MAX = FP8_E5M2
 };
 
-inline const DataType (&EnumValuesDataType())[9] {
+inline const DataType (&EnumValuesDataType())[10] {
   static const DataType values[] = {
     DataType::UNSET,
     DataType::FLOAT,
@@ -41,13 +42,14 @@ inline const DataType (&EnumValuesDataType())[9] {
     DataType::UINT8,
     DataType::INT32,
     DataType::INT8,
-    DataType::FP8_E4M3
+    DataType::FP8_E4M3,
+    DataType::FP8_E5M2
   };
   return values;
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[10] = {
+  static const char * const names[11] = {
     "UNSET",
     "FLOAT",
     "HALF",
@@ -57,13 +59,14 @@ inline const char * const *EnumNamesDataType() {
     "INT32",
     "INT8",
     "FP8_E4M3",
+    "FP8_E5M2",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameDataType(DataType e) {
-  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::FP8_E4M3)) return "";
+  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::FP8_E5M2)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDataType()[index];
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/data_types_generated.h
@@ -28,11 +28,12 @@ enum class DataType : int8_t {
   INT8 = 7,
   FP8_E4M3 = 8,
   FP8_E5M2 = 9,
+  FP8_E8M0 = 10,
   MIN = UNSET,
-  MAX = FP8_E5M2
+  MAX = FP8_E8M0
 };
 
-inline const DataType (&EnumValuesDataType())[10] {
+inline const DataType (&EnumValuesDataType())[11] {
   static const DataType values[] = {
     DataType::UNSET,
     DataType::FLOAT,
@@ -43,13 +44,14 @@ inline const DataType (&EnumValuesDataType())[10] {
     DataType::INT32,
     DataType::INT8,
     DataType::FP8_E4M3,
-    DataType::FP8_E5M2
+    DataType::FP8_E5M2,
+    DataType::FP8_E8M0
   };
   return values;
 }
 
 inline const char * const *EnumNamesDataType() {
-  static const char * const names[11] = {
+  static const char * const names[12] = {
     "UNSET",
     "FLOAT",
     "HALF",
@@ -60,13 +62,14 @@ inline const char * const *EnumNamesDataType() {
     "INT8",
     "FP8_E4M3",
     "FP8_E5M2",
+    "FP8_E8M0",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameDataType(DataType e) {
-  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::FP8_E5M2)) return "";
+  if (::flatbuffers::IsOutRange(e, DataType::UNSET, DataType::FP8_E8M0)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDataType()[index];
 }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -76,6 +76,12 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
             return static_cast<TargetType>(val->value());
         }
         break;
+    case data_objects::DataType::INT8:
+        if(auto val = tensorAttr.value.AsFloat8Value())
+        {
+            return static_cast<TargetType>(val->value());
+        }
+        break;
     case data_objects::DataType::UNSET:
         throw std::runtime_error(std::string(paramName) + " tensor has UNSET data type");
     default:

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -82,6 +82,12 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
             return static_cast<TargetType>(val->value());
         }
         break;
+    case data_objects::DataType::FP8_E4M3:
+        if(auto val = tensorAttr.value.AsFloat8Value())
+        {
+            return static_cast<TargetType>(val->value());
+        }
+        break;
     case data_objects::DataType::UNSET:
         throw std::runtime_error(std::string(paramName) + " tensor has UNSET data type");
     default:

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -88,6 +88,12 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
             return static_cast<TargetType>(val->value());
         }
         break;
+    case data_objects::DataType::FP8_E5M2:
+        if(auto val = tensorAttr.value.AsFloat8Value())
+        {
+            return static_cast<TargetType>(val->value());
+        }
+        break;
     case data_objects::DataType::UNSET:
         throw std::runtime_error(std::string(paramName) + " tensor has UNSET data type");
     default:

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/FlatbufferUtils.hpp
@@ -5,6 +5,7 @@
 
 #include <flatbuffers/flatbuffers.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -92,6 +93,13 @@ TargetType extractValueFromTensorValue(const data_objects::TensorAttributesT& te
         if(auto val = tensorAttr.value.AsFloat8Value())
         {
             return static_cast<TargetType>(val->value());
+        }
+        break;
+    case data_objects::DataType::FP8_E8M0:
+        if(auto val = tensorAttr.value.AsFloat8Value())
+        {
+            auto fp8e8m0 = hipdnn_sdk::utilities::fp8_e8m0::uchar_as_fp8_e8m0(val->value());
+            return static_cast<TargetType>(static_cast<float>(fp8e8m0));
         }
         break;
     case data_objects::DataType::UNSET:

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
@@ -561,6 +561,8 @@ inline std::unique_ptr<utilities::ITensor> createTensor(data_objects::DataType d
         return std::make_unique<Tensor<uint8_t>>(dims, strides);
     case data_objects::DataType::INT32:
         return std::make_unique<Tensor<int32_t>>(dims, strides);
+    case data_objects::DataType::INT8:
+        return std::make_unique<Tensor<int8_t>>(dims, strides);
     default:
         throw std::runtime_error("Unsupported data type for tensor");
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
@@ -569,6 +569,8 @@ inline std::unique_ptr<utilities::ITensor> createTensor(data_objects::DataType d
         return std::make_unique<Tensor<hip_fp8_e4m3>>(dims, strides);
     case data_objects::DataType::FP8_E5M2:
         return std::make_unique<Tensor<hip_fp8_e5m2>>(dims, strides);
+    case data_objects::DataType::FP8_E8M0:
+        return std::make_unique<Tensor<hip_fp8_e8m0>>(dims, strides);
     default:
         throw std::runtime_error("Unsupported data type for tensor");
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
@@ -8,6 +8,7 @@
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <iostream>
 #include <numeric>
 #include <random>
@@ -563,6 +564,8 @@ inline std::unique_ptr<utilities::ITensor> createTensor(data_objects::DataType d
         return std::make_unique<Tensor<int32_t>>(dims, strides);
     case data_objects::DataType::INT8:
         return std::make_unique<Tensor<int8_t>>(dims, strides);
+    case data_objects::DataType::FP8_E4M3:
+        return std::make_unique<Tensor<hip_fp8_e4m3>>(dims, strides);
     default:
         throw std::runtime_error("Unsupported data type for tensor");
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
@@ -7,6 +7,7 @@
 #include <hipdnn_data_sdk/utilities/MigratableMemory.hpp>
 #include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <iostream>
@@ -566,6 +567,8 @@ inline std::unique_ptr<utilities::ITensor> createTensor(data_objects::DataType d
         return std::make_unique<Tensor<int8_t>>(dims, strides);
     case data_objects::DataType::FP8_E4M3:
         return std::make_unique<Tensor<hip_fp8_e4m3>>(dims, strides);
+    case data_objects::DataType::FP8_E5M2:
+        return std::make_unique<Tensor<hip_fp8_e5m2>>(dims, strides);
     default:
         throw std::runtime_error("Unsupported data type for tensor");
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp8.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsBfp8.hpp
@@ -1,0 +1,127 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hip/hip_fp8.h>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <string>
+#include <type_traits>
+
+#define HIPDNN_NAN_BFP8 uchar_as_bfp8(static_cast<unsigned char>(0x7F))
+
+using hip_fp8_e5m2 = __hip_fp8_e5m2;
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 operator""_bfp8(long double val)
+{
+    return {static_cast<float>(val)};
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 operator-(hip_fp8_e5m2 a)
+{
+    hip_fp8_e5m2 val = a;
+    val.__x ^= 0x80;
+    return val;
+}
+
+inline __HOST_DEVICE__ bool operator==(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return a.__x == b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator!=(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return a.__x != b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator>(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return a.__x > b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator>=(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return a.__x >= b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator<(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return a.__x < b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator<=(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return a.__x <= b.__x;
+}
+
+namespace hipdnn_sdk::utilities::bfp8
+{
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 uchar_as_bfp8(const unsigned char a)
+{
+    hip_fp8_e5m2 val;
+    val.__x = a;
+    return val;
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 bfp8abs(hip_fp8_e5m2 a)
+{
+    hip_fp8_e5m2 abs = a;
+    abs.__x &= 0x7f;
+    return abs;
+}
+
+inline __HOST_DEVICE__ bool bfp8isnan(hip_fp8_e5m2 a)
+{
+    return (a.__x & 0x7f) > 0x7c;
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 bfp8max(const hip_fp8_e5m2 a, const hip_fp8_e5m2 b)
+{
+    auto aNan = bfp8isnan(a);
+    auto bNan = bfp8isnan(b);
+
+    if(aNan || bNan)
+    {
+        if(aNan && bNan)
+        {
+            return HIPDNN_NAN_BFP8; // return canonical NaN
+        }
+
+        return aNan ? b : a;
+    }
+
+    return a >= b ? a : b;
+}
+
+} // namespace hipdnn_sdk::utilities::bfp8
+
+namespace std
+{
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 fabs(hip_fp8_e5m2 num)
+{
+    return hipdnn_sdk::utilities::bfp8::bfp8abs(num);
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 abs(hip_fp8_e5m2 num)
+{
+    return hipdnn_sdk::utilities::bfp8::bfp8abs(num);
+}
+
+inline __HOST_DEVICE__ hip_fp8_e5m2 max(hip_fp8_e5m2 a, hip_fp8_e5m2 b)
+{
+    return hipdnn_sdk::utilities::bfp8::bfp8max(a, b);
+}
+
+} // namespace std
+
+template <>
+struct fmt::formatter<hip_fp8_e5m2> : fmt::formatter<float>
+{
+    template <typename FormatContext>
+    auto format(hip_fp8_e5m2 h, FormatContext& ctx) const
+    {
+        return fmt::formatter<float>::format(static_cast<float>(h), ctx);
+    }
+};

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp16.hpp
@@ -14,6 +14,43 @@ inline __HOST_DEVICE__ half operator""_h(long double value)
     return {static_cast<float>(value)};
 }
 
+inline __HOST_DEVICE__ half operator-(half a)
+{
+    auto r = static_cast<__half_raw>(a);
+    r.x ^= 0x8000u;
+    return r;
+}
+
+inline __HOST_DEVICE__ bool operator==(half a, half b)
+{
+    return static_cast<__half_raw>(a).x == static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator!=(half a, half b)
+{
+    return static_cast<__half_raw>(a).x != static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator<(half a, half b)
+{
+    return static_cast<__half_raw>(a).x < static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator>(half a, half b)
+{
+    return static_cast<__half_raw>(a).x > static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator<=(half a, half b)
+{
+    return static_cast<__half_raw>(a).x <= static_cast<__half_raw>(b).x;
+}
+
+inline __HOST_DEVICE__ bool operator>=(half a, half b)
+{
+    return static_cast<__half_raw>(a).x >= static_cast<__half_raw>(b).x;
+}
+
 namespace hipdnn_data_sdk::utilities::fp16
 {
 
@@ -33,7 +70,7 @@ inline __HOST_DEVICE__ half habs(half num)
 
 inline __HOST_DEVICE__ bool hisnan(__half x)
 {
-    __half_raw hr = x;
+    auto hr = static_cast<__half_raw>(x);
     return (hr.x & 0x7FFFU) > 0x7C00u;
 }
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
@@ -1,0 +1,126 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hip/hip_fp8.h>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <string>
+#include <type_traits>
+
+#define HIPDNN_NAN_FP8 uchar_as_fp8(static_cast<unsigned char>(0x7F))
+
+using hip_fp8_e4m3 = __hip_fp8_e4m3;
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 operator""_fp8(long double val)
+{
+    return {static_cast<float>(val)};
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 operator-(hip_fp8_e4m3 a)
+{
+    hip_fp8_e4m3 val = a;
+    val.__x ^= 0x80;
+    return val;
+}
+
+inline __HOST_DEVICE__ bool operator==(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x == b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator!=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x != b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator>(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x > b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator>=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x >= b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator<(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x < b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator<=(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return a.__x <= b.__x;
+}
+
+namespace hipdnn_sdk::utilities::fp8
+{
+inline __HOST_DEVICE__ hip_fp8_e4m3 uchar_as_fp8(const unsigned char a)
+{
+    hip_fp8_e4m3 val;
+    val.__x = a;
+    return val;
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 fp8abs(hip_fp8_e4m3 a)
+{
+    hip_fp8_e4m3 abs = a;
+    abs.__x &= 0x7f;
+    return abs;
+}
+
+inline __HOST_DEVICE__ bool fp8isnan(hip_fp8_e4m3 x)
+{
+    return (x.__x & 0x7f) == 0x7f;
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 fp8max(const hip_fp8_e4m3 a, const hip_fp8_e4m3 b)
+{
+    auto aNan = fp8isnan(a);
+    auto bNan = fp8isnan(b);
+
+    if(aNan || bNan)
+    {
+        if(aNan && bNan)
+        {
+            return HIPDNN_NAN_FP8; // return canonical NaN
+        }
+
+        return aNan ? b : a;
+    }
+
+    return a >= b ? a : b;
+}
+
+} // namespace hipdnn_sdk::utilities::fp8
+
+namespace std
+{
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 fabs(hip_fp8_e4m3 num)
+{
+    return hipdnn_sdk::utilities::fp8::fp8abs(num);
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 abs(hip_fp8_e4m3 num)
+{
+    return hipdnn_sdk::utilities::fp8::fp8abs(num);
+}
+
+inline __HOST_DEVICE__ hip_fp8_e4m3 max(hip_fp8_e4m3 a, hip_fp8_e4m3 b)
+{
+    return hipdnn_sdk::utilities::fp8::fp8max(a, b);
+}
+
+} // namespace std
+
+template <>
+struct fmt::formatter<hip_fp8_e4m3> : fmt::formatter<float>
+{
+    template <typename FormatContext>
+    auto format(hip_fp8_e4m3 h, FormatContext& ctx) const
+    {
+        return fmt::formatter<float>::format(static_cast<float>(h), ctx);
+    }
+};

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/UtilsFp8.hpp
@@ -3,6 +3,9 @@
 
 #pragma once
 
+// TMP
+#include <hip/amd_detail/amd_hip_fp16.h>
+#include <hip/amd_detail/amd_hip_mx_common.h>
 #include <hip/hip_fp8.h>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <string>
@@ -120,6 +123,109 @@ struct fmt::formatter<hip_fp8_e4m3> : fmt::formatter<float>
 {
     template <typename FormatContext>
     auto format(hip_fp8_e4m3 h, FormatContext& ctx) const
+    {
+        return fmt::formatter<float>::format(static_cast<float>(h), ctx);
+    }
+};
+
+#define HIPDNN_NAN_FP8_E8M0 hipdnn_sdk::utilities::fp8_e8m0::uchar_as_fp8_e8m0(hip_detail::e8m0_NaN)
+
+using hip_fp8_e8m0 = __hip_fp8_e8m0;
+
+inline __HOST_DEVICE__ hip_fp8_e8m0 operator""_fp8_e8m0(long double val)
+{
+    return hip_fp8_e8m0{static_cast<float>(val)};
+}
+
+inline __HOST_DEVICE__ bool operator==(hip_fp8_e8m0 a, hip_fp8_e8m0 b)
+{
+    return a.__x == b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator!=(hip_fp8_e8m0 a, hip_fp8_e8m0 b)
+{
+    return a.__x != b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator>(hip_fp8_e8m0 a, hip_fp8_e8m0 b)
+{
+    return a.__x > b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator>=(hip_fp8_e8m0 a, hip_fp8_e8m0 b)
+{
+    return a.__x >= b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator<(hip_fp8_e8m0 a, hip_fp8_e8m0 b)
+{
+    return a.__x < b.__x;
+}
+
+inline __HOST_DEVICE__ bool operator<=(hip_fp8_e8m0 a, hip_fp8_e8m0 b)
+{
+    return a.__x <= b.__x;
+}
+
+namespace hipdnn_sdk::utilities::fp8_e8m0
+{
+inline __HOST_DEVICE__ hip_fp8_e8m0 uchar_as_fp8_e8m0(const unsigned char a)
+{
+    hip_fp8_e8m0 val;
+    val.__x = a;
+    return val;
+}
+
+inline __HOST_DEVICE__ bool isnan(hip_fp8_e8m0 x)
+{
+    return x == HIPDNN_NAN_FP8_E8M0;
+}
+
+inline __HOST_DEVICE__ hip_fp8_e8m0 max(const hip_fp8_e8m0 a, const hip_fp8_e8m0 b)
+{
+    auto aNan = isnan(a);
+    auto bNan = isnan(b);
+
+    if(aNan || bNan)
+    {
+        if(aNan && bNan)
+        {
+            return HIPDNN_NAN_FP8_E8M0;
+        }
+
+        return aNan ? b : a;
+    }
+
+    return a >= b ? a : b;
+}
+
+} // namespace hipdnn_sdk::utilities::fp8_e8m0
+
+namespace std
+{
+inline __HOST_DEVICE__ hip_fp8_e8m0 fabs(hip_fp8_e8m0 x)
+{
+    return x;
+}
+inline __HOST_DEVICE__ hip_fp8_e8m0 abs(hip_fp8_e8m0 x)
+{
+    return fabs(x);
+}
+inline __HOST_DEVICE__ hip_fp8_e8m0 max(hip_fp8_e8m0 a, hip_fp8_e8m0 b)
+{
+    return hipdnn_sdk::utilities::fp8_e8m0::max(a, b);
+}
+inline __HOST_DEVICE__ bool isnan(hip_fp8_e8m0 x)
+{
+    return hipdnn_sdk::utilities::fp8_e8m0::isnan(x);
+}
+} // namespace std
+
+template <>
+struct fmt::formatter<hip_fp8_e8m0> : fmt::formatter<float>
+{
+    template <typename FormatContext>
+    auto format(hip_fp8_e8m0 h, FormatContext& ctx) const
     {
         return fmt::formatter<float>::format(static_cast<float>(h), ctx);
     }

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
@@ -80,6 +80,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType,
                                  {DataType::UINT8, "uint8"},
                                  {DataType::INT32, "int32"},
                                  {DataType::INT8, "int8"},
+                                 {DataType::FP8_E4M3, "fp8_e4m3"},
                              }
 
 )

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
@@ -81,6 +81,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType,
                                  {DataType::INT32, "int32"},
                                  {DataType::INT8, "int8"},
                                  {DataType::FP8_E4M3, "fp8_e4m3"},
+                                 {DataType::FP8_E5M2, "fp8_e5m2"},
                              }
 
 )

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
@@ -79,6 +79,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType,
                                  {DataType::DOUBLE, "double"},
                                  {DataType::UINT8, "uint8"},
                                  {DataType::INT32, "int32"},
+                                 {DataType::INT8, "int8"},
                              }
 
 )

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/Common.hpp
@@ -82,6 +82,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType,
                                  {DataType::INT8, "int8"},
                                  {DataType::FP8_E4M3, "fp8_e4m3"},
                                  {DataType::FP8_E5M2, "fp8_e5m2"},
+                                 {DataType::FP8_E8M0, "fp8_e8m0"},
                              }
 
 )

--- a/projects/hipdnn/data_sdk/schemas/data_types.fbs
+++ b/projects/hipdnn/data_sdk/schemas/data_types.fbs
@@ -14,4 +14,5 @@ enum DataType : byte {
     INT8 = 7,
     FP8_E4M3 = 8,
     FP8_E5M2 = 9,
+    FP8_E8M0 = 10,
 }

--- a/projects/hipdnn/data_sdk/schemas/data_types.fbs
+++ b/projects/hipdnn/data_sdk/schemas/data_types.fbs
@@ -11,5 +11,6 @@ enum DataType : byte {
     DOUBLE = 4,
     UINT8 = 5,
     INT32 = 6,
-    INT8 = 7
+    INT8 = 7,
+    FP8_E4M3 = 8,
 }

--- a/projects/hipdnn/data_sdk/schemas/data_types.fbs
+++ b/projects/hipdnn/data_sdk/schemas/data_types.fbs
@@ -10,5 +10,6 @@ enum DataType : byte {
     BFLOAT16 = 3,
     DOUBLE = 4,
     UINT8 = 5,
-    INT32 = 6
+    INT32 = 6,
+    INT8 = 7
 }

--- a/projects/hipdnn/data_sdk/schemas/data_types.fbs
+++ b/projects/hipdnn/data_sdk/schemas/data_types.fbs
@@ -13,4 +13,5 @@ enum DataType : byte {
     INT32 = 6,
     INT8 = 7,
     FP8_E4M3 = 8,
+    FP8_E5M2 = 9,
 }

--- a/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
@@ -5,6 +5,7 @@
 
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 
 TEST(TestUtilsFp16, BasicUsage)
 {
@@ -44,4 +45,28 @@ TEST(TestUtilsBfp16, Max)
     hip_bfloat16 b = 2.0_bf;
     EXPECT_EQ(std::max(a, b), 2.0_bf);
     EXPECT_EQ(std::max(b, a), 2.0_bf);
+}
+
+TEST(TestUtilsFp8, BasicUsage)
+{
+    hip_fp8_e4m3 fp8 = 1.0_fp8;
+    EXPECT_EQ(fp8, 1.0_fp8);
+}
+
+TEST(TestUtilsFp8, Fabs)
+{
+    EXPECT_EQ(std::fabs(-1.0_fp8), 1.0_fp8);
+    EXPECT_EQ(std::fabs(1.0_fp8), 1.0_fp8);
+}
+
+TEST(TestUtilsFp8, Max)
+{
+    hip_fp8_e4m3 a = 1.0_fp8;
+    hip_fp8_e4m3 b = 2.0_fp8;
+    hip_fp8_e4m3 nan = hipdnn_sdk::utilities::fp8::uchar_as_fp8(0x7F);
+    EXPECT_EQ(std::max(a, b), 2.0_fp8);
+    EXPECT_EQ(std::max(b, a), 2.0_fp8);
+    EXPECT_EQ(std::max(a, nan), 1.0_fp8);
+    EXPECT_EQ(std::max(nan, b), 2.0_fp8);
+    EXPECT_EQ(std::max(nan, nan), nan);
 }

--- a/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
@@ -95,3 +95,48 @@ TEST(TestUtilsTestUtilsBfp8, Max)
     EXPECT_EQ(std::max(nan, b), 2.0_bfp8);
     EXPECT_EQ(std::max(nan, nan), nan);
 }
+
+TEST(TestUtilsFp8E8M0, BasicUsage)
+{
+    hip_fp8_e8m0 x = 1.0_fp8_e8m0;
+    EXPECT_EQ(x, 1.0_fp8_e8m0);
+}
+
+TEST(TestUtilsFp8E8M0, Fabs)
+{
+    hip_fp8_e8m0 a = 1.0_fp8_e8m0;
+    EXPECT_EQ(std::fabs(a), a);
+    EXPECT_EQ(std::abs(a), a);
+}
+
+TEST(TestUtilsFp8E8M0, Max)
+{
+    hip_fp8_e8m0 a = 1.0_fp8_e8m0;
+    hip_fp8_e8m0 b = 2.0_fp8_e8m0;
+    hip_fp8_e8m0 nan = HIPDNN_NAN_FP8_E8M0;
+    EXPECT_EQ(std::max(a, b), b);
+    EXPECT_EQ(std::max(b, a), b);
+    EXPECT_EQ(std::max(a, nan), a);
+    EXPECT_EQ(std::max(nan, b), b);
+    EXPECT_EQ(std::max(nan, nan), nan);
+}
+
+TEST(TestUtilsFp8E8M0, CmpOperators)
+{
+    hip_fp8_e8m0 a = 1.0_fp8_e8m0;
+    hip_fp8_e8m0 b = 2.0_fp8_e8m0;
+    EXPECT_LT(a, b);
+    EXPECT_GT(b, a);
+    EXPECT_LE(a, a);
+    EXPECT_GE(b, a);
+    EXPECT_NE(a, b);
+    EXPECT_EQ(a, a);
+}
+
+TEST(TestUtilsFp8E8M0, IsNan)
+{
+    hip_fp8_e8m0 a = 1.0_fp8_e8m0;
+    hip_fp8_e8m0 nan = HIPDNN_NAN_FP8_E8M0;
+    EXPECT_FALSE(std::isnan(a));
+    EXPECT_TRUE(std::isnan(nan));
+}

--- a/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestFloats.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 
@@ -68,5 +69,29 @@ TEST(TestUtilsFp8, Max)
     EXPECT_EQ(std::max(b, a), 2.0_fp8);
     EXPECT_EQ(std::max(a, nan), 1.0_fp8);
     EXPECT_EQ(std::max(nan, b), 2.0_fp8);
+    EXPECT_EQ(std::max(nan, nan), nan);
+}
+
+TEST(TestUtilsBfp8, BasicUsage)
+{
+    hip_fp8_e5m2 bf = 1.0_bfp8;
+    EXPECT_EQ(bf, 1.0_bfp8);
+}
+
+TEST(TestUtilsBfp8, Fabs)
+{
+    EXPECT_EQ(std::fabs(-1.0_bfp8), 1.0_bfp8);
+    EXPECT_EQ(std::fabs(1.0_bfp8), 1.0_bfp8);
+}
+
+TEST(TestUtilsTestUtilsBfp8, Max)
+{
+    hip_fp8_e5m2 a = 1.0_bfp8;
+    hip_fp8_e5m2 b = 2.0_bfp8;
+    hip_fp8_e5m2 nan = hipdnn_sdk::utilities::bfp8::uchar_as_bfp8(0x7F);
+    EXPECT_EQ(std::max(a, b), 2.0_bfp8);
+    EXPECT_EQ(std::max(b, a), 2.0_bfp8);
+    EXPECT_EQ(std::max(a, nan), 1.0_bfp8);
+    EXPECT_EQ(std::max(nan, b), 2.0_bfp8);
     EXPECT_EQ(std::max(nan, nan), nan);
 }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -86,6 +86,7 @@ enum class DataType
     DOUBLE = 4,
     UINT8 = 5,
     INT32 = 6,
+    INT8 = 7,
 };
 typedef DataType DataType_t; // NOLINT(readability-identifier-naming)
 
@@ -122,6 +123,10 @@ DataType getDataTypeEnumFromType()
     {
         return DataType::INT32;
     }
+    else if constexpr(std::is_same_v<T, int8_t>)
+    {
+        return DataType::INT8;
+    }
     else
     {
         return DataType::NOT_SET;
@@ -157,6 +162,8 @@ inline hipdnn_data_sdk::data_objects::DataType toSdkType(const DataType& type)
         return hipdnn_data_sdk::data_objects::DataType::UINT8;
     case DataType::INT32:
         return hipdnn_data_sdk::data_objects::DataType::INT32;
+    case DataType::INT8:
+        return hipdnn_data_sdk::data_objects::DataType::INT8;
     default:
         return hipdnn_data_sdk::data_objects::DataType::UNSET;
     }
@@ -178,6 +185,8 @@ inline hipdnn_frontend::DataType fromSdkType(const hipdnn_data_sdk::data_objects
         return hipdnn_frontend::DataType::UINT8;
     case hipdnn_data_sdk::data_objects::DataType::INT32:
         return hipdnn_frontend::DataType::INT32;
+    case hipdnn_data_sdk::data_objects::DataType::INT8:
+        return hipdnn_frontend::DataType::INT8;
     default:
         return hipdnn_frontend::DataType::NOT_SET;
     }
@@ -314,6 +323,8 @@ inline const char* to_string(const DataType& type)
         return "uint8";
     case DataType::INT32:
         return "int32";
+    case DataType::INT8:
+        return "int8";
     default:
         return "unknown";
     }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -8,6 +8,7 @@
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_data_sdk/utilities/PointwiseValidation.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 
@@ -89,6 +90,7 @@ enum class DataType
     INT32 = 6,
     INT8 = 7,
     FP8_E4M3 = 8,
+    FP8_E5M2 = 9,
 };
 typedef DataType DataType_t; // NOLINT(readability-identifier-naming)
 
@@ -133,6 +135,10 @@ DataType getDataTypeEnumFromType()
     {
         return DataType::FP8_E4M3;
     }
+    else if constexpr(std::is_same_v<T, hip_fp8_e5m2>)
+    {
+        return DataType::FP8_E5M2;
+    }
     else
     {
         return DataType::NOT_SET;
@@ -172,6 +178,8 @@ inline hipdnn_data_sdk::data_objects::DataType toSdkType(const DataType& type)
         return hipdnn_data_sdk::data_objects::DataType::INT8;
     case DataType::FP8_E4M3:
         return hipdnn_data_sdk::data_objects::DataType::FP8_E4M3;
+    case DataType::FP8_E5M2:
+        return hipdnn_data_sdk::data_objects::DataType::FP8_E5M2;
     default:
         return hipdnn_data_sdk::data_objects::DataType::UNSET;
     }
@@ -197,6 +205,8 @@ inline hipdnn_frontend::DataType fromSdkType(const hipdnn_data_sdk::data_objects
         return hipdnn_frontend::DataType::INT8;
     case hipdnn_data_sdk::data_objects::DataType::FP8_E4M3:
         return hipdnn_frontend::DataType::FP8_E4M3;
+    case hipdnn_data_sdk::data_objects::DataType::FP8_E5M2:
+        return hipdnn_frontend::DataType::FP8_E5M2;
     default:
         return hipdnn_frontend::DataType::NOT_SET;
     }
@@ -337,6 +347,8 @@ inline const char* to_string(const DataType& type)
         return "int8";
     case DataType::FP8_E4M3:
         return "fp8_e4m3";
+    case DataType::FP8_E5M2:
+        return "fp8_e5m2";
     default:
         return "unknown";
     }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -9,6 +9,7 @@
 #include <hipdnn_data_sdk/utilities/PointwiseValidation.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 
 #include <bitset>
 #include <set>
@@ -87,6 +88,7 @@ enum class DataType
     UINT8 = 5,
     INT32 = 6,
     INT8 = 7,
+    FP8_E4M3 = 8,
 };
 typedef DataType DataType_t; // NOLINT(readability-identifier-naming)
 
@@ -127,6 +129,10 @@ DataType getDataTypeEnumFromType()
     {
         return DataType::INT8;
     }
+    else if constexpr(std::is_same_v<T, hip_fp8_e4m3>)
+    {
+        return DataType::FP8_E4M3;
+    }
     else
     {
         return DataType::NOT_SET;
@@ -164,6 +170,8 @@ inline hipdnn_data_sdk::data_objects::DataType toSdkType(const DataType& type)
         return hipdnn_data_sdk::data_objects::DataType::INT32;
     case DataType::INT8:
         return hipdnn_data_sdk::data_objects::DataType::INT8;
+    case DataType::FP8_E4M3:
+        return hipdnn_data_sdk::data_objects::DataType::FP8_E4M3;
     default:
         return hipdnn_data_sdk::data_objects::DataType::UNSET;
     }
@@ -187,6 +195,8 @@ inline hipdnn_frontend::DataType fromSdkType(const hipdnn_data_sdk::data_objects
         return hipdnn_frontend::DataType::INT32;
     case hipdnn_data_sdk::data_objects::DataType::INT8:
         return hipdnn_frontend::DataType::INT8;
+    case hipdnn_data_sdk::data_objects::DataType::FP8_E4M3:
+        return hipdnn_frontend::DataType::FP8_E4M3;
     default:
         return hipdnn_frontend::DataType::NOT_SET;
     }
@@ -325,6 +335,8 @@ inline const char* to_string(const DataType& type)
         return "int32";
     case DataType::INT8:
         return "int8";
+    case DataType::FP8_E4M3:
+        return "fp8_e4m3";
     default:
         return "unknown";
     }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -91,6 +91,7 @@ enum class DataType
     INT8 = 7,
     FP8_E4M3 = 8,
     FP8_E5M2 = 9,
+    FP8_E8M0 = 10,
 };
 typedef DataType DataType_t; // NOLINT(readability-identifier-naming)
 
@@ -139,6 +140,10 @@ DataType getDataTypeEnumFromType()
     {
         return DataType::FP8_E5M2;
     }
+    else if constexpr(std::is_same_v<T, hip_fp8_e8m0>)
+    {
+        return DataType::FP8_E8M0;
+    }
     else
     {
         return DataType::NOT_SET;
@@ -180,6 +185,8 @@ inline hipdnn_data_sdk::data_objects::DataType toSdkType(const DataType& type)
         return hipdnn_data_sdk::data_objects::DataType::FP8_E4M3;
     case DataType::FP8_E5M2:
         return hipdnn_data_sdk::data_objects::DataType::FP8_E5M2;
+    case DataType::FP8_E8M0:
+        return hipdnn_data_sdk::data_objects::DataType::FP8_E8M0;
     default:
         return hipdnn_data_sdk::data_objects::DataType::UNSET;
     }
@@ -207,6 +214,8 @@ inline hipdnn_frontend::DataType fromSdkType(const hipdnn_data_sdk::data_objects
         return hipdnn_frontend::DataType::FP8_E4M3;
     case hipdnn_data_sdk::data_objects::DataType::FP8_E5M2:
         return hipdnn_frontend::DataType::FP8_E5M2;
+    case hipdnn_data_sdk::data_objects::DataType::FP8_E8M0:
+        return hipdnn_frontend::DataType::FP8_E8M0;
     default:
         return hipdnn_frontend::DataType::NOT_SET;
     }
@@ -349,6 +358,8 @@ inline const char* to_string(const DataType& type)
         return "fp8_e4m3";
     case DataType::FP8_E5M2:
         return "fp8_e5m2";
+    case DataType::FP8_E8M0:
+        return "fp8_e8m0";
     default:
         return "unknown";
     }

--- a/projects/hipdnn/frontend/tests/TestNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestNode.cpp
@@ -43,7 +43,8 @@ TEST(TestNode, PostValidateNodeComputeDataType)
            {DataType::UINT8, ErrorCode::OK},
            {DataType::INT32, ErrorCode::OK},
            {DataType::INT8, ErrorCode::OK},
-           {DataType::FP8_E4M3, ErrorCode::OK}};
+           {DataType::FP8_E4M3, ErrorCode::OK},
+           {DataType::FP8_E5M2, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestNode.cpp
@@ -41,7 +41,8 @@ TEST(TestNode, PostValidateNodeComputeDataType)
            {DataType::BFLOAT16, ErrorCode::OK},
            {DataType::DOUBLE, ErrorCode::OK},
            {DataType::UINT8, ErrorCode::OK},
-           {DataType::INT32, ErrorCode::OK}};
+           {DataType::INT32, ErrorCode::OK},
+           {DataType::INT8, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestNode.cpp
@@ -42,7 +42,8 @@ TEST(TestNode, PostValidateNodeComputeDataType)
            {DataType::DOUBLE, ErrorCode::OK},
            {DataType::UINT8, ErrorCode::OK},
            {DataType::INT32, ErrorCode::OK},
-           {DataType::INT8, ErrorCode::OK}};
+           {DataType::INT8, ErrorCode::OK},
+           {DataType::FP8_E4M3, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestNode.cpp
@@ -44,7 +44,8 @@ TEST(TestNode, PostValidateNodeComputeDataType)
            {DataType::INT32, ErrorCode::OK},
            {DataType::INT8, ErrorCode::OK},
            {DataType::FP8_E4M3, ErrorCode::OK},
-           {DataType::FP8_E5M2, ErrorCode::OK}};
+           {DataType::FP8_E5M2, ErrorCode::OK},
+           {DataType::FP8_E8M0, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -205,7 +205,8 @@ TEST(TestTensorAttributes, ValidateDataType)
            {DataType::BFLOAT16, ErrorCode::OK},
            {DataType::DOUBLE, ErrorCode::OK},
            {DataType::UINT8, ErrorCode::OK},
-           {DataType::INT32, ErrorCode::OK}};
+           {DataType::INT32, ErrorCode::OK},
+           {DataType::INT8, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -206,7 +206,8 @@ TEST(TestTensorAttributes, ValidateDataType)
            {DataType::DOUBLE, ErrorCode::OK},
            {DataType::UINT8, ErrorCode::OK},
            {DataType::INT32, ErrorCode::OK},
-           {DataType::INT8, ErrorCode::OK}};
+           {DataType::INT8, ErrorCode::OK},
+           {DataType::FP8_E4M3, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -207,7 +207,8 @@ TEST(TestTensorAttributes, ValidateDataType)
            {DataType::UINT8, ErrorCode::OK},
            {DataType::INT32, ErrorCode::OK},
            {DataType::INT8, ErrorCode::OK},
-           {DataType::FP8_E4M3, ErrorCode::OK}};
+           {DataType::FP8_E4M3, ErrorCode::OK},
+           {DataType::FP8_E5M2, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorAttributes.cpp
@@ -208,7 +208,8 @@ TEST(TestTensorAttributes, ValidateDataType)
            {DataType::INT32, ErrorCode::OK},
            {DataType::INT8, ErrorCode::OK},
            {DataType::FP8_E4M3, ErrorCode::OK},
-           {DataType::FP8_E5M2, ErrorCode::OK}};
+           {DataType::FP8_E5M2, ErrorCode::OK},
+           {DataType::FP8_E8M0, ErrorCode::OK}};
 
     for(auto [dataType, errorCode] : expectedResults)
     {

--- a/projects/hipdnn/frontend/tests/TestTensorValueAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorValueAttributes.cpp
@@ -109,13 +109,13 @@ TEST(TestTensorValueAttributes, PackUnpackHalfValue)
     EXPECT_EQ(fbTensor->value_type(), TensorValue::Float16Value);
     auto hval = fbTensor->value_as_Float16Value();
     ASSERT_NE(hval, nullptr);
-    EXPECT_EQ(hval->value(), 1.0_h);
+    EXPECT_EQ(half(hval->value()), 1.0_h);
 
     auto unpacked = std::unique_ptr<TensorAttributesT>(fbTensor->UnPack());
     ASSERT_EQ(unpacked->value.type, TensorValue::Float16Value);
     auto* halfVal = unpacked->value.AsFloat16Value();
     ASSERT_NE(halfVal, nullptr);
-    EXPECT_EQ(halfVal->value(), 1.0_h);
+    EXPECT_EQ(half(halfVal->value()), 1.0_h);
 }
 
 TEST(TestTensorValueAttributes, PackUnpackBFloat1Value)

--- a/projects/hipdnn/frontend/tests/TestTypes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTypes.cpp
@@ -17,6 +17,7 @@ TEST(TestTypes, ToSdkTypeDataTypes)
     EXPECT_EQ(toSdkType(DataType::INT32), hipdnn_data_sdk::data_objects::DataType::INT32);
     EXPECT_EQ(toSdkType(DataType::INT8), hipdnn_data_sdk::data_objects::DataType::INT8);
     EXPECT_EQ(toSdkType(DataType::FP8_E4M3), hipdnn_data_sdk::data_objects::DataType::FP8_E4M3);
+    EXPECT_EQ(toSdkType(DataType::FP8_E5M2), hipdnn_data_sdk::data_objects::DataType::FP8_E5M2);
     EXPECT_EQ(toSdkType(DataType::NOT_SET), hipdnn_data_sdk::data_objects::DataType::UNSET);
 }
 
@@ -32,6 +33,7 @@ TEST(TestTypes, FromSdkTypeDataTypes)
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT32), DataType::INT32);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT8), DataType::INT8);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP8_E4M3), DataType::FP8_E4M3);
+    EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP8_E5M2), DataType::FP8_E5M2);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UNSET), DataType::NOT_SET);
 }
 
@@ -76,6 +78,7 @@ TEST(TestTypes, GetDataTypeEnumFromType)
     EXPECT_EQ(getDataTypeEnumFromType<int32_t>(), DataType::INT32);
     EXPECT_EQ(getDataTypeEnumFromType<int8_t>(), DataType::INT8);
     EXPECT_EQ(getDataTypeEnumFromType<hip_fp8_e4m3>(), DataType::FP8_E4M3);
+    EXPECT_EQ(getDataTypeEnumFromType<hip_fp8_e5m2>(), DataType::FP8_E5M2);
 
     EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType::NOT_SET);
     EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType::NOT_SET);
@@ -93,6 +96,7 @@ TEST(TestTypes, DataTypeToString)
     EXPECT_STREQ(to_string(DataType::INT32), "int32");
     EXPECT_STREQ(to_string(DataType::INT8), "int8");
     EXPECT_STREQ(to_string(DataType::FP8_E4M3), "fp8_e4m3");
+    EXPECT_STREQ(to_string(DataType::FP8_E5M2), "fp8_e5m2");
     EXPECT_STREQ(to_string(DataType::NOT_SET), "unknown");
 }
 
@@ -132,6 +136,10 @@ TEST(TestTypes, DataTypeStreamOperator)
 
     oss << DataType::FP8_E4M3;
     EXPECT_EQ(oss.str(), "fp8_e4m3");
+    oss.str("");
+
+    oss << DataType::FP8_E5M2;
+    EXPECT_EQ(oss.str(), "fp8_e5m2");
     oss.str("");
 
     oss << DataType::NOT_SET;

--- a/projects/hipdnn/frontend/tests/TestTypes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTypes.cpp
@@ -15,6 +15,7 @@ TEST(TestTypes, ToSdkTypeDataTypes)
     EXPECT_EQ(toSdkType(DataType::DOUBLE), hipdnn_data_sdk::data_objects::DataType::DOUBLE);
     EXPECT_EQ(toSdkType(DataType::UINT8), hipdnn_data_sdk::data_objects::DataType::UINT8);
     EXPECT_EQ(toSdkType(DataType::INT32), hipdnn_data_sdk::data_objects::DataType::INT32);
+    EXPECT_EQ(toSdkType(DataType::INT8), hipdnn_data_sdk::data_objects::DataType::INT8);
     EXPECT_EQ(toSdkType(DataType::NOT_SET), hipdnn_data_sdk::data_objects::DataType::UNSET);
 }
 
@@ -28,6 +29,7 @@ TEST(TestTypes, FromSdkTypeDataTypes)
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::DOUBLE), DataType::DOUBLE);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UINT8), DataType::UINT8);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT32), DataType::INT32);
+    EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT8), DataType::INT8);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UNSET), DataType::NOT_SET);
 }
 
@@ -70,6 +72,7 @@ TEST(TestTypes, GetDataTypeEnumFromType)
     EXPECT_EQ(getDataTypeEnumFromType<double>(), DataType::DOUBLE);
     EXPECT_EQ(getDataTypeEnumFromType<uint8_t>(), DataType::UINT8);
     EXPECT_EQ(getDataTypeEnumFromType<int32_t>(), DataType::INT32);
+    EXPECT_EQ(getDataTypeEnumFromType<int8_t>(), DataType::INT8);
 
     EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType::NOT_SET);
     EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType::NOT_SET);
@@ -85,6 +88,7 @@ TEST(TestTypes, DataTypeToString)
     EXPECT_STREQ(to_string(DataType::DOUBLE), "fp64");
     EXPECT_STREQ(to_string(DataType::UINT8), "uint8");
     EXPECT_STREQ(to_string(DataType::INT32), "int32");
+    EXPECT_STREQ(to_string(DataType::INT8), "int8");
     EXPECT_STREQ(to_string(DataType::NOT_SET), "unknown");
 }
 
@@ -116,6 +120,10 @@ TEST(TestTypes, DataTypeStreamOperator)
 
     oss << DataType::INT32;
     EXPECT_EQ(oss.str(), "int32");
+    oss.str("");
+
+    oss << DataType::INT8;
+    EXPECT_EQ(oss.str(), "int8");
     oss.str("");
 
     oss << DataType::NOT_SET;

--- a/projects/hipdnn/frontend/tests/TestTypes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTypes.cpp
@@ -16,6 +16,7 @@ TEST(TestTypes, ToSdkTypeDataTypes)
     EXPECT_EQ(toSdkType(DataType::UINT8), hipdnn_data_sdk::data_objects::DataType::UINT8);
     EXPECT_EQ(toSdkType(DataType::INT32), hipdnn_data_sdk::data_objects::DataType::INT32);
     EXPECT_EQ(toSdkType(DataType::INT8), hipdnn_data_sdk::data_objects::DataType::INT8);
+    EXPECT_EQ(toSdkType(DataType::FP8_E4M3), hipdnn_data_sdk::data_objects::DataType::FP8_E4M3);
     EXPECT_EQ(toSdkType(DataType::NOT_SET), hipdnn_data_sdk::data_objects::DataType::UNSET);
 }
 
@@ -30,6 +31,7 @@ TEST(TestTypes, FromSdkTypeDataTypes)
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UINT8), DataType::UINT8);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT32), DataType::INT32);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT8), DataType::INT8);
+    EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP8_E4M3), DataType::FP8_E4M3);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UNSET), DataType::NOT_SET);
 }
 
@@ -73,6 +75,7 @@ TEST(TestTypes, GetDataTypeEnumFromType)
     EXPECT_EQ(getDataTypeEnumFromType<uint8_t>(), DataType::UINT8);
     EXPECT_EQ(getDataTypeEnumFromType<int32_t>(), DataType::INT32);
     EXPECT_EQ(getDataTypeEnumFromType<int8_t>(), DataType::INT8);
+    EXPECT_EQ(getDataTypeEnumFromType<hip_fp8_e4m3>(), DataType::FP8_E4M3);
 
     EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType::NOT_SET);
     EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType::NOT_SET);
@@ -89,6 +92,7 @@ TEST(TestTypes, DataTypeToString)
     EXPECT_STREQ(to_string(DataType::UINT8), "uint8");
     EXPECT_STREQ(to_string(DataType::INT32), "int32");
     EXPECT_STREQ(to_string(DataType::INT8), "int8");
+    EXPECT_STREQ(to_string(DataType::FP8_E4M3), "fp8_e4m3");
     EXPECT_STREQ(to_string(DataType::NOT_SET), "unknown");
 }
 
@@ -124,6 +128,10 @@ TEST(TestTypes, DataTypeStreamOperator)
 
     oss << DataType::INT8;
     EXPECT_EQ(oss.str(), "int8");
+    oss.str("");
+
+    oss << DataType::FP8_E4M3;
+    EXPECT_EQ(oss.str(), "fp8_e4m3");
     oss.str("");
 
     oss << DataType::NOT_SET;

--- a/projects/hipdnn/frontend/tests/TestTypes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTypes.cpp
@@ -18,6 +18,7 @@ TEST(TestTypes, ToSdkTypeDataTypes)
     EXPECT_EQ(toSdkType(DataType::INT8), hipdnn_data_sdk::data_objects::DataType::INT8);
     EXPECT_EQ(toSdkType(DataType::FP8_E4M3), hipdnn_data_sdk::data_objects::DataType::FP8_E4M3);
     EXPECT_EQ(toSdkType(DataType::FP8_E5M2), hipdnn_data_sdk::data_objects::DataType::FP8_E5M2);
+    EXPECT_EQ(toSdkType(DataType::FP8_E8M0), hipdnn_data_sdk::data_objects::DataType::FP8_E8M0);
     EXPECT_EQ(toSdkType(DataType::NOT_SET), hipdnn_data_sdk::data_objects::DataType::UNSET);
 }
 
@@ -34,6 +35,7 @@ TEST(TestTypes, FromSdkTypeDataTypes)
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::INT8), DataType::INT8);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP8_E4M3), DataType::FP8_E4M3);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP8_E5M2), DataType::FP8_E5M2);
+    EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::FP8_E8M0), DataType::FP8_E8M0);
     EXPECT_EQ(fromSdkType(hipdnn_data_sdk::data_objects::DataType::UNSET), DataType::NOT_SET);
 }
 
@@ -79,6 +81,7 @@ TEST(TestTypes, GetDataTypeEnumFromType)
     EXPECT_EQ(getDataTypeEnumFromType<int8_t>(), DataType::INT8);
     EXPECT_EQ(getDataTypeEnumFromType<hip_fp8_e4m3>(), DataType::FP8_E4M3);
     EXPECT_EQ(getDataTypeEnumFromType<hip_fp8_e5m2>(), DataType::FP8_E5M2);
+    EXPECT_EQ(getDataTypeEnumFromType<hip_fp8_e8m0>(), DataType::FP8_E8M0);
 
     EXPECT_EQ(getDataTypeEnumFromType<float*>(), DataType::NOT_SET);
     EXPECT_EQ(getDataTypeEnumFromType<char>(), DataType::NOT_SET);
@@ -97,6 +100,7 @@ TEST(TestTypes, DataTypeToString)
     EXPECT_STREQ(to_string(DataType::INT8), "int8");
     EXPECT_STREQ(to_string(DataType::FP8_E4M3), "fp8_e4m3");
     EXPECT_STREQ(to_string(DataType::FP8_E5M2), "fp8_e5m2");
+    EXPECT_STREQ(to_string(DataType::FP8_E8M0), "fp8_e8m0");
     EXPECT_STREQ(to_string(DataType::NOT_SET), "unknown");
 }
 
@@ -140,6 +144,10 @@ TEST(TestTypes, DataTypeStreamOperator)
 
     oss << DataType::FP8_E5M2;
     EXPECT_EQ(oss.str(), "fp8_e5m2");
+    oss.str("");
+
+    oss << DataType::FP8_E8M0;
+    EXPECT_EQ(oss.str(), "fp8_e8m0");
     oss.str("");
 
     oss << DataType::NOT_SET;

--- a/projects/hipdnn/python/src/memory_bindings.cpp
+++ b/projects/hipdnn/python/src/memory_bindings.cpp
@@ -175,6 +175,8 @@ void memory_bindings(nb::module_& m)
                 return sizeof(int32_t);
             else if(dtype_str == "<u1" || dtype_str == "uint8")
                 return sizeof(uint8_t);
+            else if(dtype_str == "<i1" || dtype_str == "int8")
+                return sizeof(int8_t);
             else
                 throw std::runtime_error("Unsupported dtype: " + dtype_str);
         },

--- a/projects/hipdnn/python/src/types_bindings.cpp
+++ b/projects/hipdnn/python/src/types_bindings.cpp
@@ -19,7 +19,8 @@ void types_bindings(nb::module_& m)
         .value("DOUBLE", DataType::DOUBLE)
         .value("UINT8", DataType::UINT8)
         .value("INT32", DataType::INT32)
-        .value("INT8", DataType::INT8);
+        .value("INT8", DataType::INT8)
+        .value("FP8_E4M3", DataType::FP8_E4M3);
 
     // Bind ConvolutionMode enum
     nb::enum_<ConvolutionMode>(m, "ConvolutionMode")

--- a/projects/hipdnn/python/src/types_bindings.cpp
+++ b/projects/hipdnn/python/src/types_bindings.cpp
@@ -18,7 +18,8 @@ void types_bindings(nb::module_& m)
         .value("BFLOAT16", DataType::BFLOAT16)
         .value("DOUBLE", DataType::DOUBLE)
         .value("UINT8", DataType::UINT8)
-        .value("INT32", DataType::INT32);
+        .value("INT32", DataType::INT32)
+        .value("INT8", DataType::INT8);
 
     // Bind ConvolutionMode enum
     nb::enum_<ConvolutionMode>(m, "ConvolutionMode")

--- a/projects/hipdnn/python/src/types_bindings.cpp
+++ b/projects/hipdnn/python/src/types_bindings.cpp
@@ -20,7 +20,8 @@ void types_bindings(nb::module_& m)
         .value("UINT8", DataType::UINT8)
         .value("INT32", DataType::INT32)
         .value("INT8", DataType::INT8)
-        .value("FP8_E4M3", DataType::FP8_E4M3);
+        .value("FP8_E4M3", DataType::FP8_E4M3)
+        .value("FP8_E5M2", DataType::FP8_E5M2);
 
     // Bind ConvolutionMode enum
     nb::enum_<ConvolutionMode>(m, "ConvolutionMode")

--- a/projects/hipdnn/python/src/types_bindings.cpp
+++ b/projects/hipdnn/python/src/types_bindings.cpp
@@ -21,7 +21,8 @@ void types_bindings(nb::module_& m)
         .value("INT32", DataType::INT32)
         .value("INT8", DataType::INT8)
         .value("FP8_E4M3", DataType::FP8_E4M3)
-        .value("FP8_E5M2", DataType::FP8_E5M2);
+        .value("FP8_E5M2", DataType::FP8_E5M2)
+        .value("FP8_E8M0", DataType::FP8_E8M0);
 
     // Bind ConvolutionMode enum
     nb::enum_<ConvolutionMode>(m, "ConvolutionMode")

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
@@ -83,6 +83,58 @@ private:
     T _relativeTolerance;
 };
 
+template <class T>
+class CpuIntReferenceValidation : public IReferenceValidation
+{
+public:
+    CpuIntReferenceValidation() = default;
+    ~CpuIntReferenceValidation() override = default;
+
+    bool allClose(hipdnn_data_sdk::utilities::ITensor& reference,
+                  hipdnn_data_sdk::utilities::ITensor& implementation) const override
+    {
+        if(reference.elementCount() != implementation.elementCount()
+           || reference.dims() != implementation.dims())
+        {
+            return false;
+        }
+
+        hipdnn_data_sdk::utilities::TensorView<T> refView(reference);
+        hipdnn_data_sdk::utilities::TensorView<T> implView(implementation);
+
+        std::atomic<bool> result(true);
+
+        auto validateFunc = [&](const std::vector<int64_t>& indices) {
+            T refValue = refView.getHostValue(indices);
+            T implValue = implView.getHostValue(indices);
+
+            T absDiff = static_cast<T>(std::abs(implValue - refValue));
+
+            // Integer values ​​must be equal
+            if(absDiff > 0)
+            {
+                // Log error and mark as failed
+                HIPDNN_LOG_ERROR("Validation failed for integer values at indices {}: ",
+                                 "reference value = {}, "
+                                 "implementation value = {}, "
+                                 "absolute difference = {}",
+                                 indices,
+                                 refValue,
+                                 implValue,
+                                 absDiff);
+                result.store(false, std::memory_order_relaxed);
+            }
+            return result.load(std::memory_order_relaxed);
+        };
+
+        // Create and execute parallel functor
+        auto parallelFunc = makeParallelTensorFunctor(validateFunc, reference.dims());
+        parallelFunc(std::thread::hardware_concurrency());
+
+        return result.load();
+    }
+};
+
 inline std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>
     createAllCloseValidator(hipdnn_data_sdk::data_objects::DataType dataType,
                             float absoluteTolerance = std::numeric_limits<float>::epsilon(),
@@ -103,8 +155,29 @@ inline std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>
     case hipdnn_data_sdk::data_objects::DataType::DOUBLE:
         return std::make_unique<CpuFpReferenceValidation<double>>(
             static_cast<double>(absoluteTolerance), static_cast<double>(relativeTolerance));
+    case hipdnn_data_sdk::data_objects::DataType::INT8:
+        return std::make_unique<CpuIntReferenceValidation<int8_t>>();
+    case hipdnn_data_sdk::data_objects::DataType::UINT8:
+        return std::make_unique<CpuIntReferenceValidation<uint8_t>>();
+    case hipdnn_data_sdk::data_objects::DataType::INT32:
+        return std::make_unique<CpuIntReferenceValidation<int32_t>>();
     default:
         throw std::runtime_error("Unsupported data type for allClose validator");
+    }
+}
+
+template <typename T>
+inline std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>
+    createAllCloseValidator(T absoluteTolerance = std::numeric_limits<T>::epsilon(),
+                            T relativeTolerance = std::numeric_limits<T>::epsilon())
+{
+    if constexpr(std::is_integral_v<T>)
+    {
+        return std::make_unique<CpuIntReferenceValidation<T>>();
+    }
+    else
+    {
+        return std::make_unique<CpuFpReferenceValidation<T>>(absoluteTolerance, relativeTolerance);
     }
 }
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
@@ -221,6 +221,10 @@ constexpr T getTolerance()
     {
         return 1e-2_bf;
     }
+    else if constexpr(std::is_same_v<T, int8_t>)
+    {
+        return 0;
+    }
     else
     {
         static_assert(false, "Type not supported");

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/UnaryOperationFunctors.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/UnaryOperationFunctors.hpp
@@ -92,7 +92,7 @@ struct Negation
     template <typename X>
     auto operator()(const X& x) const -> X
     {
-        return -x;
+        return static_cast<X>(-x);
     }
 };
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -148,6 +148,19 @@ TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdInferenceNchw)
         inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor);
 }
 
+TEST(TestCpuFpReferenceBatchnormInt8, BatchnormFwdInferenceNchw)
+{
+    Tensor<int8_t> inputTensor({1, 3, 224, 224});
+    Tensor<int8_t> outputTensor({1, 3, 224, 224});
+    Tensor<float> biasTensor({1, 3});
+    Tensor<float> scaleTensor({1, 3});
+    Tensor<float> meanTensor({1, 3});
+    Tensor<float> varianceTensor({1, 3});
+
+    CpuFpReferenceBatchnorm::fwdInference(
+        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor);
+}
+
 TEST(TestCpuFpReferenceBatchnormFp32, BatchnormFwdInferenceNhwc)
 {
     Tensor<float> inputTensor({6, 3, 32, 32}, TensorLayout::NHWC);
@@ -357,6 +370,27 @@ TEST(TestCpuFpReferenceBatchnormFp16, BatchnormBackwardNchw)
     Tensor<half> xTensor({6, 3, 32, 32});
     Tensor<half> dyTensor({6, 3, 32, 32});
     Tensor<half> dxTensor({6, 3, 32, 32});
+    Tensor<float> scaleTensor({1, 3});
+    Tensor<float> meanTensor({1, 3});
+    Tensor<float> invVarianceTensor({1, 3});
+    Tensor<float> dscaleTensor({1, 3});
+    Tensor<float> dbiasTensor({1, 3});
+
+    CpuFpReferenceBatchnorm::backward(dyTensor,
+                                      xTensor,
+                                      meanTensor,
+                                      invVarianceTensor,
+                                      scaleTensor,
+                                      dxTensor,
+                                      dscaleTensor,
+                                      dbiasTensor);
+}
+
+TEST(TestCpuFpReferenceBatchnormInt8, BatchnormBackwardNchw)
+{
+    Tensor<int8_t> xTensor({6, 3, 32, 32});
+    Tensor<int8_t> dyTensor({6, 3, 32, 32});
+    Tensor<int8_t> dxTensor({6, 3, 32, 32});
     Tensor<float> scaleTensor({1, 3});
     Tensor<float> meanTensor({1, 3});
     Tensor<float> invVarianceTensor({1, 3});
@@ -1098,6 +1132,32 @@ TEST(TestCpuFpReferenceBatchnormFp64, BatchnormFwdTrainingNchw)
     Tensor<double> savedInvVariance({1, 3});
 
     inputTensor.fillWithValue(1.0);
+    for(int i = 0; i < 3; i++)
+    {
+        scaleTensor.setHostValue(1.0, 0, i);
+        biasTensor.setHostValue(0.0, 0, i);
+    }
+
+    CpuFpReferenceBatchnorm::fwdTraining(inputTensor,
+                                         scaleTensor,
+                                         biasTensor,
+                                         outputTensor,
+                                         BATCHNORM_DEFAULT_EPSILON,
+                                         0.1,
+                                         &savedMean,
+                                         &savedInvVariance);
+}
+
+TEST(TestCpuFpReferenceBatchnormInt8, BatchnormFwdTrainingNchw)
+{
+    Tensor<int8_t> inputTensor({2, 3, 4, 4});
+    Tensor<int8_t> outputTensor({2, 3, 4, 4});
+    Tensor<double> scaleTensor({1, 3});
+    Tensor<double> biasTensor({1, 3});
+    Tensor<double> savedMean({1, 3});
+    Tensor<double> savedInvVariance({1, 3});
+
+    inputTensor.fillWithValue(1);
     for(int i = 0; i < 3; i++)
     {
         scaleTensor.setHostValue(1.0, 0, i);

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -6,6 +6,7 @@
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
@@ -166,6 +167,19 @@ TEST(TestCpuFpReferenceBatchnormFp8, BatchnormFwdInferenceNchw)
 {
     Tensor<hip_fp8_e4m3> inputTensor({1, 3, 224, 224});
     Tensor<hip_fp8_e4m3> outputTensor({1, 3, 224, 224});
+    Tensor<float> biasTensor({1, 3});
+    Tensor<float> scaleTensor({1, 3});
+    Tensor<float> meanTensor({1, 3});
+    Tensor<float> varianceTensor({1, 3});
+
+    CpuFpReferenceBatchnorm::fwdInference(
+        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor);
+}
+
+TEST(TestCpuFpReferenceBatchnormBfp8, BatchnormFwdInferenceNchw)
+{
+    Tensor<hip_fp8_e5m2> inputTensor({1, 3, 224, 224});
+    Tensor<hip_fp8_e5m2> outputTensor({1, 3, 224, 224});
     Tensor<float> biasTensor({1, 3});
     Tensor<float> scaleTensor({1, 3});
     Tensor<float> meanTensor({1, 3});
@@ -426,6 +440,27 @@ TEST(TestCpuFpReferenceBatchnormFp8, BatchnormBackwardNchw)
     Tensor<hip_fp8_e4m3> xTensor({6, 3, 32, 32});
     Tensor<hip_fp8_e4m3> dyTensor({6, 3, 32, 32});
     Tensor<hip_fp8_e4m3> dxTensor({6, 3, 32, 32});
+    Tensor<float> scaleTensor({1, 3});
+    Tensor<float> meanTensor({1, 3});
+    Tensor<float> invVarianceTensor({1, 3});
+    Tensor<float> dscaleTensor({1, 3});
+    Tensor<float> dbiasTensor({1, 3});
+
+    CpuFpReferenceBatchnorm::backward(dyTensor,
+                                      xTensor,
+                                      meanTensor,
+                                      invVarianceTensor,
+                                      scaleTensor,
+                                      dxTensor,
+                                      dscaleTensor,
+                                      dbiasTensor);
+}
+
+TEST(TestCpuFpReferenceBatchnormBfp8, BatchnormBackwardNchw)
+{
+    Tensor<hip_fp8_e5m2> xTensor({6, 3, 32, 32});
+    Tensor<hip_fp8_e5m2> dyTensor({6, 3, 32, 32});
+    Tensor<hip_fp8_e5m2> dxTensor({6, 3, 32, 32});
     Tensor<float> scaleTensor({1, 3});
     Tensor<float> meanTensor({1, 3});
     Tensor<float> invVarianceTensor({1, 3});
@@ -1218,7 +1253,33 @@ TEST(TestCpuFpReferenceBatchnormFp8, BatchnormFwdTrainingNchw)
     Tensor<double> savedMean({1, 3});
     Tensor<double> savedInvVariance({1, 3});
 
-    inputTensor.fillWithValue(1);
+    inputTensor.fillWithValue(1.0_fp8);
+    for(int i = 0; i < 3; i++)
+    {
+        scaleTensor.setHostValue(1.0, 0, i);
+        biasTensor.setHostValue(0.0, 0, i);
+    }
+
+    CpuFpReferenceBatchnorm::fwdTraining(inputTensor,
+                                         scaleTensor,
+                                         biasTensor,
+                                         outputTensor,
+                                         BATCHNORM_DEFAULT_EPSILON,
+                                         0.1,
+                                         &savedMean,
+                                         &savedInvVariance);
+}
+
+TEST(TestCpuFpReferenceBatchnormBfp8, BatchnormFwdTrainingNchw)
+{
+    Tensor<hip_fp8_e5m2> inputTensor({2, 3, 4, 4});
+    Tensor<hip_fp8_e5m2> outputTensor({2, 3, 4, 4});
+    Tensor<double> scaleTensor({1, 3});
+    Tensor<double> biasTensor({1, 3});
+    Tensor<double> savedMean({1, 3});
+    Tensor<double> savedInvVariance({1, 3});
+
+    inputTensor.fillWithValue(1.0_bfp8);
     for(int i = 0; i < 3; i++)
     {
         scaleTensor.setHostValue(1.0, 0, i);

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBatchnorm.cpp
@@ -7,6 +7,7 @@
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceBatchnorm.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/FileUtilities.hpp>
@@ -152,6 +153,19 @@ TEST(TestCpuFpReferenceBatchnormInt8, BatchnormFwdInferenceNchw)
 {
     Tensor<int8_t> inputTensor({1, 3, 224, 224});
     Tensor<int8_t> outputTensor({1, 3, 224, 224});
+    Tensor<float> biasTensor({1, 3});
+    Tensor<float> scaleTensor({1, 3});
+    Tensor<float> meanTensor({1, 3});
+    Tensor<float> varianceTensor({1, 3});
+
+    CpuFpReferenceBatchnorm::fwdInference(
+        inputTensor, scaleTensor, biasTensor, meanTensor, varianceTensor, outputTensor);
+}
+
+TEST(TestCpuFpReferenceBatchnormFp8, BatchnormFwdInferenceNchw)
+{
+    Tensor<hip_fp8_e4m3> inputTensor({1, 3, 224, 224});
+    Tensor<hip_fp8_e4m3> outputTensor({1, 3, 224, 224});
     Tensor<float> biasTensor({1, 3});
     Tensor<float> scaleTensor({1, 3});
     Tensor<float> meanTensor({1, 3});
@@ -391,6 +405,27 @@ TEST(TestCpuFpReferenceBatchnormInt8, BatchnormBackwardNchw)
     Tensor<int8_t> xTensor({6, 3, 32, 32});
     Tensor<int8_t> dyTensor({6, 3, 32, 32});
     Tensor<int8_t> dxTensor({6, 3, 32, 32});
+    Tensor<float> scaleTensor({1, 3});
+    Tensor<float> meanTensor({1, 3});
+    Tensor<float> invVarianceTensor({1, 3});
+    Tensor<float> dscaleTensor({1, 3});
+    Tensor<float> dbiasTensor({1, 3});
+
+    CpuFpReferenceBatchnorm::backward(dyTensor,
+                                      xTensor,
+                                      meanTensor,
+                                      invVarianceTensor,
+                                      scaleTensor,
+                                      dxTensor,
+                                      dscaleTensor,
+                                      dbiasTensor);
+}
+
+TEST(TestCpuFpReferenceBatchnormFp8, BatchnormBackwardNchw)
+{
+    Tensor<hip_fp8_e4m3> xTensor({6, 3, 32, 32});
+    Tensor<hip_fp8_e4m3> dyTensor({6, 3, 32, 32});
+    Tensor<hip_fp8_e4m3> dxTensor({6, 3, 32, 32});
     Tensor<float> scaleTensor({1, 3});
     Tensor<float> meanTensor({1, 3});
     Tensor<float> invVarianceTensor({1, 3});
@@ -1152,6 +1187,32 @@ TEST(TestCpuFpReferenceBatchnormInt8, BatchnormFwdTrainingNchw)
 {
     Tensor<int8_t> inputTensor({2, 3, 4, 4});
     Tensor<int8_t> outputTensor({2, 3, 4, 4});
+    Tensor<double> scaleTensor({1, 3});
+    Tensor<double> biasTensor({1, 3});
+    Tensor<double> savedMean({1, 3});
+    Tensor<double> savedInvVariance({1, 3});
+
+    inputTensor.fillWithValue(1);
+    for(int i = 0; i < 3; i++)
+    {
+        scaleTensor.setHostValue(1.0, 0, i);
+        biasTensor.setHostValue(0.0, 0, i);
+    }
+
+    CpuFpReferenceBatchnorm::fwdTraining(inputTensor,
+                                         scaleTensor,
+                                         biasTensor,
+                                         outputTensor,
+                                         BATCHNORM_DEFAULT_EPSILON,
+                                         0.1,
+                                         &savedMean,
+                                         &savedInvVariance);
+}
+
+TEST(TestCpuFpReferenceBatchnormFp8, BatchnormFwdTrainingNchw)
+{
+    Tensor<hip_fp8_e4m3> inputTensor({2, 3, 4, 4});
+    Tensor<hip_fp8_e4m3> outputTensor({2, 3, 4, 4});
     Tensor<double> scaleTensor({1, 3});
     Tensor<double> biasTensor({1, 3});
     Tensor<double> savedMean({1, 3});

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
@@ -239,6 +239,38 @@ TEST(TestCpuFpReferenceConvolutionFp64, ConvolutionFwdInferenceBasic)
     EXPECT_DOUBLE_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99.0);
 }
 
+TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionFwdInferenceBasic)
+{
+    Tensor<int8_t> inputTensor({1, 1, 4, 4});
+    Tensor<int8_t> weightTensor({1, 1, 3, 3});
+    Tensor<int8_t> outputTensor({1, 1, 2, 2});
+
+    // Fill input with sequential values
+    for(int i = 0; i < 16; ++i)
+    {
+        inputTensor.memory().hostData()[i] = static_cast<int8_t>(i + 1);
+    }
+
+    // Fill weights with 1s
+    for(int i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = 1.0;
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::fprop<int8_t, int8_t, int8_t, int32_t>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+
+    // Same expected values as fp32 test
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 0), 54);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99);
+}
+
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionFwdInferenceWithDilation)
 {
     // Test with dilation = 2
@@ -1072,6 +1104,33 @@ TEST(TestCpuFpReferenceConvolutionFp64, ConvolutionBwdDataBasic)
         inputTensor, weightTensor, outputTensor, strides, dilations, padding);
 }
 
+TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionBwdDataBasic)
+{
+    // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
+    Tensor<int8_t> inputTensor({1, 1, 4, 4});
+    Tensor<int8_t> weightTensor({1, 1, 3, 3});
+    Tensor<int8_t> outputTensor({1, 1, 2, 2});
+
+    // gradOutput values: simple pattern
+    outputTensor.setHostValue(1, 0, 0, 0, 0);
+    outputTensor.setHostValue(2, 0, 0, 0, 1);
+    outputTensor.setHostValue(3, 0, 0, 1, 0);
+    outputTensor.setHostValue(4, 0, 0, 1, 1);
+
+    // Weight values: simple 3x3 kernel
+    for(size_t i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = static_cast<int8_t>(i + 1);
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::dgrad<int8_t, int8_t, int8_t, int32_t>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+}
+
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionBwdDataSimple)
 {
     // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
@@ -1879,6 +1938,42 @@ TEST(TestCpuFpReferenceConvolutionFp64, ConvolutionWrwBasic)
 
     // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 0.5 = 5.0
     EXPECT_FLOAT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 5.0);
+}
+
+TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionWrwBasic)
+{
+    // Minimal sanity test for wgrad using smallest possible tensor sizes
+    // Input: 1x1x2x2 (1 batch, 1 input channel, 2x2 spatial)
+    // Weight: 1x1x1x1 (1 output channel, 1 input channel, 1x1 kernel)
+    // GradOutput: 1x1x2x2 (1 batch, 1 output channel, 2x2 spatial)
+    Tensor<int8_t> inputTensor({1, 1, 2, 2});
+    Tensor<int8_t> gradWeightTensor({1, 1, 1, 1});
+    Tensor<int8_t> gradOutputTensor({1, 1, 2, 2});
+
+    // Set input values: [1, 2; 3, 4]
+    inputTensor.setHostValue(1, 0, 0, 0, 0);
+    inputTensor.setHostValue(2, 0, 0, 0, 1);
+    inputTensor.setHostValue(3, 0, 0, 1, 0);
+    inputTensor.setHostValue(4, 0, 0, 1, 1);
+
+    // Set gradient output values: [1, 1; 1, 1]
+    gradOutputTensor.setHostValue(1, 0, 0, 0, 0);
+    gradOutputTensor.setHostValue(1, 0, 0, 0, 1);
+    gradOutputTensor.setHostValue(1, 0, 0, 1, 0);
+    gradOutputTensor.setHostValue(1, 0, 0, 1, 1);
+
+    // Initialize weight to zero
+    gradWeightTensor.setHostValue(0, 0, 0, 0, 0);
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::wgrad<int8_t, int8_t, int8_t, int32_t>(
+        inputTensor, gradWeightTensor, gradOutputTensor, strides, dilations, padding);
+
+    // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 1 = 10
+    EXPECT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 10);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvBwdWeightMultiBatch)

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsBfp8.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
@@ -302,6 +303,38 @@ TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionFwdInferenceBasic)
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63.0_fp8);
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90.0_fp8);
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99.0_fp8);
+}
+
+TEST(TestCpuFpReferenceConvolutionBfp8, ConvolutionFwdInferenceBasic)
+{
+    Tensor<hip_fp8_e5m2> inputTensor({1, 1, 4, 4});
+    Tensor<hip_fp8_e5m2> weightTensor({1, 1, 3, 3});
+    Tensor<hip_fp8_e5m2> outputTensor({1, 1, 2, 2});
+
+    // Fill input with sequential values
+    for(int i = 0; i < 16; ++i)
+    {
+        inputTensor.memory().hostData()[i] = static_cast<hip_fp8_e5m2>(i + 1);
+    }
+
+    // Fill weights with 1s
+    for(int i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = 1.0_bfp8;
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::fprop<hip_fp8_e5m2, hip_fp8_e5m2, hip_fp8_e5m2, float>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+
+    // Same expected values as fp32 test
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 0), 54.0_bfp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63.0_bfp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90.0_bfp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99.0_bfp8);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionFwdInferenceWithDilation)
@@ -1191,6 +1224,33 @@ TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionBwdDataBasic)
         inputTensor, weightTensor, outputTensor, strides, dilations, padding);
 }
 
+TEST(TestCpuFpReferenceConvolutionBfp8, ConvolutionBwdDataBasic)
+{
+    // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
+    Tensor<hip_fp8_e5m2> inputTensor({1, 1, 4, 4});
+    Tensor<hip_fp8_e5m2> weightTensor({1, 1, 3, 3});
+    Tensor<hip_fp8_e5m2> outputTensor({1, 1, 2, 2});
+
+    // gradOutput values: simple pattern
+    outputTensor.setHostValue(1.0_bfp8, 0, 0, 0, 0);
+    outputTensor.setHostValue(2.0_bfp8, 0, 0, 0, 1);
+    outputTensor.setHostValue(3.0_bfp8, 0, 0, 1, 0);
+    outputTensor.setHostValue(4.0_bfp8, 0, 0, 1, 1);
+
+    // Weight values: simple 3x3 kernel
+    for(size_t i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = static_cast<hip_fp8_e5m2>(i + 1);
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::dgrad<hip_fp8_e5m2, hip_fp8_e5m2, hip_fp8_e5m2, float>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+}
+
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionBwdDataSimple)
 {
     // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
@@ -2070,6 +2130,42 @@ TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionWrwBasic)
 
     // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 1 = 10
     EXPECT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 10.0_fp8);
+}
+
+TEST(TestCpuFpReferenceConvolutionBfp8, ConvolutionWrwBasic)
+{
+    // Minimal sanity test for wgrad using smallest possible tensor sizes
+    // Input: 1x1x2x2 (1 batch, 1 input channel, 2x2 spatial)
+    // Weight: 1x1x1x1 (1 output channel, 1 input channel, 1x1 kernel)
+    // GradOutput: 1x1x2x2 (1 batch, 1 output channel, 2x2 spatial)
+    Tensor<hip_fp8_e5m2> inputTensor({1, 1, 2, 2});
+    Tensor<hip_fp8_e5m2> gradWeightTensor({1, 1, 1, 1});
+    Tensor<hip_fp8_e5m2> gradOutputTensor({1, 1, 2, 2});
+
+    // Set input values: [1, 2; 3, 4]
+    inputTensor.setHostValue(1.0_bfp8, 0, 0, 0, 0);
+    inputTensor.setHostValue(2.0_bfp8, 0, 0, 0, 1);
+    inputTensor.setHostValue(3.0_bfp8, 0, 0, 1, 0);
+    inputTensor.setHostValue(4.0_bfp8, 0, 0, 1, 1);
+
+    // Set gradient output values: [1, 1; 1, 1]
+    gradOutputTensor.setHostValue(1.0_bfp8, 0, 0, 0, 0);
+    gradOutputTensor.setHostValue(1.0_bfp8, 0, 0, 0, 1);
+    gradOutputTensor.setHostValue(1.0_bfp8, 0, 0, 1, 0);
+    gradOutputTensor.setHostValue(1.0_bfp8, 0, 0, 1, 1);
+
+    // Initialize weight to zero
+    gradWeightTensor.setHostValue(0.0_bfp8, 0, 0, 0, 0);
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::wgrad<hip_fp8_e5m2, hip_fp8_e5m2, hip_fp8_e5m2, float>(
+        inputTensor, gradWeightTensor, gradOutputTensor, strides, dilations, padding);
+
+    // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 1 = 10
+    EXPECT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 10.0_bfp8);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvBwdWeightMultiBatch)

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceConvolution.cpp
@@ -5,6 +5,7 @@
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsBfp16.hpp>
 #include <hipdnn_data_sdk/utilities/UtilsFp16.hpp>
+#include <hipdnn_data_sdk/utilities/UtilsFp8.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 
@@ -269,6 +270,38 @@ TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionFwdInferenceBasic)
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63);
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90);
     EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99);
+}
+
+TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionFwdInferenceBasic)
+{
+    Tensor<hip_fp8_e4m3> inputTensor({1, 1, 4, 4});
+    Tensor<hip_fp8_e4m3> weightTensor({1, 1, 3, 3});
+    Tensor<hip_fp8_e4m3> outputTensor({1, 1, 2, 2});
+
+    // Fill input with sequential values
+    for(int i = 0; i < 16; ++i)
+    {
+        inputTensor.memory().hostData()[i] = static_cast<hip_fp8_e4m3>(i + 1);
+    }
+
+    // Fill weights with 1s
+    for(int i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = 1.0_fp8;
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::fprop<hip_fp8_e4m3, hip_fp8_e4m3, hip_fp8_e4m3, float>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+
+    // Same expected values as fp32 test
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 0), 54.0_fp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 0, 1), 63.0_fp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 0), 90.0_fp8);
+    EXPECT_EQ(outputTensor.getHostValue(0, 0, 1, 1), 99.0_fp8);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionFwdInferenceWithDilation)
@@ -1131,6 +1164,33 @@ TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionBwdDataBasic)
         inputTensor, weightTensor, outputTensor, strides, dilations, padding);
 }
 
+TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionBwdDataBasic)
+{
+    // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
+    Tensor<hip_fp8_e4m3> inputTensor({1, 1, 4, 4});
+    Tensor<hip_fp8_e4m3> weightTensor({1, 1, 3, 3});
+    Tensor<hip_fp8_e4m3> outputTensor({1, 1, 2, 2});
+
+    // gradOutput values: simple pattern
+    outputTensor.setHostValue(1.0_fp8, 0, 0, 0, 0);
+    outputTensor.setHostValue(2.0_fp8, 0, 0, 0, 1);
+    outputTensor.setHostValue(3.0_fp8, 0, 0, 1, 0);
+    outputTensor.setHostValue(4.0_fp8, 0, 0, 1, 1);
+
+    // Weight values: simple 3x3 kernel
+    for(size_t i = 0; i < 9; ++i)
+    {
+        weightTensor.memory().hostData()[i] = static_cast<hip_fp8_e4m3>(i + 1);
+    }
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::dgrad<hip_fp8_e4m3, hip_fp8_e4m3, hip_fp8_e4m3, float>(
+        inputTensor, weightTensor, outputTensor, strides, dilations, padding);
+}
+
 TEST(TestCpuFpReferenceConvolutionFp32, ConvolutionBwdDataSimple)
 {
     // Basic convolution: 1x1x4x4 input, 1x1x3x3 weight -> 1x1x2x2 output
@@ -1974,6 +2034,42 @@ TEST(TestCpuFpReferenceConvolutionInt8, ConvolutionWrwBasic)
 
     // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 1 = 10
     EXPECT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 10);
+}
+
+TEST(TestCpuFpReferenceConvolutionFp8, ConvolutionWrwBasic)
+{
+    // Minimal sanity test for wgrad using smallest possible tensor sizes
+    // Input: 1x1x2x2 (1 batch, 1 input channel, 2x2 spatial)
+    // Weight: 1x1x1x1 (1 output channel, 1 input channel, 1x1 kernel)
+    // GradOutput: 1x1x2x2 (1 batch, 1 output channel, 2x2 spatial)
+    Tensor<hip_fp8_e4m3> inputTensor({1, 1, 2, 2});
+    Tensor<hip_fp8_e4m3> gradWeightTensor({1, 1, 1, 1});
+    Tensor<hip_fp8_e4m3> gradOutputTensor({1, 1, 2, 2});
+
+    // Set input values: [1, 2; 3, 4]
+    inputTensor.setHostValue(1.0_fp8, 0, 0, 0, 0);
+    inputTensor.setHostValue(2.0_fp8, 0, 0, 0, 1);
+    inputTensor.setHostValue(3.0_fp8, 0, 0, 1, 0);
+    inputTensor.setHostValue(4.0_fp8, 0, 0, 1, 1);
+
+    // Set gradient output values: [1, 1; 1, 1]
+    gradOutputTensor.setHostValue(1.0_fp8, 0, 0, 0, 0);
+    gradOutputTensor.setHostValue(1.0_fp8, 0, 0, 0, 1);
+    gradOutputTensor.setHostValue(1.0_fp8, 0, 0, 1, 0);
+    gradOutputTensor.setHostValue(1.0_fp8, 0, 0, 1, 1);
+
+    // Initialize weight to zero
+    gradWeightTensor.setHostValue(0.0_fp8, 0, 0, 0, 0);
+
+    std::vector<int64_t> strides = {1, 1};
+    std::vector<int64_t> dilations = {1, 1};
+    std::vector<int64_t> padding = {0, 0};
+
+    CpuFpReferenceConvolution::wgrad<hip_fp8_e4m3, hip_fp8_e4m3, hip_fp8_e4m3, float>(
+        inputTensor, gradWeightTensor, gradOutputTensor, strides, dilations, padding);
+
+    // Expected weight gradient: sum of (input * gradOutput) = (1+2+3+4) * 1 = 10
+    EXPECT_EQ(gradWeightTensor.getHostValue(0, 0, 0, 0), 10.0_fp8);
 }
 
 TEST(TestCpuFpReferenceConvolutionFp32, ConvBwdWeightMultiBatch)

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
@@ -79,8 +79,8 @@ protected:
         expected.fillWithValue(static_cast<OutputType>(TEST_VALUE_3));
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinarySubtractOperation()
@@ -99,8 +99,8 @@ protected:
         expected.fillWithValue(static_cast<OutputType>(TEST_VALUE_3));
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinaryAddOperationSanityValidation()
@@ -109,32 +109,58 @@ protected:
         Tensor<Input2Type> input2({1, 1, 2, 2});
         Tensor<OutputType> output({1, 1, 2, 2});
 
-        input1.setHostValue(static_cast<Input1Type>(PI), 0, 0, 0, 0); // π
-        input1.setHostValue(static_cast<Input1Type>(E), 0, 0, 0, 1); // e
-        input1.setHostValue(static_cast<Input1Type>(SQRT_2), 0, 0, 1, 0); // √2
-        input1.setHostValue(static_cast<Input1Type>(GOLDEN_RATIO), 0, 0, 1, 1); // φ (golden ratio)
+        // Create expected tensor with computed results
+        Tensor<OutputType> expected({1, 1, 2, 2});
 
-        input2.setHostValue(static_cast<Input2Type>(LN_2), 0, 0, 0, 0); // ln(2)
-        input2.setHostValue(static_cast<Input2Type>(std::sin(1.0f)), 0, 0, 0, 1);
-        input2.setHostValue(static_cast<Input2Type>(std::cos(1.0f)), 0, 0, 1, 0);
-        input2.setHostValue(static_cast<Input2Type>(std::tan(1.0f)), 0, 0, 1, 1);
+        if constexpr(std::is_integral_v<Input1Type> || std::is_integral_v<Input2Type>)
+        {
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_1), 0, 0, 0, 0);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 0, 1);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_3), 0, 0, 1, 0);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_4), 0, 0, 1, 1);
+
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_4), 0, 0, 0, 0);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_3), 0, 0, 0, 1);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_2), 0, 0, 1, 0);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_1), 0, 0, 1, 1);
+
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_1 + (-TEST_VALUE_4)), 0, 0, 0, 0);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_2 + (-TEST_VALUE_3)), 0, 0, 0, 1);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_3 + (-TEST_VALUE_2)), 0, 0, 1, 0);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_4 + (-TEST_VALUE_1)), 0, 0, 1, 1);
+        }
+        else
+        {
+            input1.setHostValue(static_cast<Input1Type>(PI), 0, 0, 0, 0); // π
+            input1.setHostValue(static_cast<Input1Type>(E), 0, 0, 0, 1); // e
+            input1.setHostValue(static_cast<Input1Type>(SQRT_2), 0, 0, 1, 0); // √2
+            input1.setHostValue(
+                static_cast<Input1Type>(GOLDEN_RATIO), 0, 0, 1, 1); // φ (golden ratio)
+
+            input2.setHostValue(static_cast<Input2Type>(LN_2), 0, 0, 0, 0); // ln(2)
+            input2.setHostValue(static_cast<Input2Type>(std::sin(1.0f)), 0, 0, 0, 1);
+            input2.setHostValue(static_cast<Input2Type>(std::cos(1.0f)), 0, 0, 1, 0);
+            input2.setHostValue(static_cast<Input2Type>(std::tan(1.0f)), 0, 0, 1, 1);
+
+            expected.setHostValue(static_cast<OutputType>(PI + LN_2), 0, 0, 0, 0); // π + ln(2)
+            expected.setHostValue(
+                static_cast<OutputType>(E + std::sin(1.0f)), 0, 0, 0, 1); // e + sin(1)
+            expected.setHostValue(
+                static_cast<OutputType>(SQRT_2 + std::cos(1.0f)), 0, 0, 1, 0); // √2 + cos(1)
+            expected.setHostValue(
+                static_cast<OutputType>(GOLDEN_RATIO + std::tan(1.0f)), 0, 0, 1, 1); // φ + tan(1)
+        }
 
         CpuReferencePointwiseImpl<OutputType, Input1Type, Input2Type>::pointwiseCompute(
             PointwiseMode::ADD, output, input1, input2);
 
-        // Create expected tensor with computed results
-        Tensor<OutputType> expected({1, 1, 2, 2});
-        expected.setHostValue(static_cast<OutputType>(PI + LN_2), 0, 0, 0, 0); // π + ln(2)
-        expected.setHostValue(
-            static_cast<OutputType>(E + std::sin(1.0f)), 0, 0, 0, 1); // e + sin(1)
-        expected.setHostValue(
-            static_cast<OutputType>(SQRT_2 + std::cos(1.0f)), 0, 0, 1, 0); // √2 + cos(1)
-        expected.setHostValue(
-            static_cast<OutputType>(GOLDEN_RATIO + std::tan(1.0f)), 0, 0, 1, 1); // φ + tan(1)
-
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinarySubtractOperationSanityValidation()
@@ -143,35 +169,63 @@ protected:
         Tensor<Input2Type> input2({1, 1, 2, 2});
         Tensor<OutputType> output({1, 1, 2, 2});
 
-        input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2 * PI), 0, 0, 0, 0); // 2π
-        input1.setHostValue(static_cast<Input1Type>(E * E), 0, 0, 0, 1); // e²
-        input1.setHostValue(static_cast<Input1Type>(SQRT_5), 0, 0, 1, 0); // √5
-        input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 1, 1); // Simple test value
+        // Create expected tensor with computed results
+        Tensor<OutputType> expected({1, 1, 2, 2});
 
-        input2.setHostValue(static_cast<Input2Type>(PI / TEST_VALUE_2), 0, 0, 0, 0); // π/2
-        input2.setHostValue(static_cast<Input2Type>(E), 0, 0, 0, 1); // e
-        input2.setHostValue(static_cast<Input2Type>(SQRT_3), 0, 0, 1, 0); // √3
-        input2.setHostValue(static_cast<Input2Type>(TEST_VALUE_1), 0, 0, 1, 1); // Simple test value
+        if constexpr(std::is_integral_v<Input1Type> || std::is_integral_v<Input2Type>)
+        {
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_1), 0, 0, 0, 0);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 0, 1);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_3), 0, 0, 1, 0);
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_4), 0, 0, 1, 1);
+
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_4), 0, 0, 0, 0);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_3), 0, 0, 0, 1);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_2), 0, 0, 1, 0);
+            input2.setHostValue(static_cast<Input2Type>(-TEST_VALUE_1), 0, 0, 1, 1);
+
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_1 - (-TEST_VALUE_4)), 0, 0, 0, 0);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_2 - (-TEST_VALUE_3)), 0, 0, 0, 1);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_3 - (-TEST_VALUE_2)), 0, 0, 1, 0);
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_4 - (-TEST_VALUE_1)), 0, 0, 1, 1);
+        }
+        else
+        {
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2 * PI), 0, 0, 0, 0); // 2π
+            input1.setHostValue(static_cast<Input1Type>(E * E), 0, 0, 0, 1); // e²
+            input1.setHostValue(static_cast<Input1Type>(SQRT_5), 0, 0, 1, 0); // √5
+            input1.setHostValue(
+                static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 1, 1); // Simple test value
+
+            input2.setHostValue(static_cast<Input2Type>(PI / TEST_VALUE_2), 0, 0, 0, 0); // π/2
+            input2.setHostValue(static_cast<Input2Type>(E), 0, 0, 0, 1); // e
+            input2.setHostValue(static_cast<Input2Type>(SQRT_3), 0, 0, 1, 0); // √3
+            input2.setHostValue(
+                static_cast<Input2Type>(TEST_VALUE_1), 0, 0, 1, 1); // Simple test value
+
+            expected.setHostValue(
+                static_cast<OutputType>((TEST_VALUE_2 * PI) - (PI / TEST_VALUE_2)),
+                0,
+                0,
+                0,
+                0); // 2π - π/2 = 3π/2
+            expected.setHostValue(static_cast<OutputType>((E * E) - E), 0, 0, 0,
+                                  1); // e² - e
+            expected.setHostValue(static_cast<OutputType>(SQRT_5 - SQRT_3), 0, 0, 1, 0); // √5 - √3
+            expected.setHostValue(
+                static_cast<OutputType>(TEST_VALUE_2 - TEST_VALUE_1), 0, 0, 1, 1); // 2 - 1
+        }
 
         CpuReferencePointwiseImpl<OutputType, Input1Type, Input2Type>::pointwiseCompute(
             PointwiseMode::SUB, output, input1, input2);
 
-        // Create expected tensor with computed results
-        Tensor<OutputType> expected({1, 1, 2, 2});
-        expected.setHostValue(static_cast<OutputType>((TEST_VALUE_2 * PI) - (PI / TEST_VALUE_2)),
-                              0,
-                              0,
-                              0,
-                              0); // 2π - π/2 = 3π/2
-        expected.setHostValue(static_cast<OutputType>((E * E) - E), 0, 0, 0,
-                              1); // e² - e
-        expected.setHostValue(static_cast<OutputType>(SQRT_5 - SQRT_3), 0, 0, 1, 0); // √5 - √3
-        expected.setHostValue(
-            static_cast<OutputType>(TEST_VALUE_2 - TEST_VALUE_1), 0, 0, 1, 1); // 2 - 1
-
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinaryAddOperation3D()
@@ -190,8 +244,8 @@ protected:
         expected.fillWithValue(static_cast<OutputType>(TEST_VALUE_4));
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinarySingleElementTensors()
@@ -200,19 +254,30 @@ protected:
         Tensor<Input2Type> input2({1, 1, 1, 1});
         Tensor<OutputType> output({1, 1, 1, 1});
 
-        input1.setHostValue(static_cast<Input1Type>(E * E), 0, 0, 0, 0); // e²
-        input2.setHostValue(static_cast<Input2Type>(E), 0, 0, 0, 0); // e
+        Tensor<OutputType> expected({1, 1, 1, 1});
+
+        if constexpr(std::is_integral_v<Input1Type> || std::is_integral_v<Input2Type>)
+        {
+            input1.setHostValue(static_cast<Input1Type>(TEST_VALUE_2), 0, 0, 0, 0);
+            input2.setHostValue(static_cast<Input2Type>(TEST_VALUE_5), 0, 0, 0, 0);
+
+            expected.setHostValue(static_cast<OutputType>(TEST_VALUE_2 - TEST_VALUE_5), 0, 0, 0, 0);
+        }
+        else
+        {
+            input1.setHostValue(static_cast<Input1Type>(E * E), 0, 0, 0, 0); // e²
+            input2.setHostValue(static_cast<Input2Type>(E), 0, 0, 0, 0); // e
+
+            expected.setHostValue(static_cast<OutputType>((E * E) - E), 0, 0, 0,
+                                  0); // e² - e
+        }
 
         CpuReferencePointwiseImpl<OutputType, Input1Type, Input2Type>::pointwiseCompute(
             PointwiseMode::SUB, output, input1, input2);
 
-        Tensor<OutputType> expected({1, 1, 1, 1});
-        expected.setHostValue(static_cast<OutputType>((E * E) - E), 0, 0, 0,
-                              0); // e² - e
-
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBinaryNumericalPrecision()
@@ -232,8 +297,8 @@ protected:
             static_cast<OutputType>(PRECISION_TEST_A + PRECISION_TEST_B), 0, 0, 0, 0);
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testElementwise1D()
@@ -260,8 +325,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(static_cast<float>(13)), 4);
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBroadcast2Dx1D()
@@ -302,8 +367,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBroadcast3D()
@@ -337,8 +402,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBroadcast3DImplicitLeading()
@@ -373,8 +438,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     // Test case: 4D × 4D: [N,C,H,W] + [1,C,1,1] → broadcast to [N,C,H,W]
@@ -424,8 +489,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     // Test case: Complex N-D broadcasting: [2,1,3,1] + [1,2,1,4] → [2,2,3,4]
@@ -478,8 +543,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testBroadcast5D()
@@ -542,8 +607,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     // ======================= UNARY OPERATIONS =======================
@@ -588,8 +653,8 @@ protected:
             static_cast<OutputType>(TEST_VALUE_1_5), 0, 2, 1, 1); // max(0, 1.5) = 1.5
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testReluBackwardOperation()
@@ -665,8 +730,8 @@ protected:
                               1); // dy=3.0, x=1.5>0: dx=3.0*1=3.0
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testParameterizedReluForwardOperation()
@@ -720,8 +785,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(TEST_VALUE_1), 0, 1, 1, 1); // 1.0 (in range)
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testParameterizedReluBackwardOperation()
@@ -804,8 +869,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testSigmoidForwardOperation()
@@ -870,8 +935,8 @@ protected:
                               1); // sigmoid(1.5)
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testSigmoidBackwardOperation()
@@ -928,8 +993,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testTanhForwardOperation()
@@ -969,8 +1034,8 @@ protected:
             static_cast<OutputType>(std::tanh(TEST_VALUE_1_5)), 0, 1, 1, 1); // tanh(1.5)
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testTanhBackwardOperation()
@@ -1025,8 +1090,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testAbsoluteValueOperation()
@@ -1066,8 +1131,8 @@ protected:
             static_cast<OutputType>(std::abs(-TEST_VALUE_4)), 0, 1, 1, 1); // |-4| = 4
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testNegationOperation()
@@ -1100,8 +1165,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(TEST_VALUE_4), 0, 1, 1, 1); // -(-4) = 4
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testUnary1DOperation()
@@ -1128,8 +1193,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(2.0f), 4); // max(0, 2) = 2
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testUnary2DOperation()
@@ -1162,8 +1227,8 @@ protected:
         }
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testUnary3DOperation()
@@ -1181,8 +1246,8 @@ protected:
         expected.fillWithValue(static_cast<OutputType>(TEST_VALUE_2_5));
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testUnarySingleElementTensor()
@@ -1200,8 +1265,8 @@ protected:
         expected.setHostValue(static_cast<OutputType>(std::tanh(E)), 0, 0, 0, 0);
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 
     void testIdentityOperation()
@@ -1234,12 +1299,12 @@ protected:
         expected.setHostValue(static_cast<OutputType>(SQRT_2), 0, 1, 1, 1); // √2
 
         auto tolerance = getMixedTypeTolerance();
-        CpuFpReferenceValidation<OutputType> validator(tolerance, tolerance);
-        EXPECT_TRUE(validator.allClose(expected, output));
+        auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
+        EXPECT_TRUE(validator->allClose(expected, output));
     }
 };
 
-using TestTypes = ::testing::Types<float, half, hip_bfloat16, double>;
+using TestTypes = ::testing::Types<float, half, hip_bfloat16, double, int8_t>;
 // Empty third argument required for C++17 compatibility with TYPED_TEST_SUITE macro
 TYPED_TEST_SUITE(CpuReferencePointwiseFixture, TestTypes, );
 
@@ -1271,6 +1336,12 @@ TYPED_TEST(CpuReferencePointwiseFixture, BinarySingleElementTensors)
 
 TYPED_TEST(CpuReferencePointwiseFixture, BinaryNumericalPrecision)
 {
+    // This test uses fractional precision test values,
+    // which don't make sense for integer types since they'd be truncated to 0.
+    if constexpr(std::is_integral_v<TypeParam>)
+    {
+        GTEST_SKIP() << "Skipping numerical precision test for integer types";
+    }
     this->testBinaryNumericalPrecision();
 }
 


### PR DESCRIPTION
## Motivation

Add FP8 E8M0 data type to hipDNN as a prerequisite for MX data types support, where E8M0 is used as the shared per-block scale/exponent

**The PR depends on rocm-systems e8m0 related changes**: https://github.com/ROCm/rocm-systems/pull/2133  and should be merged after https://github.com/ROCm/rocm-libraries/pull/3545 

## Technical Details

- Extended DataType to include FP8_E8M0
- Added frontend tests covering validation and conversions for FP8_E8M0
- Added data SDK float utility tests for FP8 E8M0 basic ops

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
