### PR TITLE
[miopen] add code coverage process

### DIFF
--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -888,6 +888,17 @@ else()
         )
 endif()
 
+if (BUILD_CODE_COVERAGE)
+	target_compile_options(MIOpen PRIVATE
+    -w
+    -fprofile-instr-generate
+    -fcoverage-mapping
+  )
+  target_link_options(MIOpen PUBLIC
+    -fprofile-instr-generate
+  )
+endif()
+
 rocm_set_soversion(MIOpen ${MIOpen_SOVERSION})
 
 clang_tidy_check(MIOpen)

--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -888,7 +888,7 @@ else()
         )
 endif()
 
-if (BUILD_CODE_COVERAGE)
+if (MIOPEN_ENABLE_COVERAGE)
 	target_compile_options(MIOpen PRIVATE
     -w
     -fprofile-instr-generate

--- a/projects/miopen/test/CMakeLists.txt
+++ b/projects/miopen/test/CMakeLists.txt
@@ -666,8 +666,8 @@ function(add_custom_test NAME)
     foreach(__environment ${PARSE_ENVIRONMENT})
         set_tests_properties(${NAME} PROPERTIES ENVIRONMENT "${__environment}")
     endforeach()
-    set_tests_properties(${NAME} PROPERTIES ENVIRONMENT
-        "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage-report/profraw/MIOpen-coverage-%p-%m.profraw"
+    set_property(TEST ${NAME} APPEND PROPERTY ENVIRONMENT
+        "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage-report/profraw/%p.%m.profraw"
     )
 
     # The tests often change the contents of the user databases, which may affect performance after testing.
@@ -861,7 +861,6 @@ if (MIOPEN_ENABLE_COVERAGE)
   add_custom_target(
     coverage_setup
     COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
-    COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
     COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   )
@@ -883,7 +882,7 @@ if (MIOPEN_ENABLE_COVERAGE)
   )
   add_custom_target(
     coverage
-    DEPENDS coverage_setup test_group_conv2d_fwd
+    DEPENDS coverage_setup check
     COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/MIOpen-coverage_*.profraw -o ./coverage-report/MIOpen.profdata
     COMMAND ${LLVM_COV} report -object ./lib/libMIOpen.so -instr-profile=./coverage-report/MIOpen.profdata
     COMMAND ${LLVM_COV} show -object ./lib/libMIOpen.so -instr-profile=./coverage-report/MIOpen.profdata -format=html -output-dir=coverage-report

--- a/projects/miopen/test/CMakeLists.txt
+++ b/projects/miopen/test/CMakeLists.txt
@@ -354,6 +354,10 @@ function(add_test_command NAME EXE)
         endif()
     endif()
     set_tests_properties(${NAME} PROPERTIES ENVIRONMENT "MIOPEN_USER_DB_PATH=${CMAKE_CURRENT_BINARY_DIR}")
+    # Append coverage env
+    set_property(TEST ${NAME} APPEND PROPERTY ENVIRONMENT
+        "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage-report/profraw/%p.%m.profraw"
+    )
 endfunction()
 
 separate_arguments(MIOPEN_TEST_FLAGS_ARGS NATIVE_COMMAND ${MIOPEN_TEST_FLAGS})
@@ -417,6 +421,11 @@ function(add_test_executable TEST_NAME)
     if(rocblas_FOUND)
         target_link_libraries( ${TEST_NAME} $<BUILD_INTERFACE:roc::rocblas> )
     endif()
+    # Append coverage env
+    set_property(TEST ${NAME} APPEND PROPERTY ENVIRONMENT
+        "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage-report/profraw/%p.%m.profraw"
+    )
+
 endfunction()
 
 set(MIOPEN_TEST_SANITIZERS)
@@ -460,6 +469,10 @@ function(rate_added_test NAME)
     else()
         set_tests_properties(${NAME} PROPERTIES COST 600)
     endif()
+    # Append coverage env
+    set_property(TEST ${NAME} APPEND PROPERTY ENVIRONMENT
+        "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage-report/profraw/%p.%m.profraw"
+    )
 endfunction()
 
 set(EXCLUDE_TESTS)
@@ -719,6 +732,9 @@ function(add_custom_test NAME)
         AND (${NAME} MATCHES "test_conv_for_implicit_gemm" ))
         set_tests_properties(${NAME} PROPERTIES DISABLED On)
     endif()
+    set_property(TEST ${NAME} APPEND PROPERTY ENVIRONMENT
+        "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage-report/profraw/%p.%m.profraw"
+    )
 endfunction()
 
 set(IMPLICITGEMM_MLIR_ENV_BASE MIOPEN_FIND_MODE=normal)
@@ -880,6 +896,7 @@ if (MIOPEN_ENABLE_COVERAGE)
     HINTS ${ROCM_PATH}/llvm/bin
     PATHS /opt/rocm/llvm/bin
   )
