### PR TITLE
[origami] Allow for targets without MALL

### DIFF
--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -552,6 +552,13 @@ class hardware_t {
    */
   dim3_t get_recommended_matrix_instruction(data_type_t mi_input_type) const;
 
+  /**
+   * @brief Check if the architecture has MALL (Memory Attached Last Level).
+   *
+   * @return true if the architecture has MALL, false otherwise
+   */
+  bool has_MALL() const;
+
  private:
   /**
    * @brief Extract substring before the first colon character.

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -590,7 +590,10 @@ double compute_memory_latency(const problem_t& problem,
   if (H_mem1 == 0) { H_mem1 = 0.5; }
 
   // 2) Estimate mall hit-rate
-  double H_mem2 = estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor);
+  double H_mem2 =
+      hardware.has_MALL()
+          ? estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor)
+          : 0.0;  // MALL is not supported, so we emulate every read as a miss
 
   // 3) Total loads are loads from A and loads from B
   size_t Ld_A_value = a_trans ?
@@ -628,7 +631,10 @@ double compute_memory_latency(const problem_t& problem,
   double bw_limited = compute_mem_bw_from_occupancy(hardware, num_active_cus);
 
   // 8) loads that reach each level
-  double Ld_mem2 = (1.0 - H_mem1) * total_Ld;
+  double Ld_mem2 =
+      hardware.has_MALL()
+          ? (1.0 - H_mem1) * total_Ld
+          : 0.0;  // MALL is not supported, we emulate it by saying there are zero loads to MALL
   double Ld_MEM  = (1.0 - H_mem2) * Ld_mem2;
 
   // 9) enforce whole‐problem minimum loads when we can fit M/N in the CUs.

--- a/shared/origami/src/origami/hardware.cpp
+++ b/shared/origami/src/origami/hardware.cpp
@@ -155,6 +155,20 @@ double hardware_t::get_adjusted_main_loop_efficiency(transpose_t transA,
   }
 }
 
+bool hardware_t::has_MALL() const {
+  switch (arch) {
+    case architecture_t::gfx90a:
+    case architecture_t::gfx942:
+    case architecture_t::gfx950:
+    case architecture_t::gfx1201:
+    case architecture_t::gfx1100:
+    case architecture_t::gfx1151: return true;
+    case architecture_t::Count:
+      // Count is not a valid architecture, this is to silence compiler warning
+      return false;
+  }
+}
+
 std::string hardware_t::get_before_first_colon(const std::string& input) {
   size_t pos = input.find(':');
   if (pos != std::string::npos) { return input.substr(0, pos); }

--- a/shared/origami/tests/test_origami.cpp
+++ b/shared/origami/tests/test_origami.cpp
@@ -123,6 +123,17 @@ TEST_CASE("Origami: hardware_arch_enum", "[origami]") {
   }
 }
 
+TEST_CASE("Origami: has_MALL", "[origami]") {
+  for (int gpu_arch : test_architectures) {
+    DYNAMIC_SECTION("gfx" << gpu_arch << " - MALL support check") {
+      auto hardware = make_hardware(gpu_arch);
+
+      // gfx942 and gfx950 have MALL support
+      if (gpu_arch == 942 || gpu_arch == 950) { REQUIRE(hardware.has_MALL() == true); }
+    }
+  }
+}
+
 TEST_CASE("Origami: best_grid_size", "[origami]") {
   for (int gpu_arch : test_architectures) {
     DYNAMIC_SECTION("gfx" << gpu_arch << " - grid size selection") {


### PR DESCRIPTION
## Motivation

In the effort to include gfx115{0,2,3} (see https://github.com/ROCm/rocm-libraries/pull/3809) it was discovered that currently there is no way to emulate targets without MALL.

## Technical Details

This patch adds a new method to `hardware_t` that will return whether the arch supports MALL. Based on this value, we will set to zero the MALL hit-rate if it is not supported. New targets that do not include MALL, must set `mem2_perf_ratio` to a very high number. (yet to be determined)

## Test Plan

`./build/tests/origami-tests`

## Test Result

```
Randomness seeded to: 1215979880
===============================================================================
All tests passed (6218 assertions in 18 test cases)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
