### PR TITLE
[origami] Add StreamK/Origami support for gfx115{0,2,3}

### DIFF
--- a/shared/origami/README.md
+++ b/shared/origami/README.md
@@ -145,7 +145,10 @@ int main() {
 | gfx942 | MI325X, MI300X, MI300A | ✔️ | ✔️ |
 | gfx950 | MI355X, MI350X | ✔️ | ✔️ |
 | gfx1100 | Radeon RX 7900 XTX, Radeon RX 7900 XT, Radeon RX 7900 GRE, Radeon RX 7900 | ✔️ | |
+| gfx1150 | AMD Strix Point iGPU | ✔️ | |
 | gfx1151 | Radeon RX 8000 series | ✔️ | |
+| gfx1152 | AMD Radeon 840M iGPU | ✔️ | |
+| gfx1153 | AMD Radeon 820M iGPU | ✔️ | |
 | gfx1201 | Radeon RX 8900 XTX, Radeon RX 8900 XT, Radeon RX 8800 XT, Radeon RX 8800, Radeon RX 8700 XT, Radeon RX 8700, Radeon RX 8600 XT, Radeon RX 8600 | ✔️ | |
 
 For more information on GPU hardware specifications, check out [ROCm documentation](https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html).

--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -38,6 +38,28 @@
 #include "origami/types.hpp"
 
 namespace origami {
+
+namespace details {
+/**
+ * @brief Map of matrix instruction latencies for gfx11 architectures.
+ *
+ * Inline to prevent ODR violations when included in multiple shared libraries.
+ * This ensures only one definition exists across all translation units. (PR#1862)
+ */
+static inline const std::unordered_map<matrix_instruction, size_t> gfx11_matrix_instructions_map = {
+    // clang-format off
+          // F16
+          {matrix_instruction(16, 16, 16, data_type_t::Half), 32},  // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
+          // BF16
+          {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32},  // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
+          // I8
+          {matrix_instruction(16, 16, 16, data_type_t::Int8), 32},  // v_wmma_i32_16x16x16_iu8
+          // I4
+          {matrix_instruction(16, 16, 16, data_type_t::Int4), 16},  // v_wmma_i32_16x16x16_iu4
+                                                          // clang-format on
+};
+}  // namespace details
+
 /**
  * @brief Represents hardware characteristics and capabilities of GPU architectures.
  *
@@ -171,28 +193,6 @@ class hardware_t {
       default: return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
     }
   }
-
-  namespace details {
-  /**
-   * @brief Map of matrix instruction latencies for gfx11 architectures.
-   *
-   * Inline to prevent ODR violations when included in multiple shared libraries.
-   * This ensures only one definition exists across all translation units. (PR#1862)
-   */
-  static inline const std::unordered_map<matrix_instruction, size_t> gfx11_matrix_instructions_map =
-      {
-          // clang-format off
-          // F16
-          {matrix_instruction(16, 16, 16, data_type_t::Half), 32},  // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
-          // BF16
-          {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32},  // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
-          // I8
-          {matrix_instruction(16, 16, 16, data_type_t::Int8), 32},  // v_wmma_i32_16x16x16_iu8
-          // I4
-          {matrix_instruction(16, 16, 16, data_type_t::Int4), 16},  // v_wmma_i32_16x16x16_iu4
-          // clang-format on
-  };
-  }  // namespace details
 
   /**
    * @brief Map of matrix instruction latencies by architecture.
@@ -412,11 +412,11 @@ class hardware_t {
              {matrix_instruction(16, 16, 16, data_type_t::Int4), 8}, // v_wmma_i32_16x16x16_iu4
              {matrix_instruction(16, 16, 32, data_type_t::Int4), 8}, // v_wmma_i32_16x16x32_iu4
          }},
-        {architecture_t::gfx1100, gfx11_matrix_instructions_map},
-        {architecture_t::gfx1150, gfx11_matrix_instructions_map}
-        {architecture_t::gfx1151, gfx11_matrix_instructions_map}
-        {architecture_t::gfx1152, gfx11_matrix_instructions_map}
-        {architecture_t::gfx1153, gfx11_matrix_instructions_map}
+        {architecture_t::gfx1100, details::gfx11_matrix_instructions_map},
+        {architecture_t::gfx1150, details::gfx11_matrix_instructions_map},
+        {architecture_t::gfx1151, details::gfx11_matrix_instructions_map},
+        {architecture_t::gfx1152, details::gfx11_matrix_instructions_map},
+        {architecture_t::gfx1153, details::gfx11_matrix_instructions_map},
       };
   // clang-format on
 

--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -156,8 +156,7 @@ class hardware_t {
       case architecture_t::gfx1151:
         return {1, 2.47, 1.21875121875121875122 * 0.93, 0.215, 2, std::make_tuple(0, 0.22, 0), 1.5};
       case architecture_t::gfx1152:
-        // TODO: Fill with correct values
-        return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
+        return {1, 0.849, 1.21875121875121875122 * 1000 /*Bigger?*/, 0.096, 4, std::make_tuple(0, 0.13, 0), 1.5};
       case architecture_t::gfx1153:
         return {1, 0.240, 1.21875121875121875122 * 1000 /*Bigger?*/, 0.066, 2, std::make_tuple(0, 0.19, 0), 1.5};
       default: return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};

