### PR TITLE
[hipDNN] Fix backend & data_sdk CMake packaging

### DIFF
--- a/projects/hipdnn/backend/cmake/hipdnn_backendConfig.cmake.in
+++ b/projects/hipdnn/backend/cmake/hipdnn_backendConfig.cmake.in
@@ -1,0 +1,16 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Find dependencies
+find_dependency(hip CONFIG REQUIRED)
+find_dependency(hipdnn_data_sdk CONFIG REQUIRED)
+find_dependency(hipdnn_plugin_sdk CONFIG REQUIRED)
+
+# Include the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/hipdnn_backendTargets.cmake")
+
+check_required_components(hipdnn_backend)

--- a/projects/hipdnn/backend/cmake/hipdnn_backendConfig.cmake.in
+++ b/projects/hipdnn/backend/cmake/hipdnn_backendConfig.cmake.in
@@ -5,10 +5,8 @@
 
 include(CMakeFindDependencyMacro)
 
-# Find dependencies
+# Find C-API dependencies
 find_dependency(hip CONFIG REQUIRED)
-find_dependency(hipdnn_data_sdk CONFIG REQUIRED)
-find_dependency(hipdnn_plugin_sdk CONFIG REQUIRED)
 
 # Include the targets file
 include("${CMAKE_CURRENT_LIST_DIR}/hipdnn_backendTargets.cmake")

