### PR TITLE
[hipblaslt][CMS] TF32 128x160x64 TN tile

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Alik_Bljk_S_MX_B_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Alik_Bljk_S_MX_B_BiasS_HAS_SAV_UserArgs.yaml
@@ -35392,6 +35392,251 @@
     reorderGRInstForDTVB: false
     tailLoopOptA: false
     tailLoopOptB: false
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: true
+    ActivationFused: true
+    AssertAIGreaterThanEqual: -1
+    AssertAILessThanEqual: -1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BaseName: Cijk_Alik_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_nm33jWJjHoAiA92oaZI4_P5NmXxccLOJeduiEUhpOcw=
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    CUOccupancy: -1
+    ClusterLocalRead: 1
+    CodeObjectVersion: '4'
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DebugStreamK: 0
+    DepthU: 64
+    DirectToLds: true
+    DirectToLdsA: true
+    DirectToLdsB: true
+    DirectToVgprA: false
+    DirectToVgprB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: true
+    EnableMatrixInstruction: true
+    ExpandPointerSwap: 0
+    ExpertSchedulingMode: 0
+    ForceDisableShadowInit: false
+    ForceUnrollSubIter: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 4
+    GlobalReadVectorWidthB: 4
+    GlobalSplitU: 0
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 4
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [9, 5, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 2, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: false, UseSFC: false, UseUniversalArgs: true}
+    Kernel: true
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT128x160x64_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA8_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT4_5_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SPO0_SRVW0_SSO0_SVW4_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA4_VWB1_WSGRA0_WSGRB0_WS64_WG32_8_1
+    LDSTrInst: false
+    LSCA: 64
+    LSCB: 64
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 1024
+    LdsBlockSizePerPadB: 1024
+    LdsBlockSizePerPadMetadata: 0
+    LdsBytesNoAmax: 152064
+    LdsInitCVgprs: false
+    LdsNumBytes: 152064
+    LdsNumElementsAlignedA: 33792
+    LdsNumElementsAlignedB: 42240
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 76032
+    LdsOffsetB: 33792
+    LdsOffsetB_Blk: 109824
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 33792
+    LdsOffsetMetadata_Blk: 109824
+    LdsPadA: 8
+    LdsPadB: 8
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 4
+    LocalSplitU: 1
+    LocalSplitUReuseLDS: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: true
+    LocalWriteUseSgprB: true
+    LoopIters: 2
+    LoopUnroll: 64
+    MFMA_BF16_1K: false
+    MIArchVgpr: false
+    MIBlock: [16, 16, 32, 1, 1, 1]
+    MIInputPerThread: 8
+    MIInputPerThreadA: 8
+    MIInputPerThreadB: 8
+    MIInputPerThreadMetadata: 8
+    MIOutputVectorWidth: 4
+    MIRegPerOut: 1
+    MIWaveGroup: [2, 2]
+    MIWaveTile: [4, 5]
+    MIWaveTileA: 4
+    MIWaveTileB: 5
+    MIWaveTileMetadata: 0
+    MacroTile0: 128
+    MacroTile1: 160
+    MacroTileA: 128
+    MacroTileB: 160
+    MagicDivAlg: 2
+    MathClocksUnrolledLoop: 0
+    MatrixInstB: 1
+    MatrixInstBM: 1
+    MatrixInstBN: 1
+    MatrixInstK: 32
+    MatrixInstM: 16
+    MatrixInstN: 16
+    MatrixInstruction: [16, 16, 32, 1]
+    MaxLDS: 163840
+    MaxOccupancy: 40
+    MbskPrefetchMethod: 0
+    MfmaInitCVgprs: true
+    NoLdsWriteCode: true
+    NoReject: false
+    NoTailLoop: false
+    NonDTLTailLoopA: false
+    NonDTLTailLoopB: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 4
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NonTemporalWS: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 80
+    NumGlobalWriteVectorsPerThread: 20
+    NumLoadsA: 8
+    NumLoadsB: 10
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 10
+    NumThreads: 256
+    NumTotalPackedLoadsA: 8
+    NumTotalPackedLoadsB: 10
+    NumWaveSplitK: 1
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 2
+    PrefetchLocalRead: 1
+    PreloadKernArgs: true
+    SFCWGM:
+    - [1, 1]
+    - [1, 1]
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 3
+    ScheduleLocalWrite: 1
+    SolutionIndex: 148
+    SolutionNameMin: Cijk_Alik_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT128x160x64_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GSUC0_GSUWGMRR0_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA8_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT4_5_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SU0_SUM0_SUS256_SPO0_SRVW0_SSO0_SVW4_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA4_VWB1_WSGRA0_WSGRB0_WS64_WG32_8_1_WGM8_WGMXCC1_WGMXCCGn1
+    SourceSwap: 1
+    SpaceFillingAlgo: []
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSwapAddr: true
+    StoreSyncOpt: 0
+    StoreVectorWidth: 4
+    StreamK: 3
+    StreamKAtomic: 0
+    StreamKFixupTreeReduction: 0
+    StreamKXCCMapping: 0
+    SubGroup0: 8
+    SubGroup1: 32
+    SubGroupA: 8
+    SubGroupB: 32
+    SuppressNoLoadLoop: false
+    SwapGlobalReadOrder: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 16
+    ThreadTile1: 5
+    ThreadTileA: 16
+    ThreadTileB: 5
+    TransposeLDS: 1
+    TransposeLDSMetadata: true
+    ULSGRODoubleG2L: 0
+    UnrollLoopSwapGlobalReadOrder: 0
+    UnrollMajorLDSA: true
+    UnrollMajorLDSB: true
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseCustomMainLoopSchedule: true
+    UseDirect32XEmulation: true
+    UseDot2F32XEmulation: false
+    UseDotInstruction: false
+    UseF32XEmulation: true
+    UseGeneralizedNLCOneA: true
+    UseGeneralizedNLCOneB: true
+    UseGeneralizedNLCOneMetadata: false
+    UseInstOffsetForGRO: 0
+    UseMFMAF32XEmulation: true
+    UsePLRPack: true
+    UseSgprForGRO: 0
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 4
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WaveSplitK: false
+    WavefrontSize: 64
+    WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingXCC: 1
+    WorkGroupMappingXCCGroup: -1
+    WorkGroupReduction: false
+    WorkspaceCheck: [4, 0, 0]
+    _DepthU: 64
+    _DepthUA: 64
+    _DepthUB: 64
+    _DepthUMetadata: 64
+    _GlobalAccumulation: PartialsBuffer
+    _UseSgprForGRO: 0
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 4
+    _staggerStrideShift: 0
+    enableGLTrA: false
+    enableGLTrB: false
+    enableLDSTrA: false
+    enableLDSTrB: false
+    numSubTiles: 1
+    reorderGRInstForDTVA: false
+    reorderGRInstForDTVB: false
+    tailLoopOptA: false
+    tailLoopOptB: false
 - [2, 3, 0, 1]
 - - - [233, 128, 1024, 32]
     - [104, 0.0]
