### PR TITLE
[hipblaslt][CMS] Add TF32 64x128x64 TN tile

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Alik_Bljk_S_MX_B_BiasS_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Alik_Bljk_S_MX_B_BiasS_HAS_SAV_UserArgs.yaml
@@ -36127,6 +36127,251 @@
     reorderGRInstForDTVB: false
     tailLoopOptA: false
     tailLoopOptB: false
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: true
+    ActivationFused: true
+    AssertAIGreaterThanEqual: -1
+    AssertAILessThanEqual: -1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BaseName: Cijk_Alik_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_AbjK9M7BB4XtWJXz6K8rmyvdJk1AwkbR7iSECF8W9Rs=
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    CUOccupancy: -1
+    ClusterLocalRead: 1
+    CodeObjectVersion: '4'
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DebugStreamK: 0
+    DepthU: 64
+    DirectToLds: true
+    DirectToLdsA: true
+    DirectToLdsB: true
+    DirectToVgprA: false
+    DirectToVgprB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: true
+    EnableMatrixInstruction: true
+    ExpandPointerSwap: 0
+    ExpertSchedulingMode: 0
+    ForceDisableShadowInit: false
+    ForceUnrollSubIter: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 4
+    GlobalReadVectorWidthB: 4
+    GlobalSplitU: 0
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 2
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [9, 5, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 2, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: false, UseSFC: false, UseUniversalArgs: true}
+    Kernel: true
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT64x128x64_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA8_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT2_4_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SPO0_SRVW0_SSO0_SVW2_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA2_VWB4_WSGRA0_WSGRB0_WS64_WG32_8_1
+    LDSTrInst: false
+    LSCA: 64
+    LSCB: 64
+    LSPA: 16
+    LSPB: 16
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 1024
+    LdsBlockSizePerPadB: 1024
+    LdsBlockSizePerPadMetadata: 0
+    LdsBytesNoAmax: 116224
+    LdsInitCVgprs: false
+    LdsNumBytes: 116224
+    LdsNumElementsAlignedA: 16896
+    LdsNumElementsAlignedB: 33792
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 65536
+    LdsOffsetB: 16896
+    LdsOffsetB_Blk: 82432
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 16896
+    LdsOffsetMetadata_Blk: 82432
+    LdsPadA: 8
+    LdsPadB: 8
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 4
+    LocalSplitU: 1
+    LocalSplitUReuseLDS: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: true
+    LocalWriteUseSgprB: true
+    LoopIters: 2
+    LoopUnroll: 64
+    MFMA_BF16_1K: false
+    MIArchVgpr: false
+    MIBlock: [16, 16, 32, 1, 1, 1]
+    MIInputPerThread: 8
+    MIInputPerThreadA: 8
+    MIInputPerThreadB: 8
+    MIInputPerThreadMetadata: 8
+    MIOutputVectorWidth: 4
+    MIRegPerOut: 1
+    MIWaveGroup: [2, 2]
+    MIWaveTile: [2, 4]
+    MIWaveTileA: 2
+    MIWaveTileB: 4
+    MIWaveTileMetadata: 0
+    MacroTile0: 64
+    MacroTile1: 128
+    MacroTileA: 64
+    MacroTileB: 128
+    MagicDivAlg: 2
+    MathClocksUnrolledLoop: 0
+    MatrixInstB: 1
+    MatrixInstBM: 1
+    MatrixInstBN: 1
+    MatrixInstK: 32
+    MatrixInstM: 16
+    MatrixInstN: 16
+    MatrixInstruction: [16, 16, 32, 1]
+    MaxLDS: 163840
+    MaxOccupancy: 40
+    MbskPrefetchMethod: 0
+    MfmaInitCVgprs: true
+    NoLdsWriteCode: true
+    NoReject: false
+    NoTailLoop: false
+    NonDTLTailLoopA: false
+    NonDTLTailLoopB: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 4
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NonTemporalWS: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 32
+    NumGlobalWriteVectorsPerThread: 16
+    NumLoadsA: 4
+    NumLoadsB: 8
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 8
+    NumThreads: 256
+    NumTotalPackedLoadsA: 4
+    NumTotalPackedLoadsB: 8
+    NumWaveSplitK: 1
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 2
+    PrefetchLocalRead: 1
+    PreloadKernArgs: true
+    SFCWGM:
+    - [1, 1]
+    - [1, 1]
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 3
+    ScheduleLocalWrite: 1
+    SolutionIndex: 151
+    SolutionNameMin: Cijk_Alik_Bljk_S_MX_B_Bias_SB_HA_S_SAV_UserArgs_MT64x128x64_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB4_GSU0_GSUAMB_GSUC0_GSUWGMRR0_GLS0_ISA950_IU1_K1_LDSTI0_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA8_LPB8_LPM0_LRVW4_LWPMn1_MIAV0_MIWT2_4_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SU0_SUM0_SUS256_SPO0_SRVW0_SSO0_SVW2_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA2_VWB4_WSGRA0_WSGRB0_WS64_WG32_8_1_WGM8_WGMXCC1_WGMXCCGn1
+    SourceSwap: 1
+    SpaceFillingAlgo: []
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSwapAddr: false
+    StoreSyncOpt: 0
+    StoreVectorWidth: 2
+    StreamK: 3
+    StreamKAtomic: 0
+    StreamKFixupTreeReduction: 0
+    StreamKXCCMapping: 0
+    SubGroup0: 8
+    SubGroup1: 32
+    SubGroupA: 8
+    SubGroupB: 32
+    SuppressNoLoadLoop: false
+    SwapGlobalReadOrder: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 8
+    ThreadTile1: 4
+    ThreadTileA: 8
+    ThreadTileB: 4
+    TransposeLDS: 1
+    TransposeLDSMetadata: true
+    ULSGRODoubleG2L: 0
+    UnrollLoopSwapGlobalReadOrder: 0
+    UnrollMajorLDSA: true
+    UnrollMajorLDSB: true
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseCustomMainLoopSchedule: true
+    UseDirect32XEmulation: true
+    UseDot2F32XEmulation: false
+    UseDotInstruction: false
+    UseF32XEmulation: true
+    UseGeneralizedNLCOneA: true
+    UseGeneralizedNLCOneB: true
+    UseGeneralizedNLCOneMetadata: false
+    UseInstOffsetForGRO: 0
+    UseMFMAF32XEmulation: true
+    UsePLRPack: true
+    UseSgprForGRO: 0
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 2
+    VectorWidthB: 4
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WaveSplitK: false
+    WavefrontSize: 64
+    WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingXCC: 1
+    WorkGroupMappingXCCGroup: -1
+    WorkGroupReduction: false
+    WorkspaceCheck: [4, 0, 0]
+    _DepthU: 64
+    _DepthUA: 64
+    _DepthUB: 64
+    _DepthUMetadata: 64
+    _GlobalAccumulation: PartialsBuffer
+    _UseSgprForGRO: 0
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 4
+    _staggerStrideShift: 0
+    enableGLTrA: false
+    enableGLTrB: false
+    enableLDSTrA: false
+    enableLDSTrB: false
+    numSubTiles: 1
+    reorderGRInstForDTVA: false
+    reorderGRInstForDTVB: false
+    tailLoopOptA: false
+    tailLoopOptB: false
 - [2, 3, 0, 1]
 - - - [233, 128, 1024, 32]
     - [104, 0.0]
