### PR TITLE
[hipDNN][hipBLASLt] Implemented hipBLASLt kernel provider for hipDNN

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,8 @@ repos:
         exclude: |
           (?x)
           ^projects/hipdnn/\.clang-format$|
-          ^dnn-providers/miopen-provider/\.clang-format$
+          ^dnn-providers/miopen-provider/\.clang-format$|
+          ^dnn-providers/hipblaslt-provider/\.clang-format$
       - id: check-added-large-files
 
   - repo: https://github.com/psf/black

--- a/dnn-providers/hipblaslt-provider/.clang-format
+++ b/dnn-providers/hipblaslt-provider/.clang-format
@@ -1,0 +1,125 @@
+# Style file for MLSE Libraries based on the modified rocBLAS style
+
+# Common settings
+BasedOnStyle:  WebKit
+TabWidth:        4
+IndentWidth:     4
+UseTab:          Never
+ColumnLimit: 100
+
+# Other languages JavaScript, Proto
+
+---
+Language: Cpp
+
+# http://releases.llvm.org/6.0.1/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
+# int formatted_code;
+# // clang-format off
+#     void    unformatted_code  ;
+# // clang-format on
+# void formatted_code_again;
+
+DisableFormat:   false
+Standard: Cpp11
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterCaseLabel: 'true'
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+#    AfterExternBlock : 'true'
+}
+
+#BreakAfterJavaFieldAnnotations: true
+#BreakBeforeInheritanceComma: false
+#BreakBeforeBinaryOperators: None
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializersBeforeComma: true
+#BreakStringLiterals: true
+
+CommentPragmas:  '^ IWYU pragma:'
+#CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+SpaceBeforeCpp11BracedList: false
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IndentCaseLabels: false
+IndentPPDirectives: None
+#FixNamespaceComments: true
+IndentWrappedFunctionNames: true
+InsertNewlineAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+#JavaScriptQuotes: Double
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+#ObjCSpaceAfterProperty: true
+#ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+#SpaceAfterTemplateKeyword: true
+#SpaceBeforeInheritanceColon: true
+
+#SortUsingDeclarations: true
+SortIncludes: true
+
+# Comments are for developers, they should arrange them
+ReflowComments: false
+
+#IncludeBlocks: Preserve
+---

--- a/dnn-providers/hipblaslt-provider/.gitignore
+++ b/dnn-providers/hipblaslt-provider/.gitignore
@@ -1,0 +1,82 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+*.ipch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Hipdnn Local install
+install/
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# vim tags
+tags
+.tags
+.*.swp
+
+# Editors
+.vscode
+.cline_storage
+
+#code ql
+scripts*/codeql-*/
+scripts*/*_codeql_*/
+
+# build-in-source directory
+
+# emacs temporary/backup files
+.\#*
+\#*\#
+*~
+
+# GDB temporary files
+.gdb_history
+install.dir*
+
+# documentation artifacts
+_build/
+_images/
+_static/
+_templates/
+_toc.yml
+_doxygen/
+
+# JetBrains IDE
+.idea/
+cmake-build*/
+build*/
+CMakeUserPresets.json
+
+# Python virtualenv
+.venv/
+hipdnn_env/
+
+# Python cache
+__pycache__/
+
+# Python egg
+*.egg-info/
+
+*.profraw

--- a/dnn-providers/hipblaslt-provider/CMakeLists.txt
+++ b/dnn-providers/hipblaslt-provider/CMakeLists.txt
@@ -37,7 +37,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib
 )
 
 option(HIPDNN_SKIP_TESTS "Skip building tests" OFF)
