### PR TITLE
[hipblaslt] CMS 256x192x32 NN TF32

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Ailk_Bljk_S_MX_B_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Ailk_Bljk_S_MX_B_BiasS_HAS_SAV_UserArgs.yaml
@@ -28243,6 +28243,251 @@
     reorderGRInstForDTVB: false
     tailLoopOptA: false
     tailLoopOptB: false
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: true
+    ActivationFused: true
+    AssertAIGreaterThanEqual: -1
+    AssertAILessThanEqual: -1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BaseName: Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_BPDb1_95q49wpIAyy7rb6890KEVav-uG0pyZk06XsW0=
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    CUOccupancy: -1
+    ClusterLocalRead: 1
+    CodeObjectVersion: '4'
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DebugStreamK: 0
+    DepthU: 32
+    DirectToLds: true
+    DirectToLdsA: true
+    DirectToLdsB: true
+    DirectToVgprA: false
+    DirectToVgprB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: true
+    EnableMatrixInstruction: true
+    ExpandPointerSwap: 0
+    ExpertSchedulingMode: 0
+    ForceDisableShadowInit: false
+    ForceUnrollSubIter: true
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 4
+    GlobalReadVectorWidthB: 4
+    GlobalSplitU: 0
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GroupLoadStore: false
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [9, 5, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 2, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: false, UseSFC: false, UseUniversalArgs: true}
+    Kernel: true
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT192x256x32_MI16x16x1_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA0_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT6_8_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR0_PKA1_SIA3_SS1_SPO0_SRVW0_SSO0_SVW2_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA2_VWB4_WSGRA0_WSGRB0_WS64_WG32_8_1
+    LDSTrInst: false
+    LSCA: 192
+    LSCB: 32
+    LSPA: 6
+    LSPB: 32
+    LVCA: 48
+    LVCB: 8
+    LVPA: 2
+    LVPB: 8
+    LdsBlockSizePerPadA: 1024
+    LdsBlockSizePerPadB: 1024
+    LdsBlockSizePerPadMetadata: 0
+    LdsBytesNoAmax: 123904
+    LdsInitCVgprs: false
+    LdsNumBytes: 123904
+    LdsNumElementsAlignedA: 24576
+    LdsNumElementsAlignedB: 33792
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 65536
+    LdsOffsetB: 24576
+    LdsOffsetB_Blk: 90112
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 24576
+    LdsOffsetMetadata_Blk: 90112
+    LdsPadA: 0
+    LdsPadB: 8
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 4
+    LocalSplitU: 1
+    LocalSplitUReuseLDS: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: true
+    LocalWriteUseSgprB: true
+    LoopIters: 1
+    LoopUnroll: 32
+    MFMA_BF16_1K: false
+    MIArchVgpr: false
+    MIBlock: [16, 16, 32, 1, 1, 1]
+    MIInputPerThread: 8
+    MIInputPerThreadA: 8
+    MIInputPerThreadB: 8
+    MIInputPerThreadMetadata: 8
+    MIOutputVectorWidth: 4
+    MIRegPerOut: 1
+    MIWaveGroup: [2, 2]
+    MIWaveTile: [6, 8]
+    MIWaveTileA: 6
+    MIWaveTileB: 8
+    MIWaveTileMetadata: 0
+    MacroTile0: 192
+    MacroTile1: 256
+    MacroTileA: 192
+    MacroTileB: 256
+    MagicDivAlg: 2
+    MathClocksUnrolledLoop: 0
+    MatrixInstB: 1
+    MatrixInstBM: 1
+    MatrixInstBN: 1
+    MatrixInstK: 32
+    MatrixInstM: 16
+    MatrixInstN: 16
+    MatrixInstruction: [16, 16, 32, 1]
+    MaxLDS: 163840
+    MaxOccupancy: 40
+    MbskPrefetchMethod: 0
+    MfmaInitCVgprs: false
+    NoLdsWriteCode: true
+    NoReject: false
+    NoTailLoop: false
+    NonDTLTailLoopA: false
+    NonDTLTailLoopB: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 4
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NonTemporalWS: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 192
+    NumGlobalWriteVectorsPerThread: 96
+    NumLoadsA: 6
+    NumLoadsB: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 6
+    NumLoadsPerpendicularB: 8
+    NumThreads: 256
+    NumTotalPackedLoadsA: 6
+    NumTotalPackedLoadsB: 8
+    NumWaveSplitK: 1
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 2
+    PrefetchLocalRead: 0
+    PreloadKernArgs: true
+    SFCWGM:
+    - [1, 1]
+    - [1, 1]
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 3
+    ScheduleLocalWrite: 1
+    SolutionIndex: 118
+    SolutionNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT192x256x32_MI16x16x1_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GSUC0_GSUWGMRR0_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA0_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT6_8_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR0_PKA1_SIA3_SS1_SU0_SUM0_SUS128_SPO0_SRVW0_SSO0_SVW2_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA2_VWB4_WSGRA0_WSGRB0_WS64_WG32_8_1_WGM8_WGMXCC1_WGMXCCGn1
+    SourceSwap: 1
+    SpaceFillingAlgo: []
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 128
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSwapAddr: false
+    StoreSyncOpt: 0
+    StoreVectorWidth: 2
+    StreamK: 3
+    StreamKAtomic: 0
+    StreamKFixupTreeReduction: 0
+    StreamKXCCMapping: 0
+    SubGroup0: 8
+    SubGroup1: 32
+    SubGroupA: 8
+    SubGroupB: 32
+    SuppressNoLoadLoop: false
+    SwapGlobalReadOrder: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 24
+    ThreadTile1: 8
+    ThreadTileA: 24
+    ThreadTileB: 8
+    TransposeLDS: 1
+    TransposeLDSMetadata: true
+    ULSGRODoubleG2L: 0
+    UnrollLoopSwapGlobalReadOrder: 0
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: true
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseCustomMainLoopSchedule: 0
+    UseDirect32XEmulation: true
+    UseDot2F32XEmulation: false
+    UseDotInstruction: false
+    UseF32XEmulation: true
+    UseGeneralizedNLCOneA: true
+    UseGeneralizedNLCOneB: true
+    UseGeneralizedNLCOneMetadata: false
+    UseInstOffsetForGRO: 0
+    UseMFMAF32XEmulation: false
+    UsePLRPack: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 2
+    VectorWidthB: 4
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WaveSplitK: false
+    WavefrontSize: 64
+    WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingXCC: 1
+    WorkGroupMappingXCCGroup: -1
+    WorkGroupReduction: false
+    WorkspaceCheck: [4, 0, 0]
+    _DepthU: 32
+    _DepthUA: 32
+    _DepthUB: 32
+    _DepthUMetadata: 32
+    _GlobalAccumulation: PartialsBuffer
+    _UseSgprForGRO: 0
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 4
+    _staggerStrideShift: 0
+    enableGLTrA: false
+    enableGLTrB: false
+    enableLDSTrA: false
+    enableLDSTrB: false
+    numSubTiles: 2
+    reorderGRInstForDTVA: false
+    reorderGRInstForDTVB: false
+    tailLoopOptA: false
+    tailLoopOptB: false
 - [2, 3, 0, 1]
 - - - [4, 30, 8192, 128]
     - [60, 0.0]
