### PR TITLE
[hipblaslt] Fix codegen error when both `UseDirect32XEmulation= False` & `UseMFMAF32XEmulation = True`

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -513,6 +513,8 @@ class RegisterSchedule:
         self.vector_widths = vector_widths
         self.matrix_inst = matrix_inst
         self.mfma_wave_group = mfma_wave_group
+        # All TF32 CMS expect UseDirect32XEmulation to be True
+        self.use_direct32x_emulation = (dtype_predicate==isTF32)
     
     def __call__(self, func: Callable) -> Callable:
         """Wrap the function with matching logic and register it."""
@@ -522,6 +524,9 @@ class RegisterSchedule:
                 return ScheduleMatchStatus.NO_MATCH, None
 
             if not self.dtype_predicate(kernel):
+                return ScheduleMatchStatus.NO_MATCH, None
+            
+            if self.use_direct32x_emulation != kernel["UseDirect32XEmulation"]:
                 return ScheduleMatchStatus.NO_MATCH, None
 
             MT0, MT1, DU = kernel["MacroTile0"], kernel["MacroTile1"], kernel["DepthU"]
@@ -2275,7 +2280,7 @@ def _get_schedule_128x192x32_TF32(kernel, useLDSTr, TLDS):
     if isNN(kernel) and not useLDSTr and TLDS==1:
         # TODO: Add NN schedule in upcoming PR
         return False, None
-    elif isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    elif isTN(kernel) and not useLDSTr and TLDS==1:
         kernel["UsePLRPack"] = True
         syncTable = [
             5,  SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="Before PackA0. Wait for all LRA0. Skip 1*LRB0.") ,
@@ -2338,7 +2343,7 @@ def _get_schedule_192x256x32_TF32(kernel, useLDSTr, TLDS):
     syncCode = []
     mfmaReorder = []
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
-    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    if isTN(kernel) and not useLDSTr and TLDS==1:
         kernel["UsePLRPack"] = True
         kernel["UseMFMAF32XEmulation"] = True
 
@@ -2470,7 +2475,7 @@ def _get_schedule_192x256x32_TF32(kernel, useLDSTr, TLDS):
         }
 
         nglshift = nllshift = 14 # vmcnt shift for ngl and nll
-    elif isNN(kernel) and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    elif isNN(kernel) and TLDS==1:
         kernel["UsePLRPack"] = True
         kernel["UseMFMAF32XEmulation"] = True
         
@@ -2668,7 +2673,7 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
     optSchedule = dict()
     syncCode = []
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
-    if isTN(kernel) and not useLDSTr and TLDS == 1 and kernel["UseDirect32XEmulation"]:
+    if isTN(kernel) and not useLDSTr and TLDS == 1:
         kernel["UsePLRPack"] = True
         numPackInstr = 24 
         numPackIndices = numPackInstr // 2 # Assign 2 pack instructions per mfma index
@@ -2769,7 +2774,7 @@ def _get_schedule_256x256x32_TF32(kernel, useLDSTr, TLDS):
     optSchedule = dict()
     syncCode = []
     nglshift = nllshift = 0
-    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    if isTN(kernel) and not useLDSTr and TLDS==1:
         kernel["UsePLRPack"] = True
         kernel["UseMFMAF32XEmulation"] = True
         # This schedule follows similar pattern as 192x256x32 TF32 schedule
@@ -2906,7 +2911,7 @@ def _get_schedule_192x128x32_TF32(kernel, useLDSTr, TLDS):
     optSchedule = dict()
     syncCode = []
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
-    if isTN(kernel) and useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    if isTN(kernel) and useLDSTr and TLDS==1:
 
         kernel["UsePLRPack"] = True
         # Used the following constrains to create schedule
@@ -3000,7 +3005,7 @@ def _get_schedule_128x128x32_TF32(kernel, useLDSTr, TLDS):
     snopCode = []
     S4 = SNop(4)
 
-    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    if isTN(kernel) and not useLDSTr and TLDS==1:
         kernel["UseMFMAF32XEmulation"] = True
 
         lra0 = [0,0,1,1]
@@ -3088,7 +3093,7 @@ def _get_schedule_128x128x64_TF32(kernel, useLDSTr, TLDS):
     syncCode = []   
     gr_inc_step = 1
 
-    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    if isTN(kernel) and not useLDSTr and TLDS==1:
         kernel["UseMFMAF32XEmulation"] = True
         kernel["UsePLRPack"] = True
 
@@ -3175,7 +3180,7 @@ def _get_schedule_128x256x32_TF32(kernel, useLDSTr, TLDS):
     optSchedule = dict()
     syncCode = []
     nglshift = nllshift = 0
