### PR TITLE
[hipblaslt] fix the bufferloadcheck to avoid offset overflow

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1645,9 +1645,9 @@ namespace TensileLite
                 // The min operator is used to handle cases where size_N is smaller than the value(usually is MacroTile1)
                 virtual bool operator()(ContractionProblemGemm const& problem) const override
                 {
-                    const uint64_t TWO_POW_32 = 4294967296;
+                    const uint64_t BUFFER_OOB = 0x80000000ULL;
                     return problem.d().strides()[1] * problem.d().elementBytes() * min(value, problem.d().sizes()[1])
-                           < TWO_POW_32;
+                           < BUFFER_OOB;
                 }
 
                 virtual std::string toString() const override
@@ -1661,7 +1661,7 @@ namespace TensileLite
                     bool rv = (*this)(problem);
                     std::ostringstream details;
                     details << "D:" << problem.d().strides()[1] << "*"
-                            << problem.d().elementBytes() << "*" << value << "<2^32";
+                            << problem.d().elementBytes() << "*" << value << "<2^31";
                     PredicateDebugger::printRow(stream, rv, this->type(), details.str());
                     return rv;
                 }


### PR DESCRIPTION
## Motivation

fix [[SWDEV-572572](Matmul produces incorrect zeros for extremely large imbalanced matrices (m over 100M))](https://ontrack-internal.amd.com/browse/SWDEV-572572)

## Technical Details

In the buffer_store instruction, the BufferOOB field in the srsrc operand is used to control the maximum offset of the instruction relative to the base address. 
The kernels generated by Tensile set BufferOOB to 0x80000000 (likely for compatibility with older hardware architectures). However, the current BufferStoreOffsetLimitCheck sets the limit to 0xFFFFFFFF. 
This causes kernels that should not be used to be invoked for excessively large shapes, producing incorrect results and ultimately leading to pytorch/pytorch#168696.


## Test Plan

Verify results for different shapes.

## Test Result

The expected behavior is to return "NO solution found!" for shapes that are not supported in the first place.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[SWDEV-572572]: https://amd-hub.atlassian.net/browse/SWDEV-572572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