### PR TITLE
[MIOpen][kernels][OCL][HIP] Port 5D tensor generic operations kernel and solver from OCL to HIP

### DIFF
--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -337,6 +337,7 @@ set( MIOpen_Source
     solver/tensorOp/Op4dTensorGeneric.cpp
     solver/tensorOp/Op4dTensorLite.cpp
     solver/tensorOp/Op5dTensorGeneric.cpp
+    solver/tensorOp/Op5dTensorGenericContiguous.cpp
     solver/tensorOp/OpTensorFwdBias.cpp
     solver/tensorOp/OpTensorLeadingOnes.cpp
     subbuffers.cpp

--- a/projects/miopen/src/include/miopen/tensorOp/solvers.hpp
+++ b/projects/miopen/src/include/miopen/tensorOp/solvers.hpp
@@ -209,6 +209,23 @@ struct Op5dTensorGeneric final : TensorOpSolver
     bool MayNeedWorkspace() const override { return false; }
 };
 
+struct Op5dTensorGenericContiguous final : TensorOpSolver
+{
+    const std::string& SolverDbId() const override { return GetSolverDbId<Op5dTensorGenericContiguous>(); }
+
+    bool IsApplicable(const ExecutionContext& context,
+                      const miopen::tensorOp::ProblemDescription& problem) const override;
+
+    ConvSolution GetSolution(const ExecutionContext& context,
+                             const miopen::tensorOp::ProblemDescription& problem) const override;
+
+    std::size_t
+    GetWorkspaceSize(const ExecutionContext& context,
+                     const miopen::tensorOp::ProblemDescription& problem) const override;
+
+    bool MayNeedWorkspace() const override { return false; }
+};
+
 } // namespace tensorOp
 
 } // namespace solver

--- a/projects/miopen/src/include/miopen/tensorOp/solvers.hpp
+++ b/projects/miopen/src/include/miopen/tensorOp/solvers.hpp
@@ -211,7 +211,10 @@ struct Op5dTensorGeneric final : TensorOpSolver
 
 struct Op5dTensorGenericContiguous final : TensorOpSolver
 {
-    const std::string& SolverDbId() const override { return GetSolverDbId<Op5dTensorGenericContiguous>(); }
+    const std::string& SolverDbId() const override
+    {
+        return GetSolverDbId<Op5dTensorGenericContiguous>();
+    }
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::tensorOp::ProblemDescription& problem) const override;

