### PR TITLE
Fix icache_flush xfail to apply for ROCm 7.1 and above

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/test_config.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/test_config.py
@@ -205,11 +205,6 @@ def findConfigs(rootDir=None):
     params = []
     for (dirpath, dirnames, filenames) in os.walk(rootDir):
         for filename in filenames:
-            # Conditionally skip icache_flush.yaml on rocm 7.1 due to ROCm bug.
-            if filename == "icache_flush.yaml" and rocm_version and rocm_version.startswith("7.1"):
-                print(f"INFO: Skipping '{filename}' on ROCm {rocm_version}.")
-                continue
-
             # Skip build client script
             if filename == "build_client.yaml":
                 continue
@@ -219,10 +214,12 @@ def findConfigs(rootDir=None):
                 if not "test_data" in filepath:
                     marks = configMarks(filepath, rootDir, availableArchs)
 
-                    # Conditionally xfail icache_flush.yaml on rocm 7.1 due to ROCm bug.
-                    if filename == "icache_flush.yaml" and rocm_version and rocm_version.startswith("7.1"):
-                        reason = "Test is expected to fail on ROCm 7.1 due to a known bug."
-                        marks.append(pytest.mark.xfail(reason=reason, strict=True))
+                    # Conditionally xfail icache_flush.yaml on rocm 7.1+ due to ROCm bug.
+                    if filename == "icache_flush.yaml" and rocm_version:
+                        parts = rocm_version.split(".")
+                        if len(parts) >= 2 and (int(parts[0]), int(parts[1])) >= (7, 1):
+                            reason = "Test is expected to fail on ROCm 7.1+ due to a known bug."
+                            marks.append(pytest.mark.xfail(reason=reason, strict=True))
 
                     relpath = os.path.relpath(filepath, printRoot)
                     params.append(pytest.param(filepath, marks=marks, id=relpath))


### PR DESCRIPTION
Remove duplicate skip logic (from bad merge) and update xfail condition to use version comparison instead of string prefix matching, so the test is properly marked as expected-to-fail on ROCm 7.1, 7.2, and beyond.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