@@ -35687,6 +35932,8 @@
     - [146, 0]
   - - [4096, 3072, 1, 8192]
     - [147, 0.0]
+  - - [2048, 2560, 1, 8192]
+    - [148, 0.0]
 - null
 - null
 - DeviceEfficiency

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -3273,3 +3273,106 @@ def _get_schedule_128x256x32_TF32(kernel, useLDSTr, TLDS):
     opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     opt1.disableValidation() # Disable validation as this schedule re-order pack instructions (Non-descending-order validator to be updated to allow this)
     return True, opt1
+
+
+@RegisterSchedule(
+    tile_config=TileConfig(128, 160, 64, 2, 1, True, 0, 0),
+    dtype_predicate=isTF32,
+    vector_widths=[4, 4, 4],
+    matrix_inst=[16, 16, 32, 1],
+    mfma_wave_group=[2, 2]
+)
+def _get_schedule_128x160x64_TF32(kernel, useLDSTr, TLDS):
+    kernel["MfmaInitCVgprs"] = True
+
+    n_mfma = 120
+    optSchedule = dict()
+    nglshift = nllshift = 0
+
+    syncs = SyncSchedule()
+    syncCode = []
+    snops: list[tuple[int, SNop]] = []
+    snopCode = []
+    S4 = SNop(4)
+    gr_inc_step = 0
+
+    if isTN(kernel) and not useLDSTr and TLDS==1:
+        kernel["UseMFMAF32XEmulation"] = True
+        kernel["UsePLRPack"] = True
+
+        grinca = [0,1,2,3,4,5,6,7,8]
+        grincb = [9,10,12,13,14,15,16,17,18]
+        lrsa   = [58]
+        lrsb   = [58]
+        lwsa   = [118]
+        lwsb   = [118]
+
+        pack_a = [0,0,0,0, 1,1,   2,2,2,2,
+                  3,3,3,3, 4,4,   5,5,5,5,
+                  6,6,6,6, 7,7,   8,8,8,8,
+                  9,9,9,9, 10,10, 11,11,11,11
+                  ]
+        pack_b = [0,0,0,0, 1,1,   2,2,2,2,
+                  3,3,3,3, 4,4,   5,5,5,5,
+                  6,6,6,6, 7,7,   8,8,8,8,
+                  9,9,9,9, 10,10, 11,11,11,11,
+                  12,12,12,12, 13,13, 14,14,14,14
+                  ]
+        lra0   = [0,1,2,3,4,5,6,7]
+        syncs.add(                 12, dscnt=4, comment="wait for LRA0 before pack to complete")
+        pack_a0 = [                i+13 for i in pack_a]
+        snops.extend([               (14, S4), (17, S4), (20, S4), (23, S4)])
+
+        lrb0   = [               8,9,10,11,12,13,14,15,16,17]
+        syncs.add(                                                   23, dscnt=0, barrier=True, comment="wait for LRB0 before pack to complete + barrier for GR")
+        pack_b0 = [                                                  i+28 for i in pack_b]
+        snops.extend([                                                 (29, S4), (32, S4), (35, S4), (38, S4), (41, S4)])
+
+        gra    = [                                    24,28,32,36, 44,48,52,56] # one index for two instructions
+        grb    = [                                                             66,70,74,78, 88,92,96,100, 110,114] # one index for two instructions
+        num_gr = len(gra) + len(grb)
+
+        syncs.add(                                                            59, vlcnt=8, barrier=True, comment="wait for previous set of global reads")
+
+        lra1   = [60,61,62,63,64,65,66,67]
+        syncs.add(                          72, dscnt=4, comment="wait for LRA1 before pack to complete")
+        pack_a1 = [                         i+73 for i in pack_a]
+        snops.extend([                        (74, S4), (77, S4), (80, S4),(83, S4)])
+
+        lrb1   = [                        68,69,70,71,72,73,74,75,76,77]
+        syncs.add(                                                            83, dscnt=0, comment="wait for LRB1 before pack to complete")
+        pack_b1 = [                                                           i+88 for i in pack_b]
+        snops.extend([                                                          (89, S4), (92, S4), (95, S4), (98, S4), (101, S4)])
+
+        optSchedule = {
+            'SYNC':   [syncs.get_indicies()],
+            'GRIncA': [grinca],
+            'GRIncB': [grincb],
+            'LRA0':   [lra0],
+            'LRB0':   [lrb0],
+            'PackA0': [pack_a0],
+            'PackB0': [pack_b0],
+            'GRA':    [duplicate_list_items(gra, 2, gr_inc_step)],
+            'GRB':    [duplicate_list_items(grb, 2, gr_inc_step)],
+            'LRSA':   [lrsa],
+            'LRSB':   [lrsb],
+            'LWSA':   [lwsa],
+            'LWSB':   [lwsb],
+            'LRA1':   [lra1],
+            'LRB1':   [lrb1],
+            'PackB1': [pack_b1],
+            'PackA1': [pack_a1],
+            'LCC':    [[n_mfma-2, n_mfma-1]],
+        }
+
+        syncCode = syncs.get_code()
+        nglshift = nllshift = num_gr
+        if snops:
+            optSchedule['SNOP'] = [ [s[0] for s in snops] ]
+            snopCode = [s[1] for s in snops]
+
+        opt1 = ScheduleInfo(1, n_mfma, optSchedule, syncCode, nglshift, nllshift, snopCode=snopCode)
+        return True, opt1
+
+    else:
+        return False, None

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -3291,58 +3291,51 @@ def _get_schedule_128x160x64_TF32(kernel, useLDSTr, TLDS):
 
     syncs = SyncSchedule()
     syncCode = []
