### PR TITLE
[hipblaslt][CMS] Fix accvgpr selection in initC when MfmaInitCVgprs and MIArchVgpr are set

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4412,11 +4412,12 @@ class KernelWriterAssembly(KernelWriter):
         regStr = vgpr("ValuC+%u"%(i-numAccvgprs)) if i >= numAccvgprs else accvgpr(i)
         module.add(copyInst(dst=regStr, src=0, comment="initC"))
 
+      _accvgpr_alias = vgpr if  kernel["MIArchVgpr"] else accvgpr
       for i in range(min(16, numCVgpr), numCVgpr, 16):
         if i + 16 <= numCVgpr:
           module.add(MFMAInstruction(instType=InstType.INST_I8, accType=InstType.INST_I32, variant=[32,32,16,1], mfma1k=False, \
-                                     acc=accvgpr(i,16), a=vgpr(tmpVgpr,2), b=vgpr(tmpVgpr,2), acc2=accvgpr(0,16), \
-                                     comment="initC: [%u, %u]"%(i, i+15)))
+                                    acc=_accvgpr_alias(i,16), a=vgpr(tmpVgpr,2), b=vgpr(tmpVgpr,2), acc2=_accvgpr_alias(0,16), \
+                                    comment="initC: [%u, %u]"%(i, i+15)))
         else:
           for j in range(i,min(i+16, numCVgpr)):
             copyInst = VMovB32 if j >= numAccvgprs else VAccvgprWrite

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4412,11 +4412,11 @@ class KernelWriterAssembly(KernelWriter):
         regStr = vgpr("ValuC+%u"%(i-numAccvgprs)) if i >= numAccvgprs else accvgpr(i)
         module.add(copyInst(dst=regStr, src=0, comment="initC"))
 
-      _accvgpr_alias = vgpr if  kernel["MIArchVgpr"] else accvgpr
+      accvgprAlias = vgpr if  kernel["MIArchVgpr"] else accvgpr
       for i in range(min(16, numCVgpr), numCVgpr, 16):
         if i + 16 <= numCVgpr:
           module.add(MFMAInstruction(instType=InstType.INST_I8, accType=InstType.INST_I32, variant=[32,32,16,1], mfma1k=False, \
-                                    acc=_accvgpr_alias(i,16), a=vgpr(tmpVgpr,2), b=vgpr(tmpVgpr,2), acc2=_accvgpr_alias(0,16), \
+                                    acc=accvgprAlias(i,16), a=vgpr(tmpVgpr,2), b=vgpr(tmpVgpr,2), acc2=accvgprAlias(0,16), \
                                     comment="initC: [%u, %u]"%(i, i+15)))
         else:
           for j in range(i,min(i+16, numCVgpr)):

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4402,7 +4402,9 @@ class KernelWriterAssembly(KernelWriter):
     module.addComment1("initC: remove ValuA/B vgpr buffer [%u...%u) from pool"%(self.states.a.startVgprValu , self.states.lastValuAB))
     numCVgpr = self.states.c.numVgprValu + numAccvgprs
 
-    if kernel["MfmaInitCVgprs"] == True and self.states.asmCaps["HasMFMA_f8f6f4"] and numCVgpr >= 32:
+    # TBD: optimize MfmaInitCVgprs case when using both VALU and ACC VGPRs (needs to init vgprs and acc separately)
+    # Alternatively, allow MFMAInstruction to accept acc2=0
+    if kernel["MfmaInitCVgprs"] == True and self.states.asmCaps["HasMFMA_f8f6f4"] and self.states.maxLimitAgprs > numCVgpr >= 32:
       tmpVgpr = self.vgprPool.checkOutAligned(2,2,"tmp vgpr for lds init C registers")
       module.add(VMovB64(dst=vgpr(tmpVgpr,2), src=0, comment="A/B=0"))
 
@@ -4412,7 +4414,7 @@ class KernelWriterAssembly(KernelWriter):
         regStr = vgpr("ValuC+%u"%(i-numAccvgprs)) if i >= numAccvgprs else accvgpr(i)
         module.add(copyInst(dst=regStr, src=0, comment="initC"))
 
