### PR TITLE
[hipblaslt] Remove block on PCI chip ID builds

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
+++ b/projects/hipblaslt/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
@@ -198,20 +198,6 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
 
     args = argParser.parse_args()
 
-    # NOTE: The feature that allows predicate based tensilelite library builds
-    # via `--architecture=gfx950[id=XXXX]` is not fully supported until the
-    # tensilelite runtime lookup and selection for these predicates is complete.
-    # As a staged approach, the TensileCreateLibrary code to enable this feature
-    # is implemented, but will remain disabled until the work is complete.
-    predicatePattern = re.compile(r"\[(.*?)\]")
-    if predicatePattern.search(args.Architecture):
-        printExit(
-            "Predicate based tensilelite library builds are supported; however, since "
-            "the runtime lookup and selection of these libraries is incomplete, the "
-            "requested build is currently disabled. Please re-run using only the "
-            "architecture name without a predicate (`--architecture=gfx950`)."
-        )
-
     arguments = {}
     arguments["RuntimeLanguage"] = args.RuntimeLanguage
     arguments["CodeObjectVersion"] = coVersionMap[args.CodeObjectVersion]


### PR DESCRIPTION
## Motivation

Device ID-based builds are currently blocked because the runtime component is not supported. There is a future PR that will add runtime device ID management, so I'm staging this change to align with that work. More PRs might also be on the way.

## Technical Details

Removes a strict `printExit` previously imposed on the argument parser.

## Test Plan

Previous work has validated the tests, this PR simply exposes the functionality. Low risk. Standard CI testing is acceptable.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
