### PR TITLE
[hipfft] Address comparison between `hipError_t` value and unnamed enum

### DIFF
--- a/projects/hipfft/library/src/amd_detail/hipfft.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfft.cpp
@@ -1707,7 +1707,7 @@ try
     if(!plan || plan->initialized())
         return HIPFFT_INVALID_PLAN;
     int dev_count = 0;
-    if(hipGetDeviceCount(&dev_count) != HIP_SUCCESS || dev_count <= 0)
+    if(hipGetDeviceCount(&dev_count) != hipSuccess || dev_count <= 0)
         return HIPFFT_INTERNAL_ERROR;
     if(std::any_of(
            gpus, gpus + count, [=](int gpu_id) { return gpu_id < 0 || gpu_id >= dev_count; }))


### PR DESCRIPTION
## Motivation & details

Addresses a mistake introduced in https://github.com/ROCm/rocm-libraries/pull/3455 that triggers build warnings.

## Test Plan

N/A.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
