### PR TITLE
[MIOpen] Update bn_driver with the new miopenBatchNormalizationForwardTraining_V3 API

### DIFF
--- a/projects/miopen/driver/bn_driver.hpp
+++ b/projects/miopen/driver/bn_driver.hpp
@@ -124,6 +124,7 @@ private:
     bool keepRunningMeanVar;
     bool estimatedMeanVar;
     bool useInverseVar;
+    bool usePingPongBuffers;
 
     int forw;
     int back;
@@ -152,6 +153,8 @@ private:
 
     // forward training
     GpumemTensor<TAcc> savedVariance;
+    GpumemTensor<TAcc> prevRunMean;
+    GpumemTensor<TAcc> prevRunVariance;
     GpumemTensor<TAcc> runMean;
     GpumemTensor<TAcc> runVariance;
     // ref
@@ -258,7 +261,11 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::GetandSetData()
         savedVariance.AllocOnHost(tensor<TAcc>{bn_layout, derivedBnDesc.GetLengths()});
         runMean.AllocOnHost(tensor<TAcc>{bn_layout, derivedBnDesc.GetLengths()});
         runVariance.AllocOnHost(tensor<TAcc>{bn_layout, derivedBnDesc.GetLengths()});
-
+        if(usePingPongBuffers)
+        {
+            prevRunMean.AllocOnHost(tensor<TAcc>{bn_layout, derivedBnDesc.GetLengths()});
+            prevRunVariance.AllocOnHost(tensor<TAcc>{bn_layout, derivedBnDesc.GetLengths()});
+        }
         // -2.0 to 2.0
         runMean.GetTensor().generate(
             uniform_signed_initializer<TAcc>(2e-3 /*scale*/, 1000 /*range*/));
@@ -372,6 +379,11 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::AddCmdLineArgs()
                          'I',
                          "0",
                          "Use inverse variance for forward inference (Default=0)",
+                         "int");
+    inflags.AddInputFlag("ping_pong_buffers",
+                         'Q',
+                         "0",
+                         "Use ping-pong buffers for running mean and variance (Default=0)",
                          "int");
 
     return miopenStatusSuccess;
@@ -573,6 +585,20 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::SetBNParametersFromCm
         printf("Inverse variance can only be used with forward inference\n");
         exit(EXIT_FAILURE); // NOLINT (concurrency-mt-unsafe)
     }
+    if(inflags.GetValueInt("ping_pong_buffers") == 1)
+    {
+        if(forw != 1 || !keepRunningMeanVar)
+        {
+            printf("Ping-pong buffers are only supported in forward training when running mean "
+                   "and variance are kept\n");
+            exit(EXIT_FAILURE); // NOLINT (concurrency-mt-unsafe)
+        }
+        usePingPongBuffers = true;
+    }
+    else
+    {
+        usePingPongBuffers = false;
+    }
 
     return miopenStatusSuccess;
 }
@@ -615,6 +641,13 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::AllocateBuffersAndCop
             q, ctx, GetTensorSize(&runMean.GetTensor().desc), buffer_check);
         status |= runVariance.AllocOnDeviceAndInit(
             q, ctx, GetTensorSize(&runVariance.GetTensor().desc), buffer_check);
+        if(usePingPongBuffers)
+        {
+            status |= prevRunMean.AllocOnDeviceAndInit(
+                q, ctx, GetTensorSize(&prevRunMean.GetTensor().desc), buffer_check);
+            status |= prevRunVariance.AllocOnDeviceAndInit(
+                q, ctx, GetTensorSize(&prevRunVariance.GetTensor().desc), buffer_check);
+        }
 
         savedMean_ref = tensor<Tref>{savedMean.GetTensor().desc.GetLayout_t(),
                                      savedMean.GetTensor().desc.GetLengths()};