@@ -28480,6 +28725,8 @@
     - [116, 0.0]
   - - [2048, 2048, 1, 8192]
     - [117, 0.0]
+  - - [4096, 3072, 1, 8192]
+    - [118, 0.0]
 - null
 - null
 - DeviceEfficiency

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Ailk_Bljk_S_MX_B_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Ailk_Bljk_S_MX_B_BiasS_HAS_SAV_UserArgs.yaml
@@ -28254,7 +28254,7 @@
     AssertSummationElementMultiple: 1
     AssignedDerivedParameters: true
     AssignedProblemIndependentDerivedParameters: true
-    BaseName: Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_BPDb1_95q49wpIAyy7rb6890KEVav-uG0pyZk06XsW0=
+    BaseName: Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_TN4M9ZX1lNgtloH_xXUR8R3YaQqbCadUQkAI1Z04Jsw=
     BufferLoad: true
     BufferStore: true
     CUCount: null
@@ -28285,7 +28285,7 @@
     GlobalSplitUAlgorithm: MultipleBuffer
     GlobalSplitUCoalesced: false
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
+    GlobalWriteVectorWidth: 1
     GroupLoadStore: false
     GuaranteeNoPartialA: false
     GuaranteeNoPartialB: true
@@ -28297,34 +28297,34 @@
       SupportUserGSU: false, UseSFC: false, UseUniversalArgs: true}
     Kernel: true
     KernelLanguage: Assembly
-    KernelNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT192x256x32_MI16x16x1_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA0_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT6_8_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR0_PKA1_SIA3_SS1_SPO0_SRVW0_SSO0_SVW2_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA2_VWB4_WSGRA0_WSGRB0_WS64_WG32_8_1
-    LDSTrInst: false
-    LSCA: 192
+    KernelNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT256x192x32_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GLS0_ISA950_IU1_K1_LDSTI1_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA0_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT8_6_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR0_PKA1_SIA3_SS1_SPO0_SRVW0_SSO0_SVW1_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA1_VWB2_WSGRA0_WSGRB0_WS64_WG32_8_1
+    LDSTrInst: true
+    LSCA: 256
     LSCB: 32
-    LSPA: 6
+    LSPA: 4
     LSPB: 32
-    LVCA: 48
+    LVCA: 64
     LVCB: 8
-    LVPA: 2
+    LVPA: 1
     LVPB: 8
     LdsBlockSizePerPadA: 1024
     LdsBlockSizePerPadB: 1024
     LdsBlockSizePerPadMetadata: 0
-    LdsBytesNoAmax: 123904
+    LdsBytesNoAmax: 123648
     LdsInitCVgprs: false
-    LdsNumBytes: 123904
-    LdsNumElementsAlignedA: 24576
-    LdsNumElementsAlignedB: 33792
+    LdsNumBytes: 123648
+    LdsNumElementsAlignedA: 32768
+    LdsNumElementsAlignedB: 25344
     LdsNumElementsAlignedMetadata: 0
     LdsOffsetA: 0
     LdsOffsetA_Blk: 65536
-    LdsOffsetB: 24576
-    LdsOffsetB_Blk: 90112
+    LdsOffsetB: 32768
+    LdsOffsetB_Blk: 98304
     LdsOffsetBias: 0
     LdsOffsetBiasGSU: 0
     LdsOffsetBiasNonGSU: 0
-    LdsOffsetMetadata: 24576
-    LdsOffsetMetadata_Blk: 90112
+    LdsOffsetMetadata: 32768
+    LdsOffsetMetadata_Blk: 98304
     LdsPadA: 0
     LdsPadB: 8
     LdsPadMetadata: 0
@@ -28346,14 +28346,14 @@
     MIOutputVectorWidth: 4
     MIRegPerOut: 1
     MIWaveGroup: [2, 2]
-    MIWaveTile: [6, 8]
-    MIWaveTileA: 6
-    MIWaveTileB: 8
+    MIWaveTile: [8, 6]
+    MIWaveTileA: 8
+    MIWaveTileB: 6
     MIWaveTileMetadata: 0
-    MacroTile0: 192
-    MacroTile1: 256
-    MacroTileA: 192
-    MacroTileB: 256
+    MacroTile0: 256
+    MacroTile1: 192
+    MacroTileA: 256
+    MacroTileB: 192
     MagicDivAlg: 2
     MathClocksUnrolledLoop: 0
     MatrixInstB: 1
@@ -28366,7 +28366,7 @@
     MaxLDS: 163840
     MaxOccupancy: 40
     MbskPrefetchMethod: 0
-    MfmaInitCVgprs: false
+    MfmaInitCVgprs: true
     NoLdsWriteCode: true
     NoReject: false
     NoTailLoop: false
