### PR TITLE
[hipblaslt] Not use 256 in workgroup tile K dimension

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/include/solution_selection.hpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/include/solution_selection.hpp
@@ -160,7 +160,7 @@ constexpr int
     // There is an error with smaller tile sizes and larger prefetchInFlight.
     // Unroll is 2 when wgt.k is greater or equal to 256, otherwise 4
     if(typeA == rocRoller::DataType::FP4 && typeB == rocRoller::DataType::FP4 && wgt.m > 32
-       && wgt.n > 32 && wgt.k < 256)
+       && wgt.n > 32)
         return 4;
     else
         return 2;

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
@@ -44,7 +44,7 @@ const int USE_WORKGROUP_MAPPING_K_SIZE = 4096;
  * compile-time known.
  */
 
-constexpr size_t possibleTileSizesCount = 35;
+constexpr size_t possibleTileSizesCount = 34;
 
 constexpr std::array<WorkGroupTileSize, possibleTileSizesCount> possibleTileSizes
     = {{{256, 256, 128}, {256, 192, 128}, {256, 128, 128}, {256, 64, 128}, {256, 32, 128},
@@ -53,7 +53,7 @@ constexpr std::array<WorkGroupTileSize, possibleTileSizesCount> possibleTileSize
         {64, 256, 128},  {64, 192, 128},  {64, 128, 128},  {64, 64, 128},  {64, 32, 128},
         {32, 256, 128},  {32, 192, 128},  {32, 128, 128},  {32, 64, 128},  {32, 32, 128},
         {32, 32, 64},    {16, 256, 128},  {64, 16, 128},   {16, 64, 128},  {32, 16, 128},
-        {16, 32, 128},   {16, 16, 128},   {16, 16, 256},   {16, 64, 256},  {128, 128, 256}}};
+        {16, 32, 128},   {16, 16, 128},   {16, 16, 256},   {16, 64, 256}}};
 
 template <rocRoller::DataType typeA, rocRoller::DataType typeB>
 auto generateTileList()


### PR DESCRIPTION
## Motivation

The K dimension of workgroup tile has to be smaller than 256 due to register pressure.

## Technical Details

Remove {128, 128, 256} from the workgroup tile list.

## Test Plan

The existing test should pass.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
