### PR TITLE
[hipblaslt][CMS] Fix LR Validator not checking LRA3s and LRB3s

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1606,7 +1606,7 @@ def verify_lrs_finished_before_vmfma(schedule_info: 'ScheduleInfo', context: dic
     """
     kernel = context["kernel"]
 
-    relevant_names = ["LRA0", "LRB0", "LRA1", "LRB1", "SYNC"]
+    relevant_names = ["LRA0", "LRB0", "LRA1", "LRB1", "LRA3", "LRB3", "SYNC"]
     timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
 
     set_lr_needed_by_for_VMFMA(timeline, kernel, schedule_info.mfmaReorder)

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -558,7 +558,26 @@ class TestValidateLRsCompleteBeforeVMFMA_ForceUnrollSubIter(CMSValidationTestBas
         return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
 
 
-    def test_bf16(self):
+    def test_bf16_pass(self):
+        assert self.num_vmfma == 16
+
+        optSchedule = {
+            "SYNC": [[3, 15]],
+            "LRA0": [[0, 0]],
+            "LRB0": [[0, 0]],
+            "LRA3": [[7, 7]],
+            "LRB3": [[7, 7]],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="For LR0s"),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="For LR3s"),
+        ]
+
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+
+    def test_bf16_fail(self):
+        """Same as above, but with the proper SWaitCnt for the LR3s."""
         assert self.num_vmfma == 16
 
         optSchedule = {
@@ -570,10 +589,10 @@ class TestValidateLRsCompleteBeforeVMFMA_ForceUnrollSubIter(CMSValidationTestBas
         }
 
         syncCode = [
-            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="For LR0s"),
         ]
 
-        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+        self.validate(optSchedule, syncCode, 1, None, None, 0, "LRA3 at index 7 is not valid. Needed before index 0, but only guaranteed at index 3.")
 
 
 class TestIndexForForceUnrollSubIter:


### PR DESCRIPTION
## Motivation

Fixing bug.

## Technical Details

LRA3 and LRB3 were not being added to the `relevant_names` list, and hence were not being validated.

## Test Plan

Fix test and add test with improper schedule to ensure it fails.

## Test Result

Passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
