### PR TITLE
Reduce boost usage by replacing time calls

### DIFF
--- a/projects/miopen/src/db.cpp
+++ b/projects/miopen/src/db.cpp
@@ -30,8 +30,6 @@
 #include <miopen/logger.hpp>
 #include <miopen/filesystem.hpp>
 
-#include <boost/date_time/posix_time/posix_time_types.hpp>
-
 #include <algorithm>
 #include <cassert>
 #include <chrono>

--- a/projects/miopen/src/include/miopen/handle_lock.hpp
+++ b/projects/miopen/src/include/miopen/handle_lock.hpp
@@ -57,10 +57,10 @@ MIOPEN_DECLARE_HANDLE_MUTEX(gpu_handle_mutex)
 
 inline fs::path get_handle_lock_path(const char* name)
 {
-    auto p = fs::current_path() / name;
+    const auto p = fs::current_path() / name;
     if(!fs::exists(p))
     {
-        auto tmp = fs::current_path() / fs::temp_directory_path();
+        const auto tmp = fs::current_path() / boost::filesystem::unique_path().string();
         std::ofstream{tmp}; // NOLINT(bugprone-unused-raii)
         fs::rename(tmp, p);
     }

--- a/projects/miopen/src/include/miopen/handle_lock.hpp
+++ b/projects/miopen/src/include/miopen/handle_lock.hpp
@@ -60,7 +60,7 @@ inline fs::path get_handle_lock_path(const char* name)
     auto p = fs::current_path() / name;
     if(!fs::exists(p))
     {
-        auto tmp = fs::current_path() / boost::filesystem::unique_path().string();
+        auto tmp = fs::current_path() / fs::temp_directory_path();
         std::ofstream{tmp}; // NOLINT(bugprone-unused-raii)
         fs::rename(tmp, p);
     }

--- a/projects/miopen/src/lock_file.cpp
+++ b/projects/miopen/src/lock_file.cpp
@@ -45,16 +45,15 @@ fs::path LockFilePath(const fs::path& filename_)
 {
     try
     {
-        auto directory = fs::temp_directory_path() / "miopen-lockfiles";
-        if(!filename_.parent_path().empty())
-            directory = filename_.parent_path() / "miopen-lockfiles";
+        const auto directory = fs::temp_directory_path() / "miopen-lockfiles";
 
         if(!fs::exists(directory))
         {
             fs::create_directories(directory);
             fs::permissions(directory, fs::perms::all);
         }
-        const auto file = directory / (filename_.filename() + ".lock");
+        const auto hash = md5(filename_.parent_path().string());
+        const auto file = directory / (hash + "_" + filename_.filename() + ".lock");
 
         return file;
     }

--- a/projects/miopen/src/lock_file.cpp
+++ b/projects/miopen/src/lock_file.cpp
@@ -45,15 +45,16 @@ fs::path LockFilePath(const fs::path& filename_)
 {
     try
     {
-        const auto directory = fs::temp_directory_path() / "miopen-lockfiles";
+        auto directory = fs::temp_directory_path() / "miopen-lockfiles";
+        if(!filename_.parent_path().empty())
+            directory = filename_.parent_path() / "miopen-lockfiles";
 
         if(!fs::exists(directory))
         {
             fs::create_directories(directory);
-            fs::permissions(directory, FS_ENUM_PERMS_ALL);
+            fs::permissions(directory, fs::perms::all);
         }
-        const auto hash = md5(filename_.parent_path().string());
-        const auto file = directory / (hash + "_" + filename_.filename() + ".lock");
+        const auto file = directory / (filename_.filename() + ".lock");
 
         return file;
     }
@@ -72,7 +73,7 @@ LockFile::LockFile(const fs::path& path_, PassKey) : path(path_)
         {
             if(!std::ofstream{path})
                 MIOPEN_THROW("Error creating file <" + path + "> for locking.");
-            fs::permissions(path, FS_ENUM_PERMS_ALL);
+            fs::permissions(path, fs::perms::all);
         }
 
         flock = decltype(flock)(path.string());

--- a/projects/miopen/src/sqlite_db.cpp
+++ b/projects/miopen/src/sqlite_db.cpp
@@ -35,7 +35,6 @@
 #if MIOPEN_EMBED_DB
 #include <miopen_data.hpp>
 #endif
-#include <boost/date_time/posix_time/posix_time_types.hpp>
 
 #include <memory>
 #include <algorithm>


### PR DESCRIPTION
## Motivation

Reduce boost usage by replacing time calls.

## Technical Details

Replace boost::posix_time related data types with the corresponsing std::chrono data types.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