-    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    if isTN(kernel) and not useLDSTr and TLDS==1:
         kernel["UsePLRPack"] = True
         kernel["UseMFMAF32XEmulation"] = True
 
@@ -3374,7 +3379,7 @@ def _get_schedule_128x160x64_TF32(kernel, useLDSTr, TLDS):
     syncCode = []
     gr_inc_step = 0
 
-    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    if isTN(kernel) and not useLDSTr and TLDS==1:
         kernel["UseMFMAF32XEmulation"] = True
         kernel["UsePLRPack"] = True
 
@@ -3465,7 +3470,7 @@ def _get_schedule_256x128x32_TF32(kernel, useLDSTr, TLDS):
     syncCode = []
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
 
-    if isTN(kernel) and useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+    if isTN(kernel) and useLDSTr and TLDS==1:
         kernel["UsePLRPack"] = True
         numPackInstr = 24 
         numPackIndices = numPackInstr // 2 # Assign 2 pack instructions per mfma index

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -2275,7 +2275,7 @@ def _get_schedule_128x192x32_TF32(kernel, useLDSTr, TLDS):
     if isNN(kernel) and not useLDSTr and TLDS==1:
         # TODO: Add NN schedule in upcoming PR
         return False, None
-    elif isTN(kernel) and not useLDSTr and TLDS==1:
+    elif isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
         kernel["UsePLRPack"] = True
         syncTable = [
             5,  SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="Before PackA0. Wait for all LRA0. Skip 1*LRB0.") ,
@@ -2338,7 +2338,7 @@ def _get_schedule_192x256x32_TF32(kernel, useLDSTr, TLDS):
     syncCode = []
     mfmaReorder = []
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
-    if isTN(kernel) and not useLDSTr and TLDS==1:
+    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
         kernel["UsePLRPack"] = True
         kernel["UseMFMAF32XEmulation"] = True
 
@@ -2470,7 +2470,7 @@ def _get_schedule_192x256x32_TF32(kernel, useLDSTr, TLDS):
         }
 
         nglshift = nllshift = 14 # vmcnt shift for ngl and nll
-    elif isNN(kernel) and TLDS==1:
+    elif isNN(kernel) and TLDS==1 and kernel["UseDirect32XEmulation"]:
         kernel["UsePLRPack"] = True
         kernel["UseMFMAF32XEmulation"] = True
         
@@ -2668,7 +2668,7 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
     optSchedule = dict()
     syncCode = []
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
-    if isTN(kernel) and not useLDSTr and TLDS == 1:
+    if isTN(kernel) and not useLDSTr and TLDS == 1 and kernel["UseDirect32XEmulation"]:
         kernel["UsePLRPack"] = True
         numPackInstr = 24 
         numPackIndices = numPackInstr // 2 # Assign 2 pack instructions per mfma index
@@ -2769,7 +2769,7 @@ def _get_schedule_256x256x32_TF32(kernel, useLDSTr, TLDS):
     optSchedule = dict()
     syncCode = []
     nglshift = nllshift = 0
-    if isTN(kernel) and not useLDSTr and TLDS==1:
+    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
         kernel["UsePLRPack"] = True
         kernel["UseMFMAF32XEmulation"] = True
         # This schedule follows similar pattern as 192x256x32 TF32 schedule
@@ -2906,7 +2906,7 @@ def _get_schedule_192x128x32_TF32(kernel, useLDSTr, TLDS):
     optSchedule = dict()
     syncCode = []
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
-    if isTN(kernel) and useLDSTr and TLDS==1:
+    if isTN(kernel) and useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
 
         kernel["UsePLRPack"] = True
         # Used the following constrains to create schedule
@@ -3000,7 +3000,7 @@ def _get_schedule_128x128x32_TF32(kernel, useLDSTr, TLDS):
     snopCode = []
     S4 = SNop(4)
 
-    if isTN(kernel) and not useLDSTr and TLDS==1:
+    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
         kernel["UseMFMAF32XEmulation"] = True
 
         lra0 = [0,0,1,1]
@@ -3088,7 +3088,7 @@ def _get_schedule_128x128x64_TF32(kernel, useLDSTr, TLDS):
     syncCode = []   
     gr_inc_step = 1
 
-    if isTN(kernel) and not useLDSTr and TLDS==1:
+    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
         kernel["UseMFMAF32XEmulation"] = True
         kernel["UsePLRPack"] = True
 
@@ -3175,7 +3175,7 @@ def _get_schedule_128x256x32_TF32(kernel, useLDSTr, TLDS):
     optSchedule = dict()
     syncCode = []
     nglshift = nllshift = 0
-    if isTN(kernel) and not useLDSTr and TLDS==1:
+    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
         kernel["UsePLRPack"] = True
         kernel["UseMFMAF32XEmulation"] = True
 
