### PR TITLE
[HIPDNN] Batch norm inference variance + activation

### DIFF
--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.cpp
@@ -472,6 +472,24 @@ void checkBatchnormTensorConfigSupported(
 }
 
 void checkBatchnormTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    checkBatchnormFwdActivationModeSupported(actAttr);
+
+    std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), actAttr.out_0_tensor_uid()};
+    std::vector<int64_t> affineTensorIds
+        = {bnInfAttr.scale_tensor_uid(), bnInfAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds
+        = {bnInfAttr.mean_tensor_uid(), bnInfAttr.inv_variance_tensor_uid()};
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, tensorMap, false);
+}
+
+void checkBatchnormTensorConfigSupported(
     const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap)

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.cpp
@@ -454,6 +454,24 @@ void checkBatchnormTensorConfigSupported(
 }
 
 void checkBatchnormTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    checkBatchnormFwdActivationModeSupported(actAttr);
+
+    std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), actAttr.out_0_tensor_uid()};
+    std::vector<int64_t> affineTensorIds
+        = {bnInfAttr.scale_tensor_uid(), bnInfAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds
+        = {bnInfAttr.mean_tensor_uid(), bnInfAttr.variance_tensor_uid()};
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, tensorMap, false);
+}
+
+void checkBatchnormTensorConfigSupported(
     const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap)

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.hpp
@@ -114,6 +114,12 @@ void checkBatchnormTensorConfigSupported(
         tensorMap);
 
 void checkBatchnormTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormTensorConfigSupported(
     const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap);

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormApplicabilityChecks.hpp
@@ -120,6 +120,12 @@ void checkBatchnormTensorConfigSupported(
         tensorMap);
 
 void checkBatchnormTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormTensorConfigSupported(
     const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap);

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
@@ -403,37 +403,65 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
         bool isFwdInferenceFirst
             = node0.attributesType()
               == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes;
+        bool isFwdInferenceWithVarianceFirst
+            = node0.attributesType()
+              == hipdnn_data_sdk::data_objects::NodeAttributes::
+                  BatchnormInferenceAttributesVarianceExt;
         bool isPointwiseSecond
             = node1.attributesType()
               == hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes;
 
-        if(!(isFwdInferenceFirst && isPointwiseSecond))
+        if(!((isFwdInferenceFirst || isFwdInferenceWithVarianceFirst) && isPointwiseSecond))
         {
             HIPDNN_LOG_INFO(
                 "Batchnorm plan builder is not applicable for this graph node order and types");
             return false;
         }
 
-        const auto& bnInfAttr
-            = node0.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
-        const auto& actAttr
-            = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
-        if(!batchnormFwdFusionCheckTensorsLogErrors(bnInfAttr, actAttr, opGraph.getTensorMap()))
+        if(isFwdInferenceFirst)
         {
-            return false;
-        }
+            const auto& bnInfAttr = node0.attributesAs<
+                hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+            const auto& actAttr
+                = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+            if(!batchnormFwdFusionCheckTensorsLogErrors(
+                   bnInfAttr, actAttr, opGraph.getTensorMap()))
+            {
+                return false;
+            }
 
-        // Since MIOpen does not provide an API to validate batchnorm applicability, we perform the
-        // checks manually.
-        try
-        {
-            checkBatchnormTensorConfigSupported(bnInfAttr, opGraph.getTensorMap());
-            checkBatchnormFwdActivationModeSupported(actAttr);
+            // Since MIOpen does not provide an API to validate batchnorm applicability, we perform
+            // the checks manually.
+            try
+            {
+                checkBatchnormTensorConfigSupported(bnInfAttr, opGraph.getTensorMap());
+                checkBatchnormFwdActivationModeSupported(actAttr);
+            }
+            catch(const std::exception& e)
+            {
+                HIPDNN_LOG_INFO(e.what());
+                return false;
+            }
         }
