### PR TITLE
[rocSOLVER] Optimize POTF2 kernel

### DIFF
--- a/projects/rocsolver/CHANGELOG.md
+++ b/projects/rocsolver/CHANGELOG.md
@@ -17,6 +17,9 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ### Changed
 ### Removed
 ### Optimized
+
+* Improved the performance of POTF2 and downstream functions such as POTRF.
+
 ### Resolved issues
 
 * Fixed a synchronization issue in STEBZ and downstream functions, such as SYEVX and SYEVDX.

--- a/projects/rocsolver/clients/gtest/lapack/potf2_potrf_gtest.cpp
+++ b/projects/rocsolver/clients/gtest/lapack/potf2_potrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -57,7 +57,8 @@ const vector<vector<int>> matrix_size_range = {
     {10, 10, 1},
     {20, 30, 0},
     {50, 50, 1},
-    {70, 80, 0}};
+    {70, 80, 0},
+    {136, 140, 1}};
 
 const vector<vector<int64_t>> matrix_size_range_64 = {
     // quick return
@@ -69,15 +70,16 @@ const vector<vector<int64_t>> matrix_size_range_64 = {
     {10, 10, 1},
     {20, 30, 0},
     {50, 50, 1},
-    {70, 80, 0}};
+    {70, 80, 0},
+    {136, 140, 1}};
 
 // for daily_lapack tests
 const vector<vector<int>> large_matrix_size_range = {
-    {192, 192, 0}, {640, 960, 1}, {1000, 1000, 0}, {1024, 1024, 1}, {2000, 2000, 0},
+    {192, 192, 0}, {215, 215, 0}, {640, 960, 1}, {1000, 1000, 0}, {1024, 1024, 1}, {2000, 2000, 0},
 };
 
 const vector<vector<int64_t>> large_matrix_size_range_64 = {
-    {192, 192, 0}, {640, 960, 1}, {1000, 1000, 0}, {1024, 1024, 1}, {2000, 2000, 0},
+    {192, 192, 0}, {215, 215, 0}, {640, 960, 1}, {1000, 1000, 0}, {1024, 1024, 1}, {2000, 2000, 0},
 };
 
 template <typename I>

--- a/projects/rocsolver/library/src/include/ideal_sizes.hpp
+++ b/projects/rocsolver/library/src/include/ideal_sizes.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/library/src/include/ideal_sizes.hpp
+++ b/projects/rocsolver/library/src/include/ideal_sizes.hpp
@@ -285,7 +285,7 @@
     when using the blocked algorithm (POTRF). It also applies to the
     corresponding batched and strided-batched routines.*/
 #ifndef POTRF_BLOCKSIZE
-#define POTRF_BLOCKSIZE(T) ((sizeof(T) == 4) ? 180 : (sizeof(T) == 8) ? 127 : 90)
+#define POTRF_BLOCKSIZE(T) ((sizeof(T) == 4) ? 256 : (sizeof(T) == 8) ? 128 : 64)
 #endif
 
 /*! \brief Determines the size at which rocSOLVER switches from
@@ -305,7 +305,7 @@
     within the LDS share memory using compact storage.
     The amount of LDS shared memory is assumed to be at least (64 * 1024) bytes. */
 #ifndef POTF2_MAX_SMALL_SIZE
-#define POTF2_MAX_SMALL_SIZE(T) ((sizeof(T) == 4) ? 180 : (sizeof(T) == 8) ? 127 : 90)
+#define POTF2_MAX_SMALL_SIZE(T) ((sizeof(T) == 4) ? 256 : (sizeof(T) == 8) ? 128 : 64)
 #endif
 
 /************************** syevj/heevj ***************************************

--- a/projects/rocsolver/library/src/include/ideal_sizes.hpp
+++ b/projects/rocsolver/library/src/include/ideal_sizes.hpp
@@ -281,7 +281,7 @@
 
 /************************** potf2/potrf ***************************************
 *******************************************************************************/
-/*! \brief Determines the maximum size at which rocSOLVER can use POTF2
+/*! \brief Determines the maximum size at which rocSOLVER can use POTF2 small-size kernel.
     \details
     POTF2 will attempt to factorize a small symmetric matrix that can fit entirely
     within the LDS shared memory using compact storage.

--- a/projects/rocsolver/library/src/include/ideal_sizes.hpp
+++ b/projects/rocsolver/library/src/include/ideal_sizes.hpp
@@ -284,7 +284,7 @@
 /*! \brief Determines the maximum size at which rocSOLVER can use POTF2
     \details
     POTF2 will attempt to factorize a small symmetric matrix that can fit entirely
-    within the LDS share memory using compact storage.
+    within the LDS shared memory using compact storage.
     The amount of LDS shared memory is assumed to be at least (64 * 1024) bytes. */
 #ifndef POTF2_MAX_SMALL_SIZE
 #define POTF2_MAX_SMALL_SIZE(T) ((sizeof(T) == 16) ? 128 : 256)

--- a/projects/rocsolver/library/src/include/ideal_sizes.hpp
+++ b/projects/rocsolver/library/src/include/ideal_sizes.hpp
@@ -281,22 +281,15 @@
 
 /************************** potf2/potrf ***************************************
 *******************************************************************************/
-/*! \brief Determines the size of the leading block that is factorized at each step
-    when using the blocked algorithm (POTRF). It also applies to the
-    corresponding batched and strided-batched routines.*/
-#ifndef POTRF_BLOCKSIZE
-#define POTRF_BLOCKSIZE(T) ((sizeof(T) == 4) ? 256 : (sizeof(T) == 8) ? 128 : 64)
-#endif
-
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing POTRF. It also applies to the
     corresponding batched and strided-batched routines.
 
-    \details POTRF will factorize blocks of POTRF_BLOCKSIZE columns at a time until
+    \details POTRF will factorize blocks of columns at a time until
     the rest of the matrix has no more than POTRF_POTF2_SWITCHSIZE columns; at this point the last block,
     if any, will be factorized with the unblocked algorithm (POTF2).*/
 #ifndef POTRF_POTF2_SWITCHSIZE
-#define POTRF_POTF2_SWITCHSIZE(T) POTRF_BLOCKSIZE(T)
+#define POTRF_POTF2_SWITCHSIZE(T) 64
 #endif
 
 /*! \brief Determines the maximum size at which rocSOLVER can use POTF2
@@ -305,7 +298,7 @@
     within the LDS share memory using compact storage.
     The amount of LDS shared memory is assumed to be at least (64 * 1024) bytes. */
 #ifndef POTF2_MAX_SMALL_SIZE
-#define POTF2_MAX_SMALL_SIZE(T) ((sizeof(T) == 4) ? 256 : (sizeof(T) == 8) ? 128 : 64)
+#define POTF2_MAX_SMALL_SIZE(T) ((sizeof(T) == 16) ? 128 : 256)
 #endif
 
 /************************** syevj/heevj ***************************************

--- a/projects/rocsolver/library/src/include/ideal_sizes.hpp
+++ b/projects/rocsolver/library/src/include/ideal_sizes.hpp
@@ -281,6 +281,15 @@
 
 /************************** potf2/potrf ***************************************
 *******************************************************************************/
