### PR TITLE
Move 128x256x32 test from NN to TN

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
@@ -253,6 +253,44 @@ BenchmarkProblems:
           - Range: [[256], [192], [1], [16, 32, 128]]
           - Range: [[8192], [6144], [1], [32, 32, 128]]
         - BiasTypeArgs: ['s']
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1, 4, 8,  2,2 ]          
+        - PrefetchGlobalRead: [2] 
+        - PrefetchLocalRead: [0]
+        - DepthU: [32]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1]
+        - LocalReadVectorWidth: [4]
+        - GlobalReadVectorWidthA: [4]
+        - GlobalReadVectorWidthB: [4] 
+        - DirectToLds: [1]
+        - StreamK: [3]
+        - LdsPadA: [-1] 
+        - LdsPadB: [-1] 
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - NonTemporalA: [0]
+        - NonTemporalB: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LDSTrInst: [False]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[128], [256], [1], [64, 64, 256]]
+          - Range: [[128], [256], [1], [1,1,64]]
+          - Range: [[128], [256], [1], [32, 64, 256]]
+        - BiasTypeArgs: ['b']
 
 ########################################
 # TF32 NN - standard
@@ -303,43 +341,5 @@ BenchmarkProblems:
           - Range: [[192], [256], [1], [64, 64, 256]]
           - Range: [[192], [256], [1], [1,1,64]]
           - Range: [[192], [256], [1], [32, 64, 256]]
-        - BiasTypeArgs: ['b']
-    - # BenchmarkProblemSizeGroup - Standard - All problem
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - KernelLanguage: ["Assembly"]
-      ForkParameters:
-        - MatrixInstruction:
-          - [16, 16, 32, 1,  1, 4, 8,  2,2 ]          
-        - PrefetchGlobalRead: [2] 
-        - PrefetchLocalRead: [0]
-        - DepthU: [32]
-        - ScheduleIterAlg: [3]
-        - ExpandPointerSwap: [0]
-        - TransposeLDS: [1]
-        - LocalReadVectorWidth: [4]
-        - GlobalReadVectorWidthA: [4]
-        - GlobalReadVectorWidthB: [4] 
-        - DirectToLds: [1]
-        - StreamK: [3]
-        - LdsPadA: [-1] 
-        - LdsPadB: [-1] 
-        - StaggerU: [0]
-        - 1LDSBuffer: [0]
-        - NonTemporalA: [0]
-        - NonTemporalB: [0]
-        - NonTemporalD: [4]
-        - SourceSwap: [1]
-        - LdsBlockSizePerPadA: [-1]
-        - LdsBlockSizePerPadB: [-1]
-        - LDSTrInst: [False]
-        - UseSgprForGRO: [0]
-        - UseCustomMainLoopSchedule: [1]
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Range: [[128], [256], [1], [64, 64, 256]]
-          - Range: [[128], [256], [1], [1,1,64]]
-          - Range: [[128], [256], [1], [32, 64, 256]]
         - BiasTypeArgs: ['b']
 


### PR DESCRIPTION
Move 128x256x32 test from NN to TN because that is what was implemented in PR #3649

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
