### PR TITLE
[HipDNN]: Make it possible to override rocm-systems during docker build

### DIFF
--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -36,6 +36,9 @@ RUN apt-get update && apt-get install -y \
     rsync \
     ca-certificates \
     wget \
+    texinfo \
+    bison \
+    flex \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================================================

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -105,6 +105,7 @@ ARG THEROCK_BUILD_MODE=Release
 ARG THEROCK_BUILD_PRESET=linux-release-package
 ARG BUILD_JOBS=0
 ARG ROCM_LIBRARIES_REF=default
+ARG ROCM_SYSTEMS_REF=default
 
 RUN git config --global user.email "docker@build.local" && \
     git config --global user.name "Docker Build"
@@ -132,6 +133,19 @@ RUN if [ "$ROCM_LIBRARIES_REF" != "default" ]; then \
         cd .. && \
         git add rocm-libraries && \
         git commit -m "Update rocm-libraries submodule to $ROCM_LIBRARIES_REF"; \
+    fi
+
+# Update rocm-systems submodule to specific ref if provided
+# we need to commit the change so that fetch_sources.py does not overwrite the change
+RUN if [ "$ROCM_SYSTEMS_REF" != "default" ]; then \
+        echo "Updating rocm-systems submodule to: $ROCM_SYSTEMS_REF"; \
+        git submodule update --init rocm-systems && \
+        cd rocm-systems && \
+        git fetch origin && \
+        git checkout $ROCM_SYSTEMS_REF && \
+        cd .. && \
+        git add rocm-systems && \
+        git commit -m "Update rocm-systems submodule to $ROCM_SYSTEMS_REF"; \
     fi
 
 RUN python3 -m venv /opt/venv


### PR DESCRIPTION
## Motivation

The rock is currently blocked upgrading rocm-systems due to some test failures.  There is a build break we need in order to build new dev containers.  For now we can upgrade our containers to use the new rocm-systems sha.  Once the rock is fixed, we can rebuild our containers again. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
