### PR TITLE
[hipDNN] [ALMIOPEN-465] Re-enable MigratableMemory tests on Windows CI

### DIFF
--- a/dnn-providers/miopen-provider/cmake/Tests.cmake
+++ b/dnn-providers/miopen-provider/cmake/Tests.cmake
@@ -169,7 +169,7 @@ function(_add_test_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
         set(TARGET_EXE "${TARGET_EXE}${CMAKE_EXECUTABLE_SUFFIX}")
     endif()
 
-    message(STATUS "Appending unclassified check target: ${TARGET} -> ${TARGET_EXE} in working directory: ${WORKING_DIR}")
+    message(STATUS "Appending ${APPEND_FUNCTION_SUFFIX} check target: ${TARGET} -> ${TARGET_EXE} in working directory: ${WORKING_DIR}")
 
     # Track the dependencies for test name validation
     set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET}

--- a/dnn-providers/miopen-provider/cmake/Tests.cmake
+++ b/dnn-providers/miopen-provider/cmake/Tests.cmake
@@ -162,14 +162,21 @@ endfunction() # finalize_test_targets
 #   WORKING_DIR - Working directory for test execution
 # ~~~
 function(_add_test_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
-    message(STATUS "Appending unclassified check target: ${TARGET} in working directory: ${WORKING_DIR}")
+    set(TARGET_EXE ${TARGET})
+
+    # Add executable suffix if needed (e.g., .exe on Windows)
+    if(CMAKE_EXECUTABLE_SUFFIX)
+        set(TARGET_EXE "${TARGET_EXE}${CMAKE_EXECUTABLE_SUFFIX}")
+    endif()
+
+    message(STATUS "Appending unclassified check target: ${TARGET} -> ${TARGET_EXE} in working directory: ${WORKING_DIR}")
 
     # Track the dependencies for test name validation
     set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET}
         CACHE INTERNAL "Accumulated global dependencies for test name validation" FORCE
     )
     # Track the binary paths for test name validation