@@ -28382,16 +28382,16 @@
     NonTemporalWS: 0
     NumElementsPerBatchStore: 0
     NumElementsPerThread: 192
-    NumGlobalWriteVectorsPerThread: 96
-    NumLoadsA: 6
-    NumLoadsB: 8
+    NumGlobalWriteVectorsPerThread: 192
+    NumLoadsA: 8
+    NumLoadsB: 6
     NumLoadsCoalescedA: 1
     NumLoadsCoalescedB: 1
-    NumLoadsPerpendicularA: 6
-    NumLoadsPerpendicularB: 8
+    NumLoadsPerpendicularA: 8
+    NumLoadsPerpendicularB: 6
     NumThreads: 256
-    NumTotalPackedLoadsA: 6
-    NumTotalPackedLoadsB: 8
+    NumTotalPackedLoadsA: 8
+    NumTotalPackedLoadsB: 6
     NumWaveSplitK: 1
     OptNoLoadLoop: 1
     PackedC0IdxChars: [I]
@@ -28408,7 +28408,7 @@
     ScheduleIterAlg: 3
     ScheduleLocalWrite: 1
     SolutionIndex: 118
-    SolutionNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT192x256x32_MI16x16x1_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GSUC0_GSUWGMRR0_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA0_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT6_8_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR0_PKA1_SIA3_SS1_SU0_SUM0_SUS128_SPO0_SRVW0_SSO0_SVW2_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA2_VWB4_WSGRA0_WSGRB0_WS64_WG32_8_1_WGM8_WGMXCC1_WGMXCCGn1
+    SolutionNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT256x192x32_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GSUC0_GSUWGMRR0_GLS0_ISA950_IU1_K1_LDSTI1_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA0_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT8_6_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR0_PKA1_SIA3_SS1_SU0_SUM0_SUS128_SPO0_SRVW0_SSO0_SVW1_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA1_VWB2_WSGRA0_WSGRB0_WS64_WG32_8_1_WGM8_WGMXCC1_WGMXCCGn1
     SourceSwap: 1
     SpaceFillingAlgo: []
     StaggerU: 0
@@ -28418,7 +28418,7 @@
     StoreRemapVectorWidth: 0
     StoreSwapAddr: false
     StoreSyncOpt: 0
-    StoreVectorWidth: 2
+    StoreVectorWidth: 1
     StreamK: 3
     StreamKAtomic: 0
     StreamKFixupTreeReduction: 0
@@ -28430,10 +28430,10 @@
     SuppressNoLoadLoop: false
     SwapGlobalReadOrder: false
     ThreadTile: [1, 1]
-    ThreadTile0: 24
-    ThreadTile1: 8
-    ThreadTileA: 24
-    ThreadTileB: 8
+    ThreadTile0: 32
+    ThreadTile1: 6
+    ThreadTileA: 32
+    ThreadTileB: 6
     TransposeLDS: 1
     TransposeLDSMetadata: true
     ULSGRODoubleG2L: 0
@@ -28442,7 +28442,7 @@
     UnrollMajorLDSB: true
     UnrollMajorLDSMetadata: true
     Use64bShadowLimit: 1
-    UseCustomMainLoopSchedule: 0
+    UseCustomMainLoopSchedule: true
     UseDirect32XEmulation: true
     UseDot2F32XEmulation: false
     UseDotInstruction: false
@@ -28451,13 +28451,13 @@
     UseGeneralizedNLCOneB: true
     UseGeneralizedNLCOneMetadata: false
     UseInstOffsetForGRO: 0
-    UseMFMAF32XEmulation: false
-    UsePLRPack: false
+    UseMFMAF32XEmulation: true
+    UsePLRPack: true
     UseSgprForGRO: 0
     Valid: true
     VectorStore: -1
-    VectorWidthA: 2
-    VectorWidthB: 4
+    VectorWidthA: 1
+    VectorWidthB: 2
     WaveSeparateGlobalReadA: 0
     WaveSeparateGlobalReadB: 0
     WaveSeparateGlobalReadMetadata: 0

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -2783,6 +2783,174 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
         syncCode = syncTable[1::2]
         nglshift = nllshift = 14 # vmcnt shift for ngl and nll
         opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