@@ -36428,6 +36673,8 @@
     - [149, 0.0]
   - - [2048, 2048, 1, 8192]
     - [150, 0.0]
+  - - [1024, 2048, 1, 8192]
+    - [151, 0.0]
 - null
 - null
 - DeviceEfficiency

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -3548,3 +3548,96 @@ def _get_schedule_256x128x32_TF32(kernel, useLDSTr, TLDS):
 
     opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     return True, opt1
+
+@RegisterSchedule(
+    tile_config=TileConfig(64, 128, 64, 2, 1, True, 0, 0),
+    dtype_predicate=isTF32,
+    vector_widths=[4, 4, 4],
+    matrix_inst=[16, 16, 32, 1],
+    mfma_wave_group=[2, 2]
+)
+def _get_schedule_64x128x64_TF32(kernel, useLDSTr, TLDS):
+    kernel["MfmaInitCVgprs"] = True
+
+    n_mfma = 48
+    optSchedule = dict()
+    nglshift = nllshift = 0
+
+    syncs = SyncSchedule()
+    syncCode = []
+    gr_inc_step = 0
+
+    if isTN(kernel) and not useLDSTr and TLDS==1 and kernel["UseDirect32XEmulation"]:
+        kernel["UseMFMAF32XEmulation"] = True
+        kernel["UsePLRPack"] = True
+
+        grinca = [0,0,1,1,2,2,3,3,4]
+        grincb = [4,5,5,6,6,7,7,8,8]
+        lrsa   = [23]
+        lrsb   = [23]
+        lwsa   = [47]
+        lwsb   = [47]
+
+        pack_a = [0,0,0,0, 2,2, 3,3,3,3,
+                  1,1,1,1, 2,2, 4,4,4,4
+                  ]
+        pack_b = [0,0,0,0, 4,4, 5,5,5,5,
+                  1,1,1,1, 4,4, 6,6,6,6,
+                  2,2,2,2, 4,4, 7,7,7,7,
+                  3,3,3,3, 4,4, 8,8,8,8
+                  ]
+        lra0   = [0,1,2,3]
+        syncs.add(                8, dscnt=5, comment="wait for necessary LRA0 before pack to start")
+        syncs.add(                10, dscnt=4, barrier=True, comment="wait for remaining LRA0 before pack to complete + barrier for GRA")
+        pack_a0 = [                i+9 for i in pack_a]  ## last index = 9 + 4 = 13
+
+        lrb0   = [        4,5, 7, 9,10,11,12,13]
+        syncs.add(                           14, dscnt=4, comment="wait for necessary LRB0 before pack to start")
+        syncs.add(                           16, dscnt=0, comment="wait for remaining LRB0 before pack to complete")
+        pack_b0 = [                          i+14 for i in pack_b]  ## last index = 14 + 8 = 22
+
+        gra    = [                 10,13,17,21] # one index for two instructions
+        grb    = [                            24,28,32,35,38,41,43,45] # one index for two instructions
+        num_gr = len(gra) + len(grb)
+
+        syncs.add(                            24, vlcnt=4, barrier=True, comment="wait for previous set of global reads + barrier for GRB")
+
+        lra1   = [24,25,26,27]
+        syncs.add(                       32, dscnt=5, comment="wait for necessary LRA1 before pack to start")
+        syncs.add(                       34, dscnt=4, comment="wait for remaining LRA1 before pack to complete")
+        pack_a1 = [                         i+33 for i in pack_a]  ## last index = 33 + 4 = 37
+
+        lrb1   = [           28,29, 31,32, 34,35,36,37]
+        syncs.add(                                     38, dscnt=4, comment="wait for necessary LRB1 before pack to start")
+        syncs.add(                                     40, dscnt=0, comment="wait for remaining LRB1 before pack to complete")
+        pack_b1 = [                                    i+38 for i in pack_b]  ## last index = 38 + 8 = 46
+
+        optSchedule = {
+            'SYNC':   [syncs.get_indicies()],
+            'GRIncA': [grinca],
+            'GRIncB': [grincb],
+            'LRA0':   [lra0],
+            'LRB0':   [lrb0],
+            'PackA0': [pack_a0],
+            'PackB0': [pack_b0],
+            'GRA':    [duplicate_list_items(gra, 2, gr_inc_step)],
+            'GRB':    [duplicate_list_items(grb, 2, gr_inc_step)],
+            'LRSA':   [lrsa],
+            'LRSB':   [lrsb],
+            'LWSA':   [lwsa],
+            'LWSB':   [lwsb],
+            'LRA1':   [lra1],
+            'LRB1':   [lrb1],
+            'PackB1': [pack_b1],
+            'PackA1': [pack_a1],
+            'LCC':    [[n_mfma-1, n_mfma-1]],
+        }
+
+        syncCode = syncs.get_code()
+        nglshift = nllshift = num_gr
+
+        opt1 = ScheduleInfo(1, n_mfma, optSchedule, syncCode, nglshift, nllshift)
+        return True, opt1
+
+    else:
+        return False, None

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -3578,23 +3578,23 @@ def _get_schedule_64x128x64_TF32(kernel, useLDSTr, TLDS):
         lwsa   = [47]
         lwsb   = [47]
 
