### PR TITLE
Enable CI for release branches

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - release/therock-*
   pull_request:
     types:
       - opened


### PR DESCRIPTION
During the release/7.10 work, we observed that CI was not enabled by default in therock-ci.yml prior to the branch cut. This PR adds support for enabling CI on release branches before the branch cut and ensures that CI checks out the latest therock branch when running.

Issue: https://github.com/ROCm/TheRock/issues/2630