@@ -879,26 +912,66 @@ void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runGPUFwdTrain(Tref 
 {
     if(saveMeanVar && keepRunningMeanVar)
     {
-        miopenBatchNormalizationForwardTraining_V2(GetHandle(),
-                                                   bn_mode,
-                                                   &alpha,
-                                                   &beta,
-                                                   &in.GetTensor().desc,
-                                                   in.GetDevicePtr(),
-                                                   &out.GetTensor().desc,
-                                                   out.GetDevicePtr(),
-                                                   &scale.GetTensor().desc,
-                                                   &bias.GetTensor().desc,
-                                                   &savedMean.GetTensor().desc,
-                                                   &savedVariance.GetTensor().desc,
-                                                   scale.GetDevicePtr(),
-                                                   bias.GetDevicePtr(),
-                                                   eAF,
-                                                   runMean.GetDevicePtr(),
-                                                   runVariance.GetDevicePtr(),
-                                                   epsilon,
-                                                   savedMean.GetDevicePtr(),
-                                                   savedVariance.GetDevicePtr());
+        if(usePingPongBuffers)
+        {
+            // copy data from current running mean/var to previous running mean/var
+            hipMemcpy(prevRunMean.GetDevicePtr(),
+                      runMean.GetDevicePtr(),
+                      runMean.GetTensor().desc.GetElementSize() * sizeof(TAcc),
+                      hipMemcpyDeviceToDevice);
+            hipMemcpy(prevRunVariance.GetDevicePtr(),
+                      runVariance.GetDevicePtr(),
+                      runVariance.GetTensor().desc.GetElementSize() * sizeof(TAcc),
+                      hipMemcpyDeviceToDevice);
+            // not required, but just in case for consistency
+            prevRunMean.CopyFromDeviceToHost(GetStream());
+            prevRunVariance.CopyFromDeviceToHost(GetStream());
+            miopenBatchNormalizationForwardTraining_V3(GetHandle(),
+                                                       bn_mode,
+                                                       &alpha,
+                                                       &beta,
+                                                       &in.GetTensor().desc,
+                                                       in.GetDevicePtr(),
+                                                       &out.GetTensor().desc,
+                                                       out.GetDevicePtr(),
+                                                       &scale.GetTensor().desc,
+                                                       &bias.GetTensor().desc,
+                                                       &savedMean.GetTensor().desc,
+                                                       &savedVariance.GetTensor().desc,
+                                                       scale.GetDevicePtr(),
+                                                       bias.GetDevicePtr(),
+                                                       eAF,
+                                                       prevRunMean.GetDevicePtr(),
+                                                       prevRunVariance.GetDevicePtr(),
+                                                       runMean.GetDevicePtr(),
+                                                       runVariance.GetDevicePtr(),
+                                                       epsilon,
+                                                       savedMean.GetDevicePtr(),
+                                                       savedVariance.GetDevicePtr());
+        }
+        else
+        {
+            miopenBatchNormalizationForwardTraining_V2(GetHandle(),
+                                                       bn_mode,
+                                                       &alpha,
+                                                       &beta,
+                                                       &in.GetTensor().desc,
+                                                       in.GetDevicePtr(),
+                                                       &out.GetTensor().desc,
+                                                       out.GetDevicePtr(),
+                                                       &scale.GetTensor().desc,
+                                                       &bias.GetTensor().desc,
+                                                       &savedMean.GetTensor().desc,
+                                                       &savedVariance.GetTensor().desc,
+                                                       scale.GetDevicePtr(),
+                                                       bias.GetDevicePtr(),
+                                                       eAF,
+                                                       runMean.GetDevicePtr(),
+                                                       runVariance.GetDevicePtr(),
+                                                       epsilon,
+                                                       savedMean.GetDevicePtr(),
+                                                       savedVariance.GetDevicePtr());
+        }
     }
     else if(saveMeanVar)
     {
@@ -925,26 +998,66 @@ void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runGPUFwdTrain(Tref 
     }
     else if(keepRunningMeanVar)
     {
-        miopenBatchNormalizationForwardTraining_V2(GetHandle(),
-                                                   bn_mode,
-                                                   &alpha,
-                                                   &beta,
-                                                   &in.GetTensor().desc,
-                                                   in.GetDevicePtr(),
-                                                   &out.GetTensor().desc,
-                                                   out.GetDevicePtr(),
-                                                   &scale.GetTensor().desc,
-                                                   &bias.GetTensor().desc,
-                                                   &savedMean.GetTensor().desc,
-                                                   &savedVariance.GetTensor().desc,
-                                                   scale.GetDevicePtr(),
-                                                   bias.GetDevicePtr(),
-                                                   eAF,
-                                                   runMean.GetDevicePtr(),
-                                                   runVariance.GetDevicePtr(),
-                                                   epsilon,
-                                                   nullptr,
-                                                   nullptr);
+        if(usePingPongBuffers)
+        {
+            // copy data from current running mean/var to previous running mean/var
+            hipMemcpy(prevRunMean.GetDevicePtr(),
+                      runMean.GetDevicePtr(),
+                      runMean.GetTensor().desc.GetElementSize() * sizeof(TAcc),
+                      hipMemcpyDeviceToDevice);
+            hipMemcpy(prevRunVariance.GetDevicePtr(),
+                      runVariance.GetDevicePtr(),
+                      runVariance.GetTensor().desc.GetElementSize() * sizeof(TAcc),
+                      hipMemcpyDeviceToDevice);
+            // not required, but just in case for consistency
+            prevRunMean.CopyFromDeviceToHost(GetStream());
+            prevRunVariance.CopyFromDeviceToHost(GetStream());
+            miopenBatchNormalizationForwardTraining_V3(GetHandle(),
+                                                       bn_mode,
+                                                       &alpha,
+                                                       &beta,
+                                                       &in.GetTensor().desc,
+                                                       in.GetDevicePtr(),
+                                                       &out.GetTensor().desc,
+                                                       out.GetDevicePtr(),
+                                                       &scale.GetTensor().desc,
+                                                       &bias.GetTensor().desc,
+                                                       &savedMean.GetTensor().desc,
+                                                       &savedVariance.GetTensor().desc,
+                                                       scale.GetDevicePtr(),
+                                                       bias.GetDevicePtr(),
+                                                       eAF,
+                                                       prevRunMean.GetDevicePtr(),
+                                                       prevRunVariance.GetDevicePtr(),
+                                                       runMean.GetDevicePtr(),
+                                                       runVariance.GetDevicePtr(),
+                                                       epsilon,
+                                                       nullptr,
+                                                       nullptr);
+        }
+        else
+        {
+            miopenBatchNormalizationForwardTraining_V2(GetHandle(),
+                                                       bn_mode,
+                                                       &alpha,
+                                                       &beta,
+                                                       &in.GetTensor().desc,
+                                                       in.GetDevicePtr(),
+                                                       &out.GetTensor().desc,
+                                                       out.GetDevicePtr(),
+                                                       &scale.GetTensor().desc,
+                                                       &bias.GetTensor().desc,
+                                                       &savedMean.GetTensor().desc,
+                                                       &savedVariance.GetTensor().desc,
+                                                       scale.GetDevicePtr(),
+                                                       bias.GetDevicePtr(),
+                                                       eAF,
+                                                       runMean.GetDevicePtr(),
+                                                       runVariance.GetDevicePtr(),
+                                                       epsilon,
+                                                       nullptr,
+                                                       nullptr);
+        }
     }
     else
     {

--- a/projects/miopen/driver/bn_driver.hpp
+++ b/projects/miopen/driver/bn_driver.hpp
@@ -74,7 +74,7 @@ template <typename TInput,
 class BatchNormDriver : public Driver
 {
 public:
-    BatchNormDriver() : Driver() { data_type = (sizeof(TInput) == 4) ? miopenFloat : miopenHalf; }
+    BatchNormDriver() : Driver() { miopenCreateActivationDescriptor(&activ_desc); }
 
     int AddCmdLineArgs() override;
     int ParseCmdLineArgs(int argc, char* argv[]) override;
@@ -113,18 +113,17 @@ public:
     // defined in MIOpen lib.
     void ValidateLayoutInputParameters(std::string layout_type);
 
-    ~BatchNormDriver() override {}
+    ~BatchNormDriver() override { miopenDestroyActivationDescriptor(activ_desc); }
 
 private:
     miopenBatchNormMode_t bn_mode;
     miopenActivationMode_t activ_mode = miopenActivationRELU;
+    miopenActivationDescriptor_t activ_desc;
 
-    bool saveMeanVar;
-    bool bsaveMeanVar;
-    bool keepRunningMeanVar;
-    bool estimatedMeanVar;
-    bool useInverseVar;
-    bool usePingPongBuffers;
+    bool saveMeanVar        = false;
+    bool keepRunningMeanVar = false;
+    bool useInverseVar      = false;
+    bool usePingPongBuffers = false;
 
     int forw;
     int back;
@@ -589,9 +588,9 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::SetBNParametersFromCm
     {
         if(forw != 1 || !keepRunningMeanVar)
         {
-            printf("Ping-pong buffers are only supported in forward training when running mean "
-                   "and variance are kept\n");
-            exit(EXIT_FAILURE); // NOLINT (concurrency-mt-unsafe)
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "Ping-pong buffers are only supported in forward training when running "
+                         "mean and variance are kept");
         }
         usePingPongBuffers = true;
     }
@@ -703,7 +702,10 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::AllocateBuffersAndCop
     }
 
     if(status != STATUS_SUCCESS)
-        printf("Fatal: Error copying data to GPU\nExiting...\n\n");
+    {
+        printf("Fatal: Error allocating GPU buffers\nExiting...\n\n");
+        return miopenStatusAllocFailed;
+    }
 
     return miopenStatusSuccess;
 }
@@ -805,8 +807,6 @@ template <typename TInput, typename Tref, typename TAcc, typename TScaleBias, ty
 void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runGPUFwdInferenceActivation(
     Tref epsilon, float alpha, float beta)
 {
-    miopenActivationDescriptor_t activ_desc;
-    miopenCreateActivationDescriptor(&activ_desc);
     miopenSetActivationDescriptor(activ_desc,
                                   activ_mode,
                                   inflags.GetValueDouble("activ_alpha"),
@@ -900,7 +900,6 @@ void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runGPUFwdInferenceAc
                                                                  activ_desc);
         }
     }
-    miopenDestroyActivationDescriptor(activ_desc);
     return;
 }
 
