### PR TITLE
hipfft: fix g++ warnings

### DIFF
--- a/projects/hipfft/library/src/amd_detail/hipfft.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfft.cpp
@@ -468,7 +468,7 @@ static hipfftResult hipfftMakePlan_internal(hipfftHandle               plan,
     const bool ignore_user_distances = !plan->ionembed.get_nembed(fft_io::fft_io_in)
                                        && !plan->ionembed.get_nembed(fft_io::fft_io_out);
     std::vector<size_t> i_strides, o_strides;
-    size_t              inDist, outDist;
+    size_t              inDist = 0, outDist = 0;
     for(auto dft_type : iotype.transform_types())
     {
         for(auto placement : {rocfft_placement_inplace, rocfft_placement_notinplace})

--- a/projects/hipfft/library/src/amd_detail/hipfftw.cpp
+++ b/projects/hipfft/library/src/amd_detail/hipfftw.cpp
@@ -145,7 +145,8 @@ namespace
     {
         if constexpr(!is_real(dft_type))
             return rocfft_array_type_complex_interleaved;
-        else if constexpr(dft_type == rocfft_transform_type_real_forward ^ io == fft_io::fft_io_in)
+        else if constexpr((dft_type == rocfft_transform_type_real_forward)
+                          ^ (io == fft_io::fft_io_in))
             return rocfft_array_type_hermitian_interleaved;
         else
             return rocfft_array_type_real;

--- a/projects/hipfft/shared/data_layout.h
+++ b/projects/hipfft/shared/data_layout.h
@@ -24,6 +24,7 @@
 #include "fft_enums.h"
 #include <algorithm>
 #include <array>
+#include <iterator>
 #include <limits>
 #include <numeric>
 #include <optional>

--- a/projects/hipfft/shared/data_layout.h
+++ b/projects/hipfft/shared/data_layout.h
@@ -133,8 +133,8 @@ static std::vector<T> default_distances(fft_transform_type                      
     validate_enums_or_throw("default_distances", dft_type, placement, io);
     if(batches.empty())
         return std::vector<T>(); // empty as well
-    auto temp_lengths = lengths;
-    temp_lengths.insert(temp_lengths.begin(), batches.begin(), batches.end());
+    auto temp_lengths = batches;
+    std::copy(lengths.begin(), lengths.end(), std::back_inserter(temp_lengths));
     std::vector<T> ret;
     if(!len_dim_order)
     {

--- a/projects/rocfft/shared/data_layout.h
+++ b/projects/rocfft/shared/data_layout.h
@@ -24,6 +24,7 @@
 #include "fft_enums.h"
 #include <algorithm>
 #include <array>
+#include <iterator>
 #include <limits>
 #include <numeric>
 #include <optional>
@@ -133,8 +134,8 @@ static std::vector<T> default_distances(fft_transform_type                      
     validate_enums_or_throw("default_distances", dft_type, placement, io);
     if(batches.empty())
         return std::vector<T>(); // empty as well
-    auto temp_lengths = lengths;
-    temp_lengths.insert(temp_lengths.begin(), batches.begin(), batches.end());
+    auto temp_lengths = batches;
+    std::copy(lengths.begin(), lengths.end(), std::back_inserter(temp_lengths));
     std::vector<T> ret;
     if(!len_dim_order)
     {


### PR DESCRIPTION
## Motivation

Fix some warnings when building hipFFT with g++.

## Technical Details

No functional change.

## Test Plan

Run regression tests.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