+/*! \brief Determines the maximum size at which rocSOLVER can use POTF2
+    \details
+    POTF2 will attempt to factorize a small symmetric matrix that can fit entirely
+    within the LDS share memory using compact storage.
+    The amount of LDS shared memory is assumed to be at least (64 * 1024) bytes. */
+#ifndef POTF2_MAX_SMALL_SIZE
+#define POTF2_MAX_SMALL_SIZE(T) ((sizeof(T) == 16) ? 128 : 256)
+#endif
+
 /*! \brief Determines the size at which rocSOLVER switches from
     the unblocked to the blocked algorithm when executing POTRF. It also applies to the
     corresponding batched and strided-batched routines.
@@ -289,16 +298,7 @@
     the rest of the matrix has no more than POTRF_POTF2_SWITCHSIZE columns; at this point the last block,
     if any, will be factorized with the unblocked algorithm (POTF2).*/
 #ifndef POTRF_POTF2_SWITCHSIZE
-#define POTRF_POTF2_SWITCHSIZE(T) 64
-#endif
-
-/*! \brief Determines the maximum size at which rocSOLVER can use POTF2
-    \details
-    POTF2 will attempt to factorize a small symmetric matrix that can fit entirely
-    within the LDS share memory using compact storage.
-    The amount of LDS shared memory is assumed to be at least (64 * 1024) bytes. */
-#ifndef POTF2_MAX_SMALL_SIZE
-#define POTF2_MAX_SMALL_SIZE(T) ((sizeof(T) == 16) ? 128 : 256)
+#define POTRF_POTF2_SWITCHSIZE(T) ((sizeof(T) == 4) ? 256 : 128)
 #endif
 
 /************************** syevj/heevj ***************************************

--- a/projects/rocsolver/library/src/lapack/roclapack_potf2.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_potf2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -206,7 +206,7 @@ rocblas_status rocsolver_potf2_template(rocblas_handle handle,
     rocblas_get_pointer_mode(handle, &old_mode);
     rocblas_set_pointer_mode(handle, rocblas_pointer_mode_device);
 
-    if(n <= POTRF_BLOCKSIZE(T))
+    if(n <= POTF2_MAX_SMALL_SIZE(T))
     {
         // ----------------------
         // use specialized kernel

--- a/projects/rocsolver/library/src/lapack/roclapack_potrf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_potrf.hpp
@@ -80,16 +80,11 @@ I potrf_get_block_size(const I n)
 {
     if constexpr(sizeof(T) == 4)
     {
-        if(n <= 4096)
-            return 64;
-        else
-            return 256;
+        return 256;
     }
     else if constexpr(sizeof(T) == 8)
     {
-        if(n <= 3200)
-            return 64;
-        else if(n <= 5120)
+        if(n <= 6400)
             return 128;
         else
             return 256;

--- a/projects/rocsolver/library/src/lapack/roclapack_potrf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_potrf.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,6 +70,34 @@ ROCSOLVER_KERNEL void chk_positive(INFO* iinfo, INFO* info, I j, I batch_count)
         info[id] = iinfo[id] + j;
 }
 
+/******************* Host functions for potrf **********************/
+/*******************************************************************/
+
+// Method to determine configuration for potrf block size depending on n
+// TODO: fine tuning may be required
+template <typename T, typename I>
+I potrf_get_block_size(const I n)
+{
+    if constexpr(sizeof(T) == 4)
+    {
+        if(n <= 4096)
+            return 64;
+        else
+            return 256;
+    }
+    else if constexpr(sizeof(T) == 8)
+    {
+        if(n <= 3200)
+            return 64;
+        else if(n <= 5120)
+            return 128;
+        else
+            return 256;
+    }
+
+    return POTF2_MAX_SMALL_SIZE(T);
+}
+
 template <bool BATCHED, bool STRIDED, typename T, typename I>
 void rocsolver_potrf_getMemorySize(const I n,
                                    const rocblas_fill uplo,
@@ -97,7 +125,7 @@ void rocsolver_potrf_getMemorySize(const I n,
         return;
     }
 
-    I nb = POTRF_BLOCKSIZE(T);
+    I nb = potrf_get_block_size<T>(n);
     if(n <= POTRF_POTF2_SWITCHSIZE(T))
     {
         // requirements for calling a single POTF2
@@ -184,7 +212,7 @@ rocblas_status rocsolver_potrf_template(rocblas_handle handle,
 
     // if the matrix is small, use the unblocked (BLAS-levelII) variant of the
     // algorithm
-    I nb = POTRF_BLOCKSIZE(T);
+    I nb = potrf_get_block_size<T>(n);
     if(n <= POTRF_POTF2_SWITCHSIZE(T))
         return rocsolver_potf2_template<T>(handle, uplo, n, A, shiftA, lda, strideA, info,
                                            batch_count, scalars, (T*)work1, pivots);

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -413,7 +413,6 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
     assert(AA != nullptr);
     assert(info != nullptr);
 
-    // TODO: offset A here based on block/tid?
     T* const A = load_ptr_batch(AA, bid, shiftA, strideA);
     INFO* const info_bid = info + bid;
 
@@ -426,7 +425,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
     // load A to registers
     T Arg[(NB * (NB + 1)) / 2] = {0};
 
-    // TODO: incrementing idx instead of idx_lower
+    I arg_idx = 0;
     for(I j = 0; j < NB; j++)
     {
         for(I i = j; i < NB; i++)
@@ -436,20 +435,23 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             if(col < n && row < n && row >= col)
             {
                 const auto idx = col * lda + row;
-                Arg[idx_lower<I>(i, j, NB)] = A[idx];
+                Arg[arg_idx] = A[idx];
             }
+
+            arg_idx++;
         }
     }
 
     // Panel Cholesky decomposition
+    arg_idx = 0;
     for(I j = 0; j < NB; j++)
     {
         // load panel to lds
-        for(I i = j; i < NB; i++)
+        for(I i = 0; i < NB - j; i++)
         {
-            const auto row = (i - j) * PANEL_SIZE + tidx;
+            const auto row = i * PANEL_SIZE + tidx;
             const auto idx = tidy * ldash + row;
-            Ash[idx] = Arg[idx_lower<I>(i, j, NB)];
+            Ash[idx] = Arg[arg_idx + i];
         }
 
         __syncthreads();
@@ -523,6 +525,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
         }
 
         // update trailing matrix
+        I karg_idx = arg_idx + NB - j;
         for(I k = j + 1; k < NB; k++)
         {
             for(I i = k; i < NB; i++)
@@ -532,18 +535,20 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
 
                 for(I p = 0; p < PANEL_SIZE; p++)
                 {
-                    Arg[idx_lower<I>(i, k, NB)] -= Ash[row + p * ldash] * conj(Ash[col + p * ldash]);
+                    Arg[karg_idx + i - k] -= Ash[row + p * ldash] * conj(Ash[col + p * ldash]);
                 }
             }
+            karg_idx += NB - k;
         }
 
         // write panel back to registers
-        for(I i = j; i < NB; i++)
+        for(I i = 0; i < NB - j; i++)
         {
-            const auto row = (i - j) * PANEL_SIZE + tidx;
+            const auto row = i * PANEL_SIZE + tidx;
             const auto idx = tidy * ldash + row;
-            Arg[idx_lower<I>(i, j, NB)] = Ash[idx];
+            Arg[arg_idx + i] = Ash[idx];
         }
+        arg_idx += NB - j;
 
         __syncthreads();
 
@@ -552,6 +557,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
     }
 
     // write A from registers
