### PR TITLE
Fix PytestUnknownMarkWarning by registering custom marks

### DIFF
--- a/projects/hipblaslt/tensilelite/pytest.ini
+++ b/projects/hipblaslt/tensilelite/pytest.ini
@@ -19,27 +19,29 @@ markers =
 
  gfx11: Common tests for gfx11.
  gfx12: Common tests for gfx12.
+ gfx94x: Common tests for gfx94x.
+ gfx950: Common tests for gfx950.
 
  validate: All tests which validate the results.
  validateAll: All tests which validate all data points.
  GEMM: All tests which run standard GEMMs
  Assembly: Tests with assembly kernels.
- bfloat16: Data type
- bfloat8_fnuz: Data type
- bfloat8Float8_fnuz: Data type
- bfloat8: Data type
- bfloat8Float8: Data type
- complexDouble : Data type
- complexSingle : Data type
- double : Data type
- float8_fnuz : Data type
- float8Bfloat8_fnuz : Data type
- float8 : Data type
- float8Bfloat8 : Data type
- half : Data type
- int8x4 : Data type
- int8 : Data type
- single: Data type
+ Float: Data type (float/single precision)
+ Double: Data type (double precision)
+ ComplexFloat: Data type (complex single precision)
+ ComplexDouble: Data type (complex double precision)
+ Half: Data type (half precision / FP16)
+ BFloat16: Data type (bfloat16)
+ Int8: Data type (8-bit integer)
+ Int8x4: Data type (packed 8-bit integers)
+ Float8: Data type (OCP FP8 E4M3)
+ BFloat8: Data type (OCP FP8 E5M2)
+ Float8BFloat8: Data type (OCP mixed FP8)
+ BFloat8Float8: Data type (OCP mixed FP8)
+ Float8_fnuz: Data type (NANOO FP8 E4M3)
+ BFloat8_fnuz: Data type (NANOO FP8 E5M2)
+ Float8BFloat8_fnuz: Data type (NANOO mixed FP8)
+ BFloat8Float8_fnuz: Data type (NANOO mixed FP8)
  xfail-gfx000:  architecture
  xfail-gfx900:  architecture
  xfail-gfx906:  architecture


### PR DESCRIPTION
## Motivation

When running the `common` tests through tox, these warning messages clutter up the logs:

```
Tensile/Tests/common/test_config.py:90
  /home/talumbau/src/dev2/rocm-libraries/projects/hipblaslt/tensilelite/Tensile/Tests/common/test_config.py:90: PytestUnknownMarkWarning: Unknown pytest.mark.BFloat8 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    return getattr(pytest.mark, name)
```

In this PR, we register the correct data type and architecture marks in pytest.ini to match the actual mark names generated by test_config.py. The marks are generated from DataTypeEnum names which use PascalCase (e.g., Half, BFloat16, Float8) rather than lowercase. Also add missing architecture marks gfx94x and gfx950.

## Technical Details

Edit pytest.ini to include the actual mark names.

## Test Plan

TENSILELITE_CLIENT_ARGS="--build-type Debug --gpu-targets gfx950 --clean" tox -e unit -- Tensile/Tests/unit

## Test Result

================================================== 185 passed, 1 xfailed in 24.80s ==================================================
  unit: OK (31.65=setup[6.18]+cmd[25.47] seconds)
  congratulations :) (31.67 seconds)