--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -159,8 +159,7 @@ class hardware_t {
         // TODO: Fill with correct values
         return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
       case architecture_t::gfx1153:
-        // TODO: Fill with correct values
-        return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
+        return {1, 0.240, 1.21875121875121875122 * 1000 /*Bigger?*/, 0.066, 2, std::make_tuple(0, 0.19, 0), 1.5};
       default: return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
     }
   }

--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -151,8 +151,7 @@ class hardware_t {
       case architecture_t::gfx1100:
         return {1, 7.12, 1.21875121875121875122 * 3.48, 0.732, 2, std::make_tuple(0, 0.11, 0), 1.5};
       case architecture_t::gfx1150:
-        // TODO: Fill with correct values
-        return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
+        return {1, 1.497, 1.21875121875121875122 * 1000 /*Bigger*/, 0.077, 16, std::make_tuple(0, 0.18, 0), 1.5};
       case architecture_t::gfx1151:
         return {1, 2.47, 1.21875121875121875122 * 0.93, 0.215, 2, std::make_tuple(0, 0.22, 0), 1.5};
       case architecture_t::gfx1152:

--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -48,7 +48,18 @@ class hardware_t {
    * @brief Enumeration of supported GPU architectures.
    *
    */
-  enum class architecture_t { gfx90a, gfx942, gfx950, gfx1201, gfx1100, gfx1151, Count };
+  enum class architecture_t {
+    gfx90a,
+    gfx942,
+    gfx950,
+    gfx1201,
+    gfx1100,
+    gfx1150,
+    gfx1151,
+    gfx1152,
+    gfx1153,
+    Count
+  };
 
   /**
    * @brief Convert architecture name string to architecture_t enum.
@@ -62,7 +73,10 @@ class hardware_t {
     if (str == "gfx950") return architecture_t::gfx950;
     if (str == "gfx1201") return architecture_t::gfx1201;
     if (str == "gfx1100") return architecture_t::gfx1100;
+    if (str == "gfx1150") return architecture_t::gfx1150;
     if (str == "gfx1151") return architecture_t::gfx1151;
+    if (str == "gfx1152") return architecture_t::gfx1152;
+    if (str == "gfx1153") return architecture_t::gfx1153;
     return architecture_t::Count;
   }
 
@@ -136,11 +150,42 @@ class hardware_t {
         return {1, 5.74, 1.21875121875121875122 * 2.41, 0.464, 2, std::make_tuple(0, 0.17, 0), 1.5};
       case architecture_t::gfx1100:
         return {1, 7.12, 1.21875121875121875122 * 3.48, 0.732, 2, std::make_tuple(0, 0.11, 0), 1.5};
+      case architecture_t::gfx1150:
+        // TODO: Fill with correct values
+        return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
       case architecture_t::gfx1151:
         return {1, 2.47, 1.21875121875121875122 * 0.93, 0.215, 2, std::make_tuple(0, 0.22, 0), 1.5};
+      case architecture_t::gfx1152:
+        // TODO: Fill with correct values
+        return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
+      case architecture_t::gfx1153:
+        // TODO: Fill with correct values
+        return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
       default: return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
     }
   }
+
+  namespace details {
+  /**
+   * @brief Map of matrix instruction latencies for gfx11 architectures.
+   *
+   * Inline to prevent ODR violations when included in multiple shared libraries.
+   * This ensures only one definition exists across all translation units. (PR#1862)
+   */
+  static inline const std::unordered_map<matrix_instruction, size_t> gfx11_matrix_instructions_map =
+      {
+          // clang-format off
+          // F16
+          {matrix_instruction(16, 16, 16, data_type_t::Half), 32},  // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
+          // BF16
+          {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32},  // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
+          // I8
+          {matrix_instruction(16, 16, 16, data_type_t::Int8), 32},  // v_wmma_i32_16x16x16_iu8
+          // I4
+          {matrix_instruction(16, 16, 16, data_type_t::Int4), 16},  // v_wmma_i32_16x16x16_iu4
+          // clang-format on
+  };
+  }  // namespace details
 
   /**
    * @brief Map of matrix instruction latencies by architecture.
@@ -360,34 +405,12 @@ class hardware_t {
              {matrix_instruction(16, 16, 16, data_type_t::Int4), 8}, // v_wmma_i32_16x16x16_iu4
              {matrix_instruction(16, 16, 32, data_type_t::Int4), 8}, // v_wmma_i32_16x16x32_iu4
          }},
-        {architecture_t::gfx1100,
-         {
-             // F16
-             {matrix_instruction(16, 16, 16, data_type_t::Half), 32}, // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
-
-             // BF16
-             {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32}, // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
-
-             // I8
-             {matrix_instruction(16, 16, 16, data_type_t::Int8), 32}, // v_wmma_i32_16x16x16_iu8
-
-             // I4
-             {matrix_instruction(16, 16, 16, data_type_t::Int4), 16}, // v_wmma_i32_16x16x16_iu4
-         }},
-        {architecture_t::gfx1151,
-         {
-             // F16
-             {matrix_instruction(16, 16, 16, data_type_t::Half), 32}, // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
-
-             // BF16
-             {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32}, // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
-
-             // I8
-             {matrix_instruction(16, 16, 16, data_type_t::Int8), 32}, // v_wmma_i32_16x16x16_iu8
-
-             // I4
-             {matrix_instruction(16, 16, 16, data_type_t::Int4), 16}, // v_wmma_i32_16x16x16_iu4
-         }}};
+        {architecture_t::gfx1100, gfx11_matrix_instructions_map},
+        {architecture_t::gfx1150, gfx11_matrix_instructions_map}
+        {architecture_t::gfx1151, gfx11_matrix_instructions_map}
+        {architecture_t::gfx1152, gfx11_matrix_instructions_map}
+        {architecture_t::gfx1153, gfx11_matrix_instructions_map}
+      };
   // clang-format on
 
   architecture_t arch;  ///< GPU architecture type

--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -129,6 +129,12 @@ class hardware_t {
   };
 
   /**
+   * MALL value for those architectures that do not support it.
+   * The value '1000' is just a big number.
+   */
+  static constexpr double NO_MALL_AVAILABLE =  1.21875121875121875122 * 1000;
+
+  /**
    * @brief Get architecture-specific constants for a given architecture.
    *
    * Returns the pre-configured constants (memory performance ratios, bandwidth
@@ -151,13 +157,17 @@ class hardware_t {
       case architecture_t::gfx1100:
         return {1, 7.12, 1.21875121875121875122 * 3.48, 0.732, 2, std::make_tuple(0, 0.11, 0), 1.5};
       case architecture_t::gfx1150:
-        return {1, 1.497, 1.21875121875121875122 * 1000 /*Bigger*/, 0.077, 16, std::make_tuple(0, 0.18, 0), 1.5};
+        // AMD Strix Point iGPU
+        return {1, 1.497, NO_MALL_AVAILABLE, 0.077, 16, std::make_tuple(0, 0.18, 0), 1.5};
       case architecture_t::gfx1151:
+        // AMD Strix Halo iGPU
         return {1, 2.47, 1.21875121875121875122 * 0.93, 0.215, 2, std::make_tuple(0, 0.22, 0), 1.5};
       case architecture_t::gfx1152:
-        return {1, 0.849, 1.21875121875121875122 * 1000 /*Bigger?*/, 0.096, 4, std::make_tuple(0, 0.13, 0), 1.5};
+        // AMD Radeon 840M iGPU
+        return {1, 0.849, NO_MALL_AVAILABLE, 0.096, 4, std::make_tuple(0, 0.13, 0), 1.5};
       case architecture_t::gfx1153:
-        return {1, 0.240, 1.21875121875121875122 * 1000 /*Bigger?*/, 0.066, 2, std::make_tuple(0, 0.19, 0), 1.5};
+        // AMD Radeon 820M iGPU
+        return {1, 0.240, NO_MALL_AVAILABLE, 0.066, 2, std::make_tuple(0, 0.19, 0), 1.5};
       default: return {0, 0, 0, 0, 0, std::make_tuple(0, 0, 0), 0};
     }
   }

--- a/shared/origami/src/origami/hardware.cpp
+++ b/shared/origami/src/origami/hardware.cpp
@@ -172,6 +172,9 @@ bool hardware_t::has_MALL() const {
     case architecture_t::gfx1201:
     case architecture_t::gfx1100:
     case architecture_t::gfx1151: return true;
+    case architecture_t::gfx1150:
+    case architecture_t::gfx1152:
+    case architecture_t::gfx1153: return false;
     case architecture_t::Count:
       // Count is not a valid architecture, this is to silence compiler warning
       return false;


### PR DESCRIPTION
## Motivation

Add support for gfx115{0,2,3}. These targets do not have MALL, so it requires of this PR to land before https://github.com/ROCm/rocm-libraries/pull/3876

  - [x] https://github.com/ROCm/rocm-libraries/pull/3876 has landed 

## Technical Details

  - Add the targets hardware coefficients to the already existing array.
    - [x] What value should be used for the missing MALL?
  - Refactoring of same capabilities of different archs.

## Test Plan

.

## Test Result

.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