-        catch(const std::exception& e)
+        else
         {
-            HIPDNN_LOG_INFO(e.what());
-            return false;
+            const auto& bnInfAttr = node0.attributesAs<
+                hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+            const auto& actAttr
+                = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+
+            // TODO: Add tensor check for variance ext fusion if needed, or reuse existing if compatible
+            // For now, we rely on the applicability check which we just added support for.
+
+            try
+            {
+                checkBatchnormTensorConfigSupported(bnInfAttr, actAttr, opGraph.getTensorMap());
+            }
+            catch(const std::exception& e)
+            {
+                HIPDNN_LOG_INFO(e.what());
+                return false;
+            }
         }
 
         HIPDNN_LOG_INFO("Batchnorm plan builder applicable for batchnorm inference + "
@@ -586,6 +614,24 @@ void buildPlanFusedFwdInferenceActivation([[maybe_unused]] const HipdnnEnginePlu
     executionContext.setPlan(std::move(plan));
 }
 
+void buildPlanFusedFwdInferenceWithVarianceActivation(
+    [[maybe_unused]] const HipdnnEnginePluginHandle& handle,
+    const hipdnn_plugin_sdk::IGraph& opGraph,
+    HipdnnEnginePluginExecutionContext& executionContext)
+{
+    const auto& node0 = opGraph.getNodeWrapper(0);
+    const auto& node1 = opGraph.getNodeWrapper(1);
+
+    const auto& fwdInference = node0.attributesAs<
+        hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt>();
+    const auto& activation
+        = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+
+    BatchnormFwdInferenceWithVarianceParams params(fwdInference, activation, opGraph.getTensorMap());
+    auto plan = std::make_unique<BatchnormFwdInferenceWithVariancePlan>(std::move(params));
+    executionContext.setPlan(std::move(plan));
+}
+
 } // namespace
 
 void MiopenBatchnormPlanBuilder::buildPlan(
@@ -595,8 +641,21 @@ void MiopenBatchnormPlanBuilder::buildPlan(
 {
     if(opGraph.nodeCount() == 2)
     {
-        HIPDNN_LOG_INFO("Building batchnorm inference + activation fusion plan");
-        buildPlanFusedFwdInferenceActivation(handle, opGraph, executionContext);
+        const auto& node0 = opGraph.getNodeWrapper(0);
+        if(node0.attributesType()
+           == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes)
+        {
+            HIPDNN_LOG_INFO("Building batchnorm inference + activation fusion plan");
+            buildPlanFusedFwdInferenceActivation(handle, opGraph, executionContext);
+        }
+        else if(node0.attributesType()
+                == hipdnn_data_sdk::data_objects::NodeAttributes::
+                    BatchnormInferenceAttributesVarianceExt)
+        {
+            HIPDNN_LOG_INFO(
+                "Building batchnorm inference with variance + activation fusion plan");
+            buildPlanFusedFwdInferenceWithVarianceActivation(handle, opGraph, executionContext);
+        }
         return;
     }
     if(opGraph.nodeCount() == 3)

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
@@ -403,10 +403,9 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
         bool isFwdInferenceFirst
             = node0.attributesType()
               == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes;
-        bool isFwdInferenceWithVarianceFirst
-            = node0.attributesType()
-              == hipdnn_data_sdk::data_objects::NodeAttributes::
-                  BatchnormInferenceAttributesVarianceExt;
+        bool isFwdInferenceWithVarianceFirst = node0.attributesType()
+                                               == hipdnn_data_sdk::data_objects::NodeAttributes::
+                                                   BatchnormInferenceAttributesVarianceExt;
         bool isPointwiseSecond
             = node1.attributesType()
               == hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes;
@@ -420,12 +419,11 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
 
         if(isFwdInferenceFirst)
         {
-            const auto& bnInfAttr = node0.attributesAs<
-                hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+            const auto& bnInfAttr
+                = node0.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
             const auto& actAttr
                 = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
-            if(!batchnormFwdFusionCheckTensorsLogErrors(
-                   bnInfAttr, actAttr, opGraph.getTensorMap()))
+            if(!batchnormFwdFusionCheckTensorsLogErrors(bnInfAttr, actAttr, opGraph.getTensorMap()))
             {
                 return false;
             }
@@ -627,7 +625,8 @@ void buildPlanFusedFwdInferenceWithVarianceActivation(
     const auto& activation
         = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
 
-    BatchnormFwdInferenceWithVarianceParams params(fwdInference, activation, opGraph.getTensorMap());
+    BatchnormFwdInferenceWithVarianceParams params(
+        fwdInference, activation, opGraph.getTensorMap());
     auto plan = std::make_unique<BatchnormFwdInferenceWithVariancePlan>(std::move(params));
     executionContext.setPlan(std::move(plan));
 }
@@ -652,8 +651,7 @@ void MiopenBatchnormPlanBuilder::buildPlan(
                 == hipdnn_data_sdk::data_objects::NodeAttributes::
                     BatchnormInferenceAttributesVarianceExt)
         {
-            HIPDNN_LOG_INFO(
-                "Building batchnorm inference with variance + activation fusion plan");
+            HIPDNN_LOG_INFO("Building batchnorm inference with variance + activation fusion plan");
             buildPlanFusedFwdInferenceWithVarianceActivation(handle, opGraph, executionContext);
         }
         return;

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
@@ -509,8 +509,7 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
             // the checks manually.
             try
             {
-                checkBatchnormTensorConfigSupported(bnInfAttr, opGraph.getTensorMap());
-                checkBatchnormFwdActivationModeSupported(actAttr);
+                checkBatchnormTensorConfigSupported(bnInfAttr, actAttr, opGraph.getTensorMap());
             }
             catch(const std::exception& e)
             {

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
@@ -292,6 +292,83 @@ bool batchnormFwdFusionCheckTensorsLogErrors(
     }
 }
 
+void batchnormFwdFusionCheckTensors(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    static const std::unordered_set<PM> s_supportedActivations = {PM::RELU_FWD};
+
+    if(s_supportedActivations.count(actAttr.operation()) == 0)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Batchnorm fusion currently only supports RELU_FWD activation");
+    }
+
+    // in_0 must be the batchnorm inference output (forward path)
+    if(actAttr.in_0_tensor_uid() != bnInfAttr.y_tensor_uid())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Activation in_0 must be the batchnorm inference output tensor (y)");
+    }
+
+    // Check for virtual tensors
+    const auto& bnInfTensorX
+        = miopen_utils::findTensorAttributes(tensorMap, bnInfAttr.x_tensor_uid());
+    const auto& bnInfTensorMean
+        = miopen_utils::findTensorAttributes(tensorMap, bnInfAttr.mean_tensor_uid());
+    const auto& bnInfTensorVariance
+        = miopen_utils::findTensorAttributes(tensorMap, bnInfAttr.variance_tensor_uid());
+    const auto& bnInfTensorScale
+        = miopen_utils::findTensorAttributes(tensorMap, bnInfAttr.scale_tensor_uid());
+    const auto& bnInfTensorBias
+        = miopen_utils::findTensorAttributes(tensorMap, bnInfAttr.bias_tensor_uid());
+    const auto& bnInfTensorY
+        = miopen_utils::findTensorAttributes(tensorMap, bnInfAttr.y_tensor_uid());
+
+    if(bnInfTensorX.virtual_() || bnInfTensorMean.virtual_() || bnInfTensorVariance.virtual_()
+       || bnInfTensorScale.virtual_() || bnInfTensorBias.virtual_() || !bnInfTensorY.virtual_())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Batchnorm inference input tensors must be non-virtual, output tensor must be virtual");
+    }
+
+    const auto& actTensorIn0
+        = miopen_utils::findTensorAttributes(tensorMap, actAttr.in_0_tensor_uid());
+    const auto& actTensorOut
+        = miopen_utils::findTensorAttributes(tensorMap, actAttr.out_0_tensor_uid());
+
+    if(!actTensorIn0.virtual_() || actTensorOut.virtual_())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Activation input from batchnorm must be virtual, output must be non virtual");
+    }
+}
+
+bool batchnormFwdFusionCheckTensorsLogErrors(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    try
+    {
+        batchnormFwdFusionCheckTensors(bnInfAttr, actAttr, tensorMap);
+        return true;
+    }
+    catch(const std::exception& e)
+    {
+        HIPDNN_LOG_INFO(e.what());
+        return false;
+    }
+}
+
 } // namespace
 
 bool MiopenBatchnormPlanBuilder::isApplicable(
@@ -448,8 +525,10 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
             const auto& actAttr
                 = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
 
-            // TODO: Add tensor check for variance ext fusion if needed, or reuse existing if compatible
-            // For now, we rely on the applicability check which we just added support for.
+            if(!batchnormFwdFusionCheckTensorsLogErrors(bnInfAttr, actAttr, opGraph.getTensorMap()))
+            {
+                return false;
+            }
 
             try
             {

--- a/dnn-providers/miopen-provider/integration_tests/CMakeLists.txt
+++ b/dnn-providers/miopen-provider/integration_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
     IntegrationGpuBatchnormBackwardActivation.cpp
     IntegrationGpuBatchnormForwardInference.cpp
     IntegrationGpuBatchnormForwardInferenceWithVariance.cpp
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivation.cpp
     IntegrationGpuBatchnormFwdPlusActive.cpp
     IntegrationGpuBatchnormForwardTraining.cpp
     IntegrationGpuBatchnormFwdTrainingActiv.cpp

--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivation.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivation.cpp
@@ -1,0 +1,362 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <filesystem>
+#include <random>
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "../tests/common/ActivationCommon.hpp"
+#include "../tests/common/BatchnormCommon.hpp"
+#include "IntegrationGraphVerificationHarness.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities;
+using namespace miopen_legacy_plugin::test_utilities;
+using namespace test_bn_common;
+
+namespace
+{
+
+template <typename DataType, typename IntermediateType, typename TestCaseType>
+class BatchnormForwardInferenceWithVarianceAndActivation
+    : public IntegrationGraphVerificationHarness<DataType, TestCaseType>
+{
+protected:
+    void runGraphTest(DataType tolerance, const TensorLayout& layout = TensorLayout::NCHW) override
+    {
+        const auto& [testCase, activeCase] = this->GetParam();
+
+        auto derivedDims = getDerivedShape(testCase.dims);
+
+        hipdnn_frontend::graph::Graph graphObj;
+
+        graphObj.set_name("BatchnormInferenceWithVarianceAndActivationTest");
+
+        auto dataType = getDataTypeEnumFromType<DataType>();
+        auto intermediateDataType = getDataTypeEnumFromType<IntermediateType>();
+        graphObj.set_intermediate_data_type(intermediateDataType)
+            .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+            .set_io_data_type(dataType);
+
+        auto xAttr = graph::makeTensorAttributes(
+            "X", testCase.dims, generateStrides(testCase.dims, layout.strideOrder));
+        auto xTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(xAttr));
+
+        // Channel-only tensors are layout-agnostic, specifying stride order is unnecessary
+        auto meanAttr = graph::makeTensorAttributes(
+            "mean", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto meanTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(meanAttr));
+
+        auto varianceAttr = graph::makeTensorAttributes(
+            "variance", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto varianceTensorAttr
+            = std::make_shared<graph::TensorAttributes>(std::move(varianceAttr));
+
+        auto scaleAttr = graph::makeTensorAttributes(
+            "scale", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto scaleTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(scaleAttr));
+
+        auto biasAttr = graph::makeTensorAttributes(
+            "bias", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto biasTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(biasAttr));
+
+        // Epsilon (pass-by-value)
+        auto epsilonTensorAttr = std::make_shared<graph::TensorAttributes>();
+        epsilonTensorAttr->set_name("epsilon").set_value(1e-5f);
+
+        graph::BatchnormInferenceAttributesVarianceExt bnAttrs;
+
+        auto yTensorAttr = graphObj.batchnorm_inference_variance_ext(xTensorAttr,
+                                                                     meanTensorAttr,
+                                                                     varianceTensorAttr,
+                                                                     scaleTensorAttr,
+                                                                     biasTensorAttr,
+                                                                     epsilonTensorAttr,
+                                                                     bnAttrs);
+
+        yTensorAttr->set_data_type(dataType);
+
+        graph::PointwiseAttributes pointwiseAttrs;
+        pointwiseAttrs.set_mode(static_cast<hipdnn_frontend::PointwiseMode>(activeCase.mode));
+        if(activeCase.reluLowerClip.has_value())
+        {
+            pointwiseAttrs.set_relu_lower_clip(activeCase.reluLowerClip.value());
+        }
+        if(activeCase.reluUpperClip.has_value())
+        {
+            pointwiseAttrs.set_relu_upper_clip(activeCase.reluUpperClip.value());
+        }
+        if(activeCase.reluLowerClipSlope.has_value())
+        {
+            pointwiseAttrs.set_relu_lower_clip_slope(activeCase.reluLowerClipSlope.value());
+        }
+        if(activeCase.swishBeta.has_value())
+        {
+            pointwiseAttrs.set_swish_beta(activeCase.swishBeta.value());
+        }
+        if(activeCase.eluAlpha.has_value())
+        {
+            pointwiseAttrs.set_elu_alpha(activeCase.eluAlpha.value());
+        }
+        if(activeCase.softplusBeta.has_value())
+        {
+            pointwiseAttrs.set_softplus_beta(activeCase.softplusBeta.value());
+        }
+
+        auto outTensorAttr = graphObj.pointwise(yTensorAttr, pointwiseAttrs);
+        outTensorAttr->set_output(true);
+
+        this->registerValidator(outTensorAttr, tolerance);
+
+        this->verifyGraph(graphObj, testCase.seed);
+    }
+};
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp32
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        float,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwBfp16
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        hip_bfloat16,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp16
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        half,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp32
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        float,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcBfp16
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        hip_bfloat16,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp16
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        half,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwFp32
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        float,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwBfp16
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        hip_bfloat16,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwFp16
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        half,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp32
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        float,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcBfp16
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        hip_bfloat16,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp16
+    = BatchnormForwardInferenceWithVarianceAndActivation<
+        half,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+} // namespace
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNchwFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNhwcFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCDHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCDHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCDHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNcdhwFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NDHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NDHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NDHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivationNdhwcFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormApplicabilityChecks.cpp
@@ -3591,32 +3591,36 @@ inline std::vector<BatchnormInferenceVarianceExtFusedConfigTestCase>
         {
             for(const auto& typeConfig : bn_type_configs::VALID)
             {
-                auto configs = createBatchnormInferenceWithVarianceTensors(typeConfig, dims, *layout);
+                auto configs
+                    = createBatchnormInferenceWithVarianceTensors(typeConfig, dims, *layout);
                 // Add virtual tensor for fusion
-                auto strides = hipdnn_data_sdk::utilities::generateStrides(dims, layout->strideOrder);
-                configs.push_back(createIoTensor(bnYVirtualUid, "bn_y", typeConfig.io, dims, strides, true));
+                auto strides
+                    = hipdnn_data_sdk::utilities::generateStrides(dims, layout->strideOrder);
+                configs.push_back(
+                    createIoTensor(bnYVirtualUid, "bn_y", typeConfig.io, dims, strides, true));
 
-                cases.push_back(
-                    {"AcceptsInferenceVarExtFused_" + generateName(dims, *layout) + "_"
-                         + toString(typeConfig),
-                     true,
-                     configs,
-                     UIDs::X,
-                     UIDs::Y,
-                     UIDs::SCALE,
-                     UIDs::BIAS,
-                     UIDs::EPSILON,
-                     UIDs::MEAN,
-                     UIDs::VARIANCE,
-                     PM::RELU_FWD});
+                cases.push_back({"AcceptsInferenceVarExtFused_" + generateName(dims, *layout) + "_"
+                                     + toString(typeConfig),
+                                 true,
+                                 configs,
+                                 UIDs::X,
+                                 UIDs::Y,
+                                 UIDs::SCALE,
+                                 UIDs::BIAS,
+                                 UIDs::EPSILON,
+                                 UIDs::MEAN,
+                                 UIDs::VARIANCE,
+                                 PM::RELU_FWD});
             }
         }
     }
 
     // Unhappy paths - unsupported activation mode
     const auto& sampleDims = shapes::INFERENCE_4D[0];
-    auto configs = createBatchnormInferenceWithVarianceTensors(bn_type_configs::ALL_FLOAT, sampleDims, TensorLayout::NCHW);
-    auto strides = hipdnn_data_sdk::utilities::generateStrides(sampleDims, TensorLayout::NCHW.strideOrder);
+    auto configs = createBatchnormInferenceWithVarianceTensors(
+        bn_type_configs::ALL_FLOAT, sampleDims, TensorLayout::NCHW);
+    auto strides
+        = hipdnn_data_sdk::utilities::generateStrides(sampleDims, TensorLayout::NCHW.strideOrder);
     configs.push_back(createIoTensor(bnYVirtualUid, "bn_y", DT::FLOAT, sampleDims, strides, true));
 
     cases.push_back({"RejectsInferenceVarExtFused_UnsupportedActivation",
@@ -3707,7 +3711,8 @@ TEST_P(TestCheckBatchnormInferenceWithVarianceFusedConfigSupported, ValidatesCor
 
     if(tc.shouldPass)
     {
-        EXPECT_NO_THROW({ checkBatchnormTensorConfigSupported(*bnAttrs, *actAttrs, graph.getTensorMap()); });
+        EXPECT_NO_THROW(
+            { checkBatchnormTensorConfigSupported(*bnAttrs, *actAttrs, graph.getTensorMap()); });
     }
     else
     {

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormApplicabilityChecks.cpp
@@ -759,6 +759,27 @@ struct BatchnormFusedBackwardConfigTestCase
     }
 };
 
+struct BatchnormInferenceVarianceExtFusedConfigTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    int64_t xUid;
+    int64_t yUid;
+    int64_t scaleUid;
+    int64_t biasUid;
+    int64_t epsilonUid;
+    int64_t meanUid;
+    int64_t varianceUid;
+    hipdnn_data_sdk::data_objects::PointwiseMode activationMode;
+
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const BatchnormInferenceVarianceExtFusedConfigTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
 struct ActivationModeTestCase
 {
     std::string name;
@@ -1138,6 +1159,100 @@ inline flatbuffers::FlatBufferBuilder
         hipdnn_data_sdk::data_objects::DataType::FLOAT,
         hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
         bnBwdAttrs.Union()));
+
+    // Build graph
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test_graph",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorOffsets,
+        &nodes);
+
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+inline flatbuffers::FlatBufferBuilder buildBatchnormInferenceWithVarianceFusedGraph(
+    const std::vector<TensorConfig>& configs,
+    int64_t xUid,
+    int64_t yUid,
+    int64_t scaleUid,
+    int64_t biasUid,
+    int64_t epsilonUid,
+    int64_t meanUid,
+    int64_t varianceUid,
+    int64_t bnYVirtualUid,
+    hipdnn_data_sdk::data_objects::PointwiseMode activationMode
+    = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD)
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    tensorOffsets.reserve(configs.size());
+    for(const auto& cfg : configs)
+    {
+        if(cfg.isPassByValue)
+        {
+            hipdnn_data_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
+            auto valueOffset = builder.CreateStruct(floatValue).Union();
+            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                cfg.uid,
+                cfg.name.c_str(),
+                cfg.dataType,
+                &cfg.strides,
+                &cfg.dims,
+                cfg.isVirtual,
+                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
+                valueOffset));
+        }
+        else
+        {
+            tensorOffsets.push_back(
+                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                            cfg.uid,
+                                                                            cfg.name.c_str(),
+                                                                            cfg.dataType,
+                                                                            &cfg.strides,
+                                                                            &cfg.dims,
+                                                                            cfg.isVirtual));
+        }
+    }
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Node 0: Batchnorm Inference with Variance
+    auto bnAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, xUid, meanUid, varianceUid, scaleUid, biasUid, bnYVirtualUid, epsilonUid);
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_inference_variance_ext",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnAttrs.Union()));
+
+    // Node 1: Activation
+    auto actAttrs = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        activationMode,
+        flatbuffers::nullopt, // relu_lower_clip
+        flatbuffers::nullopt, // relu_upper_clip
+        flatbuffers::nullopt, // relu_lower_clip_slope
+        flatbuffers::nullopt, // axis_tensor_uid
+        bnYVirtualUid, // in_0_tensor_uid
+        flatbuffers::nullopt, // in_1_tensor_uid
+        flatbuffers::nullopt, // in_2_tensor_uid
+        yUid); // out_0_tensor_uid
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "activation",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttrs.Union()));
 
     // Build graph
     auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