@@ -3374,7 +3374,7 @@ def _get_schedule_128x160x64_TF32(kernel, useLDSTr, TLDS):
     syncCode = []
     gr_inc_step = 0
 
-    if isTN(kernel) and not useLDSTr and TLDS==1:
+    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
         kernel["UseMFMAF32XEmulation"] = True
         kernel["UsePLRPack"] = True
 
@@ -3465,7 +3465,7 @@ def _get_schedule_256x128x32_TF32(kernel, useLDSTr, TLDS):
     syncCode = []
     nglshift = nllshift = 0 # vmcnt shift for ngl and nll
 
-    if isTN(kernel) and useLDSTr and TLDS==1:
+    if isTN(kernel) and useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
         kernel["UsePLRPack"] = True
         numPackInstr = 24 
         numPackIndices = numPackInstr // 2 # Assign 2 pack instructions per mfma index

--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -408,14 +408,14 @@ class LocalReadMFMA(LocalRead):
                                     vHi1 = vgpr("Valu%s_X%u_I%u+%u+1"%(tc, bufferIdx, iui, (valuiIdx-baseValuiIdx)/2 + baseValuiIdx))
 
                                     if kernel["UseMFMAF32XEmulation"]:
-                                        vTBase = str(v0t.regName)
+                                        vBaseRegs = vgpr(str(v0t.regName),4) if v0t.regName else vgpr(str(v0t.regIdx),4)
                                         vHiBase = str(vHi0.regName)
                                         idMat = vgpr(writer.states.startVgprIdentityMatrix,2)
                                         tmpDelay = writer.vgprPool.checkOut(1)
                                         # We use a single MFMA 4x4x4_16b to perform 4 `vT - vHi` operations. 
                                         # - A is set to negative identity matrix
                                         # - no need for DPP as B has the same layout as C & D
-                                        packCodeT.add(MFMAInstruction(instType=InstType.INST_BF16, accType=InstType.INST_F32, variant=[4,4,4,16], mfma1k=False,acc=vgpr(vTBase,4), a=idMat, b=vgpr(vHiBase,2), acc2=vgpr(vTBase,4), 
+                                        packCodeT.add(MFMAInstruction(instType=InstType.INST_BF16, accType=InstType.INST_F32, variant=[4,4,4,16], mfma1k=False,acc=vBaseRegs, a=idMat, b=vgpr(vHiBase,2), acc2=vBaseRegs, 
                                         comment="Calculate low bits for TF32 emulation"))
                                         writer.vgprPool.checkIn(tmpDelay)
                                     else:

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -4781,14 +4781,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
       
     if kernel["UseDirect32XEmulation"]:
       numVgprsEmu = (self.states.a.numVgprValu + self.states.b.numVgprValu) // 2
-      if (vgprIdx >= (self.states.regCaps["MaxVgpr"] - numVgprsEmu)):
-        kernel["UseDirect32XEmulation"] = False
-        kernel["UseDot2F32XEmulation"] = True
-      else:
-        #align 64 bit
-        vgprIdx = ((vgprIdx+1)//2)*2
-        self.states.startVgprCvt = vgprIdx
-        vgprIdx += numVgprsEmu # for vgpr 32XEmulation
+      #align 64 bit
+      vgprIdx = ((vgprIdx+1)//2)*2
+      self.states.startVgprCvt = vgprIdx
+      vgprIdx += numVgprsEmu # for vgpr 32XEmulation
 
     # TODO: Serial is always the first/last register in the pool so the store
     # code doesn't have to deal with fragmentation

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -67,6 +67,7 @@ def create_base_kernel():
         "SwapGlobalReadOrder": False, # For asserting it gets set
         "UsePLRPack": False, # For asserting it gets set
         "UseF32XEmulation": False,
+        "UseDirect32XEmulation" : False,
         "MIWaveTileA": 2,
         "MIWaveTileB": 2,
     }


### PR DESCRIPTION
## Description

With TF32, `UseDirect32XEmulation` is set to True by default. In certain cases, tensilelite changes this value to False. As a consequence, we use temporary VGPRs to store input TF32 values during packing.

This PR contains :

- Updates the mfma4x4x4 instructions to use these temporary VGPRs when `UseDirect32XEmulation=False` and `UseMFMAF32XEmulation=True`.
- Ensures that all existing TF32 CMS have `UseDirect32XEmulation` set to True to avoid validation errors (since the number of pack instructions increases when storing to temporary VGPRs).
- Remove late modification of `UseMFMAF32XEmulation` to False when the VPGR count is high. This was bringing inconsistent behaviors when calling hasCustomSchedule function. This will essentially let the solution generation fail due to vgpr overflow if it needs to.