-option(HIPBLASLT_ENABLE_CLANG_FORMAT "Enable clang-format targets" ON)
+option(ENABLE_CLANG_FORMAT "Enable clang-format targets" ON)
 
 list(
     PREPEND
@@ -76,8 +76,8 @@ include(Dependencies)
 if (NOT HIPDNN_SKIP_TESTS)
     include(Tests)
 endif()
-if (HIPBLASLT_ENABLE_CLANG_FORMAT)
-    include(ClangFormat)
+if (ENABLE_CLANG_FORMAT)
+    include(ClangCheck)
 endif()
 
 if(WIN32)

--- a/dnn-providers/hipblaslt-provider/CMakeLists.txt
+++ b/dnn-providers/hipblaslt-provider/CMakeLists.txt
@@ -1,0 +1,140 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+cmake_minimum_required(VERSION 3.25.2)
+add_compile_definitions(__HIP_PLATFORM_AMD__)
+
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/ClangToolChain.cmake"
+    CACHE STRING "Toolchain file"
+)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(HIPBLASLT_PLUGIN "0.0.1")
+project(hipDNN VERSION ${HIPBLASLT_PLUGIN} LANGUAGES CXX)
+
+if(NOT WIN32)
+    # Only set if not already specified by user
+    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+        set(CMAKE_INSTALL_PREFIX "${ROCM_PATH}" CACHE PATH "Install path prefix" FORCE)
+    endif()
+    message(STATUS "Setting CMAKE_INSTALL_PREFIX to ${CMAKE_INSTALL_PREFIX}")
+endif()
+
+include(GNUInstallDirs)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE
+    CACHE BOOL "Add paths to linker search and installed rpath"
+)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib/cmake/hip
+     ${HIP_DIR}/cmake
+)
+
+option(HIPDNN_SKIP_TESTS "Skip building tests" OFF)
+option(HIPBLASLT_ENABLE_CLANG_FORMAT "Enable clang-format targets" ON)
+
+list(
+    PREPEND
+    HIPDNN_WARNING_COMPILE_OPTIONS
+    -Werror # Treat all warnings as errors
+    -Wall # Enable most common warnings
+    -Wextra # Enable additional warnings not covered by -Wall
+    -Wpedantic # Enforce strict ISO C++ compliance
+    -Wshadow # Warn about variable shadowing
+    -Wnon-virtual-dtor # Warn if a class with virtual functions has a non-virtual destructor
+    -Wold-style-cast # Warn about C-style casts
+    -Wcast-align # Warn about potential performance issues with misaligned casts
+    -Woverloaded-virtual # Warn if a base class function is hidden by a derived class function
+                         # with the same name
+    -Wconversion # Warn about implicit type conversions that may alter a value
+    -Wsign-conversion # Warn about implicit conversions between signed and unsigned types
+    -Wnull-dereference # Warn about dereferencing null pointers
+    -Wdouble-promotion # Warn when a float is implicitly promoted to a double
+    -Wformat=2 # Enable stricter format string checks
+    -Winit-self # Warn about variables initialized with itself
+    -Wunreachable-code # Warn about unreachable code
+    -Wno-error=unused-command-line-argument # Disable error for unused command line arguments
+    -Wswitch-default # Warn if a switch statement does not have a default case
+)
+
+# NOTE: Workaround until llvm & hip cmake modules fixes symlink logic in their config files;
+# remove when fixed. Added to prevent issues with not finding hip cmake.
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH} ${ROCM_PATH}/hip)
+
+find_package(hip REQUIRED)
+find_package(hipdnn_data_sdk CONFIG REQUIRED)
+find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+
+# Setup testing dependencies, tests & clang format
+include(Dependencies)
+if (NOT HIPDNN_SKIP_TESTS)
+    include(Tests)
+endif()
+if (HIPBLASLT_ENABLE_CLANG_FORMAT)
+    include(ClangFormat)
+endif()
+
+if(WIN32)
+    set(HIPDNN_PLUGIN_ENGINE_ROOTDIR "bin")
+else()
+    set(HIPDNN_PLUGIN_ENGINE_ROOTDIR "lib")
+endif()
+
+set(HIPDNN_BUILD_PLUGIN_ENGINE_DIR
+    "${CMAKE_BINARY_DIR}/${HIPDNN_PLUGIN_ENGINE_ROOTDIR}/${HIPDNN_PLUGIN_ENGINE_SUBDIR}"
+)
+
+message(STATUS "Plugin build directory: ${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}")
+message(STATUS "Plugin install directory: ${HIPDNN_INSTALL_PLUGIN_ENGINE_DIR}")
+file(MAKE_DIRECTORY ${HIPDNN_BUILD_PLUGIN_ENGINE_DIR})
+
+find_package(hipblaslt CONFIG REQUIRED)
+
+add_library(
+    hipblaslt_plugin_private
+    engines/HipblasltEngine.cpp
+    EngineManager.cpp
+    HipblasltHandleFactory.cpp
+    HipblasltContainer.cpp
+    HipblasltPlugin.cpp
+    HipblasltUtils.cpp
+)
+target_compile_definitions(
+    hipblaslt_plugin_private PRIVATE COMPONENT_NAME="hipblaslt_plugin"
+)
+target_include_directories(hipblaslt_plugin_private PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(hipblaslt_plugin_private PUBLIC roc::hipblaslt hipdnn_data_sdk hipdnn_plugin_sdk hip::host)
+target_compile_options(hipblaslt_plugin_private PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+
+add_library(hipblaslt_plugin SHARED HipblasltPluginPublic.cpp)
+target_compile_definitions(hipblaslt_plugin PRIVATE COMPONENT_NAME="hipblaslt_plugin")
+target_link_libraries(hipblaslt_plugin PRIVATE hipblaslt_plugin_private)
+target_link_libraries(
+    hipblaslt_plugin PRIVATE "-Xlinker --exclude-libs=ALL"
+) # Hide symbols from linked static libs
+target_compile_options(hipblaslt_plugin PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+set_target_properties(
+    hipblaslt_plugin
+    PROPERTIES CXX_VISIBILITY_PRESET hidden
+               LIBRARY_OUTPUT_DIRECTORY "${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}"
+               RUNTIME_OUTPUT_DIRECTORY "${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}"
+               ARCHIVE_OUTPUT_DIRECTORY "${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}"
+               INSTALL_RPATH "${ROCM_PATH}/lib"
+               INSTALL_RPATH_USE_LINK_PATH TRUE
+               BUILD_WITH_INSTALL_RPATH TRUE
+)
+
+if(NOT HIPDNN_SKIP_TESTS)
+    add_subdirectory(tests)
+endif()
+
+install(TARGETS hipblaslt_plugin EXPORT hipblaslt-plugin
+        LIBRARY DESTINATION ${HIPDNN_RELATIVE_INSTALL_PLUGIN_ENGINE_DIR}
+        RUNTIME DESTINATION ${HIPDNN_RELATIVE_INSTALL_PLUGIN_ENGINE_DIR}
+)

--- a/dnn-providers/hipblaslt-provider/EngineManager.cpp
+++ b/dnn-providers/hipblaslt-provider/EngineManager.cpp
@@ -1,0 +1,74 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <algorithm>
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "EngineManager.hpp"
+#include "engines/HipblasltEngine.hpp"
+
+using namespace hipdnn_plugin_sdk;
+
+namespace hipblaslt_plugin
+{
+
+void EngineManager::addEngine(std::unique_ptr<IEngine> engine)
+{
+    _engines.emplace(engine->id(), std::move(engine));
+}
+
+std::vector<int64_t> EngineManager::getApplicableEngineIds(HipdnnEnginePluginHandle& handle,
+                                                           const hipdnn_plugin_sdk::IGraph& opGraph)
+{
+    std::vector<int64_t> applicable;
+    for(const auto& engine : _engines)
+    {
+        if(engine.second->isApplicable(handle, opGraph))
+        {
+            applicable.push_back(engine.second->id());
+        }
+    }
+    return applicable;
+}
+
+void EngineManager::getEngineDetails(HipdnnEnginePluginHandle& handle,
+                                     [[maybe_unused]] const hipdnn_plugin_sdk::IGraph& opGraph,
+                                     int64_t engineId,
+                                     hipdnnPluginConstData_t& engineDetailsOut)
+{
+    auto& engine = getEngine(engineId);
+    engine.getDetails(handle, engineDetailsOut);
+}
+
+size_t EngineManager::getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                                       int64_t engineId,
+                                       const hipdnn_plugin_sdk::IGraph& opGraph) const
+{
+    auto& engine = getEngine(engineId);
+    return engine.getWorkspaceSize(handle, opGraph);
+}
+
+void EngineManager::initializeExecutionContext(
+    const HipdnnEnginePluginHandle& handle,
+    const hipdnn_plugin_sdk::IGraph& opGraph,
+    const hipdnn_plugin_sdk::IEngineConfig& engineConfig,
+    HipdnnEnginePluginExecutionContext& executionContext) const
+{
+    auto& engine = getEngine(engineConfig.engineId());
+    engine.initializeExecutionContext(handle, opGraph, executionContext);
+}
+
+IEngine& EngineManager::getEngine(int64_t engineId) const
+{
+    auto it = _engines.find(engineId);
+    if(it == _engines.end())
+    {
+        throw HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INVALID_VALUE,
+                                    "Engine with ID " + std::to_string(engineId) + " not found.");
+    }
+    return *it->second;
+}
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/EngineManager.hpp
+++ b/dnn-providers/hipblaslt-provider/EngineManager.hpp
@@ -1,0 +1,53 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+#include "engines/EngineInterface.hpp"
+
+namespace hipblaslt_plugin
+{
+
+class EngineManager
+{
+public:
+    EngineManager() = default;
+    ~EngineManager() = default;
+
+    //disallow copy and assignment
+    EngineManager(const EngineManager&) = delete;
+    EngineManager& operator=(const EngineManager&) = delete;
+
+    void addEngine(std::unique_ptr<IEngine> engine);
+
+    std::vector<int64_t> getApplicableEngineIds(HipdnnEnginePluginHandle& handle,
+                                                const hipdnn_plugin_sdk::IGraph& opGraph);
+
+    void getEngineDetails(HipdnnEnginePluginHandle& handle,
+                          const hipdnn_plugin_sdk::IGraph& opGraph,
+                          int64_t engineId,
+                          hipdnnPluginConstData_t& engineDetailsOut);
+
+    size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                            int64_t engineId,
+                            const hipdnn_plugin_sdk::IGraph& opGraph) const;
+
+    void initializeExecutionContext(const HipdnnEnginePluginHandle& handle,
+                                    const hipdnn_plugin_sdk::IGraph& opGraph,
+                                    const hipdnn_plugin_sdk::IEngineConfig& engineConfig,
+                                    HipdnnEnginePluginExecutionContext& executionContext) const;
+
+private:
+    IEngine& getEngine(int64_t engineId) const;
+
+    std::unordered_map<int64_t, std::unique_ptr<IEngine>> _engines;
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/HipblasltContainer.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltContainer.cpp
@@ -1,0 +1,34 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+
+#include "EngineManager.hpp"
+#include "HipblasltContainer.hpp"
+#include "engines/HipblasltEngine.hpp"
+
+namespace hipblaslt_plugin
+{
+
+HipblasltContainer::HipblasltContainer()
+{
+    HIPDNN_LOG_INFO("Creating HipblasltContainer");
+
+    int64_t engineId = 1;
+    auto hipblasltEngine = std::make_unique<HipblasltEngine>(engineId++);
+
+    _engineManager = std::make_unique<EngineManager>();
+    _engineManager->addEngine(std::move(hipblasltEngine));
+}
+
+HipblasltContainer::~HipblasltContainer()
+{
+    HIPDNN_LOG_INFO("Destroying HipblasltContainer");
+}
+
+EngineManager& HipblasltContainer::getEngineManager()
+{
+    return *_engineManager;
+}
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/HipblasltContainer.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltContainer.hpp
@@ -1,0 +1,35 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+#include <set>
+
+namespace hipblaslt_plugin
+{
+
+class EngineManager;
+
+/*
+ * Container class to manage the intantiation and ownership of all hipBLASlt plan builders and engines.
+ * The class designs use dependency injection to get the components they need in order to function.
+ * This makes it easier to test and maintain the code as you can swap out implementations.
+ *
+ * The construction sequence should contain no logic other than the creation of various classes.
+ * If logic is needed, it should be placed in a separate function that can be called after the
+ * container has finished constructing all its components.
+ */
+class HipblasltContainer
+{
+public:
+    HipblasltContainer();
+    ~HipblasltContainer();
+
+    EngineManager& getEngineManager();
+
+private:
+    std::unique_ptr<EngineManager> _engineManager;
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/HipblasltHandleFactory.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltHandleFactory.cpp
@@ -1,0 +1,51 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "HipblasltHandleFactory.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+
+using namespace hipdnn_plugin_sdk;
+
+namespace hipblaslt_plugin
+{
+
+void HipblasltHandleFactory::createHipblasltHandle(hipdnnEnginePluginHandle_t* handle)
+{
+    if(handle == nullptr)
+    {
+        throw HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM, "handle is null");
+    }
+
+    *handle = new HipdnnEnginePluginHandle();
+
+    hipblasStatus_t status = hipblasLtCreate(&(*handle)->hipblasltHandle);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        delete *handle;
+        *handle = nullptr;
+        throw HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                                    "Failed to create Hipblaslt handle");
+    }
+}
+
+void HipblasltHandleFactory::destroyHipblasltHandle(hipdnnEnginePluginHandle_t handle)
+{
+    if(handle == nullptr)
+    {
+        throw HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM, "handle is null");
+    }
+
+    hipblasStatus_t status = hipblasLtDestroy(handle->hipblasltHandle);
+
+    if(status != HIPBLAS_STATUS_SUCCESS)
+    {
+        throw HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                                    "Failed to destroy Hipblaslt handle");
+    }
+}
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/HipblasltHandleFactory.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltHandleFactory.hpp
@@ -1,0 +1,19 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hipblaslt_plugin
+{
+
+class HipblasltHandleFactory
+{
+public:
+    static void createHipblasltHandle(hipdnnEnginePluginHandle_t* handle);
+
+    static void destroyHipblasltHandle(hipdnnEnginePluginHandle_t handle);
+};
+
+} // namespace hipblaslt

--- a/dnn-providers/hipblaslt-provider/HipblasltPlugin.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltPlugin.cpp
@@ -1,0 +1,446 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_plugin_sdk/EnginePluginApi.h>
+#include <hipdnn_plugin_sdk/PluginApi.h>
+#include <hipdnn_plugin_sdk/PluginDataTypeHelpers.hpp>
+#include <hipdnn_plugin_sdk/PluginHelpers.hpp>
+#include <hipdnn_plugin_sdk/PluginLastErrorManager.hpp>
+
+#include "EngineManager.hpp"
+#include "HipblasltContainer.hpp"
+#include "HipblasltHandleFactory.hpp"
+#include "HipblasltPlugin.hpp"
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+
+static const char* pluginName = "hipblaslt_plugin";
+static const char* pluginVersion = "1.0.0";
+
+using namespace hipdnn_plugin_sdk;
+using namespace hipblaslt_plugin;
+
+// NOLINTNEXTLINE
+thread_local char PluginLastErrorManager::s_lastError[HIPDNN_PLUGIN_ERROR_STRING_MAX_LENGTH] = "";
+
+std::weak_ptr<HipblasltContainer> hipblasltContainerLifecyclePtr;
+
+extern "C" {
+
+hipdnnPluginStatus_t hipdnnPluginGetNameImpl(const char** name)
+{
+    LOG_API_ENTRY("name_ptr={:p}", static_cast<void*>(name));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(name);
+
+        *name = pluginName;
+
+        LOG_API_SUCCESS(apiName, "pluginName={:p}", static_cast<void*>(name));
+    });
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetVersionImpl(const char** version)
+{
+    LOG_API_ENTRY("versionPtr={:p}", static_cast<void*>(version));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(version);
+
+        *version = pluginVersion;
+
+        LOG_API_SUCCESS(apiName, "version={:p}", static_cast<void*>(version));
+    });
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetTypeImpl(hipdnnPluginType_t* type)
+{
+    LOG_API_ENTRY("typePtr={:p}", static_cast<void*>(type));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(type);
+
+        *type = HIPDNN_PLUGIN_TYPE_ENGINE;
+
+        LOG_API_SUCCESS(apiName, "type={}", *type);
+    });
+}
+
+void hipdnnPluginGetLastErrorStringImpl(const char** errorStr)
+{
+    LOG_API_ENTRY("errorStrPtr={:p}", static_cast<void*>(errorStr));
+
+    hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(errorStr);
+
+        *errorStr = PluginLastErrorManager::getLastError();
+
+        LOG_API_SUCCESS(apiName, "errorStr={:p}", static_cast<void*>(errorStr));
+    });
+}
+
+// Once plugins are loaded via plugin manager then logging will work for them
+hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callback)
+{
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(callback);
+        hipdnn::logging::initializeCallbackLogging(pluginName, callback);
+        LOG_API_SUCCESS(apiName, "", "");
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
+                                                           uint32_t maxEngines,
+                                                           uint32_t* numEngines)
+{
+    LOG_API_ENTRY("engineIds={:p}, maxEngines={}, numEngines={:p}",
+                  static_cast<void*>(engineIds),
+                  maxEngines,
+                  static_cast<void*>(numEngines));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        if(maxEngines != 0)
+        {
+            throwIfNull(engineIds);
+        }
+        throwIfNull(numEngines);
+
+        // For now, we will just return a single engine ID.
+        auto allEngineIds = std::vector<int64_t>({1});
+        if(allEngineIds.size() > std::numeric_limits<uint32_t>::max())
+        {
+            throw HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                                        "Number of engines exceeds maximum uint32_t value.");
+        }
+
+        if(maxEngines == 0)
+        {
+            *numEngines = static_cast<uint32_t>(allEngineIds.size());
+        }
+        else
+        {
+            *numEngines = 0;
+            for(auto engineId : allEngineIds)
+            {
+                if(*numEngines == maxEngines)
+                {
+                    *numEngines = static_cast<uint32_t>(allEngineIds.size());
+                    HIPDNN_LOG_INFO("Maximum number of engines reached ({}), ignoring additional "
+                                    "engines, numEngines count: {}",
+                                    maxEngines,
+                                    *numEngines);
+                    break;
+                }
+
+                engineIds[*numEngines] = engineId;
+                (*numEngines)++;
+            }
+        }
+
+        LOG_API_SUCCESS(apiName, "numEngines={}", *numEngines);
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* handle)
+{
+    LOG_API_ENTRY("handle_ptr={:p}", static_cast<void*>(handle));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+
+        hipblaslt_plugin::HipblasltHandleFactory::createHipblasltHandle(handle);
+
+        auto hipblasltContainerPtr = hipblasltContainerLifecyclePtr.lock();
+        if(hipblasltContainerPtr != nullptr)
+        {
+            (*handle)->hipblasltContainer = hipblasltContainerPtr;
+        }
+        else
+        {
+            static std::mutex s_hipblasltContainerMutex;
+            std::lock_guard<std::mutex> lock(s_hipblasltContainerMutex);
+
+            // if we do have a race condition that results in threads getting locked, we want to
+            // ensure that we only create one instance.  Therefore, the second thread to get
+            // through will just read from the weak pointer rather than create a new instance.
+            hipblasltContainerPtr = hipblasltContainerLifecyclePtr.lock();
+            if(hipblasltContainerPtr != nullptr)
+            {
+                (*handle)->hipblasltContainer = hipblasltContainerPtr;
+            }
+            else
+            {
+                (*handle)->hipblasltContainer = std::make_shared<HipblasltContainer>();
+                hipblasltContainerLifecyclePtr = (*handle)->hipblasltContainer;
+            }
+        }
+
+        LOG_API_SUCCESS(apiName, "createdHandle={:p}", static_cast<void*>(*handle));
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t handle)
+{
+    LOG_API_ENTRY("handle={:p}", static_cast<void*>(handle));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+
+        hipblaslt_plugin::HipblasltHandleFactory::destroyHipblasltHandle(handle);
+        delete handle;
+        handle = nullptr;
+
+        LOG_API_SUCCESS(apiName, "", "");
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginSetStreamImpl(hipdnnEnginePluginHandle_t handle,
+                                                     hipStream_t stream)
+{
+    LOG_API_ENTRY(
+        "handle={:p}, stream_id={:p}", static_cast<void*>(handle), static_cast<void*>(stream));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+
+        handle->setStream(stream);
+
+        LOG_API_SUCCESS(apiName, "", "");
+    });
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetApplicableEngineIdsImpl(hipdnnEnginePluginHandle_t handle,
+                                                 const hipdnnPluginConstData_t* opGraph,
+                                                 int64_t* engineIds,
+                                                 uint32_t maxEngines,
+                                                 uint32_t* numEngines)
+{
+    LOG_API_ENTRY("handle={:p}, opGraph={:p}, engineIds={:p}, maxEngines={}, numEngines={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<const void*>(opGraph),
+                  static_cast<void*>(engineIds),
+                  maxEngines,
+                  static_cast<void*>(numEngines));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(opGraph);
+        if(maxEngines != 0)
+        {
+            throwIfNull(engineIds);
+        }
+        throwIfNull(numEngines);
+
+        auto& engineManager = handle->getEngineManager();
+        GraphWrapper opGraphWrapper(opGraph->ptr, opGraph->size);
+
+        auto applicableEngines = engineManager.getApplicableEngineIds(*handle, opGraphWrapper);
+
+        *numEngines = 0;
+        for(auto& engineId : applicableEngines)
+        {
+            if(*numEngines == maxEngines)
+            {
+                *numEngines = static_cast<uint32_t>(applicableEngines.size());
+                HIPDNN_LOG_INFO("Maximum number of engines reached ({}), ignoring additional "
+                                "engines, numEngines count: {}",
+                                maxEngines,
+                                *numEngines);
+                break;
+            }
+
+            engineIds[*numEngines] = engineId;
+            (*numEngines)++;
+        }
+
+        LOG_API_SUCCESS(apiName, "numEngines={}", *numEngines);
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
+                                                            int64_t engineId,
+                                                            const hipdnnPluginConstData_t* opGraph,
+                                                            hipdnnPluginConstData_t* engineDetails)
+{
+    LOG_API_ENTRY("handle={:p}, engineId={}, opGraph={:p}, engineDetails={:p}",
+                  static_cast<void*>(handle),
+                  engineId,
+                  static_cast<const void*>(opGraph),
+                  static_cast<void*>(engineDetails));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(opGraph);
+        throwIfNull(engineDetails);
+
+        auto& engineManager = handle->getEngineManager();
+        GraphWrapper opGraphWrapper(opGraph->ptr, opGraph->size);
+
+        engineManager.getEngineDetails(*handle, opGraphWrapper, engineId, *engineDetails);
+
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+    });
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginDestroyEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
+                                               hipdnnPluginConstData_t* engineDetails)
+{
+    LOG_API_ENTRY("handle={:p}, engineDetails={}",
+                  static_cast<void*>(handle),
+                  static_cast<void*>(engineDetails));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(engineDetails);
+        throwIfNull(engineDetails->ptr);
+
+        handle->removeEngineDetailsDetachedBuffer(engineDetails->ptr);
+
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+    });
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetWorkspaceSizeImpl(hipdnnEnginePluginHandle_t handle,
+                                           const hipdnnPluginConstData_t* engineConfig,
+                                           const hipdnnPluginConstData_t* opGraph,
+                                           size_t* workspaceSize)
+{
+    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, workspaceSize={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<const void*>(engineConfig),
+                  static_cast<const void*>(opGraph),
+                  static_cast<void*>(workspaceSize));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(engineConfig);
+        throwIfNull(opGraph);
+        throwIfNull(workspaceSize);
+
+        auto& engineManager = handle->getEngineManager();
+
+        EngineConfigWrapper engineConfigWrapper(engineConfig->ptr, engineConfig->size);
+        GraphWrapper opGraphWrapper(opGraph->ptr, opGraph->size);
+        *workspaceSize = engineManager.getWorkspaceSize(
+            *handle, engineConfigWrapper.engineId(), opGraphWrapper);
+
+        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle,
+    const hipdnnPluginConstData_t* engineConfig,
+    const hipdnnPluginConstData_t* opGraph,
+    hipdnnEnginePluginExecutionContext_t* executionContext)
+{
+    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, executionContext={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<const void*>(engineConfig),
+                  static_cast<const void*>(opGraph),
+                  static_cast<void*>(executionContext));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(engineConfig);
+        throwIfNull(opGraph);
+        throwIfNull(executionContext);
+
+        GraphWrapper opGraphWrapper(opGraph->ptr, opGraph->size);
+        EngineConfigWrapper engineConfigWrapper(engineConfig->ptr, engineConfig->size);
+
+        auto& engineManager = handle->getEngineManager();
+
+        auto context = new HipdnnEnginePluginExecutionContext;
+
+        try
+        {
+            engineManager.initializeExecutionContext(
+                *handle, opGraphWrapper, engineConfigWrapper, *context);
+        }
+        catch(...)
+        {
+            delete context;
+            throw;
+        }
+
+        *executionContext = context;
+
+        LOG_API_SUCCESS(
+            apiName, "created_execution_context={:p}", static_cast<void*>(*executionContext));
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle, hipdnnEnginePluginExecutionContext_t executionContext)
+{
+    LOG_API_ENTRY("handle={:p}, executionContext={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<void*>(executionContext));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(executionContext);
+
+        delete executionContext;
+
+        LOG_API_SUCCESS(apiName, "destroyed executionContext", "");
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle,
+    hipdnnEnginePluginExecutionContext_t executionContext,
+    size_t* workspaceSize)
+{
+    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspaceSize={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<const void*>(executionContext),
+                  static_cast<void*>(workspaceSize));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(executionContext);
+        throwIfNull(workspaceSize);
+
+        *workspaceSize = executionContext->plan().getWorkspaceSize(*handle);
+
+        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+    });
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginExecuteOpGraphImpl(hipdnnEnginePluginHandle_t handle,
+                                         hipdnnEnginePluginExecutionContext_t executionContext,
+                                         void* workspace,
+                                         const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                         uint32_t numDeviceBuffers)
+{
+    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspace={:p}, deviceBuffers={:p}, "
+                  "numDeviceBuffers={}",
+                  static_cast<void*>(handle),
+                  static_cast<void*>(executionContext),
+                  workspace,
+                  static_cast<const void*>(deviceBuffers),
+                  numDeviceBuffers);
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(executionContext);
+        throwIfNull(deviceBuffers);
+
+        executionContext->plan().execute(*handle, deviceBuffers, numDeviceBuffers, workspace);
+
+        LOG_API_SUCCESS(apiName, "executed graph", "");
+    });
+}
+
+} // extern "C"