@@ -3458,6 +3573,67 @@ inline std::vector<BatchnormInferenceVarianceExtConfigTestCase>
     return cases;
 }
 
+inline std::vector<BatchnormInferenceVarianceExtFusedConfigTestCase>
+    getCheckBatchnormInferenceWithVarianceFusedConfigSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using UIDs = BnInferenceVarianceExtTensorIds;
+    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+
+    std::vector<BatchnormInferenceVarianceExtFusedConfigTestCase> cases;
+    const int64_t bnYVirtualUid = 100;
+
+    // Happy paths - all shapes × all 4D layouts × all valid type configurations
+    for(const auto& dims : shapes::INFERENCE_4D)
+    {
+        for(const auto* layout : LAYOUTS_4D)
+        {
+            for(const auto& typeConfig : bn_type_configs::VALID)
+            {
+                auto configs = createBatchnormInferenceWithVarianceTensors(typeConfig, dims, *layout);
+                // Add virtual tensor for fusion
+                auto strides = hipdnn_data_sdk::utilities::generateStrides(dims, layout->strideOrder);
+                configs.push_back(createIoTensor(bnYVirtualUid, "bn_y", typeConfig.io, dims, strides, true));
+
+                cases.push_back(
+                    {"AcceptsInferenceVarExtFused_" + generateName(dims, *layout) + "_"
+                         + toString(typeConfig),
+                     true,
+                     configs,
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     UIDs::MEAN,
+                     UIDs::VARIANCE,
+                     PM::RELU_FWD});
+            }
+        }
+    }
+
+    // Unhappy paths - unsupported activation mode
+    const auto& sampleDims = shapes::INFERENCE_4D[0];
+    auto configs = createBatchnormInferenceWithVarianceTensors(bn_type_configs::ALL_FLOAT, sampleDims, TensorLayout::NCHW);
+    auto strides = hipdnn_data_sdk::utilities::generateStrides(sampleDims, TensorLayout::NCHW.strideOrder);
+    configs.push_back(createIoTensor(bnYVirtualUid, "bn_y", DT::FLOAT, sampleDims, strides, true));
+
+    cases.push_back({"RejectsInferenceVarExtFused_UnsupportedActivation",
+                     false,
+                     configs,
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     UIDs::MEAN,
+                     UIDs::VARIANCE,
+                     PM::SIGMOID_FWD});
+
+    return cases;
+}
+
 class TestCheckBatchnormInferenceWithVarianceConfigSupported
     : public ::testing::TestWithParam<BatchnormInferenceVarianceExtConfigTestCase>
 {
@@ -3497,6 +3673,54 @@ INSTANTIATE_TEST_SUITE_P(
     AllCases,
     TestCheckBatchnormInferenceWithVarianceConfigSupported,
     testing::ValuesIn(getCheckBatchnormInferenceWithVarianceConfigSupportedTestCases()));
+
+class TestCheckBatchnormInferenceWithVarianceFusedConfigSupported
+    : public ::testing::TestWithParam<BatchnormInferenceVarianceExtFusedConfigTestCase>
+{
+};
+
+TEST_P(TestCheckBatchnormInferenceWithVarianceFusedConfigSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+    const int64_t bnYVirtualUid = 100;
+
+    auto builder = buildBatchnormInferenceWithVarianceFusedGraph(tc.tensorConfigs,
+                                                                 tc.xUid,
+                                                                 tc.yUid,
+                                                                 tc.scaleUid,
+                                                                 tc.biasUid,
+                                                                 tc.epsilonUid,
+                                                                 tc.meanUid,
+                                                                 tc.varianceUid,
+                                                                 bnYVirtualUid,
+                                                                 tc.activationMode);
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& bnNode = graph.getNode(0);
+    const auto& actNode = graph.getNode(1);
+
+    auto* bnAttrs = bnNode.attributes_as_BatchnormInferenceAttributesVarianceExt();
+    auto* actAttrs = actNode.attributes_as_PointwiseAttributes();
+
+    ASSERT_NE(bnAttrs, nullptr);
+    ASSERT_NE(actAttrs, nullptr);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ checkBatchnormTensorConfigSupported(*bnAttrs, *actAttrs, graph.getTensorMap()); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { checkBatchnormTensorConfigSupported(*bnAttrs, *actAttrs, graph.getTensorMap()); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllCases,
+    TestCheckBatchnormInferenceWithVarianceFusedConfigSupported,
+    testing::ValuesIn(getCheckBatchnormInferenceWithVarianceFusedConfigSupportedTestCases()));
 
 // --- Integration Tests: Peer Stats Validation ---
 

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdInferenceWithVariancePlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdInferenceWithVariancePlan.cpp
@@ -37,3 +37,39 @@ TEST(TestMiopenBatchnormFwdInferenceWithVarianceParams, InitializesAllTensorsFro
     EXPECT_NO_THROW(params.epsilonValue());
     EXPECT_NEAR(params.epsilonValue(), 1e-5, 1e-10);
 }
+
+TEST(TestMiopenBatchnormFwdInferenceWithVarianceParams, InitializesAllTensorsFromValidGraphWithActivation)
+{
+    // Create a valid batchnorm graph with variance and activation
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceActivGraph();
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    // Get the batchnorm node and attributes
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_BatchnormInferenceAttributesVarianceExt();
+    ASSERT_NE(attrs, nullptr);
+
+    // Get the activation node and attributes
+    const auto& activNode = graph.getNode(1);
+    auto* activAttrs = activNode.attributes_as_PointwiseAttributes();
+    ASSERT_NE(activAttrs, nullptr);
+
+    // Expect that params construction doesn't throw
+    EXPECT_NO_THROW(BatchnormFwdInferenceWithVarianceParams(*attrs, *activAttrs, graph.getTensorMap()));
+
+    BatchnormFwdInferenceWithVarianceParams params(*attrs, *activAttrs, graph.getTensorMap());
+
+    // verify activation optional params are present
+    EXPECT_NE(params.optActivation(), std::nullopt);
+    EXPECT_NE(params.activationOut(), std::nullopt);
+
+    // Verify required tensors are initialized
+    EXPECT_NO_THROW(params.x());
+    EXPECT_NO_THROW(params.y());
+    EXPECT_NO_THROW(params.scale());
+    EXPECT_NO_THROW(params.bias());
+    EXPECT_NO_THROW(params.estMean());
+    EXPECT_NO_THROW(params.variance());
+    EXPECT_NO_THROW(params.epsilonValue());
+    EXPECT_NEAR(params.epsilonValue(), 1e-5, 1e-10);
+}

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdInferenceWithVariancePlan.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormFwdInferenceWithVariancePlan.cpp
@@ -38,10 +38,12 @@ TEST(TestMiopenBatchnormFwdInferenceWithVarianceParams, InitializesAllTensorsFro
     EXPECT_NEAR(params.epsilonValue(), 1e-5, 1e-10);
 }
 
-TEST(TestMiopenBatchnormFwdInferenceWithVarianceParams, InitializesAllTensorsFromValidGraphWithActivation)
+TEST(TestMiopenBatchnormFwdInferenceWithVarianceParams,
+     InitializesAllTensorsFromValidGraphWithActivation)
 {
     // Create a valid batchnorm graph with variance and activation
-    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceActivGraph();
+    auto builder
+        = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceActivGraph();
     hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
 
     // Get the batchnorm node and attributes
@@ -55,7 +57,8 @@ TEST(TestMiopenBatchnormFwdInferenceWithVarianceParams, InitializesAllTensorsFro
     ASSERT_NE(activAttrs, nullptr);
 
     // Expect that params construction doesn't throw
-    EXPECT_NO_THROW(BatchnormFwdInferenceWithVarianceParams(*attrs, *activAttrs, graph.getTensorMap()));
+    EXPECT_NO_THROW(
+        BatchnormFwdInferenceWithVarianceParams(*attrs, *activAttrs, graph.getTensorMap()));
 
     BatchnormFwdInferenceWithVarianceParams params(*attrs, *activAttrs, graph.getTensorMap());
 

--- a/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/plans/TestMiopenBatchnormPlanBuilder.cpp
@@ -34,9 +34,9 @@ void createBatchnormFusionTensorAttributes(
     static const std::unordered_set<int64_t> s_derivedDimTensorIds = {2, 3, 4, 5, 8, 9, 12};
 
     std::vector<int64_t> dims = {1, 3, 224, 224};
-    std::vector<int64_t> strides = {1, 3, 224, 224};
+    std::vector<int64_t> strides = {150528, 50176, 224, 1};
     std::vector<int64_t> derivedDims = {1, 3, 1, 1};
-    std::vector<int64_t> derivedStrides = {1, 3, 1, 1};
+    std::vector<int64_t> derivedStrides = {3, 1, 1, 1};
 
     for(int64_t i = 1; i <= numTensors; ++i)
     {
@@ -413,8 +413,8 @@ TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsFalseForInvalidLayoutI
 
     std::vector<int64_t> strides3D = {42, 14, 1}; // 3D instead of 4D/5D
     std::vector<int64_t> dims3D = {1, 3, 14};
-    std::vector<int64_t> derivedStrides = {3, 1, 1};
-    std::vector<int64_t> derivedDims = {1, 3, 1};
+    std::vector<int64_t> derivedStrides = {3, 1, 1, 1};
+    std::vector<int64_t> derivedDims = {1, 3, 1, 1};
 
     tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
@@ -1758,6 +1758,229 @@ TEST_F(TestMiopenBatchnormPlanBuilder,
         builder,
         "act",
         hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+// ============================================================================
+// Variance Extension Fusion Tests
+// ============================================================================
+
+TEST_F(TestMiopenBatchnormPlanBuilder, IsApplicableReturnsTrueForFusedTwoNodeGraphWithVariance)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with variance
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf_var",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnInfAttr.Union()));
+
+    // Activation
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        6,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestMiopenBatchnormPlanBuilder,
+       IsApplicableReturnsFalseForFusedTwoNodeGraphWithVarianceAndBrokenConnectivity)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with variance
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf_var",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnInfAttr.Union()));
+
+    // Activation with wrong input
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        5, // Wrong input!
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestMiopenBatchnormPlanBuilder,
+       IsApplicableReturnsFalseForFusedTwoNodeGraphWithVarianceAndNonVirtualIntermediate)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {}); // No virtual tensors
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with variance
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf_var",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnInfAttr.Union()));
+
+    // Activation
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        6,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestMiopenBatchnormPlanBuilder,
+       IsApplicableReturnsFalseForFusedTwoNodeGraphWithVarianceAndUnsupportedActivation)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with variance
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf_var",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnInfAttr.Union()));
+
+    // Activation with unsupported MUL
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::MUL, // Unsupported!
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        6,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
         hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
         actAttr.Union()));
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
@@ -217,6 +217,137 @@ inline flatbuffers::FlatBufferBuilder createValidBatchnormWithVarianceInferenceG
     return builder;
 }
 
