### PR TITLE
[Origami] Add grid_selection mode to gemm config

### DIFF
--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -261,7 +261,7 @@ struct runtime_options {
 
   /**
    * @brief Get the global runtime options instance.
-   * 
+   *
    * Inline to prevent ODR violations when included in multiple shared libraries.
    * Static local variable ensures only one instance exists across all translation units. (PR#1862)
    */
@@ -323,6 +323,9 @@ struct config_t {
 
   /// Reduction strategy.
   reduction_t reduction_strategy = reduction_t::none;
+
+  /// Grid selection algorithm.
+  grid_selection_t grid_selection = grid_selection_t::k_split_aware;
 
   constexpr bool operator==(const config_t& o) const noexcept {
     return mt == o.mt && mi == o.mi && cache_hints_a == o.cache_hints_a &&
@@ -410,6 +413,8 @@ struct hash<origami::matrix_instruction> {
 
 template <>
 struct hash<origami::config_t> {
-  inline std::size_t operator()(const origami::config_t& config) const noexcept { return config.hash(); }
+  inline std::size_t operator()(const origami::config_t& config) const noexcept {
+    return config.hash();
+  }
 };
 }  // namespace std

--- a/shared/origami/python/origami_module.cpp
+++ b/shared/origami/python/origami_module.cpp
@@ -119,7 +119,8 @@ NB_MODULE(origami, m) {
       .def_rw("cache_hints_a", &origami::config_t::cache_hints_a)
       .def_rw("cache_hints_b", &origami::config_t::cache_hints_b)
       .def_rw("workspace_size", &origami::config_t::workspace_size)
-      .def_rw("workspace_size_per_elem_c", &origami::config_t::workspace_size_per_elem_c);
+      .def_rw("workspace_size_per_elem_c", &origami::config_t::workspace_size_per_elem_c)
+      .def_rw("grid_selection", &origami::config_t::grid_selection);
 
   nanobind::class_<origami::prediction_result_t>(m, "prediction_result_t")
       .def(nanobind::init<>())

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -371,7 +371,8 @@ double estimate_l2_hit(const problem_t& problem,
 
   // Number of CUs that might share the same K-tiles, adjusted for K-splitting.
   // This affects contention on the L2 cache partitions (XCDs).
-  const size_t effective_cus = math::safe_ceil_div(concurrent_workgroups, splitting_factor * problem.batch);
+  const size_t effective_cus =
+      math::safe_ceil_div(concurrent_workgroups, splitting_factor * problem.batch);
   const size_t cu_per_xcd =
       std::max(math::safe_ceil_div(effective_cus, hardware.NUM_XCD), static_cast<size_t>(1));
 
@@ -657,8 +658,9 @@ double compute_memory_latency(const problem_t& problem,
   mall_m = std::max(std::min(grid_m, mall_m), static_cast<size_t>(1));
   mall_n = std::max(std::min(grid_n, mall_n), static_cast<size_t>(1));
   // This is the minimum unique bytes needed from HBM to feed the concurrent workgroups.
-  double concurrent_batches = std::min(static_cast<double>(problem.batch),
-      std::max(static_cast<double>(num_active_cus) / (grid_m * grid_n), 1.));
+  double concurrent_batches =
+      std::min(static_cast<double>(problem.batch),
+               std::max(static_cast<double>(num_active_cus) / (grid_m * grid_n), 1.));
   double min_load = static_cast<double>((mall_m * config.mt.mk() * a_bytes) +
                                         (mall_n * config.mt.nk() * b_bytes)) *
                     concurrent_batches;  // Apply batching to the minimum load itself.
@@ -816,7 +818,8 @@ double compute_timestep_latency(const problem_t& problem,
                                 size_t num_active_cus,
                                 size_t splitting_factor) {
   // Assume latency of a timestep is latency of a single K-complete output tile computed on one CU.
-  double L_timestep = compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor);
+  double L_timestep =
+      compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor);
 
   return L_timestep;
 }
@@ -883,13 +886,14 @@ double compute_total_latency(const problem_t& problem,
   }
 
   // 1-1) To compute the latency, use default WGM. And WGM can't be greater than one
-  int defaultWGM = batch > 1 ? 1 : static_cast<int>(ceil(std::sqrt(hardware.N_CU / hardware.NUM_XCD)));
+  int defaultWGM =
+      batch > 1 ? 1 : static_cast<int>(ceil(std::sqrt(hardware.N_CU / hardware.NUM_XCD)));
   auto config_with_default_wgm              = config;
   config_with_default_wgm.workgroup_mapping = std::max(defaultWGM, 1);
 
   // 1-2) Find CU occupancy
   auto [num_wgs, num_active_cus, num_timesteps, splitting_factor] = compute_cu_occupancy(
-      problem, hardware, config_with_default_wgm, grid_selection_t::k_split_aware, max_cus);
+      problem, hardware, config_with_default_wgm, config_with_default_wgm.grid_selection, max_cus);
 
   // 2) Compute latency of a timestep
   double L_timestep = compute_timestep_latency(


### PR DESCRIPTION
## Motivation

The `grid_selection_t` parameter was hardcoded as `k_split_aware` in `gemm.cpp` when calling `compute_cu_occupancy()`. This prevented users from calling with different grid selection algorithms, which are critical for optimizing kernel performance across different frameworks.

## Technical Details
This PR adds a `grid_selection` field to the `config_t` structure in `shared/origami/include/origami/types.hpp` with a default value of `grid_selection_t::k_split_aware` to maintain backward compatibility. The hardcoded `grid_selection_t::k_split_aware` parameter in `shared/origami/src/origami/gemm.cpp` (line ~1009) was replaced with `config_with_default_wgm.grid_selection`, allowing the configuration to control which grid selection algorithm is used. Finally, the Python bindings in `shared/origami/python/origami_module.cpp` were updated to expose the `grid_selection` field via `.def_rw("grid_selection", &origami::config_t::grid_selection)`, enabling Python users to read and modify this parameter. The `grid_selection_t` enum was already exposed in the Python API, so no additional enum binding was needed.

## Test Plan
CI

## Test Result
(See Below)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