--- a/dnn-providers/hipblaslt-provider/HipblasltPlugin.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltPlugin.hpp
@@ -1,0 +1,60 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_plugin_sdk/PluginApi.h>
+
+extern "C" {
+
+hipdnnPluginStatus_t hipdnnPluginGetNameImpl(const char** name);
+
+hipdnnPluginStatus_t hipdnnPluginGetVersionImpl(const char** version);
+hipdnnPluginStatus_t hipdnnPluginGetTypeImpl(hipdnnPluginType_t* type);
+void hipdnnPluginGetLastErrorStringImpl(const char** errorStr);
+hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callback);
+hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
+                                                           uint32_t maxEngines,
+                                                           uint32_t* numEngines);
+hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* handle);
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t handle);
+hipdnnPluginStatus_t hipdnnEnginePluginSetStreamImpl(hipdnnEnginePluginHandle_t handle,
+                                                     hipStream_t stream);
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetApplicableEngineIdsImpl(hipdnnEnginePluginHandle_t handle,
+                                                 const hipdnnPluginConstData_t* opGraph,
+                                                 int64_t* engineIds,
+                                                 uint32_t maxEngines,
+                                                 uint32_t* numEngines);
+hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
+                                                            int64_t engineId,
+                                                            const hipdnnPluginConstData_t* opGraph,
+                                                            hipdnnPluginConstData_t* engineDetails);
+hipdnnPluginStatus_t
+    hipdnnEnginePluginDestroyEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
+                                               hipdnnPluginConstData_t* engineDetails);
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetWorkspaceSizeImpl(hipdnnEnginePluginHandle_t handle,
+                                           const hipdnnPluginConstData_t* engineConfig,
+                                           const hipdnnPluginConstData_t* opGraph,
+                                           size_t* workspaceSize);
+hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle,
+    const hipdnnPluginConstData_t* engineConfig,
+    const hipdnnPluginConstData_t* opGraph,
+    hipdnnEnginePluginExecutionContext_t* executionContext);
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle, hipdnnEnginePluginExecutionContext_t executionContext);
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle,
+    hipdnnEnginePluginExecutionContext_t executionContext,
+    size_t* workspaceSize);
+hipdnnPluginStatus_t
+    hipdnnEnginePluginExecuteOpGraphImpl(hipdnnEnginePluginHandle_t handle,
+                                         hipdnnEnginePluginExecutionContext_t executionContext,
+                                         void* workspace,
+                                         const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                         uint32_t numDeviceBuffers);
+
+} // extern "C"

