### PR TITLE
[rocSOLVER] Skip test if VRAM is insufficient

### DIFF
--- a/projects/rocsolver/clients/common/containers/d_vector.hpp
+++ b/projects/rocsolver/clients/common/containers/d_vector.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,6 +47,10 @@ class d_vector
 private:
     size_t size, bytes;
 
+protected:
+    // Memory allocation status
+    hipError_t mem_status;
+
 public:
     inline size_t nmemb() const noexcept
     {
@@ -62,7 +66,9 @@ public:
     T* device_vector_setup()
     {
         T* d = nullptr;
-        if((hipMalloc)(&d, bytes) != hipSuccess)
+
+        mem_status = (hipMalloc)(&d, bytes);
+        if(mem_status != hipSuccess)
         {
             fmt::print(stderr, "Error allocating {} bytes ({} GB)\n", bytes, bytes >> 30);
             d = nullptr;

--- a/projects/rocsolver/clients/common/containers/device_batch_vector.hpp
+++ b/projects/rocsolver/clients/common/containers/device_batch_vector.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -237,14 +237,11 @@ public:
 
     //!
     //! @brief Check if memory exists.
-    //! @return hipSuccess if memory exists, hipErrorOutOfMemory otherwise.
+    //! @return The status of memory allocation and initialization.
     //!
     hipError_t memcheck() const
     {
-        if(*this)
-            return hipSuccess;
-        else
-            return hipErrorOutOfMemory;
+        return this->mem_status;
     }
 
 private:
@@ -261,8 +258,9 @@ private:
     bool try_initialize_memory()
     {
         bool success = false;
+        this->mem_status = (hipMalloc)(&this->m_device_data, this->m_batch_count * sizeof(T*));
 
-        success = (hipSuccess == (hipMalloc)(&this->m_device_data, this->m_batch_count * sizeof(T*)));
+        success = (hipSuccess == this->mem_status);
         if(success)
         {
             success = (nullptr != (this->m_data = (T**)calloc(this->m_batch_count, sizeof(T*))));
@@ -270,6 +268,7 @@ private:
             {
                 for(int64_t batch_index = 0; batch_index < this->m_batch_count; ++batch_index)
                 {
+                    // device_vector_setup() sets mem_status
                     success = (nullptr != (this->m_data[batch_index] = this->device_vector_setup()));
                     if(!success)
                     {
@@ -279,10 +278,15 @@ private:
 
                 if(success)
                 {
-                    success = (hipSuccess
-                               == hipMemcpy(this->m_device_data, this->m_data,
-                                            sizeof(T*) * this->m_batch_count, hipMemcpyHostToDevice));
+                    this->mem_status
+                        = hipMemcpy(this->m_device_data, this->m_data,
+                                    sizeof(T*) * this->m_batch_count, hipMemcpyHostToDevice);
+                    success = (hipSuccess == this->mem_status);
                 }
+            }
+            else
+            {
+                this->mem_status = hipErrorMemoryAllocation;
             }
         }
         return success;

--- a/projects/rocsolver/clients/common/containers/device_strided_batch_vector.hpp
+++ b/projects/rocsolver/clients/common/containers/device_strided_batch_vector.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -107,6 +107,10 @@ public:
         if(valid_parameters)
         {
             this->m_data = this->device_vector_setup();
+        }
+        else
+        {
+            this->mem_status = hipErrorInvalidValue;
         }
     }
 
@@ -232,14 +236,11 @@ public:
 
     //!
     //! @brief Check if memory exists.
-    //! @return hipSuccess if memory exists, hipErrorOutOfMemory otherwise.
+    //! @return The status of memory allocation and initialization.
     //!
     hipError_t memcheck() const
     {
-        if(*this)
-            return hipSuccess;
-        else
-            return hipErrorOutOfMemory;
+        return this->mem_status;
     }
 
 private:

--- a/projects/rocsolver/clients/common/lapack/testing_getrf_large.hpp
+++ b/projects/rocsolver/clients/common/lapack/testing_getrf_large.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -257,21 +257,21 @@ void getrf_large_getError(const rocblas_handle handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(rocsolver_getf2_getrf(STRIDED, GETRF, handle, n, n, dA.data(), lda, stA,
-                                              dIpiv.data(), stP, dInfo.data(), bc));
+    CHECK_ROCBLAS_ALLOCATION(rocsolver_getf2_getrf(STRIDED, GETRF, handle, n, n, dA.data(), lda,
+                                                   stA, dIpiv.data(), stP, dInfo.data(), bc));
 
     // Solve Ax = b for x
-    CHECK_ROCBLAS_ERROR(rocsolver_getrs(STRIDED, handle, rocblas_operation_none, n, nrhs, dA, lda,
-                                        stA, dIpiv, stP, dX, ldb, stB, bc));
+    CHECK_ROCBLAS_ALLOCATION(rocsolver_getrs(STRIDED, handle, rocblas_operation_none, n, nrhs, dA,
+                                             lda, stA, dIpiv, stP, dX, ldb, stB, bc));
 
     // Resetting the value of dA.
     CHECK_HIP_ERROR(dA.transfer_from(hA));
 
     // Compute Ax
     T alpha = T(1), beta = T(0);
-    CHECK_ROCBLAS_ERROR(rocblas_gemm(STRIDED, handle, rocblas_operation_none,
-                                     rocblas_operation_none, n, nrhs, n, &alpha, dA, lda, stA, dX,
-                                     ldb, stB, &beta, dB, ldb, stB, bc));
+    CHECK_ROCBLAS_ALLOCATION(rocblas_gemm(STRIDED, handle, rocblas_operation_none,
+                                          rocblas_operation_none, n, nrhs, n, &alpha, dA, lda, stA,
+                                          dX, ldb, stB, &beta, dB, ldb, stB, bc));
     CHECK_HIP_ERROR(hBRes.transfer_from(dB));
 
     double err;
@@ -397,15 +397,15 @@ void testing_getrf_large(Arguments& argus)
         device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
 
         if(size_A)
-            CHECK_HIP_ERROR(dA.memcheck());
+            CHECK_DEVICE_ALLOCATION(dA.memcheck());
         if(size_B)
         {
-            CHECK_HIP_ERROR(dB.memcheck());
-            CHECK_HIP_ERROR(dX.memcheck());
+            CHECK_DEVICE_ALLOCATION(dB.memcheck());
+            CHECK_DEVICE_ALLOCATION(dX.memcheck());
         }
         if(size_P)
-            CHECK_HIP_ERROR(dIpiv.memcheck());
-        CHECK_HIP_ERROR(dInfo.memcheck());
+            CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
+        CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
         // check computations
         if(argus.unit_check || argus.norm_check)
@@ -438,15 +438,15 @@ void testing_getrf_large(Arguments& argus)
         device_strided_batch_vector<rocblas_int> dInfo(1, 1, 1, bc);
 
         if(size_A)
-            CHECK_HIP_ERROR(dA.memcheck());
+            CHECK_DEVICE_ALLOCATION(dA.memcheck());
         if(size_B)
         {
-            CHECK_HIP_ERROR(dB.memcheck());
-            CHECK_HIP_ERROR(dX.memcheck());
+            CHECK_DEVICE_ALLOCATION(dB.memcheck());
+            CHECK_DEVICE_ALLOCATION(dX.memcheck());
         }
         if(size_P)
-            CHECK_HIP_ERROR(dIpiv.memcheck());
-        CHECK_HIP_ERROR(dInfo.memcheck());
+            CHECK_DEVICE_ALLOCATION(dIpiv.memcheck());
+        CHECK_DEVICE_ALLOCATION(dInfo.memcheck());
 
         // check computations
         if(argus.unit_check || argus.norm_check)

--- a/projects/rocsolver/clients/common/misc/rocblas_test.hpp
+++ b/projects/rocsolver/clients/common/misc/rocblas_test.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -56,21 +56,38 @@
 #define CHECK_HIP_ERROR2(ERROR) ASSERT_EQ(ERROR, hipSuccess)
 #define CHECK_HIP_ERROR(ERROR) CHECK_HIP_ERROR2(ERROR)
 
-#define CHECK_DEVICE_ALLOCATION(ERROR)                                                     \
-    do                                                                                     \
-    {                                                                                      \
-        auto error = ERROR;                                                                \
-        if(error == hipErrorOutOfMemory)                                                   \
-        {                                                                                  \
-            SUCCEED() << LIMITED_MEMORY_STRING;                                            \
-            return;                                                                        \
-        }                                                                                  \
-        else if(error != hipSuccess)                                                       \
-        {                                                                                  \
-            fprintf(stderr, "error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), error, \
-                    __FILE__, __LINE__);                                                   \
-            return;                                                                        \
-        }                                                                                  \
+#define CHECK_DEVICE_ALLOCATION(ERROR)             \
+    do                                             \
+    {                                              \
+        auto error = ERROR;                        \
+        if(error == hipErrorOutOfMemory)           \
+        {                                          \
+            /* Reset hip error code */             \
+            error = hipGetLastError();             \
+            GTEST_SKIP() << LIMITED_MEMORY_STRING; \
+            return;                                \
+        }                                          \
+        else if(error != hipSuccess)               \
+        {                                          \
+            FAIL() << hipGetErrorString(error);    \
+            return;                                \
+        }                                          \
+    } while(0)
+
+#define CHECK_ROCBLAS_ALLOCATION(ERROR)                \
+    do                                                 \
+    {                                                  \
+        auto error = ERROR;                            \
+        if(error == rocblas_status_memory_error)       \
+        {                                              \
+            GTEST_SKIP() << LIMITED_MEMORY_STRING;     \
+            return;                                    \
+        }                                              \
+        else if(error != rocblas_status_success)       \
+        {                                              \
+            FAIL() << rocblas_status_to_string(error); \
+            return;                                    \
+        }                                              \
     } while(0)
 
 #define CHECK_ALLOC_QUERY(STATUS)                                  \


### PR DESCRIPTION
## Motivation
Large tests will fail if the device does not have enough VRAM. This PR introduces a method to skip tests if memory allocation fails due to insufficient VRAM.

## Technical Details
This PR adds the following:
1. Propagate device memory allocation error from client container initialization to `memcheck()` call. This helps to discern between out-of-memory error and other hip errors so tests aren't unnecessarily skipped.
2. Use macro to skip test if memory allocation failed due to insufficient VRAM.
3. Use a similar macro to check if rocblas memory allocation fails.
4. Currently this is only applied to large tests. **Should this be applied to all tests?**

## Test Plan
Run large tests on machines with insufficient memory to check this feature.
CI results will determine if other tests are affected.

## Test Result
In progress...

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