+
+    elif isNN(kernel) and TLDS==1:
+        kernel["UsePLRPack"] = True
+        kernel["UseMFMAF32XEmulation"] = True
+        
+        numLrReadA = 32 
+        numLrReadB = 6
+
+        # mfma Reordering
+        mfmaReorder = [i for i in range(0,numMfma//4)] + [i for i in range(numMfma//2,3*numMfma//4)]+[i for i in range(numMfma//4,numMfma//2)]+[i for i in range(3*numMfma//4,numMfma)]
+
+        # Interleaving of LBR0 and GRINCB to hide LRB0 latency
+        lrb0 = create_range(min_val = 0, num = 6, step = 1, repeat = 1)
+        grIncB = create_range(min_val = max(lrb0)+1, num = 3, step = 1, repeat = 3)
+        grIncA = create_range(min_val = max(grIncB)+1, num = 3, step = 1, repeat = 3)
+        waitLRB0 = max(grIncA)
+
+        # PackB0 using mfma4x4x4_16b
+        startPACKB0 = waitLRB0
+        packBOffset = [ 
+                   0, 0, 1, 1, 
+                   6, 6,
+                   7, 7, 8, 8,
+
+                   2, 2, 3, 3, 
+                   6, 6,
+                   9, 9, 10, 10,
+
+                   4, 4, 5, 5, 
+                   6, 6,
+                   11, 11, 12, 12,
+                   ]
+
+        packB0 = [x + startPACKB0 for x in packBOffset]
+        packB0Done = max(packB0)
+
+        # Sanity check
+        assert packB0Done < numMfma//4, f"packB0Done {packB0Done} >= numMfma//4 {numMfma//4}"
+
+        # GRB (1st block) interleaved with LRA0
+        grB = [create_range(min_val = packB0Done+2,num = 3,step = 4, repeat = 2),
+               create_range(min_val = packB0Done+1,num = 3,step = 4, repeat = 2)]
+       
+        # LRA0 
+        lra0 = [create_range(min_val = max(packB0)+1, num = numLrReadA // 2, step = 2, repeat = 2),
+                create_range(min_val = max(packB0)+2, num = numLrReadA // 2, step = 2, repeat = 2)]
+       
+        # PackA0
+        waitLRA0 = max(lra0[1])
+        startPACKA0 = waitLRA0
+
+        packAOffset = [ 
+            0, 0, 1, 1, 
+            8, 8,
+            9, 9, 10, 10,
+
+            2, 2, 3, 3, 
+            8, 8,
+            11, 11, 12, 12,
+
+            4, 4, 5, 5, 
+            8, 8,
+            13, 13, 14, 14,
+
+            6, 6, 7, 7, 
+            8, 8,
+            15, 15, 16, 16,
+            ]
+        packA0 = [x + startPACKA0 for x in packAOffset]
+
+        halfMFMA = numMfma//2
+        assert max(packA0) < halfMFMA, f"max(packA0) {max(packA0)} >= halfMFMA {halfMFMA}"
+
+        # LRA3 interleaved with GRB (2nd half)
+        startLRA3 = halfMFMA
+        lra3 = [create_range(min_val = startLRA3, num = numLrReadA // 2, step = 2, repeat = 2),
+                create_range(min_val = startLRA3+1, num = numLrReadA // 2, step = 2, repeat = 2)]
+        grB[0] += create_range(min_val = startLRA3+1,num = 3,step = 2, repeat = 2)
+        grB[1] += create_range(min_val = startLRA3,num = 3,step = 2, repeat = 2)
+        # waitLRA3 = max(lra3[1])+6  
+    
+        # LRB3 + PACKA3 & PACKB3
+        startLRB3 = (3*numMfma)//4 - 4 # Starts 4 indexes before 3/4 MFMAs to accommodate LRB3 latency
+        lrb3 = create_range(min_val = startLRB3,num=numLrReadB - 2,step=1,repeat=1)
+        grA = [create_range(min_val = min(lrb3)+1, num = 8, step = 1,repeat = 1),
+               create_range(min_val = min(lrb3)+3, num = 8, step = 1,repeat = 1)]
+        lrb3 += create_range(min_val = max(lrb3)+3,num=2,step=1,repeat=1)
+        
+        waitLRB3 = max(lrb3) + 9 
+
+        # Grouping segment of 4x4x4_16B MFMAs together for PackB3 & PackA3 (reduce MFMA type switching cost)
+        packB3 = [x + waitLRB3 for x in packBOffset]
+        start_4x4x4 = packB3[4] # 5th index is start of 4x4x4_16B MFMA for PackB3
+        waitLRA3 = max(lrb3)+1
+        packA3 = [ 
+                   *create_range(min_val = waitLRA3, num = 2, step = 1, repeat = 2),
+                   start_4x4x4,start_4x4x4,
+                   *create_range(min_val = max(packB3)+1, num = 2, step = 1, repeat = 2),
+
+                   *create_range(min_val = waitLRA3+2, num = 2, step = 1, repeat = 2),
+                   start_4x4x4,start_4x4x4,
+                   *create_range(min_val = max(packB3)+3, num = 2, step = 1, repeat = 2),
+
+                   *create_range(min_val = waitLRA3+4, num = 2, step = 1, repeat = 2),
+                   start_4x4x4,start_4x4x4,
+                   *create_range(min_val = max(packB3)+5, num = 2, step = 1, repeat = 2),
+
+                   *create_range(min_val = waitLRA3+6, num = 2, step = 1, repeat = 2),
+                   start_4x4x4,start_4x4x4,
+                   *create_range(min_val = max(packB3)+7, num = 2, step = 1, repeat = 2),
+                   ]
+
+        # GRA 2nd half
+        grA[0] += create_range(min_val = max(packB3)+1, num = 4, step = 1,repeat = 2)
+        grA[1] += create_range(min_val = max(packB3)+1, num = 4, step = 1,repeat = 2)
+
+        syncTable = [                                      
+                    waitLRB0, SWaitCnt(dscnt=4, vlcnt=-1, vscnt=-1, comment="Wait for 4/8 LRB0 to complete"),
+                    waitLRB0+4, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for all LRB0 to complete"),
+                    waitLRB0+4, SBarrier(comment="Barrier before GRB"), 
+
+                    
+                    waitLRA0, SWaitCnt(dscnt=min(15,numLrReadA-4), vlcnt=-1, vscnt=-1, comment="Wait for 4 LRA0 to complete"),
+                    # waitLRA0+1, SWaitCnt(dscnt=min(15,numLrReadA-8), vlcnt=-1, vscnt=-1, comment="Wait for 8 LRA0 to complete"),
+                    # waitLRA0+2, SWaitCnt(dscnt=min(15,numLrReadA-12), vlcnt=-1, vscnt=-1, comment="Wait for 12 LRA0 to complete"),
+                    # waitLRA0+3, SWaitCnt(dscnt=min(15,numLrReadA-16), vlcnt=-1, vscnt=-1, comment="Wait for 16 LRA0 to complete"),
+                    waitLRA0+4, SWaitCnt(dscnt=min(15,numLrReadA-20), vlcnt=-1, vscnt=-1, comment="Wait for 20 LRA0 to complete"),
+                    waitLRA0+5, SWaitCnt(dscnt=min(15,numLrReadA-24), vlcnt=-1, vscnt=-1, comment="Wait for 24 LRA0 to complete"),
+                    waitLRA0+6, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0 to complete"),
+
+                    startLRA3-1,SWaitCnt(dscnt=-1, vlcnt=3, vscnt=-1, comment="Wait for previous GRA&B"),
+                    startLRA3-1,SBarrier(comment="Sync before GRA, LRA3 & LRB3"),
+
+                    # incremental wait on LRA3
+                    waitLRA3, SWaitCnt(dscnt=15, vlcnt=-1, vscnt=-1, comment="Wait for half LRA3 to complete"),                    
+                    waitLRA3+7, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA3/LRB3 to complete"),                    
+
+                    ]
+
+        syncCode = syncTable[1::2]
+        optSchedule = {
+
+            'SYNC': [syncTable[::2]],
+
+            'GRIncA': [grIncA],
+            'GRIncB': [grIncB],
+            'LRA0': [*lra0],
+            'LRB0': [lrb0],
+            'PackA0' : [packA0],
+            'PackB0' : [packB0],
+            'GRA': [*grA],
+            'GRB': [*grB],              
+            'LRSA': [[max(lra0[1])+1]],
+            'LRSB': [[max(lra0[1])+1]],
+            'LWSA': [[numMfma-2]],
+            'LWSB': [[numMfma-2]],
+            'LCC': [[numMfma-1, numMfma-1]],
+            'LRA3': [*lra3],
+            'LRB3': [lrb3],
+            'PackB3' : [packB3],
+            'PackA3' : [packA3],
+
+        }
+
+        nglshift = nllshift = 14
+        opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift, mfmaReorder=mfmaReorder)
+        # opt1.disableValidation()
+    
     else:
         return False, None
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -2796,10 +2796,12 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
 
         # Interleaving of LBR0 and GRINCB to hide LRB0 latency
         lrb0 = create_range(min_val = 0, num = 6, step = 1, repeat = 1)
-        grIncB = create_range(min_val = max(lrb0)+1, num = 3, step = 1, repeat = 3)
+        grIncB = create_range(min_val = 0, num = 6, step = 1, repeat = 1)
+        grIncB += create_range(min_val = max(lrb0)+1, num = 1, step = 1, repeat = 3)
         
-        grIncA = create_range(min_val = max(grIncB)+1, num = 3, step = 1, repeat = 3)
+        grIncA = create_range(min_val = max(grIncB)+1, num = 2, step = 1, repeat = 3)
         waitLRB0 = max(grIncA)
+        grIncA += create_range(min_val = max(grIncA)+2, num = 3, step = 1, repeat = 1)
 
         # PackB0 using mfma4x4x4_16b
         startPACKB0 = waitLRB0
@@ -2832,7 +2834,7 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
                 create_range(min_val = max(packB0)+2, num = numLrReadA // 2, step = 2, repeat = 2)]
        
         # PackA0
-        waitLRA0 = max(lra0[1])
+        waitLRA0 = max(lra0[1])+1
         startPACKA0 = waitLRA0
 
         packAOffset = [ 
@@ -2861,13 +2863,18 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
         startLRA3 = halfMFMA
         lra3 = [create_range(min_val = startLRA3+1, num = numLrReadA // 2, step = 2, repeat = 2),
                 create_range(min_val = startLRA3, num = numLrReadA // 2, step = 2, repeat = 2)]
-        grB[0] += create_range(min_val = startLRA3,num = 3,step = 2, repeat = 2)
-        grB[1] += create_range(min_val = startLRA3+1,num = 3,step = 2, repeat = 2)
+
+        grB[0] += [startLRA3-2,startLRA3]
+        grB[1] += [startLRA3-2,startLRA3+1]
+
+        grB[0] += create_range(min_val = startLRA3+2,num = 2,step = 2, repeat = 2)
+        grB[1] += create_range(min_val = startLRA3+3,num = 2,step = 2, repeat = 2)
         # waitLRA3 = max(lra3[1])+6  
     
         # LRB3 + PACKA3 & PACKB3
         startLRB3 = (3*numMfma)//4 - 4 # Starts 4 indexes before 3/4 MFMAs to accommodate LRB3 latency
         lrb3 = create_range(min_val = startLRB3,num=numLrReadB - 2,step=1,repeat=1)
+        
         grA = [create_range(min_val = max(lra3[0])+1, num = 8, step = 1,repeat = 1),
                create_range(min_val = max(lra3[1])+1, num = 8, step = 1,repeat = 1)]
         lrb3 += create_range(min_val = max(lrb3)+3,num=2,step=1,repeat=1)
@@ -2880,19 +2887,19 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
         waitLRA3 = max(lrb3)+1
         packA3 = [ 
                    *create_range(min_val = waitLRA3, num = 2, step = 1, repeat = 2),
-                   start_4x4x4,start_4x4x4,
+                   start_4x4x4, start_4x4x4,
                    *create_range(min_val = max(packB3)+1, num = 2, step = 1, repeat = 2),
 
                    *create_range(min_val = waitLRA3+2, num = 2, step = 1, repeat = 2),
-                   start_4x4x4,start_4x4x4,
+                   start_4x4x4, start_4x4x4,
                    *create_range(min_val = max(packB3)+3, num = 2, step = 1, repeat = 2),
 
                    *create_range(min_val = waitLRA3+4, num = 2, step = 1, repeat = 2),
-                   start_4x4x4,start_4x4x4,
+                   start_4x4x4, start_4x4x4,
                    *create_range(min_val = max(packB3)+5, num = 2, step = 1, repeat = 2),
 
                    *create_range(min_val = waitLRA3+6, num = 2, step = 1, repeat = 2),
-                   start_4x4x4,start_4x4x4,
+                   start_4x4x4, start_4x4x4,
                    *create_range(min_val = max(packB3)+7, num = 2, step = 1, repeat = 2),
                    ]
 
@@ -2901,9 +2908,11 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
         grA[1] += create_range(min_val = max(packB3)+1, num = 4, step = 1,repeat = 2)
 
         syncTable = [                                      
-                    waitLRB0, SWaitCnt(dscnt=4, vlcnt=-1, vscnt=-1, comment="Wait for 4/8 LRB0 to complete"),
-                    waitLRB0+4, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for all LRB0 to complete"),
-                    waitLRB0+4, SBarrier(comment="Barrier before GRB"), 
+                    waitLRB0, SWaitCnt(dscnt=6, vlcnt=-1, vscnt=-1, comment="Wait for 4/8 LRB0 to complete"),
+                    waitLRB0+4, SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="Wait for all LRB0 to complete"),
+                    waitLRB0+5, SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="Wait for all LRB0 to complete"),
+                    waitLRB0+6, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for all LRB0 to complete"),
+                    waitLRB0+6, SBarrier(comment="Barrier before GRB"), 
 
                     
                     waitLRA0, SWaitCnt(dscnt=min(15,numLrReadA-4), vlcnt=-1, vscnt=-1, comment="Wait for 4 LRA0 to complete"),
@@ -2932,12 +2941,12 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
             'GRIncB': [grIncB],
             'LRA0': [*lra0],
             'LRB0': [lrb0],
+            'LRSA': [[packA0[4]]],
+            'LRSB': [[packA0[4]]],
             'PackA0' : [packA0],
             'PackB0' : [packB0],
             'GRA': [*grA],
             'GRB': [*grB],              
-            'LRSA': [[max(lra0[1])+1]],
-            'LRSB': [[max(lra0[1])+1]],
             'LWSA': [[numMfma-2]],
             'LWSB': [[numMfma-2]],
             'LCC': [[numMfma-1, numMfma-1]],

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -2907,11 +2907,13 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
         grA[1] += create_range(min_val = max(packB3)+1, num = 4, step = 1,repeat = 2)
 
         syncTable = [                                      
-                    waitLRB0, SWaitCnt(dscnt=6, vlcnt=-1, vscnt=-1, comment="Wait for 4/8 LRB0 to complete"),
-                    waitLRB0+4, SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="Wait for all LRB0 to complete"),
-                    waitLRB0+5, SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="Wait for all LRB0 to complete"),
-                    waitLRB0+6, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for all LRB0 to complete"),
-                    waitLRB0+6, SBarrier(comment="Barrier before GRB"), 
+                    waitLRB0, SWaitCnt(dscnt=5, vlcnt=-1, vscnt=-1, comment="Wait for 1/6 LRB0 to complete"),
+                    waitLRB0+1, SWaitCnt(dscnt=4, vlcnt=-1, vscnt=-1, comment="Wait for 2/6 LRB0 to complete"),
+                    waitLRB0+2, SWaitCnt(dscnt=3, vlcnt=-1, vscnt=-1, comment="Wait for 3/6 LRB0 to complete"),
+                    waitLRB0+3, SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="Wait for 4/6 LRB0 to complete"),
+                    waitLRB0+4, SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="Wait for 5/6 LRB0 to complete"),
+                    waitLRB0+5, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for 6/6 LRB0 to complete"),
+                    waitLRB0+5, SBarrier(comment="Barrier before GRB"), 
 
                     # incremental wait on LRA0
                     waitLRA0, SWaitCnt(dscnt=min(15,numLrReadA-4), vlcnt=-1, vscnt=-1, comment="Wait for 4 LRA0 to complete"),
@@ -2923,8 +2925,9 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
                     startLRA3-1,SBarrier(comment="Sync before GRA, LRA3 & LRB3"),
 
                     # incremental wait on LRA3 & LRB3
-                    waitLRA3, SWaitCnt(dscnt=15, vlcnt=-1, vscnt=-1, comment="Wait for half LRA3 to complete"),                    
-                    waitLRA3+7, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA3/LRB3 to complete"),                    
+                    waitLRA3, SWaitCnt(dscnt=15, vlcnt=-1, vscnt=-1, comment="Wait for 17/32 LRA3 to complete"),         
+                    waitLRA3+4, SWaitCnt(dscnt=6, vlcnt=-1, vscnt=-1, comment="Wait for LRA3 to complete"),                    
+                    waitLRA3+7, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB3 to complete"),                    
 
                     ]
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -2694,7 +2694,6 @@ def _get_schedule_192x256x32_TF32(kernel, useLDSTr, TLDS):
     mfma_wave_group=[2, 2]
 )
 def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
-    # print('kernel', kernel)
     kernel["MfmaInitCVgprs"] = True
     numMfma = 144
     optSchedule = dict()
@@ -2794,16 +2793,16 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
         # mfma Reordering
         mfmaReorder = [i for i in range(0,numMfma//4)] + [i for i in range(numMfma//2,3*numMfma//4)]+[i for i in range(numMfma//4,numMfma//2)]+[i for i in range(3*numMfma//4,numMfma)]
 
-        # Interleaving of LBR0 and GRINCB to hide LRB0 latency
+        # Interleave LBR0 and GRINCB
         lrb0 = create_range(min_val = 0, num = 6, step = 1, repeat = 1)
         grIncB = create_range(min_val = 0, num = 6, step = 1, repeat = 1)
         grIncB += create_range(min_val = max(lrb0)+1, num = 1, step = 1, repeat = 3)
         
+        # Interleave GRINCA and PACKB0
         grIncA = create_range(min_val = max(grIncB)+1, num = 2, step = 1, repeat = 3)
         waitLRB0 = max(grIncA)
         grIncA += create_range(min_val = max(grIncA)+2, num = 3, step = 1, repeat = 1)
 
-        # PackB0 using mfma4x4x4_16b
         startPACKB0 = waitLRB0
         packBOffset = [ 
                    0, 0, 1, 1, 
@@ -2864,13 +2863,13 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
         lra3 = [create_range(min_val = startLRA3+1, num = numLrReadA // 2, step = 2, repeat = 2),
                 create_range(min_val = startLRA3, num = numLrReadA // 2, step = 2, repeat = 2)]
 
+        # M0 update before barrier to prevent bad interleaving between the 2 codepaths
         grB[0] += [startLRA3-2,startLRA3]
         grB[1] += [startLRA3-2,startLRA3+1]
 
         grB[0] += create_range(min_val = startLRA3+2,num = 2,step = 2, repeat = 2)
         grB[1] += create_range(min_val = startLRA3+3,num = 2,step = 2, repeat = 2)
-        # waitLRA3 = max(lra3[1])+6  
-    
+        
         # LRB3 + PACKA3 & PACKB3
         startLRB3 = (3*numMfma)//4 - 4 # Starts 4 indexes before 3/4 MFMAs to accommodate LRB3 latency
         lrb3 = create_range(min_val = startLRB3,num=numLrReadB - 2,step=1,repeat=1)
@@ -2914,19 +2913,16 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
                     waitLRB0+6, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for all LRB0 to complete"),
                     waitLRB0+6, SBarrier(comment="Barrier before GRB"), 
 
-                    
+                    # incremental wait on LRA0
                     waitLRA0, SWaitCnt(dscnt=min(15,numLrReadA-4), vlcnt=-1, vscnt=-1, comment="Wait for 4 LRA0 to complete"),
-                    # waitLRA0+1, SWaitCnt(dscnt=min(15,numLrReadA-8), vlcnt=-1, vscnt=-1, comment="Wait for 8 LRA0 to complete"),
-                    # waitLRA0+2, SWaitCnt(dscnt=min(15,numLrReadA-12), vlcnt=-1, vscnt=-1, comment="Wait for 12 LRA0 to complete"),
-                    # waitLRA0+3, SWaitCnt(dscnt=min(15,numLrReadA-16), vlcnt=-1, vscnt=-1, comment="Wait for 16 LRA0 to complete"),
-                    waitLRA0+4, SWaitCnt(dscnt=min(15,numLrReadA-20), vlcnt=-1, vscnt=-1, comment="Wait for 20 LRA0 to complete"),
-                    waitLRA0+5, SWaitCnt(dscnt=min(15,numLrReadA-24), vlcnt=-1, vscnt=-1, comment="Wait for 24 LRA0 to complete"),
+                    waitLRA0+4, SWaitCnt(dscnt=numLrReadA-20, vlcnt=-1, vscnt=-1, comment="Wait for 20 LRA0 to complete"),
+                    waitLRA0+5, SWaitCnt(dscnt=numLrReadA-24, vlcnt=-1, vscnt=-1, comment="Wait for 24 LRA0 to complete"),
                     waitLRA0+6, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0 to complete"),
 
                     startLRA3-1,SWaitCnt(dscnt=-1, vlcnt=3, vscnt=-1, comment="Wait for previous GRA&B"),
                     startLRA3-1,SBarrier(comment="Sync before GRA, LRA3 & LRB3"),
 
-                    # incremental wait on LRA3
+                    # incremental wait on LRA3 & LRB3
                     waitLRA3, SWaitCnt(dscnt=15, vlcnt=-1, vscnt=-1, comment="Wait for half LRA3 to complete"),                    
                     waitLRA3+7, SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA3/LRB3 to complete"),                    
 
@@ -2941,7 +2937,7 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
             'GRIncB': [grIncB],
             'LRA0': [*lra0],
             'LRB0': [lrb0],
-            'LRSA': [[packA0[4]]],
+            'LRSA': [[packA0[4]]],#Use slot between MFMA 16x16x32 & 4x4x4 for LRSA
             'LRSB': [[packA0[4]]],
             'PackA0' : [packA0],
             'PackB0' : [packB0],
@@ -2959,7 +2955,6 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
 
         nglshift = nllshift = 14
         opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift, mfmaReorder=mfmaReorder)
-        # opt1.disableValidation()
     
     else:
         return False, None

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -2797,6 +2797,7 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
         # Interleaving of LBR0 and GRINCB to hide LRB0 latency
         lrb0 = create_range(min_val = 0, num = 6, step = 1, repeat = 1)
         grIncB = create_range(min_val = max(lrb0)+1, num = 3, step = 1, repeat = 3)
+        
         grIncA = create_range(min_val = max(grIncB)+1, num = 3, step = 1, repeat = 3)
         waitLRB0 = max(grIncA)
 
@@ -2858,17 +2859,17 @@ def _get_schedule_256x192x32_TF32(kernel, useLDSTr, TLDS):
 
         # LRA3 interleaved with GRB (2nd half)
         startLRA3 = halfMFMA
-        lra3 = [create_range(min_val = startLRA3, num = numLrReadA // 2, step = 2, repeat = 2),
-                create_range(min_val = startLRA3+1, num = numLrReadA // 2, step = 2, repeat = 2)]
-        grB[0] += create_range(min_val = startLRA3+1,num = 3,step = 2, repeat = 2)
-        grB[1] += create_range(min_val = startLRA3,num = 3,step = 2, repeat = 2)
+        lra3 = [create_range(min_val = startLRA3+1, num = numLrReadA // 2, step = 2, repeat = 2),
+                create_range(min_val = startLRA3, num = numLrReadA // 2, step = 2, repeat = 2)]
+        grB[0] += create_range(min_val = startLRA3,num = 3,step = 2, repeat = 2)
+        grB[1] += create_range(min_val = startLRA3+1,num = 3,step = 2, repeat = 2)
         # waitLRA3 = max(lra3[1])+6  
     
         # LRB3 + PACKA3 & PACKB3
         startLRB3 = (3*numMfma)//4 - 4 # Starts 4 indexes before 3/4 MFMAs to accommodate LRB3 latency
         lrb3 = create_range(min_val = startLRB3,num=numLrReadB - 2,step=1,repeat=1)
-        grA = [create_range(min_val = min(lrb3)+1, num = 8, step = 1,repeat = 1),
-               create_range(min_val = min(lrb3)+3, num = 8, step = 1,repeat = 1)]
+        grA = [create_range(min_val = max(lra3[0])+1, num = 8, step = 1,repeat = 1),
+               create_range(min_val = max(lra3[1])+1, num = 8, step = 1,repeat = 1)]
         lrb3 += create_range(min_val = max(lrb3)+3,num=2,step=1,repeat=1)
         
         waitLRB3 = max(lrb3) + 9 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
@@ -631,4 +631,36 @@ BenchmarkProblems:
           - Range: [[128], [128], [1], [1,1,64]]
           - Range: [[128], [128], [1], [32, 64, 256]]
         - BiasTypeArgs: ['s']
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1, 8, 6,  2, 2 ]          
+        - PrefetchGlobalRead: [2] 
+        - PrefetchLocalRead: [0]
+        - DepthU: [32]
+        - TransposeLDS: [1]
+        - DirectToLds: [1]
+        - StreamK: [3]
+        - LdsPadA: [-1] 
+        - LdsPadB: [-1] 
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - NonTemporalA: [0]
+        - NonTemporalB: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - VectorWidthA: [1]
+        - LDSTrInst: [False]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[256], [192], [1], [64, 64, 256]]
+          - Range: [[256], [192], [1], [1,1,64]]
+          - Range: [[256], [192], [1], [32, 64, 256]]
+        - BiasTypeArgs: ['b']
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -633,6 +633,33 @@ class TestCustomScheduleTF32:
         valid, message = isValid(schedule_info, {"kernel": kernel})
         assert valid, message
 
+    def test_schedule_256x192x32_TF32(self):
+        """Tests the 256x192x32 TF32 NN schedule."""
+        kernel = create_base_kernel()
+        kernel["ProblemType"].update({
+            "TransposeA": False, "TransposeB": False
+        })
+        kernel.update({
+            "UseF32XEmulation": True,
+            "ForceUnrollSubIter": True,
+            "MacroTile0": 256, "MacroTile1": 192, "DepthU": 32,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
+            "DirectToLds": True,
+            "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,
+            "MatrixInstruction": [16, 16, 32, 1], "MIWaveGroup": [2, 2],
+            "LDSTrInst": False, "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 6,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 2
+        assert schedule_info.numMfma == 144
+        assert kernel["UsePLRPack"]
+        assert kernel["UseMFMAF32XEmulation"]
+        valid, message = isValid(schedule_info, {"kernel": kernel})
+        assert valid, message
+
     def test_schedule_192x128x32_TF32(self):
         """Tests the 192x128x32 TF32 TN schedule."""
         kernel = create_base_kernel()

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -633,33 +633,6 @@ class TestCustomScheduleTF32:
         valid, message = isValid(schedule_info, {"kernel": kernel})
         assert valid, message
 
-    def test_schedule_256x192x32_TF32(self):
-        """Tests the 256x192x32 TF32 NN schedule."""
-        kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": False, "TransposeB": False
-        })
-        kernel.update({
-            "UseF32XEmulation": True,
-            "ForceUnrollSubIter": True,
-            "MacroTile0": 256, "MacroTile1": 192, "DepthU": 32,
-            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
-            "DirectToLds": True,
-            "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,
-            "MatrixInstruction": [16, 16, 32, 1], "MIWaveGroup": [2, 2],
-            "LDSTrInst": False, "TransposeLDS": 1, "MIWaveTileA": 8, "MIWaveTileB": 6,
-        })
-
-        has_schedule, schedule_info = hasCustomSchedule(kernel)
-        assert has_schedule
-        assert isinstance(schedule_info, ScheduleInfo)
-        assert schedule_info.numCodePaths == 2
-        assert schedule_info.numMfma == 144
-        assert kernel["UsePLRPack"]
-        assert kernel["UseMFMAF32XEmulation"]
-        valid, message = isValid(schedule_info, {"kernel": kernel})
-        assert valid, message
-
     def test_schedule_192x128x32_TF32(self):
         """Tests the 192x128x32 TF32 TN schedule."""
         kernel = create_base_kernel()
@@ -712,11 +685,18 @@ class TestCustomScheduleTF32:
         valid, message = isValid(schedule_info, {"kernel": kernel})
         assert valid, message
 
-    def test_schedule_256x192x32_TF32(self):
+    @pytest.mark.parametrize(
+        # fmt: off
+        "transA, transB", [
+        (  True,  False),
+        ( False,   False),
+        # fmt: on
+        ])
+    def test_schedule_256x192x32_TF32(self, transA, transB):
         """Tests the 256x192x32 TF32 TN schedule."""
         kernel = create_base_kernel()
         kernel["ProblemType"].update({
-            "TransposeA": True, "TransposeB": False
+            "TransposeA": transA, "TransposeB": transB
         })
         kernel.update({
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
@@ -735,6 +715,8 @@ class TestCustomScheduleTF32:
         assert schedule_info.numCodePaths == 2
         assert schedule_info.numMfma == 144
         assert kernel["UsePLRPack"]
+        if transA == False and transB == False:
+            assert kernel["UseMFMAF32XEmulation"]
         valid, message = isValid(schedule_info, {"kernel": kernel})
         assert valid, message
 


### PR DESCRIPTION
# Description

CMS for  256x192x32 NN TF32 using 4x4x4_16b mfma for Packing.

## Perf results

### Tensile
 - no CMS : 657 us
 - CMS : 426 us (loop efficiency of 85%)
 - **35 % speedup**

### Hipblaslt-bench
 - 256x256 custom asm kernel : 562 us
 - this PR : 529 us
 -  **5.8 % speedup**

Note : If `VectorWidthA` is not specified, Tensile picks `VectorWidthA=4`. This leads to lots of bank conflicts because codegen uses ds_read_b32 for A strided by 16 bytes. The timing for the non CMS version with `VectorWidthA=4` is 891 us (vs 657 us with `VectorWidthA=1` ). As the consequence, the above results use `VectorWidthA=1`

Command used: `./hipblaslt-bench --transA N --transB N -m 4096 -n 3072 -k 8192 --function matmul --a_type f32_r --b_type f32_r --c_type f32_r --d_type f32_r --compute_type xf32_r --scale_type f32_r --bias_type f32_r --scaleA 0 --scaleB 0 --batch_count 1 --initialization trig_float --alpha 1 --beta 0 --stride_a 0 --stride_b 0 --stride_c 0 --stride_d 0 --rotating 512 --flush --print_kernel_info --use_gpu_timer --iters 5000 --cold_iters 5000 -v`

AIGECORE-62