+    arg_idx = 0;
     for(I j = 0; j < NB; j++)
     {
         for(I i = j; i < NB; i++)
@@ -561,8 +567,10 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             if(col < n && row < n && row >= col)
             {
                 const auto idx = col * lda + row;
-                A[idx] = Arg[idx_lower<I>(i, j, NB)];
+                A[idx] = Arg[arg_idx];
             }
+
+            arg_idx++;
         }
     }
 }

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -430,12 +430,25 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
     {
         for(I i = j; i < NB; i++)
         {
-            const auto col = j * PANEL_SIZE + tidy;
-            const auto row = i * PANEL_SIZE + tidx;
-            if(col < n && row < n && row >= col)
+            if(is_upper)
             {
-                const auto idx = col * lda + row;
-                Arg[arg_idx] = A[idx];
+                const auto col = i * PANEL_SIZE + tidy;
+                const auto row = j * PANEL_SIZE + tidx;
+                if(col < n && row < n && row <= col)
+                {
+                    const auto idx = col * lda + row;
+                    Arg[arg_idx] = A[idx];
+                }
+            }
+            else
+            {
+                const auto col = j * PANEL_SIZE + tidy;
+                const auto row = i * PANEL_SIZE + tidx;
+                if(col < n && row < n && row >= col)
+                {
+                    const auto idx = col * lda + row;
+                    Arg[arg_idx] = A[idx];
+                }
             }
 
             arg_idx++;
@@ -446,12 +459,22 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
     arg_idx = 0;
     for(I j = 0; j < NB; j++)
     {
-        // load panel to lds
+        // write panel to lds
         for(I i = 0; i < NB - j; i++)
         {
-            const auto row = i * PANEL_SIZE + tidx;
-            const auto idx = tidy * ldash + row;
-            Ash[idx] = Arg[arg_idx + i];
+            // write to lds as lower and compute as lower
+            if(is_upper)
+            {
+                const auto col = i * PANEL_SIZE + tidy;
+                const auto idx = tidx * ldash + col;
+                Ash[idx] = Arg[arg_idx + i];
+            }
+            else
+            {
+                const auto row = i * PANEL_SIZE + tidx;
+                const auto idx = tidy * ldash + row;
+                Ash[idx] = Arg[arg_idx + i];
+            }
         }
 
         __syncthreads();
@@ -530,23 +553,45 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
         {
             for(I i = k; i < NB; i++)
             {
-                const auto col = (k - j) * PANEL_SIZE + tidy;
-                const auto row = (i - j) * PANEL_SIZE + tidx;
-
-                for(I p = 0; p < PANEL_SIZE; p++)
+                if(is_upper)
                 {
-                    Arg[karg_idx + i - k] -= Ash[row + p * ldash] * conj(Ash[col + p * ldash]);
+                    const auto col = (i - j) * PANEL_SIZE + tidy;
+                    const auto row = (k - j) * PANEL_SIZE + tidx;
+
+                    for(I p = 0; p < PANEL_SIZE; p++)
+                    {
+                        Arg[karg_idx + i - k] -= conj(Ash[row + p * ldash]) * Ash[col + p * ldash];
+                    }
+                }
+                else
+                {
+                    const auto col = (k - j) * PANEL_SIZE + tidy;
+                    const auto row = (i - j) * PANEL_SIZE + tidx;
+
+                    for(I p = 0; p < PANEL_SIZE; p++)
+                    {
+                        Arg[karg_idx + i - k] -= Ash[row + p * ldash] * conj(Ash[col + p * ldash]);
+                    }
                 }
             }
             karg_idx += NB - k;
         }
 
-        // write panel back to registers
+        // load panel back to registers
         for(I i = 0; i < NB - j; i++)
         {
-            const auto row = i * PANEL_SIZE + tidx;
-            const auto idx = tidy * ldash + row;
-            Arg[arg_idx + i] = Ash[idx];
+            if(is_upper)
+            {
+                const auto col = i * PANEL_SIZE + tidy;
+                const auto idx = tidx * ldash + col;
+                Arg[arg_idx + i] = Ash[idx];
+            }
+            else
+            {
+                const auto row = i * PANEL_SIZE + tidx;
+                const auto idx = tidy * ldash + row;
+                Arg[arg_idx + i] = Ash[idx];
+            }
         }
         arg_idx += NB - j;
 
@@ -562,12 +607,25 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
     {
         for(I i = j; i < NB; i++)
         {
-            const auto col = j * PANEL_SIZE + tidy;
-            const auto row = i * PANEL_SIZE + tidx;
-            if(col < n && row < n && row >= col)
+            if(is_upper)
             {
-                const auto idx = col * lda + row;
-                A[idx] = Arg[arg_idx];
+                const auto col = i * PANEL_SIZE + tidy;
+                const auto row = j * PANEL_SIZE + tidx;
+                if(col < n && row < n && row <= col)
+                {
+                    const auto idx = col * lda + row;
+                    A[idx] = Arg[arg_idx];
+                }
+            }
+            else
+            {
+                const auto col = j * PANEL_SIZE + tidy;
+                const auto row = i * PANEL_SIZE + tidx;
+                if(col < n && row < n && row >= col)
+                {
+                    const auto idx = col * lda + row;
+                    A[idx] = Arg[arg_idx];
+                }
             }
 
             arg_idx++;

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -413,6 +413,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
     assert(AA != nullptr);
     assert(info != nullptr);
 
+    // TODO: offset A here based on block/tid?
     T* const A = load_ptr_batch(AA, bid, shiftA, strideA);
     INFO* const info_bid = info + bid;
 
@@ -464,6 +465,9 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             auto kk = kcol * ldash + kcol;
             auto const akk = std::real(Ash[kk]);
             bool const isok = (akk > 0) && (std::isfinite(akk));
+
+            __syncthreads();
+
             if(!isok)
             {
                 if(tid == 0)
@@ -474,6 +478,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
                         *info_bid = j * PANEL_SIZE + kcol + 1;
                 }
                 failed = true;
+                __syncthreads();
                 break;
             }
 
@@ -482,8 +487,6 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             {
                 Ash[kk] = lkk;
             }
-
-            __syncthreads();
 
             // ------------------------------------------------------------
             //   (2) vl21 * l11' = va21 =>  vl21 = va21/ l11', scale vector
@@ -520,18 +523,11 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             __syncthreads();
         }
 
-        __syncthreads();
-
         // update trailing matrix
         for(I k = j + 1; k < NB; k++)
         {
             for(I i = k; i < NB; i++)
             {
-                // const auto c_row
-                //     = (i - j) * tile_size + widx * 16 + get_c_row<T>(cmajor_j_16x4, cmajor_i_16x4, reg, (I)0, (I)0);
-                // const auto c_col
-                //     = (k - j) * tile_size + widy * 16 + get_c_col<T>(cmajor_j_16x4, cmajor_i_16x4, reg, (I)0, (I)0);
-
                 const auto col = (k - j) * PANEL_SIZE + tidy;
                 const auto row = (i - j) * PANEL_SIZE + tidx;
 
@@ -542,9 +538,6 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             }
         }
 
-        // TODO: reevaluate syncthreads
-        __syncthreads();
-
         // write panel back to registers
         for(I i = j; i < NB; i++)
         {
@@ -552,6 +545,8 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             const auto idx = tidy * ldash + row;
             Arg[idx_lower<I>(i, j, NB)] = Ash[idx];
         }
+
+        __syncthreads();
 
         if(failed)
             break;

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -390,6 +390,189 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
     __syncthreads();
 }
 
+template <int NB, int PANEL_SIZE, typename T, typename I, typename INFO, typename U>
+ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
+                                                  const I n,
+                                                  U AA,
+                                                  const rocblas_stride shiftA,
+                                                  const I lda,
+                                                  const rocblas_stride strideA,
+                                                  INFO* const info)
+{
+    bool const is_lower = (!is_upper);
+
+    auto const tid = hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
+    auto const inc = hipBlockDim_y * hipBlockDim_x;
+    auto const tidx = hipThreadIdx_x;
+    auto const tidy = hipThreadIdx_y;
+
+    assert(hipBlockDim_z == 1);
+
+    // get batch index
+    auto const bid = hipBlockIdx_z;
+    assert(AA != nullptr);
+    assert(info != nullptr);
+
+    T* const A = load_ptr_batch(AA, bid, shiftA, strideA);
+    INFO* const info_bid = info + bid;
+
+    extern __shared__ rocblas_int lsmem[];
+    T* Ash = reinterpret_cast<T*>(lsmem);
+    auto constexpr ldash = NB * PANEL_SIZE;
+
+    bool failed = false;
+
+    // load A to registers
+    T Arg[(NB * (NB + 1)) / 2] = {0};
+
+    // TODO: incrementing idx instead of idx_lower
+    for(I j = 0; j < NB; j++)
+    {
+        for(I i = j; i < NB; i++)
+        {
+            const auto col = j * PANEL_SIZE + tidy;
+            const auto row = i * PANEL_SIZE + tidx;
+            if(col < n && row < n && row >= col)
+            {
+                const auto idx = col * lda + row;
+                Arg[idx_lower<I>(i, j, NB)] = A[idx];
+            }
+        }
+    }
+
+    // Panel Cholesky decomposition
+    for(I j = 0; j < NB; j++)
+    {
+        // load panel to lds
+        for(I i = j; i < NB; i++)
+        {
+            const auto row = (i - j) * PANEL_SIZE + tidx;
+            const auto idx = tidy * ldash + row;
+            Ash[idx] = Arg[idx_lower<I>(i, j, NB)];
+        }
+
+        __syncthreads();
+
+        I nn = n - j * PANEL_SIZE;
+
+        // factorize panel
+        for(I kcol = 0; kcol < PANEL_SIZE; kcol++)
+        {
+            if(kcol >= nn)
+                break;
+
+            auto kk = kcol * ldash + kcol;
+            auto const akk = std::real(Ash[kk]);
+            bool const isok = (akk > 0) && (std::isfinite(akk));
+            if(!isok)
+            {
+                if(tid == 0)
+                {
+                    Ash[kk] = akk;
+                    // Fortran 1-based index
+                    if(*info_bid == 0)
+                        *info_bid = j * PANEL_SIZE + kcol + 1;
+                }
+                failed = true;
+                break;
+            }
+
+            auto const lkk = std::sqrt(akk);
+            if(tid == 0)
+            {
+                Ash[kk] = lkk;
+            }
+
+            __syncthreads();
+
+            // ------------------------------------------------------------
+            //   (2) vl21 * l11' = va21 =>  vl21 = va21/ l11', scale vector
+            // ------------------------------------------------------------
+
+            auto const conj_lkk = conj(lkk);
+            for(I j0 = (kcol + 1) + tid; j0 < nn; j0 += inc)
+            {
+                auto const j0k = j0 + kcol * ldash;
+
+                Ash[j0k] = (Ash[j0k] / conj_lkk);
+            }
+
+            __syncthreads();
+
+            // ------------------------------------------------------------
+            //   (3a) A22 = A22 - vl21 * vl21',  symmetric rank-1 update
+            //
+            //   note: update lower triangular part
+            // ------------------------------------------------------------
+
+            for(I j = (kcol + 1) + tidy; j < PANEL_SIZE; j += hipBlockDim_y)
+            {
+                auto const vj = Ash[j + kcol * ldash];
+                // TODO: j + tidx
+                for(I i = (kcol + 1) + tidx; i < nn; i += hipBlockDim_x)
+                {
+                    auto const vi = Ash[i + kcol * ldash];
+                    auto const ij = i + j * ldash;
+
+                    Ash[ij] = Ash[ij] - vi * conj(vj);
+                }
+            }
+            __syncthreads();
+        }
+
+        __syncthreads();
+
+        // update trailing matrix
+        for(I k = j + 1; k < NB; k++)
+        {
+            for(I i = k; i < NB; i++)
+            {
+                // const auto c_row
+                //     = (i - j) * tile_size + widx * 16 + get_c_row<T>(cmajor_j_16x4, cmajor_i_16x4, reg, (I)0, (I)0);
+                // const auto c_col
+                //     = (k - j) * tile_size + widy * 16 + get_c_col<T>(cmajor_j_16x4, cmajor_i_16x4, reg, (I)0, (I)0);
+
+                const auto col = (k - j) * PANEL_SIZE + tidy;
+                const auto row = (i - j) * PANEL_SIZE + tidx;
+
+                for(I p = 0; p < PANEL_SIZE; p++)
+                {
+                    Arg[idx_lower<I>(i, k, NB)] -= Ash[row + p * ldash] * conj(Ash[col + p * ldash]);
+                }
+            }
+        }
+
+        // TODO: reevaluate syncthreads
+        __syncthreads();
+
+        // write panel back to registers
+        for(I i = j; i < NB; i++)
+        {
+            const auto row = (i - j) * PANEL_SIZE + tidx;
+            const auto idx = tidy * ldash + row;
+            Arg[idx_lower<I>(i, j, NB)] = Ash[idx];
+        }
+
+        if(failed)
+            break;
+    }
+
+    // write A from registers
+    for(I j = 0; j < NB; j++)
+    {
+        for(I i = j; i < NB; i++)
+        {
+            const auto col = j * PANEL_SIZE + tidy;
+            const auto row = i * PANEL_SIZE + tidx;
+            if(col < n && row < n && row >= col)
+            {
+                const auto idx = col * lda + row;
+                A[idx] = Arg[idx_lower<I>(i, j, NB)];
+            }
+        }
+    }
+}
+
 /*************************************************************
     Launchers of specilized kernels
 *************************************************************/
@@ -411,12 +594,21 @@ rocblas_status potf2_run_small(rocblas_handle handle,
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
 
-    size_t lmemsize = sizeof(T) * (n * (n + 1)) / 2;
+    const auto nb = (n + BS2 - 1) / BS2;
+
+    size_t lmemsize = sizeof(T) * nb * BS2 * BS2;
 
     bool const is_upper = (uplo == rocblas_fill_upper);
-    ROCSOLVER_LAUNCH_KERNEL((potf2_kernel_small<T, I, INFO, U>), dim3(1, 1, batch_count),
-                            dim3(BS2, BS2, 1), lmemsize, stream, is_upper, n, A, shiftA, lda,
-                            strideA, info);
+    auto kernel = std::array{potf2_register_kernel_small<1, BS2, T, I, INFO, U>,
+                             potf2_register_kernel_small<2, BS2, T, I, INFO, U>,
+                             potf2_register_kernel_small<3, BS2, T, I, INFO, U>,
+                             potf2_register_kernel_small<4, BS2, T, I, INFO, U>,
+                             potf2_register_kernel_small<5, BS2, T, I, INFO, U>,
+                             potf2_register_kernel_small<6, BS2, T, I, INFO, U>,
+                             potf2_register_kernel_small<7, BS2, T, I, INFO, U>,
+                             potf2_register_kernel_small<8, BS2, T, I, INFO, U>};
+    ROCSOLVER_LAUNCH_KERNEL(kernel[nb - 1], dim3(1, 1, batch_count), dim3(BS2, BS2, 1), lmemsize,
+                            stream, is_upper, n, A, shiftA, lda, strideA, info);
 
     return rocblas_status_success;
 }

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -39,6 +39,17 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+/**
+ * ------------------------------------------------------
+ * Perform Cholesky factorization for small n by n matrix.
+ * The function executes in a single thread block per matrix.
+ * ------------------------------------------------------
+ *
+ * NB           Number of panels to perform blocked decomposition.
+ *              ceildiv(n, PANEL_SIZE)
+ * PANEL_SIZE   Size of panel to perform non-blocked decompostion.
+ *              PANEL_SIZE == BlockDim.x == BlockDim.y
+**/
 template <int NB, int PANEL_SIZE, typename T, typename I, typename INFO, typename U>
 ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
                                          const I n,
@@ -48,8 +59,6 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
                                          const rocblas_stride strideA,
                                          INFO* const info)
 {
-    bool const is_lower = (!is_upper);
-
     auto const tid = hipThreadIdx_y * hipBlockDim_x + hipThreadIdx_x;
     auto const inc = hipBlockDim_y * hipBlockDim_x;
     auto const tidx = hipThreadIdx_x;

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -511,8 +511,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             for(I j = (kcol + 1) + tidy; j < PANEL_SIZE; j += hipBlockDim_y)
             {
                 auto const vj = Ash[j + kcol * ldash];
-                // TODO: j + tidx
-                for(I i = (kcol + 1) + tidx; i < nn; i += hipBlockDim_x)
+                for(I i = j + tidx; i < nn; i += hipBlockDim_x)
                 {
                     auto const vi = Ash[i + kcol * ldash];
                     auto const ij = i + j * ldash;

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -316,6 +316,12 @@ rocblas_status potf2_run_small(rocblas_handle handle,
 
     size_t lmemsize = sizeof(T) * nb * BS2 * BS2;
 
+    const hipDeviceProp_t* props = rocblas_internal_get_device_prop(handle);
+    if(lmemsize > props->sharedMemPerBlock)
+    {
+        return rocblas_status_internal_error;
+    }
+
     bool const is_upper = (uplo == rocblas_fill_upper);
     auto kernel = std::array{
         potf2_kernel_small<1, BS2, T, I, INFO, U>, potf2_kernel_small<2, BS2, T, I, INFO, U>,

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -39,243 +39,7 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
-/**
- * indexing for packed storage
- * for upper triangular
- *
- * ---------------------------
- * 0 1 3
- *   2 4
- *     5
- * ---------------------------
- *
- **/
-
-template <typename I>
-__device__ static I idx_upper(I i, I j, I n)
-{
-    assert((0 <= i) && (i <= (n - 1)));
-    assert((0 <= j) && (j <= (n - 1)));
-    assert(i <= j);
-
-    return (i + (j * (j + 1)) / 2);
-}
-
-/**
- * indexing for packed storage
- * for lower triangular
- *
- * ---------------------------
- * 0
- * 1      n
- * *      (n+1)
- * *
- * (n-1)  ...        n*(n+1)/2
- * ---------------------------
- **/
-template <typename I>
-__device__ static I idx_lower(I i, I j, I n)
-{
-    assert((0 <= i) && (i <= (n - 1)));
-    assert((0 <= j) && (j <= (n - 1)));
-    assert(i >= j);
-
-    return ((i - j) + (j * (2 * n + 1 - j)) / 2);
-}
-
-/**
- * ------------------------------------------------------
- * Perform Cholesky factorization for small n by n matrix.
- * The function executes in a single thread block.
- * ------------------------------------------------------
-**/
-template <typename T, typename I, typename INFO>
-__device__ static void potf2_simple(bool const is_upper, I const n, T* const A, INFO* const info)
-{
-    auto const lda = n;
-    bool const is_lower = (!is_upper);
-
-    auto const i_start = hipThreadIdx_x;
-    auto const i_inc = hipBlockDim_x;
-    auto const j_start = hipThreadIdx_y;
-    auto const j_inc = hipBlockDim_y;
-    assert(hipBlockDim_z == 1);
-
-    auto const tid = hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x
-        + hipThreadIdx_z * (hipBlockDim_x * hipBlockDim_y);
-    auto const nthreads = (hipBlockDim_x * hipBlockDim_y) * hipBlockDim_z;
-
-    auto const j0_start = tid;
-    auto const j0_inc = nthreads;
-
-    if(is_lower)
-    {
-        // ---------------------------------------------------
-        // [  l11     ]  * [ l11'   vl21' ]  =  [ a11       ]
-        // [ vl21  L22]    [        L22' ]     [ va21, A22 ]
-        //
-        //
-        //   assume l11 is scalar 1x1 matrix
-        //
-        //   (1) l11 * l11' = a11 =>  l11 = sqrt( abs(a11) ), scalar computation
-        //   (2) vl21 * l11' = va21 =>  vl21 = va21/ l11', scale vector
-        //   (3) L22 * L22' + vl21 * vl21' = A22
-        //
-        //   (3a) A22 = A22 - vl21 * vl21',  symmetric rank-1 update
-        //   (3b) L22 * L22' = A22,   cholesky factorization, tail recursion
-        // ---------------------------------------------------
-
-        for(I kcol = 0; kcol < n; kcol++)
-        {
-            auto kk = idx_lower(kcol, kcol, lda);
-            auto const akk = std::real(A[kk]);
-            bool const isok = (akk > 0) && (std::isfinite(akk));
-            if(!isok)
-            {
-                if(tid == 0)
-                {
-                    A[kk] = akk;
-                    // Fortran 1-based index
-                    if(*info == 0)
-                        *info = kcol + 1;
-                }
-                break;
-            }
-
-            auto const lkk = std::sqrt(akk);
-            if(tid == 0)
-            {
-                A[kk] = lkk;
-            }
-
-            __syncthreads();
-
-            // ------------------------------------------------------------
-            //   (2) vl21 * l11' = va21 =>  vl21 = va21/ l11', scale vector
-            // ------------------------------------------------------------
-
-            auto const conj_lkk = conj(lkk);
-            for(I j0 = (kcol + 1) + j0_start; j0 < n; j0 += j0_inc)
-            {
-                auto const j0k = idx_lower(j0, kcol, lda);
-
-                A[j0k] = (A[j0k] / conj_lkk);
-            }
-
-            __syncthreads();
-
-            // ------------------------------------------------------------
-            //   (3a) A22 = A22 - vl21 * vl21',  symmetric rank-1 update
-            //
-            //   note: update lower triangular part
-            // ------------------------------------------------------------
-
-            for(I j = (kcol + 1) + j_start; j < n; j += j_inc)
-            {
-                auto const vj = A[idx_lower(j, kcol, lda)];
-                for(I i = (kcol + 1) + i_start; i < n; i += i_inc)
-                {
-                    bool const lower_part = (i >= j);
-                    if(lower_part)
-                    {
-                        auto const vi = A[idx_lower(i, kcol, lda)];
-                        auto const ij = idx_lower(i, j, lda);
-
-                        A[ij] = A[ij] - vi * conj(vj);
-                    }
-                }
-            }
-
-            __syncthreads();
-
-        } // end for kcol
-    }
-    else
-    {
-        // --------------------------------------------------
-        // [u11'        ] * [u11    vU12 ] = [ a11     vA12 ]
-        // [vU12'   U22']   [       U22  ]   [ vA12'   A22  ]
-        //
-        // (1) u11' * u11 = a11 =?  u11 = sqrt( abs( a11 ) )
-        // (2) vU12' * u11 = vA12', or u11' * vU12 = vA12
-        //     or vU12 = vA12/u11'
-        // (3) vU12' * vU12 + U22'*U22 = A22
-        //
-        // (3a) A22 = A22 - vU12' * vU12
-        // (3b) U22' * U22 = A22,  cholesky factorization, tail recursion
-        // --------------------------------------------------
-
-        for(I kcol = 0; kcol < n; kcol++)
-        {
-            auto const kk = idx_upper(kcol, kcol, lda);
-            auto const akk = std::real(A[kk]);
-            bool const isok = (akk > 0) && (std::isfinite(akk));
-            if(!isok)
-            {
-                if(tid == 0)
-                {
-                    A[kk] = akk;
-                    // Fortran 1-based index
-                    if(*info == 0)
-                        *info = kcol + 1;
-                }
-
-                break;
-            }
-
-            auto const ukk = std::sqrt(akk);
-            if(tid == 0)
-            {
-                A[kk] = ukk;
-            }
-            __syncthreads();
-
-            // ----------------------------------------------
-            // (2) vU12' * u11 = vA12', or u11' * vU12 = vA12
-            // ----------------------------------------------
-            for(I j0 = (kcol + 1) + j0_start; j0 < n; j0 += j0_inc)
-            {
-                auto const kj0 = idx_upper(kcol, j0, lda);
-
-                A[kj0] = A[kj0] / ukk;
-            }
-
-            __syncthreads();
-
-            // -----------------------------
-            // (3a) A22 = A22 - vU12' * vU12
-            //
-            // note: update upper triangular part
-            // -----------------------------
-            for(I j = (kcol + 1) + j_start; j < n; j += j_inc)
-            {
-                auto const vj = A[idx_upper(kcol, j, lda)];
-                for(I i = (kcol + 1) + i_start; i < n; i += i_inc)
-                {
-                    bool const upper_part = (i <= j);
-                    if(upper_part)
-                    {
-                        auto const vi = A[idx_upper(kcol, i, lda)];
-                        auto const ij = idx_upper(i, j, lda);
-
-                        A[ij] = A[ij] - conj(vi) * vj;
-                    }
-                }
-            }
-
-            __syncthreads();
-
-        } // end for kcol
-    }
-}
-
-/*************************************************************
-    Templated kernels are instantiated in separate cpp
-    files in order to improve compilation times and reduce
-    the library size.
-*************************************************************/
-
-template <typename T, typename I, typename INFO, typename U>
+template <int NB, int PANEL_SIZE, typename T, typename I, typename INFO, typename U>
 ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
                                          const I n,
                                          U AA,
@@ -283,121 +47,6 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
                                          const I lda,
                                          const rocblas_stride strideA,
                                          INFO* const info)
-{
-    bool const is_lower = (!is_upper);
-
-    auto const i_start = hipThreadIdx_x;
-    auto const i_inc = hipBlockDim_x;
-    auto const j_start = hipThreadIdx_y;
-    auto const j_inc = hipBlockDim_y;
-    assert(hipBlockDim_z == 1);
-
-    // --------------------------------
-    // note hipGridDim_z == batch_count
-    // --------------------------------
-    auto const bid = hipBlockIdx_z;
-    assert(AA != nullptr);
-    assert(info != nullptr);
-
-    T* const A = load_ptr_batch(AA, bid, shiftA, strideA);
-    INFO* const info_bid = info + bid;
-
-    assert(A != nullptr);
-
-    // -----------------------------------------
-    // assume n by n matrix will fit in LDS cache
-    // -----------------------------------------
-    extern __shared__ rocblas_int lsmem[];
-    T* Ash = reinterpret_cast<T*>(lsmem);
-
-    // --------------------------------------------------------
-    // factoring Lower triangular matrix may be slightly faster
-    // due to simpler index calculation down a column
-    // --------------------------------------------------------
-    bool const use_compute_lower = true;
-
-    // ------------------------------------
-    // copy n by n packed matrix into shared memory
-    // ------------------------------------
-    __syncthreads();
-
-    if(is_lower)
-    {
-        for(I j = j_start; j < n; j += j_inc)
-        {
-            for(I i = j + i_start; i < n; i += i_inc)
-            {
-                auto const ij = i + j * static_cast<int64_t>(lda);
-                auto const ij_packed = idx_lower(i, j, n);
-
-                Ash[ij_packed] = A[ij];
-            }
-        }
-    }
-    else
-    {
-        for(I j = j_start; j < n; j += j_inc)
-        {
-            for(I i = i_start; i <= j; i += i_inc)
-            {
-                auto const ij = i + j * static_cast<int64_t>(lda);
-                auto const ij_packed = (use_compute_lower) ? idx_lower(j, i, n) : idx_upper(i, j, n);
-
-                auto const aij = A[ij];
-                Ash[ij_packed] = (use_compute_lower) ? conj(aij) : aij;
-            }
-        }
-    }
-
-    __syncthreads();
-
-    bool const is_up = (use_compute_lower) ? false : is_upper;
-    potf2_simple<T>(is_up, n, Ash, info_bid);
-
-    __syncthreads();
-
-    // -------------------------------------
-    // copy n by n packed matrix into global memory
-    // -------------------------------------
-    if(is_lower)
-    {
-        for(I j = j_start; j < n; j += j_inc)
-        {
-            for(I i = j + i_start; i < n; i += i_inc)
-            {
-                auto const ij = i + j * static_cast<int64_t>(lda);
-                auto const ij_packed = idx_lower(i, j, n);
-
-                A[ij] = Ash[ij_packed];
-            }
-        }
-    }
-    else
-    {
-        for(I j = j_start; j < n; j += j_inc)
-        {
-            for(I i = i_start; i <= j; i += i_inc)
-            {
-                auto const ij = i + j * static_cast<int64_t>(lda);
-                auto const ij_packed = (use_compute_lower) ? idx_lower(j, i, n) : idx_upper(i, j, n);
-
-                auto const aij_packed = Ash[ij_packed];
-                A[ij] = (use_compute_lower) ? conj(aij_packed) : aij_packed;
-            }
-        }
-    }
-
-    __syncthreads();
-}
-
-template <int NB, int PANEL_SIZE, typename T, typename I, typename INFO, typename U>
-ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
-                                                  const I n,
-                                                  U AA,
-                                                  const rocblas_stride shiftA,
-                                                  const I lda,
-                                                  const rocblas_stride strideA,
-                                                  INFO* const info)
 {
     bool const is_lower = (!is_upper);
 
@@ -426,14 +75,14 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
     T Arg[(NB * (NB + 1)) / 2] = {0};
 
     I arg_idx = 0;
-    for(I j = 0; j < NB; j++)
+    for(I jb = 0; jb < NB; jb++)
     {
-        for(I i = j; i < NB; i++)
+        for(I i = jb; i < NB; i++)
         {
             if(is_upper)
             {
                 const auto col = i * PANEL_SIZE + tidy;
-                const auto row = j * PANEL_SIZE + tidx;
+                const auto row = jb * PANEL_SIZE + tidx;
                 if(col < n && row < n && row <= col)
                 {
                     const auto idx = col * lda + row;
@@ -442,7 +91,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             }
             else
             {
-                const auto col = j * PANEL_SIZE + tidy;
+                const auto col = jb * PANEL_SIZE + tidy;
                 const auto row = i * PANEL_SIZE + tidx;
                 if(col < n && row < n && row >= col)
                 {
@@ -457,10 +106,10 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
 
     // Panel Cholesky decomposition
     arg_idx = 0;
-    for(I j = 0; j < NB; j++)
+    for(I kb = 0; kb < NB; kb++)
     {
         // write panel to lds
-        for(I i = 0; i < NB - j; i++)
+        for(I i = 0; i < NB - kb; i++)
         {
             // write to lds as lower and compute as lower
             if(is_upper)
@@ -479,7 +128,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
 
         __syncthreads();
 
-        I nn = n - j * PANEL_SIZE;
+        I nn = n - kb * PANEL_SIZE;
 
         // factorize panel
         for(I kcol = 0; kcol < PANEL_SIZE; kcol++)
@@ -500,7 +149,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
                     Ash[kk] = akk;
                     // Fortran 1-based index
                     if(*info_bid == 0)
-                        *info_bid = j * PANEL_SIZE + kcol + 1;
+                        *info_bid = kb * PANEL_SIZE + kcol + 1;
                 }
                 failed = true;
                 __syncthreads();
@@ -548,37 +197,37 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
         }
 
         // update trailing matrix
-        I karg_idx = arg_idx + NB - j;
-        for(I k = j + 1; k < NB; k++)
+        I upd_arg_idx = arg_idx + NB - kb;
+        for(I j = kb + 1; j < NB; j++)
         {
-            for(I i = k; i < NB; i++)
+            for(I i = j; i < NB; i++)
             {
                 if(is_upper)
                 {
-                    const auto col = (i - j) * PANEL_SIZE + tidy;
-                    const auto row = (k - j) * PANEL_SIZE + tidx;
+                    const auto col = (i - kb) * PANEL_SIZE + tidy;
+                    const auto row = (j - kb) * PANEL_SIZE + tidx;
 
                     for(I p = 0; p < PANEL_SIZE; p++)
                     {
-                        Arg[karg_idx + i - k] -= conj(Ash[row + p * ldash]) * Ash[col + p * ldash];
+                        Arg[upd_arg_idx + i - j] -= conj(Ash[row + p * ldash]) * Ash[col + p * ldash];
                     }
                 }
                 else
                 {
-                    const auto col = (k - j) * PANEL_SIZE + tidy;
-                    const auto row = (i - j) * PANEL_SIZE + tidx;
+                    const auto col = (j - kb) * PANEL_SIZE + tidy;
+                    const auto row = (i - kb) * PANEL_SIZE + tidx;
 
                     for(I p = 0; p < PANEL_SIZE; p++)
                     {
-                        Arg[karg_idx + i - k] -= Ash[row + p * ldash] * conj(Ash[col + p * ldash]);
+                        Arg[upd_arg_idx + i - j] -= Ash[row + p * ldash] * conj(Ash[col + p * ldash]);
                     }
                 }
             }
-            karg_idx += NB - k;
+            upd_arg_idx += NB - j;
         }
 
         // load panel back to registers
-        for(I i = 0; i < NB - j; i++)
+        for(I i = 0; i < NB - kb; i++)
         {
             if(is_upper)
             {
@@ -593,7 +242,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
                 Arg[arg_idx + i] = Ash[idx];
             }
         }
-        arg_idx += NB - j;
+        arg_idx += NB - kb;
 
         __syncthreads();
 
@@ -603,14 +252,14 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
 
     // write A from registers
     arg_idx = 0;
-    for(I j = 0; j < NB; j++)
+    for(I jb = 0; jb < NB; jb++)
     {
-        for(I i = j; i < NB; i++)
+        for(I i = jb; i < NB; i++)
         {
             if(is_upper)
             {
                 const auto col = i * PANEL_SIZE + tidy;
-                const auto row = j * PANEL_SIZE + tidx;
+                const auto row = jb * PANEL_SIZE + tidx;
                 if(col < n && row < n && row <= col)
                 {
                     const auto idx = col * lda + row;
@@ -619,7 +268,7 @@ ROCSOLVER_KERNEL void potf2_register_kernel_small(const bool is_upper,
             }
             else
             {
-                const auto col = j * PANEL_SIZE + tidy;
+                const auto col = jb * PANEL_SIZE + tidy;
                 const auto row = i * PANEL_SIZE + tidx;
                 if(col < n && row < n && row >= col)
                 {
@@ -659,14 +308,11 @@ rocblas_status potf2_run_small(rocblas_handle handle,
     size_t lmemsize = sizeof(T) * nb * BS2 * BS2;
 
     bool const is_upper = (uplo == rocblas_fill_upper);
-    auto kernel = std::array{potf2_register_kernel_small<1, BS2, T, I, INFO, U>,
-                             potf2_register_kernel_small<2, BS2, T, I, INFO, U>,
-                             potf2_register_kernel_small<3, BS2, T, I, INFO, U>,
-                             potf2_register_kernel_small<4, BS2, T, I, INFO, U>,
-                             potf2_register_kernel_small<5, BS2, T, I, INFO, U>,
-                             potf2_register_kernel_small<6, BS2, T, I, INFO, U>,
-                             potf2_register_kernel_small<7, BS2, T, I, INFO, U>,
-                             potf2_register_kernel_small<8, BS2, T, I, INFO, U>};
+    auto kernel = std::array{
+        potf2_kernel_small<1, BS2, T, I, INFO, U>, potf2_kernel_small<2, BS2, T, I, INFO, U>,
+        potf2_kernel_small<3, BS2, T, I, INFO, U>, potf2_kernel_small<4, BS2, T, I, INFO, U>,
+        potf2_kernel_small<5, BS2, T, I, INFO, U>, potf2_kernel_small<6, BS2, T, I, INFO, U>,
+        potf2_kernel_small<7, BS2, T, I, INFO, U>, potf2_kernel_small<8, BS2, T, I, INFO, U>};
     ROCSOLVER_LAUNCH_KERNEL(kernel[nb - 1], dim3(1, 1, batch_count), dim3(BS2, BS2, 1), lmemsize,
                             stream, is_upper, n, A, shiftA, lda, strideA, info);
 

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -80,7 +80,14 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
 
     bool failed = false;
 
-    // load A to registers
+    /* -----------------------------------------------------------
+    Load PANEL_SIZE x PANEL_SIZE blocks of A into registers. Where
+    each thread in a workgroup has a corresponding element in the
+    matrix block.
+    If uplo == rocblas_fill_upper then only the upper triangular
+    blocks are stored, otherwise only the lower triangular blocks
+    are stored.
+    ----------------------------------------------------------- */
     T Arg[(NB * (NB + 1)) / 2] = {0};
 
     I arg_idx = 0;
@@ -113,11 +120,17 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
         }
     }
 
-    // Panel Cholesky decomposition
+    /* ---------------------------------------------------------
+    Panel Cholesky decomposition: iterate through each panel and
+    decompose in LDS. Update the trailing matrix in register.
+    --------------------------------------------------------- */
     arg_idx = 0;
     for(I kb = 0; kb < NB; kb++)
     {
-        // write panel to lds
+        /* --------------------------------------------------------
+        Write panel A(kb:kb+PANEL_SIZE, kb:N)^T to LDS if upper,
+        or A(kb:N, kb:kb+PANEL_SIZE) otherwise. (N = NB*PANEL_SIZE)
+        -------------------------------------------------------- */
         for(I i = 0; i < NB - kb; i++)
         {
             // write to lds as lower and compute as lower
@@ -139,7 +152,9 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
 
         I nn = n - kb * PANEL_SIZE;
 
-        // factorize panel
+        /* ----------------------------
+        Factor panel matrix Ash in LDS.
+        ---------------------------- */
         for(I kcol = 0; kcol < PANEL_SIZE; kcol++)
         {
             if(kcol >= nn)
@@ -165,6 +180,10 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
                 break;
             }
 
+            // -----------------------------------------------------
+            //   (1) |l11|^2 = a11 =>  l11 = sqrt(a11), get diagonal
+            // -----------------------------------------------------
+
             auto const lkk = std::sqrt(akk);
             if(tid == 0)
             {
@@ -185,11 +204,11 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
 
             __syncthreads();
 
-            // ------------------------------------------------------------
-            //   (3a) A22 = A22 - vl21 * vl21',  symmetric rank-1 update
+            // --------------------------------------------------------------
+            //   (3a) A22 = A22 - vl21 * vl21(0:PANEL_SIZE)', update trailing
             //
-            //   note: update lower triangular part
-            // ------------------------------------------------------------
+            //   note: only update elements below the diagonal
+            // --------------------------------------------------------------
 
             for(I j = (kcol + 1) + tidy; j < PANEL_SIZE; j += hipBlockDim_y)
             {
@@ -205,7 +224,9 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
             __syncthreads();
         }
 
-        // update trailing matrix
+        /* ------------------------------------
+        Update the trailing matrix in register.
+        ------------------------------------ */
         I upd_arg_idx = arg_idx + NB - kb;
         for(I j = kb + 1; j < NB; j++)
         {
@@ -213,6 +234,13 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
             {
                 if(is_upper)
                 {
+                    // ---------------------------------------------------------------------------------
+                    // formulate gemm problem:
+                    //    A22 = A(kb+PANEL_SIZE:N, kb+PANEL_SIZE:N)
+                    //    A12 = Ash(PANEL_SIZE:N, 0:PANEL_SIZE)^T = A(kb:kb+PANEL_SIZE, kb+PANEL_SIZE:N)
+                    //
+                    //    operation: A22 = A12' * A12
+                    // ---------------------------------------------------------------------------------
                     const auto col = (i - kb) * PANEL_SIZE + tidy;
                     const auto row = (j - kb) * PANEL_SIZE + tidx;
 
@@ -223,6 +251,13 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
                 }
                 else
                 {
+                    // -------------------------------------------------------------------------------
+                    // formulate gemm problem:
+                    //    A22 = A(kb+PANEL_SIZE:N, kb+PANEL_SIZE:N)
+                    //    A21 = Ash(PANEL_SIZE:N, 0:PANEL_SIZE) = A(kb+PANEL_SIZE:N, kb:kb+PANEL_SIZE)
+                    //
+                    //    operation: A22 = A21 * A21'
+                    // -------------------------------------------------------------------------------
                     const auto col = (j - kb) * PANEL_SIZE + tidy;
                     const auto row = (i - kb) * PANEL_SIZE + tidx;
 
@@ -235,7 +270,9 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
             upd_arg_idx += NB - j;
         }
 
-        // load panel back to registers
+        /* ---------------------------------
+        Load panel in LDS back to registers.
+        --------------------------------- */
         for(I i = 0; i < NB - kb; i++)
         {
             if(is_upper)
@@ -259,7 +296,9 @@ ROCSOLVER_KERNEL void potf2_kernel_small(const bool is_upper,
             break;
     }
 
-    // write A from registers
+    /* ----------------------------------------------------
+    Write blocks of the matrix in registers back to memory.
+    ---------------------------------------------------- */
     arg_idx = 0;
     for(I jb = 0; jb < NB; jb++)
     {

--- a/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
+++ b/projects/rocsolver/library/src/specialized/roclapack_potf2_specialized_kernels.hpp
@@ -47,7 +47,7 @@ ROCSOLVER_BEGIN_NAMESPACE
  *
  * NB           Number of panels to perform blocked decomposition.
  *              ceildiv(n, PANEL_SIZE)
- * PANEL_SIZE   Size of panel to perform non-blocked decompostion.
+ * PANEL_SIZE   Size of panel to perform non-blocked decomposition.
  *              PANEL_SIZE == BlockDim.x == BlockDim.y
 **/
 template <int NB, int PANEL_SIZE, typename T, typename I, typename INFO, typename U>


### PR DESCRIPTION
## Motivation
This PR adds a new POTF2 kernel to improve the performance of POTF2 and POTRF.

## Technical Details
The new kernel performs right looking panel Cholesky decomposition. Elements of the matrix are stored in register and updated in place or in LDS. A panel is factored in LDS and the remaining elements are updated while remaining in register.

A few test cases have been added to cover additional edge cases.

## Test Plan
Run rocsolver-test to verify correctness.
Run benchmarks to validate performance improvements.

## Test Result
waiting for CI results.
Local test shows 1.2-1.6x speedup to POTRF on MI300a.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