+
   add_custom_target(
     coverage
     DEPENDS coverage_setup check

--- a/projects/miopen/test/CMakeLists.txt
+++ b/projects/miopen/test/CMakeLists.txt
@@ -666,6 +666,9 @@ function(add_custom_test NAME)
     foreach(__environment ${PARSE_ENVIRONMENT})
         set_tests_properties(${NAME} PROPERTIES ENVIRONMENT "${__environment}")
     endforeach()
+    set_tests_properties(${NAME} PROPERTIES ENVIRONMENT
+        "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage-report/profraw/MIOpen-coverage-%p-%m.profraw"
+    )
 
     # The tests often change the contents of the user databases, which may affect performance after testing.
     # For example, MIOPEN_DEBUG_FIND_ONLY_SOLVER results in non-optimal records in user-find-db.
@@ -853,6 +856,41 @@ add_custom_test(conv_transposed_bwd_find_2
 add_custom_test(conv_transposed_wrw_find_2
     COMMAND $<TARGET_FILE:test_conv2d_find2> ${TEST_CONV_VERBOSE_W} --input 64 64  28 28 --weights 64  64  1 1 --pads_strides_dilations 0 0 1 1 1 1 --cmode transpose ${MIOPEN_TEST_FLAGS_ARGS}
 )
+
+if (MIOPEN_ENABLE_COVERAGE)
+  add_custom_target(
+    coverage_setup
+    COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
+    COMMAND ${CMAKE_COMMAND} -E rm -rf ./coverage-report
+    COMMAND ${CMAKE_COMMAND} -E make_directory ./coverage-report/profraw
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+  find_program(
+    LLVM_PROFDATA
+    llvm-profdata
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+
+  find_program(
+    LLVM_COV
+    llvm-cov
+    REQUIRED
+    HINTS ${ROCM_PATH}/llvm/bin
+    PATHS /opt/rocm/llvm/bin
+  )
+  add_custom_target(
+    coverage
+    DEPENDS coverage_setup test_group_conv2d_fwd
+    COMMAND ${LLVM_PROFDATA} merge -sparse ./coverage-report/profraw/MIOpen-coverage_*.profraw -o ./coverage-report/MIOpen.profdata
+    COMMAND ${LLVM_COV} report -object ./lib/libMIOpen.so -instr-profile=./coverage-report/MIOpen.profdata
+    COMMAND ${LLVM_COV} show -object ./lib/libMIOpen.so -instr-profile=./coverage-report/MIOpen.profdata -format=html -output-dir=coverage-report
+    COMMAND ${LLVM_COV} export -object ./lib/libMIOpen.so -instr-profile=./coverage-report/MIOpen.profdata -format=lcov > ./coverage-report/coverage.info
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+endif()
 
 #Dont install the tests if we are building each test separately
 #When the tests are built as a single unit, then we want to be


### PR DESCRIPTION
## Motivation

We want to generate code coverage reports for MIOpen

## Technical Details

Added the process.  Still a WIP at the time of creating this PR.  Right now I am trying to embed the `LLVM_PROFILE_FILE` environment variable into the test cases.  I suspect that, because coverage counts aren't being dropped into the coverage-report/profraw dir is because the build didn't get instrumented somehow. 

Also need to know if there are any other targets that should be considered in the report.  We don't want to instrument test cases, just product code.

## Test Plan

We will generate a coverage report using the `make coverage` target

## Test Result

TBD

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