-      accvgprAlias = vgpr if  kernel["MIArchVgpr"] else accvgpr
+      accvgprAlias = vgpr if kernel["MIArchVgpr"] else accvgpr
       for i in range(min(16, numCVgpr), numCVgpr, 16):
         if i + 16 <= numCVgpr:
           module.add(MFMAInstruction(instType=InstType.INST_I8, accType=InstType.INST_I32, variant=[32,32,16,1], mfma1k=False, \

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4404,7 +4404,7 @@ class KernelWriterAssembly(KernelWriter):
 
     # TBD: optimize MfmaInitCVgprs case when using both VALU and ACC VGPRs (needs to init vgprs and acc separately)
     # Alternatively, allow MFMAInstruction to accept acc2=0
-    if kernel["MfmaInitCVgprs"] == True and self.states.asmCaps["HasMFMA_f8f6f4"] and self.states.maxLimitAgprs > numCVgpr >= 32:
+    if kernel["MfmaInitCVgprs"] == True and self.states.asmCaps["HasMFMA_f8f6f4"] and self.states.maxLimitAgprs >= numCVgpr >= 32:
       tmpVgpr = self.vgprPool.checkOutAligned(2,2,"tmp vgpr for lds init C registers")
       module.add(VMovB64(dst=vgpr(tmpVgpr,2), src=0, comment="A/B=0"))
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
@@ -238,7 +238,7 @@ BenchmarkProblems:
         - LDSTrInst: [False]
         - UseSgprForGRO: [0]
         - UseCustomMainLoopSchedule: [1]
-        - MIArchVgpr: [0,1]
+        - MIArchVgpr: [0]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
@@ -176,6 +176,44 @@ BenchmarkProblems:
           - Range: [[128], [128], [1], [1,1,64]]
           - Range: [[128], [128], [1], [32, 64, 256]]
         - BiasTypeArgs: ['s']
+    - # BenchmarkProblemSizeGroup - Standard - All problem   
+      # This test verifies correctness for a specific parameter combination: CMS=1, MIArchVgpr=True, MfmaInitCVgprs=True (set manually in _get_schedule_128x128x32_TF32)
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1, 4, 4,  2,2 ]         
+        - PrefetchGlobalRead: [2] 
+        - PrefetchLocalRead: [0]
+        - DepthU: [32]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1]
+        - LocalReadVectorWidth: [4]
+        - GlobalReadVectorWidthA: [4]
+        - GlobalReadVectorWidthB: [4]
+        - DirectToLds: [1]
+        - StreamK: [3]
+        - LdsPadA: [-1] 
+        - LdsPadB: [-1] 
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - NonTemporalA: [0]
+        - NonTemporalB: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LDSTrInst: [False]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+        - MIArchVgpr: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [512, 8192, 1, 1980]
+        - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem        
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -200,6 +238,7 @@ BenchmarkProblems:
         - LDSTrInst: [False]
         - UseSgprForGRO: [0]
         - UseCustomMainLoopSchedule: [1]
+        - MIArchVgpr: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Currently when `MIArchVgpr` is set, the vgrp selection ignores it and selects `acc` instead of `v`.
This PR fixes it.
Added test for `MIArchVgpr=1` in custom_mainloop_scheduling_tf32.yaml

## Test Result
1. Ran custom_mainloop_scheduling_tf32.yaml

2. Ran tests with [init_vgpr_and_acc_tests.yaml](https://github.com/user-attachments/files/24680161/init_vgpr_and_acc_tests.yaml) (needs modifications for each test case below)
`rocm-libraries/projects/hipblaslt/tensilelite# ./Tensile/bin/Tensile ./init_vgpr_and_acc_tests.yaml tmp`
Also, requires manual modification of `state["MfmaInitCVgprs"] = True` in Solution.py

Verified that initC happens properly, results:
```
MacroTile	CMS		MIAV*	acc		accInit 	vgprs	vgprInit        Notes
----------------------------------------------------------------------------------------
320x256		0		0		256		mfma(1)		64		v_mov_b32
			0		1												invalid (requires total of 487 vgprs)
			1														no CMS avail
			
256x256		0		0		256		mfma(1)		0		n/a
			0		1												invalid (requires total of 405 vgprs)
			1		0		256		mfma(1)		0		n/a
			1		1												invalid (requires total of 407 vgprs)

192x256		0		0		192		mfma(1)		0		n/a
			0		1												invalid (requires total of 321 vgprs)
			1		0		192		mfma(1)		0		n/a

128x256		0		0		128		mfma(1)		0		n/a
			0		1		0		n/a			128		mfma(2)		Fails accuracy both in PR and in phase2 branch
			1		0		128		mfma(1)		0		n/a
			1		1												Invalid CMS: Code path 0: PackA0 has 20 instructions, but 24 instructions are required

128x128		0		0		64		mfma(1)		0		n/a
			0		1		0		n/a			64		mfma(2)
			1		0		64		mfma(1)		0		n/a
			1		1		0		n/a			64		mfma(2)
			
1 - first 16 acc   are initialized using v_accvgpr_write and the rest using v_mfma_i32_32x32x16_i8
2 - first 16 vgprs are initialized using v_mov_b32       and the rest using v_mfma_i32_32x32x16_i8
* MIAV = MIArchVgpr
```
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