-    snops: list[tuple[int, SNop]] = []
-    snopCode = []
-    S4 = SNop(4)
     gr_inc_step = 0
 
     if isTN(kernel) and not useLDSTr and TLDS==1:
         kernel["UseMFMAF32XEmulation"] = True
         kernel["UsePLRPack"] = True
 
-        grinca = [0,1,2,3,4,5,6,7,8]
-        grincb = [9,10,12,13,14,15,16,17,18]
+        grinca = [0,0,1,1,2,2,3,3,4]
+        grincb = [4,5,5,6,6,7,7,8,8]
         lrsa   = [58]
-        lrsb   = [58]
+        lrsb   = [59]
         lwsa   = [118]
         lwsb   = [118]
 
-        pack_a = [0,0,0,0, 1,1,   2,2,2,2,
-                  3,3,3,3, 4,4,   5,5,5,5,
-                  6,6,6,6, 7,7,   8,8,8,8,
-                  9,9,9,9, 10,10, 11,11,11,11
+        pack_a = [0,0,1,1, 8,8, 9,9,10,10,
+                  2,2,3,3, 8,8, 11,11,12,12,
+                  4,4,5,5, 8,8, 13,13,14,14,
+                  6,6,7,7, 8,8, 15,15,16,16
                   ]
-        pack_b = [0,0,0,0, 1,1,   2,2,2,2,
-                  3,3,3,3, 4,4,   5,5,5,5,
-                  6,6,6,6, 7,7,   8,8,8,8,
-                  9,9,9,9, 10,10, 11,11,11,11,
-                  12,12,12,12, 13,13, 14,14,14,14
+        pack_b = [0,0,1,1, 10,10, 11,11,12,12,
+                  2,2,3,3, 10,10, 13,13,14,14,
+                  4,4,5,5, 10,10, 15,15,16,16,
+                  6,6,7,7, 10,10, 17,17,18,18,
+                  8,8,9,9, 10,10, 19,19,20,20
                   ]
         lra0   = [0,1,2,3,4,5,6,7]
         syncs.add(                 12, dscnt=4, comment="wait for LRA0 before pack to complete")
-        pack_a0 = [                i+13 for i in pack_a]
-        snops.extend([               (14, S4), (17, S4), (20, S4), (23, S4)])
+        pack_a0 = [                i+13 for i in pack_a]  ## last element = 13 + 16 = 29
 
         lrb0   = [               8,9,10,11,12,13,14,15,16,17]
         syncs.add(                                                   23, dscnt=0, barrier=True, comment="wait for LRB0 before pack to complete + barrier for GR")
-        pack_b0 = [                                                  i+28 for i in pack_b]
-        snops.extend([                                                 (29, S4), (32, S4), (35, S4), (38, S4), (41, S4)])
+        pack_b0 = [                                                  i+28 for i in pack_b]  ## last element = 28 + 20 = 48
 
-        gra    = [                                    24,28,32,36, 44,48,52,56] # one index for two instructions
-        grb    = [                                                             66,70,74,78, 88,92,96,100, 110,114] # one index for two instructions
+        gra    = [                                    24,28,32,36, 46,50,54,58] # one index for two instructions
+        grb    = [                                                             68,72,76,80, 90,94,98,102, 112,116] # one index for two instructions
         num_gr = len(gra) + len(grb)
 
         syncs.add(                                                            59, vlcnt=8, barrier=True, comment="wait for previous set of global reads")
 
         lra1   = [60,61,62,63,64,65,66,67]
         syncs.add(                          72, dscnt=4, comment="wait for LRA1 before pack to complete")
-        pack_a1 = [                         i+73 for i in pack_a]
-        snops.extend([                        (74, S4), (77, S4), (80, S4),(83, S4)])
+        pack_a1 = [                         i+73 for i in pack_a]  ## last element = 73 + 16 = 89
 
         lrb1   = [                        68,69,70,71,72,73,74,75,76,77]
         syncs.add(                                                            83, dscnt=0, comment="wait for LRB1 before pack to complete")
-        pack_b1 = [                                                           i+88 for i in pack_b]
-        snops.extend([                                                          (89, S4), (92, S4), (95, S4), (98, S4), (101, S4)])
+        pack_b1 = [                                                           i+88 for i in pack_b]  ## last element = 88 + 20 = 108
 
         optSchedule = {
             'SYNC':   [syncs.get_indicies()],
@@ -3367,11 +3360,8 @@ def _get_schedule_128x160x64_TF32(kernel, useLDSTr, TLDS):
 
         syncCode = syncs.get_code()
         nglshift = nllshift = num_gr
-        if snops:
-            optSchedule['SNOP'] = [ [s[0] for s in snops] ]
-            snopCode = [s[1] for s in snops]
 
-        opt1 = ScheduleInfo(1, n_mfma, optSchedule, syncCode, nglshift, nllshift, snopCode=snopCode)
+        opt1 = ScheduleInfo(1, n_mfma, optSchedule, syncCode, nglshift, nllshift)
         return True, opt1
 
     else:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -3316,26 +3316,26 @@ def _get_schedule_128x160x64_TF32(kernel, useLDSTr, TLDS):
                   8,8,9,9, 10,10, 19,19,20,20
                   ]
         lra0   = [0,1,2,3,4,5,6,7]
-        syncs.add(                 12, dscnt=4, comment="wait for LRA0 before pack to complete")
+        syncs.add(                 12, dscnt=4, barrier=True, comment="wait for LRA0 before pack to complete + barrier for GRA")
         pack_a0 = [                i+13 for i in pack_a]  ## last element = 13 + 16 = 29
 
-        lrb0   = [               8,9,10,11,12,13,14,15,16,17]
-        syncs.add(                                                   23, dscnt=0, barrier=True, comment="wait for LRB0 before pack to complete + barrier for GR")
-        pack_b0 = [                                                  i+28 for i in pack_b]  ## last element = 28 + 20 = 48
+        lrb0   = [               8,9,10,11, 13,14,15,16, 18,19]
+        syncs.add(                                               24, dscnt=0, comment="wait for LRB0 before pack to complete")
+        pack_b0 = [                                                  i+30 for i in pack_b]  ## last element = 30 + 20 = 50
 
-        gra    = [                                    24,28,32,36, 46,50,54,58] # one index for two instructions
-        grb    = [                                                             68,72,76,80, 90,94,98,102, 112,116] # one index for two instructions
+        gra    = [                                    17,22,27,32, 42,47,52,57] # one index for two instructions
+        grb    = [                                                               67,71,75,79, 89,93,97,101, 112,116] # one index for two instructions
         num_gr = len(gra) + len(grb)
 
-        syncs.add(                                                            59, vlcnt=8, barrier=True, comment="wait for previous set of global reads")
+        syncs.add(                                                            59, vlcnt=8, barrier=True, comment="wait for previous set of global reads + barrier for GRB")
 
         lra1   = [60,61,62,63,64,65,66,67]
         syncs.add(                          72, dscnt=4, comment="wait for LRA1 before pack to complete")
         pack_a1 = [                         i+73 for i in pack_a]  ## last element = 73 + 16 = 89
 
-        lrb1   = [                        68,69,70,71,72,73,74,75,76,77]
-        syncs.add(                                                            83, dscnt=0, comment="wait for LRB1 before pack to complete")
-        pack_b1 = [                                                           i+88 for i in pack_b]  ## last element = 88 + 20 = 108
+        lrb1   = [                        68,69,70,71, 73,74,75,76, 78,79]
+        syncs.add(                                                            85, dscnt=0, comment="wait for LRB1 before pack to complete")
+        pack_b1 = [                                                           i+90 for i in pack_b]  ## last element = 90 + 20 = 110
 
         optSchedule = {
             'SYNC':   [syncs.get_indicies()],
@@ -3345,8 +3345,10 @@ def _get_schedule_128x160x64_TF32(kernel, useLDSTr, TLDS):
             'LRB0':   [lrb0],
             'PackA0': [pack_a0],
             'PackB0': [pack_b0],
-            'GRA':    [duplicate_list_items(gra, 2, gr_inc_step)],
-            'GRB':    [duplicate_list_items(grb, 2, gr_inc_step)],
+            'GRA':    [duplicate_list_items(gra, 2, gr_inc_step),
+                       duplicate_list_items([x+1 for x in gra], 2, gr_inc_step)],
+            'GRB':    [duplicate_list_items(grb, 2, gr_inc_step),
+                       duplicate_list_items([x+1 for x in grb], 2, gr_inc_step)],
             'LRSA':   [lrsa],
             'LRSB':   [lrsb],
             'LWSA':   [lwsa],
@@ -3361,7 +3363,7 @@ def _get_schedule_128x160x64_TF32(kernel, useLDSTr, TLDS):
         syncCode = syncs.get_code()
         nglshift = nllshift = num_gr
 
-        opt1 = ScheduleInfo(1, n_mfma, optSchedule, syncCode, nglshift, nllshift)
+        opt1 = ScheduleInfo(2, n_mfma, optSchedule, syncCode, nglshift, nllshift)
         return True, opt1
 
     else:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
@@ -253,6 +253,43 @@ BenchmarkProblems:
           - Range: [[256], [192], [1], [16, 32, 128]]
           - Range: [[8192], [6144], [1], [32, 32, 128]]
         - BiasTypeArgs: ['s']
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1, 4, 5,  2,2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - TransposeLDS: [1]
+        - LocalReadVectorWidth: [4]
+        - GlobalReadVectorWidthA: [4]
+        - GlobalReadVectorWidthB: [4]
+        - DirectToLds: [1]
+        - StreamK: [3]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - NonTemporalA: [0]
+        - NonTemporalB: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LDSTrInst: [False]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[128], [160], [1], [64, 64, 256]]
+          - Range: [[128], [160], [1], [1,1,64]]
+          - Range: [[128], [160], [1], [32, 64, 256]]
+        - BiasTypeArgs: ['s']
 
 ########################################
 # TF32 NN - standard

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -717,6 +717,39 @@ class TestCustomScheduleTF32:
         valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
+    @pytest.mark.parametrize(
+        # fmt: off
+        "transA, transB, lds_tr_inst,  tr_lds", [
+        (  True,  False,       False,       1),
+        # fmt: on
+        ])
+    def test_schedule_128x160x64(self, transA, transB, lds_tr_inst, tr_lds):
+        """Tests the 129x160x64 TF32 TN schedule."""
+        kernel = create_base_kernel()
+        kernel["ProblemType"].update({
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "UseF32XEmulation": True,
+            "MacroTile0": 128, "MacroTile1": 160, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
+            "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": lds_tr_inst, "TransposeLDS": tr_lds, "MIWaveTileA": 4, "MIWaveTileB": 5,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        numMfma = ((kernel["MacroTile0"] // kernel["MIWaveGroup"][0] // kernel["MatrixInstruction"][0]) *
+                   (kernel["MacroTile1"] // kernel["MIWaveGroup"][1] // kernel["MatrixInstruction"][1]) *
+                    3 * # tf32 emulated with 3 bf16
+                    2   # two sub-iterations due to DepthU=64
+        )
+        assert schedule_info.numMfma == numMfma
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
+        assert valid, message
 
 class TestCustomScheduleValidation:
     def test_schedule_validation_disable(self):


### PR DESCRIPTION
## Motivation

CMS for TF 128x160x64 TN tile

## Technical Details

Problem size: [2048, 2560, 8192]

- **Tensile**: CMS achieves **~25% speedup** w.r.t. non-CMS
- **hipblaslt-bench**: no gains (**~1.6% regression**)
- **hipblaslt-bench** with `K=4096`: **8.7% speedup**.
- - main-loop efficiency: improved from 49.7% to **63.3%**.

After optimizing further by [2f5cb96](https://github.com/ROCm/rocm-libraries/pull/3751/commits/2f5cb96751f70b829eab39692d6a5c6ba204abc7)

- **Tensile**: CMS achieves **~35% speedup** w.r.t. non-CMS
- **hipblaslt-bench**: **~4.8% speedup** w.r.t. the custom 256x256x32 solution.
- **hipblaslt-bench** with `K=4096`: **17.4% speedup** w.r.t. the custom 256x256x32 solution.
- main-loop efficiency: improved from 49.7% to **72.9%**.
- All tests PASSED locally.

After optimizing further by [4e6bc13](https://github.com/ROCm/rocm-libraries/pull/3751/commits/4e6bc13802efb78381a274e59e7fcd0ec8030eed)

- **Tensile**: CMS achieves **~37.5% speedup** w.r.t. non-CMS
- **hipblaslt-bench**: **~5.1% speedup** w.r.t. the custom 256x256x32 solution.
- **hipblaslt-bench** with `K=4096`: **17.7% speedup** w.r.t. the custom 256x256x32 solution.
- main-loop efficiency: improved from 49.7% to **76.8%**.
- All tests PASSED locally.


## Test Result

All tests PASSED via `Tensile` as well as `hipblaslt-test`

```
        - ProblemSizes:
          - Exact: [2048, 2560, 1, 8192]
          - Range: [[128], [160], [1], [64, 64, 256]]
          - Range: [[128], [160], [1], [1,1,64]]
          - Range: [[128], [160], [1], [32, 64, 256]]
```
```
[----------] Global test environment tear-down
[==========] 21891 tests from 12 test suites ran. (1447922 ms total)
[  PASSED  ] 21891 tests.
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

AIGECORE-63