### PR TITLE
[hipsparse] Fix documentation failure caused by deprecation macro

### DIFF
--- a/projects/hipsparse/docs/doxygen/Doxyfile
+++ b/projects/hipsparse/docs/doxygen/Doxyfile
@@ -2167,7 +2167,8 @@ INCLUDE_FILE_PATTERNS  =
 
 PREDEFINED             = __attribute__(x)= \
                          __inline= \
-                         HIPSPARSE_EXPORT=
+                         HIPSPARSE_EXPORT= \
+                         HIPSPARSE_DEPRECATED_MSG(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/projects/hipsparse/library/include/internal/generic/hipsparse_spsm.h
+++ b/projects/hipsparse/library/include/internal/generic/hipsparse_spsm.h
@@ -248,7 +248,7 @@ hipsparseStatus_t hipsparseSpSM_analysis(hipsparseHandle_t           handle,
 *  </table>
 *
 *  \note This routine does not correctly match the parameter list of the corresponding cusparse API, \p cusparseSpSM_solve, 
-*  which does not take the external buffer paramter. We provide an alternate routine \ref hipsparseSpSM_solve_ex which
+*  which does not take the external buffer parameter. We provide an alternate routine \ref hipsparseSpSM_solve_ex which
 *  correctly matches the parameter list of \p cusparseSpSM_solve.
 *
 *  @param[in]


### PR DESCRIPTION
## Motivation

Fixes documentation failure caused by `HIPSPARSE_DEPRECATED_MSG` macro used with `hipsparse_spsm` routine. Solution is to add this the the Doxyfile `PREDEFINED`. Also fixed a spelling typo paramter->parameter.

