### PR TITLE
Add BFloat16 support to Softmax

### DIFF
--- a/projects/miopen/driver/dm_softmax.cpp
+++ b/projects/miopen/driver/dm_softmax.cpp
@@ -32,6 +32,8 @@ static Driver* makeDriver(const std::string& base_arg)
         return new SoftmaxDriver<float, double>();
     if(base_arg == "softmaxfp16")
         return new SoftmaxDriver<float16, double>();
+    if(base_arg == "softmaxbfp16")
+        return new SoftmaxDriver<bfloat16, double>();
     return nullptr;
 }
 

--- a/projects/miopen/driver/driver.hpp
+++ b/projects/miopen/driver/driver.hpp
@@ -383,7 +383,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
 {
     printf("Usage: ./driver *base_arg* *other_args*\n");
     printf("Supported Base Arguments: conv[fp16|int8|bfp16], CBAInfer[fp16|bfp16], "
-           "CAInfer[fp16|bfp16], pool[fp16], lrn[fp16], activ[fp16], softmax[fp16], "
+           "CAInfer[fp16|bfp16], pool[fp16], lrn[fp16], activ[fp16], softmax[bfp16|fp16], "
            "bnorm[fp16|bfp16], rnn[fp16], rnn_seq[fp16], gemm[fp16], ctc, dropout[fp16], tensorop, "
            "reduce[fp16|fp64], layernorm[bfp16|fp16], groupnorm[bfp16|fp16], cat[bfp16|fp16], "
            "addlayernorm[bfp16|fp16], t5layernorm[bfp16|fp16], adam[fp16], ampadam, "
@@ -423,6 +423,7 @@ inline std::string ParseBaseArg(int argc, char* argv[])
                                                         "activfp16",
                                                         "softmax",
                                                         "softmaxfp16",
+                                                        "softmaxbfp16",
                                                         "bnorm",
                                                         "bnormfp16",
                                                         "bnormbfp16",

--- a/projects/miopen/driver/softmax_driver.hpp
+++ b/projects/miopen/driver/softmax_driver.hpp
@@ -33,7 +33,9 @@ public:
         miopenCreateTensorDescriptor(&dInputTensor);
         miopenCreateTensorDescriptor(&dOutputTensor);
 
-        data_type = (sizeof(Tgpu) == 4) ? miopenFloat : miopenHalf;
+        data_type = std::is_same_v<Tgpu, float>              ? miopenFloat
+                    : std::is_same_v<Tgpu, half_float::half> ? miopenHalf
+                                                             : miopenBFloat16;
     }
 
     int AddCmdLineArgs() override;
@@ -52,6 +54,7 @@ public:
     int RunBackwardGPU() override;
     int RunBackwardCPU();
 
+    Tref GetTolerance();
     int VerifyBackward() override;
     int VerifyForward() override;
     ~SoftmaxDriver() override
@@ -389,13 +392,24 @@ int SoftmaxDriver<Tgpu, Tref>::RunBackwardGPU()
 }
 
 template <typename Tgpu, typename Tref>