@@ -1113,8 +1112,6 @@ void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runGPUFwdTrainActiva
                                                                                      float alpha,
                                                                                      float beta)
 {
-    miopenActivationDescriptor_t activ_desc;
-    miopenCreateActivationDescriptor(&activ_desc);
     miopenSetActivationDescriptor(activ_desc,
                                   activ_mode,
                                   inflags.GetValueDouble("activ_alpha"),
@@ -1240,7 +1237,6 @@ void BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::runGPUFwdTrainActiva
                                              nullptr,
                                              activ_desc);
 #endif
-    miopenDestroyActivationDescriptor(activ_desc);
 }
 
 template <typename TInput, typename Tref, typename TAcc, typename TScaleBias, typename TOut>
@@ -1539,8 +1535,6 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::RunBackwardGPU()
     float lowtime   = 100000000.0;
     float avgtime   = 0.;
 
-    miopenActivationDescriptor_t activ_desc;
-    miopenCreateActivationDescriptor(&activ_desc);
     miopenSetActivationDescriptor(activ_desc,
                                   activ_mode,
                                   inflags.GetValueDouble("activ_alpha"),
@@ -1694,7 +1688,6 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::RunBackwardGPU()
                    lowtime);
         }
     }
-    miopenDestroyActivationDescriptor(activ_desc);
 
     if(WALL_CLOCK)
     {


### PR DESCRIPTION
## Motivation

This PR updates the `bn_driver` with the new `miopenBatchNormalizationForwardTraining_V3` API introduced in [this PR](https://github.com/ROCm/rocm-libraries/pull/3487), addressing the feedback raised in [this review comment](https://github.com/ROCm/rocm-libraries/pull/3487#pullrequestreview-3657191536).

## Technical Details

- Adds support in `MIOpenDriver` to test the `miopenBatchNormalizationForwardTraining_V3` API.
- Introduces a new flag to enable ping-pong buffer usage with the batchnorm forward training APIs.
- Adds the required state and memory to store the previous running mean and variance.

## Test Plan

- Verified the changes through the `MIOpenDriver` by enabling ping-pong buffers using the `--ping_pong_buffers 1` flag along with other required arguments.

## Test Result

Tests pass on gfx90a and gfx942.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