+inline flatbuffers::FlatBufferBuilder createValidBatchnormWithVarianceInferenceActivGraph(
+    const std::vector<int64_t>& strides = {1, 3, 224, 224},
+    const std::vector<int64_t>& dims = {1, 3, 224, 224},
+    hipdnn_data_sdk::data_objects::DataType inputDataType
+    = hipdnn_data_sdk::data_objects::DataType::FLOAT,
+    hipdnn_data_sdk::data_objects::DataType computeDataType
+    = hipdnn_data_sdk::data_objects::DataType::FLOAT)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    std::vector<int64_t> derivedStrides = hipdnn_data_sdk::utilities::getDerivedShape(strides);
+    std::vector<int64_t> derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+
+    int64_t uid = 1;
+
+    const auto xUid = uid++;
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, xUid, "x", inputDataType, &strides, &dims));
+
+    const auto yBnUid = uid++;
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, yBnUid, "y_bn", inputDataType, &strides, &dims, true)); // virtual
+
+    const auto scaleUid = uid++;
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        scaleUid,
+        "scale",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+
+    const auto biasUid = uid++;
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        biasUid,
+        "bias",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+
+    const auto meanUid = uid++;
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        meanUid,
+        "est_mean",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+
+    const auto varUid = uid++;
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        varUid,
+        "variance",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+
+    // Epsilon (pass-by-value)
+    std::vector<int64_t> passByValueDims = {1};
+    hipdnn_data_sdk::data_objects::Float32Value epsilonVal(1e-5f);
+    const auto epsUid = uid++;
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        epsUid,
+        "epsilon",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &passByValueDims,
+        &passByValueDims,
+        false,
+        hipdnn_data_sdk::data_objects::TensorValue::Float32Value,
+        builder.CreateStruct(epsilonVal).Union()));
+
+    const auto yUid = uid++;
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, yUid, "y", inputDataType, &strides, &dims));
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    auto bnormAttributes
+        = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+            builder,
+            xUid,
+            meanUid,
+            varUid,
+            scaleUid,
+            biasUid,
+            yBnUid, // Virtual output
+            epsUid);
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnormWithVariance",
+        computeDataType,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnormAttributes.Union()));
+
+    auto activAttributes = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt, // relu_lower_clip
+        flatbuffers::nullopt, // relu_upper_clip
+        flatbuffers::nullopt, // relu_lower_clip_slope
+        flatbuffers::nullopt, // axis_tensor_uid
+        yBnUid, // in_0_tensor_uid (virtual)
+        flatbuffers::nullopt, // in_1_tensor_uid
+        flatbuffers::nullopt, // in_2_tensor_uid
+        yUid); // out_0_tensor_uid
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "activation",
+        computeDataType,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        activAttributes.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+
 inline flatbuffers::FlatBufferBuilder
     createValidBatchnormBwdGraph(const std::vector<int64_t>& strides = {150528, 50176, 224, 1},
                                  const std::vector<int64_t>& dims = {1, 3, 224, 224},


### PR DESCRIPTION
## Motivation

This PR enables fusion of Batchnorm Inference (with variance) with Activation operations.  It updates the Plan Builder to recognize and support the `BatchnormInferenceAttributesVarianceExt` node followed by `PointwiseAttributes (Activation)`. 

## Test Plan

 It includes comprehensive integration tests for the fused operation, along with unit tests for the plan builder and applicability checks to ensure correctness and stability.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