+Tref SoftmaxDriver<Tgpu, Tref>::GetTolerance()
+{
+    auto tolerance = data_type == miopenFloat ? 1e-3 : 5e-2;
+
+    // bf16 mantissa has 7 bits, by 3 bits shorter than fp16.
+    if(std::is_same<Tgpu, bfloat16>::value)
+        tolerance *= 8.0;
+    return tolerance;
+}
+
+template <typename Tgpu, typename Tref>
 int SoftmaxDriver<Tgpu, Tref>::VerifyForward()
 {
     mloSoftmaxForwardRunHost<Tgpu, Tref>(
         inputTensor, outputTensor, in.data(), outhost.data(), alpha, beta, algo, mode);
 
     auto error           = miopen::rms_range(outhost, out);
-    const Tref tolerance = data_type == miopenHalf ? 5e-2 : 1e-3; // 1e-6;
+    const Tref tolerance = GetTolerance();
     if(!std::isfinite(error) || error > tolerance)
     {
         std::cout << "Forward Softmax FAILED: " << error << std::endl;
@@ -429,7 +443,7 @@ int SoftmaxDriver<Tgpu, Tref>::VerifyBackward()
                                           mode);
 
     auto error           = miopen::rms_range(dinhost, din);
-    const Tref tolerance = data_type == miopenHalf ? 5e-2 : 1e-3; // 1e-6;
+    const Tref tolerance = GetTolerance();
 
     if(!std::isfinite(error) || error > tolerance)
     {

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -140,9 +140,9 @@ get_dy_index(int n, int i, int s, int s0, int s1, const int dy_offset)
     return get_index<IS_DOUTPUT_CONTIGUOUS>(n, i, s, s0, s1, dy_offset);
 }
 
-template <typename TI, typename TO>
-__forceinline__ __device__ void softmaxfwd(const TI* __restrict__ x,
-                                           TO* __restrict__ y,
+template <typename T>
+__forceinline__ __device__ void softmaxfwd(const T* __restrict__ x,
+                                           T* __restrict__ y,
                                            const int x_offset,
                                            const int y_offset,
                                            const float alpha,
@@ -395,10 +395,10 @@ __forceinline__ __device__ void softmaxfwd(const TI* __restrict__ x,
     }
 }
 
-template <typename TI, typename TO>
-__forceinline__ __device__ void softmaxbwd(const TI* __restrict__ y,
-                                           const TI* __restrict__ dy,
-                                           TO* __restrict__ dx,
+template <typename T>
+__forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
+                                           const T* __restrict__ dy,
+                                           T* __restrict__ dx,
                                            const int y_offset,
                                            const int dy_offset,
                                            const int dx_offset,
@@ -531,24 +531,24 @@ __forceinline__ __device__ void softmaxbwd(const TI* __restrict__ y,
     }
 }
 
-extern "C" __global__ void SoftmaxFwd(const INPUT_TYPE* __restrict__ x,
-                                      OUTPUT_TYPE* __restrict__ y,
+extern "C" __global__ void SoftmaxFwd(const DATA_TYPE* __restrict__ x,
+                                      DATA_TYPE* __restrict__ y,
                                       const int x_offset,
                                       const int y_offset,
                                       const float alpha,
                                       const float beta)
 {
-    softmaxfwd<INPUT_TYPE, OUTPUT_TYPE>(x, y, x_offset, y_offset, alpha, beta);
+    softmaxfwd<DATA_TYPE>(x, y, x_offset, y_offset, alpha, beta);
 }
 
-extern "C" __global__ void SoftmaxBwd(const INPUT_TYPE* __restrict__ y,
-                                      const INPUT_TYPE* __restrict__ dy,
-                                      OUTPUT_TYPE* __restrict__ dx,
+extern "C" __global__ void SoftmaxBwd(const DATA_TYPE* __restrict__ y,
+                                      const DATA_TYPE* __restrict__ dy,
+                                      DATA_TYPE* __restrict__ dx,
                                       const int y_offset,
                                       const int dy_offset,
                                       const int dx_offset,
                                       const float alpha,
                                       const float beta)
 {
-    softmaxbwd<INPUT_TYPE, OUTPUT_TYPE>(y, dy, dx, y_offset, dy_offset, dx_offset, alpha, beta);
+    softmaxbwd<DATA_TYPE>(y, dy, dx, y_offset, dy_offset, dx_offset, alpha, beta);
 }

--- a/projects/miopen/src/softmax_api.cpp
+++ b/projects/miopen/src/softmax_api.cpp
@@ -39,10 +39,13 @@ static void LogCmdSoftmax(const miopenTensorDescriptor_t xDesc,
     if(miopen::IsLoggingCmd())
     {
         std::stringstream ss;
-        if(miopen::deref(xDesc).GetType() == miopenHalf)
-            ss << "softmaxfp16";
-        else
-            ss << "softmax";
+        switch(miopen::deref(xDesc).GetType())
+        {
+        case miopenFloat: ss << "softmax"; break;
+        case miopenHalf: ss << "softmaxfp16"; break;
+        case miopenBFloat16: ss << "softmaxbfp16"; break;
+        default: MIOPEN_THROW("Invalid type");
+        }
         // clang-format off
         ss << " -n " << miopen::deref(xDesc).GetLengths()[0]
            << " -c " << miopen::deref(xDesc).GetLengths()[1]
@@ -67,12 +70,6 @@ extern "C" miopenStatus_t miopenSoftmaxForward(miopenHandle_t handle,
 {
     MIOPEN_LOG_FUNCTION(alpha, xDesc, x, beta, yDesc, y);
 
-    // bfloat16 not supported for softmax operation
-    if(miopen::deref(xDesc).GetType() == miopenBFloat16 ||
-       miopen::deref(yDesc).GetType() == miopenBFloat16)
-    {
-        return miopenStatusNotImplemented;
-    }
     LogCmdSoftmax(xDesc, MIOPEN_SOFTMAX_ACCURATE, MIOPEN_SOFTMAX_MODE_CHANNEL, alpha, beta, true);
     return miopen::try_([&] {
         miopen::SoftmaxForward(miopen::deref(handle),
@@ -102,13 +99,6 @@ extern "C" miopenStatus_t miopenSoftmaxBackward(miopenHandle_t handle,
 
     MIOPEN_LOG_FUNCTION(alpha, yDesc, y, dyDesc, dy, beta, dxDesc, dx);
 
-    // bfloat16 not supported for softmax operation
-    if(miopen::deref(dyDesc).GetType() == miopenBFloat16 ||
-       miopen::deref(dxDesc).GetType() == miopenBFloat16 ||
-       miopen::deref(yDesc).GetType() == miopenBFloat16)
-    {
-        return miopenStatusNotImplemented;
-    }
     LogCmdSoftmax(dxDesc, MIOPEN_SOFTMAX_ACCURATE, MIOPEN_SOFTMAX_MODE_CHANNEL, alpha, beta, false);
 
     return miopen::try_([&] {
@@ -140,12 +130,6 @@ extern "C" miopenStatus_t miopenSoftmaxForward_V2(miopenHandle_t handle,
                                                   miopenSoftmaxMode_t mode)
 {
     MIOPEN_LOG_FUNCTION(alpha, xDesc, x, beta, yDesc, y, algorithm, mode);
-    // check for supported data types
-    if(miopen::deref(xDesc).GetType() == miopenBFloat16 ||
-       miopen::deref(yDesc).GetType() == miopenBFloat16)
-    {
-        return miopenStatusNotImplemented;
-    }
     LogCmdSoftmax(xDesc, algorithm, mode, alpha, beta, true);
     return miopen::try_([&] {
         miopen::SoftmaxForward(miopen::deref(handle),
@@ -176,12 +160,6 @@ extern "C" miopenStatus_t miopenSoftmaxBackward_V2(miopenHandle_t handle,
 {
 
     MIOPEN_LOG_FUNCTION(alpha, yDesc, y, dyDesc, dy, beta, dxDesc, dx, algorithm, mode);
-    if(miopen::deref(yDesc).GetType() == miopenBFloat16 ||
-       miopen::deref(dyDesc).GetType() == miopenBFloat16 ||
-       miopen::deref(dxDesc).GetType() == miopenBFloat16)
-    {
-        return miopenStatusNotImplemented;
-    }
     LogCmdSoftmax(dxDesc, algorithm, mode, alpha, beta, false);
     return miopen::try_([&] {
         miopen::SoftmaxBackward(miopen::deref(handle),

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -44,7 +44,9 @@ bool Softmax::IsApplicable(
     [[maybe_unused]] const ExecutionContext& context,
     [[maybe_unused]] const miopen::softmax::ProblemDescription& problem) const
 {
-    if(!(problem.GetYDesc().GetType() == miopenFloat || problem.GetYDesc().GetType() == miopenHalf))
+    if(!(problem.GetYDesc().GetType() == miopenFloat ||
+         problem.GetYDesc().GetType() == miopenHalf ||
+         problem.GetYDesc().GetType() == miopenBFloat16))
     {
         return false;
     }
@@ -92,13 +94,12 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
-    auto lengths      = problem.GetXDesc().GetLengths();
-    auto strides      = problem.GetXDesc().GetStrides();
-    auto dtype        = problem.GetXDesc().GetType();
-    auto input_dtype  = miopen::GetDataType(problem.GetXDesc().GetType());
-    auto output_dtype = miopen::GetDataType(problem.GetYDesc().GetType());
-    auto algorithm    = problem.GetAlgorithm();
-    auto mode         = problem.GetMode();
+    auto lengths    = problem.GetXDesc().GetLengths();
+    auto strides    = problem.GetXDesc().GetStrides();
+    auto dtype      = problem.GetXDesc().GetType();
+    auto data_dtype = miopen::GetDataType(problem.GetXDesc().GetType());
+    auto algorithm  = problem.GetAlgorithm();
+    auto mode       = problem.GetMode();
 
     auto grid_size =
         mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? lengths[0] : lengths[0] * lengths[2] * lengths[3];
@@ -127,8 +128,8 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     const auto build_params =
         KernelBuildParameters{{"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
                               {"MIOPEN_USE_FP32", static_cast<int>(dtype == miopenFloat)},
-                              {"INPUT_TYPE", input_dtype},
-                              {"OUTPUT_TYPE", output_dtype},
+                              {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
+                              {"DATA_TYPE", data_dtype == "bfloat16" ? "ushort" : data_dtype},
                               {"USE_SOFTMAX_FAST", algorithm == MIOPEN_SOFTMAX_FAST},
                               {"USE_SOFTMAX_ACCURATE", algorithm == MIOPEN_SOFTMAX_ACCURATE},
                               {"USE_SOFTMAX_LOG", algorithm == MIOPEN_SOFTMAX_LOG},

--- a/projects/miopen/test/gtest/soft_max.cpp
+++ b/projects/miopen/test/gtest/soft_max.cpp
@@ -66,8 +66,8 @@ void AddTestCasesForDifferentScales(std::vector<TestCase>& test_cases,
                                     const std::vector<std::vector<float>>& scales)
 {
     // Result does not fit in data type
-    if(miopen_type<T>{} == miopenHalf && in_dim[1] * in_dim[2] * in_dim[3] >= 2048 &&
-       mode == MIOPEN_SOFTMAX_MODE_INSTANCE)
+    if((miopen_type<T>{} == miopenHalf || miopen_type<T>{} == miopenBFloat16) &&
+       in_dim[1] * in_dim[2] * in_dim[3] >= 2048 && mode == MIOPEN_SOFTMAX_MODE_INSTANCE)
     {
         return;
     }
@@ -132,8 +132,9 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
     {
         const TestCase& test_case = GetParam();
 
-        uint64_t max_value =
-            miopen_type<T>{} == miopenHalf ? (test_case.algo == MIOPEN_SOFTMAX_LOG ? 3 : 5) : 17;
+        uint64_t max_value = miopen_type<T>{} == miopenFloat        ? 17
+                             : test_case.algo == MIOPEN_SOFTMAX_LOG ? 3
+                                                                    : 5;
 
         input = tensor<T>{test_case.layout, test_case.in_dim}.generate(
             tensor_elem_gen_integer{max_value});
@@ -219,9 +220,9 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
 
                     if(test_case.algo == MIOPEN_SOFTMAX_LOG)
                     {
-                        double neg_inf = input.desc.GetType() == miopenHalf
-                                             ? NEGATIVE_CUTOFF_VAL_FP16
-                                             : NEGATIVE_CUTOFF_VAL_FP32;
+                        double neg_inf = input.desc.GetType() == miopenFloat
+                                             ? NEGATIVE_CUTOFF_VAL_FP32
+                                             : NEGATIVE_CUTOFF_VAL_FP16;
                         double sum     = neg_inf;
                         miopen::ford(in_c, in_h, in_w)([&](int w, int i, int j) {
                             sum = logaddexp(
@@ -292,9 +293,9 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
 
                     if(test_case.algo == MIOPEN_SOFTMAX_LOG)
                     {
-                        double neg_inf = input.desc.GetType() == miopenHalf
-                                             ? NEGATIVE_CUTOFF_VAL_FP16
-                                             : NEGATIVE_CUTOFF_VAL_FP32;
+                        double neg_inf = input.desc.GetType() == miopenFloat
+                                             ? NEGATIVE_CUTOFF_VAL_FP32
+                                             : NEGATIVE_CUTOFF_VAL_FP16;
                         double sum     = neg_inf;
                         miopen::ford(in_c)([&](int w) {
                             sum = logaddexp(
@@ -487,13 +488,12 @@ struct SoftmaxCommon : public testing::TestWithParam<TestCase>
     {
         const TestCase& test_case = GetParam();
 
-        // taken from the original c test
-        double tolerance = 8000;
-
-        if(std::is_same_v<T, half_float::half>)
-        {
-            tolerance = 80;
-        }
+        // float tolerance taken from the original c test
+        // cppcheck can't properly handle this trinary
+        // cppcheck-suppress assignBoolToFloat
+        double tolerance = std::is_same_v<T, bfloat16>           ? 10
+                           : std::is_same_v<T, half_float::half> ? 80
+                                                                 : 8000;
 
         double threshold = std::numeric_limits<T>::epsilon() * tolerance;
         double error     = miopen::rms_range(tensorCPUData, tensorGPUData);
@@ -515,11 +515,14 @@ private:
     tensor<T> dout;
 };
 
-using GPU_Softmax_FP32 = SoftmaxCommon<float>;
-using GPU_Softmax_FP16 = SoftmaxCommon<half_float::half>;
+using GPU_Softmax_FP32  = SoftmaxCommon<float>;
+using GPU_Softmax_FP16  = SoftmaxCommon<half_float::half>;
+using GPU_Softmax_BFP16 = SoftmaxCommon<bfloat16>;
 
 TEST_P(GPU_Softmax_FP32, TestFloat) { this->Run(); }
 TEST_P(GPU_Softmax_FP16, TestFloat16) { this->Run(); }
+TEST_P(GPU_Softmax_BFP16, TestBFloat16) { this->Run(); }
 
 INSTANTIATE_TEST_SUITE_P(Full, GPU_Softmax_FP32, GetCases<float>());
 INSTANTIATE_TEST_SUITE_P(Full, GPU_Softmax_FP16, GetCases<half_float::half>());
+INSTANTIATE_TEST_SUITE_P(Full, GPU_Softmax_BFP16, GetCases<bfloat16>());

--- a/projects/miopen/test/gtest/softmax_find20.cpp
+++ b/projects/miopen/test/gtest/softmax_find20.cpp
@@ -269,7 +269,7 @@ public:
                                                softmax_descriptor.GetMode());
 
             double error           = miopen::rms_range(dxTensorRef.data, dinhost);
-            const double tolerance = 1e-4;
+            const double tolerance = 1e-3;
 
             std::cout << "error =  " << error << std::endl;
 
@@ -398,6 +398,32 @@ TEST(GPU_SoftmaxFind20_FP16, softmaxBackward_log_channel_mode_fp16)
     Handle& handle = get_handle();
 
     SoftmaxFind20Test<half> test(false, MIOPEN_SOFTMAX_LOG, MIOPEN_SOFTMAX_MODE_CHANNEL);
+
+    std::vector<miopenSolution_t> solutions = test.TestFindSolutions(handle);
+    test.TestSolutionAttributes(solutions);
+
+    test.TestRunSolutionsBackward(handle, solutions);
+    test.Finalize();
+}
+
+TEST(GPU_SoftmaxFind20_BFP16, softmaxBackward_log_instance_mode_bfp16)
+{
+    Handle& handle = get_handle();
+
+    SoftmaxFind20Test<bfloat16> test(false, MIOPEN_SOFTMAX_LOG, MIOPEN_SOFTMAX_MODE_INSTANCE);
+
+    std::vector<miopenSolution_t> solutions = test.TestFindSolutions(handle);
+    test.TestSolutionAttributes(solutions);
+
+    test.TestRunSolutionsBackward(handle, solutions);
+    test.Finalize();
+}
+
+TEST(GPU_SoftmaxFind20_BFP16, softmaxBackward_log_channel_mode_bfp16)
+{
+    Handle& handle = get_handle();
+
+    SoftmaxFind20Test<bfloat16> test(false, MIOPEN_SOFTMAX_LOG, MIOPEN_SOFTMAX_MODE_CHANNEL);
 
     std::vector<miopenSolution_t> solutions = test.TestFindSolutions(handle);
     test.TestSolutionAttributes(solutions);


### PR DESCRIPTION
## Motivation

This PR adds support for BFloat16 to Softmax.

## Technical Details

- Add support for BFloat16 to Softmax.
- Add BFloat16 tests to Softmax.
- Create softmaxbfp16 MIOpenDriver.

## Test Plan

Build and run the test target `test_soft_max`.

## Test Result

Both new and existing tests should pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
