### PR TITLE
[hipblaslt][CMS] Validator for TF32 4x4x4 MFMA Pack

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1465,13 +1465,13 @@ def hook_up_packs(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int
             
             _set_pack_needed_by(packs, pack_name, i_loop, mfma_reorder, mfmas_by_index, timeline.num_vmfma, kernel)
 
-def precompute_issue_times(instructions: list[ValidatorInstruction], is_4x4mfma: bool) -> list[int]:
+def precompute_issue_times(instructions: list[ValidatorInstruction], is_4x4mfma_tf32_packs: bool) -> list[int]:
     """
     Returns a list where issue_times[i] represents the quad-cycle when instruction i starts issuing.
     
     Args:
         instructions: List of ValidatorInstruction objects in execution order.
-        is_4x4mfma: True if using TF32 4x4 MFMA mode (affects Pack timing).
+        is_4x4mfma_tf32_packs: True if using TF32 4x4 MFMA mode (affects Pack timing).
     """
     class MFMAType(Enum):
         """Used for tracking type switching penalties in quad-cycle estimation."""
@@ -1490,7 +1490,7 @@ def precompute_issue_times(instructions: list[ValidatorInstruction], is_4x4mfma:
         """
         if isinstance(instruction, MFMA):
             return (MFMAType.STANDARD, 3)
-        if isinstance(instruction, Pack) and is_4x4mfma:
+        if isinstance(instruction, Pack) and is_4x4mfma_tf32_packs:
             idx_in_group = instruction.issue_index % 10
             if idx_in_group in [4, 5]:
                 return (MFMAType.MFMA_4X4, 1)

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -24,6 +24,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from collections import defaultdict
 from copy import deepcopy
+from enum import Enum
 from math import floor
 from typing import Optional, Union
 
@@ -309,6 +310,8 @@ class ValidatorInstruction(ABC):
     """
     name: str
     issued_at: float
+    # The minimum number of quad-cycles that this instruction takes to issue.
+    __min_issue_quad_cycles__: int = 1
 
     @abstractmethod
     def validate(self) -> Optional[str]:
@@ -322,6 +325,9 @@ class ValidatorInstruction(ABC):
         E.g. The done_idx of a LocalRead/GlobalRead is the index of the SWaitCnt that waits on them.
         """
         ...
+
+    def min_issue_quad_cycles(self) -> int:
+        return self.__min_issue_quad_cycles__
 
 @dataclass
 class LocalRead(ValidatorInstruction):
@@ -399,6 +405,13 @@ class Pack(ValidatorInstruction):
     pair_consumer: Optional['Pack'] = None  # The pack that should be the next one scheduled 
     next_scheduled_middle_16: Optional['Pack'] = None  # Next middle-16 pack scheduled after this one
 
+    # The minimum number of quad-cycles that must pass before the result of this pack is used.
+    # Measure from the point that this Pack is finished being issued.
+    min_quad_cycles_before_result_used: int = 0
+    # The estimated number of quad-cycles that passed between the pack being issued and the result being used.
+    # This is a lower bound estimate (does not account for most stalls and such).
+    estimated_quad_cycles_before_result_used: int = 0
+
     def done_idx(self) -> Union[int, float]:
         return self.issued_at
 
@@ -408,8 +421,11 @@ class Pack(ValidatorInstruction):
         if (
             (self.must_start_after.done_idx() < self.issued_at < self.needed_by.done_idx()) 
             and (self.pair_consumer is self.next_scheduled_middle_16)
+            and (self.min_quad_cycles_before_result_used <= self.estimated_quad_cycles_before_result_used)
         ):
             return None
+        
+        # TODO: Add info about the issue index of the instruction that failed when printing the error message.
         
         # Issued too early
         if self.issued_at < self.must_start_after.done_idx():
@@ -435,6 +451,11 @@ class Pack(ValidatorInstruction):
                 next_issued_at = floor(self.next_scheduled_middle_16.issued_at) % self.num_vmfma
                 pair_issued_at = floor(self.pair_consumer.issued_at) % self.num_vmfma
                 return f"{self.name} @ idx={issued_at} has wrong interleaving. Should have been followed by {self.pair_consumer.name} @ idx={pair_issued_at} but was followed by {self.next_scheduled_middle_16.name} @ idx={next_issued_at}."
+
+        # Not enough time before result was used
+        if self.estimated_quad_cycles_before_result_used < self.min_quad_cycles_before_result_used:
+            needed_by_at = floor(self.needed_by.issued_at) % self.num_vmfma
+            return f"{self.name} @ idx={issued_at} has too little gap between it and {self.needed_by.name} @ idx={needed_by_at}. Expected at least {self.min_quad_cycles_before_result_used} quad-cycles but only {self.estimated_quad_cycles_before_result_used} passed."
 
         return f"{self.name} at index {issued_at} is not valid."
 
@@ -528,6 +549,22 @@ class Barrier(ValidatorInstruction):
     def validate(self) -> Optional[str]:
         return f"Barrier at index {floor(self.issued_at)} is not valid. Must be >= -1." if self.issued_at < -1 else None
 
+@dataclass
+class SNop(ValidatorInstruction):
+    issued_at: Union[int, float]
+    wait_state: int
+    name: str = "SNop"
+
+    def min_issue_quad_cycles(self) -> int:
+        # Base instruction quad-cycles plus wait_state additional cycles
+        return self.__min_issue_quad_cycles__ + self.wait_state
+
+    def done_idx(self) -> Union[int, float]:
+        return self.issued_at
+
+    def validate(self) -> Optional[str]:
+        return None
+
 MAIN_LOOP_PREV = "ML-1"
 MAIN_LOOP = "ML"
 NO_GLOBAL_LOAD_LOOP = "NGL"
@@ -601,9 +638,17 @@ class Timeline:
         """
         assert kernel["DirectToLds"], "Only DirectToLds cases are supported by validator."
 
-        halfway_point = self.num_vmfma // 2
         swap_global_read_order = kernel["SwapGlobalReadOrder"]
-        
+
+        # Explicitly add MFMAs to timeline.
+        # Do at the top here so they are the first ones scheduled at each vmfma index.
+        for i_vmfma in range(self.num_vmfma):
+            if schedule_info.mfmaReorder:
+                i_vmfma = schedule_info.mfmaReorder[i_vmfma]
+                
+            mfma = MFMA(name="MFMA", issued_at=i_vmfma)
+            self._insert(i_vmfma, mfma, kernel)
+
         # NOTE: Relative ordering of instructions must be preserved.
         #       Order dictates the order in which instructions are scheduled if they are scheduled at the same vmfmaindex.
         for name in schedule_info.optSchedule.keys():
@@ -622,6 +667,13 @@ class Timeline:
                         raise ValueError(f"Unexpected sync instruction type: {type(sync)}")
                     
                     self._insert(idx_vmfma, sync_instruction, kernel)
+            elif name == "SNOP":
+                for idx_snop, (idx_vmfma, snop) in enumerate(zip(schedule_get(name, code_path, schedule_info), schedule_info.snopCode)):
+                    assert idx_vmfma >= -1, f"Code path {code_path}: SNop at index {idx_snop} is not valid. Must be >= -1."
+                    # The waitState is stored as the first parameter in the rocisa SNop instruction
+                    wait_state = snop.getParams()[0]
+                    snop_instruction = SNop(issued_at=idx_vmfma, wait_state=wait_state)
+                    self._insert(idx_vmfma, snop_instruction, kernel)
             elif name.startswith("LRA") or name.startswith("LRB"):
                 for idx_LR, idx_vmfma in enumerate(schedule_get(name, code_path, schedule_info)):
                     assert idx_vmfma >= -1, f"Code path {code_path}: LocalRead {name} at index {idx_LR} is not valid. Must be >= -1."
@@ -685,6 +737,7 @@ class Timeline:
                 adjust = self.num_vmfma * self.loops.index(loop)
                 _instruction.issued_at += adjust
 
+                # Adjust for NLL/NGL shifts.
                 if isinstance(_instruction, SWait):
                     if _instruction.vlcnt != -1:
                         vlcnt = max(0, _instruction.vlcnt - self.vlcnt_shift[loop])
@@ -903,7 +956,7 @@ def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) 
             for _, gr in grs:
                 gr.needed_by = LR_target.issued_at
 
-def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reorder: list[int], num_vmfma: int, kernel: 'Solution') -> None:
+def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reorder: list[int], mfmas_by_index: dict[int, MFMA], num_vmfma: int,kernel: 'Solution') -> None:
     """
     Set the needed_by field for Pack instructions.
     This function handles all cases (BF16 and TF32).
@@ -915,17 +968,15 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
     Args:
         packs: List of Pack instructions to set needed_by for.
         pack_name: The name of the pack (e.g., "PackA0", "PackB1").
-        use_plr_pack: Whether UsePLRPack flag is set.
-        force_unroll_sub_iter: Whether ForceUnrollSubIter flag is set.
         i_loop: The loop index (0 for MAIN_LOOP_PREV, 1 for MAIN_LOOP, etc.).
-        n_tiles_a: Number of tiles in the A dimension (MIWaveTileA).
-        n_tiles_b: Number of tiles in the B dimension (MIWaveTileB).
-        is_tf32_emulation: Whether TF32 emulation mode is enabled.
         mfma_reorder: The reordering mapping for MFMA indices.
-        num_vmfma: Number of MFMAs per iteration.
+        mfmas_by_index: Dictionary mapping MFMA indices to MFMA instructions.
+        num_vmfma: The number of MFMAs per iteration (not total across loops).
+        kernel: The kernel class containing metadata.
     """
     force_unroll_sub_iter = kernel.get("ForceUnrollSubIter", False)
     is_tf32_emulation = kernel.get("UseF32XEmulation", False)