--- a/projects/hipdnn/backend/include/HipdnnBackendCallbackTypes.h
+++ b/projects/hipdnn/backend/include/HipdnnBackendCallbackTypes.h
@@ -10,8 +10,8 @@ extern "C" {
 // This file's definitions are duplicated from the data_sdk CallbackTypes.h.
 // Please ensure any updates are synced between the two files!
 
-// Definition guard to avoid redefinition
 #ifndef HIPDNN_CALLBACK_TYPES_DEFINED
+#define HIPDNN_CALLBACK_TYPES_DEFINED
 
 /**
  * @brief Severity levels for logging in hipDNN
@@ -34,9 +34,6 @@ typedef enum
 typedef void (*hipdnnCallback_t)(hipdnnSeverity_t severity, const char* message);
 
 #endif // HIPDNN_CALLBACK_TYPES_DEFINED
-
-// Mark that callback types are defined, so other headers can check this
-#define HIPDNN_CALLBACK_TYPES_DEFINED
 
 #ifdef __cplusplus
 }

--- a/projects/hipdnn/backend/include/HipdnnBackendCallbackTypes.h
+++ b/projects/hipdnn/backend/include/HipdnnBackendCallbackTypes.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-// This file's definitions are duplicated by HipdnnBackendCallbackTypes.h.
+// This file's definitions are duplicated from the data_sdk CallbackTypes.h.
 // Please ensure any updates are synced between the two files!
 
 // Definition guard to avoid redefinition

--- a/projects/hipdnn/backend/include/hipdnn_backend.h
+++ b/projects/hipdnn/backend/include/hipdnn_backend.h
@@ -10,12 +10,12 @@
 
 #include "HipdnnBackendAttributeName.h"
 #include "HipdnnBackendAttributeType.h"
+#include "HipdnnBackendCallbackTypes.h"
 #include "HipdnnBackendDescriptorType.h"
 #include "HipdnnBackendHeuristicType.h"
 #include "HipdnnBackendLimits.h"
 #include "HipdnnBackendPluginLoadingMode.h"
 #include "HipdnnStatus.h"
-#include <hipdnn_data_sdk/logging/CallbackTypes.h>
 
 // NOLINTBEGIN
 #ifdef __cplusplus

--- a/projects/hipdnn/backend/src/CMakeLists.txt
+++ b/projects/hipdnn/backend/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Copyright © Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
+include(CMakePackageConfigHelpers)
+
 find_package(hip REQUIRED)
 
 set(HIP_DNN_BACKEND_EXPORT_INCLUDE_DIR "${PROJECT_BINARY_DIR}/backend/include/")
@@ -51,6 +53,12 @@ target_include_directories(
            $<BUILD_INTERFACE:${HIP_DNN_BACKEND_EXPORT_INCLUDE_DIR}>
 )
 
+# Backend headers include HIP headers, so both backend and consumers need this definition
+# Use INTERFACE to ensure it's exported to consumers (SHARED libraries don't export PUBLIC properly)
+target_compile_definitions(hipdnn_backend PUBLIC __HIP_PLATFORM_AMD__)
+# Also define it privately for building the backend itself
+# target_compile_definitions(hipdnn_backend PRIVATE __HIP_PLATFORM_AMD__)
+
 target_compile_options(hipdnn_backend PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 # This definition is used to enable logging in the backend.  It is #ifdef'ed in the backend code.
 # This is to stop the frontend/plugin from having lazy log initialization which will end up with the
@@ -58,6 +66,8 @@ target_compile_options(hipdnn_backend PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 # different name.
 target_compile_definitions(hipdnn_backend PRIVATE HIPDNN_BACKEND_COMPILATION)
 target_link_libraries(hipdnn_backend PRIVATE hipdnn_backend_private)
+# Export dependencies for consumers - backend headers include HIP and data_sdk headers
+target_link_libraries(hipdnn_backend INTERFACE hip::host hipdnn_data_sdk)
 # HIDE symbols from linked static libs
 target_link_libraries(hipdnn_backend PRIVATE "-Xlinker --exclude-libs=ALL")
 set_target_properties(hipdnn_backend PROPERTIES CXX_VISIBILITY_PRESET hidden)
@@ -79,7 +89,7 @@ install(
 
 export(
     TARGETS hipdnn_backend
-    FILE ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_backend/hipdnn_backendConfig.cmake
+    FILE ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_backend/hipdnn_backendTargets.cmake
 )
 
 install(
@@ -95,5 +105,16 @@ install(FILES ${HIP_DNN_BACKEND_EXPORT_INCLUDE_DIR}/hipdnn_backend_export.h
 )
 
 install(EXPORT hipdnn_backend_targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_backend
-        FILE hipdnn_backendConfig.cmake COMPONENT Development
+        FILE hipdnn_backendTargets.cmake COMPONENT Development
+)
+
+# Generate the Config.cmake file from template
+configure_package_config_file(
+    "${CMAKE_CURRENT_LIST_DIR}/../cmake/hipdnn_backendConfig.cmake.in"
+    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_backend/hipdnn_backendConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_backend
+)
+
+install(FILES "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_backend/hipdnn_backendConfig.cmake"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipdnn_backend COMPONENT Development
 )

--- a/projects/hipdnn/backend/src/CMakeLists.txt
+++ b/projects/hipdnn/backend/src/CMakeLists.txt
@@ -64,8 +64,8 @@ target_compile_options(hipdnn_backend PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 # different name.
 target_compile_definitions(hipdnn_backend PRIVATE HIPDNN_BACKEND_COMPILATION)
 target_link_libraries(hipdnn_backend PRIVATE hipdnn_backend_private)
-# Export dependencies for consumers - backend headers include HIP and data_sdk headers
-target_link_libraries(hipdnn_backend INTERFACE hip::host hipdnn_data_sdk)
+# Export dependencies for consumers - backend public API only needs HIP
+target_link_libraries(hipdnn_backend INTERFACE hip::host)
 # HIDE symbols from linked static libs
 target_link_libraries(hipdnn_backend PRIVATE "-Xlinker --exclude-libs=ALL")
 set_target_properties(hipdnn_backend PROPERTIES CXX_VISIBILITY_PRESET hidden)

--- a/projects/hipdnn/backend/src/CMakeLists.txt
+++ b/projects/hipdnn/backend/src/CMakeLists.txt
@@ -54,10 +54,8 @@ target_include_directories(
 )
 
 # Backend headers include HIP headers, so both backend and consumers need this definition
-# Use INTERFACE to ensure it's exported to consumers (SHARED libraries don't export PUBLIC properly)
+# Use PUBLIC to ensure it's exported to consumers
 target_compile_definitions(hipdnn_backend PUBLIC __HIP_PLATFORM_AMD__)
-# Also define it privately for building the backend itself
-# target_compile_definitions(hipdnn_backend PRIVATE __HIP_PLATFORM_AMD__)
 
 target_compile_options(hipdnn_backend PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 # This definition is used to enable logging in the backend.  It is #ifdef'ed in the backend code.

--- a/projects/hipdnn/backend/src/CMakeLists.txt
+++ b/projects/hipdnn/backend/src/CMakeLists.txt
@@ -64,7 +64,7 @@ target_compile_options(hipdnn_backend PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 # different name.
 target_compile_definitions(hipdnn_backend PRIVATE HIPDNN_BACKEND_COMPILATION)
 target_link_libraries(hipdnn_backend PRIVATE hipdnn_backend_private)
-# Export dependencies for consumers - backend public API only needs HIP
+# Export dependencies for consumers because backend public API needs HIP runtime dep
 target_link_libraries(hipdnn_backend INTERFACE hip::host)
 # HIDE symbols from linked static libs
 target_link_libraries(hipdnn_backend PRIVATE "-Xlinker --exclude-libs=ALL")

--- a/projects/hipdnn/backend/src/HipdnnBackend.cpp
+++ b/projects/hipdnn/backend/src/HipdnnBackend.cpp
@@ -13,7 +13,6 @@
 #include "logging/Logging.hpp"
 #include "plugin/EnginePluginResourceManager.hpp"
 
-#include <hipdnn_data_sdk/logging/CallbackTypes.h>
 #include <hipdnn_data_sdk/utilities/StringUtil.hpp>
 
 using namespace hipdnn_backend;

--- a/projects/hipdnn/backend/src/logging/Logging.cpp
+++ b/projects/hipdnn/backend/src/logging/Logging.cpp
@@ -4,12 +4,12 @@
 #include "Logging.hpp"
 #include "PlatformUtils.hpp"
 
+#include <hipdnn_data_sdk/logging/CallbackTypes.h>
 #include <hipdnn_data_sdk/logging/ComponentFormatter.hpp>
 #include <hipdnn_data_sdk/logging/LoggingUtils.hpp>
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
 #include <iostream>
 
-#include <hipdnn_data_sdk/logging/CallbackTypes.h>
 #include <spdlog/async.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>

--- a/projects/hipdnn/data_sdk/CMakeLists.txt
+++ b/projects/hipdnn/data_sdk/CMakeLists.txt
@@ -12,6 +12,7 @@ hipdnn_add_dependency(spdlog VERSION ${HIPDNN_SPDLOG_VERSION})
 hipdnn_add_dependency(nlohmann_json VERSION ${HIPDNN_NLOHMANN_JSON_VERSION})
 
 find_package(fmt ${HIPDNN_FMTLIB_VERSION} QUIET)
+find_package(hip REQUIRED)
 
 # For dependencies we are going to check if they weren't imported, and then install it along with
 # the SDK headers to allow it to work for local builds that want to install. If the dependecy is
@@ -100,6 +101,9 @@ hipdnn_add_dependency_includes(hipdnn_data_sdk flatbuffers::flatbuffers)
 hipdnn_add_dependency_includes(hipdnn_data_sdk spdlog::spdlog_header_only)
 hipdnn_add_dependency_includes(hipdnn_data_sdk nlohmann_json::nlohmann_json)
 
+target_link_libraries(hipdnn_data_sdk INTERFACE hip::host)
+target_compile_definitions(hipdnn_data_sdk INTERFACE __HIP_PLATFORM_AMD__)
+
 if (fmt_FOUND)
     message(STATUS "Found fmt: using system fmt")
     hipdnn_add_dependency_includes(hipdnn_data_sdk fmt::fmt COMPILE_DEFINITIONS SPDLOG_FMT_EXTERNAL)
@@ -159,8 +163,8 @@ if(HIPDNN_GENERATE_SDK_HEADERS)
     add_dependencies(hipdnn_data_sdk generate_hipdnn_data_sdk_headers)
 endif()
 
-# This is required to use hip/hip_fp16.h and hip/hip_bfloat16.h in any code that includes the sdk By
-# doing this, we don't need to link to hip::device
+# __HIPCC__ is required to use hip/hip_fp16.h and hip/hip_bfloat16.h
+# This allows non-hipcc compilers to use these HIP type headers
 target_compile_definitions(hipdnn_data_sdk INTERFACE __HIPCC__)
 
 export(TARGETS hipdnn_data_sdk ${_hipdnn_data_sdk_local_export_targets}

--- a/projects/hipdnn/data_sdk/cmake/hipdnn_data_sdkConfig_imported.cmake.in
+++ b/projects/hipdnn/data_sdk/cmake/hipdnn_data_sdkConfig_imported.cmake.in
@@ -43,6 +43,8 @@ find_package(Threads REQUIRED)
 
 include(CMakeFindDependencyMacro)
 
+find_dependency(hip CONFIG REQUIRED)
+
 find_dependency(flatbuffers REQUIRED)
 find_dependency(spdlog REQUIRED)
 find_dependency(nlohmann_json REQUIRED)

--- a/projects/hipdnn/data_sdk/cmake/hipdnn_data_sdkConfig_local.cmake.in
+++ b/projects/hipdnn/data_sdk/cmake/hipdnn_data_sdkConfig_local.cmake.in
@@ -3,6 +3,10 @@
 
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+find_dependency(hip CONFIG REQUIRED)
+
 # Find required dependencies
 find_package(Threads REQUIRED)
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/logging/CallbackTypes.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/logging/CallbackTypes.h
@@ -10,8 +10,8 @@ extern "C" {
 // This file's definitions are duplicated by HipdnnBackendCallbackTypes.h.
 // Please ensure any updates are synced between the two files!
 
-// Definition guard to avoid redefinition
 #ifndef HIPDNN_CALLBACK_TYPES_DEFINED
+#define HIPDNN_CALLBACK_TYPES_DEFINED
 
 /**
  * @brief Severity levels for logging in hipDNN
@@ -34,9 +34,6 @@ typedef enum
 typedef void (*hipdnnCallback_t)(hipdnnSeverity_t severity, const char* message);
 
 #endif // HIPDNN_CALLBACK_TYPES_DEFINED
-
-// Mark that callback types are defined, so other headers can check this
-#define HIPDNN_CALLBACK_TYPES_DEFINED
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Motivation

The backend and data_sdk weren't correctly exposing the dependencies they need. Furthermore, they were missing hip compile definitions when used alone.

## Technical Details

- Adds needed find_dependency calls to the config files to propagate to consumers.
- Adds HIP AMD compile definitions.
- Uses target_link_libraries since I don't think this is problematic for HIP or our sdks.
- Backend publicly exposes it's HIP linkage for consumers.

## Test Plan

Test consumption of each separate installed lib in TheRock.

## Test Result

Error-free consumption.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
