### PR TITLE
[rocroller] Remove launchTimeSubExpression calls from FastDivision

### DIFF
--- a/shared/rocroller/lib/include/rocRoller/KernelOptions_detail.hpp
+++ b/shared/rocroller/lib/include/rocRoller/KernelOptions_detail.hpp
@@ -83,7 +83,7 @@ namespace rocRoller
          * Increasing this value could decrease SGPR pressure; decreasing it could speed up a
          * kernel if there are enough available SGPRs.
          */
-        int minLaunchTimeExpressionComplexity = 20;
+        int minLaunchTimeExpressionComplexity = 6;
 
         /**
          * The maximum number of concurrent subexpressions given at once to the scheduler when
@@ -96,7 +96,7 @@ namespace rocRoller
          * If you are running out of registers (particularly SGPRs), reducing this number
          * might help.
          */
-        int maxConcurrentSubExpressions = 2;
+        int maxConcurrentSubExpressions = 4;
 
         /**
          * The maximum number of concurrent control operations given at once to the scheduler

--- a/shared/rocroller/lib/source/ExpressionTransformations/FastDivision.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/FastDivision.cpp
@@ -48,19 +48,19 @@ namespace rocRoller
         std::tuple<ExpressionPtr, ExpressionPtr, ExpressionPtr>
             getMagicMultipleShiftAndSign(ExpressionPtr denominator, ContextPtr context)
         {
-            auto multiple = launchTimeSubExpressions(magicMultiple(denominator), context);
+            auto multiple = magicMultiple(denominator);
 
             auto resultType = resultVariableType(denominator);
             auto typeInfo   = DataTypeInfo::Get(resultType);
 
             if(!typeInfo.isSigned)
             {
-                auto shifts = launchTimeSubExpressions(magicShifts(denominator), context);
+                auto shifts = magicShifts(denominator);
 
                 return {multiple, shifts, nullptr};
             }
 
-            auto bitfield = launchTimeSubExpressions(magicShiftAndSign(denominator), context);
+            auto bitfield = magicShiftAndSign(denominator);
 
             auto mask   = typeInfo.elementBits - 1;
             auto shifts = bitfield & literal(mask);
@@ -105,12 +105,13 @@ namespace rocRoller
             auto const& [magicExpr, numShiftsExpr, signExpr]
                 = getMagicMultipleShiftAndSign(expr, context);
 
+            // Verify expressions are at least KernelLaunch-evaluable
             auto magicTimes = evaluationTimes(magicExpr);
             auto shiftTimes = evaluationTimes(numShiftsExpr);
 
             EvaluationTimes theTimes = magicTimes & shiftTimes;
 
-            AssertFatal(theTimes[EvaluationTime::KernelExecute],
+            AssertFatal(theTimes[EvaluationTime::KernelLaunch],
                         ShowValue(magicTimes),
                         ShowValue(shiftTimes),
                         ShowValue(magicExpr),
@@ -121,7 +122,7 @@ namespace rocRoller
                 AssertFatal(signExpr != nullptr);
                 auto signTimes = evaluationTimes(signExpr);
 
-                AssertFatal(signTimes[EvaluationTime::KernelExecute],
+                AssertFatal(signTimes[EvaluationTime::KernelLaunch],
                             ShowValue(signTimes),
                             ShowValue(signExpr));
             }
@@ -156,22 +157,6 @@ namespace rocRoller
             auto const& [magicExpr, numShiftsExpr, signExpr]
                 = getMagicMultipleShiftAndSign(denominator, context);
 
-            {
-                EvaluationTimes evalTimes
-                    = evaluationTimes(magicExpr) & evaluationTimes(numShiftsExpr);
-
-                if(!evalTimes[EvaluationTime::KernelExecute]
-                   && !evalTimes[EvaluationTime::Translate])
-                {
-                    Log::debug("Returning nullptr from magicNumberDivision expr / shift "
-                               "({})\nmagic: {}\n shift: {}",
-                               toString(evalTimes),
-                               toString(magicExpr),
-                               toString(numShiftsExpr));
-                    return nullptr;
-                }
-            }
-
             ExpressionPtr result;
 
             auto one = literal(1, denominatorType);
@@ -188,18 +173,6 @@ namespace rocRoller
             }
             else
             {
-                {
-                    EvaluationTimes evalTimes = evaluationTimes(signExpr);
-
-                    if(!evalTimes[EvaluationTime::KernelExecute]
-                       && !evalTimes[EvaluationTime::Translate])
-                    {
-                        Log::debug("Returning nullptr from magicNumberDivision sign ({})",
-                                   toString(evalTimes));
-                        return nullptr;
-                    }
-                }
-
                 // Create expression that performs division using the new arguments
 
                 auto numBytes = denominatorType.getElementSize();
@@ -236,12 +209,7 @@ namespace rocRoller
                 setComment(result, "Magic result (signed)");
             }
 
-            result = launchTimeSubExpressions(simplify(result), context);
-
-            {
-                auto evalTimes = evaluationTimes(result);
-                AssertFatal(evalTimes[EvaluationTime::KernelExecute], toString(result), evalTimes);
-            }
+            result = simplify(result);
 
             return result;
         }


### PR DESCRIPTION
## Motivation


## Technical Details


## Test Plan


## Test Result