-        pack_a = [0,0,0,0, 2,2, 3,3,3,3,
-                  1,1,1,1, 2,2, 4,4,4,4
-                  ]
-        pack_b = [0,0,0,0, 4,4, 5,5,5,5,
-                  1,1,1,1, 4,4, 6,6,6,6,
-                  2,2,2,2, 4,4, 7,7,7,7,
-                  3,3,3,3, 4,4, 8,8,8,8
-                  ]
+        pack_a_offset = [0,0,0,0, 2,2, 3,3,3,3,
+                         1,1,1,1, 2,2, 4,4,4,4
+                        ]
+        pack_b_offset = [0,0,0,0, 4,4, 5,5,5,5,
+                         1,1,1,1, 4,4, 6,6,6,6,
+                         2,2,2,2, 4,4, 7,7,7,7,
+                         3,3,3,3, 4,4, 8,8,8,8
+                        ]
         lra0   = [0,1,2,3]
         syncs.add(                8, dscnt=5, comment="wait for necessary LRA0 before pack to start")
         syncs.add(                10, dscnt=4, barrier=True, comment="wait for remaining LRA0 before pack to complete + barrier for GRA")
-        pack_a0 = [                i+9 for i in pack_a]  ## last index = 9 + 4 = 13
+        pack_a0 = [                i+9 for i in pack_a_offset]  ## last index = 9 + 4 = 13
 
         lrb0   = [        4,5, 7, 9,10,11,12,13]
         syncs.add(                           14, dscnt=4, comment="wait for necessary LRB0 before pack to start")
         syncs.add(                           16, dscnt=0, comment="wait for remaining LRB0 before pack to complete")