--- a/dnn-providers/hipblaslt-provider/HipblasltPluginPublic.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltPluginPublic.cpp
@@ -1,0 +1,128 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <hipdnn_plugin_sdk/EnginePluginApi.h>
+#include <hipdnn_plugin_sdk/PluginApi.h>
+
+#include "HipblasltPlugin.hpp"
+
+extern "C" {
+
+hipdnnPluginStatus_t hipdnnPluginGetName(const char** name)
+{
+    return hipdnnPluginGetNameImpl(name);
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetVersion(const char** version)
+{
+    return hipdnnPluginGetVersionImpl(version);
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetType(hipdnnPluginType_t* type)
+{
+    return hipdnnPluginGetTypeImpl(type);
+}
+
+void hipdnnPluginGetLastErrorString(const char** errorStr)
+{
+    hipdnnPluginGetLastErrorStringImpl(errorStr);
+}
+
+hipdnnPluginStatus_t hipdnnPluginSetLoggingCallback(hipdnnCallback_t callback)
+{
+    return hipdnnPluginSetLoggingCallbackImpl(callback);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetAllEngineIds(int64_t* engineIds, uint32_t maxEngines, uint32_t* numEngines)
+{
+    return hipdnnEnginePluginGetAllEngineIdsImpl(engineIds, maxEngines, numEngines);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginCreate(hipdnnEnginePluginHandle_t* handle)
+{
+    return hipdnnEnginePluginCreateImpl(handle);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroy(hipdnnEnginePluginHandle_t handle)
+{
+    return hipdnnEnginePluginDestroyImpl(handle);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginSetStream(hipdnnEnginePluginHandle_t handle,
+                                                 hipStream_t stream)
+{
+    return hipdnnEnginePluginSetStreamImpl(handle, stream);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetApplicableEngineIds(hipdnnEnginePluginHandle_t handle,
+                                             const hipdnnPluginConstData_t* opGraph,
+                                             int64_t* engineIds,
+                                             uint32_t maxEngines,
+                                             uint32_t* numEngines)
+{
+    return hipdnnEnginePluginGetApplicableEngineIdsImpl(
+        handle, opGraph, engineIds, maxEngines, numEngines);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetails(hipdnnEnginePluginHandle_t handle,
+                                                        int64_t engineId,
+                                                        const hipdnnPluginConstData_t* opGraph,
+                                                        hipdnnPluginConstData_t* engineDetails)
+{
+    return hipdnnEnginePluginGetEngineDetailsImpl(handle, engineId, opGraph, engineDetails);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyEngineDetails(hipdnnEnginePluginHandle_t handle,
+                                                            hipdnnPluginConstData_t* engineDetails)
+{
+    return hipdnnEnginePluginDestroyEngineDetailsImpl(handle, engineDetails);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSize(hipdnnEnginePluginHandle_t handle,
+                                                        const hipdnnPluginConstData_t* engineConfig,
+                                                        const hipdnnPluginConstData_t* opGraph,
+                                                        size_t* workspaceSize)
+{
+    return hipdnnEnginePluginGetWorkspaceSizeImpl(handle, engineConfig, opGraph, workspaceSize);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginCreateExecutionContext(hipdnnEnginePluginHandle_t handle,
+                                             const hipdnnPluginConstData_t* engineConfig,
+                                             const hipdnnPluginConstData_t* opGraph,
+                                             hipdnnEnginePluginExecutionContext_t* executionContext)
+{
+    return hipdnnEnginePluginCreateExecutionContextImpl(
+        handle, engineConfig, opGraph, executionContext);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginDestroyExecutionContext(hipdnnEnginePluginHandle_t handle,
+                                              hipdnnEnginePluginExecutionContext_t executionContext)
+{
+    return hipdnnEnginePluginDestroyExecutionContextImpl(handle, executionContext);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContext(
+    hipdnnEnginePluginHandle_t handle,
+    hipdnnEnginePluginExecutionContext_t executionContext,
+    size_t* workspaceSize)
+{
+    return hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+        handle, executionContext, workspaceSize);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginExecuteOpGraph(hipdnnEnginePluginHandle_t handle,
+                                     hipdnnEnginePluginExecutionContext_t executionContext,
+                                     void* workspace,
+                                     const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                     uint32_t numDeviceBuffers)
+{
+    return hipdnnEnginePluginExecuteOpGraphImpl(
+        handle, executionContext, workspace, deviceBuffers, numDeviceBuffers);
+}
+
+} // extern "C"

--- a/dnn-providers/hipblaslt-provider/HipblasltUtils.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltUtils.cpp
@@ -1,0 +1,31 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipblasltUtils.hpp"
+
+namespace hipblaslt_plugin::hipblaslt_utils
+{
+
+hipDataType tensorDataTypeToHipDataType(const hipdnn_data_sdk::data_objects::DataType& dataType)
+{
+    switch(dataType)
+    {
+    case hipdnn_data_sdk::data_objects::DataType::FLOAT:
+        return HIP_R_32F;
+    case hipdnn_data_sdk::data_objects::DataType::INT32:
+        return HIP_R_32I;
+    case hipdnn_data_sdk::data_objects::DataType::HALF:
+        return HIP_R_16F;
+    case hipdnn_data_sdk::data_objects::DataType::BFLOAT16:
+        return HIP_R_16BF;
+    case hipdnn_data_sdk::data_objects::DataType::INT8:
+        return HIP_R_8I;
+    default:
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Unsupported data type for hipBLASLt: "
+                + std::string(hipdnn_data_sdk::data_objects::toString(dataType)));
+    }
+}
+
+} // namespace hipblaslt_plugin::hipblaslt_utils

--- a/dnn-providers/hipblaslt-provider/HipblasltUtils.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltUtils.hpp
@@ -1,0 +1,81 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipblaslt/hipblaslt.h>
+#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <string>
+
+#define LOG_ON_HIPBLASLT_FAILURE(status)                                                           \
+    do                                                                                             \
+    {                                                                                              \
+        if(status != HIPBLAS_STATUS_SUCCESS)                                                       \
+        {                                                                                          \
+            HIPDNN_LOG_ERROR("hipBLASLt error occurred: {}",                                       \
+                             hipblaslt_plugin::hipblaslt_utils::hipblas_status_to_string(status)); \
+        }                                                                                          \
+    } while(0)
+
+#define THROW_ON_HIPBLASLT_FAILURE(status)                                                     \
+    do                                                                                         \
+    {                                                                                          \
+        if(status != HIPBLAS_STATUS_SUCCESS)                                                   \
+        {                                                                                      \
+            throw hipdnn_plugin_sdk::HipdnnPluginException(                                    \
+                HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,                                           \
+                "hipBLASLt error occurred: "                                                   \
+                    + std::string(                                                             \
+                        hipblaslt_plugin::hipblaslt_utils::hipblas_status_to_string(status))); \
+        }                                                                                      \
+    } while(0)
+
+#define HIPDNN_PREPEND_MESSAGE_ON_THROW(statement, message)                               \
+    do                                                                                    \
+    {                                                                                     \
+        try                                                                               \
+        {                                                                                 \
+            statement;                                                                    \
+        }                                                                                 \
+        catch(hipdnn_plugin_sdk::HipdnnPluginException error)                             \
+        {                                                                                 \
+            throw hipdnn_plugin_sdk::HipdnnPluginException(error.getStatus(),             \
+                                                           message + error.getMessage()); \
+        }                                                                                 \
+    } while(0)
+
+namespace hipblaslt_plugin::hipblaslt_utils
+{
+
+inline const char* hipblas_status_to_string(hipblasStatus_t status)
+{
+#define CASE(x) \
+    case x:     \
+        return #x
+    switch(status)
+    {
+        CASE(HIPBLAS_STATUS_SUCCESS);
+        CASE(HIPBLAS_STATUS_NOT_INITIALIZED);
+        CASE(HIPBLAS_STATUS_ALLOC_FAILED);
+        CASE(HIPBLAS_STATUS_INVALID_VALUE);
+        CASE(HIPBLAS_STATUS_MAPPING_ERROR);
+        CASE(HIPBLAS_STATUS_EXECUTION_FAILED);
+        CASE(HIPBLAS_STATUS_INTERNAL_ERROR);
+        CASE(HIPBLAS_STATUS_NOT_SUPPORTED);
+        CASE(HIPBLAS_STATUS_ARCH_MISMATCH);
+        CASE(HIPBLAS_STATUS_INVALID_ENUM);
+        CASE(HIPBLAS_STATUS_UNKNOWN);
+        CASE(HIPBLAS_STATUS_HANDLE_IS_NULLPTR);
+    default:
+        return "<undefined hipblasStatus_t value>";
+    }
+#undef CASE
+}
+
+hipDataType tensorDataTypeToHipDataType(const hipdnn_data_sdk::data_objects::DataType& dataType);
+
+} // namespace hipblaslt_plugin::hipblaslt_utils

--- a/dnn-providers/hipblaslt-provider/HipdnnEnginePluginExecutionContext.hpp
+++ b/dnn-providers/hipblaslt-provider/HipdnnEnginePluginExecutionContext.hpp
@@ -1,0 +1,46 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+
+#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "engines/plans/PlanInterface.hpp"
+
+struct HipdnnEnginePluginExecutionContext
+{
+public:
+    virtual ~HipdnnEnginePluginExecutionContext() = default;
+
+    bool hasValidPlan() const
+    {
+        return _plan != nullptr;
+    }
+
+    void setPlan(std::unique_ptr<hipblaslt_plugin::IPlan> plan)
+    {
+        _plan = std::move(plan);
+    }
+
+    virtual hipblaslt_plugin::IPlan& plan() const
+    {
+        if(!hasValidPlan())
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                "Cannot get plan in execution context, its not set");
+        }
+        return *_plan;
+    }
+
+private:
+    std::unique_ptr<hipblaslt_plugin::IPlan> _plan;
+};

--- a/dnn-providers/hipblaslt-provider/HipdnnEnginePluginHandle.hpp
+++ b/dnn-providers/hipblaslt-provider/HipdnnEnginePluginHandle.hpp
@@ -1,0 +1,72 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <flatbuffers/flatbuffers.h>
+#include <hipblaslt/hipblaslt.h>
+#include <memory>
+#include <unordered_map>
+
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "HipblasltContainer.hpp"
+#include "HipblasltUtils.hpp"
+
+// NOLINTBEGIN
+struct HipdnnEnginePluginHandle
+{
+public:
+    virtual ~HipdnnEnginePluginHandle() = default;
+
+    hipblasLtHandle_t hipblasltHandle = nullptr;
+
+    void setStream(hipStream_t stream)
+    {
+        _stream = stream;
+    }
+
+    hipStream_t getStream() const
+    {
+        return _stream;
+    }
+
+    std::shared_ptr<hipblaslt_plugin::HipblasltContainer> hipblasltContainer;
+    hipblaslt_plugin::EngineManager& getEngineManager()
+    {
+        return hipblasltContainer->getEngineManager();
+    }
+
+    void storeEngineDetailsDetachedBuffer(const void* ptr,
+                                          std::unique_ptr<flatbuffers::DetachedBuffer> buffer)
+    {
+        HIPDNN_LOG_INFO("Storing detached buffer at address: {:p}", ptr);
+        _engineDetailsBuffers[ptr] = std::move(buffer);
+    }
+
+    void removeEngineDetailsDetachedBuffer(const void* ptr)
+    {
+        HIPDNN_LOG_INFO("Removing detached buffer at address: {:p}", ptr);
+
+        auto it = _engineDetailsBuffers.find(ptr);
+        if(it != _engineDetailsBuffers.end())
+        {
+            _engineDetailsBuffers.erase(it);
+        }
+        else
+        {
+            HIPDNN_LOG_WARN("No detached buffer found at address: {:p}. Could not remove engine "
+                            "details. Ensure you "
+                            "are using the same hipdnn handle you used for engine details creation",
+                            ptr);
+        }
+    }
+
+private:
+    hipStream_t _stream = nullptr;
+    std::unordered_map<const void*, std::unique_ptr<flatbuffers::DetachedBuffer>>
+        _engineDetailsBuffers;
+};
+
+// NOLINTEND

--- a/dnn-providers/hipblaslt-provider/README.md
+++ b/dnn-providers/hipblaslt-provider/README.md
@@ -1,0 +1,12 @@
+# hipBLASLt Provider Plugin
+A plugin wrapping hipBLASLt in order to provide engines to solve some hipDNN graphs.
+
+:construction: **This project is under active development** :construction:
+
+## Building
+This plugin is built as a standalone plugin. To build the plugin you need to have installed hipDNN and hipBLASLt on the system first.
+
+1. Navigate to the `dnn-providers/hipblaslt-provider` directory.
+1. Make a build directory, `mkdir build && cd build`.
+1. Run `cmake -DCMAKE_CXX_COMPILER=<path to amdclang>/clang++ ..` to configure the build.
+1. Run `ninja` to build the plugin.

--- a/dnn-providers/hipblaslt-provider/README.md
+++ b/dnn-providers/hipblaslt-provider/README.md
@@ -1,12 +1,12 @@
 # hipBLASLt Provider Plugin
-A plugin wrapping hipBLASLt in order to provide engines to solve some hipDNN graphs.
+The hipBLASLt provider plugin is a wrapping around hipBLASLt that provides engines to solve certain hipDNN graphs.
 
 :construction: **This project is under active development** :construction:
 
 ## Building
-This plugin is built as a standalone plugin. To build the plugin you need to have installed hipDNN and hipBLASLt on the system first.
+This plugin is built as a standalone plugin. To build the plugin, first install hipDNN and hipBLASLt on the system and then follow these steps:
 
 1. Navigate to the `dnn-providers/hipblaslt-provider` directory.
-1. Make a build directory, `mkdir build && cd build`.
-1. Run `cmake -DCMAKE_CXX_COMPILER=<path to amdclang>/clang++ ..` to configure the build.
-1. Run `ninja` to build the plugin.
+1. Make a build directory using `mkdir build && cd build`.
+1. Configure the build using `cmake -DCMAKE_CXX_COMPILER=<path to amdclang>/clang++ ..`.
+1. Finally, run `ninja` to build the plugin.

--- a/dnn-providers/hipblaslt-provider/cmake/ClangCheck.cmake
+++ b/dnn-providers/hipblaslt-provider/cmake/ClangCheck.cmake
@@ -2,18 +2,22 @@
 # SPDX-License-Identifier:  MIT
 
 # clang-format tool for code style
+set(EXPECTED_CLANG_FORMAT_VERSION "20")
 
-if(HIPBLASLT_ENABLE_CLANG_FORMAT)
+if(ENABLE_CLANG_FORMAT)
     find_program(
-        HIPBLASLT_CLANG_FORMAT_BIN
-        NAMES clang-format-20
+        CLANG_FORMAT_BINARY
+        NAMES "clang-format-${EXPECTED_CLANG_FORMAT_VERSION}"
         HINTS ${ROCM_PATH}/llvm/bin /opt/rocm/llvm/bin
         DOC "clang-format executable used for formatting"
     )
-    if(HIPBLASLT_CLANG_FORMAT_BIN)
-        message(STATUS "clang-format-20 has been found; format targets will be built")
+    if(CLANG_FORMAT_BINARY)
+        message(
+            STATUS
+                "clang-format-${EXPECTED_CLANG_FORMAT_VERSION} has been found; format targets will be built"
+        )
 
-        set(HIPBLASLT_CLANG_FORMAT_PRUNE
+        set(CLANG_FORMAT_PRUNE
             -path
             "./build"
             -prune
@@ -23,20 +27,20 @@ if(HIPBLASLT_ENABLE_CLANG_FORMAT)
             -prune
             -o
         )
-        set(HIPBLASLT_CLANG_FORMAT_REGEX ".*\\.\\(cpp\\|hpp\\|h\\)")
+        set(CLANG_FORMAT_REGEX ".*\\.\\(cpp\\|hpp\\|c\\|h\\)")
         add_custom_target(
-            hipblaslt_check_format
-            COMMAND find ${CMAKE_CURRENT_SOURCE_DIR} ${HIPBLASLT_CLANG_FORMAT_PRUNE} -regex
-                    "${HIPBLASLT_CLANG_FORMAT_REGEX}" -exec ${HIPBLASLT_CLANG_FORMAT_BIN}
+            check_format
+            COMMAND find ${CMAKE_CURRENT_SOURCE_DIR} ${CLANG_FORMAT_PRUNE} -regex
+                    "${CLANG_FORMAT_REGEX}" -exec ${CLANG_FORMAT_BINARY}
                     -style=file --dry-run --Werror {} +
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             COMMENT "Checking code style with clang-format"
             VERBATIM
         )
         add_custom_target(
-            hipblaslt_format
-            COMMAND find ${CMAKE_CURRENT_SOURCE_DIR} ${HIPBLASLT_CLANG_FORMAT_PRUNE} -regex
-                    "${HIPBLASLT_CLANG_FORMAT_REGEX}" -exec ${HIPBLASLT_CLANG_FORMAT_BIN}
+            format
+            COMMAND find ${CMAKE_CURRENT_SOURCE_DIR} ${CLANG_FORMAT_PRUNE} -regex
+                    "${CLANG_FORMAT_REGEX}" -exec ${CLANG_FORMAT_BINARY}
                     -style=file -i {} +
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             COMMENT "Applying clang-format to hipblaslt-provider sources"
@@ -45,7 +49,7 @@ if(HIPBLASLT_ENABLE_CLANG_FORMAT)
     else()
         message(
             WARNING
-                "HIPBLASLT_ENABLE_CLANG_FORMAT=ON but clang-format-20 not found; skipping format targets"
+                "ENABLE_CLANG_FORMAT=ON but clang-format-${EXPECTED_CLANG_FORMAT_VERSION} not found; skipping format targets"
         )
     endif()
 endif()

--- a/dnn-providers/hipblaslt-provider/cmake/ClangFormat.cmake
+++ b/dnn-providers/hipblaslt-provider/cmake/ClangFormat.cmake
@@ -1,0 +1,51 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+# clang-format tool for code style
+
+if(HIPBLASLT_ENABLE_CLANG_FORMAT)
+    find_program(
+        HIPBLASLT_CLANG_FORMAT_BIN
+        NAMES clang-format-20
+        HINTS ${ROCM_PATH}/llvm/bin /opt/rocm/llvm/bin
+        DOC "clang-format executable used for formatting"
+    )
+    if(HIPBLASLT_CLANG_FORMAT_BIN)
+        message(STATUS "clang-format-20 has been found; format targets will be built")
+
+        set(HIPBLASLT_CLANG_FORMAT_PRUNE
+            -path
+            "./build"
+            -prune
+            -o
+            -path
+            "./install"
+            -prune
+            -o
+        )
+        set(HIPBLASLT_CLANG_FORMAT_REGEX ".*\\.\\(cpp\\|hpp\\|h\\)")
+        add_custom_target(
+            hipblaslt_check_format
+            COMMAND find ${CMAKE_CURRENT_SOURCE_DIR} ${HIPBLASLT_CLANG_FORMAT_PRUNE} -regex
+                    "${HIPBLASLT_CLANG_FORMAT_REGEX}" -exec ${HIPBLASLT_CLANG_FORMAT_BIN}
+                    -style=file --dry-run --Werror {} +
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "Checking code style with clang-format"
+            VERBATIM
+        )
+        add_custom_target(
+            hipblaslt_format
+            COMMAND find ${CMAKE_CURRENT_SOURCE_DIR} ${HIPBLASLT_CLANG_FORMAT_PRUNE} -regex
+                    "${HIPBLASLT_CLANG_FORMAT_REGEX}" -exec ${HIPBLASLT_CLANG_FORMAT_BIN}
+                    -style=file -i {} +
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMENT "Applying clang-format to hipblaslt-provider sources"
+            VERBATIM
+        )
+    else()
+        message(
+            WARNING
+                "HIPBLASLT_ENABLE_CLANG_FORMAT=ON but clang-format-20 not found; skipping format targets"
+        )
+    endif()
+endif()

--- a/dnn-providers/hipblaslt-provider/cmake/ClangToolChain.cmake
+++ b/dnn-providers/hipblaslt-provider/cmake/ClangToolChain.cmake
@@ -1,0 +1,38 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+# Platform-specific compiler configuration
+
+if(UNIX)
+    set(DEFAULT_ROCM_PATH "/opt/rocm")
+    set(DEFAULT_ROCM_LLVM_ROOT "/llvm")
+    set(DEFAULT_ROCM_COMPILER_EXTENSION "")
+elseif(WIN32)
+    set(DEFAULT_ROCM_PATH "C:/dist/therock")
+    set(DEFAULT_ROCM_LLVM_ROOT "/lib/llvm")
+    set(DEFAULT_ROCM_COMPILER_EXTENSION ".exe")
+endif()
+
+if(NOT DEFINED ROCM_PATH)
+    set(ROCM_PATH ${DEFAULT_ROCM_PATH} CACHE PATH "Path to ROCm installation")
+endif()
+
+list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES "ROCM_PATH")
+
+# Unix/Linux: Use ROCm LLVM Clang
+set(ROCM_LLVM_BIN_DIR ${ROCM_PATH}${DEFAULT_ROCM_LLVM_ROOT}/bin)
+set(ROCM_LLVM_LIB_DIR ${ROCM_PATH}${DEFAULT_ROCM_LLVM_ROOT}/lib)
+set(CMAKE_RC_COMPILER rc.exe)
+
+if(EXISTS ${ROCM_LLVM_BIN_DIR})
+    # Set the C and C++ compilers to clang and clang++ with a specific directory hint
+    set(CMAKE_C_COMPILER ${ROCM_LLVM_BIN_DIR}/clang${DEFAULT_ROCM_COMPILER_EXTENSION})
+    set(CMAKE_CXX_COMPILER ${ROCM_LLVM_BIN_DIR}/clang++${DEFAULT_ROCM_COMPILER_EXTENSION})
+
+    message(STATUS "Using ROCm Clang compilers from ${ROCM_LLVM_BIN_DIR}")
+else()
+    message(
+        FATAL_ERROR
+            "The directory ${ROCM_LLVM_BIN_DIR} does not exist. Cannot auto select clang compilers."
+    )
+endif()

--- a/dnn-providers/hipblaslt-provider/cmake/Dependencies.cmake
+++ b/dnn-providers/hipblaslt-provider/cmake/Dependencies.cmake
@@ -1,0 +1,29 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+cmake_minimum_required(VERSION 3.25.2)
+
+# Only setup dependencies for standalone builds
+if(NOT BUILD_PLUGIN_AS_DEPENDENCY AND NOT HIPDNN_SKIP_TESTS)
+    include(FetchContent)
+
+    # Try to find GTest first
+    find_package(GTest CONFIG QUIET)
+
+    if(NOT GTest_FOUND)
+        message(STATUS "Fetching GTest for standalone plugin build")
+
+        fetchcontent_declare(
+            googletest URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
+                           DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        )
+
+        set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
+        set(INSTALL_GTEST OFF CACHE INTERNAL "")
+        set(BUILD_GMOCK ON CACHE INTERNAL "")
+
+        fetchcontent_makeavailable(googletest)
+    else()
+        message(STATUS "Found system GTest")
+    endif()
+endif()

--- a/dnn-providers/hipblaslt-provider/cmake/Tests.cmake
+++ b/dnn-providers/hipblaslt-provider/cmake/Tests.cmake
@@ -1,0 +1,241 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+include(GoogleTest)
+
+find_package(Python3 COMPONENTS Interpreter)
+
+set(CHECK_DEPENDS_GLOBAL "" CACHE INTERNAL "Accumulated global dependencies for test name validation" FORCE)
+set(CHECK_EXECUTABLE_PATHS_GLOBAL "" CACHE INTERNAL "Accumulated global check executable paths" FORCE)
+
+# Builds the test environment list with optional code coverage support
+# ~~~
+# Parameters:
+#   OUT_VAR - The name of the variable to store the result in (will be set in PARENT_SCOPE)
+# ~~~
+function(_build_test_environment_list_internal OUT_VAR)
+    set(ENVIRONMENT_LIST "")
+    if(DEFINED TEST_ENVIRONMENT)
+        set(ENVIRONMENT_LIST ${TEST_ENVIRONMENT})
+    endif()
+
+    if(HIPDNN_ENABLE_COVERAGE)
+        # Ensure coverage report directory exists
+        file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/coverage_report/profraw")
+
+        # For code coverage builds, we want each profraw file to have a unique name.  The %m in the
+        # LLVM_PROFILE_FILE environment variable will auto generate a unique id.
+        list(APPEND ENVIRONMENT_LIST
+             "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage_report/profraw/%m.profraw"
+        )
+    endif()
+
+    set(${OUT_VAR} ${ENVIRONMENT_LIST} PARENT_SCOPE)
+endfunction() # _build_test_environment_list_internal
+
+# Creates a custom target to validate test names using a Python script
+function(_create_test_name_validation_target_internal)
+    if(Python3_FOUND)
+        # Write list of test executables with their paths to a file
+        set(TEST_EXECUTABLES_FILE ${CMAKE_BINARY_DIR}/test_executables.txt)
+        list(REMOVE_DUPLICATES CHECK_EXECUTABLE_PATHS_GLOBAL)
+        file(WRITE ${TEST_EXECUTABLES_FILE} "")
+        foreach(test_executable ${CHECK_EXECUTABLE_PATHS_GLOBAL})
+            file(APPEND ${TEST_EXECUTABLES_FILE} "${test_executable}\n")
+        endforeach()
+
+        add_custom_command(
+            OUTPUT ${CMAKE_BINARY_DIR}/test_names_validated
+            COMMAND
+                ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/scripts/test_name_validator.py
+                --test-executables ${TEST_EXECUTABLES_FILE} --build-dir ${CMAKE_BINARY_DIR} --strict
+            COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/test_names_validated
+            DEPENDS ${CMAKE_SOURCE_DIR}/cmake/scripts/test_name_validator.py ${CHECK_DEPENDS_GLOBAL}
+            COMMENT "Validating test names with --gtest_list_tests test collection"
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            VERBATIM
+        )
+
+        add_custom_target(
+            validate_test_names DEPENDS ${CMAKE_BINARY_DIR}/test_names_validated
+            COMMENT "Validating test names"
+        )
+    else()
+        message(WARNING "Python3 not found. Test name validation will be skipped.")
+        add_custom_target(
+            validate_test_names COMMAND ${CMAKE_COMMAND} -E echo
+                                        "Test name validation skipped - Python3 not found"
+            COMMENT "Skipping test name validation"
+        )
+    endif() # Python3_FOUND
+endfunction() # _create_test_name_validation_target_internal
+
+enable_testing() # Cmake wont discover or run tests without this line
+
+# Internal helper function to create a ctest target
+# ~~~
+# Parameters:
+#   TARGET_NAME - Name of the ctest target to create
+#   LABEL - Optional label filter for ctest (empty string for no filter)
+#   VERBOSE - Set to TRUE to add --verbose flag, FALSE otherwise
+#   COMMENT - Comment describing the target
+# ~~~
+function(_add_ctest_target_internal TARGET_NAME LABEL VERBOSE COMMENT)
+    # Build the ctest command
+    set(CTEST_CMD ${CMAKE_COMMAND} -E env ${CTEST_ENV} ${CMAKE_CTEST_COMMAND})
+
+    # Add label filter if specified
+    if(NOT "${LABEL}" STREQUAL "")
+        list(APPEND CTEST_CMD -L "${LABEL}")
+    endif()
+
+    # Always add --output-on-failure
+    list(APPEND CTEST_CMD --output-on-failure)
+
+    # Add --verbose if requested
+    if(VERBOSE)
+        list(APPEND CTEST_CMD --verbose)
+    endif()
+
+    # Add configuration
+    list(APPEND CTEST_CMD -C ${CMAKE_CFG_INTDIR})
+
+    # Create the target
+    add_custom_target(${TARGET_NAME} COMMAND ${CTEST_CMD} COMMENT "${COMMENT}" USES_TERMINAL)
+    add_dependencies(${TARGET_NAME} validate_test_names)
+    message(VERBOSE "Created ${TARGET_NAME} target")
+endfunction() # _add_ctest_target_internal
+
+# Internal helper function to create the check targets for running tests via ctest
+function(_create_ctest_targets_internal)
+    # cmake-format: off
+    # Build test environment once for all ctest targets
+    _build_test_environment_list_internal(CTEST_ENV)
+
+    # Regular targets (without --verbose)
+    _add_ctest_target_internal(check_ctest "" FALSE "Running all tests via ctest")
+    _add_ctest_target_internal(unit-check_ctest "unit_test" FALSE "Running unit tests via ctest")
+    _add_ctest_target_internal(integration-check_ctest "integration_test" FALSE "Running integration tests via ctest")
+
+    # Verbose targets (with --verbose)
+    _add_ctest_target_internal(check_ctest-verbose "" TRUE "Running all tests via ctest (verbose)")
+    _add_ctest_target_internal(unit-check_ctest-verbose "unit_test" TRUE "Running unit tests via ctest (verbose)")
+    _add_ctest_target_internal(integration-check_ctest-verbose "integration_test" TRUE "Running integration tests via ctest (verbose)")
+    # cmake-format: on
+endfunction() # create_ctest_targets
+
+# Finalizes and creates all of the test targets
+function(finalize_test_targets)
+    _create_test_name_validation_target_internal()
+
+    _create_ctest_targets_internal()
+
+    # cmake-format: off
+    # Create alias test targets without '_ctest' in the name
+    # Regular targets (without --verbose)
+    add_custom_target(check DEPENDS check_ctest COMMENT "Running all tests via ctest")
+    add_custom_target(unit-check DEPENDS unit-check_ctest COMMENT "Running unit tests via ctest")
+    add_custom_target(integration-check DEPENDS integration-check_ctest COMMENT "Running integration tests via ctest")
+    message(STATUS "Created ctest targets: check, unit-check, integration-check")
+    # Verbose targets (with --verbose)
+    add_custom_target(check-verbose DEPENDS check_ctest-verbose COMMENT "Running all tests via ctest (verbose)")
+    add_custom_target(unit-check-verbose DEPENDS unit-check_ctest-verbose COMMENT "Running unit tests via ctest (verbose)")
+    add_custom_target(integration-check-verbose DEPENDS integration-check_ctest-verbose COMMENT "Running integration tests via ctest (verbose)")
+    message(STATUS "Created ctest verbose targets: check-verbose, unit-check-verbose, integration-check-verbose")
+    # cmake-format: on
+endfunction() # finalize_test_targets
+
+# ~~~
+# Internal helper function to record, configure, and register a ctest test target. Assumes that the
+# test target is a gtest executable, setting up:
+# - Test name validation tracking (adds to global dependency and executable path lists)
+# - RPATH settings for relocatable test executables
+# - Installation rules for test binaries
+# - CTest registration with appropriate labels (e.g. unit / integration test labels)
+# Parameters:
+#   APPEND_FUNCTION_SUFFIX - Label to apply to the test (e.g., "unit_test", "integration_test", "test")
+#   TARGET - Name of the test executable target (must already exist)
+#   WORKING_DIR - Working directory for test execution
+# ~~~
+function(_add_test_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
+    message(STATUS "Appending unclassified check target: ${TARGET} in working directory: ${WORKING_DIR}")
+
+    # Track the dependencies for test name validation
+    set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET}
+        CACHE INTERNAL "Accumulated global dependencies for test name validation" FORCE
+    )
+    # Track the binary paths for test name validation
+    set(CHECK_EXECUTABLE_PATHS_GLOBAL ${CHECK_EXECUTABLE_PATHS_GLOBAL} "${CMAKE_INSTALL_BINDIR}/${TARGET}"
+        CACHE INTERNAL "Accumulated global check executable paths" FORCE
+    )
+
+    # Track this test target for later use in generating installed CTestTestfile.cmake
+    set_property(GLOBAL APPEND PROPERTY HIPDNN_TEST_TARGETS ${TARGET})
+
+    set_target_properties(
+        ${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}"
+    )
+
+    # Track this test target for later use in generating installed CTestTestfile.cmake
+    set_property(GLOBAL APPEND PROPERTY HIPBLASLT_TEST_TARGETS ${TARGET})
+
+    # Make test executables relocatable so they can find libraries when build directory is moved
+    # Include both the main lib directory and the engine plugin directories
+    set_target_properties(
+        ${TARGET}
+        PROPERTIES
+            INSTALL_RPATH
+            "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR};\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}/hipdnn_plugins/engines"
+            INSTALL_RPATH_USE_LINK_PATH TRUE
+            BUILD_RPATH_USE_ORIGIN TRUE
+    )
+
+    # Install test executables to bin directory
+    install(TARGETS ${TARGET} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    add_test(NAME ${TARGET} COMMAND ${TARGET} WORKING_DIRECTORY ${WORKING_DIR})
+    set_tests_properties(${TARGET} PROPERTIES LABELS ${APPEND_FUNCTION_SUFFIX})
+endfunction() # _add_gtest_target_internal
+
+# Adds a generic test target
+function(add_unclassified_test_target TARGET WORKING_DIR)
+    _add_test_target_internal(test ${TARGET} ${WORKING_DIR})
+endfunction() # add_unclassified_test_target
+
+# Adds a unit test target
+function(add_unit_test_target TARGET WORKING_DIR)
+    _add_test_target_internal(unit_test ${TARGET} ${WORKING_DIR})
+endfunction() # add_unit_test_target
+
+# Adds an integration test target
+function(add_integration_test_target TARGET WORKING_DIR)
+    _add_test_target_internal(integration_test ${TARGET} ${WORKING_DIR})
+endfunction() # add_integration_test_target
+
+# Install CTest configuration files for direct test execution This should be called once at the end
+# of the main CMakeLists.txt after all tests are registered
+function(install_hipblaslt_plugin_ctest_files)
+    # Define the CTest installation directory
+    set(HIPBLASLT_PLUGIN_CTEST_FILE_INSTALL_PATH "${CMAKE_INSTALL_BINDIR}/hipblaslt_plugin")
+
+    # Generate a new CTestTestfile.cmake that references installed test executables
+    set(INSTALLED_CTEST_FILE "${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake.install")
+
+    file(WRITE "${INSTALLED_CTEST_FILE}"
+         "# Autogenerated CTestTestfile for installed hipblaslt_plugin tests\n"
+    )
+    file(APPEND "${INSTALLED_CTEST_FILE}" "# Generated by hipblaslt_plugin build system\n\n")
+
+    # Get all test targets that were registered
+    get_property(all_tests GLOBAL PROPERTY HIPBLASLT_TEST_TARGETS)
+
+    foreach(test_target ${all_tests})
+        file(APPEND "${INSTALLED_CTEST_FILE}" "add_test(${test_target} \"../${test_target}\")\n")
+    endforeach()
+
+    # Install the generated CTestTestfile.cmake to HIPBLASLT_PLUGIN_CTEST_FILE_INSTALL_PATH
+    install(FILES "${INSTALLED_CTEST_FILE}"
+            DESTINATION ${HIPBLASLT_PLUGIN_CTEST_FILE_INSTALL_PATH} RENAME CTestTestfile.cmake
+    )
+
+endfunction() # install_hipblaslt_plugin_ctest_files

--- a/dnn-providers/hipblaslt-provider/engines/EngineInterface.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/EngineInterface.hpp
@@ -1,0 +1,40 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <stdint.h>
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hipblaslt_plugin
+{
+
+class IEngine
+{
+public:
+    virtual ~IEngine() = default;
+
+    virtual int64_t id() const = 0;
+
+    virtual bool isApplicable(HipdnnEnginePluginHandle& handle,
+                              const hipdnn_plugin_sdk::IGraph& opGraph) const
+        = 0;
+    virtual void getDetails(HipdnnEnginePluginHandle& handle,
+                            hipdnnPluginConstData_t& detailsOut) const
+        = 0;
+
+    virtual size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                                    const hipdnn_plugin_sdk::IGraph& opGraph) const
+        = 0;
+
+    virtual void
+        initializeExecutionContext(const HipdnnEnginePluginHandle& handle,
+                                   const hipdnn_plugin_sdk::IGraph& opGraph,
+                                   HipdnnEnginePluginExecutionContext& executionContext) const
+        = 0;
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/engines/HipblasltEngine.cpp
+++ b/dnn-providers/hipblaslt-provider/engines/HipblasltEngine.cpp
@@ -1,0 +1,83 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipblasltEngine.hpp"
+
+#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
+
+namespace hipblaslt_plugin
+{
+
+HipblasltEngine::HipblasltEngine(int64_t id)
+    : _id(id)
+{
+}
+
+int64_t HipblasltEngine::id() const
+{
+    return _id;
+}
+
+bool HipblasltEngine::isApplicable(HipdnnEnginePluginHandle& handle,
+                                   const hipdnn_plugin_sdk::IGraph& opGraph) const
+{
+    // This is wrong if we ever have more than 1 plan builder thats applicable.
+    // If this is the case, we should split plan builders accross multiple engines.
+    for(const auto& planBuilder : _planBuilders)
+    {
+        if(planBuilder->isApplicable(handle, opGraph))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void HipblasltEngine::getDetails(HipdnnEnginePluginHandle& handle,
+                                 hipdnnPluginConstData_t& detailsOut) const
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto engineDetails = hipdnn_data_sdk::data_objects::CreateEngineDetails(builder, _id);
+    builder.Finish(engineDetails);
+    auto detachedBuffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
+    detailsOut.ptr = detachedBuffer->data();
+    detailsOut.size = detachedBuffer->size();
+
+    handle.storeEngineDetailsDetachedBuffer(detailsOut.ptr, std::move(detachedBuffer));
+}
+
+size_t HipblasltEngine::getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                                         const hipdnn_plugin_sdk::IGraph& opGraph) const
+{
+    size_t workspaceSize = 0;
+    for(const auto& planBuilder : _planBuilders)
+    {
+        if(planBuilder->isApplicable(handle, opGraph))
+        {
+            workspaceSize = std::max(workspaceSize, planBuilder->getWorkspaceSize(handle, opGraph));
+        }
+    }
+    return workspaceSize;
+}
+
+void HipblasltEngine::initializeExecutionContext(
+    const HipdnnEnginePluginHandle& handle,
+    const hipdnn_plugin_sdk::IGraph& opGraph,
+    HipdnnEnginePluginExecutionContext& executionContext) const
+{
+    for(const auto& planBuilder : _planBuilders)
+    {
+        if(planBuilder->isApplicable(handle, opGraph))
+        {
+            planBuilder->buildPlan(handle, opGraph, executionContext);
+            break;
+        }
+    }
+}
+
+void HipblasltEngine::addPlanBuilder(std::unique_ptr<IPlanBuilder> planBuilder)
+{
+    _planBuilders.push_back(std::move(planBuilder));
+}
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/engines/HipblasltEngine.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/HipblasltEngine.hpp
@@ -1,0 +1,42 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+#include <set>
+
+#include "EngineInterface.hpp"
+#include "plans/PlanBuilderInterface.hpp"
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hipblaslt_plugin
+{
+
+class HipblasltEngine : public IEngine
+{
+public:
+    HipblasltEngine(int64_t id);
+
+    int64_t id() const override;
+
+    bool isApplicable(HipdnnEnginePluginHandle& handle,
+                      const hipdnn_plugin_sdk::IGraph& opGraph) const override;
+    void getDetails(HipdnnEnginePluginHandle& handle,
+                    hipdnnPluginConstData_t& detailsOut) const override;
+    size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                            const hipdnn_plugin_sdk::IGraph& opGraph) const override;
+
+    void initializeExecutionContext(
+        const HipdnnEnginePluginHandle& handle,
+        const hipdnn_plugin_sdk::IGraph& opGraph,
+        HipdnnEnginePluginExecutionContext& executionContext) const override;
+
+    void addPlanBuilder(std::unique_ptr<IPlanBuilder> planBuilder);
+
+private:
+    int64_t _id;
+    std::vector<std::unique_ptr<IPlanBuilder>> _planBuilders;
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/engines/plans/PlanBuilderInterface.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/PlanBuilderInterface.hpp
@@ -1,0 +1,36 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <stdint.h>
+
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+
+namespace hipblaslt_plugin
+{
+
+class IPlanBuilder
+{
+public:
+    virtual ~IPlanBuilder() = default;
+
+    virtual bool isApplicable(const HipdnnEnginePluginHandle& handle,
+                              const hipdnn_plugin_sdk::IGraph& opGraph) const
+        = 0;
+
+    virtual size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                                    const hipdnn_plugin_sdk::IGraph& opGraph) const
+        = 0;
+
+    virtual void buildPlan(const HipdnnEnginePluginHandle& handle,
+                           const hipdnn_plugin_sdk::IGraph& opGraph,
+                           HipdnnEnginePluginExecutionContext& executionContext) const
+        = 0;
+};
+}

--- a/dnn-providers/hipblaslt-provider/engines/plans/PlanInterface.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/PlanInterface.hpp
@@ -1,0 +1,25 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hipblaslt_plugin
+{
+
+class IPlan
+{
+public:
+    virtual ~IPlan() = default;
+
+    virtual size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle) const = 0;
+
+    virtual void execute(const HipdnnEnginePluginHandle& handle,
+                         const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                         uint32_t numDeviceBuffers,
+                         void* workspace = nullptr) const
+        = 0;
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/tests/CMakeLists.txt
+++ b/dnn-providers/hipblaslt-provider/tests/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+add_compile_definitions(__HIP_PLATFORM_AMD__)
+find_package(hip REQUIRED)
+find_package(Threads REQUIRED)
+
+if(NOT BUILD_PLUGIN_AS_DEPENDENCY)
+    find_package(hipdnn_test_sdk CONFIG REQUIRED)
+    find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+endif()
+
+add_executable(
+    hipblaslt_plugin_tests
+    engines/TestHipblasltEngine.cpp
+    main.cpp
+    TestHipblasltEngineManager.cpp
+    TestHipblasltEnginePluginApi.cpp
+    TestHipblasltHandleFactory.cpp
+    TestHipblasltHipdnnEnginePluginHandle.cpp
+    TestHipblasltHipdnnPluginExecutionContext.cpp
+    TestHipblasltPluginApi.cpp
+    TestHipblasltUtils.cpp
+)
+
+target_compile_options(hipblaslt_plugin_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+
+target_link_libraries(
+    hipblaslt_plugin_tests PUBLIC GTest::gtest GTest::gmock hip::host
+                                  hipblaslt_plugin_private hipdnn_test_sdk hipdnn_plugin_sdk Threads::Threads
+)
+
+# make it so tests inside folders can find the mocks folder without having to use a relative path.
+target_include_directories(hipblaslt_plugin_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_unit_test_target(hipblaslt_plugin_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltEngineManager.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltEngineManager.cpp
@@ -1,0 +1,198 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <memory>
+#include <set>
+
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
+#include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+
+#include "EngineManager.hpp"
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+#include "mocks/MockEngine.hpp"
+#include "mocks/MockHipdnnEnginePluginExecutionContext.hpp"
+
+using namespace hipblaslt_plugin;
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_plugin_sdk;
+using ::testing::Return;
+
+TEST(TestHipblasltEngineManager, ReturnsApplicableEngineIds)
+{
+    std::set<std::unique_ptr<IEngine>> engines;
+
+    auto mockEngine1 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine1, id()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mockEngine1, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(true));
+
+    auto mockEngine2 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine2, id()).WillRepeatedly(Return(2));
+    EXPECT_CALL(*mockEngine2, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(false));
+
+    EngineManager manager;
+    manager.addEngine(std::move(mockEngine1));
+    manager.addEngine(std::move(mockEngine2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    auto applicable = manager.getApplicableEngineIds(dummyHandle, mockGraph);
+
+    EXPECT_EQ(applicable.size(), 1);
+    EXPECT_EQ(applicable[0], 1);
+}
+
+TEST(TestHipblasltEngineManager, ReturnsMultipleApplicableEngineIds)
+{
+    std::set<std::unique_ptr<IEngine>> engines;
+
+    auto mockEngine1 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine1, id()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mockEngine1, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(true));
+
+    auto mockEngine2 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine2, id()).WillRepeatedly(Return(2));
+    EXPECT_CALL(*mockEngine2, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(true));
+
+    EngineManager manager;
+    manager.addEngine(std::move(mockEngine1));
+    manager.addEngine(std::move(mockEngine2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    auto applicable = manager.getApplicableEngineIds(dummyHandle, mockGraph);
+
+    EXPECT_EQ(applicable.size(), 2);
+    EXPECT_TRUE(std::find(applicable.begin(), applicable.end(), 1) != applicable.end());
+    EXPECT_TRUE(std::find(applicable.begin(), applicable.end(), 2) != applicable.end());
+}
+
+TEST(TestHipblasltEngineManager, ReturnsNoApplicableEngineIds)
+{
+    std::set<std::unique_ptr<IEngine>> engines;
+
+    auto mockEngine1 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine1, id()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mockEngine1, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(false));
+
+    auto mockEngine2 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine2, id()).WillRepeatedly(Return(2));
+    EXPECT_CALL(*mockEngine2, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(false));
+
+    EngineManager manager;
+    manager.addEngine(std::move(mockEngine1));
+    manager.addEngine(std::move(mockEngine2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    auto applicable = manager.getApplicableEngineIds(dummyHandle, mockGraph);
+
+    EXPECT_TRUE(applicable.empty());
+}
+
+TEST(TestHipblasltEngineManager, ReturnsEngineDetails)
+{
+    EngineManager manager;
+
+    hipdnnPluginConstData_t engineDetails;
+    engineDetails.ptr = reinterpret_cast<const void*>(0x12345678);
+    engineDetails.size = 200;
+    auto mockEngine = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine, id()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mockEngine, getDetails(::testing::_, ::testing::_))
+        .WillOnce([&engineDetails](HipdnnEnginePluginHandle& handle, hipdnnPluginConstData_t& out) {
+            (void)handle;
+            out.ptr = engineDetails.ptr;
+            out.size = engineDetails.size;
+        });
+
+    manager.addEngine(std::move(mockEngine));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle = {};
+    hipdnnPluginConstData_t details;
+    manager.getEngineDetails(dummyHandle, mockGraph, 1, details);
+
+    EXPECT_EQ(details.ptr, engineDetails.ptr);
+    EXPECT_EQ(details.size, engineDetails.size);
+}
+
+TEST(TestHipblasltEngineManager, ThrowsOnInvalidEngineId)
+{
+    EngineManager manager;
+
+    MockGraph mockGraph;
+    hipdnnPluginConstData_t engineDetails;
+
+    HipdnnEnginePluginHandle dummyHandle = {};
+    EXPECT_THROW(manager.getEngineDetails(dummyHandle, mockGraph, 999, engineDetails),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestHipblasltEngineManager, GetWorkspaceSizeReturnsCorrectValue)
+{
+    EngineManager manager;
+
+    auto mockEngine = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine, id()).WillRepeatedly(Return(42));
+    HipdnnEnginePluginHandle dummyHandle = {};
+    MockGraph mockGraph;
+    EXPECT_CALL(*mockEngine, getWorkspaceSize(::testing::_, ::testing::_)).WillOnce(Return(4096));
+
+    manager.addEngine(std::move(mockEngine));
+
+    size_t workspaceSize = manager.getWorkspaceSize(dummyHandle, 42, mockGraph);
+    EXPECT_EQ(workspaceSize, 4096);
+}
+
+TEST(TestHipblasltEngineManager, GetWorkspaceSizeThrowsOnInvalidEngineId)
+{
+    EngineManager manager;
+    HipdnnEnginePluginHandle dummyHandle = {};
+    MockGraph mockGraph;
+
+    EXPECT_THROW(manager.getWorkspaceSize(dummyHandle, 999, mockGraph),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestHipblasltEngineManager, InitializeExecutionContextCallsEngine)
+{
+    auto mockEngine = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine, id()).WillRepeatedly(Return(7));
+    EXPECT_CALL(*mockEngine, initializeExecutionContext(::testing::_, ::testing::_, ::testing::_))
+        .Times(1);
+
+    EngineManager manager;
+    manager.addEngine(std::move(mockEngine));
+    HipdnnEnginePluginHandle dummyHandle = {};
+    MockGraph mockGraph;
+    MockEngineConfig mockEngineConfig;
+    ON_CALL(mockEngineConfig, engineId()).WillByDefault(Return(7));
+    EXPECT_CALL(mockEngineConfig, engineId()).Times(testing::AnyNumber()); // Uninteresting call
+    MockHipdnnEnginePluginExecutionContext execCtx;
+
+    manager.initializeExecutionContext(dummyHandle, mockGraph, mockEngineConfig, execCtx);
+}
+
+TEST(TestHipblasltEngineManager, InitializeExecutionContextThrowsOnInvalidEngineId)
+{
+    MockHipdnnEnginePluginExecutionContext execCtx;
+    EngineManager manager;
+    HipdnnEnginePluginHandle dummyHandle = {};
+    MockGraph mockGraph;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_CALL(mockEngineConfig, engineId()).Times(testing::AnyNumber()); // Uninteresting call
+    EXPECT_THROW(
+        manager.initializeExecutionContext(dummyHandle, mockGraph, mockEngineConfig, execCtx),
+        hipdnn_plugin_sdk::HipdnnPluginException);
+}

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltEnginePluginApi.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltEnginePluginApi.cpp
@@ -1,0 +1,359 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include <HipblasltPlugin.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
+#include <hipdnn_plugin_sdk/EnginePluginApi.h>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+#include <hipdnn_plugin_sdk/PluginGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+#include "mocks/MockHipdnnEnginePluginExecutionContext.hpp"
+
+TEST(TestHipblasltEnginePluginApi, GetAllEngineIdsNull)
+{
+    std::array<int64_t, 1> engineIds = {0};
+    uint32_t numEngines = 0;
+
+    EXPECT_EQ(hipdnnEnginePluginGetAllEngineIdsImpl(nullptr, 0, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetAllEngineIdsImpl(nullptr, 1, &numEngines),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetAllEngineIdsImpl(engineIds.data(), 1, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, GetAllEngineIdsValid)
+{
+    std::array<int64_t, 1> engineIds = {0};
+    uint32_t numEngines = 0;
+
+    // get max 1 engine
+    auto status = hipdnnEnginePluginGetAllEngineIdsImpl(engineIds.data(), 1, &numEngines);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(numEngines, 1u);
+    EXPECT_EQ(engineIds[0], 1u);
+
+    status = hipdnnEnginePluginGetAllEngineIdsImpl(nullptr, 0, &numEngines);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(numEngines, 1u);
+}
+
+TEST(TestHipblasltEnginePluginApi, CreateNullHandle)
+{
+    EXPECT_EQ(hipdnnEnginePluginCreateImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, DestroyNullHandle)
+{
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, SetStreamNullHandle)
+{
+    EXPECT_EQ(hipdnnEnginePluginSetStreamImpl(nullptr, nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, GetApplicableEngineIdsNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto opGraph = reinterpret_cast<hipdnnPluginConstData_t*>(0x5678);
+    std::array<int64_t, 1> engineIds = {0};
+    uint32_t numEngines = 0;
+
+    EXPECT_EQ(hipdnnEnginePluginGetApplicableEngineIdsImpl(nullptr, nullptr, nullptr, 0, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetApplicableEngineIdsImpl(
+                  nullptr, opGraph, engineIds.data(), 1, &numEngines),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetApplicableEngineIdsImpl(
+                  handle, nullptr, engineIds.data(), 1, &numEngines),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(
+        hipdnnEnginePluginGetApplicableEngineIdsImpl(handle, opGraph, nullptr, 1, &numEngines),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(
+        hipdnnEnginePluginGetApplicableEngineIdsImpl(handle, opGraph, engineIds.data(), 1, nullptr),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, GetEngineDetailsNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto opGraph = reinterpret_cast<hipdnnPluginConstData_t*>(0x5678);
+    hipdnnPluginConstData_t engineDetailsOut;
+
+    EXPECT_EQ(hipdnnEnginePluginGetEngineDetailsImpl(nullptr, 1, nullptr, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetEngineDetailsImpl(nullptr, 1, opGraph, &engineDetailsOut),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetEngineDetailsImpl(handle, 1, nullptr, &engineDetailsOut),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetEngineDetailsImpl(handle, 1, opGraph, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, DestroyEngineDetailsNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    hipdnnPluginConstData_t engineDetailsOut;
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyEngineDetailsImpl(nullptr, &engineDetailsOut),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyEngineDetailsImpl(handle, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    engineDetailsOut.ptr = nullptr;
+    EXPECT_EQ(hipdnnEnginePluginDestroyEngineDetailsImpl(handle, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, GetWorkspaceSizeNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto engineConfig = reinterpret_cast<hipdnnPluginConstData_t*>(0x5678);
+    auto opGraph = reinterpret_cast<hipdnnPluginConstData_t*>(0x9abc);
+    size_t workspaceSize = 123;
+
+    // Null handle
+    EXPECT_EQ(
+        hipdnnEnginePluginGetWorkspaceSizeImpl(nullptr, engineConfig, opGraph, &workspaceSize),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null engineConfig
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeImpl(handle, nullptr, opGraph, &workspaceSize),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null opGraph
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeImpl(handle, engineConfig, nullptr, &workspaceSize),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null workspaceSize
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeImpl(handle, engineConfig, opGraph, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, CreateExecutionContextNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto engineConfig = reinterpret_cast<hipdnnPluginConstData_t*>(0x5678);
+    auto opGraph = reinterpret_cast<hipdnnPluginConstData_t*>(0x9abc);
+    hipdnnEnginePluginExecutionContext_t executionContext;
+
+    // Null handle
+    EXPECT_EQ(hipdnnEnginePluginCreateExecutionContextImpl(
+                  nullptr, engineConfig, opGraph, &executionContext),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null engineConfig
+    EXPECT_EQ(
+        hipdnnEnginePluginCreateExecutionContextImpl(handle, nullptr, opGraph, &executionContext),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null opGraph
+    EXPECT_EQ(hipdnnEnginePluginCreateExecutionContextImpl(
+                  handle, engineConfig, nullptr, &executionContext),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null executionContext
+    EXPECT_EQ(hipdnnEnginePluginCreateExecutionContextImpl(handle, engineConfig, opGraph, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, DestroyExecutionContextNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    MockHipdnnEnginePluginExecutionContext executionContext;
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyExecutionContextImpl(nullptr, &executionContext),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyExecutionContextImpl(handle, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipblasltEnginePluginApi, GetWorkspaceSizeFromExecutionContextNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto executionContext = reinterpret_cast<hipdnnEnginePluginExecutionContext_t>(0x5678);
+    size_t workspaceSize = 123;
+
+    // Null handle
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+                  nullptr, executionContext, &workspaceSize),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null executionContext
+    EXPECT_EQ(
+        hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(handle, nullptr, &workspaceSize),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null workspaceSize
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+                  handle, executionContext, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestGpuHipblasltEnginePluginApi, CreateAlsoCreatesHipblasltHandleOnSuccess)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+
+    auto status = hipdnnEnginePluginCreateImpl(&handle);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+    ASSERT_NE(handle->hipblasltHandle, nullptr);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipblasltEnginePluginApi, CreateTwiceGivesTheSameContainerHandle)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle1 = nullptr;
+    auto status1 = hipdnnEnginePluginCreateImpl(&handle1);
+
+    hipdnnEnginePluginHandle_t handle2 = nullptr;
+    auto status2 = hipdnnEnginePluginCreateImpl(&handle2);
+
+    EXPECT_EQ(status1, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(status2, HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    EXPECT_EQ(handle1->hipblasltContainer, handle2->hipblasltContainer);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle1), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle2), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipblasltEnginePluginApi, CreateNonNullHandlePointer)
+{
+    SKIP_IF_NO_DEVICES();
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto status = hipdnnEnginePluginCreateImpl(&handle);
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+    // Clean up
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipblasltEnginePluginApi, SetStreamNullStream)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    EXPECT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnEnginePluginSetStreamImpl(handle, nullptr), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    // Clean up
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipblasltEnginePluginApi, SetStreamValidStream)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    EXPECT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    hipStream_t stream = nullptr;
+    EXPECT_EQ(hipStreamCreate(&stream), hipSuccess);
+    EXPECT_EQ(hipdnnEnginePluginSetStreamImpl(handle, stream), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(handle->getStream(), stream);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipStreamDestroy(stream), hipSuccess);
+}
+
+TEST(TestGpuHipblasltEnginePluginApi, GetEngineDetailsValid)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
+    auto serializedGraph = builder.Release();
+    hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
+    hipdnnPluginConstData_t engineDetailsOut;
+
+    auto status = hipdnnEnginePluginGetEngineDetailsImpl(handle, 1, &opGraph, &engineDetailsOut);
+
+    hipdnn_plugin_sdk::EngineDetailsWrapper engineDetails(engineDetailsOut.ptr,
+                                                          engineDetailsOut.size);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(engineDetails.engineId(), 1);
+
+    // Clean up
+    EXPECT_EQ(hipdnnEnginePluginDestroyEngineDetailsImpl(handle, &engineDetailsOut),
+              HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipblasltEnginePluginApi, GetWorkspaceSizeValid)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    // Create a valid flatbuffer graph and engine config
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
+    auto serializedGraph = builder.Release();
+    hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
+
+    auto engineConfigBuilder = hipdnn_test_sdk::utilities::createValidEngineConfig(1);
+    auto serializedEngineConfig = engineConfigBuilder.Release();
+    hipdnnPluginConstData_t engineConfig
+        = hipdnn_plugin_sdk::createValidConstDataEngineConfig(serializedEngineConfig);
+
+    size_t workspaceSize = 0;
+    auto status
+        = hipdnnEnginePluginGetWorkspaceSizeImpl(handle, &engineConfig, &opGraph, &workspaceSize);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(workspaceSize, 0u);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipblasltEnginePluginApi, CreateExecutionContextValid)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
+    auto serializedGraph = builder.Release();
+    hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
+
+    auto engineConfigBuilder = hipdnn_test_sdk::utilities::createValidEngineConfig(1);
+    auto serializedEngineConfig = engineConfigBuilder.Release();
+    hipdnnPluginConstData_t engineConfig
+        = hipdnn_plugin_sdk::createValidConstDataEngineConfig(serializedEngineConfig);
+
+    hipdnnEnginePluginExecutionContext_t executionContext = nullptr;
+    auto status = hipdnnEnginePluginCreateExecutionContextImpl(
+        handle, &engineConfig, &opGraph, &executionContext);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    ASSERT_NE(executionContext, nullptr);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyExecutionContextImpl(handle, executionContext),
+              HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltHandleFactory.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltHandleFactory.cpp
@@ -1,0 +1,39 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <hipblaslt/hipblaslt.h>
+
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "HipblasltHandleFactory.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+
+using namespace hipblaslt_plugin;
+using namespace hipdnn_plugin_sdk;
+
+TEST(TestHipblasltHandleFactory, ThrowsOnNullHandle)
+{
+    EXPECT_THROW(HipblasltHandleFactory::createHipblasltHandle(nullptr), HipdnnPluginException);
+}
+
+TEST(TestHipblasltHandleFactory, ThrowsOnDestroyNullHandle)
+{
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    EXPECT_THROW(HipblasltHandleFactory::destroyHipblasltHandle(handle), HipdnnPluginException);
+}
+
+TEST(TestGpuHipblasltHandleFactory, CreatesAndDestroysHandle)
+{
+    SKIP_IF_NO_DEVICES();
+
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    EXPECT_NO_THROW(HipblasltHandleFactory::createHipblasltHandle(&handle));
+    ASSERT_NE(handle, nullptr);
+    ASSERT_NE(handle->hipblasltHandle, nullptr);
+
+    EXPECT_NO_THROW(HipblasltHandleFactory::destroyHipblasltHandle(handle));
+
+    delete handle;
+}

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltHipdnnEnginePluginHandle.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltHipdnnEnginePluginHandle.cpp
@@ -1,0 +1,92 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <flatbuffers/flatbuffers.h>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+
+#include "HipdnnEnginePluginHandle.hpp"
+
+class TestHipblasltHipdnnEnginePluginHandle : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        _handle = std::make_unique<HipdnnEnginePluginHandle>();
+    }
+
+    std::unique_ptr<HipdnnEnginePluginHandle> _handle;
+};
+
+TEST_F(TestHipblasltHipdnnEnginePluginHandle, DefaultConstruction)
+{
+    EXPECT_EQ(_handle->hipblasltHandle, nullptr);
+    EXPECT_EQ(_handle->hipblasltContainer, nullptr);
+    EXPECT_EQ(_handle->getStream(), nullptr);
+}
+
+TEST_F(TestHipblasltHipdnnEnginePluginHandle, StoreDetachedBuffer)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto createdString = builder.CreateString("test");
+    builder.Finish(createdString);
+    auto buffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
+    const void* ptr = reinterpret_cast<const void*>(0x12354);
+
+    _handle->storeEngineDetailsDetachedBuffer(ptr, std::move(buffer));
+
+    // Buffer should be stored, verify by trying to remove it
+    _handle->removeEngineDetailsDetachedBuffer(ptr);
+}
+
+TEST_F(TestHipblasltHipdnnEnginePluginHandle, RemoveDetachedBuffer)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto createdString = builder.CreateString("test");
+    builder.Finish(createdString);
+    auto buffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
+    const void* ptr = reinterpret_cast<const void*>(0x12354);
+
+    _handle->storeEngineDetailsDetachedBuffer(ptr, std::move(buffer));
+    _handle->removeEngineDetailsDetachedBuffer(ptr);
+
+    // Should not crash when removing non-existent buffer
+    _handle->removeEngineDetailsDetachedBuffer(ptr);
+}
+
+TEST_F(TestHipblasltHipdnnEnginePluginHandle, RemoveNonExistentBuffer)
+{
+    const void* fakePtr = reinterpret_cast<const void*>(0x12345678);
+
+    // Should not crash when removing non-existent buffer
+    EXPECT_NO_THROW(_handle->removeEngineDetailsDetachedBuffer(fakePtr));
+}
+
+TEST_F(TestHipblasltHipdnnEnginePluginHandle, MultipleBuffers)
+{
+    flatbuffers::FlatBufferBuilder builder1;
+    auto createdString1 = builder1.CreateString("test");
+    builder1.Finish(createdString1);
+    auto buffer1 = std::make_unique<flatbuffers::DetachedBuffer>(builder1.Release());
+    const void* ptr1 = reinterpret_cast<const void*>(0x12354);
+
+    flatbuffers::FlatBufferBuilder builder2;
+    auto createdString2 = builder2.CreateString("test2");
+    builder2.Finish(createdString2);
+    auto buffer2 = std::make_unique<flatbuffers::DetachedBuffer>(builder2.Release());
+    const void* ptr2 = reinterpret_cast<const void*>(0x54311);
+
+    _handle->storeEngineDetailsDetachedBuffer(ptr1, std::move(buffer1));
+    _handle->storeEngineDetailsDetachedBuffer(ptr2, std::move(buffer2));
+
+    _handle->removeEngineDetailsDetachedBuffer(ptr1);
+    _handle->removeEngineDetailsDetachedBuffer(ptr2);
+}
+
+TEST_F(TestHipblasltHipdnnEnginePluginHandle, SetStreamStoresStream)
+{
+    hipStream_t fakeStream = reinterpret_cast<hipStream_t>(0x123);
+
+    EXPECT_NO_THROW(_handle->setStream(fakeStream));
+    EXPECT_EQ(_handle->getStream(), fakeStream);
+}

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltHipdnnPluginExecutionContext.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltHipdnnPluginExecutionContext.cpp
@@ -1,0 +1,55 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+#include "mocks/MockPlan.hpp"
+
+using namespace hipblaslt_plugin;
+
+TEST(TestHipblasltHipdnnEnginePluginExecutionContext, SetAndGetPlan)
+{
+    HipdnnEnginePluginExecutionContext ctx;
+
+    auto mockPlan = std::make_unique<hipblaslt_plugin::MockPlan>();
+    auto* planPtr = mockPlan.get();
+    ctx.setPlan(std::move(mockPlan));
+
+    hipblaslt_plugin::IPlan& planRef = ctx.plan();
+
+    EXPECT_EQ(&planRef, planPtr);
+}
+
+TEST(TestHipblasltHipdnnEnginePluginExecutionContext, HasValidPlan)
+{
+    HipdnnEnginePluginExecutionContext ctx;
+
+    EXPECT_FALSE(ctx.hasValidPlan());
+
+    auto mockPlan = std::make_unique<hipblaslt_plugin::MockPlan>();
+    ctx.setPlan(std::move(mockPlan));
+
+    EXPECT_TRUE(ctx.hasValidPlan());
+}
+
+TEST(TestHipblasltHipdnnEnginePluginExecutionContext, GetPlanThrowsIfNotSet)
+{
+    HipdnnEnginePluginExecutionContext ctx;
+
+    EXPECT_THROW(ctx.plan(), hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestHipblasltHipdnnEnginePluginExecutionContext, GetWorkspaceSize)
+{
+    HipdnnEnginePluginExecutionContext ctx;
+
+    auto mockPlan = std::make_unique<hipblaslt_plugin::MockPlan>();
+    EXPECT_CALL(*mockPlan, getWorkspaceSize(::testing::_)).WillOnce(testing::Return(42));
+    ctx.setPlan(std::move(mockPlan));
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(ctx.plan().getWorkspaceSize(dummyHandle), 42);
+}

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltPluginApi.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltPluginApi.cpp
@@ -1,0 +1,78 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "hipdnn_plugin_sdk/PluginApi.h"
+#include <HipblasltPlugin.hpp>
+#include <array>
+#include <gtest/gtest.h>
+#include <iostream>
+
+namespace
+{
+void testLoggingCallback(hipdnnSeverity_t severity, const char* msg)
+{
+    (void)severity;
+    // std::cout << msg << "\n"; // uncomment to see formatted log messages during tests.
+    // It does not use the true callback yet since the plugin is not yet loaded.
+    (void)msg;
+}
+
+class TestHipblasltPluginApi : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_EQ(hipdnnPluginSetLoggingCallbackImpl(testLoggingCallback),
+                  HIPDNN_PLUGIN_STATUS_SUCCESS);
+    }
+};
+} // namespace
+
+TEST_F(TestHipblasltPluginApi, GetNameSuccess)
+{
+    const char* name = nullptr;
+    EXPECT_EQ(hipdnnPluginGetNameImpl(&name), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_STREQ(name, "hipblaslt_plugin");
+}
+
+TEST_F(TestHipblasltPluginApi, GetNameNullptr)
+{
+    EXPECT_EQ(hipdnnPluginGetNameImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestHipblasltPluginApi, GetVersionSuccess)
+{
+    const char* version = nullptr;
+    EXPECT_EQ(hipdnnPluginGetVersionImpl(&version), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_STREQ(version, "1.0.0");
+}
+
+TEST_F(TestHipblasltPluginApi, GetVersionNullptr)
+{
+    EXPECT_EQ(hipdnnPluginGetVersionImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestHipblasltPluginApi, GetTypeSuccess)
+{
+    hipdnnPluginType_t type;
+    EXPECT_EQ(hipdnnPluginGetTypeImpl(&type), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(type, HIPDNN_PLUGIN_TYPE_ENGINE);
+}
+
+TEST_F(TestHipblasltPluginApi, GetTypeNullptr)
+{
+    EXPECT_EQ(hipdnnPluginGetTypeImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestHipblasltPluginApi, GetLastErrorStringSuccess)
+{
+    const char* errorStr = nullptr;
+    hipdnnPluginGetLastErrorStringImpl(&errorStr);
+    ASSERT_NE(errorStr, nullptr);
+    EXPECT_GE(strlen(errorStr), 0u);
+}
+
+TEST_F(TestHipblasltPluginApi, GetLastErrorStringNullptr)
+{
+    EXPECT_NO_THROW(hipdnnPluginGetLastErrorStringImpl(nullptr));
+}

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltUtils.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltUtils.cpp
@@ -1,0 +1,30 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipblasltUtils.hpp"
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+using namespace hipblaslt_plugin;
+using namespace hipblaslt_utils;
+
+TEST(TestHipblasltUtils, TensorDataTypeToHipblasltDataType)
+{
+    using namespace hipdnn_data_sdk::data_objects;
+
+    EXPECT_EQ(hipblaslt_utils::tensorDataTypeToHipDataType(DataType::FLOAT), HIP_R_32F);
+    EXPECT_EQ(hipblaslt_utils::tensorDataTypeToHipDataType(DataType::INT32), HIP_R_32I);
+    EXPECT_EQ(hipblaslt_utils::tensorDataTypeToHipDataType(DataType::HALF), HIP_R_16F);
+    EXPECT_EQ(hipblaslt_utils::tensorDataTypeToHipDataType(DataType::BFLOAT16), HIP_R_16BF);
+    EXPECT_EQ(hipblaslt_utils::tensorDataTypeToHipDataType(DataType::INT8), HIP_R_8I);
+}
+
+TEST(TestHipblasltUtils, TensorDataTypeToHipblasltDataTypeThrowsOnUnsupported)
+{
+    // Use a value not in the enum
+    EXPECT_THROW(hipblaslt_utils::tensorDataTypeToHipDataType(
+                     static_cast<hipdnn_data_sdk::data_objects::DataType>(-1)),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}

--- a/dnn-providers/hipblaslt-provider/tests/engines/TestHipblasltEngine.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/engines/TestHipblasltEngine.cpp
@@ -1,0 +1,237 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <set>
+
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+
+#include "engines/HipblasltEngine.hpp"
+#include "mocks/MockHipdnnEnginePluginExecutionContext.hpp"
+#include "mocks/MockPlanBuilder.hpp"
+
+using namespace hipblaslt_plugin;
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_plugin_sdk;
+
+TEST(TestHipblasltEngine, ConstructorAndId)
+{
+    HipblasltEngine engine(42);
+    EXPECT_EQ(engine.id(), 42);
+}
+
+TEST(TestHipblasltEngine, WorkspaceSizeReturnsZeroIfNoPlanBuilders)
+{
+    HipblasltEngine engine(1);
+
+    MockGraph mockGraph;
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(engine.getWorkspaceSize(dummyHandle, mockGraph), 0u);
+}
+
+TEST(TestHipblasltEngine, WorkspaceSizeReturnsPlanBuilderWorkspace)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder, getWorkspaceSize(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(1337u));
+
+    HipblasltEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+
+    MockGraph mockGraph;
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(engine.getWorkspaceSize(dummyHandle, mockGraph), 1337u);
+}
+
+TEST(TestHipblasltEngine, WorkspaceSizeReturnsMaxPlanBuilderWorkspace)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder, getWorkspaceSize(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(1337u));
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder2, getWorkspaceSize(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(45000u));
+
+    HipblasltEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(engine.getWorkspaceSize(dummyHandle, mockGraph), 45000u);
+}
+
+TEST(TestHipblasltEngine, WorkspaceSizeReturnsZeroIfNoPlanBuilderApplicable)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+
+    HipblasltEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+
+    MockGraph mockGraph;
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(engine.getWorkspaceSize(dummyHandle, mockGraph), 0u);
+}
+
+TEST(TestHipblasltEngine, IsApplicableReturnsTrueIfAnyPlanBuilderApplicable)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+
+    HipblasltEngine engine(0);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+
+    MockGraph mockGraph;
+    auto graphBuilder = hipdnn_test_sdk::utilities::createEmptyValidGraph();
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_TRUE(engine.isApplicable(dummyHandle, mockGraph));
+}
+
+TEST(TestHipblasltEngine, IsApplicableReturnsAfterTheFirstApplicablePlanBuilder)
+{
+    auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    EXPECT_CALL(*mockPlanBuilder1, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_)).Times(0);
+
+    HipblasltEngine engine(0);
+    engine.addPlanBuilder(std::move(mockPlanBuilder1));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+    auto graphBuilder = hipdnn_test_sdk::utilities::createEmptyValidGraph();
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_TRUE(engine.isApplicable(dummyHandle, mockGraph));
+}
+
+TEST(TestHipblasltEngine, IsApplicableReturnsFalseIfNoPlanBuilders)
+{
+    HipblasltEngine engine(0);
+
+    MockGraph mockGraph;
+    auto graphBuilder = hipdnn_test_sdk::utilities::createEmptyValidGraph();
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_FALSE(engine.isApplicable(dummyHandle, mockGraph));
+}
+
+TEST(TestHipblasltEngine, IsApplicableReturnsFalseIfNoPlanBuilderApplicable)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+
+    HipblasltEngine engine(0);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+
+    MockGraph mockGraph;
+    auto graphBuilder = hipdnn_test_sdk::utilities::createEmptyValidGraph();
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_FALSE(engine.isApplicable(dummyHandle, mockGraph));
+}
+
+TEST(TestHipblasltEngine, GetDetailsReturnsSerializedEngineDetails)
+{
+    HipblasltEngine engine(1);
+    HipdnnEnginePluginHandle dummyHandle;
+
+    hipdnnPluginConstData_t result;
+    engine.getDetails(dummyHandle, result);
+
+    hipdnn_plugin_sdk::EngineDetailsWrapper engineDetails(result.ptr, result.size);
+    EXPECT_EQ(engineDetails.engineId(), 1);
+}
+
+TEST(TestHipblasltEngine, InitializeExecutionContextInvokesFirstApplicablePlanBuilder)
+{
+    auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    // Only the first plan builder is applicable
+    EXPECT_CALL(*mockPlanBuilder1, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder1, buildPlan(::testing::_, ::testing::_, ::testing::_)).Times(1);
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockPlanBuilder2, buildPlan(::testing::_, ::testing::_, ::testing::_)).Times(0);
+
+    HipblasltEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder1));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, ctx);
+}
+
+TEST(TestHipblasltEngine, InitializeExecutionContextSkipsNonApplicableBuilders)
+{
+    auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    // First plan builder not applicable, second is
+    EXPECT_CALL(*mockPlanBuilder1, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+    EXPECT_CALL(*mockPlanBuilder1, buildPlan(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder2, buildPlan(::testing::_, ::testing::_, ::testing::_)).Times(1);
+
+    HipblasltEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder1));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, ctx);
+}
+
+TEST(TestHipblasltEngine, InitializeExecutionContextDoesNotCallBuildPlanIfNoApplicableBuilders)
+{
+    auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    EXPECT_CALL(*mockPlanBuilder1, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+    EXPECT_CALL(*mockPlanBuilder1, buildPlan(::testing::_, ::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+    EXPECT_CALL(*mockPlanBuilder2, buildPlan(::testing::_, ::testing::_, ::testing::_)).Times(0);
+
+    HipblasltEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder1));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, ctx);
+}

--- a/dnn-providers/hipblaslt-provider/tests/main.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/main.cpp
@@ -1,0 +1,26 @@
+/*
+Copyright © Advanced Micro Devices, Inc., or its affiliates.
+SPDX-License-Identifier: MIT
+*/
+
+#include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
+#include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    hipdnn::logging::initializeCallbackLogging(COMPONENT_NAME,
+                                               hipdnn_test_sdk::utilities::testLoggingCallback);
+
+    // Register HipErrorHandler to check and clear HIP errors after each test
+    testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+    listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
+
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
+}

--- a/dnn-providers/hipblaslt-provider/tests/mocks/MockEngine.hpp
+++ b/dnn-providers/hipblaslt-provider/tests/mocks/MockEngine.hpp
@@ -1,0 +1,42 @@
+/*
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+*/
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+#include "engines/EngineInterface.hpp"
+
+namespace hipblaslt_plugin
+{
+
+class MockEngine : public IEngine
+{
+public:
+    MOCK_METHOD(int64_t, id, (), (const, override));
+    MOCK_METHOD(bool,
+                isApplicable,
+                (HipdnnEnginePluginHandle & handle, const hipdnn_plugin_sdk::IGraph& opGraph),
+                (const, override));
+    MOCK_METHOD(void,
+                getDetails,
+                (HipdnnEnginePluginHandle & handle, hipdnnPluginConstData_t& detailsOut),
+                (const, override));
+    MOCK_METHOD(size_t,
+                getWorkspaceSize,
+                (const HipdnnEnginePluginHandle& handle, const hipdnn_plugin_sdk::IGraph& opGraph),
+                (const, override));
+
+    MOCK_METHOD(void,
+                initializeExecutionContext,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnn_plugin_sdk::IGraph& opGraph,
+                 HipdnnEnginePluginExecutionContext& executionContext),
+                (const, override));
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/tests/mocks/MockHipdnnEnginePluginExecutionContext.hpp
+++ b/dnn-providers/hipblaslt-provider/tests/mocks/MockHipdnnEnginePluginExecutionContext.hpp
@@ -1,0 +1,25 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+
+#include "mocks/MockPlan.hpp"
+
+#include "HipdnnEnginePluginExecutionContext.hpp"
+
+struct MockHipdnnEnginePluginExecutionContext : public HipdnnEnginePluginExecutionContext
+{
+    MockHipdnnEnginePluginExecutionContext()
+        : mockPlan(std::make_unique<hipblaslt_plugin::MockPlan>())
+    {
+    }
+
+    hipblaslt_plugin::IPlan& plan() const override
+    {
+        return *mockPlan;
+    }
+
+    std::unique_ptr<hipblaslt_plugin::MockPlan> mockPlan;
+};

--- a/dnn-providers/hipblaslt-provider/tests/mocks/MockPlan.hpp
+++ b/dnn-providers/hipblaslt-provider/tests/mocks/MockPlan.hpp
@@ -1,0 +1,29 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include "engines/plans/PlanInterface.hpp"
+#include <gmock/gmock.h>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hipblaslt_plugin
+{
+
+class MockPlan : public IPlan
+{
+public:
+    MOCK_METHOD(size_t,
+                getWorkspaceSize,
+                (const HipdnnEnginePluginHandle& handle),
+                (const, override));
+    MOCK_METHOD(void,
+                execute,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                 uint32_t numDeviceBuffers,
+                 void* workspace),
+                (const, override));
+};
+
+}

--- a/dnn-providers/hipblaslt-provider/tests/mocks/MockPlanBuilder.hpp
+++ b/dnn-providers/hipblaslt-provider/tests/mocks/MockPlanBuilder.hpp
@@ -1,0 +1,35 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+
+#include "engines/plans/PlanBuilderInterface.hpp"
+
+namespace hipblaslt_plugin
+{
+
+class MockPlanBuilder : public IPlanBuilder
+{
+public:
+    MOCK_METHOD(bool,
+                isApplicable,
+                (const HipdnnEnginePluginHandle& handle, const hipdnn_plugin_sdk::IGraph& opGraph),
+                (const, override));
+    MOCK_METHOD(size_t,
+                getWorkspaceSize,
+                (const HipdnnEnginePluginHandle& handle, const hipdnn_plugin_sdk::IGraph& opGraph),
+                (const, override));
+
+    MOCK_METHOD(void,
+                buildPlan,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnn_plugin_sdk::IGraph& opGraph,
+                 HipdnnEnginePluginExecutionContext& executionContext),
+                (const, override));
+};
+
+}


### PR DESCRIPTION
## Motivation

hipBLASLt contains primitives for GEMM which can be used in hipDNN as a part of ALMIOPEN-824.
This PR adds skeleton of hipBLASLt kernel provider for hipDNN as first step of integration. The next steps will be support of GEMM and CI job.

## Technical Details

Implemented skeleton of hipBLASLt kernel provider for hipDNN to `dnn-providers` folder using miopen-legacy-plugin as example. For now, there are only base classes and implementation without any primitives.

Added clang-format as target for better experience: `cmake --build . --target format` or `cmake --build . --target check_format`.

## Test Plan

The PR contains the corresponding tests for each class in general. It's aligned with miopen plugin tests

## Test Result

The tests are successfully passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
