### PR TITLE
[hipDNN] Bump TheRock version used for hipdnn clang-tidy checks.

### DIFF
--- a/.github/workflows/hipdnn-clang-tidy.yml
+++ b/.github/workflows/hipdnn-clang-tidy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install ROCm
         run: |
           sudo .venv/bin/python3 TheRock/build_tools/install_rocm_from_artifacts.py \
-            --release 7.11.0a20260112 \
+            --release 7.11.0a20260115 \
             --amdgpu-family gfx94X-dcgpu \
             --output-dir /opt/rocm \
             --base-only


### PR DESCRIPTION
## Motivation

Needed to unblock CI for https://github.com/ROCm/rocm-libraries/pull/3619.

## Technical Details

New APIs added to MIOpen are available in TheRock nighty builds starting 2026-01-15.

## Test Plan

CI Passes.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

<!-- ALMIOPEN-408 -->