### PR TITLE
Fix tensilelite client YAML build

### DIFF
--- a/projects/hipblaslt/tensilelite/src/Tensile.cpp
+++ b/projects/hipblaslt/tensilelite/src/Tensile.cpp
@@ -49,10 +49,12 @@ namespace TensileLite
     TENSILE_API SolutionAdapter::~SolutionAdapter() = default;
 
 #ifdef TENSILE_DEFAULT_SERIALIZATION
+#ifdef TENSILE_MSGPACK
     std::map<int, std::string> LoadLibraryMapping(std::string const& filename)
     {
         return MessagePackLoadLibraryMapping(filename);
     }
+#endif
 
     template <typename MyProblem, typename MySolution>
     std::shared_ptr<SolutionLibrary<MyProblem, MySolution>>


### PR DESCRIPTION
## Motivation

Fixes builds of tensilelite client with msgpack turned off

## Technical Details

Tensile client defaults to msgpack backend, but is able to use yaml instead. Yaml backend is sometimes useful for debug or testing purposes, but has been broken in develop for some time. This small change fixes the build.

## Test Plan

Builds locally.