-        pack_b0 = [                          i+14 for i in pack_b]  ## last index = 14 + 8 = 22
+        pack_b0 = [                          i+14 for i in pack_b_offset]  ## last index = 14 + 8 = 22
 
         gra    = [                 10,13,17,21] # one index for two instructions
         grb    = [                            24,28,32,35,38,41,43,45] # one index for two instructions
@@ -3605,12 +3605,12 @@ def _get_schedule_64x128x64_TF32(kernel, useLDSTr, TLDS):
         lra1   = [24,25,26,27]
         syncs.add(                       32, dscnt=5, comment="wait for necessary LRA1 before pack to start")
         syncs.add(                       34, dscnt=4, comment="wait for remaining LRA1 before pack to complete")
-        pack_a1 = [                         i+33 for i in pack_a]  ## last index = 33 + 4 = 37
+        pack_a1 = [                         i+33 for i in pack_a_offset]  ## last index = 33 + 4 = 37
 
         lrb1   = [           28,29, 31,32, 34,35,36,37]
         syncs.add(                                     38, dscnt=4, comment="wait for necessary LRB1 before pack to start")
         syncs.add(                                     40, dscnt=0, comment="wait for remaining LRB1 before pack to complete")
-        pack_b1 = [                                    i+38 for i in pack_b]  ## last index = 38 + 8 = 46
+        pack_b1 = [                                    i+38 for i in pack_b_offset]  ## last index = 38 + 8 = 46
 
         optSchedule = {
             'SYNC':   [syncs.get_indicies()],

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
@@ -391,6 +391,43 @@ BenchmarkProblems:
           - Range: [[256], [128], [1], [1, 1, 64]]
           - Range: [[256], [128], [1], [64, 64, 256]]
         - BiasTypeArgs: ['s']
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1, 2, 4,  2,2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - TransposeLDS: [1]
+        - LocalReadVectorWidth: [4]
+        - GlobalReadVectorWidthA: [4]
+        - GlobalReadVectorWidthB: [4]
+        - DirectToLds: [1]
+        - StreamK: [3]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - NonTemporalA: [0]
+        - NonTemporalB: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LDSTrInst: [False]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[64], [128], [1], [64, 64, 256]]
+          - Range: [[64], [128], [1], [1,1,64]]
+          - Range: [[64], [128], [1], [32, 64, 256]]
+        - BiasTypeArgs: ['s']
 
 ########################################
 # TF32 NN - standard

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -804,6 +804,7 @@ class TestCustomScheduleTF32:
         assert schedule_info.numMfma == numMfma
         valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