+    is_4x4mfma_tf32 = kernel.get("UseMFMAF32XEmulation", False)
     is_pack_B = pack_name.startswith("PackB")
     use_plr_pack = kernel.get("UsePLRPack", False)
     n_tiles_a = kernel["MIWaveTileA"]
@@ -941,7 +992,7 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
                 needed_by_offset += num_vmfma // 4
             else:
                 # Needed for 3rd quarter
-                needed_by_offset += 3 * (num_vmfma // 4)
+                needed_by_offset += num_vmfma // 2
         else:  # Pack3
             # Both A and B are needed for 1st quarter, the flag impacts whether it's this iteration's or next iteration's 1st quarter.
             if use_plr_pack:
@@ -958,7 +1009,91 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
     iteration_offset = (needed_by_offset // num_vmfma) * num_vmfma
     base_offset = needed_by_offset % num_vmfma
     
-    if is_tf32_emulation:
+    if not is_tf32_emulation:
+        # BF16 case
+        # Calculate packs_per_tile dynamically based on actual pack count
+        n_tiles = n_tiles_b if is_pack_B else n_tiles_a
+        packs_per_tile = len(packs) // n_tiles
+        
+        for pack in packs:
+            # Determine which tile this pack belongs to
+            tile_index = pack.issue_index // packs_per_tile
+            # Calculate the base needed_by index (in column-major order, relative to offset)
+            pack_offset = (tile_index * n_tiles_a if is_pack_B else tile_index)
+            
+            # Combine with half-iteration offset to get logical MFMA index within iteration
+            logical_index = base_offset + pack_offset
+            
+            # Apply mfma_reorder to get execution position within iteration
+            if mfma_reorder:
+                execution_index = mfma_reorder[logical_index]
+            else:
+                execution_index = logical_index
+            
+            # Add iteration offset to get final position
+            needed_by = iteration_offset + execution_index
+            pack.needed_by = mfmas_by_index[needed_by]
+        return    
+
+    if is_4x4mfma_tf32:
+        # TF32 4x4 MFMA: Packs come in groups of 10
+        # First 4 packs (CVT0) feed into indices 4-5 (4x4 MFMAs)
+        # Middle 2 packs are 4x4 MFMAs.
+        # Last 4 packs (CVT1) feed into the actual MFMAs starting at base_offset
+        n_tiles_a_quarter = n_tiles_a // 4
+
+        packs = sorted(packs, key=lambda x: x.issue_index)
+        for i_pack, pack in enumerate(packs):
+            idx_in_group = pack.issue_index % 10
+
+            # The first 4 packs have both a needed_by for MFMAs, and a needed_by for the next packs
+            # First 4 CVT0 packs (indices 0-3) feed into 4x4 MFMAs (indices 4-5)
+            # Packs 0 and 1 are needed by Pack 4 (first 4x4 MFMA)
+            # Packs 2 and 3 are needed by Pack 5 (second 4x4 MFMA)
+            if idx_in_group in [0, 1]:
+                pack.needed_by = packs[i_pack + (4 - idx_in_group)]
+            elif idx_in_group in [2, 3]:
+                pack.needed_by = packs[i_pack + (5 - idx_in_group)]
+            elif idx_in_group == 4:
+                # Pack 4's result is first used by pack 8.
+                pack.needed_by = packs[i_pack + 4]
+                continue
+            elif idx_in_group == 5:
+                # Pack 5's result is first used by pack 6.
+                pack.needed_by = packs[i_pack + 1]
+                continue
+            
+            # Calculate pack_offset within the quarter
+            if idx_in_group < 4:
+                # First 4 CVT0 packs: These feed into 4x4 MFMAs
+                # For validation, we set needed_by to the first MFMA in the quarter
+                pack_offset = 0
+            else:
+                # Last 4 CVT1 packs (indices 6-9)
+                # These produce error terms used by actual MFMAs
+                # Following the same pattern as regular TF32 (groups of 24):
+                # A_error is used in mfma 2/3
+                # B_error is used in mfma 3/3
+                pack_offset = 2 if is_pack_B else 1
+            
+            # Combine with quarter offset to get logical MFMA index within iteration
+            logical_index = base_offset + pack_offset
+            
+            # Apply mfma_reorder to get execution position within iteration
+            if mfma_reorder:
+                execution_index = mfma_reorder[logical_index]
+            else:
+                execution_index = logical_index
+            
+            # Add iteration offset to get final position
+            needed_by = iteration_offset + execution_index
+            mfma_needed_by = mfmas_by_index[needed_by]
+            # Packs 0-3 have multiple needed_by. But since both have the same min quad-cycle wait,
+            # We can pick the one that occurs sooner as it's the active constraint.
+            if pack.needed_by.issued_at > mfma_needed_by.issued_at:
+                pack.needed_by = mfma_needed_by
+    else:
+        # Regular TF32: Packs come in groups of 24
         n_tiles_a_quarter = n_tiles_a // 4
         for pack in packs:
             idx_in_group = pack.issue_index % 24
@@ -997,31 +1132,43 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
             
             # Add iteration offset to get final position
             needed_by = iteration_offset + execution_index
-            pack.needed_by = MFMA(issued_at=needed_by)
-    else:
-        # BF16 case
-        # Calculate packs_per_tile dynamically based on actual pack count
-        n_tiles = n_tiles_b if is_pack_B else n_tiles_a
-        packs_per_tile = len(packs) // n_tiles
-        
+            pack.needed_by = mfmas_by_index[needed_by]
+       
+
+def _handle_min_pack_quad_cycles(packs: list[Pack], is_4x4mfma: bool) -> None:
+    """
+    Set the min_quad_cycles_before_result_used field for Pack instructions.
+    This is used to enforce timing constraints for TF32 emulation modes.
+    
+    Args:
+        packs: List of Pack instructions to set minimum quad-cycles for.
+        is_4x4mfma: True if using TF32 4x4 MFMA mode (groups of 10), 
+                    False for main TF32 mode (groups of 24).
+    """
+    
+    if is_4x4mfma:
+        # For TF32 4x4 MFMA: packs come in groups of 10
+        # - First 4 packs (CVT0): need 2 quad-cycles before first 4x4 MFMA
+        # - Middle 2 packs: are 4x4 MFMAs themselves, no constraint
+        # - Last 4 packs (CVT1): need 2 quad-cycles before "real" MFMAs that use the result
         for pack in packs:
-            # Determine which tile this pack belongs to
-            tile_index = pack.issue_index // packs_per_tile
-            # Calculate the base needed_by index (in column-major order, relative to offset)
-            pack_offset = (tile_index * n_tiles_a if is_pack_B else tile_index)
-            
-            # Combine with half-iteration offset to get logical MFMA index within iteration
-            logical_index = base_offset + pack_offset
-            
-            # Apply mfma_reorder to get execution position within iteration
-            if mfma_reorder:
-                execution_index = mfma_reorder[logical_index]
+            idx_in_group = pack.issue_index % 10
+            if 4 <= idx_in_group < 6:
+                # Middle 2 packs are 4x4 MFMAs, need 5 quad-cycles before the CVT1 instructions 
+                pack.min_quad_cycles_before_result_used = 5
             else:
-                execution_index = logical_index
-            
-            # Add iteration offset to get final position
-            needed_by = iteration_offset + execution_index
-            pack.needed_by = MFMA(issued_at=needed_by)
+                # First 4 and last 4 packs (CVT instructions) need 2 quad-cycles before MFMAs can use their results.
+                pack.min_quad_cycles_before_result_used = 2
+
+    else:
+        # For main TF32 mode: packs come in groups of 24
+        # - First 4 packs (indices 0-3): CVT0, need 2 quad-cycles before MFMA
+        # - Middle 16 packs (indices 4-19): v_cvt_f32_bf16 + v_sub_f32 pairs, no constraint
+        # - Last 4 packs (indices 20-23): CVT1, need 2 quad-cycles before MFMA
+        for pack in packs:
+            if not (4 <= pack.issue_index % 24 < 20):
+                # First 4 and last 4 packs (CVT instructions) need 2 quad-cycles before MFMAs can use their results.
+                pack.min_quad_cycles_before_result_used = 2
 
 def _hook_up_packs_bf16(packs: list[Pack], local_reads: list[LocalRead]) -> None:
     """
@@ -1056,7 +1203,7 @@ def _hook_up_packs_bf16(packs: list[Pack], local_reads: list[LocalRead]) -> None
         if latest_lr.guaranteed_by > pack.must_start_after.done_idx():
             pack.must_start_after = latest_lr
 
-def _hook_up_packs_f32x(packs: list[Pack], all_middle_16_packs: list[Pack], local_reads: list[LocalRead]) -> None:
+def _hook_up_packs_f32(packs: list[Pack], all_middle_16_packs: list[Pack], local_reads: list[LocalRead]) -> None:
     """
     For TF32 emulation, data is loaded as fp32 and converted into pairs of bf16 values.
     Each fp32 value is converted into a bf16 approximation and an error term.
@@ -1154,6 +1301,79 @@ def _hook_up_packs_f32x(packs: list[Pack], all_middle_16_packs: list[Pack], loca
             continue
         pack.next_scheduled_middle_16 = all_middle_16_packs[all_middle_16_packs.index(pack) + 1]
 
+def _hook_up_packs_f32_mfma(packs: list[Pack], local_reads: list[LocalRead]) -> None:
+    """
+    For TF32 emulation, data is loaded as fp32 and converted into pairs of bf16 values.
+    Each fp32 value is converted into a bf16 approximation and an error term.
+
+    Conversion happens in groups of 8 VGPRs (32*8 = 256 bytes).
+    Input is 8 VGPRs, each holding one fp32 value.
+    Output is 8 VGPRs, all holding packed bf16 values.
+    The first 4 output registers hold the bf16 approximations (packed in pairs).
+    The second 4 output registers hold the error terms (packed in pairs).
+
+    Pack instructions in order (24 instructions total):
+    - 4 `v_cvt_pk_bf16_f32` to calculate and pack the bf16 approximations.
+    - 2 `v_mfma_f32_4x4x4_16b_bf16` to calculate the error terms.
+    - 4 `v_cvt_pk_bf16_f32` to pack the error terms into final registers.
+    """
+    # Sort by index in the list of pack instructions rather than by the mfma_index they are placed at.
+    # This is necessary to handle inter-pack dependencies.
+    packs = sorted(packs, key=lambda x: x.issue_index)
+
+    assert len(packs) % 10 == 0, "Packs must be issued in groups of 10."
+    n_pack_groups = len(packs) // 10
+
+    assert len(local_reads) % n_pack_groups == 0, "Case not supported: Different number of LRs for each Pack group."
+    n_lrs_per_group = len(local_reads) // n_pack_groups
+
+    # NOTE: Assuming that all LRs are of the same width.
+    vgprs_per_local_read = 8 // n_lrs_per_group
+
+    # Partial Pack->Pack dependency graph within a group of 24.
+    # Key: pack index (0-23), Value: list of pack indices it depends on.
+    # Empty list means it has no dependencies on other packs.
+    # NOTE: Does not handle the quad-cycle spacing dependencies between packs and MFMAs.
+    pack_dependencies: dict[int, list[int]] = {
+        # First 4 packs only depend on local reads.
+        0: [], 1: [], 2: [], 3: [],
+        # Middle 2 Packs are vmfma and depend on the previous 4 packs.
+        4: [0, 1],
+        5: [2, 3],
+        # Last 2 packs are vmfma and depend on the previous 2 packs.
+        6: [5],
+        7: [5, 6],
+        8: [4, 7],
+        9: [4, 8],
+    }
+
+    for group_idx in range(n_pack_groups):
+        start = group_idx * n_lrs_per_group
+        end = start + n_lrs_per_group
+        local_reads_for_group = local_reads[start:end]
+
+        start = group_idx * 10
+        end = start + 10
+        pack_group = packs[start:end]
+
+        # Set must_start_after
+        for pack_idx, pack in enumerate(pack_group):
+            if pack_idx < 4:
+                # First 4 packs depend only on local reads.
+                first_lr = (pack_idx * 2) // vgprs_per_local_read
+                last_lr = (pack_idx * 2 + 1) // vgprs_per_local_read
+                pack_lrs = local_reads_for_group[first_lr:last_lr + 1]
+                latest_lr = max(pack_lrs, key=lambda lr: lr.done_idx())
+                
+                if latest_lr.guaranteed_by > pack.must_start_after.done_idx():
+                    pack.must_start_after = latest_lr
+            else:
+                # Packs 4-9 depend on other packs (via pack_dependencies).
+                dependencies = pack_dependencies[pack_idx]
+                latest_dep = max((pack_group[d] for d in dependencies), key=lambda p: p.done_idx())
+                if latest_dep.done_idx() > pack.must_start_after.done_idx():
+                    pack.must_start_after = latest_dep
+
 def _get_lrs_for_pack(timeline: Timeline, use_plr_pack: bool, pack_name: str, loop: str) -> list[LocalRead]:
     """
     For a given Pack instruction, get all the LocalRead instructions it depends on.
@@ -1203,6 +1423,10 @@ def hook_up_packs(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int
     is_tf32_emulation = kernel.get("UseF32XEmulation", False)
     is_4x4mfma_tf32 = kernel.get("UseMFMAF32XEmulation", False)
 
+    mfmas_by_index: dict[int, MFMA] = {
+        int(mfma.issued_at): mfma for _, mfma in timeline.get_instructions_combined("MFMA")
+    }
+
     use_plr_pack = kernel.get("UsePLRPack", False)
     for i_loop, loop in enumerate(timeline.loops):
         # 1. Gather all Packs in the current loop.
@@ -1232,15 +1456,147 @@ def hook_up_packs(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int
 
             if is_tf32_emulation:
                 if is_4x4mfma_tf32:
-                    raise NotImplementedError("TF32 emulation mode with MFMA F32X emulation is not supported.")
+                    _hook_up_packs_f32_mfma(packs, local_reads)
                 else:
-                    _hook_up_packs_f32x(packs, all_middle_16_packs, local_reads)
+                    _hook_up_packs_f32(packs, all_middle_16_packs, local_reads)
+                _handle_min_pack_quad_cycles(packs, is_4x4mfma_tf32)
             else:
                 _hook_up_packs_bf16(packs, local_reads)
             
-            # Set needed_by for all packs in one place, handling all cases
-            _set_pack_needed_by(packs, pack_name, i_loop, mfma_reorder, timeline.num_vmfma, kernel)
+            _set_pack_needed_by(packs, pack_name, i_loop, mfma_reorder, mfmas_by_index, timeline.num_vmfma, kernel)
 
+def precompute_issue_times(instructions: list[ValidatorInstruction], is_4x4mfma: bool) -> list[int]:
+    """
+    Returns a list where issue_times[i] represents the quad-cycle when instruction i starts issuing.
+    
+    Args:
+        instructions: List of ValidatorInstruction objects in execution order.
+        is_4x4mfma: True if using TF32 4x4 MFMA mode (affects Pack timing).
+    """
+    class MFMAType(Enum):
+        """Used for tracking type switching penalties in quad-cycle estimation."""
+        NONE = 0      # Not an MFMA instruction
+        STANDARD = 1  # Standard MFMA instruction
+        MFMA_4X4 = 2  # 4x4 MFMA Pack instruction (indices 4-5 in groups of 10)
+
+    def get_mfma_info(instruction: ValidatorInstruction) -> tuple[MFMAType, Optional[int]]:
+        """
+        Get MFMA information for an instruction.
+        
+        Returns:
+            Tuple of (mfma_type, finish_cycles):
+            - mfma_type: The type of MFMA instruction
+            - finish_cycles: Number of quad-cycles the MFMA takes to finish, or None if not an MFMA
+        """
+        if isinstance(instruction, MFMA):
+            return (MFMAType.STANDARD, 3)
+        if isinstance(instruction, Pack) and is_4x4mfma:
+            idx_in_group = instruction.issue_index % 10
+            if idx_in_group in [4, 5]:
+                return (MFMAType.MFMA_4X4, 1)
+        return (MFMAType.NONE, None)
+        
+    mfma_free_at = 0
+    current_issue = 0
+    last_mfma_type = MFMAType.NONE
+    last_mfma_issue = -1
+    
+    issue_times = []
+    for instruction in instructions:
+        mfma_type, finish_cycles = get_mfma_info(instruction)
+        if mfma_type != MFMAType.NONE:
+            # MFMAs must wait for previous MFMA to finish
+            current_issue = max(current_issue, mfma_free_at)
+            
+            # MFMA type switch penalty
+            if last_mfma_type != MFMAType.NONE and last_mfma_type != mfma_type:
+                gap = current_issue - last_mfma_issue
+                threshold = 5 if last_mfma_type == MFMAType.STANDARD else 3
+                if gap < threshold:
+                    current_issue += 1
+            
+            mfma_free_at = current_issue + 1 + finish_cycles  # 1 to issue + finish_cycles to complete
+
+            last_mfma_issue = current_issue
+            last_mfma_type = mfma_type
+        
+        issue_times.append(current_issue)
+        current_issue = current_issue + instruction.min_issue_quad_cycles()
+    
+    return issue_times
+
+def estimate_quad_cycles_precomputed(i_start: int, i_end: int, issue_times: list[int]) -> int:
+    """
+    Calculates the number of quad-cycles between when the instruction at i_start HAS BEEN issued
+    and when the instruction at i_end STARTS being issued.
+    
+    issue_times[i_end] is when i_end starts issuing
+    issue_times[i_start] is when i_start starts issuing
+    After i_start finishes issuing (1 cycle later), we're at issue_times[i_start] + 1
+    
+    Args:
+        i_start: Index of the starting instruction (already issued).
+        i_end: Index of the ending instruction (about to start issuing).
+        issue_times: Pre-computed list of issue times from precompute_issue_times.
+    
+    Returns:
+        Number of quad-cycles between the two instructions.
+    """
+    return issue_times[i_end] - issue_times[i_start] - 1
+
+def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
+    """
+    Perform a rough estimate on the number of quad-cycles that pass between when a instruction is issued and when its result is used.
+    Only operates on instructions which have a set needed_by field and a set min_quad_cycles_before_result_used field.
+
+    All instructions take 1 quad-cycles to issue minimum.
+    Swaits will stall everything else for 1 + wait_state number of quad-cycles.
+    SWait is assumed to be only 1 quad-cycle, have no easy way to determine stalls.
+    SBarrier is assumed to be only 1 quad-cycle, have no easy way to determine stalls.
+    MFMAs take a different number of quad-cycles to finish. Currently assumed that it's 4 quad-cycles (1 issue + 3 finish).
+    Packs take a different number of quad-cycles to finish (since some are actually MFMAs).
+        - Specifically the 5th and 6th pack for 4x4MFMA TF32 approximation, which will take 2 quad-cycles (1 issue + 1 finish).
+
+    During the finish cycles of an MFMA we can issue other instructions.
+    E.g.: MFMA, SNop(2)
+    There will have an execution time of 4 quad-cycles.
+    The SNop(2) which takes 3 quad-cycles (1 issue + 2 finish) will be executed in parallel with the MFMA finishing and fit intirely behind the 3 cycles the mfma takes to finish.
+    """
+    if not kernel.get("UseF32XEmulation", False):
+        # Only F32 emulation issues instructions (Packs) which need estimation of quad-cycles for correctness.
+        return
+
+    # Build helper lookup
+    index_for_inst_id = {id(inst): i for i, inst in enumerate(timeline.combined_timeline)}
+    
+    # TODO: Needed by LR, pointing to MFMA by index. Redo implementation of LR.
+    mfma_for_mfma_index = {
+        inst.issued_at: inst 
+        for inst in timeline.combined_timeline 
+        if isinstance(inst, MFMA)
+    }
+
+    # Precompute issue times
+    issue_times = precompute_issue_times(timeline.combined_timeline, kernel.get("UseMFMAF32XEmulation", False))
+        
+    # Estimate number of quad-cycles between being issued and result being used
+    for i_instruction, instruction in enumerate(timeline.combined_timeline):
+        # TODO: Get rid of the float("inf") check once LocalRead uses the new needed_by version.
+        if not hasattr(instruction, "needed_by") or instruction.needed_by is None or instruction.needed_by is float("inf"):
+            continue
+        
+        if not hasattr(instruction, "min_quad_cycles_before_result_used") or instruction.min_quad_cycles_before_result_used == 0:
+            continue
+
+        needed_by = instruction.needed_by
+        if not isinstance(instruction.needed_by, ValidatorInstruction):
+            needed_by = mfma_for_mfma_index.get(instruction.needed_by)
+            if needed_by is None:
+                continue
+        
+        i_needed_by = index_for_inst_id.get(id(needed_by))
+        estimate = estimate_quad_cycles_precomputed(i_instruction, i_needed_by, issue_times)
+        instruction.estimated_quad_cycles_before_result_used = estimate
 
 def validate_timeline(timeline: Timeline) -> Optional[str]:
     """
@@ -1623,11 +1979,7 @@ def verify_packs_start_and_end_at_correct_indices(schedule_info: 'ScheduleInfo',
     """
     Ensure that the Packs start and end at the correct indices.
     """
-    if context["kernel"].get("UseMFMAF32XEmulation", False):
-        printWarning("Pack validation is not supported for MFMA F32X emulation mode.")
-        return True, ""
-
-    relevant_names = ["SYNC"]
+    relevant_names = ["SYNC", "SNOP"]
     for num in [0, 1, 3]:
         relevant_names.append(f"PackA{num}")
         relevant_names.append(f"PackB{num}")
@@ -1640,6 +1992,7 @@ def verify_packs_start_and_end_at_correct_indices(schedule_info: 'ScheduleInfo',
     apply_barriers(timeline)
     set_lr_needed_by_for_VMFMA(timeline, kernel, schedule_info.mfmaReorder)
     hook_up_packs(timeline, kernel, schedule_info.mfmaReorder)
+    estimate_quad_cycles(timeline, kernel)
 
     message = validate_timeline(timeline)
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -407,6 +407,7 @@ class Pack(ValidatorInstruction):
 
     # The minimum number of quad-cycles that must pass before the result of this pack is used.
     # Measure from the point that this Pack is finished being issued.
+    # See section 7.6 of the CDNA 4 ISA
     min_quad_cycles_before_result_used: int = 0
     # The estimated number of quad-cycles that passed between the pack being issued and the result being used.
     # This is a lower bound estimate (does not account for most stalls and such).
@@ -956,14 +957,24 @@ def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) 
             for _, gr in grs:
                 gr.needed_by = LR_target.issued_at
 
-def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reorder: list[int], mfmas_by_index: dict[int, MFMA], num_vmfma: int,kernel: 'Solution') -> None:
+def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reorder: list[int], mfmas_by_index: dict[int, MFMA], num_vmfma: int, kernel: 'Solution') -> None:
     """
     Set the needed_by field for Pack instructions.
     This function handles all cases (BF16 and TF32).
     
-    For BF16: Each pack's needed_by is calculated based on its position in the pack sequence.
-    For TF32: Only the first 4 and last 4 packs in each group of 24 have needed_by set.
-        The middle 16 packs (indices 4-19) are depended on by the last 4 packs implicitly.
+    For BF16:
+        - The packs are only ever needed by the VMFMA instructions.
+    For regular TF32:
+        - The first and last 4 packs are needed by the VMFMA instructions.
+          There is a minimum number of quad-cycle restriction on the spacing between these packs and their VMFMAs.
+        - The middle-16 packs are handled implicitly.
+    For 4x4 MFMA TF32: 
+        - The first 4 packs are needed by the 5th and 6th packs (which are VMFMAs) as well as the regular VMFMs.
+          Both must be accounted, and both are subject to a minimum number of quad-cycle spacing restrictions.
+        - The 5th and 6th packs (middle 2) are needed by the last 4 packs.
+          These are subject to a minimum number of quad-cycle spacing restrictions.
+        - The last 4 packs are needed by regular VMFMs.
+          These are subject to a minimum number of quad-cycle spacing restrictions.
     
     Args:
         packs: List of Pack instructions to set needed_by for.
@@ -1410,6 +1421,7 @@ def _get_lrs_for_pack(timeline: Timeline, use_plr_pack: bool, pack_name: str, lo
 
 def hook_up_packs(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int]) -> None:
     """
+    Set the needed_by fields 
     Set the needed_by and must_start_after fields of Packs based on the LR(s) they depend on.
 
     Args:
@@ -1552,6 +1564,17 @@ def estimate_quad_cycles_precomputed(i_start: int, i_end: int, issue_times: list
 def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
     """
     Perform a rough estimate on the number of quad-cycles that pass between when a instruction is issued and when its result is used.
+    Needed to ensure the restrictions laied out in section 7.6 of the CDNA 4 ISA are met. Failing to meet these restrictions will result in deterministic errors.
+    
+    E.g. for the 4x4 MFMA TF32 route the 6th and 7th pack instructions map to:
+    v_mfma_f32_4x4x4_16b_bf16 v[0:3], ..., ..., ...
+    v_cvt_pk_bf16_f32 v[3], v[2], v[3]
+
+    As listed above, the sequency of instructions is incorrect since (they reference the same VGPRs and) there must be a minimum of 5 quad-cycles between when v_mfma_f32_4x4x4_16b_bf16 has been issued and when v_cvt_pk_bf16_f32 starts issuing. As written there is a 0 quad-cycle gap (the v_cvt issues and completes in parallel with the v_mfma completing.) One way to write a correct sequency would be A correct sequence would be:
+    v_mfma_f32_4x4x4_16b_bf16 v[0:3], ..., ..., ...
+    s_nop 4
+    v_cvt_pk_bf16_f32 v[3], v[2], v[3]
+
     Only operates on instructions which have a set needed_by field and a set min_quad_cycles_before_result_used field.
 
     All instructions take 1 quad-cycles to issue minimum.
@@ -1986,6 +2009,13 @@ def verify_lrs_finished_before_vmfma(schedule_info: 'ScheduleInfo', context: dic
 def verify_packs_start_and_end_at_correct_indices(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
     Ensure that the Packs start and end at the correct indices.
+    The pack commands take the data loaded into registers by LR commands and manipulate it in various ways to prepare it for the VMFMA instructions.
+
+    There are several restrictions placed on Pack instructions:
+    1. For all gemm types (tf32, bf16, etc.) the Pack instructions must be issued after the data is guaranteed to be loaded into the registers (guaranteed by SWaitCnt instructions). And they must finish before the first VMFMA that uses their results.
+    2. For fp32 GEMMs, there are additional restrictions on:
+        1. The ordering of the Pack instructions.
+        2. The minimum number of quad-cycles that must pass between issuing certain pack instructions and when their results get used. These restrictions are defined in section 7.6 of the CDNA 4 ISA.
     """
     relevant_names = ["SYNC", "SNOP"]
     for num in [0, 1, 3]:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1420,8 +1420,13 @@ def hook_up_packs(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int
     if mfma_reorder and len(mfma_reorder) != timeline.num_vmfma:
         raise ValueError(f"Incorrect number of VMFMA indices in mfmaReorder. Expected {timeline.num_vmfma}, given {len(mfma_reorder)}.")
     
+
     is_tf32_emulation = kernel.get("UseF32XEmulation", False)
     is_4x4mfma_tf32 = kernel.get("UseMFMAF32XEmulation", False)
+    is_direct_32x_emulation = kernel.get("UseDirect32XEmulation", False)
+
+    if is_tf32_emulation and not is_direct_32x_emulation:
+        raise ValueError("UseDirect32XEmulation is False, case not supported.")
 
     mfmas_by_index: dict[int, MFMA] = {
         int(mfma.issued_at): mfma for _, mfma in timeline.get_instructions_combined("MFMA")
@@ -1565,6 +1570,9 @@ def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
     if not kernel.get("UseF32XEmulation", False):
         # Only F32 emulation issues instructions (Packs) which need estimation of quad-cycles for correctness.
         return
+
+    if not kernel.get("UseDirect32XEmulation", False):
+        raise ValueError("UseDirect32XEmulation is False, case not supported.")
 
     # Build helper lookup
     index_for_inst_id = {id(inst): i for i, inst in enumerate(timeline.combined_timeline)}
@@ -1987,6 +1995,10 @@ def verify_packs_start_and_end_at_correct_indices(schedule_info: 'ScheduleInfo',
         relevant_names.append(f"LRB{num}")
     kernel = context["kernel"]
     timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
+    
+    if kernel.get("UseF32XEmulation", False) and not kernel.get("UseDirect32XEmulation", False):
+        printWarning("UseF32XEmulation is set to True but UseDirect32XEmulation is not set to True. Skipping CMS validation for packs.")
+        return True, ""
     
     apply_swaits(timeline)
     apply_barriers(timeline)

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1323,7 +1323,7 @@ def _hook_up_packs_f32_mfma(packs: list[Pack], local_reads: list[LocalRead]) -> 
     The first 4 output registers hold the bf16 approximations (packed in pairs).
     The second 4 output registers hold the error terms (packed in pairs).
 
-    Pack instructions in order (24 instructions total):
+    Pack instructions in order (10 instructions total):
     - 4 `v_cvt_pk_bf16_f32` to calculate and pack the bf16 approximations.
     - 2 `v_mfma_f32_4x4x4_16b_bf16` to calculate the error terms.
     - 4 `v_cvt_pk_bf16_f32` to pack the error terms into final registers.
@@ -1341,8 +1341,8 @@ def _hook_up_packs_f32_mfma(packs: list[Pack], local_reads: list[LocalRead]) -> 
     # NOTE: Assuming that all LRs are of the same width.
     vgprs_per_local_read = 8 // n_lrs_per_group
 
-    # Partial Pack->Pack dependency graph within a group of 24.
-    # Key: pack index (0-23), Value: list of pack indices it depends on.
+    # Partial Pack->Pack dependency graph within a group of 10.
+    # Key: pack index (0-9), Value: list of pack indices it depends on.
     # Empty list means it has no dependencies on other packs.
     # NOTE: Does not handle the quad-cycle spacing dependencies between packs and MFMAs.
     pack_dependencies: dict[int, list[int]] = {

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1570,7 +1570,7 @@ def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
     v_mfma_f32_4x4x4_16b_bf16 v[0:3], ..., ..., ...
     v_cvt_pk_bf16_f32 v[3], v[2], v[3]
 
-    As listed above, the sequence of instructions is incorrect since (they reference the same VGPRs and) there must be a minimum of 5 quad-cycles between when v_mfma_f32_4x4x4_16b_bf16 has been issued and when v_cvt_pk_bf16_f32 starts issuing. As written there is a 0 quad-cycle gap (the v_cvt issues and completes in parallel with the v_mfma completing.) One way to write a correct sequency would be A correct sequence would be:
+    As listed above, the sequence of instructions is incorrect since (they reference the same VGPRs and) there must be a minimum of 5 quad-cycles between when v_mfma_f32_4x4x4_16b_bf16 has been issued and when v_cvt_pk_bf16_f32 starts issuing. As written there is a 0 quad-cycle gap (the v_cvt issues and completes in parallel with the v_mfma completing.) One way to write a correct sequency would be:
     v_mfma_f32_4x4x4_16b_bf16 v[0:3], ..., ..., ...
     s_nop 4
     v_cvt_pk_bf16_f32 v[3], v[2], v[3]

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1577,7 +1577,7 @@ def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
 
     Only operates on instructions which have a set needed_by field and a set min_quad_cycles_before_result_used field.
 
-    All instructions take 1 quad-cycles to issue minimum.
+    All instructions take 1 quad-cycle to issue minimum.
     Swaits will stall everything else for 1 + wait_state number of quad-cycles.
     SWait is assumed to be only 1 quad-cycle, have no easy way to determine stalls.
     SBarrier is assumed to be only 1 quad-cycle, have no easy way to determine stalls.

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1570,7 +1570,7 @@ def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
     v_mfma_f32_4x4x4_16b_bf16 v[0:3], ..., ..., ...
     v_cvt_pk_bf16_f32 v[3], v[2], v[3]
 
-    As listed above, the sequency of instructions is incorrect since (they reference the same VGPRs and) there must be a minimum of 5 quad-cycles between when v_mfma_f32_4x4x4_16b_bf16 has been issued and when v_cvt_pk_bf16_f32 starts issuing. As written there is a 0 quad-cycle gap (the v_cvt issues and completes in parallel with the v_mfma completing.) One way to write a correct sequency would be A correct sequence would be:
+    As listed above, the sequence of instructions is incorrect since (they reference the same VGPRs and) there must be a minimum of 5 quad-cycles between when v_mfma_f32_4x4x4_16b_bf16 has been issued and when v_cvt_pk_bf16_f32 starts issuing. As written there is a 0 quad-cycle gap (the v_cvt issues and completes in parallel with the v_mfma completing.) One way to write a correct sequency would be A correct sequence would be:
     v_mfma_f32_4x4x4_16b_bf16 v[0:3], ..., ..., ...
     s_nop 4
     v_cvt_pk_bf16_f32 v[3], v[2], v[3]

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -1097,7 +1097,6 @@ def _get_schedule_256x256x64_16bit(kernel, useLDSTr, TLDS):
 
     numMfma = 128
     opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
-    opt1.disableValidation()
     return True, opt1
 
 @RegisterSchedule(

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -683,6 +683,58 @@ class TestCustomScheduleTF32:
         valid, message = isValid(schedule_info, {"kernel": kernel})
         assert valid, message
 
+    def test_schedule_256x192x32_TF32(self):
+        """Tests the 256x192x32 TF32 TN schedule."""
+        kernel = create_base_kernel()
+        kernel["ProblemType"].update({
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "UseF32XEmulation": True,
+            "ForceUnrollSubIter": True,
+            "MacroTile0": 256, "MacroTile1": 192, "DepthU": 32,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
+            "DirectToLds": True,
+            "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,
+            "MatrixInstruction": [16, 16, 32, 1], "MIWaveGroup": [2, 2],
+            "LDSTrInst": False, "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 6,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 144
+        assert kernel["UsePLRPack"]
+        valid, message = isValid(schedule_info, {"kernel": kernel})
+        assert valid, message
+
+    def test_schedule_128x256x32_TF32(self):
+        """Tests the 128x256x32 TF32 TN schedule."""
+        kernel = create_base_kernel()
+        kernel["ProblemType"].update({
+            "TransposeA": True, "TransposeB": False
+        })
+        kernel.update({
+            "UseF32XEmulation": True,
+            "ForceUnrollSubIter": True,
+            "MacroTile0": 128, "MacroTile1": 256, "DepthU": 32,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
+            "DirectToLds": True,
+            "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,
+            "MatrixInstruction": [16, 16, 32, 1], "MIWaveGroup": [2, 2],
+            "LDSTrInst": False, "TransposeLDS": 1, "MIWaveTileA": 4, "MIWaveTileB": 8,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 96
+        assert kernel["UsePLRPack"]
+        valid, message = isValid(schedule_info, {"kernel": kernel})
+        assert valid, message
+
     @pytest.mark.parametrize(
         # fmt: off
         "transA, transB, lds_tr_inst,  tr_lds", [

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -588,7 +588,7 @@ class TestCustomScheduleTF32:
             "TransposeA": transA, "TransposeB": transB
         })
         kernel.update({
-            "UseF32XEmulation": True,
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 192, "MacroTile1": 256, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
@@ -614,7 +614,7 @@ class TestCustomScheduleTF32:
             "TransposeA": True, "TransposeB": False
         })
         kernel.update({
-            "UseF32XEmulation": True,
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "MacroTile0": 128, "MacroTile1": 192, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
             "DirectToLds": True,
@@ -639,7 +639,7 @@ class TestCustomScheduleTF32:
             "TransposeA": True, "TransposeB": False
         })
         kernel.update({
-            "UseF32XEmulation": True,
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "MacroTile0": 192, "MacroTile1": 128, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
             "DirectToLds": True,
@@ -664,7 +664,7 @@ class TestCustomScheduleTF32:
             "TransposeA": True, "TransposeB": False
         })
         kernel.update({
-            "UseF32XEmulation": True,
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 256, "MacroTile1": 256, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
@@ -690,7 +690,7 @@ class TestCustomScheduleTF32:
             "TransposeA": True, "TransposeB": False
         })
         kernel.update({
-            "UseF32XEmulation": True,
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 256, "MacroTile1": 192, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
@@ -716,7 +716,7 @@ class TestCustomScheduleTF32:
             "TransposeA": True, "TransposeB": False
         })
         kernel.update({
-            "UseF32XEmulation": True,
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 128, "MacroTile1": 256, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
@@ -748,7 +748,7 @@ class TestCustomScheduleTF32:
             "TransposeA": transA, "TransposeB": transB
         })
         kernel.update({
-            "UseF32XEmulation": True,
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 128, "MacroTile1": 128, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
@@ -782,7 +782,7 @@ class TestCustomScheduleTF32:
             "TransposeA": transA, "TransposeB": transB
         })
         kernel.update({
-            "UseF32XEmulation": True,
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "MacroTile0": 128, "MacroTile1": 128, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,
@@ -815,7 +815,7 @@ class TestCustomScheduleTF32:
             "TransposeA": transA, "TransposeB": transB
         })
         kernel.update({
-            "UseF32XEmulation": True,
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "MacroTile0": 128, "MacroTile1": 160, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
@@ -33,7 +33,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         Helper method to validate quad-cycle estimation.
         
         Ensures:
-        1. The estimate function returns the expected quad cycles
+        1. The estimate function returns the expected quad-cycles
         2. Only the starting instruction has estimated_quad_cycles_before_result_used set to expected value  
         3. All other instructions have estimated_quad_cycles_before_result_used set to 0
         """
@@ -58,7 +58,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         Test that consecutive MFMA instructions correctly stall each other.
         
         Validates that when multiple MFMA instructions are issued back-to-back,
-        the estimated quad cycles account for the execution latency and stalling.
+        the estimated quad-cycles account for the execution latency and stalling.
         """
         target_mfma = MFMA(issued_at=3)
         pack0 = Pack(name="Pack0", issue_index=0, issued_at=0, num_vmfma=0, needed_by=target_mfma)

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
@@ -1,0 +1,269 @@
+################################################################################
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+################################################################################
+
+import unittest
+
+from Tensile.Components.CMSValidator import estimate_quad_cycles_precomputed, MFMA, Pack, precompute_issue_times, SNop, ValidatorInstruction
+
+class TestEstimateQuadCyclesValidator(unittest.TestCase):
+    def validate(self, instruction: ValidatorInstruction, expected_quad_cycles: int, all_instructions: list[ValidatorInstruction], is_4x4mfma: bool):
+        """
+        Helper method to validate quad-cycle estimation.
+        
+        Ensures:
+        1. The estimate function returns the expected quad cycles
+        2. Only the starting instruction has estimated_quad_cycles_before_result_used set to expected value  
+        3. All other instructions have estimated_quad_cycles_before_result_used set to 0
+        """
+        issue_times = precompute_issue_times(all_instructions, is_4x4mfma)
+        i_instruction = all_instructions.index(instruction)
+        i_needed_by = all_instructions.index(instruction.needed_by)
+        
+        result = estimate_quad_cycles_precomputed(i_instruction, i_needed_by, issue_times)
+        instruction.estimated_quad_cycles_before_result_used = result
+
+        for i, instr in enumerate(all_instructions):
+            if hasattr(instr, 'estimated_quad_cycles_before_result_used'):
+                if instr is instruction:
+                    assert instr.estimated_quad_cycles_before_result_used == expected_quad_cycles, \
+                        f"Instruction at index {i} should have estimated_quad_cycles_before_result_used={expected_quad_cycles}, got {instr.estimated_quad_cycles_before_result_used}"
+                else:
+                    assert instr.estimated_quad_cycles_before_result_used == 0, \
+                        f"Instruction at index {i} should have estimated_quad_cycles_before_result_used=0, got {instr.estimated_quad_cycles_before_result_used}"
+        
+    def test_back_to_back_mfma(self):
+        """
+        Test that consecutive MFMA instructions correctly stall each other.
+        
+        Validates that when multiple MFMA instructions are issued back-to-back,
+        the estimated quad cycles account for the execution latency and stalling.
+        """
+        target_mfma = MFMA(issued_at=3)
+        pack0 = Pack(name="Pack0", issue_index=0, issued_at=0, num_vmfma=0, needed_by=target_mfma)
+        all_instructions = [
+            pack0,
+            MFMA(issued_at=0),
+            MFMA(issued_at=1),
+            MFMA(issued_at=2),
+            target_mfma,
+        ]
+        # +4x3 for the 3 MFMAs to issue + finish
+        self.validate(pack0, 12, all_instructions, False)
+        
+    
+    def test_back_to_back_scalar(self):
+        """
+        Test that consecutive non-MFMA instructions are estimated correctly.
+        """
+        target_snop = SNop(issued_at=0.2, wait_state=0)
+        pack0 = Pack(name="Pack0", issue_index=0, issued_at=0, num_vmfma=0, needed_by=target_snop)
+        all_instructions = [
+            pack0,
+            SNop(issued_at=0, wait_state=0),
+            SNop(issued_at=0.1, wait_state=0),
+            target_snop,
+        ]
+        # +1 for 1st SNop
+        # +1 for 2nd SNop
+        self.validate(pack0, 2, all_instructions, False)
+
+    def test_parallel_mfma_snop(self):
+        """
+        Test that MFMA and non-MFMA instructions execute in parallel without stalling.
+        
+        Validates that when MFMA instructions are interleaved with non-MFMA operations,
+        the cycle estimation reflects parallel execution on different execution units,
+        with no unnecessary stalls between these independent instruction types.
+        """
+        target_mfma = MFMA(issued_at=1)
+        pack0 = Pack(name="Pack0", issue_index=0, issued_at=0, num_vmfma=0, needed_by=target_mfma)
+        all_instructions = [
+            pack0,
+            MFMA(issued_at=0),
+            SNop(issued_at=0, wait_state=0),
+            SNop(issued_at=0, wait_state=0),
+            SNop(issued_at=0, wait_state=0),
+            target_mfma
+        ]
+        # +1 for MFMA to issue
+        # +3 for MFMA to finish (3 SNops hidden in this latency)
+        self.validate(pack0, 4, all_instructions, False)
+    
+    def test_mfma_before_start_non_mfma_instruction(self):
+        """
+        Test that an MFMA preceding the window does not stall a leading non-MFMA instruction.
+        
+        Validates that when the instruction window starts with a non-MFMA instruction,
+        an MFMA immediately before the window boundary does not cause stalls for the
+        first instruction, as they execute on different hardware units.
+        """
+        target_mfma = MFMA(issued_at=1)
+        pack0 = Pack(name="Pack0", issue_index=0, issued_at=0, num_vmfma=0, needed_by=target_mfma)
+        all_instructions = [
+            MFMA(issued_at=0),
+            # Window starts with Pack
+            pack0,
+            SNop(issued_at=0, wait_state=0),
+            SNop(issued_at=0, wait_state=0),
+            SNop(issued_at=0, wait_state=0),
+            target_mfma
+        ]
+        self.validate(pack0, 3, all_instructions, False)
+    
+    def test_mfma_before_start_non_mfma_instruction_2(self):
+        """
+        Test that an out-of-window MFMA correctly stalls a subsequent in-window MFMA.
+        
+        Validates that when the window starts with a non-MFMA instruction (which is not
+        stalled by a preceding out-of-window MFMA), but a later MFMA instruction appears
+        within the window, that in-window MFMA is correctly stalled by the out-of-window
+        MFMA instruction. This tests the propagation of stall effects across instruction
+        types.
+        """
+        target_snop = SNop(issued_at=1.5, wait_state=0)
+        pack0 = Pack(name="Pack0", issue_index=0, issued_at=0, num_vmfma=0, needed_by=target_snop)
+        all_instructions = [
+            MFMA(issued_at=0),
+            # Window starts with Pack
+            pack0,
+            MFMA(issued_at=1),  # +2 qs of stall
+            SNop(issued_at=1, wait_state=0),
+            target_snop
+        ]
+        # +3 quad-cycles for MFMA before window to finish.
+        # +1 quad-cycle for MFMA in window to issue  
+        # (last SNop issues in parallel with MFMA finish)
+        self.validate(pack0, 4, all_instructions, False)
+    
+    def test_mfma_before_start_mfma_instruction(self):
+        """
+        Test that an MFMA preceding the window correctly stalls the first MFMA in the window.
+
+        The effect of this is that the issuing of the MFMA is stalled, 
+        but the number of quad-cycles in the window is smaller than in the tests above.
+        """
+        target_snop = SNop(issued_at=2.5, wait_state=0)
+        pack0 = Pack(name="Pack0", issue_index=0, issued_at=0, num_vmfma=0, needed_by=target_snop)
+        all_instructions = [
+            MFMA(issued_at=0),
+            # Window starts with Pack
+            pack0,
+            MFMA(issued_at=1),
+            SNop(issued_at=1, wait_state=0),
+            MFMA(issued_at=2),  # +2 qs of stall
+            SNop(issued_at=2, wait_state=0),
+            target_snop
+        ]
+        # +1 for Pack to issue
+        # +3 for first MFMA in window to finish (1 SNop issues in parallel)
+        # +3 for second MFMA to finish (1 SNop issues in parallel)
+        # +1 for final SNop to issue
+        self.validate(pack0, 8, all_instructions, False)
+
+    def test_4x4mfma_pack_parallel(self):
+        """
+        The 5th and 6th Pack for 4x4MFMA are MFMAs which take 1 cycle to finish.
+        Ensure that we can issue things in parallel with them.
+        """
+        target_snop = SNop(issued_at=0, wait_state=0)
+        pack0 = Pack(name="PackA0", issue_index=5, issued_at=0, num_vmfma=0, needed_by=target_snop)
+        all_instructions = [
+            pack0,
+            SNop(issued_at=0, wait_state=1),
+            target_snop,
+        ]
+        # +1 for Pack to finish (SNop issues in parallel)
+        # +1 for SNop to finish
+        self.validate(pack0, 2, all_instructions, True)
+
+    def test_4x4mfma_to_mfma_extra_stall(self):
+        """
+        Extra 4 quad-cycle latency associated with switching MFMA type.
+        """
+        target_snop = SNop(issued_at=1, wait_state=0)
+        pack0 = Pack(name="PackA0", issue_index=5, issued_at=0, num_vmfma=0, needed_by=target_snop)
+        all_instructions = [
+            pack0,
+            MFMA(issued_at=1),
+            target_snop,
+        ]
+        # +1 for Pack to finish (MFMA stalls)
+        # +1 extra since switching MFMA type
+        # +1 for MFMA to issue
+        self.validate(pack0, 3, all_instructions, True)
+
+    def test_4x4mfma_to_mfma_extra_stall_missing(self):
+        """
+        4x4 -> 16x16 has extra 4 quad-cycle latency only when issuing in the first 3 quad-cycles after the MFMA.
+        """
+        target_snop = SNop(issued_at=1, wait_state=0)
+        pack0 = Pack(name="PackA0", issue_index=5, issued_at=0, num_vmfma=0, needed_by=target_snop)
+        all_instructions = [
+            pack0,
+            SNop(issued_at=0, wait_state=1),
+            MFMA(issued_at=1),
+            target_snop,
+        ]
+        # +1 for Pack to finish (Snop issue hidden)
+        # +1 for SNop finish
+        # +1 for MFMA to issue
+        self.validate(pack0, 3, all_instructions, True)
+
+    def test_mfma_to_4x4mfma_extra_stall(self):
+        """
+        Extra 4 quad-cycle latency associated with switching MFMA type.
+        """
+        target_snop = SNop(issued_at=1, wait_state=0)
+        pack0 = Pack(name="Pack0", issue_index=0, issued_at=0, num_vmfma=0, needed_by=target_snop)
+        all_instructions = [
+            pack0,
+            MFMA(issued_at=1),
+            Pack(name="PackA0", issue_index=5, issued_at=0, num_vmfma=0),
+            target_snop,
+        ]
+        # +1 for MFMA to issue
+        # +3 for MFMA to finish (PackA0 stalls)
+        # +1 extra since switching MFMA type
+        # +1 for PackA0 to issue
+        self.validate(pack0, 6, all_instructions, True)
+    
+    def test_mfma_to_4x4mfma_extra_stall_missing(self):
+        """
+        16x16 -> 4x4 has extra 4 quad-cycle latency only when issuing in the first 4 quad-cycles after the MFMA.
+        """
+        target_snop = SNop(issued_at=1, wait_state=0)
+        pack0 = Pack(name="Pack0", issue_index=0, issued_at=0, num_vmfma=0, needed_by=target_snop)
+        all_instructions = [
+            pack0,
+            MFMA(issued_at=1),
+            SNop(issued_at=1, wait_state=3),
+            Pack(name="PackA0", issue_index=5, issued_at=0, num_vmfma=0),
+            target_snop,
+        ]
+        # +1 for MFMA to issue
+        # +3 for MFMA to finish (SNop issue + 2 wait hidden)
+        # +1 for SNop to finish (3rd of 3 wait_state)
+        # +1 for PackA0 to issue
+        self.validate(pack0, 6, all_instructions, True)

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
@@ -28,7 +28,7 @@ import unittest
 from Tensile.Components.CMSValidator import estimate_quad_cycles_precomputed, MFMA, Pack, precompute_issue_times, SNop, ValidatorInstruction
 
 class TestEstimateQuadCyclesValidator(unittest.TestCase):
-    def validate(self, instruction: ValidatorInstruction, expected_quad_cycles: int, all_instructions: list[ValidatorInstruction], is_4x4mfma: bool):
+    def validate(self, instruction: ValidatorInstruction, expected_quad_cycles: int, all_instructions: list[ValidatorInstruction], is_4x4mfma_tf32_packs: bool):
         """
         Helper method to validate quad-cycle estimation.
         
@@ -37,7 +37,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         2. Only the starting instruction has estimated_quad_cycles_before_result_used set to expected value  
         3. All other instructions have estimated_quad_cycles_before_result_used set to 0
         """
-        issue_times = precompute_issue_times(all_instructions, is_4x4mfma)
+        issue_times = precompute_issue_times(all_instructions, is_4x4mfma_tf32_packs)
         i_instruction = all_instructions.index(instruction)
         i_needed_by = all_instructions.index(instruction.needed_by)
         

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
@@ -368,6 +368,7 @@ class TestValidatePackTF32(CMSValidationTestBase):
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
         kernel_updates["ForceUnrollSubIter"] = True
+        kernel_updates["UseDirect32XEmulation"] = True
         kernel_updates["DepthU"] = 32
         super().setUp(kernel_updates)
 
@@ -548,6 +549,7 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
+        kernel_updates["UseDirect32XEmulation"] = True
         kernel_updates["ForceUnrollSubIter"] = True
         kernel_updates["DepthU"] = 32
         super().setUp(kernel_updates)
@@ -627,6 +629,7 @@ class TestValidatePackTF32CrossPackInterleaving(CMSValidationTestBase):
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
+        kernel_updates["UseDirect32XEmulation"] = True
         kernel_updates["ForceUnrollSubIter"] = True
         kernel_updates["DepthU"] = 32
         kernel_updates["MIWaveTileA"] = 4
@@ -733,6 +736,7 @@ class TestValidatePackTF32MultipleGroups(CMSValidationTestBase):
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
+        kernel_updates["UseDirect32XEmulation"] = True
         kernel_updates["ForceUnrollSubIter"] = True
         kernel_updates["DepthU"] = 32
 
@@ -873,6 +877,7 @@ class TestValidatePackTF32MFMA4x4x4(CMSValidationTestBase):
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
         kernel_updates["UseMFMAF32XEmulation"] = True
+        kernel_updates["UseDirect32XEmulation"] = True
         kernel_updates["ForceUnrollSubIter"] = True
         kernel_updates["DepthU"] = 32
         kernel_updates["MIWaveTileA"] = 4

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
@@ -24,9 +24,8 @@
 ################################################################################
 
 from typing import Any, Optional
-from rocisa.instruction import SWaitCnt
+from rocisa.instruction import SWaitCnt, SNop
 
-from Tensile.Common.DataType import DataType
 from Tensile.Components.CMSValidator import verify_packs_start_and_end_at_correct_indices
 from cms_validation_base import CMSValidationTestBase
 
@@ -446,6 +445,7 @@ class TestValidatePackTF32(CMSValidationTestBase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
         ]
+        
         self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackB0 @ idx=3 issued too early, must be issued after idx=5 (because of LRB0 issued @ idx=3).")
 
     def test_failing_too_late(self):
@@ -472,6 +472,64 @@ class TestValidatePackTF32(CMSValidationTestBase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
         ]
         self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackA0 @ idx=5 issued too late, must be issued before MFMA @ idx=3.")
+
+    def test_failing_too_late_B(self):
+        """
+        Failing case where PackB0s are issued too late (after their result is needed by the v_mfmas).
+
+        """
+        # 2 A tiles, 2 B tiles, 3 bf16 MFMAs per tile
+        assert self.num_vmfma == 12
+        optSchedule = {
+            "SYNC": [[self.q1s+1, self.q2s+1]],
+
+            # Must finish before 2nd quarter (i < 3)
+            "LRA0": [[self.q1s] * 2],
+            "PackA0": [[self.q1e] * 24],
+
+            # Must finish before 3rd quarter (i < 6)
+            "LRB0": [[self.q2s] * 2],
+            "PackB0": [[self.q3e] * 24],  # Issued in 3rd quarter, too late
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
+        ]
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackB0 @ idx=8 issued too late, must be issued before MFMA @ idx=6.")
+
+    def test_failing_not_enough_time_CVT1_MFMA(self):
+        """
+        Failing case where there is not enough time between the last cvt pack command the first "real" mfma using the result.
+        """
+        assert self.num_vmfma == 12
+
+        optSchedule = {
+            "SYNC": [[self.q1s+2, self.q2s+2]],
+            "SNOP": [[self.q2s]],  # 
+
+            # Must finish before 2nd quarter (i < 3)
+            "LRA0": [[self.q1s+1] * 2],
+            "PackA0": [
+                [self.q1e] * 22 +
+                [self.q2s] *2 
+            ],
+
+            # Must finish before 3rd quarter (i < 6)
+            "LRB0": [[self.q2s+1] * 2],
+            "PackB0": [[self.q2e] * 24],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
+        ]
+
+        snopCode = [
+            SNop(waitState=1, comment="Needed to force the last 2 PackA0s to be too close to the MFMA."),
+        ]
+
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackA0 @ idx=3 has too little gap between it and MFMA @ idx=4. Expected at least 2 quad-cycles but only 1 passed.", snopCode=snopCode)
 
 class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
     """
@@ -805,3 +863,294 @@ class TestValidatePackTF32MultipleGroups(CMSValidationTestBase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
         ]
         self.validate(optSchedule, syncCode, 1, 2, 2, 0, 'PackA0 @ idx=2 has wrong interleaving. Should have been followed by PackA0 @ idx=3 but was followed by PackA0 @ idx=2.')
+
+class TestValidatePackTF32MFMA4x4x4(CMSValidationTestBase):
+    """
+    Tests for TF32 validation with 4x4x4 MFMA.
+    """
+    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
+        kernel_updates = kernel_updates.copy() if kernel_updates else {}
+        kernel_updates["UsePLRPack"] = True
+        kernel_updates["UseF32XEmulation"] = True
+        kernel_updates["UseMFMAF32XEmulation"] = True
+        kernel_updates["ForceUnrollSubIter"] = True
+        kernel_updates["DepthU"] = 32
+        kernel_updates["MIWaveTileA"] = 4
+        kernel_updates["MIWaveTileB"] = 4
+        super().setUp(kernel_updates)
+
+        self.q1s = 0
+        self.q1e = self.num_vmfma // 4 - 1
+
+        self.q2s = self.q1e + 1
+        self.q2e = self.num_vmfma // 2 - 1
+
+        self.q3s = self.q2e + 1
+        self.q3e = self.num_vmfma // 4 * 3 - 1
+
+        self.q4s = self.q3e + 1
+        self.q4e = self.num_vmfma - 1
+    
+    def validation_function(self, sched, kernel_dict, codePathIdx):
+        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    
+    def test_passing(self):
+        """
+        Simple passing case.
+        """
+        assert self.num_vmfma == 48
+
+        optSchedule = {
+            "SYNC": [[self.q1s+1, self.q2s+1, self.q3s+1, self.q4s+1]],
+
+            "LRA0": [[self.q1s] * 2],
+            "PackA0": [
+                [self.q1s+2] * 4 + 
+                [self.q1s+2] * 2 +
+                [self.q1s+4] * 4  # Needs +2 MFMAs to satisfy the 5 quad-cycle gap.
+            ],
+
+            "LRB0": [[self.q2s] * 2],
+            "PackB0": [
+                [self.q2s+2] * 4 +
+                [self.q2s+2] * 2 +
+                [self.q2s+4] * 4  # Needs +2 MFMAs to satisfy the 5 quad-cycle gap.
+            ],
+            
+            "LRB3": [[self.q3s] * 2],
+            "PackB3": [
+                [self.q3s+2] * 4 +
+                [self.q3s+2] * 2 +
+                [self.q3s+4] * 4  # Needs +2 MFMAs to satisfy the 5 quad-cycle gap.
+            ],
+
+            "LRA3": [[self.q4s] * 2],
+            "PackA3": [
+                [self.q4s+2] * 4 +
+                [self.q4s+2] * 2 +
+                [self.q4s+4] * 4  # Needs +2 MFMAs to satisfy the 5 quad-cycle gap.
+            ],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB3s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA3s")
+        ]
+
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, None)
+
+    def test_failing_too_early(self):
+        """
+        Failing case where the PackB0 are issued before the LRB0s are complete.
+        """
+        assert self.num_vmfma == 48
+
+        optSchedule = {
+            "SYNC": [[self.q1s+1, self.q2e]],
+
+            "LRA0": [[self.q1s] * 2],
+            "PackA0": [
+                [self.q1s+2] * 4 +
+                [self.q1s+2] * 2 +
+                [self.q1s+4] * 4
+            ],
+
+            "LRB0": [[self.q2s] * 2],
+            "PackB0": [
+                [self.q2s+1] +  # Issued too early.
+                [self.q3s] * 3 +
+                [self.q3s] * 2 +
+                [self.q3s+2] * 4
+            ],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
+        ]
+        
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackB0 @ idx=13 issued too early, must be issued after idx=23 (because of LRB0 issued @ idx=12).")
+
+    def test_failing_too_late(self):
+        """
+        Failing case where PackA0s are issued too late (after their result is needed by the v_mfmas).
+        """
+        assert self.num_vmfma == 48
+
+        optSchedule = {
+            "SYNC": [[self.q1s+1, self.q2s+1]],
+
+            # Must finish before 2nd quarter
+            "LRA0": [[self.q1s] * 2],
+            "PackA0": [
+                [self.q1s+1] * 4 +
+                [self.q1s+1] * 2 +
+                [self.q2s+2] * 4  # Issued after the 2nd mfma in the 2nd quarter
+            ],
+
+            # Must finish before 3rd quarter
+            "LRB0": [[self.q2s] * 2],
+            "PackB0": [
+                [self.q2s+2] * 4 +
+                [self.q2s+2] * 2 +
+                [self.q2s+3] * 4
+            ],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
+        ]
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackA0 @ idx=14 issued too late, must be issued before MFMA @ idx=13.")
+
+    def test_passing_snop(self):
+        """
+        Passing case that relies on s_nop instructions to guarantee there is enough time around the 4x4 MFMAs.
+        This test verifies that SNop instructions are properly counted for quad-cycle spacing.
+        The first 4 packs (CVT0) need 2 quad-cycles before their result is used by the 4x4 MFMA.
+        
+        For TF32 4x4 MFMA with MIWaveTileA=4, MIWaveTileB=4:
+        - 48 total vmfmas (4*4*3)
+        - q1: 0-11, q2: 12-23, q3: 24-35, q4: 36-47
+        - PackA0 packs are needed for MFMAs in q2 starting at idx 12
+        """
+        assert self.num_vmfma == 48
+
+        optSchedule = {
+            "SYNC": [[self.q1s+1, self.q2s+1]],
+            "SNOP": [[self.q1s+2, self.q2s+2]],
+
+            # Must finish before 2nd quarter
+            "LRA0": [[self.q1s, self.q1s]],
+            "PackA0": [
+                [self.q1s+1] * 4 +
+                [self.q1s+1] + 
+                [self.q1s+1] + # Only 2 quad-cycles before Pack[6] without SNop.
+                [self.q1s+2] * 4
+            ],
+
+            # Must finish before 3rd quarter
+            "LRB0": [[self.q2s, self.q2s]],
+            "PackB0": [
+                [self.q2s+1] * 4 +
+                [self.q2s+1] +
+                [self.q2s+1] + # Only 2 quad-cycles before Pack[6] without SNop.
+                [self.q2s+2] * 4
+            ],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
+        ]
+
+        snopCode = [
+            SNop(waitState=1, comment="Needed to have 5 quad-cycle space between PackA0[5] and PackBo[6]."),
+            SNop(waitState=1, comment="Needed to have 5 quad-cycle space between PackB0[5] and PackB0[6]."),
+        ]
+
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, None, snopCode=snopCode)
+
+    def test_failing_not_enough_time_CVTO_MFMA(self):
+        """
+        Failing case where there is not enough time between the first pair of CVT0 and the first 4x4 MFMA.
+        """
+        assert self.num_vmfma == 48
+
+        optSchedule = {
+            "SYNC": [[self.q1s+1, self.q2s+1]],
+            
+            "LRA0": [[self.q1s] * 2],
+            "PackA0": [
+                [self.q1s+1] * 2 +
+                [self.q1s+2] * 2 +
+                [self.q1s+1] +
+                [self.q1s+3] +
+                [self.q1s+4] * 4
+            ],
+
+            "LRB0": [[self.q2s] * 2],
+            "PackB0": [
+                [self.q2s+1] * 2 +
+                [self.q2s+2] * 2 +
+                [self.q2s+1] +
+                [self.q2s+3] +
+                [self.q2s+4] * 4
+            ],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
+        ]
+
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackA0 @ idx=1 has too little gap between it and PackA0 @ idx=1. Expected at least 2 quad-cycles but only 1 passed.")
+    
+    def test_failing_not_enough_time_MFMA_CVT1(self):
+        """
+        Failing case where there is not enough time between the 4x4 MFMA (Pack 5) and the first CVT1 pack (Pack 6).
+        Pack 5 (second 4x4 MFMA) needs 5 quad-cycles before Pack 6 (first CVT1) can use its result.
+        With only 1 standard MFMA between them, there's only 3 quad-cycles, which is not enough.
+        """
+        assert self.num_vmfma == 48
+
+        optSchedule = {
+            "SYNC": [[self.q1s+1, self.q2s+1]],
+
+            "LRA0": [[self.q1s] * 2],
+            "PackA0": [
+                [self.q1s+2] * 4 +
+                [self.q1s+2] * 2 +
+                [self.q1s+3] * 4     # CVT1: indices 6-9 at vmfma 3 (only 1 MFMA between, not enough time!)
+            ],
+
+            "LRB0": [[self.q2s] * 2],
+            "PackB0": [
+                [self.q2s+2] * 4 +
+                [self.q2s+2] * 2 +
+                [self.q2s+4] * 4  # CVT1 at vmfma q2s+4, enough time for B
+            ],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
+        ]
+
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackA0 @ idx=2 has too little gap between it and PackA0 @ idx=3. Expected at least 5 quad-cycles but only 3 passed.")
+
+    def test_failing_not_enough_time_CVT1_MFMA(self):
+        """
+        Failing case where there is not enough time between the last CVT1 pack and the first "real" MFMA using the result.
+        CVT1 packs (indices 6-9) need 2 quad-cycles before the MFMAs can use their results.
+        """
+        assert self.num_vmfma == 48
+
+        optSchedule = {
+            "SYNC": [[self.q1s+2, self.q2s+2]],
+            "SNOP": [[self.q2s]],
+
+            "LRA0": [[self.q1s+1] * 2],
+            "PackA0": [
+                [self.q1s+2] * 4 +
+                [self.q1s+2] * 2 +
+                [self.q1e] * 2 +
+                [self.q2s] * 2       # CVT1 (8-9) at vmfma 12 (too close to MFMA at q2s+1)
+            ],
+
+            "LRB0": [[self.q2s+1] * 2],
+            "PackB0": [[self.q2e] * 10],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
+        ]
+
+        snopCode = [
+            SNop(waitState=1, comment="Needed to force the last 2 PackA0s to be too close to the MFMA."),
+        ]
+
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackA0 @ idx=12 has too little gap between it and MFMA @ idx=13. Expected at least 2 quad-cycles but only 1 passed.", snopCode=snopCode)


### PR DESCRIPTION
## Motivation

Validation missing for the 4x4x4 MFMA Pack route. Validation was also missing the needed cycle gap between mfmas and certain pack instructions.

## Technical Details
1. Calculate a lower-bound estimate of what cycle each instruction gets issued at.
  - Account for deterministic stalls from issuing instructions too close to each other (e.g. back to back MFMAs).
  - Account for penalty for switching between MFMA types too early.
  - Account for issuing scalar and vector instructions in parallel.
  - Handle SNops.
2. Ensure there are enough cycles between when mfmas produce/use results in vgprs and when cvt instructions use/produce use those same values.
3. Improve error logging to indicate why a given Pack instruction must complete by a given mfma index.

## Test Plan

1. Run existing tests.
2. Run new tests.

## Test Result

New and existing tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