--- a/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
+++ b/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
@@ -1284,7 +1284,7 @@ extern "C" __global__ void Op5dTensorGeneric(const MIOPEN_TYPE* __restrict__ a, 
     for(wide_t i = static_cast<wide_t>(tid); i < static_cast<wide_t>(total_work);
         i += static_cast<wide_t>(tcount))
     {
-           // widen dims once
+        // widen dims once
         const wide_t cw  = static_cast<wide_t>(c_w);
         const wide_t ch  = static_cast<wide_t>(c_h);
         const wide_t cd  = static_cast<wide_t>(c_d);
@@ -1328,12 +1328,12 @@ extern "C" __global__ void Op5dTensorGeneric(const MIOPEN_TYPE* __restrict__ a, 
 
         if(!use_beta)
         {
-               c_base[static_cast<size_t>(c_off)] = tmp;
+            c_base[static_cast<size_t>(c_off)] = tmp;
         }
         else
         {
-               const MIOPEN_TYPE cv               = c_base[static_cast<size_t>(c_off)];
-               c_base[static_cast<size_t>(c_off)] = tmp + cv * beta;
+            const MIOPEN_TYPE cv               = c_base[static_cast<size_t>(c_off)];
+            c_base[static_cast<size_t>(c_off)] = tmp + cv * beta;
         }
     }
 #endif // USE_PACKED_INNER

--- a/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
+++ b/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
@@ -1283,7 +1283,7 @@ extern "C" __global__ void Op5dTensorGeneric(const MIOPEN_TYPE* __restrict__ a, 
     for(wide_t i = static_cast<wide_t>(tid); i < static_cast<wide_t>(total_work);
         i += static_cast<wide_t>(tcount))
     {
-           // widen dims once
+        // widen dims once
         const wide_t cw  = static_cast<wide_t>(c_w);
         const wide_t ch  = static_cast<wide_t>(c_h);
         const wide_t cd  = static_cast<wide_t>(c_d);
@@ -1327,12 +1327,12 @@ extern "C" __global__ void Op5dTensorGeneric(const MIOPEN_TYPE* __restrict__ a, 
 
         if(!use_beta)
         {
-               c_base[static_cast<size_t>(c_off)] = tmp;
+            c_base[static_cast<size_t>(c_off)] = tmp;
         }
         else
         {
-               const MIOPEN_TYPE cv               = c_base[static_cast<size_t>(c_off)];
-               c_base[static_cast<size_t>(c_off)] = tmp + cv * beta;
+            const MIOPEN_TYPE cv               = c_base[static_cast<size_t>(c_off)];
+            c_base[static_cast<size_t>(c_off)] = tmp + cv * beta;
         }
     }
 #endif // USE_PACKED_INNER

--- a/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
+++ b/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
@@ -1258,10 +1258,9 @@ extern "C" __global__ void Op5dTensorGeneric(const MIOPEN_TYPE* __restrict__ a, 
                         static_cast<wide_t>(w) * c_wstride;
 
                     // execute tensor op for the tail part
-                    const MIOPEN_TYPE av = a_base[static_cast<size_t>(a_off_tail)];
-                    const MIOPEN_TYPE bv_tail =
-                        should_cache_bw ? bv_cached : b_base[static_cast<size_t>(b_off_tail)];
-                    const MIOPEN_TYPE tmp = MIOPEN_TENSOR_OP(av * alpha0, bv_tail * alpha1);
+                    const MIOPEN_TYPE av      = a_base[static_cast<size_t>(a_off_tail)];
+                    const MIOPEN_TYPE bv_tail = b_base[static_cast<size_t>(b_off_tail)];
+                    const MIOPEN_TYPE tmp     = MIOPEN_TENSOR_OP(av * alpha0, bv_tail * alpha1);
 
                     if(!use_beta)
                     {
@@ -1284,7 +1283,7 @@ extern "C" __global__ void Op5dTensorGeneric(const MIOPEN_TYPE* __restrict__ a, 
     for(wide_t i = static_cast<wide_t>(tid); i < static_cast<wide_t>(total_work);
         i += static_cast<wide_t>(tcount))
     {
-        // widen dims once
+           // widen dims once
         const wide_t cw  = static_cast<wide_t>(c_w);
         const wide_t ch  = static_cast<wide_t>(c_h);
         const wide_t cd  = static_cast<wide_t>(c_d);
@@ -1328,12 +1327,12 @@ extern "C" __global__ void Op5dTensorGeneric(const MIOPEN_TYPE* __restrict__ a, 
 
         if(!use_beta)
         {
-            c_base[static_cast<size_t>(c_off)] = tmp;
+               c_base[static_cast<size_t>(c_off)] = tmp;
         }
         else
         {
-            const MIOPEN_TYPE cv               = c_base[static_cast<size_t>(c_off)];
-            c_base[static_cast<size_t>(c_off)] = tmp + cv * beta;
+               const MIOPEN_TYPE cv               = c_base[static_cast<size_t>(c_off)];
+               c_base[static_cast<size_t>(c_off)] = tmp + cv * beta;
         }
     }
 #endif // USE_PACKED_INNER

--- a/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
+++ b/projects/miopen/src/kernels/MIOpenTensorKernelsHip.cpp
@@ -908,3 +908,580 @@ extern "C" __global__ void Op2dTensorLite(const MIOPEN_TYPE* a,
     }
 }
 #endif
+
+#ifdef USE_5D_TENSOR_GENERIC
+
+// register-level packet processing to improve parallelism and reduce div/mod overhead.
+// PACK_T = how many consecutive elements each thread handles per inner iteration.
+// If the solver didn't define it at JIT time, fall back to 8 for standalone builds.
+#ifndef PACK_T
+#define PACK_T 8
+#endif
+
+static_assert(PACK_T >= 1 && PACK_T <= 16, "PACK_T must be in [1..16]");
+
+// When c_w is a power of 2, integer division and modulo can be replaced with
+// bitwise operations:
+//   x % c_w  ->  x & (c_w - 1)
+//   x / c_w  ->  x >> log2(c_w)
+//
+// The solver detects power-of-2 at JIT compile time and used then:
+//   CW_IS_POW2 = 1       - indicates c_w is power of 2
+//   CW_LOG2    = log2(c_w) - shift amount for division
+//
+// These macros provide a hybrid approach:
+// When CW_IS_POW2 is defined: use compile-time optimized bit operations
+// Otherwise: fall back to runtime division/modulo
+
+#ifdef CW_IS_POW2
+// Power-of-2 optimized: use bit operations (compile-time constant shift)
+#define CW_MOD(x, cw) ((x) & ((cw)-1))
+#define CW_DIV(x, cw) ((x) >> CW_LOG2)
+#else
+// General case: use standard division/modulo (runtime)
+#define CW_MOD(x, cw) ((x) % (cw))
+#define CW_DIV(x, cw) ((x) / (cw))
+#endif
+
+// Adaptive selection between the narrow (32-bit) and wide (64-bit) index/offset types.
+// 32-bit for faster arithmetic when the address range allows that.
+// Offsets remain 64-bit to safely handle very large tensors or base offsets.
+#ifdef USE_INDEX32
+using offset_t = uint64_t;
+using len_t    = unsigned int;
+using idx_t    = uint32_t;
+#else
+using offset_t = uint64_t;
+using len_t    = unsigned long long;
+using idx_t    = uint64_t;
+#endif
+
+// below - __restrict__ is used to allow compiler to aggressively optimize load/read operations
+// on tensors since we guarantee that there is no overlap between a, b, c pointers
+extern "C" __global__ void Op5dTensorGeneric(const MIOPEN_TYPE* __restrict__ a, // Input Tensor A
+                                             const MIOPEN_TYPE* __restrict__ b, // Operand Tensor B
+                                             MIOPEN_TYPE* __restrict__ c,       // Output Tensor C
+                                             const offset_t Aoffset,            // A-offset
+                                             const offset_t Boffset,            // B-offset
+                                             const offset_t Coffset,            // C-offset
+                                             const len_t b_n,                   // b_n
+                                             const len_t b_c,                   // b_c
+                                             const len_t b_d,                   // b_d
+                                             const len_t b_h,                   // b_h
+                                             const len_t b_w,                   // b_w
+                                             const len_t c_n,                   // c_n
+                                             const len_t c_c,                   // c_c
+                                             const len_t c_d,                   // c_d
+                                             const len_t c_h,                   // c_h
+                                             const len_t c_w,                   // c_w
+                                             const len_t a_nstride,             // a_n fixed stride
+                                             const len_t a_cstride,             // a_c fixed stride
+                                             const len_t a_dstride,             // a_d fixed stride
+                                             const len_t a_hstride,             // a_h fixed stride
+                                             const len_t a_wstride,             // a_w fixed stride
+                                             const len_t b_nstride,             // b_n fixed stride
+                                             const len_t b_cstride,             // b_c fixed stride
+                                             const len_t b_dstride,             // b_d fixed stride
+                                             const len_t b_hstride,             // b_h fixed stride
+                                             const len_t b_wstride,             // b_w fixed stride
+                                             const len_t c_nstride,             // c_n strides
+                                             const len_t c_cstride,             // c_c strides
+                                             const len_t c_dstride,             // c_d strides
+                                             const len_t c_hstride,             // c_h strides
+                                             const len_t c_wstride,             // c_w strides
+                                             const MIOPEN_TYPE alpha0, // a_0 coeff - scalar
+                                             const MIOPEN_TYPE alpha1, // a_1 coeff - scalar
+                                             const MIOPEN_TYPE beta,   // beta-factor
+                                             const len_t total_work,   // total number of operations
+                                             const bool use_beta)      // use beta
+{
+    const MIOPEN_TYPE* a_base = a + static_cast<size_t>(Aoffset);
+    const MIOPEN_TYPE* b_base = b + static_cast<size_t>(Boffset);
+    MIOPEN_TYPE* c_base       = c + static_cast<size_t>(Coffset);
+
+// USE_PACKED_INNER toggles optimization on
+#ifndef USE_PACKED_INNER
+#define USE_PACKED_INNER 1
+#endif
+
+    // calc thread index and total thread count
+    const idx_t tcount = static_cast<idx_t>(blockDim.x) * static_cast<idx_t>(gridDim.x);
+    const idx_t tid    = static_cast<idx_t>(blockIdx.x) * static_cast<idx_t>(blockDim.x) +
+                      static_cast<idx_t>(threadIdx.x);
+
+#if USE_PACKED_INNER
+    // keep wide_t strictly 64-bit to avoid overflow in index calculations
+    using wide_t = uint64_t;
+
+    // each thread processes multiple PACK_T-sized blocks, cast to wider type only for the
+    // current packs amount and total work, to avoid potential overflow
+    for(wide_t i = static_cast<wide_t>(tid);
+        i * static_cast<wide_t>(PACK_T) < static_cast<wide_t>(total_work);
+        i += static_cast<wide_t>(tcount))
+    {
+
+        const wide_t base = i * static_cast<wide_t>(PACK_T);
+
+        // Decompose indices for C ( == A) per one block of PACK_T elements
+        const wide_t cw  = static_cast<wide_t>(c_w);
+        const wide_t ch  = static_cast<wide_t>(c_h);
+        const wide_t cd  = static_cast<wide_t>(c_d);
+        const wide_t ccw = static_cast<wide_t>(c_c);
+
+        wide_t tmp_w = base;
+
+        // Use optimized bit operations for W dimension when c_w is power of 2
+        const idx_t w0 = static_cast<idx_t>(CW_MOD(tmp_w, cw));
+        tmp_w          = CW_DIV(tmp_w, cw);
+        const idx_t h0 = static_cast<idx_t>(tmp_w % ch);
+        tmp_w /= ch;
+        const idx_t d0 = static_cast<idx_t>(tmp_w % cd);
+        tmp_w /= cd;
+        const idx_t c0 = static_cast<idx_t>(tmp_w % ccw);
+        tmp_w /= ccw;
+        const idx_t n0 = static_cast<idx_t>(tmp_w);
+
+        // Broadcast indices for B, each dimension of B may be either 1, i.e.
+        // broadcast or equal to the corresponding C dim.
+        const idx_t bn0 = (b_n == 1) ? 0 : ((b_n == c_n) ? n0 : (n0 % static_cast<idx_t>(b_n)));
+        const idx_t bc0 = (b_c == 1) ? 0 : ((b_c == c_c) ? c0 : (c0 % static_cast<idx_t>(b_c)));
+        const idx_t bd0 = (b_d == 1) ? 0 : ((b_d == c_d) ? d0 : (d0 % static_cast<idx_t>(b_d)));
+        const idx_t bh0 = (b_h == 1) ? 0 : ((b_h == c_h) ? h0 : (h0 % static_cast<idx_t>(b_h)));
+
+        // Check W for possible broadcasting for A and B When true,
+        // the same element reused for all W positions for A only case with stride == 0
+        // for B: stride == 0 or size == 1
+        const bool aw0  = (a_wstride == 0);
+        const idx_t bw0 = (b_w == 1) ? 0 : ((b_w == c_w) ? w0 : (w0 % static_cast<idx_t>(b_w)));
+        const bool should_cache_bw = (b_w == 1);
+
+        // Base offsets for A, B, C tensors
+        wide_t a_off = static_cast<wide_t>(n0) * a_nstride + static_cast<wide_t>(c0) * a_cstride +
+                       static_cast<wide_t>(d0) * a_dstride + static_cast<wide_t>(h0) * a_hstride +
+                       (aw0 ? static_cast<wide_t>(0) : static_cast<wide_t>(w0) * a_wstride);
+
+        wide_t b_off = static_cast<wide_t>(bn0) * b_nstride + static_cast<wide_t>(bc0) * b_cstride +
+                       static_cast<wide_t>(bd0) * b_dstride + static_cast<wide_t>(bh0) * b_hstride +
+                       static_cast<wide_t>(bw0) * b_wstride;
+
+        wide_t c_off = static_cast<wide_t>(n0) * c_nstride + static_cast<wide_t>(c0) * c_cstride +
+                       static_cast<wide_t>(d0) * c_dstride + static_cast<wide_t>(h0) * c_hstride +
+                       static_cast<wide_t>(w0) * c_wstride;
+
+        // Increments for A, B, C ptrs
+        const wide_t a_inc_w = aw0 ? static_cast<wide_t>(0) : static_cast<wide_t>(a_wstride);
+        const wide_t b_inc_w = should_cache_bw ? 0 : static_cast<wide_t>(b_wstride);
+        const wide_t c_inc_w = static_cast<wide_t>(c_wstride);
+
+        // Remaining elements in current C-row by W. Compute via wide_t then narrow.
+        const wide_t w_rem_w = cw - static_cast<wide_t>(w0);
+        const idx_t w_run    = static_cast<idx_t>(
+            w_rem_w < static_cast<wide_t>(PACK_T) ? w_rem_w : static_cast<wide_t>(PACK_T));
+
+        // Cache broadcast values to avoid redundant loads
+        MIOPEN_TYPE av_cached = MIOPEN_TYPE(0);
+        if(aw0)
+            av_cached = a_base[static_cast<size_t>(a_off)];
+
+        MIOPEN_TYPE bv_cached = MIOPEN_TYPE(0);
+        if(should_cache_bw)
+            bv_cached = b_base[static_cast<size_t>(b_off)];
+
+// "unroll" below - to unwind small simple loops for better
+// performance through improving instruction-level parallelism
+// assumed for pack sizes 8 or 16, otherwise may reduce performance
+#pragma unroll PACK_T
+
+        // execute operation for the main part of the pack
+        for(idx_t k = 0; k < static_cast<idx_t>(PACK_T); ++k)
+        {
+            if(k < w_run)
+            {
+                const MIOPEN_TYPE av = aw0 ? av_cached : a_base[static_cast<size_t>(a_off)];
+                const MIOPEN_TYPE bv =
+                    should_cache_bw ? bv_cached : b_base[static_cast<size_t>(b_off)];
+                const MIOPEN_TYPE res = MIOPEN_TENSOR_OP(av * alpha0, bv * alpha1);
+
+                if(!use_beta)
+                {
+                    c_base[static_cast<size_t>(c_off)] = res;
+                }
+                else
+                {
+                    const MIOPEN_TYPE cv               = c_base[static_cast<size_t>(c_off)];
+                    c_base[static_cast<size_t>(c_off)] = res + cv * beta;
+                }
+
+                a_off += a_inc_w;
+                b_off += b_inc_w;
+                c_off += c_inc_w;
+            }
+        }
+
+        // process remaining elements (tail) if any are present
+        // two paths: optimized incremental (when c_w >= PACK_T) or fallback full decomposition
+        if(w_run < static_cast<idx_t>(PACK_T))
+        {
+            // guard: incremental tail only safe when tail can't span multiple W-rows
+            // when c_w >= PACK_T, tail elements (at most PACK_T - 1) fit in single row
+            if(cw >= static_cast<wide_t>(PACK_T))
+            {
+                // Guard: skip if no tail elements (avoids OOB in pre-load below)
+                const wide_t first_tail_idx = base + static_cast<wide_t>(w_run);
+                if(first_tail_idx >= static_cast<wide_t>(total_work)) {}
+                else
+                {
+                    // optimized path: continue from main loop state with carry propagation
+                    idx_t h_t = h0 + 1;
+                    idx_t d_t = d0;
+                    idx_t c_t = c0;
+                    idx_t n_t = n0;
+
+                    // handle carry propagation for row wrap
+                    if(h_t >= static_cast<idx_t>(c_h))
+                    {
+                        h_t = 0;
+                        d_t++;
+                        if(d_t >= static_cast<idx_t>(c_d))
+                        {
+                            d_t = 0;
+                            c_t++;
+                            if(c_t >= static_cast<idx_t>(c_c))
+                            {
+                                c_t = 0;
+                                n_t++;
+                            }
+                        }
+                    }
+
+                    // B broadcast indices for new row position
+                    const idx_t bn_t =
+                        (b_n == 1) ? 0 : ((b_n == c_n) ? n_t : (n_t % static_cast<idx_t>(b_n)));
+                    const idx_t bc_t =
+                        (b_c == 1) ? 0 : ((b_c == c_c) ? c_t : (c_t % static_cast<idx_t>(b_c)));
+                    const idx_t bd_t =
+                        (b_d == 1) ? 0 : ((b_d == c_d) ? d_t : (d_t % static_cast<idx_t>(b_d)));
+                    const idx_t bh_t =
+                        (b_h == 1) ? 0 : ((b_h == c_h) ? h_t : (h_t % static_cast<idx_t>(b_h)));
+
+                    // base offsets for tail starting position (w = 0)
+                    wide_t a_off_t = static_cast<wide_t>(n_t) * a_nstride +
+                                     static_cast<wide_t>(c_t) * a_cstride +
+                                     static_cast<wide_t>(d_t) * a_dstride +
+                                     static_cast<wide_t>(h_t) * a_hstride;
+                    wide_t b_off_t = static_cast<wide_t>(bn_t) * b_nstride +
+                                     static_cast<wide_t>(bc_t) * b_cstride +
+                                     static_cast<wide_t>(bd_t) * b_dstride +
+                                     static_cast<wide_t>(bh_t) * b_hstride;
+                    wide_t c_off_t = static_cast<wide_t>(n_t) * c_nstride +
+                                     static_cast<wide_t>(c_t) * c_cstride +
+                                     static_cast<wide_t>(d_t) * c_dstride +
+                                     static_cast<wide_t>(h_t) * c_hstride;
+
+                    // cache B value for tail row if W-broadcast
+                    MIOPEN_TYPE bv_tail_cached = MIOPEN_TYPE(0);
+                    if(should_cache_bw)
+                        bv_tail_cached = b_base[static_cast<size_t>(b_off_t)];
+
+                    // process tail elements with incremental W-stride updates
+                    for(idx_t k = w_run; k < static_cast<idx_t>(PACK_T); ++k)
+                    {
+                        const wide_t idx_w = base + static_cast<wide_t>(k);
+                        if(idx_w >= static_cast<wide_t>(total_work))
+                            break;
+
+                        const MIOPEN_TYPE av = a_base[static_cast<size_t>(a_off_t)];
+                        const MIOPEN_TYPE bv =
+                            should_cache_bw ? bv_tail_cached : b_base[static_cast<size_t>(b_off_t)];
+                        const MIOPEN_TYPE res = MIOPEN_TENSOR_OP(av * alpha0, bv * alpha1);
+
+                        if(!use_beta)
+                        {
+                            c_base[static_cast<size_t>(c_off_t)] = res;
+                        }
+                        else
+                        {
+                            const MIOPEN_TYPE cv = c_base[static_cast<size_t>(c_off_t)];
+                            c_base[static_cast<size_t>(c_off_t)] = res + cv * beta;
+                        }
+
+                        a_off_t += a_inc_w;
+                        b_off_t += b_inc_w;
+                        c_off_t += c_inc_w;
+                    }
+                } // end else (valid tail elements exist)
+            }
+            else
+            {
+                // fallback path: full decomposition for each tail element
+                // used when c_w < PACK_T (tail may span multiple rows)
+                for(idx_t k = w_run; k < static_cast<idx_t>(PACK_T); ++k)
+                {
+                    const wide_t idx_w = base + static_cast<wide_t>(k);
+                    if(idx_w >= static_cast<wide_t>(total_work))
+                        break;
+
+                    // decompose linear index (use optimized W operations when power of 2)
+                    const idx_t w      = static_cast<idx_t>(CW_MOD(idx_w, cw));
+                    const wide_t tmp_h = CW_DIV(idx_w, cw);
+                    const idx_t h      = static_cast<idx_t>(tmp_h % ch);
+                    const idx_t d      = static_cast<idx_t>((tmp_h / ch) % cd);
+                    const idx_t c1     = static_cast<idx_t>((tmp_h / (ch * cd)) % ccw);
+                    const idx_t n      = static_cast<idx_t>(tmp_h / (ch * cd * ccw));
+
+                    // B broadcast mapping
+                    const idx_t bn =
+                        (b_n == 1) ? 0 : ((b_n == c_n) ? n : (n % static_cast<idx_t>(b_n)));
+                    const idx_t bc =
+                        (b_c == 1) ? 0 : ((b_c == c_c) ? c1 : (c1 % static_cast<idx_t>(b_c)));
+                    const idx_t bd =
+                        (b_d == 1) ? 0 : ((b_d == c_d) ? d : (d % static_cast<idx_t>(b_d)));
+                    const idx_t bh =
+                        (b_h == 1) ? 0 : ((b_h == c_h) ? h : (h % static_cast<idx_t>(b_h)));
+                    const idx_t bw =
+                        (b_w == 1) ? 0 : ((b_w == c_w) ? w : (w % static_cast<idx_t>(b_w)));
+
+                    // offsets
+                    const wide_t a_off_tail =
+                        static_cast<wide_t>(n) * a_nstride + static_cast<wide_t>(c1) * a_cstride +
+                        static_cast<wide_t>(d) * a_dstride + static_cast<wide_t>(h) * a_hstride +
+                        static_cast<wide_t>(w) * a_wstride;
+
+                    const wide_t b_off_tail =
+                        static_cast<wide_t>(bn) * b_nstride + static_cast<wide_t>(bc) * b_cstride +
+                        static_cast<wide_t>(bd) * b_dstride + static_cast<wide_t>(bh) * b_hstride +
+                        static_cast<wide_t>(bw) * b_wstride;
+
+                    const wide_t c_off_tail =
+                        static_cast<wide_t>(n) * c_nstride + static_cast<wide_t>(c1) * c_cstride +
+                        static_cast<wide_t>(d) * c_dstride + static_cast<wide_t>(h) * c_hstride +
+                        static_cast<wide_t>(w) * c_wstride;
+
+                    // execute tensor op for the tail part
+                    const MIOPEN_TYPE av = a_base[static_cast<size_t>(a_off_tail)];
+                    const MIOPEN_TYPE bv_tail =
+                        should_cache_bw ? bv_cached : b_base[static_cast<size_t>(b_off_tail)];
+                    const MIOPEN_TYPE tmp = MIOPEN_TENSOR_OP(av * alpha0, bv_tail * alpha1);
+
+                    if(!use_beta)
+                    {
+                        c_base[static_cast<size_t>(c_off_tail)] = tmp;
+                    }
+                    else
+                    {
+                        const MIOPEN_TYPE cv = c_base[static_cast<size_t>(c_off_tail)];
+                        c_base[static_cast<size_t>(c_off_tail)] = tmp + cv * beta;
+                    }
+                }
+            }
+        }
+    }
+#else
+    // scalar version without inner packing
+    using wide_t = uint64_t;
+
+#pragma unroll 1
+    for(wide_t i = static_cast<wide_t>(tid); i < static_cast<wide_t>(total_work);
+        i += static_cast<wide_t>(tcount))
+    {
+           // widen dims once
+        const wide_t cw  = static_cast<wide_t>(c_w);
+        const wide_t ch  = static_cast<wide_t>(c_h);
+        const wide_t cd  = static_cast<wide_t>(c_d);
+        const wide_t ccw = static_cast<wide_t>(c_c);
+
+        // decompose linear index (use optimized W operations when power of 2)
+        const idx_t w      = static_cast<idx_t>(CW_MOD(i, cw));
+        const wide_t tmp_h = CW_DIV(i, cw);
+        const idx_t h      = static_cast<idx_t>(tmp_h % ch);
+        const idx_t d      = static_cast<idx_t>((tmp_h / ch) % cd);
+        const idx_t c1     = static_cast<idx_t>((tmp_h / (ch * cd)) % ccw);
+        const idx_t n      = static_cast<idx_t>(tmp_h / (ch * cd * ccw));
+
+        // B broadcast mapping
+        const idx_t bn = (b_n == 1) ? 0 : ((b_n == c_n) ? n : (n % static_cast<idx_t>(b_n)));
+        const idx_t bc = (b_c == 1) ? 0 : ((b_c == c_c) ? c1 : (c1 % static_cast<idx_t>(b_c)));
+        const idx_t bd = (b_d == 1) ? 0 : ((b_d == c_d) ? d : (d % static_cast<idx_t>(b_d)));
+        const idx_t bh = (b_h == 1) ? 0 : ((b_h == c_h) ? h : (h % static_cast<idx_t>(b_h)));
+        const idx_t bw = (b_w == 1) ? 0 : ((b_w == c_w) ? w : (w % static_cast<idx_t>(b_w)));
+
+        // offsets
+        const wide_t a_off =
+            static_cast<wide_t>(n) * a_nstride + static_cast<wide_t>(c1) * a_cstride +
+            static_cast<wide_t>(d) * a_dstride + static_cast<wide_t>(h) * a_hstride +
+            static_cast<wide_t>(w) * a_wstride;
+
+        const wide_t b_off =
+            static_cast<wide_t>(bn) * b_nstride + static_cast<wide_t>(bc) * b_cstride +
+            static_cast<wide_t>(bd) * b_dstride + static_cast<wide_t>(bh) * b_hstride +
+            static_cast<wide_t>(bw) * b_wstride;
+
+        const wide_t c_off =
+            static_cast<wide_t>(n) * c_nstride + static_cast<wide_t>(c1) * c_cstride +
+            static_cast<wide_t>(d) * c_dstride + static_cast<wide_t>(h) * c_hstride +
+            static_cast<wide_t>(w) * c_wstride;
+
+        // execute tensor op
+        const MIOPEN_TYPE av  = a_base[static_cast<size_t>(a_off)];
+        const MIOPEN_TYPE bv  = b_base[static_cast<size_t>(b_off)];
+        const MIOPEN_TYPE tmp = MIOPEN_TENSOR_OP(av * alpha0, bv * alpha1);
+
+        if(!use_beta)
+        {
+               c_base[static_cast<size_t>(c_off)] = tmp;
+        }
+        else
+        {
+               const MIOPEN_TYPE cv               = c_base[static_cast<size_t>(c_off)];
+               c_base[static_cast<size_t>(c_off)] = tmp + cv * beta;
+        }
+    }
+#endif // USE_PACKED_INNER
+}
+#endif // USE_5D_TENSOR_GENERIC
+
+#ifdef USE_5D_TENSOR_GENERIC_CONTIGUOUS
+
+// register-level packet processing to improve parallelism and reduce div/mod overhead.
+// PACK_T = how many consecutive elements each thread handles per inner iteration.
+// If the solver didn't define it at JIT time, fall back to 8 for standalone builds.
+#ifndef PACK_T
+#define PACK_T 8
+#endif
+
+static_assert(PACK_T >= 1 && PACK_T <= 16, "PACK_T must be in [1..16]");
+
+// Adaptive selection between the narrow (32-bit) and wide (64-bit) index/offset types.
+// 32-bit for faster arithmetic when the address range allows that. 64-bit
+// to safely handle very large tensors or strides/offsets.
+#ifdef USE_INDEX32
+using offset_t = uint64_t;
+using len_t    = unsigned int;
+using idx_t    = uint32_t;
+#else
+using offset_t = uint64_t;
+using len_t    = unsigned long long;
+using idx_t    = uint64_t;
+#endif
+
+// NOTE: Contiguous fast path assumes B and C have identical shapes (blens == clens).
+// We keep b_* and c_* parameters for interface compatibility with the generic kernel,
+// only (b_w, c_w) are currently used, the rest are intentionally unused.
+
+// below - __restrict__ is used to allow compiler to aggressively optimize load/read operations
+// on tensors since we guarantee that there is no overlap between a, b, c pointers
+extern "C" __global__ void
+Op5dTensorGenericContiguous(const MIOPEN_TYPE* __restrict__ a, // Input Tensor A
+                            const MIOPEN_TYPE* __restrict__ b, // Operand Tensor B
+                            MIOPEN_TYPE* __restrict__ c,       // Output Tensor C
+                            const offset_t Aoffset,            // A-offset
+                            const offset_t Boffset,            // B-offset
+                            const offset_t Coffset,            // C-offset
+                            [[maybe_unused]] const len_t b_n,  // b_n = c_n
+                            [[maybe_unused]] const len_t b_c,  // b_c = c_c
+                            [[maybe_unused]] const len_t b_d,  // b_d = c_d
+                            [[maybe_unused]] const len_t b_h,  // b_h = c_h
+                            const len_t b_w,                   // b_w = c_w
+                            [[maybe_unused]] const len_t c_n,  // c_n
+                            [[maybe_unused]] const len_t c_c,  // c_c
+                            [[maybe_unused]] const len_t c_d,  // c_d
+                            [[maybe_unused]] const len_t c_h,  // c_h
+                            const len_t c_w,                   // c_w
+                            const MIOPEN_TYPE alpha0,          // a_0 coeff - scalar
+                            const MIOPEN_TYPE alpha1,          // a_1 coeff - scalar
+                            const MIOPEN_TYPE beta,            // beta-factor
+                            const len_t total_work,            // total number of operations
+                            const bool use_beta)               // use beta
+{
+    const MIOPEN_TYPE* a_base = a + static_cast<size_t>(Aoffset);
+    const MIOPEN_TYPE* b_base = b + static_cast<size_t>(Boffset);
+    MIOPEN_TYPE* c_base       = c + static_cast<size_t>(Coffset);
+
+    const uint64_t tid    = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint64_t stride = uint64_t(blockDim.x) * gridDim.x;
+
+    constexpr int pack_size  = PACK_T;
+    const int effective_pack = (c_w < 16) ? 1 : pack_size;
+
+    for(uint64_t base = tid * effective_pack; base < total_work; base += stride * effective_pack)
+    {
+        const uint64_t remaining =
+            (base + effective_pack <= total_work) ? effective_pack : total_work - base;
+
+        if(effective_pack == 1)
+        {
+            // narrow path (c_w < 16) -> reduce register pressure by processing single element per
+            // thread
+            const size_t idx = static_cast<size_t>(base);
+
+            const MIOPEN_TYPE a_val = a_base[idx];
+            const MIOPEN_TYPE b_val = b_base[idx];
+
+            MIOPEN_TYPE tmp = MIOPEN_TENSOR_OP(a_val * alpha0, b_val * alpha1);
+
+            if(use_beta)
+            {
+                const MIOPEN_TYPE c_val = c_base[idx];
+                c_base[idx]             = tmp + beta * c_val;
+            }
+            else
+            {
+                c_base[idx] = tmp;
+            }
+        }
+        else
+        {
+            // wide path (c_w >= 16): process multiple elements per thread
+            // process per pack size
+            MIOPEN_TYPE a_val[pack_size];
+            MIOPEN_TYPE b_val[pack_size];
+            MIOPEN_TYPE c_val[pack_size];
+
+            // Load A and B values
+#pragma unroll
+            for(int i = 0; i < pack_size; i++)
+            {
+                if(i < remaining)
+                {
+                    a_val[i] = a_base[static_cast<size_t>(base) + i];
+                    b_val[i] = b_base[static_cast<size_t>(base) + i];
+                }
+            }
+
+            // Load C if needed
+            if(use_beta)
+            {
+#pragma unroll
+                for(int i = 0; i < pack_size; i++)
+                {
+                    if(i < remaining)
+                    {
+                        c_val[i] = c_base[static_cast<size_t>(base) + i];
+                    }
+                }
+            }
+
+            // execute tensor op
+#pragma unroll
+            for(int i = 0; i < pack_size; i++)
+            {
+                if(i < remaining)
+                {
+                    MIOPEN_TYPE tmp = MIOPEN_TENSOR_OP(a_val[i] * alpha0, b_val[i] * alpha1);
+                    c_val[i]        = use_beta ? (tmp + beta * c_val[i]) : tmp;
+                }
+            }
+
+            // Store results
+#pragma unroll
+            for(int i = 0; i < pack_size; i++)
+            {
+                if(i < remaining)
+                {
+                    c_base[static_cast<size_t>(base) + i] = c_val[i];
+                }
+            }
+        }
+    }
+}
+#endif

--- a/projects/miopen/src/solver/tensorOp/Op5dTensorGeneric.cpp
+++ b/projects/miopen/src/solver/tensorOp/Op5dTensorGeneric.cpp
@@ -38,6 +38,16 @@ namespace solver {
 
 namespace tensorOp {
 
+// Software-level caps for the number of work-groups, used as a safety net
+// on top of hardware / CU-based heuristics.
+//
+// For small tensors, launching too many WGs increases dispatch overhead
+// and leads to tail inefficiency, as for larger tensors - allow more WGs to improve latency hiding.
+// Values are empirical and intentionally conservative.
+constexpr size_t k_SmallTensorElemsThreshold = 1024 * 1024;
+constexpr size_t k_MaxNumWgSmallTensor       = 1024;
+constexpr size_t k_MaxNumWgLargeTensor       = 4096;
+
 bool Op5dTensorGeneric::IsApplicable([[maybe_unused]] const ExecutionContext& context,
                                      const miopen::tensorOp::ProblemDescription& problem) const
 {
@@ -70,6 +80,7 @@ Op5dTensorGeneric::GetSolution([[maybe_unused]] const ExecutionContext& context,
     const auto& bTensorDesc = problem.GetBTensorDesc();
     const auto& cTensorDesc = problem.GetCTensorDesc();
 
+    const auto& alens = aTensorDesc.GetLengths();
     const auto& blens = bTensorDesc.GetLengths();
     const auto& clens = cTensorDesc.GetLengths();
 
@@ -83,87 +94,271 @@ Op5dTensorGeneric::GetSolution([[maybe_unused]] const ExecutionContext& context,
     std::tie(cstrides[0], cstrides[1], cstrides[2], cstrides[3], cstrides[4]) =
         miopen::tien<5>(cTensorDesc.GetStrides());
 
+    auto bstrides_fix = bstrides;
+    auto astrides_fix = astrides;
+    for(int i = 0; i < 5; ++i)
+    {
+        if(blens[i] == 1)
+            bstrides_fix[i] = 0;
+        if(alens[i] == 1)
+            astrides_fix[i] = 0;
+    }
+
+    KernelBuildParameters build_params = KernelBuildParameters{};
+    GetCommonParams(build_params, problem, false);
+    build_params.Define("USE_5D_TENSOR_GENERIC");
+
+    // PACK_T - how many consecutive elements each thread handles per inner iteration.
+    // declaration + define as main source, in kernel defined as fallback - only
+    constexpr size_t k_PACK_T = 8;
+    build_params.Define("PACK_T", k_PACK_T);
+
+    // Power-of-2 optimization for W dimension:
+    // Replace div/mod with bit ops (x % c_w -> x & (c_w-1), x / c_w -> x >> log2)
+    // Applied at JIT time via CW_IS_POW2/CW_LOG2 macros
+    const size_t c_w_val = clens[4];
+
+    // Check if c_w is a power of 2: (x & (x-1)) == 0 for powers of 2, and x > 0
+    const bool cw_is_pow2 = (c_w_val > 0) && ((c_w_val & (c_w_val - 1)) == 0);
+
+    if(cw_is_pow2)
+    {
+        build_params.Define("CW_IS_POW2", 1);
+
+        // log2(c_w) via bit counting
+        unsigned int cw_log2 = 0;
+        size_t temp          = c_w_val;
+        while(temp > 1)
+        {
+            temp >>= 1;
+            ++cw_log2;
+        }
+        build_params.Define("CW_LOG2", cw_log2);
+    }
+
+    const TensorDescriptor aTempDesc(aTensorDesc.GetType(), alens);
+    const TensorDescriptor bTempDesc(bTensorDesc.GetType(), blens);
+
+    const uint64_t a_max = static_cast<uint64_t>(aTempDesc.GetElementSpace());
+    const uint64_t b_max = static_cast<uint64_t>(bTempDesc.GetElementSpace());
+    const uint64_t c_max = static_cast<uint64_t>(cTensorDesc.GetElementSpace());
+
+    // determine necessity to use 32-bit indexing
+    bool use_i32 = (a_max < 0x7fffffffULL) && (b_max < 0x7fffffffULL) && (c_max < 0x7fffffffULL);
+    use_i32      = use_i32 && aTensorDesc.AllDimsFitIntoInt() && bTensorDesc.AllDimsFitIntoInt() &&
+              cTensorDesc.AllDimsFitIntoInt();
+
+    // check if total work fits in u32 or not
+    auto mul_u64_sat = [](uint64_t a, uint64_t b) -> uint64_t {
+        if(a == 0 || b == 0)
+            return uint64_t{0};
+        if(a > (std::numeric_limits<uint64_t>::max() / b))
+            return std::numeric_limits<uint64_t>::max();
+        return a * b;
+    };
+
+    uint64_t total_work_u64 = 1;
+    for(int i = 0; i < 5; ++i)
+        total_work_u64 = mul_u64_sat(total_work_u64, static_cast<uint64_t>(clens[i]));
+    const bool total_work_fits_u32 = (total_work_u64 <= uint64_t{0xFFFFFFFFu});
+
+    use_i32 = use_i32 && total_work_fits_u32;
+    if(use_i32)
+        build_params.Define("USE_INDEX32");
+
+    auto kernel                = KernelInfo{};
     miopenDataType_t data_type = bTensorDesc.GetType();
 
-    auto&& [num_wg, work_per_wg, bitmap] = GetBitmapAndWgInfo(blens, clens);
+    const size_t warp_size   = context.GetStream().GetWavefrontWidth();
+    const size_t total_elems = clens[0] * clens[1] * clens[2] * clens[3] * clens[4];
+    const size_t cu_count    = context.GetStream().GetMaxComputeUnits();
 
-    int num_wg_orig = num_wg;
-    int max_num_wg  = 4096;
-    num_wg          = num_wg > max_num_wg ? max_num_wg : num_wg;
+    size_t local_threads;
+    size_t num_wg;
+    size_t global_threads;
 
-    size_t local_threads  = 256;
-    size_t global_threads = num_wg * local_threads;
+    // Each thread processes PACK_T consecutive elements
+    const size_t total_packets = (total_elems + k_PACK_T - 1) / k_PACK_T;
+
+    /*!
+     * @anchor cu_scaled_wg_cap
+     * @brief Heuristic: CU-scaled work-group cap for latency hiding
+     *
+     * Heuristic cap for the number of work-groups to launch, proportional to the number of
+     * compute units (CU). The goal is to keep enough wavefronts resident to hide memory latency,
+     * while avoiding a cascade of tiny work-groups on small problems (scheduler overhead & tail
+     * waste).
+     *
+     * On AMD GPUs, a wavefront consists of 64 threads. With local_threads = 256, each work-group
+     * contains 256 / 64 = 4 wavefronts. The multipliers below roughly target a desired number of
+     * wavefronts per CU:
+     *
+     *  - cu_count * 32  -> ~32 WGs/CU × 4 waves/WG ≈ 128 waves/CU (large problems)
+     *  - cu_count * 16  -> ~16 WGs/CU × 4 waves/WG ≈  64 waves/CU (mid-size problems)
+     *  - cu_count *  8  -> ~ 8 WGs/CU × 4 waves/WG ≈  32 waves/CU (small problems)
+     *
+     * The cap is downscaled when total_packets is small to reduce launch/dispatch overhead and
+     * avoid over-fragmentation, while still keeping enough wavefronts per CU to hide latency.
+     *
+     * For the special case b_w == 1 (W-broadcast on B), memory access patterns tend to be less
+     * favorable; the cap is slightly increased to allow more work-groups in flight and improve
+     * latency hiding.
+     */
+    size_t max_num_wg_hw = cu_count * 32;
+    if(total_packets < 512)
+        max_num_wg_hw = cu_count * 16;
+    if(total_packets < 128)
+        max_num_wg_hw = cu_count * 8;
+
+    local_threads = warp_size * 4; // 256 threads = 4 wavefronts
+
+    // Small adjustments for narrow problems and W-broadcast cases:
+    // For small total packet counts - reduce local_threads to avoid spawning many half-empty waves
+    // For b_w == 1 - i.e. "heavy broadcast", limit local_threads to 128 to allow more WGs per CU.
+    const bool bw_is_one = (blens[4] == 1);
+
+    if(total_packets < 512)
+        local_threads = 128;
+    if(total_packets < 128)
+        local_threads = 64;
+    if(bw_is_one && local_threads > 128)
+        local_threads = 128;
+
+    // For W-broadcast, slightly increase the upper WG cap to better hide memory latency.
+    if(bw_is_one)
+        max_num_wg_hw = std::max(max_num_wg_hw, cu_count * 48);
+
+    // Required number of WGs given the chosen local_threads
+    const size_t need_wg = (total_packets + local_threads - 1) / local_threads;
+
+    // Software-level safety cap on top of the hardware heuristic limit
+    const size_t max_num_wg_sw =
+        (total_elems < k_SmallTensorElemsThreshold) ? k_MaxNumWgSmallTensor : k_MaxNumWgLargeTensor;
+
+    // Final cap
+    const size_t max_num_wg = std::min(max_num_wg_hw, max_num_wg_sw);
+
+    // Final number of WGs to launch
+    num_wg = std::clamp(need_wg, static_cast<size_t>(1), max_num_wg);
+
+    global_threads = num_wg * local_threads;
 
     const std::array<size_t, 3> vld{local_threads, 1, 1};
     const std::array<size_t, 3> vgd{global_threads, 1, 1};
 
-    KernelBuildParameters build_params = KernelBuildParameters{};
-
-    GetCommonParams(build_params, problem, false);
-
-    build_params.Define("USE_5D_TENSOR_GENERIC");
-    build_params.Define("MAX_NUM_WG", std::to_string(max_num_wg));
-
-    auto kernel = KernelInfo{};
-
-    kernel.comp_options = build_params.GenerateFor(kbp::OpenCL{});
-    kernel.kernel_file  = "MIOpenTensorKernels.cl";
+    kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
+    kernel.kernel_file  = "MIOpenTensorKernelsHip.cpp";
     kernel.kernel_name  = "Op5dTensorGeneric";
 
     using std::begin, std::end;
-
     kernel.l_wk.insert(end(kernel.l_wk), begin(vld), end(vld));
     kernel.g_wk.insert(end(kernel.g_wk), begin(vgd), end(vgd));
 
     result.invoker_factory =
-        [data_type, blens, clens, astrides, bstrides, cstrides, bitmap, work_per_wg, num_wg_orig](
-            const std::vector<Kernel> kernels) {
-            return [=](const Handle& handle_, const AnyInvokeParams& raw_params) {
-                decltype(auto) kernel = handle_.Run(kernels.front());
-                decltype(auto) params = raw_params.CastTo<miopen::tensorOp::InvokeParams>();
+        [data_type, blens, clens, cstrides, astrides_fix, bstrides_fix, mul_u64_sat, use_i32](
+            const std::vector<Kernel>& kernels) {
+            return [=](const Handle& handle, const AnyInvokeParams& raw_params) {
+                auto kernel = handle.Run(kernels.front());
+                auto params = raw_params.CastTo<miopen::tensorOp::InvokeParams>();
 
                 visit_float(data_type, [&](auto as_float) {
-                    auto miopen_alpha0 = as_float(*(static_cast<const float*>(params.alpha0)));
-                    auto miopen_alpha1 = as_float(*(static_cast<const float*>(params.alpha1)));
-                    auto miopen_beta   = as_float(*(static_cast<const float*>(params.beta)));
+                    const float alpha0f = *static_cast<const float*>(params.alpha0);
+                    const float alpha1f = *static_cast<const float*>(params.alpha1);
+                    const float betaf   = *static_cast<const float*>(params.beta);
+                    const auto alpha0   = as_float(alpha0f);
+                    const auto alpha1   = as_float(alpha1f);
+                    const auto beta     = as_float(betaf);
 
-                    kernel(params.ATensor,
-                           static_cast<int>(astrides[0]),
-                           static_cast<int>(astrides[1]),
-                           static_cast<int>(astrides[2]),
-                           static_cast<int>(astrides[3]),
-                           params.BTensor,
-                           static_cast<int>(blens[1]),    // b_c,
-                           static_cast<int>(blens[2]),    // b_d,
-                           static_cast<int>(blens[3]),    // b_h,
-                           static_cast<int>(blens[4]),    // b_w,
-                           static_cast<int>(bstrides[0]), // b_nstride,
-                           static_cast<int>(bstrides[1]), // b_cstride,
-                           static_cast<int>(bstrides[2]), // b_dstride,
-                           static_cast<int>(bstrides[3]), // b_hstride,
-                           params.CTensor,
-                           static_cast<int>(clens[1]),    // c_c,
-                           static_cast<int>(clens[2]),    // c_d,
-                           static_cast<int>(clens[3]),    // c_h,
-                           static_cast<int>(clens[4]),    // c_w,
-                           static_cast<int>(cstrides[0]), // c_nstride,
-                           static_cast<int>(cstrides[1]), // c_cstride,
-                           static_cast<int>(cstrides[2]), // c_dstride,
-                           static_cast<int>(cstrides[3]), // c_hstride,
-                           miopen_alpha0,
-                           miopen_alpha1,
-                           miopen_beta,
-                           bitmap,
-                           work_per_wg,
-                           static_cast<int64_t>(params.Aoffset),
-                           static_cast<int64_t>(params.Boffset),
-                           static_cast<int64_t>(params.Coffset),
-                           static_cast<int>(num_wg_orig));
+                    uint64_t total_work = 1;
+                    for(int i = 0; i < 5; ++i)
+                        total_work = mul_u64_sat(total_work, static_cast<uint64_t>(clens[i]));
+
+                    // Parameter types must match kernel's len_t (32-bit if USE_INDEX32, else
+                    // 64-bit) Offsets are always uint64_t
+                    if(use_i32)
+                    {
+                        // 32-bit path: len_t = unsigned int
+                        kernel(params.ATensor,                      // Input Tensor A
+                               params.BTensor,                      // Operand Tensor B
+                               params.CTensor,                      // Output Tensor C
+                               uint64_t(params.Aoffset),            // A-offset (always 64-bit)
+                               uint64_t(params.Boffset),            // B-offset (always 64-bit)
+                               uint64_t(params.Coffset),            // C-offset (always 64-bit)
+                               static_cast<unsigned int>(blens[0]), // b_n
+                               static_cast<unsigned int>(blens[1]), // b_c
+                               static_cast<unsigned int>(blens[2]), // b_d
+                               static_cast<unsigned int>(blens[3]), // b_h
+                               static_cast<unsigned int>(blens[4]), // b_w
+                               static_cast<unsigned int>(clens[0]), // c_n
+                               static_cast<unsigned int>(clens[1]), // c_c
+                               static_cast<unsigned int>(clens[2]), // c_d
+                               static_cast<unsigned int>(clens[3]), // c_h
+                               static_cast<unsigned int>(clens[4]), // c_w
+                               static_cast<unsigned int>(astrides_fix[0]), // a_n fixed stride
+                               static_cast<unsigned int>(astrides_fix[1]), // a_c fixed stride
+                               static_cast<unsigned int>(astrides_fix[2]), // a_d fixed stride
+                               static_cast<unsigned int>(astrides_fix[3]), // a_h fixed stride
+                               static_cast<unsigned int>(astrides_fix[4]), // a_w fixed stride
+                               static_cast<unsigned int>(bstrides_fix[0]), // b_n fixed stride
+                               static_cast<unsigned int>(bstrides_fix[1]), // b_c fixed stride
+                               static_cast<unsigned int>(bstrides_fix[2]), // b_d fixed stride
+                               static_cast<unsigned int>(bstrides_fix[3]), // b_h fixed stride
+                               static_cast<unsigned int>(bstrides_fix[4]), // b_w fixed stride
+                               static_cast<unsigned int>(cstrides[0]),     // c_n strides
+                               static_cast<unsigned int>(cstrides[1]),     // c_c strides
+                               static_cast<unsigned int>(cstrides[2]),     // c_d strides
+                               static_cast<unsigned int>(cstrides[3]),     // c_h strides
+                               static_cast<unsigned int>(cstrides[4]),     // c_w strides
+                               alpha0,                                     // a_0 coeff - scalar
+                               alpha1,                                     // a_1 coeff - scalar
+                               beta,                                       // beta-factor
+                               static_cast<unsigned int>(total_work),      // total_work (32-bit)
+                               !float_equal(beta, 0.0f));                  // use beta
+                    }
+                    else
+                    {
+                        // 64-bit path: len_t = unsigned long long
+                        kernel(params.ATensor,                                   // Input Tensor A
+                               params.BTensor,                                   // Operand Tensor B
+                               params.CTensor,                                   // Output Tensor C
+                               uint64_t(params.Aoffset),                         // A-offset
+                               uint64_t(params.Boffset),                         // B-offset
+                               uint64_t(params.Coffset),                         // C-offset
+                               static_cast<unsigned long long>(blens[0]),        // b_n
+                               static_cast<unsigned long long>(blens[1]),        // b_c
+                               static_cast<unsigned long long>(blens[2]),        // b_d
+                               static_cast<unsigned long long>(blens[3]),        // b_h
+                               static_cast<unsigned long long>(blens[4]),        // b_w
+                               static_cast<unsigned long long>(clens[0]),        // c_n
+                               static_cast<unsigned long long>(clens[1]),        // c_c
+                               static_cast<unsigned long long>(clens[2]),        // c_d
+                               static_cast<unsigned long long>(clens[3]),        // c_h
+                               static_cast<unsigned long long>(clens[4]),        // c_w
+                               static_cast<unsigned long long>(astrides_fix[0]), // a_n fixed stride
+                               static_cast<unsigned long long>(astrides_fix[1]), // a_c fixed stride
+                               static_cast<unsigned long long>(astrides_fix[2]), // a_d fixed stride
+                               static_cast<unsigned long long>(astrides_fix[3]), // a_h fixed stride
+                               static_cast<unsigned long long>(astrides_fix[4]), // a_w fixed stride
+                               static_cast<unsigned long long>(bstrides_fix[0]), // b_n fixed stride
+                               static_cast<unsigned long long>(bstrides_fix[1]), // b_c fixed stride
+                               static_cast<unsigned long long>(bstrides_fix[2]), // b_d fixed stride
+                               static_cast<unsigned long long>(bstrides_fix[3]), // b_h fixed stride
+                               static_cast<unsigned long long>(bstrides_fix[4]), // b_w fixed stride
+                               static_cast<unsigned long long>(cstrides[0]),     // c_n strides
+                               static_cast<unsigned long long>(cstrides[1]),     // c_c strides
+                               static_cast<unsigned long long>(cstrides[2]),     // c_d strides
+                               static_cast<unsigned long long>(cstrides[3]),     // c_h strides
+                               static_cast<unsigned long long>(cstrides[4]),     // c_w strides
+                               alpha0,                                      // a_0 coeff - scalar
+                               alpha1,                                      // a_1 coeff - scalar
+                               beta,                                        // beta-factor
+                               static_cast<unsigned long long>(total_work), // total_work (64-bit)
+                               !float_equal(beta, 0.0f));                   // use beta
+                    }
                 });
             };
         };
     result.construction_params.push_back(kernel);
-
     return result;
 }
 

--- a/projects/miopen/src/solver/tensorOp/Op5dTensorGenericContiguous.cpp
+++ b/projects/miopen/src/solver/tensorOp/Op5dTensorGenericContiguous.cpp
@@ -1,0 +1,261 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "tensor_op_helpers.hpp"
+#include <miopen/tensorOp/solvers.hpp>
+#include <miopen/tensorOp/invoke_params.hpp>
+#include <miopen/tensor.hpp>
+#include <miopen/kernel_build_params.hpp>
+#include <miopen/float_equal.hpp>
+#include <miopen/datatype.hpp>
+
+namespace miopen {
+
+namespace solver {
+
+namespace tensorOp {
+
+// Software-level caps for the number of work-groups, used as a safety net
+// on top of hardware / CU-based heuristics.
+//
+// For small tensors, launching too many WGs increases dispatch overhead
+// and leads to tail inefficiency, as for larger tensors - allow more WGs to improve latency hiding.
+// Values are empirical and intentionally conservative.
+constexpr size_t k_SmallTensorElemsThreshold = 1024 * 1024;
+constexpr size_t k_MaxNumWgSmallTensor       = 1024;
+constexpr size_t k_MaxNumWgLargeTensor       = 4096;
+
+bool Op5dTensorGenericContiguous::IsApplicable(
+    [[maybe_unused]] const ExecutionContext&,
+    const miopen::tensorOp::ProblemDescription& problem) const
+{
+    const auto& aTensorDesc = problem.GetATensorDesc();
+    const auto& bTensorDesc = problem.GetBTensorDesc();
+    const auto& cTensorDesc = problem.GetCTensorDesc();
+
+    if(aTensorDesc.GetLengths().size() != 5)
+        return false;
+    if(aTensorDesc.GetLengths() != bTensorDesc.GetLengths())
+        return false;
+    if(bTensorDesc.GetLengths() != cTensorDesc.GetLengths())
+        return false;
+
+    if(!(aTensorDesc.IsContiguous() && bTensorDesc.IsContiguous() && cTensorDesc.IsContiguous()))
+        return false;
+
+    if(!(aTensorDesc.AllLengthsFitIntoInt() && bTensorDesc.AllLengthsFitIntoInt() &&
+         cTensorDesc.AllLengthsFitIntoInt()))
+        return false;
+
+    const auto& cl = cTensorDesc.GetLengths();
+    uint64_t total = 1;
+    for(int i = 0; i < 5; ++i)
+    {
+        const uint64_t t = static_cast<uint64_t>(cl[i]);
+        if(t == 0)
+            return false;
+        if(total > (std::numeric_limits<uint64_t>::max() / t))
+            return false;
+        total *= t;
+    }
+    if(total > std::numeric_limits<uint32_t>::max())
+        return false;
+
+    return true;
+}
+
+std::size_t Op5dTensorGenericContiguous::GetWorkspaceSize(
+    [[maybe_unused]] const ExecutionContext&,
+    [[maybe_unused]] const miopen::tensorOp::ProblemDescription&) const
+{
+    return 0;
+}
+
+ConvSolution
+Op5dTensorGenericContiguous::GetSolution(const ExecutionContext& context,
+                                         const miopen::tensorOp::ProblemDescription& problem) const
+{
+    ConvSolution result{miopenStatusSuccess};
+
+    const auto& cTensorDesc = problem.GetCTensorDesc();
+    const auto& clens       = cTensorDesc.GetLengths();
+
+    KernelBuildParameters build_params;
+    GetCommonParams(build_params, problem, false);
+    build_params.Define("USE_5D_TENSOR_GENERIC_CONTIGUOUS");
+
+    // PACK_T - how many consecutive elements each thread handles per inner iteration.
+    // declaration + define as main source, in kernel defined as fallback - only
+    constexpr size_t k_PACK_T = 8;
+    build_params.Define("PACK_T", k_PACK_T);
+
+    // Overflow-safe u64 multiplication (saturates to max on overflow)
+    auto mul_u64_sat = [](uint64_t a, uint64_t b) -> uint64_t {
+        if(a == 0 || b == 0)
+            return uint64_t{0};
+        if(a > (std::numeric_limits<uint64_t>::max() / b))
+            return std::numeric_limits<uint64_t>::max();
+        return a * b;
+    };
+
+    // Compute total elements with overflow-safe multiplication
+    uint64_t total_elems_u64 = 1;
+    for(int i = 0; i < 5; ++i)
+        total_elems_u64 = mul_u64_sat(total_elems_u64, static_cast<uint64_t>(clens[i]));
+
+    // Verify total work fits in 32-bit space before enabling 32-bit indexing
+    const bool total_work_fits_u32 = (total_elems_u64 <= uint64_t{0xFFFFFFFFu});
+    if(total_work_fits_u32)
+        build_params.Define("USE_INDEX32");
+
+    /*
+     * For more context @ref cu_scaled_wg_cap "CU-scaled WG cap heuristic".
+     */
+    const size_t total_elems   = static_cast<size_t>(total_elems_u64);
+    const size_t total_packets = (total_elems + k_PACK_T - 1) / k_PACK_T;
+
+    // Adaptive local_threads based on problem size
+    size_t local_threads = 256; // default for large problems
+    if(total_packets < 512)
+        local_threads = 128;
+    if(total_packets < 128)
+        local_threads = 64;
+
+    const size_t cu_count = context.GetStream().GetMaxComputeUnits();
+    const size_t need_wg  = (total_packets + local_threads - 1) / local_threads;
+
+    // Adaptive CU multiplier based on problem size
+    size_t cu_multiplier = 32; // default for large problems
+    if(total_packets < 512)
+        cu_multiplier = 16;
+    if(total_packets < 128)
+        cu_multiplier = 8;
+
+    const size_t cu_scaled_cap = std::max<size_t>(cu_count * cu_multiplier, 1);
+
+    // Software safety cap based on tensor size
+    const size_t software_cap =
+        (total_elems < k_SmallTensorElemsThreshold) ? k_MaxNumWgSmallTensor : k_MaxNumWgLargeTensor;
+
+    const size_t max_num_wg = std::min(cu_scaled_cap, software_cap);
+    const size_t num_wg     = std::max<size_t>(size_t{1}, std::min(need_wg, max_num_wg));
+
+    const size_t global_threads = num_wg * local_threads;
+    const std::array<size_t, 3> vld{local_threads, 1, 1};
+    const std::array<size_t, 3> vgd{global_threads, 1, 1};
+
+    miopenDataType_t data_type = cTensorDesc.GetType();
+
+    KernelInfo kernel;
+    kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
+    kernel.kernel_file  = "MIOpenTensorKernelsHip.cpp";
+    kernel.kernel_name  = "Op5dTensorGenericContiguous";
+    kernel.l_wk         = {vld[0], vld[1], vld[2]};
+    kernel.g_wk         = {vgd[0], vgd[1], vgd[2]};
+
+    const bool use_i32 = total_work_fits_u32;
+
+    result.invoker_factory =
+        [data_type, clens, total_elems_u64, use_i32](const std::vector<Kernel>& kernels) {
+            return [=](const Handle& handle, const AnyInvokeParams& raw_params) {
+                auto kernel       = handle.Run(kernels.front());
+                const auto params = raw_params.CastTo<miopen::tensorOp::InvokeParams>();
+
+                visit_float(data_type, [&](auto as_float) {
+                    const float alpha0f = *static_cast<const float*>(params.alpha0);
+                    const float alpha1f = *static_cast<const float*>(params.alpha1);
+                    const float betaf   = *static_cast<const float*>(params.beta);
+                    const auto alpha0   = as_float(alpha0f);
+                    const auto alpha1   = as_float(alpha1f);
+                    const auto beta     = as_float(betaf);
+
+                    // Shapes match: blens == clens, so we can reuse clens for both B and C
+                    // dimensions.
+                    // Parameter types must match kernel's len_t (32-bit if USE_INDEX32, else
+                    // 64-bit)
+                    if(use_i32)
+                    {
+                        // 32-bit path: len_t = unsigned int, total_work fits in 32-bit
+                        kernel(params.ATensor,                        // Input Tensor A
+                               params.BTensor,                        // Operand Tensor B
+                               params.CTensor,                        // Output Tensor C
+                               static_cast<uint64_t>(params.Aoffset), // A-offset (always 64-bit)
+                               static_cast<uint64_t>(params.Boffset), // B-offset (always 64-bit)
+                               static_cast<uint64_t>(params.Coffset), // C-offset (always 64-bit)
+                               static_cast<unsigned int>(clens[0]),   // b_n = c_n
+                               static_cast<unsigned int>(clens[1]),   // b_c = c_c
+                               static_cast<unsigned int>(clens[2]),   // b_d = c_d
+                               static_cast<unsigned int>(clens[3]),   // b_h = c_h
+                               static_cast<unsigned int>(clens[4]),   // b_w = c_w
+                               static_cast<unsigned int>(clens[0]),   // c_n
+                               static_cast<unsigned int>(clens[1]),   // c_c
+                               static_cast<unsigned int>(clens[2]),   // c_d
+                               static_cast<unsigned int>(clens[3]),   // c_h
+                               static_cast<unsigned int>(clens[4]),   // c_w
+                               alpha0,                                // a_0 coeff - scalar
+                               alpha1,                                // a_1 coeff - scalar
+                               beta,                                  // beta-factor
+                               static_cast<unsigned int>(total_elems_u64), // total_work (32-bit)
+                               !float_equal(beta, 0.0f));                  // use beta
+                    }
+                    else
+                    {
+                        // 64-bit path: len_t = unsigned long long
+                        kernel(params.ATensor,                        // Input Tensor A
+                               params.BTensor,                        // Operand Tensor B
+                               params.CTensor,                        // Output Tensor C
+                               static_cast<uint64_t>(params.Aoffset), // A-offset (always 64-bit)
+                               static_cast<uint64_t>(params.Boffset), // B-offset (always 64-bit)
+                               static_cast<uint64_t>(params.Coffset), // C-offset (always 64-bit)
+                               static_cast<unsigned long long>(clens[0]), // b_n = c_n
+                               static_cast<unsigned long long>(clens[1]), // b_c = c_c
+                               static_cast<unsigned long long>(clens[2]), // b_d = c_d
+                               static_cast<unsigned long long>(clens[3]), // b_h = c_h
+                               static_cast<unsigned long long>(clens[4]), // b_w = c_w
+                               static_cast<unsigned long long>(clens[0]), // c_n
+                               static_cast<unsigned long long>(clens[1]), // c_c
+                               static_cast<unsigned long long>(clens[2]), // c_d
+                               static_cast<unsigned long long>(clens[3]), // c_h
+                               static_cast<unsigned long long>(clens[4]), // c_w
+                               alpha0,                                    // a_0 coeff - scalar
+                               alpha1,                                    // a_1 coeff - scalar
+                               beta,                                      // beta-factor
+                               static_cast<unsigned long long>(total_elems_u64), // total_work
+                               !float_equal(beta, 0.0f));                        // use beta
+                    }
+                });
+            };
+        };
+
+    result.construction_params.push_back(kernel);
+    return result;
+}
+
+} // namespace tensorOp
+
+} // namespace solver
+
+} // namespace miopen

--- a/projects/miopen/src/tensor.cpp
+++ b/projects/miopen/src/tensor.cpp
@@ -2150,6 +2150,7 @@ void OpTensor(const Handle& handle,
                          solver::SolverContainer<solver::tensorOp::Op2dTensorLite>{} +
                          solver::SolverContainer<solver::tensorOp::Op2dTensorSquash>{} +
                          solver::SolverContainer<solver::tensorOp::Op5dTensorGeneric>{} +
+                         solver::SolverContainer<solver::tensorOp::Op5dTensorGenericContiguous>{} +
                          solver::SolverContainer<solver::tensorOp::Op4dTensorGeneric>{} +
                          solver::SolverContainer<solver::tensorOp::Op3dTensorGeneric>{} +
                          solver::SolverContainer<solver::tensorOp::Op2dTensorGeneric>{} +


### PR DESCRIPTION


- added register-level packet processing
- added adaptive index type selection 32/64 bit
- value caching for reused elements
- added two-pass processing: main + tail loop
- adaptive local thread size based on task size
- added pecialized contiguous tensor path
- added adaptive packing width selection

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