+
     @pytest.mark.parametrize(
         # fmt: off
         "transA, transB, lds_tr_inst,  tr_lds", [
@@ -811,7 +812,7 @@ class TestCustomScheduleTF32:
         # fmt: on
         ])
     def test_schedule_128x160x64(self, transA, transB, lds_tr_inst, tr_lds):
-        """Tests the 129x160x64 TF32 TN schedule."""
+        """Tests the 128x160x64 TF32 TN schedule."""
         kernel = create_base_kernel()
         kernel["ProblemType"].update({
             "TransposeA": transA, "TransposeB": transB
@@ -829,6 +830,40 @@ class TestCustomScheduleTF32:
         assert has_schedule
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == 2
+        numMfma = ((kernel["MacroTile0"] // kernel["MIWaveGroup"][0] // kernel["MatrixInstruction"][0]) *
+                   (kernel["MacroTile1"] // kernel["MIWaveGroup"][1] // kernel["MatrixInstruction"][1]) *
+                    3 * # tf32 emulated with 3 bf16
+                    2   # two sub-iterations due to DepthU=64
+        )
+        assert schedule_info.numMfma == numMfma
+        valid, message = isValid(schedule_info, {"kernel" : kernel})
+        assert valid, message
+
+    @pytest.mark.parametrize(
+        # fmt: off
+        "transA, transB, lds_tr_inst,  tr_lds", [
+        (  True,  False,       False,       1),
+        # fmt: on
+        ])
+    def test_schedule_64x128x64(self, transA, transB, lds_tr_inst, tr_lds):
+        """Tests the 64x128x64 TF32 TN schedule."""
+        kernel = create_base_kernel()
+        kernel["ProblemType"].update({
+            "TransposeA": transA, "TransposeB": transB
+        })
+        kernel.update({
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True,
+            "MacroTile0": 64, "MacroTile1": 128, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
+            "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidth": 4,
+            "MatrixInstruction": [16,16,32,1], "MIWaveGroup": [2,2],
+            "LDSTrInst": lds_tr_inst, "TransposeLDS": tr_lds, "MIWaveTileA": 2, "MIWaveTileB": 4,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 1
         numMfma = ((kernel["MacroTile0"] // kernel["MIWaveGroup"][0] // kernel["MatrixInstruction"][0]) *
                    (kernel["MacroTile1"] // kernel["MIWaveGroup"][1] // kernel["MatrixInstruction"][1]) *
                     3 * # tf32 emulated with 3 bf16


### PR DESCRIPTION
## Motivation

Add CMS implementation for TF32 64x128x64 TN tile

## Technical Details

Problem size: [M, N, K] = [1024, 2048, 8192]

- **Tensile**: CMS achieves ~**28.5% speedup** vs. non-CMS
- **main-loop efficiency**: improved from 32.7% (2346 cycles) to **55.9%** (1373 cycles)
- **hipblaslt-bench**: no gains (~**8% regression** w.r.t. custom 256x256x32 solution)
- **hipblaslt-bench** with K=4096: ~**18.8% speedup** w.r.t. baseline)

## Test Result

All tests `PASSED` via Tensile as well as **hipblaslt-test**
```
        - ProblemSizes:
          - Exact: [1024, 2048, 1, 8192]
          - Range: [[64], [128], [1], [64, 64, 256]]
          - Range: [[64], [128], [1], [1,1,64]]
          - Range: [[64], [128], [1], [32, 64, 256]]
```
```
[----------] Global test environment tear-down
[==========] 21891 tests from 12 test suites ran. (1495979 ms total)
[  PASSED  ] 21891 tests.
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

AIGECORE-81