### PR TITLE
Revert "Disable conv_wino_fury_RxS for gfx115x"

### DIFF
--- a/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
@@ -390,15 +390,6 @@ bool ConvWinoFuryRxSCommon<Winodata, Winofilter>::IsApplicable(const ExecutionCo
     if(!(StartsWith(dev_name, "gfx11") || StartsWith(dev_name, "gfx12")))
         return false;
 
-    if(StartsWith(dev_name, "gfx115"))
-    {
-        // Triggers this error on gfx1151
-        // kernel: [drm:gfx_v11_0_bad_op_irq [amdgpu]] *ERROR* Illegal opcode in command stream
-        // stderr: HSA_STATUS_ERROR_INVALID_ISA: The instruction set architecture is invalid. code:
-        // 0x100f
-        return false;
-    }
-
     if(!(problem.GetKernelStrideH() == 1 && problem.GetKernelStrideW() == 1))
         return false;
     if(!(problem.GetDilationH() == 1 && problem.GetDilationW() == 1))

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
@@ -55,7 +55,8 @@ auto GetConvTestCasesWrw(miopenDataType_t datatype)
 const auto& GetTestParams()
 {
     static const auto params = [] {
-        auto p = miopen::unit_tests::UnitTestConvSolverParams(Gpu::gfx110X | Gpu::gfx120X);
+        auto p = miopen::unit_tests::UnitTestConvSolverParams(Gpu::gfx110X | Gpu::gfx120X |
+                                                              Gpu::gfx115X);
         return p;
     }();
     return params;


### PR DESCRIPTION
Make Fury Wino kernel available again for gfx115x.

This reverts commit cc95574580f67fa452025fcd94333abce60bd5fb.

## Motivation

Fury Wino kernel was disabled due to issue related with incorrect vgrp amount on driver side (refs: https://github.com/ROCm/TheRock/issues/435, https://github.com/ROCm/MIOpen/pull/3685), driver's patch is merged, so time to re-enable Fury Wino.

## Technical Details
The root cause of the issue is fixed in the next commit firmware patch ->
https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/?id=e2c1b151087b2983249e106868877bd19761b976 (rocr also updated https://github.com/ROCm/rocm-systems/pull/1807), therefore, in MIOpen, remove the if condition that prevented the Fury kernel from being selected on gfx115x.

## Test Plan
1. Unit tests: `miopen_gtest --gtest_filter=*GPU_UnitTestConvSolverWinoFury2x3*`
1. Problem from https://github.com/ROCm/TheRock/issues/435#issuecomment-2886754396 : `MIOpenDriver conv -n 1 -c 256 -H 1024 -W 1024 -k 256 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1`

## Test Result
1. passed [ut.txt](https://github.com/user-attachments/files/24030139/ut.txt)

1. passed

[problem.txt](https://github.com/user-attachments/files/24030213/problem.txt)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

(cherry picked from commit 11fdfe08b66ae0587bcac860f2f7aa6549dfe506)