-    set(CHECK_EXECUTABLE_PATHS_GLOBAL ${CHECK_EXECUTABLE_PATHS_GLOBAL} "${CMAKE_INSTALL_BINDIR}/${TARGET}"
+    set(CHECK_EXECUTABLE_PATHS_GLOBAL ${CHECK_EXECUTABLE_PATHS_GLOBAL} "${CMAKE_INSTALL_BINDIR}/${TARGET_EXE}"
         CACHE INTERNAL "Accumulated global check executable paths" FORCE
     )
 

--- a/projects/hipdnn/backend/src/PlatformUtils.windows.cpp
+++ b/projects/hipdnn/backend/src/PlatformUtils.windows.cpp
@@ -86,22 +86,22 @@ std::string getSystemInfo()
     versionInfo.dwOSVersionInfoSize = sizeof(versionInfo);
 
     HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-    if(ntdll)
+    if(ntdll != nullptr)
     {
-        auto RtlGetVersion
+        auto rtlGetVersion
             = reinterpret_cast<RtlGetVersionPtr>(GetProcAddress(ntdll, "RtlGetVersion"));
-        if(RtlGetVersion)
+        if(rtlGetVersion != nullptr)
         {
-            RtlGetVersion(&versionInfo);
+            rtlGetVersion(&versionInfo);
         }
     }
 
     // Get computer name
-    char computerName[MAX_COMPUTERNAME_LENGTH + 1];
-    DWORD size = sizeof(computerName);
-    if(!GetComputerNameA(computerName, &size))
+    std::array<char, MAX_COMPUTERNAME_LENGTH + 1> computerName;
+    auto size = static_cast<DWORD>(computerName.size());
+    if(GetComputerNameA(computerName.data(), &size) == FALSE)
     {
-        strcpy_s(computerName, "Unknown");
+        strcpy_s(computerName.data(), computerName.size(), "Unknown");
     }
 
     // Get system architecture
@@ -126,7 +126,7 @@ std::string getSystemInfo()
 
     return fmt::format("System Information: {{System Name: Windows, Node Name: {}, Release: {}.{}, "
                        "Version: {}, Machine: {}}}",
-                       computerName,
+                       computerName.data(),
                        versionInfo.dwMajorVersion,
                        versionInfo.dwMinorVersion,
                        versionInfo.dwBuildNumber,

--- a/projects/hipdnn/cmake/Tests.cmake
+++ b/projects/hipdnn/cmake/Tests.cmake
@@ -166,14 +166,21 @@ endfunction() # finalize_test_targets
 #   WORKING_DIR - Working directory for test execution
 # ~~~
 function(_add_test_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
-    message(STATUS "Appending ${APPEND_FUNCTION_SUFFIX} check target: ${TARGET} in working directory: ${WORKING_DIR}")
+    set(TARGET_EXE ${TARGET})
+
+    # Add executable suffix if needed (e.g., .exe on Windows)
+    if(CMAKE_EXECUTABLE_SUFFIX)
+        set(TARGET_EXE "${TARGET_EXE}${CMAKE_EXECUTABLE_SUFFIX}")
+    endif()
+
+    message(STATUS "Appending ${APPEND_FUNCTION_SUFFIX} check target: ${TARGET} -> ${TARGET_EXE} in working directory: ${WORKING_DIR}")
 
     # Track the dependencies for test name validation
     set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET}
         CACHE INTERNAL "Accumulated global dependencies for test name validation" FORCE
     )
     # Track the binary paths for test name validation
-    set(CHECK_EXECUTABLE_PATHS_GLOBAL ${CHECK_EXECUTABLE_PATHS_GLOBAL} "${CMAKE_INSTALL_BINDIR}/${TARGET}"
+    set(CHECK_EXECUTABLE_PATHS_GLOBAL ${CHECK_EXECUTABLE_PATHS_GLOBAL} "${CMAKE_INSTALL_BINDIR}/${TARGET_EXE}"
         CACHE INTERNAL "Accumulated global check executable paths" FORCE
     )
 

--- a/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
@@ -114,7 +114,6 @@ TEST(TestMigratableMemory, Resize)
 
 TEST(TestMigratableMemory, MigrateToDevice)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     MigratableMemory<float> memory(10);
@@ -133,7 +132,6 @@ TEST(TestMigratableMemory, MigrateToDevice)
 
 TEST(TestMigratableMemory, MigrateToDeviceNonDefaultStream)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -160,7 +158,6 @@ TEST(TestMigratableMemory, MigrateToDeviceNonDefaultStream)
 
 TEST(TestMigratableMemory, MigrateToDeviceAsyncNonDefaultStream)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -187,7 +184,6 @@ TEST(TestMigratableMemory, MigrateToDeviceAsyncNonDefaultStream)
 
 TEST(TestMigratableMemory, MigrateToHost)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     MigratableMemory<float> memory(10);
@@ -215,7 +211,6 @@ TEST(TestMigratableMemory, MigrateToHost)
 
 TEST(TestMigratableMemory, MigrateToHostNonDefaultStream)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -254,7 +249,6 @@ TEST(TestMigratableMemory, MigrateToHostNonDefaultStream)
 
 TEST(TestMigratableMemory, MigrateToHostAsyncNonDefaultStream)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;

--- a/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
@@ -138,7 +138,9 @@ TEST(TestMigratableMemory, MigrateToDevice)
     EXPECT_EQ(memory.location(), MemoryLocation::BOTH);
 
     std::cout << "Checking buffer\n";
-    checkBuffer(static_cast<float*>(memory.deviceData()), memory.count());
+    initBuffer(memory.hostData(), memory.count(), 0.0f);
+    memory.markDeviceModified();
+    checkBuffer(static_cast<float*>(memory.hostData()), memory.count());
 }
 
 TEST(TestMigratableMemory, MigrateToDeviceNonDefaultStream)

--- a/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
@@ -116,22 +116,34 @@ TEST(TestMigratableMemory, MigrateToDevice)
 {
     SKIP_IF_NO_DEVICES();
 
+    std::cout << "Creating MigratableMemory\n";
     MigratableMemory<float> memory(10);
 
+    std::cout << "Checking empty\n";
     EXPECT_FALSE(memory.empty());
+
+    std::cout << "Checking count\n";
     EXPECT_EQ(memory.count(), 10);
+
+    std::cout << "Checking location\n";
     EXPECT_EQ(memory.location(), MemoryLocation::HOST);
 
+    std::cout << "Initializing buffer\n";
     initBuffer(memory.hostData(), memory.count());
 
+    std::cout << "Getting device pointer\n";
     EXPECT_NE(memory.deviceData(), nullptr);
+
+    std::cout << "Checking location (2nd time)\n";
     EXPECT_EQ(memory.location(), MemoryLocation::BOTH);
 
+    std::cout << "Checking buffer\n";
     checkBuffer(static_cast<float*>(memory.deviceData()), memory.count());
 }
 
 TEST(TestMigratableMemory, MigrateToDeviceNonDefaultStream)
 {
+    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -158,6 +170,7 @@ TEST(TestMigratableMemory, MigrateToDeviceNonDefaultStream)
 
 TEST(TestMigratableMemory, MigrateToDeviceAsyncNonDefaultStream)
 {
+    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -184,6 +197,7 @@ TEST(TestMigratableMemory, MigrateToDeviceAsyncNonDefaultStream)
 
 TEST(TestMigratableMemory, MigrateToHost)
 {
+    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     MigratableMemory<float> memory(10);
@@ -211,6 +225,7 @@ TEST(TestMigratableMemory, MigrateToHost)
 
 TEST(TestMigratableMemory, MigrateToHostNonDefaultStream)
 {
+    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -249,6 +264,7 @@ TEST(TestMigratableMemory, MigrateToHostNonDefaultStream)
 
 TEST(TestMigratableMemory, MigrateToHostAsyncNonDefaultStream)
 {
+    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;

--- a/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
@@ -116,28 +116,17 @@ TEST(TestMigratableMemory, MigrateToDevice)
 {
     SKIP_IF_NO_DEVICES();
 
-    std::cout << "Creating MigratableMemory\n";
     MigratableMemory<float> memory(10);
 
-    std::cout << "Checking empty\n";
     EXPECT_FALSE(memory.empty());
-
-    std::cout << "Checking count\n";
     EXPECT_EQ(memory.count(), 10);
-
-    std::cout << "Checking location\n";
     EXPECT_EQ(memory.location(), MemoryLocation::HOST);
 
-    std::cout << "Initializing buffer\n";
     initBuffer(memory.hostData(), memory.count());
 
-    std::cout << "Getting device pointer\n";
     EXPECT_NE(memory.deviceData(), nullptr);
-
-    std::cout << "Checking location (2nd time)\n";
     EXPECT_EQ(memory.location(), MemoryLocation::BOTH);
 
-    std::cout << "Checking buffer\n";
     initBuffer(memory.hostData(), memory.count(), 0.0f);
     memory.markDeviceModified();
     checkBuffer(static_cast<float*>(memory.hostData()), memory.count());
@@ -145,7 +134,6 @@ TEST(TestMigratableMemory, MigrateToDevice)
 
 TEST(TestMigratableMemory, MigrateToDeviceNonDefaultStream)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -164,7 +152,9 @@ TEST(TestMigratableMemory, MigrateToDeviceNonDefaultStream)
     EXPECT_NE(memory.deviceData(), nullptr);
     EXPECT_EQ(memory.location(), MemoryLocation::BOTH);
 
-    checkBufferSynchronized(static_cast<float*>(memory.deviceData()), memory.count(), stream);
+    initBuffer(memory.hostData(), memory.count(), 0.0f);
+    memory.markDeviceModified();
+    checkBufferSynchronized(static_cast<float*>(memory.hostData()), memory.count(), stream);
 
     error = hipStreamDestroy(stream);
     EXPECT_EQ(error, hipSuccess) << "Failed to destroy HIP stream";
@@ -172,7 +162,6 @@ TEST(TestMigratableMemory, MigrateToDeviceNonDefaultStream)
 
 TEST(TestMigratableMemory, MigrateToDeviceAsyncNonDefaultStream)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -191,7 +180,9 @@ TEST(TestMigratableMemory, MigrateToDeviceAsyncNonDefaultStream)
     EXPECT_NE(memory.deviceDataAsync(), nullptr);
     EXPECT_EQ(memory.location(), MemoryLocation::BOTH);
 
-    checkBufferSynchronized(static_cast<float*>(memory.deviceDataAsync()), memory.count(), stream);
+    initBuffer(memory.hostData(), memory.count(), 0.0f);
+    memory.markDeviceModified();
+    checkBufferSynchronized(static_cast<float*>(memory.hostDataAsync()), memory.count(), stream);
 
     error = hipStreamDestroy(stream);
     EXPECT_EQ(error, hipSuccess) << "Failed to destroy HIP stream";
@@ -199,7 +190,6 @@ TEST(TestMigratableMemory, MigrateToDeviceAsyncNonDefaultStream)
 
 TEST(TestMigratableMemory, MigrateToHost)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     MigratableMemory<float> memory(10);
@@ -210,7 +200,8 @@ TEST(TestMigratableMemory, MigrateToHost)
 
     initBuffer(memory.hostData(), memory.count());
 
-    checkBuffer(static_cast<float*>(memory.deviceData()), memory.count());
+    auto tmpPtr = memory.deviceData();
+    EXPECT_NE(tmpPtr, nullptr);
     EXPECT_EQ(memory.location(), MemoryLocation::BOTH);
 
     std::array<float, 10> array;
@@ -227,7 +218,6 @@ TEST(TestMigratableMemory, MigrateToHost)
 
 TEST(TestMigratableMemory, MigrateToHostNonDefaultStream)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -243,7 +233,8 @@ TEST(TestMigratableMemory, MigrateToHostNonDefaultStream)
 
     initBuffer(memory.hostData(), memory.count());
 
-    checkBufferSynchronized(static_cast<float*>(memory.deviceData()), memory.count(), stream);
+    auto tmpPtr = memory.deviceData();
+    EXPECT_NE(tmpPtr, nullptr);
     EXPECT_EQ(memory.location(), MemoryLocation::BOTH);
 
     std::array<float, 10> array;
@@ -266,7 +257,6 @@ TEST(TestMigratableMemory, MigrateToHostNonDefaultStream)
 
 TEST(TestMigratableMemory, MigrateToHostAsyncNonDefaultStream)
 {
-    SKIP_IF_WINDOWS();
     SKIP_IF_NO_DEVICES();
 
     hipStream_t stream;
@@ -282,7 +272,8 @@ TEST(TestMigratableMemory, MigrateToHostAsyncNonDefaultStream)
 
     initBuffer(memory.hostData(), memory.count());
 
-    checkBufferSynchronized(static_cast<float*>(memory.deviceDataAsync()), memory.count(), stream);
+    auto tmpPtr = memory.deviceDataAsync();
+    EXPECT_NE(tmpPtr, nullptr);
     EXPECT_EQ(memory.location(), MemoryLocation::BOTH);
 
     std::array<float, 10> array;


### PR DESCRIPTION
## Motivation
We want as complete 1:1 test coverage between Windows and Linux.  Previously, we had CI/CD errors when running these specific tests, so I'm re-enabling to attempt to fix them.

## Technical Details
- Re-enabled several tests relating to data_sdk's MigratableMemory class.

## Test Plan
- CI tests pass

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
