### PR TITLE
[rocSOLVER] Stack-based single array allocation for GESVD

### DIFF
--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.cpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.cpp
@@ -74,28 +74,55 @@ rocblas_status rocsolver_bdsqr_impl(rocblas_handle handle,
     // memory workspace sizes:
     // size of re-usable workspace
     size_t size_splits_map, size_work, size_completed;
-    rocsolver_bdsqr_getMemorySize<S>(n, nv, nu, nc, batch_count, &size_splits_map, &size_work,
-                                     &size_completed);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_splits_map, size_work,
-                                                      size_completed);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_bdsqr_getMemorySize<S>(n, nv, nu, nc, batch_count, &size_splits_map, &size_work,
+                                         &size_completed);
 
-    // memory workspace allocation
-    void *splits_map, *work, *completed;
-    rocblas_device_malloc mem(handle, size_splits_map, size_work, size_completed);
-    if(!mem)
-        return rocblas_status_memory_error;
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_splits_map, size_work,
+                                                          size_completed);
 
-    splits_map = mem[0];
-    work = mem[1];
-    completed = mem[2];
+        // memory workspace allocation
+        void *splits_map, *work, *completed;
+        rocblas_device_malloc mem(handle, size_splits_map, size_work, size_completed);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_bdsqr_template<T>(handle, uplo, n, nv, nu, nc, D, strideD, E, strideE, V,
-                                       shiftV, ldv, strideV, U, shiftU, ldu, strideU, C, shiftC,
-                                       ldc, strideC, info, batch_count, (rocblas_int*)splits_map,
-                                       (S*)work, (rocblas_int*)completed);
+        splits_map = mem[0];
+        work = mem[1];
+        completed = mem[2];
+
+        // execution
+        return rocsolver_bdsqr_template<T>(handle, uplo, n, nv, nu, nc, D, strideD, E, strideE, V,
+                                           shiftV, ldv, strideV, U, shiftU, ldu, strideU, C, shiftC,
+                                           ldc, strideC, info, batch_count, (rocblas_int*)splits_map,
+                                           (S*)work, (rocblas_int*)completed);
+    }
+    else
+    {
+        size_t size_work_bdsqr = 0;
+        rocsolver_bdsqr_getMemorySize_alt<S>(n, nv, nu, nc, batch_count, &size_work_bdsqr);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work_bdsqr);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work_bdsqr);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work_bdsqr = (void*)mem[0];
+
+        // execution
+        return rocsolver_bdsqr_template_alt<T, S>(handle, uplo, n, nv, nu, nc, D, strideD, E,
+                                                  strideE, V, shiftV, ldv, strideV, U, shiftU, ldu,
+                                                  strideU, C, shiftC, ldc, strideC, info, batch_count,
+
+                                                  work_bdsqr, size_work_bdsqr);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_bdsqr.hpp
@@ -40,7 +40,13 @@
 
 #include "rocauxiliary_bdsqr_hybrid.hpp"
 
+#include "rocsolver_mem_utils.hpp"
+
 ROCSOLVER_BEGIN_NAMESPACE
+
+#ifndef USE_ORIGINAL
+#define USE_ORIGINAL false
+#endif
 
 /******************** Device functions *************************/
 /***************************************************************/
@@ -1122,11 +1128,12 @@ void rocsolver_bdsqr_getMemorySize(const rocblas_int n,
                                    size_t* size_completed)
 {
     // if quick return, no workspace is needed
+    *size_splits_map = 0;
+    *size_work = 0;
+    *size_completed = 0;
+
     if(n == 0 || batch_count == 0)
     {
-        *size_splits_map = 0;
-        *size_work = 0;
-        *size_completed = 0;
         return;
     }
 
@@ -1143,6 +1150,36 @@ void rocsolver_bdsqr_getMemorySize(const rocblas_int n,
 
     // size of temporary workspace to indicate problem completion
     *size_completed = sizeof(rocblas_int) * (batch_count + 2);
+
+    adjust_for_alignment(size_splits_map);
+    adjust_for_alignment(size_work);
+    adjust_for_alignment(size_completed);
+}
+
+template <typename T>
+void rocsolver_bdsqr_getMemorySize_alt(const rocblas_int n,
+                                       const rocblas_int nv,
+                                       const rocblas_int nu,
+                                       const rocblas_int nc,
+                                       const rocblas_int batch_count,
+
+                                       size_t* p_size_bdsqr)
+{
+    size_t size_splits_map = 0;
+    size_t size_work1 = 0;
+    size_t size_completed = 0;
+
+    rocsolver_bdsqr_getMemorySize<T>(n, nv, nu, nc, batch_count,
+
+                                     &size_splits_map, &size_work1, &size_completed);
+
+    size_t size_bdsqr = 0;
+
+    size_bdsqr += size_splits_map;
+    size_bdsqr += size_work1;
+    size_bdsqr += size_completed;
+
+    *p_size_bdsqr = size_bdsqr;
 }
 
 template <typename S, typename W>
@@ -1357,6 +1394,69 @@ rocblas_status rocsolver_bdsqr_template(rocblas_handle handle,
                             C, shiftC, ldc, strideC, info, splits_map, completed);
 
     return rocblas_status_success;
+}
+
+template <typename T, typename S, typename W1, typename W2, typename W3>
+rocblas_status rocsolver_bdsqr_template_alt(rocblas_handle handle,
+                                            const rocblas_fill uplo,
+                                            const rocblas_int n,
+                                            const rocblas_int nv,
+                                            const rocblas_int nu,
+                                            const rocblas_int nc,
+                                            S* D,
+                                            const rocblas_stride strideD,
+                                            S* E,
+                                            const rocblas_stride strideE,
+                                            W1 V,
+                                            const rocblas_int shiftV,
+                                            const rocblas_int ldv,
+                                            const rocblas_stride strideV,
+                                            W2 U,
+                                            const rocblas_int shiftU,
+                                            const rocblas_int ldu,
+                                            const rocblas_stride strideU,
+                                            W3 C,
+                                            const rocblas_int shiftC,
+                                            const rocblas_int ldc,
+                                            const rocblas_stride strideC,
+                                            rocblas_int* info,
+                                            const rocblas_int batch_count,
+
+                                            void* const work,
+                                            size_t const size_work)
+
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_splits_map = 0;
+    size_t size_work1 = 0;
+    size_t size_completed = 0;
+
+    // ---------------------------------------------
+    // !! NOTE: using type S in template argument for  getMemory
+    // ---------------------------------------------
+    rocsolver_bdsqr_getMemorySize<S>(n, nv, nu, nc, batch_count,
+
+                                     &size_splits_map, &size_work1, &size_completed);
+
+    rocblas_int* const splits_map = (rocblas_int*)pfree;
+    pfree += size_splits_map;
+
+    S* const work1 = (S*)pfree;
+    pfree += size_work1;
+
+    rocblas_int* completed = (rocblas_int*)pfree;
+    pfree += size_completed;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_bdsqr_template<T, S, W1, W2, W3>(
+        handle, uplo, n, nv, nu, nc, D, strideD, E, strideE, V, shiftV, ldv, strideV, U, shiftU,
+        ldu, strideU, C, shiftC, ldc, strideC, info, batch_count,
+
+        splits_map, work1, completed);
+    return (istat);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.cpp
@@ -65,33 +65,64 @@ rocblas_status rocsolver_orgbr_ungbr_impl(rocblas_handle handle,
     size_t size_work;
     size_t size_Abyx_tmptr;
     size_t size_trfact;
-    rocsolver_orgbr_ungbr_getMemorySize<false, T>(storev, m, n, k, batch_count, &size_scalars,
-                                                  &size_work, &size_Abyx_tmptr, &size_trfact,
-                                                  &size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work,
-                                                      size_Abyx_tmptr, size_trfact, size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_orgbr_ungbr_getMemorySize<false, T>(storev, m, n, k, batch_count, &size_scalars,
+                                                      &size_work, &size_Abyx_tmptr, &size_trfact,
+                                                      &size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *work, *Abyx_tmptr, *trfact, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work, size_Abyx_tmptr, size_trfact,
-                              size_workArr);
-    if(!mem)
-        return rocblas_status_memory_error;
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_work, size_Abyx_tmptr, size_trfact, size_workArr);
 
-    scalars = mem[0];
-    work = mem[1];
-    Abyx_tmptr = mem[2];
-    trfact = mem[3];
-    workArr = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        // memory workspace allocation
+        void *scalars, *work, *Abyx_tmptr, *trfact, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work, size_Abyx_tmptr, size_trfact,
+                                  size_workArr);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_orgbr_ungbr_template<false, false, T>(
-        handle, storev, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count, (T*)scalars,
-        (T*)work, (T*)Abyx_tmptr, (T*)trfact, (T**)workArr);
+        scalars = mem[0];
+        work = mem[1];
+        Abyx_tmptr = mem[2];
+        trfact = mem[3];
+        workArr = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_orgbr_ungbr_template<false, false, T>(
+            handle, storev, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+            (T*)scalars, (T*)work, (T*)Abyx_tmptr, (T*)trfact, (T**)workArr);
+    }
+    else
+    {
+        size_t size_orgbr = 0;
+        rocsolver_orgbr_ungbr_getMemorySize_alt<false, T>(storev, m, n, k, batch_count, &size_orgbr);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_orgbr);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_orgbr);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work_orgbr = (void*)mem[0];
+
+        // ------------------------------------------------------------
+        // note: scalars[] initialized in  rocauxiliary_orgbr_ungbr.hpp
+        // ------------------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_orgbr_ungbr_template_alt<false, false, T>(
+            handle, storev, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+
+            work_orgbr, size_orgbr);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_orgbr_ungbr.hpp
@@ -39,6 +39,10 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+#ifndef USE_ORIGINAL
+#define USE_ORIGINAL false
+#endif
+
 template <bool BATCHED, typename T>
 void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
                                          const rocblas_int m,
@@ -51,14 +55,15 @@ void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
                                          size_t* size_trfact,
                                          size_t* size_workArr)
 {
+    *size_scalars = 0;
+    *size_work = 0;
+    *size_Abyx_tmptr = 0;
+    *size_trfact = 0;
+    *size_workArr = 0;
+
     // if quick return no workspace needed
     if(m == 0 || n == 0 || batch_count == 0)
     {
-        *size_scalars = 0;
-        *size_work = 0;
-        *size_Abyx_tmptr = 0;
-        *size_trfact = 0;
-        *size_workArr = 0;
         return;
     }
 
@@ -101,6 +106,42 @@ void rocsolver_orgbr_ungbr_getMemorySize(const rocblas_storev storev,
             *size_work = std::max(s1, s2);
         }
     }
+
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_work);
+    adjust_for_alignment(size_Abyx_tmptr);
+    adjust_for_alignment(size_trfact);
+    adjust_for_alignment(size_workArr);
+}
+
+template <bool BATCHED, typename T>
+void rocsolver_orgbr_ungbr_getMemorySize_alt(const rocblas_storev storev,
+                                             const rocblas_int m,
+                                             const rocblas_int n,
+                                             const rocblas_int k,
+                                             const rocblas_int batch_count,
+
+                                             size_t* p_size_orgbr)
+{
+    size_t size_scalars = 0;
+    size_t size_work = 0;
+    size_t size_Abyx_tmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(storev, m, n, k, batch_count,
+
+                                                    &size_scalars, &size_work, &size_Abyx_tmptr,
+                                                    &size_trfact, &size_workArr);
+    size_t size_orgbr = 0;
+
+    size_orgbr += size_scalars;
+    size_orgbr += size_work;
+    size_orgbr += size_Abyx_tmptr;
+    size_orgbr += size_trfact;
+    size_orgbr += size_workArr;
+
+    *p_size_orgbr = size_orgbr;
 }
 
 template <typename T, typename U>
@@ -240,6 +281,66 @@ rocblas_status rocsolver_orgbr_ungbr_template(rocblas_handle handle,
     }
 
     return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_orgbr_ungbr_template_alt(rocblas_handle handle,
+                                                  const rocblas_storev storev,
+                                                  const rocblas_int m,
+                                                  const rocblas_int n,
+                                                  const rocblas_int k,
+                                                  U A,
+                                                  const rocblas_int shiftA,
+                                                  const rocblas_int lda,
+                                                  const rocblas_stride strideA,
+                                                  T* ipiv,
+                                                  const rocblas_stride strideP,
+                                                  const rocblas_int batch_count,
+
+                                                  void* const work,
+                                                  size_t const size_work)
+
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_work1 = 0;
+    size_t size_Abyx_tmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_orgbr_ungbr_getMemorySize<BATCHED, T>(storev, m, n, k, batch_count,
+
+                                                    &size_scalars, &size_work1, &size_Abyx_tmptr,
+                                                    &size_trfact, &size_workArr);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    T* const work1 = (T*)pfree;
+    pfree += size_work1;
+
+    T* const Abyx_tmptr = (T*)pfree;
+    pfree += size_Abyx_tmptr;
+
+    T* const trfact = (T*)pfree;
+    pfree += size_trfact;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_orgbr_ungbr_template<BATCHED, STRIDED, T, U>(
+        handle, storev, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+
+        scalars, work1, Abyx_tmptr, trfact, workArr);
+    return (istat);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.cpp
@@ -68,32 +68,63 @@ rocblas_status rocsolver_orglq_unglq_impl(rocblas_handle handle,
     size_t size_Abyx_tmptr;
     // size of temporary array for triangular factor
     size_t size_trfact;
-    rocsolver_orglq_unglq_getMemorySize<false, T>(m, n, k, batch_count, &size_scalars, &size_work,
-                                                  &size_Abyx_tmptr, &size_trfact, &size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work,
-                                                      size_Abyx_tmptr, size_trfact, size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_orglq_unglq_getMemorySize<false, T>(m, n, k, batch_count, &size_scalars, &size_work,
+                                                      &size_Abyx_tmptr, &size_trfact, &size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *work, *Abyx_tmptr, *trfact, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work, size_Abyx_tmptr, size_trfact,
-                              size_workArr);
-    if(!mem)
-        return rocblas_status_memory_error;
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_work, size_Abyx_tmptr, size_trfact, size_workArr);
 
-    scalars = mem[0];
-    work = mem[1];
-    Abyx_tmptr = mem[2];
-    trfact = mem[3];
-    workArr = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        // memory workspace allocation
+        void *scalars, *work, *Abyx_tmptr, *trfact, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work, size_Abyx_tmptr, size_trfact,
+                                  size_workArr);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_orglq_unglq_template<false, false, T>(
-        handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count, (T*)scalars, (T*)work,
-        (T*)Abyx_tmptr, (T*)trfact, (T**)workArr);
+        scalars = mem[0];
+        work = mem[1];
+        Abyx_tmptr = mem[2];
+        trfact = mem[3];
+        workArr = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_orglq_unglq_template<false, false, T>(
+            handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count, (T*)scalars,
+            (T*)work, (T*)Abyx_tmptr, (T*)trfact, (T**)workArr);
+    }
+    else
+    {
+        size_t size_orglq = 0;
+        rocsolver_orglq_unglq_getMemorySize_alt<false, T>(m, n, k, batch_count, &size_orglq);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_orglq);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_orglq);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work_orglq = mem[0];
+
+        // -----------------------------------------------------------
+        // note: scalars[] initialized in rocauxiliary_orglq_unglq.hpp
+        // -----------------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_orglq_unglq_template_alt<false, false, T>(
+            handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+
+            work_orglq, size_orglq);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
@@ -95,6 +95,11 @@ void rocsolver_orglq_unglq_getMemorySize(const rocblas_int m,
         // size of temporary array for triangular factor
         *size_trfact = sizeof(T) * jb * jb * batch_count;
     }
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_work);
+    adjust_for_alignment(size_Abyx_tmptr);
+    adjust_for_alignment(size_trfact);
+    adjust_for_alignment(size_workArr);
 }
 
 template <bool BATCHED, typename T>

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_orglq_unglq.hpp
@@ -38,7 +38,13 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
+#include "rocsolver_mem_utils.hpp"
+
 ROCSOLVER_BEGIN_NAMESPACE
+
+#ifndef USE_ORIGINAL
+#define USE_ORIGINAL false
+#endif
 
 template <bool BATCHED, typename T>
 void rocsolver_orglq_unglq_getMemorySize(const rocblas_int m,
@@ -89,6 +95,37 @@ void rocsolver_orglq_unglq_getMemorySize(const rocblas_int m,
         // size of temporary array for triangular factor
         *size_trfact = sizeof(T) * jb * jb * batch_count;
     }
+}
+
+template <bool BATCHED, typename T>
+void rocsolver_orglq_unglq_getMemorySize_alt(const rocblas_int m,
+                                             const rocblas_int n,
+                                             const rocblas_int k,
+                                             const rocblas_int batch_count,
+
+                                             size_t* p_size_orglq)
+
+{
+    size_t size_scalars = 0;
+    size_t size_work = 0;
+    size_t size_Abyx_tmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_orglq_unglq_getMemorySize<BATCHED, T>(m, n, k, batch_count,
+
+                                                    &size_scalars, &size_work, &size_Abyx_tmptr,
+                                                    &size_trfact, &size_workArr);
+
+    size_t size_orglq = 0;
+
+    size_orglq += size_scalars;
+    size_orglq += size_work;
+    size_orglq += size_Abyx_tmptr;
+    size_orglq += size_trfact;
+    size_orglq += size_workArr;
+
+    *p_size_orglq = size_orglq;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename U>
@@ -186,6 +223,65 @@ rocblas_status rocsolver_orglq_unglq_template(rocblas_handle handle,
     }
 
     return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_orglq_unglq_template_alt(rocblas_handle handle,
+                                                  const rocblas_int m,
+                                                  const rocblas_int n,
+                                                  const rocblas_int k,
+                                                  U A,
+                                                  const rocblas_int shiftA,
+                                                  const rocblas_int lda,
+                                                  const rocblas_stride strideA,
+                                                  T* ipiv,
+                                                  const rocblas_stride strideP,
+                                                  const rocblas_int batch_count,
+
+                                                  void* const work,
+                                                  size_t const size_work)
+
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_work1 = 0;
+    size_t size_Abyx_tmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_orglq_unglq_getMemorySize<BATCHED, T>(m, n, k, batch_count,
+
+                                                    &size_scalars, &size_work1, &size_Abyx_tmptr,
+                                                    &size_trfact, &size_workArr);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    T* const work1 = (T*)pfree;
+    pfree += size_work1;
+
+    T* const Abyx_tmptr = (T*)pfree;
+    pfree += size_Abyx_tmptr;
+
+    T* const trfact = (T*)pfree;
+    pfree += size_trfact;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_orglq_unglq_template<BATCHED, STRIDED, T, U>(
+        handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+
+        scalars, work1, Abyx_tmptr, trfact, workArr);
+    return (istat);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.cpp
@@ -68,32 +68,63 @@ rocblas_status rocsolver_orgqr_ungqr_impl(rocblas_handle handle,
     size_t size_Abyx_tmptr;
     // size of temporary array for triangular factor
     size_t size_trfact;
-    rocsolver_orgqr_ungqr_getMemorySize<false, T>(m, n, k, batch_count, &size_scalars, &size_work,
-                                                  &size_Abyx_tmptr, &size_trfact, &size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work,
-                                                      size_Abyx_tmptr, size_trfact, size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_orgqr_ungqr_getMemorySize<false, T>(m, n, k, batch_count, &size_scalars, &size_work,
+                                                      &size_Abyx_tmptr, &size_trfact, &size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *work, *Abyx_tmptr, *trfact, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work, size_Abyx_tmptr, size_trfact,
-                              size_workArr);
-    if(!mem)
-        return rocblas_status_memory_error;
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_work, size_Abyx_tmptr, size_trfact, size_workArr);
 
-    scalars = mem[0];
-    work = mem[1];
-    Abyx_tmptr = mem[2];
-    trfact = mem[3];
-    workArr = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        // memory workspace allocation
+        void *scalars, *work, *Abyx_tmptr, *trfact, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work, size_Abyx_tmptr, size_trfact,
+                                  size_workArr);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_orgqr_ungqr_template<false, false, T>(
-        handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count, (T*)scalars, (T*)work,
-        (T*)Abyx_tmptr, (T*)trfact, (T**)workArr);
+        scalars = mem[0];
+        work = mem[1];
+        Abyx_tmptr = mem[2];
+        trfact = mem[3];
+        workArr = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_orgqr_ungqr_template<false, false, T>(
+            handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count, (T*)scalars,
+            (T*)work, (T*)Abyx_tmptr, (T*)trfact, (T**)workArr);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_orgqr_ungqr_getMemorySize_alt<false, T>(m, n, k, batch_count, &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // -----------------------------------------------------------
+        // note: scalars[] initialized in rocauxiliary_orgqr_ungqr.hpp
+        // -----------------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_orgqr_ungqr_template_alt<false, false, T>(
+            handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+
+            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_orgqr_ungqr.hpp
@@ -38,7 +38,13 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
+#include "rocsolver_mem_utils.hpp"
+
 ROCSOLVER_BEGIN_NAMESPACE
+
+#ifndef USE_ORIGINAL
+#define USE_ORIGINAL false
+#endif
 
 template <bool BATCHED, typename T>
 void rocsolver_orgqr_ungqr_getMemorySize(const rocblas_int m,
@@ -52,13 +58,13 @@ void rocsolver_orgqr_ungqr_getMemorySize(const rocblas_int m,
                                          size_t* size_workArr)
 {
     // if quick return no workspace needed
+    *size_scalars = 0;
+    *size_work = 0;
+    *size_Abyx_tmptr = 0;
+    *size_trfact = 0;
+    *size_workArr = 0;
     if(m == 0 || n == 0 || batch_count == 0)
     {
-        *size_scalars = 0;
-        *size_work = 0;
-        *size_Abyx_tmptr = 0;
-        *size_trfact = 0;
-        *size_workArr = 0;
         return;
     }
 
@@ -89,6 +95,42 @@ void rocsolver_orgqr_ungqr_getMemorySize(const rocblas_int m,
         // size of temporary array for triangular factor
         *size_trfact = sizeof(T) * jb * jb * batch_count;
     }
+
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_work);
+    adjust_for_alignment(size_Abyx_tmptr);
+    adjust_for_alignment(size_trfact);
+    adjust_for_alignment(size_workArr);
+}
+
+template <bool BATCHED, typename T>
+void rocsolver_orgqr_ungqr_getMemorySize_alt(const rocblas_int m,
+                                             const rocblas_int n,
+                                             const rocblas_int k,
+                                             const rocblas_int batch_count,
+
+                                             size_t* p_size_orgqr)
+{
+    size_t size_scalars = 0;
+    size_t size_work = 0;
+    size_t size_Abyx_tmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(m, n, k, batch_count,
+
+                                                    &size_scalars, &size_work, &size_Abyx_tmptr,
+                                                    &size_trfact, &size_workArr);
+
+    size_t size_orgqr = 0;
+
+    size_orgqr += size_scalars;
+    size_orgqr += size_work;
+    size_orgqr += size_Abyx_tmptr;
+    size_orgqr += size_trfact;
+    size_orgqr += size_workArr;
+
+    *p_size_orgqr = size_orgqr;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename U>
@@ -186,6 +228,65 @@ rocblas_status rocsolver_orgqr_ungqr_template(rocblas_handle handle,
     }
 
     return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_orgqr_ungqr_template_alt(rocblas_handle handle,
+                                                  const rocblas_int m,
+                                                  const rocblas_int n,
+                                                  const rocblas_int k,
+                                                  U A,
+                                                  const rocblas_int shiftA,
+                                                  const rocblas_int lda,
+                                                  const rocblas_stride strideA,
+                                                  T* ipiv,
+                                                  const rocblas_stride strideP,
+                                                  const rocblas_int batch_count,
+
+                                                  void* const work,
+                                                  size_t const size_work)
+
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_work1 = 0;
+    size_t size_Abyx_tmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_orgqr_ungqr_getMemorySize<BATCHED, T>(m, n, k, batch_count,
+
+                                                    &size_scalars, &size_work1, &size_Abyx_tmptr,
+                                                    &size_trfact, &size_workArr);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    T* const work1 = (T*)pfree;
+    pfree += size_work1;
+
+    T* const Abyx_tmptr = (T*)pfree;
+    pfree += size_Abyx_tmptr;
+
+    T* const trfact = (T*)pfree;
+    pfree += size_trfact;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_orgqr_ungqr_template<BATCHED, STRIDED, T, U>(
+        handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+
+        scalars, work1, Abyx_tmptr, trfact, workArr);
+    return (istat);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.cpp
@@ -72,33 +72,65 @@ rocblas_status rocsolver_ormbr_unmbr_impl(rocblas_handle handle,
     size_t size_AbyxORwork, size_diagORtmptr;
     size_t size_trfact;
     size_t size_workArr;
-    rocsolver_ormbr_unmbr_getMemorySize<false, T>(storev, side, m, n, k, batch_count, &size_scalars,
-                                                  &size_AbyxORwork, &size_diagORtmptr, &size_trfact,
-                                                  &size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_AbyxORwork,
-                                                      size_diagORtmptr, size_trfact, size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_ormbr_unmbr_getMemorySize<false, T>(storev, side, m, n, k, batch_count,
+                                                      &size_scalars, &size_AbyxORwork,
+                                                      &size_diagORtmptr, &size_trfact, &size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *AbyxORwork, *diagORtmptr, *trfact, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_AbyxORwork, size_diagORtmptr, size_trfact,
-                              size_workArr);
-    if(!mem)
-        return rocblas_status_memory_error;
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_AbyxORwork, size_diagORtmptr, size_trfact, size_workArr);
 
-    scalars = mem[0];
-    AbyxORwork = mem[1];
-    diagORtmptr = mem[2];
-    trfact = mem[3];
-    workArr = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        // memory workspace allocation
+        void *scalars, *AbyxORwork, *diagORtmptr, *trfact, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_AbyxORwork, size_diagORtmptr,
+                                  size_trfact, size_workArr);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_ormbr_unmbr_template<false, false, T>(
-        handle, storev, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC, ldc,
-        strideC, batch_count, (T*)scalars, (T*)AbyxORwork, (T*)diagORtmptr, (T*)trfact, (T**)workArr);
+        scalars = mem[0];
+        AbyxORwork = mem[1];
+        diagORtmptr = mem[2];
+        trfact = mem[3];
+        workArr = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_ormbr_unmbr_template<false, false, T>(
+            handle, storev, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC,
+            ldc, strideC, batch_count, (T*)scalars, (T*)AbyxORwork, (T*)diagORtmptr, (T*)trfact,
+            (T**)workArr);
+    }
+    else
+    {
+        size_t size_ormbr = 0;
+        rocsolver_ormbr_unmbr_getMemorySize_alt<false, T>(storev, side, m, n, k, batch_count,
+                                                          &size_ormbr);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_ormbr);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_ormbr);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // ---------------------------------------
+        // note: scalars[] initialized in HPP file
+        // ---------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_ormbr_unmbr_template_alt<false, false, T>(
+            handle, storev, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC,
+            ldc, strideC, batch_count, work, size_ormbr);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_ormbr_unmbr.hpp
@@ -37,7 +37,13 @@
 #include "rocblas.hpp"
 #include "rocsolver/rocsolver.h"
 
+#include "rocsolver_mem_utils.hpp"
+
 ROCSOLVER_BEGIN_NAMESPACE
+
+#ifndef USE_ORIGINAL
+#define USE_ORIGINAL false
+#endif
 
 template <bool BATCHED, typename T>
 void rocsolver_ormbr_unmbr_getMemorySize(const rocblas_storev storev,
@@ -53,13 +59,13 @@ void rocsolver_ormbr_unmbr_getMemorySize(const rocblas_storev storev,
                                          size_t* size_workArr)
 {
     // if quick return no workspace needed
+    *size_scalars = 0;
+    *size_AbyxORwork = 0;
+    *size_diagORtmptr = 0;
+    *size_trfact = 0;
+    *size_workArr = 0;
     if(m == 0 || n == 0 || k == 0 || batch_count == 0)
     {
-        *size_scalars = 0;
-        *size_AbyxORwork = 0;
-        *size_diagORtmptr = 0;
-        *size_trfact = 0;
-        *size_workArr = 0;
         return;
     }
 
@@ -75,6 +81,45 @@ void rocsolver_ormbr_unmbr_getMemorySize(const rocblas_storev storev,
         rocsolver_ormlq_unmlq_getMemorySize<BATCHED, T>(side, m, n, std::min(nq, k), batch_count,
                                                         size_scalars, size_AbyxORwork,
                                                         size_diagORtmptr, size_trfact, size_workArr);
+
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_AbyxORwork);
+    adjust_for_alignment(size_diagORtmptr);
+    adjust_for_alignment(size_trfact);
+    adjust_for_alignment(size_workArr);
+}
+
+template <bool BATCHED, typename T>
+void rocsolver_ormbr_unmbr_getMemorySize_alt(const rocblas_storev storev,
+                                             const rocblas_side side,
+                                             const rocblas_int m,
+                                             const rocblas_int n,
+                                             const rocblas_int k,
+                                             const rocblas_int batch_count,
+
+                                             size_t* p_size_ormbr)
+
+{
+    size_t size_scalars = 0;
+    size_t size_AbyxORwork = 0;
+    size_t size_diagORtmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_ormbr_unmbr_getMemorySize<BATCHED, T>(storev, side, m, n, k, batch_count,
+
+                                                    &size_scalars, &size_AbyxORwork,
+                                                    &size_diagORtmptr, &size_trfact, &size_workArr);
+
+    size_t size_ormbr = 0;
+
+    size_ormbr += size_scalars;
+    size_ormbr += size_AbyxORwork;
+    size_ormbr += size_diagORtmptr;
+    size_ormbr += size_trfact;
+    size_ormbr += size_workArr;
+
+    *p_size_ormbr = size_ormbr;
 }
 
 template <bool COMPLEX, typename T, typename U>
@@ -230,31 +275,98 @@ rocblas_status rocsolver_ormbr_unmbr_template(rocblas_handle handle,
     return rocblas_status_success;
 }
 
+template <bool BATCHED, bool STRIDED, typename T, typename U, bool COMPLEX = rocblas_is_complex<T>>
+rocblas_status rocsolver_ormbr_unmbr_template_alt(rocblas_handle handle,
+                                                  const rocblas_storev storev,
+                                                  const rocblas_side side,
+                                                  const rocblas_operation trans,
+                                                  const rocblas_int m,
+                                                  const rocblas_int n,
+                                                  const rocblas_int k,
+                                                  U A,
+                                                  const rocblas_int shiftA,
+                                                  const rocblas_int lda,
+                                                  const rocblas_stride strideA,
+                                                  T* ipiv,
+                                                  const rocblas_stride strideP,
+                                                  U C,
+                                                  const rocblas_int shiftC,
+                                                  const rocblas_int ldc,
+                                                  const rocblas_stride strideC,
+                                                  const rocblas_int batch_count,
+
+                                                  void* const work,
+                                                  size_t const size_work)
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_AbyxORwork = 0;
+    size_t size_diagORtmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_ormbr_unmbr_getMemorySize<BATCHED, T>(storev, side, m, n, k, batch_count,
+
+                                                    &size_scalars, &size_AbyxORwork,
+                                                    &size_diagORtmptr, &size_trfact, &size_workArr);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    T* const AbyxORwork = (T*)pfree;
+    pfree += size_AbyxORwork;
+
+    T* const diagORtmptr = (T*)pfree;
+    pfree += size_diagORtmptr;
+
+    T* const trfact = (T*)pfree;
+    pfree += size_trfact;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_ormbr_unmbr_template<BATCHED, STRIDED, T, U, COMPLEX>(
+        handle, storev, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, C, shiftC,
+        ldc, strideC, batch_count,
+
+        scalars, AbyxORwork, diagORtmptr, trfact, workArr);
+
+    return (istat);
+}
+
 /** Adapts A and C to be of the same type **/
 template <bool BATCHED, bool STRIDED, typename T>
-void rocsolver_ormbr_unmbr_template(rocblas_handle handle,
-                                    const rocblas_storev storev,
-                                    const rocblas_side side,
-                                    const rocblas_operation trans,
-                                    const rocblas_int m,
-                                    const rocblas_int n,
-                                    const rocblas_int k,
-                                    T* const A[],
-                                    const rocblas_int shiftA,
-                                    const rocblas_int lda,
-                                    const rocblas_stride strideA,
-                                    T* ipiv,
-                                    const rocblas_stride strideP,
-                                    T* C,
-                                    const rocblas_int shiftC,
-                                    const rocblas_int ldc,
-                                    const rocblas_stride strideC,
-                                    const rocblas_int batch_count,
-                                    T* scalars,
-                                    T* AbyxORwork,
-                                    T* diagORtmptr,
-                                    T* trfact,
-                                    T** workArr)
+rocblas_status rocsolver_ormbr_unmbr_template(rocblas_handle handle,
+                                              const rocblas_storev storev,
+                                              const rocblas_side side,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              const rocblas_int k,
+                                              T* const A[],
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              T* C,
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr)
 {
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -263,37 +375,109 @@ void rocsolver_ormbr_unmbr_template(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, workArr, C, strideC,
                             batch_count);
 
-    rocsolver_ormbr_unmbr_template<BATCHED, STRIDED>(
+    return (rocsolver_ormbr_unmbr_template<BATCHED, STRIDED>(
         handle, storev, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP,
         (T* const*)workArr, shiftC, ldc, strideC, batch_count, scalars, AbyxORwork, diagORtmptr,
-        trfact, (workArr + batch_count));
+        trfact, (workArr + batch_count)));
+}
+
+template <bool BATCHED, bool STRIDED, typename T>
+rocblas_status rocsolver_ormbr_unmbr_template_alt(rocblas_handle handle,
+                                                  const rocblas_storev storev,
+                                                  const rocblas_side side,
+                                                  const rocblas_operation trans,
+                                                  const rocblas_int m,
+                                                  const rocblas_int n,
+                                                  const rocblas_int k,
+                                                  T* const A[],
+                                                  const rocblas_int shiftA,
+                                                  const rocblas_int lda,
+                                                  const rocblas_stride strideA,
+                                                  T* ipiv,
+                                                  const rocblas_stride strideP,
+                                                  T* C,
+                                                  const rocblas_int shiftC,
+                                                  const rocblas_int ldc,
+                                                  const rocblas_stride strideC,
+                                                  const rocblas_int batch_count,
+
+                                                  void* const work,
+                                                  size_t const size_work)
+
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_AbyxORwork = 0;
+    size_t size_diagORtmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_ormbr_unmbr_getMemorySize<BATCHED, T>(storev, side, m, n, k, batch_count,
+
+                                                    &size_scalars, &size_AbyxORwork,
+                                                    &size_diagORtmptr, &size_trfact, &size_workArr);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    T* const AbyxORwork = (T*)pfree;
+    pfree += size_AbyxORwork;
+
+    T* const diagORtmptr = (T*)pfree;
+    pfree += size_diagORtmptr;
+
+    T* const trfact = (T*)pfree;
+    pfree += size_trfact;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    MEM_CHECK(pfree);
+
+    rocblas_int blocks = (batch_count - 1) / 256 + 1;
+    ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, workArr, C, strideC,
+                            batch_count);
+
+    return (rocsolver_ormbr_unmbr_template<BATCHED, STRIDED>(
+        handle, storev, side, trans, m, n, k, A, shiftA, lda, strideA, ipiv, strideP,
+        (T* const*)workArr, shiftC, ldc, strideC, batch_count, scalars, AbyxORwork, diagORtmptr,
+        trfact, (workArr + batch_count)));
 }
 
 /** Adapts A and C to be of the same type **/
 template <bool BATCHED, bool STRIDED, typename T>
-void rocsolver_ormbr_unmbr_template(rocblas_handle handle,
-                                    const rocblas_storev storev,
-                                    const rocblas_side side,
-                                    const rocblas_operation trans,
-                                    const rocblas_int m,
-                                    const rocblas_int n,
-                                    const rocblas_int k,
-                                    T* A,
-                                    const rocblas_int shiftA,
-                                    const rocblas_int lda,
-                                    const rocblas_stride strideA,
-                                    T* ipiv,
-                                    const rocblas_stride strideP,
-                                    T* const C[],
-                                    const rocblas_int shiftC,
-                                    const rocblas_int ldc,
-                                    const rocblas_stride strideC,
-                                    const rocblas_int batch_count,
-                                    T* scalars,
-                                    T* AbyxORwork,
-                                    T* diagORtmptr,
-                                    T* trfact,
-                                    T** workArr)
+rocblas_status rocsolver_ormbr_unmbr_template(rocblas_handle handle,
+                                              const rocblas_storev storev,
+                                              const rocblas_side side,
+                                              const rocblas_operation trans,
+                                              const rocblas_int m,
+                                              const rocblas_int n,
+                                              const rocblas_int k,
+                                              T* A,
+                                              const rocblas_int shiftA,
+                                              const rocblas_int lda,
+                                              const rocblas_stride strideA,
+                                              T* ipiv,
+                                              const rocblas_stride strideP,
+                                              T* const C[],
+                                              const rocblas_int shiftC,
+                                              const rocblas_int ldc,
+                                              const rocblas_stride strideC,
+                                              const rocblas_int batch_count,
+                                              T* scalars,
+                                              T* AbyxORwork,
+                                              T* diagORtmptr,
+                                              T* trfact,
+                                              T** workArr)
 {
     hipStream_t stream;
     rocblas_get_stream(handle, &stream);
@@ -302,10 +486,81 @@ void rocsolver_ormbr_unmbr_template(rocblas_handle handle,
     ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, workArr, A, strideA,
                             batch_count);
 
-    rocsolver_ormbr_unmbr_template<BATCHED, STRIDED>(
+    return (rocsolver_ormbr_unmbr_template<BATCHED, STRIDED>(
         handle, storev, side, trans, m, n, k, (T* const*)workArr, shiftA, lda, strideA, ipiv,
         strideP, C, shiftC, ldc, strideC, batch_count, scalars, AbyxORwork, diagORtmptr, trfact,
-        (workArr + batch_count));
+        (workArr + batch_count)));
 }
 
+template <bool BATCHED, bool STRIDED, typename T>
+rocblas_status rocsolver_ormbr_unmbr_template_alt(rocblas_handle handle,
+                                                  const rocblas_storev storev,
+                                                  const rocblas_side side,
+                                                  const rocblas_operation trans,
+                                                  const rocblas_int m,
+                                                  const rocblas_int n,
+                                                  const rocblas_int k,
+                                                  T* A,
+                                                  const rocblas_int shiftA,
+                                                  const rocblas_int lda,
+                                                  const rocblas_stride strideA,
+                                                  T* ipiv,
+                                                  const rocblas_stride strideP,
+                                                  T* const C[],
+                                                  const rocblas_int shiftC,
+                                                  const rocblas_int ldc,
+                                                  const rocblas_stride strideC,
+                                                  const rocblas_int batch_count,
+
+                                                  void* const work,
+                                                  size_t const size_work)
+
+{
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_AbyxORwork = 0;
+    size_t size_diagORtmptr = 0;
+    size_t size_trfact = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_ormbr_unmbr_getMemorySize<BATCHED, T>(storev, side, m, n, k, batch_count,
+
+                                                    &size_scalars, &size_AbyxORwork,
+                                                    &size_diagORtmptr, &size_trfact, &size_workArr);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    T* const AbyxORwork = (T*)pfree;
+    pfree += size_AbyxORwork;
+
+    T* const diagORtmptr = (T*)pfree;
+    pfree += size_diagORtmptr;
+
+    T* const trfact = (T*)pfree;
+    pfree += size_trfact;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    MEM_CHECK(pfree);
+
+    rocblas_int blocks = (batch_count - 1) / 256 + 1;
+    ROCSOLVER_LAUNCH_KERNEL(get_array, dim3(blocks), dim3(256), 0, stream, workArr, A, strideA,
+                            batch_count);
+
+    return (rocsolver_ormbr_unmbr_template<BATCHED, STRIDED>(
+        handle, storev, side, trans, m, n, k, (T* const*)workArr, shiftA, lda, strideA, ipiv,
+        strideP, C, shiftC, ldc, strideC, batch_count, scalars, AbyxORwork, diagORtmptr, trfact,
+        (workArr + batch_count)));
+}
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/include/rocsolver_mem_utils.hpp
+++ b/projects/rocsolver/library/src/include/rocsolver_mem_utils.hpp
@@ -1,3 +1,6 @@
+/* ************************************************************************
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc.
+ * ************************************************************************/
 #pragma once
 static inline void adjust_for_alignment(size_t& size_work)
 {
@@ -17,8 +20,10 @@ static inline void adjust_for_alignment(size_t* p_size_work)
     *p_size_work = size_work;
 }
 
+#ifndef IS_POINTER_BATCHED
 #define IS_POINTER_BATCHED(A, T) \
     (std::is_pointer_v<std::remove_cv_t<std::remove_cv_t<std::remove_reference_t<decltype((A)[0])>>>>)
+#endif
 
 #ifndef MEM_CHECK
 #define MEM_CHECK(pfree)                                        \

--- a/projects/rocsolver/library/src/lapack/mem_utils.hpp
+++ b/projects/rocsolver/library/src/lapack/mem_utils.hpp
@@ -1,0 +1,44 @@
+#pragma once
+static inline void adjust_for_alignment(size_t& size_work)
+{
+    constexpr int ialign = 256;
+
+    auto ceil = [](auto n, auto base) { return ((n - 1) / base + 1); };
+
+    size_work = ceil(size_work, ialign) * ialign;
+}
+
+static inline void adjust_for_alignment(size_t* p_size_work)
+{
+    size_t size_work = *p_size_work;
+
+    adjust_for_alignment(size_work);
+
+    *p_size_work = size_work;
+}
+
+#define IS_POINTER_BATCHED(A, T) \
+    (std::is_pointer_v<std::remove_cv_t<std::remove_cv_t<std::remove_reference_t<decltype((A)[0])>>>>)
+
+#ifndef MEM_CHECK
+#define MEM_CHECK(pfree)                                        \
+    {                                                           \
+        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
+        if(!is_mem_ok_)                                         \
+        {                                                       \
+            return (rocblas_status_memory_error);               \
+        }                                                       \
+    }
+#endif
+
+#ifndef MEM_CHECK_THROW
+#define MEM_CHECK_THROW(pfree)                                  \
+    {                                                           \
+        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
+        if(!is_mem_ok_)                                         \
+        {                                                       \
+            istat = rocblas_status_memory_error;                \
+            throw(istat);                                       \
+        }                                                       \
+    }
+#endif

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd.cpp
@@ -75,34 +75,80 @@ rocblas_status rocsolver_gebrd_impl(rocblas_handle handle,
     // size for temporary resulting orthogonal matrices when calling LABRD
     size_t size_X;
     size_t size_Y;
-    rocsolver_gebrd_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                            &size_Abyx_norms, &size_X, &size_Y);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms, size_X, size_Y);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_gebrd_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
+                                                &size_Abyx_norms, &size_X, &size_Y);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms, *X, *Y;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms, size_X,
-                              size_Y);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
+                                                          size_Abyx_norms, size_X, size_Y);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        // memory workspace allocation
+        void *scalars, *work_workArr, *Abyx_norms, *X, *Y;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms, size_X,
+                                  size_Y);
 
-    scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms = mem[2];
-    X = mem[3];
-    Y = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_gebrd_template<false, false, T>(
-        handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
-        (T*)X, shiftX, m, strideX, (T*)Y, shiftY, n, strideY, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms);
+        scalars = mem[0];
+        work_workArr = mem[1];
+        Abyx_norms = mem[2];
+        X = mem[3];
+        Y = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gebrd_template<false, false, T>(
+            handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup,
+            strideP, (T*)X, shiftX, m, strideX, (T*)Y, shiftY, n, strideY, batch_count, (T*)scalars,
+            work_workArr, (T*)Abyx_norms);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_gebrd_getMemorySize_alt<false, T>(m, n, batch_count, &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // --------------------------------------------------
+        // note: scalars[] initialized in roclapack_gebrd.hpp
+        // --------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gebrd_template_alt<false, false, T>(handle, m, n,
+
+                                                             A, shiftA, lda, strideA,
+
+                                                             D, strideD,
+
+                                                             E, strideE,
+
+                                                             tauq, strideQ, taup, strideP,
+
+                                                             //  (T*)X,
+                                                             shiftX, m, strideX,
+
+                                                             //  (T*)Y,
+                                                             shiftY, n, strideY,
+
+                                                             batch_count,
+
+                                                             work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
@@ -135,6 +135,40 @@ void rocsolver_gebrd_getMemorySize_alt(const rocblas_int m,
     *p_size_gebrd = size_gebrd;
 }
 
+template <bool BATCHED, typename T>
+void rocsolver_gebrd_getMemorySize_alt_pass_xy(const rocblas_int m,
+                                               const rocblas_int n,
+                                               const rocblas_int batch_count,
+
+                                               size_t* p_size_gebrd)
+
+{
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms = 0;
+    size_t size_X = 0;
+    size_t size_Y = 0;
+
+    rocsolver_gebrd_getMemorySize<BATCHED, T>(m, n, batch_count,
+
+                                              &size_scalars, &size_work_workArr, &size_Abyx_norms,
+                                              &size_X, &size_Y);
+
+    size_t size_gebrd = 0;
+
+    size_gebrd += size_scalars;
+    size_gebrd += size_work_workArr;
+    size_gebrd += size_Abyx_norms;
+
+    // ----------------------------------------
+    // note: assume X, Y are not scratch arrays
+    // ----------------------------------------
+    // size_gebrd += size_X;
+    // size_gebrd += size_Y;
+
+    *p_size_gebrd = size_gebrd;
+}
+
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
 rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
                                         const rocblas_int m,

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
@@ -38,7 +38,13 @@
 #include "rocsolver/rocsolver.h"
 #include "rocsolver_run_specialized_kernels.hpp"
 
+#include "mem_utils.hpp"
+
 ROCSOLVER_BEGIN_NAMESPACE
+
+#ifndef USE_ORIGINAL
+#define USE_ORIGINAL false
+#endif
 
 template <bool BATCHED, typename T>
 void rocsolver_gebrd_getMemorySize(const rocblas_int m,
@@ -51,13 +57,13 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
                                    size_t* size_Y)
 {
     // if quick return no workspace needed
+    *size_scalars = 0;
+    *size_work_workArr = 0;
+    *size_Abyx_norms = 0;
+    *size_X = 0;
+    *size_Y = 0;
     if(m == 0 || n == 0 || batch_count == 0)
     {
-        *size_scalars = 0;
-        *size_work_workArr = 0;
-        *size_Abyx_norms = 0;
-        *size_X = 0;
-        *size_Y = 0;
         return;
     }
 
@@ -90,6 +96,36 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
         *size_Y = n * k;
         *size_Y *= sizeof(T) * batch_count;
     }
+}
+
+template <bool BATCHED, typename T>
+void rocsolver_gebrd_getMemorySize_alt(const rocblas_int m,
+                                       const rocblas_int n,
+                                       const rocblas_int batch_count,
+
+                                       size_t* p_size_gebrd)
+
+{
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms = 0;
+    size_t size_X = 0;
+    size_t size_Y = 0;
+
+    rocsolver_gebrd_getMemorySize<BATCHED, T>(m, n, batch_count,
+
+                                              &size_scalars, &size_work_workArr, &size_Abyx_norms,
+                                              &size_X, &size_Y);
+
+    size_t size_gebrd = 0;
+
+    size_gebrd += size_scalars;
+    size_gebrd += size_work_workArr;
+    size_gebrd += size_Abyx_norms;
+    size_gebrd += size_X;
+    size_gebrd += size_Y;
+
+    *p_size_gebrd = size_gebrd;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
@@ -201,6 +237,87 @@ rocblas_status rocsolver_gebrd_template(rocblas_handle handle,
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
+rocblas_status rocsolver_gebrd_template_alt(rocblas_handle handle,
+                                            const rocblas_int m,
+                                            const rocblas_int n,
+                                            U A,
+                                            const rocblas_int shiftA,
+                                            const rocblas_int lda,
+                                            const rocblas_stride strideA,
+                                            S* D,
+                                            const rocblas_stride strideD,
+                                            S* E,
+                                            const rocblas_stride strideE,
+                                            T* tauq,
+                                            const rocblas_stride strideQ,
+                                            T* taup,
+                                            const rocblas_stride strideP,
+                                            // T* X,
+                                            const rocblas_int shiftX,
+                                            const rocblas_int ldx,
+                                            const rocblas_stride strideX,
+                                            // T* Y,
+                                            const rocblas_int shiftY,
+                                            const rocblas_int ldy,
+                                            const rocblas_stride strideY,
+                                            const rocblas_int batch_count,
+
+                                            void* const work,
+                                            size_t const size_work)
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms = 0;
+
+    size_t size_X = 0;
+    size_t size_Y = 0;
+
+    rocsolver_gebrd_getMemorySize<BATCHED, T>(m, n, batch_count,
+
+                                              &size_scalars, &size_work_workArr, &size_Abyx_norms,
+                                              &size_X, &size_Y);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    void* const work_workArr = (void*)pfree;
+    pfree += size_work_workArr;
+
+    T* const Abyx_norms = (T*)pfree;
+    pfree += size_Abyx_norms;
+
+    T* const X = (T*)pfree;
+    pfree += size_X;
+
+    T* const Y = (T*)pfree;
+    pfree += size_Y;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_gebrd_template<BATCHED, STRIDED, T, S, U>(
+        handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
+
+        X, // note X is temporary array
+        shiftX, ldx, strideX,
+
+        Y, // note Y is temporary array
+        shiftY, ldy, strideY,
+
+        batch_count,
+
+        scalars, work_workArr, Abyx_norms);
+
+    return (istat);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
@@ -327,4 +327,83 @@ rocblas_status rocsolver_gebrd_template_alt(rocblas_handle handle,
     return (istat);
 }
 
+template <bool BATCHED, bool STRIDED, typename T, typename S, typename U>
+rocblas_status rocsolver_gebrd_template_alt(rocblas_handle handle,
+                                            const rocblas_int m,
+                                            const rocblas_int n,
+                                            U A,
+                                            const rocblas_int shiftA,
+                                            const rocblas_int lda,
+                                            const rocblas_stride strideA,
+                                            S* D,
+                                            const rocblas_stride strideD,
+                                            S* E,
+                                            const rocblas_stride strideE,
+                                            T* tauq,
+                                            const rocblas_stride strideQ,
+                                            T* taup,
+                                            const rocblas_stride strideP,
+                                            T* X,
+                                            const rocblas_int shiftX,
+                                            const rocblas_int ldx,
+                                            const rocblas_stride strideX,
+                                            T* Y,
+                                            const rocblas_int shiftY,
+                                            const rocblas_int ldy,
+                                            const rocblas_stride strideY,
+                                            const rocblas_int batch_count,
+
+                                            void* const work,
+                                            size_t const size_work)
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms = 0;
+
+    size_t size_X = 0;
+    size_t size_Y = 0;
+
+    rocsolver_gebrd_getMemorySize<BATCHED, T>(m, n, batch_count,
+
+                                              &size_scalars, &size_work_workArr, &size_Abyx_norms,
+                                              &size_X, &size_Y);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    void* const work_workArr = (void*)pfree;
+    pfree += size_work_workArr;
+
+    T* const Abyx_norms = (T*)pfree;
+    pfree += size_Abyx_norms;
+
+    // T* const X = (T*)pfree; pfree += size_X;
+
+    // T* const Y = (T*)pfree; pfree += size_Y;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_gebrd_template<BATCHED, STRIDED, T, S, U>(
+        handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
+
+        X, // note X is argument array
+        shiftX, ldx, strideX,
+
+        Y, // note Y is argument array
+        shiftY, ldy, strideY,
+
+        batch_count,
+
+        scalars, work_workArr, Abyx_norms);
+
+    return (istat);
+}
+
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
@@ -62,6 +62,7 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
     *size_Abyx_norms = 0;
     *size_X = 0;
     *size_Y = 0;
+
     if(m == 0 || n == 0 || batch_count == 0)
     {
         return;
@@ -96,6 +97,12 @@ void rocsolver_gebrd_getMemorySize(const rocblas_int m,
         *size_Y = n * k;
         *size_Y *= sizeof(T) * batch_count;
     }
+
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_work_workArr);
+    adjust_for_alignment(size_Abyx_norms);
+    adjust_for_alignment(size_X);
+    adjust_for_alignment(size_Y);
 }
 
 template <bool BATCHED, typename T>

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd.hpp
@@ -38,7 +38,7 @@
 #include "rocsolver/rocsolver.h"
 #include "rocsolver_run_specialized_kernels.hpp"
 
-#include "mem_utils.hpp"
+#include "rocsolver_mem_utils.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd_batched.cpp
@@ -78,34 +78,80 @@ rocblas_status rocsolver_gebrd_batched_impl(rocblas_handle handle,
     // size for temporary resulting orthogonal matrices when calling LABRD
     size_t size_X;
     size_t size_Y;
-    rocsolver_gebrd_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                           &size_Abyx_norms, &size_X, &size_Y);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms, size_X, size_Y);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_gebrd_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
+                                               &size_Abyx_norms, &size_X, &size_Y);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms, *X, *Y;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms, size_X,
-                              size_Y);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
+                                                          size_Abyx_norms, size_X, size_Y);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        // memory workspace allocation
+        void *scalars, *work_workArr, *Abyx_norms, *X, *Y;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms, size_X,
+                                  size_Y);
 
-    scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms = mem[2];
-    X = mem[3];
-    Y = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_gebrd_template<true, false, T>(
-        handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
-        (T*)X, shiftX, m, strideX, (T*)Y, shiftY, n, strideY, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms);
+        scalars = mem[0];
+        work_workArr = mem[1];
+        Abyx_norms = mem[2];
+        X = mem[3];
+        Y = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gebrd_template<true, false, T>(
+            handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup,
+            strideP, (T*)X, shiftX, m, strideX, (T*)Y, shiftY, n, strideY, batch_count, (T*)scalars,
+            work_workArr, (T*)Abyx_norms);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_gebrd_getMemorySize_alt<true, T>(m, n, batch_count, &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        //  --------------------------------------------------
+        //  note: scalars[] initialized in roclapack_gebrd.hpp
+        //  --------------------------------------------------
+        //  if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gebrd_template_alt<true, false, T>(handle, m, n,
+
+                                                            A, shiftA, lda, strideA,
+
+                                                            D, strideD,
+
+                                                            E, strideE,
+
+                                                            tauq, strideQ, taup, strideP,
+
+                                                            // (T*)X,
+                                                            shiftX, m, strideX,
+
+                                                            // (T*)Y,
+                                                            shiftY, n, strideY,
+
+                                                            batch_count,
+
+                                                            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gebrd_strided_batched.cpp
@@ -78,34 +78,80 @@ rocblas_status rocsolver_gebrd_strided_batched_impl(rocblas_handle handle,
     // size for temporary resulting orthogonal matrices when calling LABRD
     size_t size_X;
     size_t size_Y;
-    rocsolver_gebrd_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                            &size_Abyx_norms, &size_X, &size_Y);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms, size_X, size_Y);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_gebrd_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
+                                                &size_Abyx_norms, &size_X, &size_Y);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms, *X, *Y;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms, size_X,
-                              size_Y);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
+                                                          size_Abyx_norms, size_X, size_Y);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        // memory workspace allocation
+        void *scalars, *work_workArr, *Abyx_norms, *X, *Y;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms, size_X,
+                                  size_Y);
 
-    scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms = mem[2];
-    X = mem[3];
-    Y = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_gebrd_template<false, true, T>(
-        handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup, strideP,
-        (T*)X, shiftX, m, strideX, (T*)Y, shiftY, n, strideY, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms);
+        scalars = mem[0];
+        work_workArr = mem[1];
+        Abyx_norms = mem[2];
+        X = mem[3];
+        Y = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gebrd_template<false, true, T>(
+            handle, m, n, A, shiftA, lda, strideA, D, strideD, E, strideE, tauq, strideQ, taup,
+            strideP, (T*)X, shiftX, m, strideX, (T*)Y, shiftY, n, strideY, batch_count, (T*)scalars,
+            work_workArr, (T*)Abyx_norms);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_gebrd_getMemorySize_alt<false, T>(m, n, batch_count, &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // --------------------------------------------------
+        // note: scalars[] initialized in roclapack_gdbrd.hpp
+        // --------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gebrd_template_alt<false, true, T>(handle, m, n,
+
+                                                            A, shiftA, lda, strideA,
+
+                                                            D, strideD,
+
+                                                            E, strideE,
+
+                                                            tauq, strideQ, taup, strideP,
+
+                                                            // (T*)X,
+                                                            shiftX, m, strideX,
+
+                                                            // (T*)Y,
+                                                            shiftY, n, strideY,
+
+                                                            batch_count,
+
+                                                            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gelqf.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gelqf.cpp
@@ -64,34 +64,66 @@ rocblas_status rocsolver_gelqf_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GELQ2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_gelqf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_gelqf_getMemorySize<false, T>(m, n, batch_count, &size_scalars,
+                                                &size_work_workArr, &size_Abyx_norms_trfact,
+                                                &size_diag_tmptr, &size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
+                                                          size_Abyx_norms_trfact, size_diag_tmptr,
+                                                          size_workArr);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        // memory workspace allocation
+        void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
+                                  size_diag_tmptr, size_workArr);
 
-    scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_gelqf_template<false, false, T>(
-        handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        scalars = mem[0];
+        work_workArr = mem[1];
+        Abyx_norms_trfact = mem[2];
+        diag_tmptr = mem[3];
+        workArr = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gelqf_template<false, false, T>(
+            handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
+            work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_gelqf_getMemorySize_alt<false, T>(m, n, batch_count, &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // --------------------------------------------------
+        // note: scalars[] initialized in roclapack_gelqf.hpp
+        // --------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gelqf_template_alt<false, false, T>(handle, m, n, A, shiftA, lda, strideA,
+                                                             ipiv, stridep, batch_count,
+
+                                                             work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gelqf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gelqf.hpp
@@ -38,7 +38,13 @@
 #include "roclapack_gelq2.hpp"
 #include "rocsolver/rocsolver.h"
 
+#include "mem_utils.hpp"
+
 ROCSOLVER_BEGIN_NAMESPACE
+
+#ifndef USE_ORIGINAL
+#define USE_ORIGINAL true
+#endif
 
 template <bool BATCHED, typename T>
 void rocsolver_gelqf_getMemorySize(const rocblas_int m,
@@ -51,13 +57,13 @@ void rocsolver_gelqf_getMemorySize(const rocblas_int m,
                                    size_t* size_workArr)
 {
     // if quick return no workspace needed
+    *size_scalars = 0;
+    *size_work_workArr = 0;
+    *size_Abyx_norms_trfact = 0;
+    *size_diag_tmptr = 0;
+    *size_workArr = 0;
     if(m == 0 || n == 0 || batch_count == 0)
     {
-        *size_scalars = 0;
-        *size_work_workArr = 0;
-        *size_Abyx_norms_trfact = 0;
-        *size_diag_tmptr = 0;
-        *size_workArr = 0;
         return;
     }
 
@@ -95,6 +101,41 @@ void rocsolver_gelqf_getMemorySize(const rocblas_int m,
         if(BATCHED)
             *size_workArr *= 2;
     }
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_work_workArr);
+    adjust_for_alignment(size_Abyx_norms_trfact);
+    adjust_for_alignment(size_diag_tmptr);
+    adjust_for_alignment(size_workArr);
+}
+
+template <bool BATCHED, typename T>
+void rocsolver_gelqf_getMemorySize_alt(const rocblas_int m,
+                                       const rocblas_int n,
+                                       const rocblas_int batch_count,
+
+                                       size_t* p_size_gelqf)
+{
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms_trfact = 0;
+    size_t size_diag_tmptr = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_gelqf_getMemorySize<BATCHED, T>(m, n, batch_count,
+
+                                              &size_scalars, &size_work_workArr,
+                                              &size_Abyx_norms_trfact, &size_diag_tmptr,
+                                              &size_workArr);
+
+    size_t size_gelqf = 0;
+
+    size_gelqf += size_scalars;
+    size_gelqf += size_work_workArr;
+    size_gelqf += size_Abyx_norms_trfact;
+    size_gelqf += size_diag_tmptr;
+    size_gelqf += size_workArr;
+
+    *p_size_gelqf = size_gelqf;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename U>
@@ -171,6 +212,65 @@ rocblas_status rocsolver_gelqf_template(rocblas_handle handle,
                                     work_workArr, Abyx_norms_trfact, diag_tmptr);
 
     return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+rocblas_status rocsolver_gelqf_template_alt(rocblas_handle handle,
+                                            const rocblas_int m,
+                                            const rocblas_int n,
+                                            U A,
+                                            const rocblas_int shiftA,
+                                            const rocblas_int lda,
+                                            const rocblas_stride strideA,
+                                            T* ipiv,
+                                            const rocblas_stride strideP,
+                                            const rocblas_int batch_count,
+
+                                            void* const work,
+                                            size_t const size_work)
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms_trfact = 0;
+    size_t size_diag_tmptr = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_gelqf_getMemorySize<BATCHED, T>(m, n, batch_count,
+
+                                              &size_scalars, &size_work_workArr,
+                                              &size_Abyx_norms_trfact, &size_diag_tmptr,
+                                              &size_workArr);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    void* const work_workArr = (void*)pfree;
+    pfree += size_work_workArr;
+
+    T* const Abyx_norms_trfact = (T*)pfree;
+    pfree += size_Abyx_norms_trfact;
+
+    T* const diag_tmptr = (T*)pfree;
+    pfree += size_diag_tmptr;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_gelqf_template<BATCHED, STRIDED, T, U>(
+        handle, m, n, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+
+        scalars, work_workArr, Abyx_norms_trfact, diag_tmptr, workArr);
+
+    return (istat);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gelqf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gelqf.hpp
@@ -38,7 +38,7 @@
 #include "roclapack_gelq2.hpp"
 #include "rocsolver/rocsolver.h"
 
-#include "mem_utils.hpp"
+#include "rocsolver_mem_utils.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 

--- a/projects/rocsolver/library/src/lapack/roclapack_gelqf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gelqf.hpp
@@ -43,7 +43,7 @@
 ROCSOLVER_BEGIN_NAMESPACE
 
 #ifndef USE_ORIGINAL
-#define USE_ORIGINAL true
+#define USE_ORIGINAL false
 #endif
 
 template <bool BATCHED, typename T>

--- a/projects/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gelqf_batched.cpp
@@ -65,34 +65,66 @@ rocblas_status rocsolver_gelqf_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GELQ2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_gelqf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                           &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_gelqf_getMemorySize<true, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
+                                               &size_Abyx_norms_trfact, &size_diag_tmptr,
+                                               &size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
+                                                          size_Abyx_norms_trfact, size_diag_tmptr,
+                                                          size_workArr);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        // memory workspace allocation
+        void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
+                                  size_diag_tmptr, size_workArr);
 
-    scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_gelqf_template<true, false, T>(
-        handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        scalars = mem[0];
+        work_workArr = mem[1];
+        Abyx_norms_trfact = mem[2];
+        diag_tmptr = mem[3];
+        workArr = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gelqf_template<true, false, T>(
+            handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
+            work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_gelqf_getMemorySize_alt<true, T>(m, n, batch_count, &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // --------------------------------------------------
+        // note: scalars[] initialized in roclapack_gelqf.hpp
+        // --------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gelqf_template_alt<true, false, T>(handle, m, n, A, shiftA, lda, strideA,
+                                                            ipiv, stridep, batch_count,
+
+                                                            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gelqf_strided_batched.cpp
@@ -63,34 +63,66 @@ rocblas_status rocsolver_gelqf_strided_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GELQ2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_gelqf_getMemorySize<false, T>(m, n, batch_count, &size_scalars, &size_work_workArr,
-                                            &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
-                                                      size_Abyx_norms_trfact, size_diag_tmptr,
-                                                      size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_gelqf_getMemorySize<false, T>(m, n, batch_count, &size_scalars,
+                                                &size_work_workArr, &size_Abyx_norms_trfact,
+                                                &size_diag_tmptr, &size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
-                              size_diag_tmptr, size_workArr);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_scalars, size_work_workArr,
+                                                          size_Abyx_norms_trfact, size_diag_tmptr,
+                                                          size_workArr);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        // memory workspace allocation
+        void *scalars, *work_workArr, *Abyx_norms_trfact, *diag_tmptr, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_trfact,
+                                  size_diag_tmptr, size_workArr);
 
-    scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_trfact = mem[2];
-    diag_tmptr = mem[3];
-    workArr = mem[4];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_gelqf_template<false, true, T>(
-        handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+        scalars = mem[0];
+        work_workArr = mem[1];
+        Abyx_norms_trfact = mem[2];
+        diag_tmptr = mem[3];
+        workArr = mem[4];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gelqf_template<false, true, T>(
+            handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
+            work_workArr, (T*)Abyx_norms_trfact, (T*)diag_tmptr, (T**)workArr);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_gelqf_getMemorySize_alt<false, T>(m, n, batch_count, &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // --------------------------------------------------
+        // note: scalars[] initialized in roclapack_gelqf.hpp
+        // --------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gelqf_template_alt<false, true, T>(handle, m, n, A, shiftA, lda, strideA,
+                                                            ipiv, stridep, batch_count,
+
+                                                            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_geqrf.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_geqrf.cpp
@@ -61,40 +61,72 @@ rocblas_status
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<false, false, T>(
-        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
-        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(
-            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
-            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_geqrf_getMemorySize<false, false, T>(
+            m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+            &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
-        *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
-                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+                size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        // memory workspace allocation
+        void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+            *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2,
+                                  size_work3, size_work4, size_Abyx_norms_trfact, size_diag_tmptr,
+                                  size_workArr);
 
-    scalars = mem[0];
-    work_workArr_work1 = mem[1];
-    work2 = mem[2];
-    work3 = mem[3];
-    work4 = mem[4];
-    Abyx_norms_trfact = mem[5];
-    diag_tmptr = mem[6];
-    workArr = mem[7];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_geqrf_template<false, false, T>(
-        handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
-        (T**)workArr, optim_mem);
+        scalars = mem[0];
+        work_workArr_work1 = mem[1];
+        work2 = mem[2];
+        work3 = mem[3];
+        work4 = mem[4];
+        Abyx_norms_trfact = mem[5];
+        diag_tmptr = mem[6];
+        workArr = mem[7];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_geqrf_template<false, false, T>(
+            handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
+            work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+            (T**)workArr, optim_mem);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_geqrf_getMemorySize_alt<false, false, T>(m, n, batch_count, &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = mem[0];
+
+        // --------------------------------------------------
+        // note: scalars[] initialized in roclapack_geqrf.hpp
+        // --------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_geqrf_template_alt<false, false, T>(handle, m, n, A, shiftA, lda, strideA,
+                                                             ipiv, stridep, batch_count,
+
+                                                             work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_geqrf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_geqrf.hpp
@@ -42,7 +42,7 @@
 ROCSOLVER_BEGIN_NAMESPACE
 
 #ifndef USE_ORIGINAL
-#define USE_ORIGINAL true
+#define USE_ORIGINAL false
 #endif
 
 template <bool BATCHED, typename T, typename I>

--- a/projects/rocsolver/library/src/lapack/roclapack_geqrf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_geqrf.hpp
@@ -40,6 +40,33 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+#ifndef USE_ORIGINAL
+#define USE_ORIGINAL true
+#endif
+
+#ifndef MEM_CHECK
+#define MEM_CHECK(pfree)                                        \
+    {                                                           \
+        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
+        if(!is_mem_ok_)                                         \
+        {                                                       \
+            return (rocblas_status_memory_error);               \
+        }                                                       \
+    }
+#endif
+
+#ifndef MEM_CHECK_THROW
+#define MEM_CHECK_THROW(pfree)                                  \
+    {                                                           \
+        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
+        if(!is_mem_ok_)                                         \
+        {                                                       \
+            istat = rocblas_status_memory_error;                \
+            throw(istat);                                       \
+        }                                                       \
+    }
+#endif
+
 template <bool BATCHED, typename T, typename I>
 void rocsolver_geqrf_getMemorySize(const I m,
                                    const I n,
@@ -51,13 +78,13 @@ void rocsolver_geqrf_getMemorySize(const I m,
                                    size_t* size_workArr)
 {
     // if quick return no workspace needed
+    *size_scalars = 0;
+    *size_work_workArr = 0;
+    *size_Abyx_norms_trfact = 0;
+    *size_diag_tmptr = 0;
+    *size_workArr = 0;
     if(m == 0 || n == 0 || batch_count == 0)
     {
-        *size_scalars = 0;
-        *size_work_workArr = 0;
-        *size_Abyx_norms_trfact = 0;
-        *size_diag_tmptr = 0;
-        *size_workArr = 0;
         return;
     }
 
@@ -95,6 +122,36 @@ void rocsolver_geqrf_getMemorySize(const I m,
         if(BATCHED)
             *size_workArr *= 2;
     }
+}
+
+template <bool BATCHED, typename T, typename I>
+void rocsolver_geqrf_getMemorySize_alts(const I m,
+                                        const I n,
+                                        const I batch_count,
+
+                                        size_t* p_size_geqrf)
+{
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms_trfact = 0;
+    size_t size_diag_tmptr = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_geqrf_getMemorySize<BATCHED, T, I>(m, n, batch_count,
+
+                                                 &size_scalars, &size_work_workArr,
+                                                 &size_Abyx_norms_trfact, &size_diag_tmptr,
+                                                 &size_workArr);
+
+    size_t size_geqrf = 0;
+
+    size_geqrf += size_scalars;
+    size_geqrf += size_work_workArr;
+    size_geqrf += size_Abyx_norms_trfact;
+    size_geqrf += size_diag_tmptr;
+    size_geqrf += size_workArr;
+
+    *p_size_geqrf = size_geqrf;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename I, typename U>
@@ -175,6 +232,64 @@ rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
     return rocblas_status_success;
 }
 
+template <bool BATCHED, bool STRIDED, typename T, typename I, typename U>
+rocblas_status rocsolver_geqrf_template_alts(rocblas_handle handle,
+                                             const I m,
+                                             const I n,
+                                             U A,
+                                             const rocblas_stride shiftA,
+                                             const I lda,
+                                             const rocblas_stride strideA,
+                                             T* ipiv,
+                                             const rocblas_stride strideP,
+                                             const I batch_count,
+
+                                             void* const work,
+                                             size_t const size_work)
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms_trfact = 0;
+    size_t size_diag_tmptr = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_geqrf_getMemorySize<BATCHED, T, I>(m, n, batch_count,
+
+                                                 &size_scalars, &size_work_workArr,
+                                                 &size_Abyx_norms_trfact, &size_diag_tmptr,
+                                                 &size_workArr);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    void* const work_workArr = (void*)pfree;
+    pfree += size_work_workArr;
+
+    T* const Abyx_norms_trfact = (T*)pfree;
+    pfree += size_Abyx_norms_trfact;
+
+    T* const diag_tmptr = (T*)pfree;
+    pfree += size_diag_tmptr;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_geqrf_template<BATCHED, STRIDED, T, I, U>(
+        handle, m, n, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+
+        scalars, work_workArr, Abyx_norms_trfact, diag_tmptr, workArr);
+    return (istat);
+}
+
 template <bool BATCHED, bool STRIDED, typename T, typename I>
 void rocsolver_geqrf_getMemorySize(const I m,
                                    const I n,
@@ -242,6 +357,49 @@ void rocsolver_geqrf_getMemorySize(const I m,
         if(BATCHED)
             *size_workArr *= 2;
     }
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename I>
+void rocsolver_geqrf_getMemorySize_alt(const I m,
+                                       const I n,
+                                       const I batch_count,
+
+                                       size_t* p_size_geqrf)
+{
+    bool optim_mem = true;
+
+    size_t size_scalars = 0;
+    size_t size_work_workArr_work1 = 0;
+    size_t size_work2 = 0;
+    size_t size_work3 = 0;
+    size_t size_work4 = 0;
+
+    size_t size_Abyx_norms_trfact = 0;
+    size_t size_diag_tmptr = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_geqrf_getMemorySize<BATCHED, STRIDED, T, I>(
+        m, n, batch_count,
+
+        &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3, &size_work4,
+
+        &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr,
+
+        &optim_mem);
+
+    size_t size_geqrf = 0;
+
+    size_geqrf += size_scalars;
+    size_geqrf += size_work_workArr_work1;
+    size_geqrf += size_work2;
+    size_geqrf += size_work3;
+    size_geqrf += size_work4;
+
+    size_geqrf += size_Abyx_norms_trfact;
+    size_geqrf += size_diag_tmptr;
+    size_geqrf += size_workArr;
+
+    *p_size_geqrf = size_geqrf;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename I, typename U>
@@ -324,6 +482,82 @@ rocblas_status rocsolver_geqrf_template(rocblas_handle handle,
                                     work_workArr_work1, Abyx_norms_trfact, diag_tmptr);
 
     return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename I, typename U>
+rocblas_status rocsolver_geqrf_template_alt(rocblas_handle handle,
+                                            const I m,
+                                            const I n,
+                                            U A,
+                                            const rocblas_stride shiftA,
+                                            const I lda,
+                                            const rocblas_stride strideA,
+                                            T* ipiv,
+                                            const rocblas_stride strideP,
+                                            const I batch_count,
+
+                                            void* const work,
+                                            size_t const size_work)
+{
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    size_t size_scalars = 0;
+    size_t size_work_workArr_work1 = 0;
+    size_t size_work2 = 0;
+    size_t size_work3 = 0;
+    size_t size_work4 = 0;
+
+    size_t size_Abyx_norms_trfact = 0;
+    size_t size_diag_tmptr = 0;
+    size_t size_workArr = 0;
+
+    bool optim_mem = true;
+
+    rocsolver_geqrf_getMemorySize<BATCHED, STRIDED, T, I>(
+        m, n, batch_count,
+
+        &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3, &size_work4,
+
+        &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+    {
+        init_scalars(handle, (T*)scalars);
+    }
+
+    void* const work_workArr_work1 = (void*)pfree;
+    pfree += size_work_workArr_work1;
+
+    void* const work2 = (void*)pfree;
+    pfree += size_work2;
+
+    void* const work3 = (void*)pfree;
+    pfree += size_work3;
+
+    void* const work4 = (void*)pfree;
+    pfree += size_work4;
+
+    T* const Abyx_norms_trfact = (T*)pfree;
+    pfree += size_Abyx_norms_trfact;
+
+    T* const diag_tmptr = (T*)pfree;
+    pfree += size_diag_tmptr;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    MEM_CHECK(pfree);
+
+    rocblas_status const istat = rocsolver_geqrf_template<BATCHED, STRIDED, T, I, U>(
+        handle, m, n, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
+
+        scalars, work_workArr_work1, work2, work3, work4, Abyx_norms_trfact, diag_tmptr, workArr,
+        optim_mem);
+
+    return (istat);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_geqrf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_geqrf.hpp
@@ -38,33 +38,11 @@
 #include "roclapack_geqr2.hpp"
 #include "rocsolver/rocsolver.h"
 
+#include "mem_utils.hpp"
 ROCSOLVER_BEGIN_NAMESPACE
 
 #ifndef USE_ORIGINAL
 #define USE_ORIGINAL true
-#endif
-
-#ifndef MEM_CHECK
-#define MEM_CHECK(pfree)                                        \
-    {                                                           \
-        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
-        if(!is_mem_ok_)                                         \
-        {                                                       \
-            return (rocblas_status_memory_error);               \
-        }                                                       \
-    }
-#endif
-
-#ifndef MEM_CHECK_THROW
-#define MEM_CHECK_THROW(pfree)                                  \
-    {                                                           \
-        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
-        if(!is_mem_ok_)                                         \
-        {                                                       \
-            istat = rocblas_status_memory_error;                \
-            throw(istat);                                       \
-        }                                                       \
-    }
 #endif
 
 template <bool BATCHED, typename T, typename I>
@@ -83,6 +61,7 @@ void rocsolver_geqrf_getMemorySize(const I m,
     *size_Abyx_norms_trfact = 0;
     *size_diag_tmptr = 0;
     *size_workArr = 0;
+
     if(m == 0 || n == 0 || batch_count == 0)
     {
         return;
@@ -122,6 +101,12 @@ void rocsolver_geqrf_getMemorySize(const I m,
         if(BATCHED)
             *size_workArr *= 2;
     }
+
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_work_workArr);
+    adjust_for_alignment(size_Abyx_norms_trfact);
+    adjust_for_alignment(size_diag_tmptr);
+    adjust_for_alignment(size_workArr);
 }
 
 template <bool BATCHED, typename T, typename I>
@@ -308,10 +293,12 @@ void rocsolver_geqrf_getMemorySize(const I m,
     *size_work_workArr_work1 = 0;
     *size_Abyx_norms_trfact = 0;
     *size_diag_tmptr = 0;
+
     *size_workArr = 0;
     *size_work2 = 0;
     *size_work3 = 0;
     *size_work4 = 0;
+
     *optim_mem = true;
 
     // if quick return no workspace needed
@@ -357,6 +344,15 @@ void rocsolver_geqrf_getMemorySize(const I m,
         if(BATCHED)
             *size_workArr *= 2;
     }
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_work_workArr_work1);
+    adjust_for_alignment(size_Abyx_norms_trfact);
+    adjust_for_alignment(size_diag_tmptr);
+
+    adjust_for_alignment(size_workArr);
+    adjust_for_alignment(size_work2);
+    adjust_for_alignment(size_work3);
+    adjust_for_alignment(size_work4);
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename I>

--- a/projects/rocsolver/library/src/lapack/roclapack_geqrf.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_geqrf.hpp
@@ -38,7 +38,7 @@
 #include "roclapack_geqr2.hpp"
 #include "rocsolver/rocsolver.h"
 
-#include "mem_utils.hpp"
+#include "rocsolver_mem_utils.hpp"
 ROCSOLVER_BEGIN_NAMESPACE
 
 #ifndef USE_ORIGINAL

--- a/projects/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_geqrf_batched.cpp
@@ -66,40 +66,73 @@ rocblas_status rocsolver_geqrf_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<true, false, T>(
-        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
-        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(
-            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
-            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_geqrf_getMemorySize<true, false, T>(
+            m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+            &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
-        *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
-                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+                size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        // memory workspace allocation
+        void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+            *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2,
+                                  size_work3, size_work4, size_Abyx_norms_trfact, size_diag_tmptr,
+                                  size_workArr);
 
-    scalars = mem[0];
-    work_workArr_work1 = mem[1];
-    work2 = mem[2];
-    work3 = mem[3];
-    work4 = mem[4];
-    Abyx_norms_trfact = mem[5];
-    diag_tmptr = mem[6];
-    workArr = mem[7];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_geqrf_template<true, false, T>(
-        handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
-        (T**)workArr, optim_mem);
+        scalars = mem[0];
+        work_workArr_work1 = mem[1];
+        work2 = mem[2];
+        work3 = mem[3];
+        work4 = mem[4];
+        Abyx_norms_trfact = mem[5];
+        diag_tmptr = mem[6];
+        workArr = mem[7];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_geqrf_template<true, false, T>(
+            handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
+            work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+            (T**)workArr, optim_mem);
+    }
+    else
+    {
+        size_t size_work = 0;
+
+        rocsolver_geqrf_getMemorySize_alt<true, false, T>(m, n, batch_count, &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // --------------------------------------------------
+        // note: scalars[] initialized in roclapack_geqrf.hpp
+        // --------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_geqrf_template_alt<true, false, T>(handle, m, n, A, shiftA, lda, strideA,
+                                                            ipiv, stridep, batch_count,
+
+                                                            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_geqrf_strided_batched.cpp
@@ -64,40 +64,75 @@ rocblas_status rocsolver_geqrf_strided_batched_impl(rocblas_handle handle,
     size_t size_Abyx_norms_trfact;
     // extra requirements for calling GEQR2 and LARFB
     size_t size_diag_tmptr;
-    rocsolver_geqrf_getMemorySize<false, true, T>(
-        m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
-        &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(
-            handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
-            size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
+    if(USE_ORIGINAL)
+    {
+        rocsolver_geqrf_getMemorySize<false, true, T>(
+            m, n, batch_count, &size_scalars, &size_work_workArr_work1, &size_work2, &size_work3,
+            &size_work4, &size_Abyx_norms_trfact, &size_diag_tmptr, &size_workArr, &optim_mem);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
-        *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2, size_work3,
-                              size_work4, size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_work_workArr_work1, size_work2, size_work3, size_work4,
+                size_Abyx_norms_trfact, size_diag_tmptr, size_workArr);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        // memory workspace allocation
+        void *scalars, *work_workArr_work1, *work2, *work3, *work4, *Abyx_norms_trfact, *diag_tmptr,
+            *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr_work1, size_work2,
+                                  size_work3, size_work4, size_Abyx_norms_trfact, size_diag_tmptr,
+                                  size_workArr);
 
-    scalars = mem[0];
-    work_workArr_work1 = mem[1];
-    work2 = mem[2];
-    work3 = mem[3];
-    work4 = mem[4];
-    Abyx_norms_trfact = mem[5];
-    diag_tmptr = mem[6];
-    workArr = mem[7];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    // execution
-    return rocsolver_geqrf_template<false, true, T>(
-        handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
-        work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
-        (T**)workArr, optim_mem);
+        scalars = mem[0];
+        work_workArr_work1 = mem[1];
+        work2 = mem[2];
+        work3 = mem[3];
+        work4 = mem[4];
+        Abyx_norms_trfact = mem[5];
+        diag_tmptr = mem[6];
+        workArr = mem[7];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_geqrf_template<false, true, T>(
+            handle, m, n, A, shiftA, lda, strideA, ipiv, stridep, batch_count, (T*)scalars,
+            work_workArr_work1, work2, work3, work4, (T*)Abyx_norms_trfact, (T*)diag_tmptr,
+            (T**)workArr, optim_mem);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_geqrf_getMemorySize_alt<false, true, T>(m, n, batch_count,
+
+                                                          &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // --------------------------------------------------
+        // note: scalars[] initialized in roclapack_geqrf.hpp
+        // --------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_geqrf_template_alt<false, true, T>(handle, m, n, A, shiftA, lda, strideA,
+                                                            ipiv, stridep, batch_count,
+
+                                                            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.cpp
@@ -83,44 +83,81 @@ rocblas_status rocsolver_gesvd_impl(rocblas_handle handle,
     // size of array of pointers (only for batched case)
     size_t size_workArr;
 
-    rocsolver_gesvd_getMemorySize<false, T, TT>(
-        left_svect, right_svect, m, n, batch_count, fast_alg, &size_scalars, &size_work_workArr,
-        &size_Abyx_norms_tmptr, &size_Abyx_norms_trfact_X, &size_diag_tmptr_Y, &size_tau_splits,
-        &size_tempArrayT, &size_tempArrayC, &size_workArr);
+    if(use_original)
+    {
+        rocsolver_gesvd_getMemorySize<false, T, TT>(
+            left_svect, right_svect, m, n, batch_count, fast_alg, &size_scalars, &size_work_workArr,
+            &size_Abyx_norms_tmptr, &size_Abyx_norms_trfact_X, &size_diag_tmptr_Y, &size_tau_splits,
+            &size_tempArrayT, &size_tempArrayC, &size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(
-            handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr, size_Abyx_norms_trfact_X,
-            size_diag_tmptr_Y, size_tau_splits, size_tempArrayT, size_tempArrayC, size_workArr);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr,
+                size_Abyx_norms_trfact_X, size_diag_tmptr_Y, size_tau_splits, size_tempArrayT,
+                size_tempArrayC, size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_tmptr, *Abyx_norms_trfact_X, *diag_tmptr_Y, *tau_splits;
-    void *tempArrayT, *tempArrayC, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr,
-                              size_Abyx_norms_trfact_X, size_diag_tmptr_Y, size_tau_splits,
-                              size_tempArrayT, size_tempArrayC, size_workArr);
+        // memory workspace allocation
+        void *scalars, *work_workArr, *Abyx_norms_tmptr, *Abyx_norms_trfact_X, *diag_tmptr_Y,
+            *tau_splits;
+        void *tempArrayT, *tempArrayC, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr,
+                                  size_Abyx_norms_trfact_X, size_diag_tmptr_Y, size_tau_splits,
+                                  size_tempArrayT, size_tempArrayC, size_workArr);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_tmptr = mem[2];
-    Abyx_norms_trfact_X = mem[3];
-    diag_tmptr_Y = mem[4];
-    tau_splits = mem[5];
-    tempArrayT = mem[6];
-    tempArrayC = mem[7];
-    workArr = mem[8];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        scalars = mem[0];
+        work_workArr = mem[1];
+        Abyx_norms_tmptr = mem[2];
+        Abyx_norms_trfact_X = mem[3];
+        diag_tmptr_Y = mem[4];
+        tau_splits = mem[5];
+        tempArrayT = mem[6];
+        tempArrayC = mem[7];
+        workArr = mem[8];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
 
-    // execution
-    return rocsolver_gesvd_template<false, false, T>(
-        handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu, strideU,
-        V, ldv, strideV, E, strideE, fast_alg, info, batch_count, (T*)scalars, work_workArr,
-        (T*)Abyx_norms_tmptr, (T*)Abyx_norms_trfact_X, (T*)diag_tmptr_Y, (T*)tau_splits,
-        (T*)tempArrayT, (T*)tempArrayC, (T**)workArr);
+        // execution
+        return rocsolver_gesvd_template<false, false, T>(
+            handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu,
+            strideU, V, ldv, strideV, E, strideE, fast_alg, info, batch_count, (T*)scalars,
+            work_workArr, (T*)Abyx_norms_tmptr, (T*)Abyx_norms_trfact_X, (T*)diag_tmptr_Y,
+            (T*)tau_splits, (T*)tempArrayT, (T*)tempArrayC, (T**)workArr);
+    }
+    else
+    {
+        size_t size_work = 0;
+
+        rocsolver_gesvd_getMemorySize_alt<false, T, TT>(left_svect, right_svect, m, n, batch_count,
+                                                        fast_alg,
+
+                                                        &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = mem[0];
+
+        // ------------------------------------------------------------------------
+        // note: initialization of scalars[] array  performed in roclapack_gesvd.hpp
+        // ------------------------------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gesvd_template_alt<false, false, T>(
+            handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu,
+            strideU, V, ldv, strideV, E, strideE, fast_alg, info, batch_count,
+
+            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.cpp
@@ -83,7 +83,7 @@ rocblas_status rocsolver_gesvd_impl(rocblas_handle handle,
     // size of array of pointers (only for batched case)
     size_t size_workArr;
 
-    if(use_original)
+    if(USE_ORIGINAL)
     {
         rocsolver_gesvd_getMemorySize<false, T, TT>(
             left_svect, right_svect, m, n, batch_count, fast_alg, &size_scalars, &size_work_workArr,

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -81,6 +81,36 @@ void local_orgqrlq_ungqrlq_template(rocblas_handle handle,
                                                          Abyx_tmptr, trfact, workArr);
 }
 
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+void local_orgqrlq_ungqrlq_template_alt(rocblas_handle handle,
+                                        const rocblas_int m,
+                                        const rocblas_int n,
+                                        const rocblas_int k,
+                                        U A,
+                                        const rocblas_int shiftA,
+                                        const rocblas_int lda,
+                                        const rocblas_stride strideA,
+                                        T* ipiv,
+                                        const rocblas_stride strideP,
+                                        const rocblas_int batch_count,
+                                        const bool row,
+
+                                        void* const work,
+                                        size_t const size_work)
+{
+    if(row)
+    {
+        rocsolver_orgqr_ungqr_template_alt<BATCHED, STRIDED>(
+            handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count, work, size_work);
+    }
+    else
+    {
+        rocsolver_orglq_unglq_template_alt<BATCHED, STRIDED>(handle, m, n, k, A, shiftA, lda,
+                                                             strideA, ipiv, strideP, batch_count,
+
+                                                             work, size_work);
+    }
+}
 /** wrapper to GEQRF/GELQF_TEMPLATE **/
 template <bool BATCHED, bool STRIDED, typename T, typename U>
 void local_geqrlq_template(rocblas_handle handle,
@@ -109,7 +139,7 @@ void local_geqrlq_template(rocblas_handle handle,
                                                    strideP, batch_count, scalars, work_workArr,
                                                    Abyx_norms_trfact, diag_tmptr, workArr);
 }
-#if(0)
+
 template <bool BATCHED, bool STRIDED, typename T, typename U>
 void local_geqrlq_template_alt(rocblas_handle handle,
                                const rocblas_int m,
@@ -141,7 +171,6 @@ void local_geqrlq_template_alt(rocblas_handle handle,
                                                        work, size_work);
     }
 }
-#endif
 
 /** Argument checking **/
 template <typename T, typename TT, typename W>
@@ -205,6 +234,7 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
                                    const rocblas_int n,
                                    const rocblas_int batch_count,
                                    const rocblas_workmode fast_alg,
+
                                    size_t* size_scalars,
                                    size_t* size_work_workArr,
                                    size_t* size_Abyx_norms_tmptr_cmplt,
@@ -367,6 +397,16 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
     *size_Abyx_norms_tmptr_cmplt = *std::max_element(std::begin(a), std::end(a));
     *size_Abyx_norms_trfact_X = *std::max_element(std::begin(x), std::end(x));
     *size_diag_tmptr_Y = *std::max_element(std::begin(y), std::end(y));
+
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_work_workArr);
+    adjust_for_alignment(size_Abyx_norms_tmptr_cmplt);
+    adjust_for_alignment(size_Abyx_norms_trfact_X);
+    adjust_for_alignment(size_diag_tmptr_Y);
+    adjust_for_alignment(size_tau_splits);
+    adjust_for_alignment(size_tempArrayT);
+    adjust_for_alignment(size_tempArrayC);
+    adjust_for_alignment(size_workArr);
 }
 
 template <bool BATCHED, typename T, typename S>
@@ -378,6 +418,303 @@ void rocsolver_gesvd_getMemorySize_alt(const rocblas_svect left_svect,
                                        const rocblas_workmode fast_alg,
 
                                        size_t* p_size_gesvd)
+{
+    size_t size_gesvd = 0;
+    *p_size_gesvd = size_gesvd;
+
+    // if quick return, set workspace to zero
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms_tmptr_cmplt = 0;
+    size_t size_Abyx_norms_trfact_X = 0;
+    size_t size_diag_tmptr_Y = 0;
+
+    size_t size_tau_splits = 0;
+    size_t size_tempArrayT = 0;
+    size_t size_tempArrayC = 0;
+    size_t size_workArr = 0;
+
+    if(n == 0 || m == 0 || batch_count == 0)
+    {
+        return;
+    }
+
+    size_t w[6] = {0, 0, 0, 0, 0, 0};
+    size_t a[6] = {0, 0, 0, 0, 0, 0};
+    size_t x[6] = {0, 0, 0, 0, 0, 0};
+    size_t y[3] = {0, 0, 0};
+    size_t unused;
+
+    // booleans used to determine the path that the execution will follow:
+    const bool row = (m >= n);
+    const bool leftvS = (left_svect == rocblas_svect_singular);
+    const bool leftvO = (left_svect == rocblas_svect_overwrite);
+    const bool leftvA = (left_svect == rocblas_svect_all);
+    const bool leftvN = (left_svect == rocblas_svect_none);
+    const bool rightvS = (right_svect == rocblas_svect_singular);
+    const bool rightvO = (right_svect == rocblas_svect_overwrite);
+    const bool rightvA = (right_svect == rocblas_svect_all);
+    const bool rightvN = (right_svect == rocblas_svect_none);
+    //const bool leadvS = row ? leftvS : rightvS;
+    const bool leadvO = row ? leftvO : rightvO;
+    const bool leadvA = row ? leftvA : rightvA;
+    const bool leadvN = row ? leftvN : rightvN;
+    //const bool othervS = !row ? leftvS : rightvS;
+    const bool othervO = !row ? leftvO : rightvO;
+    //const bool othervA = !row ? leftvA : rightvA;
+    const bool othervN = !row ? leftvN : rightvN;
+    const bool thinSVD = (m >= THIN_SVD_SWITCH * n || n >= THIN_SVD_SWITCH * m);
+    const bool fast_thinSVD = (thinSVD && fast_alg == rocblas_outofplace);
+
+    // auxiliary sizes and variables
+    const rocblas_int k = std::min(m, n);
+    const rocblas_int kk = std::max(m, n);
+    const rocblas_int nu = leftvN ? 0 : ((fast_thinSVD || (thinSVD && leadvN)) ? k : m);
+    const rocblas_int nv = rightvN ? 0 : ((fast_thinSVD || (thinSVD && leadvN)) ? k : n);
+    const rocblas_storev storev_lead = row ? rocblas_column_wise : rocblas_row_wise;
+    const rocblas_storev storev_other = row ? rocblas_row_wise : rocblas_column_wise;
+    const rocblas_side side = row ? rocblas_side_right : rocblas_side_left;
+    rocblas_int mn;
+
+    // size of array of pointers to workspace
+    if(BATCHED)
+        size_workArr = 2 * sizeof(T*) * batch_count;
+    else
+        size_workArr = 0;
+
+    // size of arrays to store temporary copies
+    size_tempArrayT
+        = (fast_thinSVD || (thinSVD && leadvO && othervN)) ? sizeof(T) * k * k * batch_count : 0;
+    size_tempArrayC
+        = (fast_thinSVD && (othervN || othervO || leadvO)) ? sizeof(T) * m * n * batch_count : 0;
+
+    // workspace required for the bidiagonalization
+    size_t size_gebrd = 0;
+
+    if(thinSVD)
+    {
+        size_t size_work_temp = 0;
+        rocsolver_gebrd_getMemorySize_alt<BATCHED, T>(k, k, batch_count, &size_work_temp);
+
+        size_gebrd = std::max(size_gebrd, size_work_temp);
+    }
+    else
+    {
+        size_t size_work_temp = 0;
+        rocsolver_gebrd_getMemorySize_alt<BATCHED, T>(m, n, batch_count, &size_work_temp);
+
+        size_gebrd = std::max(size_gebrd, size_work_temp);
+    }
+
+    // workspace required for the SVD of the bidiagonal form
+
+    size_t size_bdsqr = 0;
+
+    {
+        size_t size_work_temp = 0;
+        rocsolver_bdsqr_getMemorySize_alt<S>(k, nv, nu, 0, batch_count, &size_work_temp);
+        size_bdsqr = std::max(size_bdsqr, size_work_temp);
+    }
+
+    // size of array tau to store householder scalars on intermediate
+    // orthonormal/unitary matrices
+    size_tau_splits = std::max(size_tau_splits, 2 * sizeof(T) * std::min(m, n) * batch_count);
+
+    // extra requirements for QR/LQ factorization
+    size_t size_geqrf = 0;
+    size_t size_gelqf = 0;
+
+    if(thinSVD)
+    {
+        if(row)
+        {
+            bool constexpr STRIDED = true;
+
+            size_t size_work_temp = 0;
+            rocsolver_geqrf_getMemorySize_alt<BATCHED, STRIDED, T>(m, n, batch_count,
+                                                                   &size_work_temp);
+
+            size_geqrf = std::max(size_geqrf, size_work_temp);
+        }
+        else
+        {
+            size_t size_work_temp = 0;
+            rocsolver_gelqf_getMemorySize_alt<BATCHED, T>(m, n, batch_count, &size_work_temp);
+
+            size_gelqf = std::max(size_gelqf, size_work_temp);
+        }
+    }
+
+    // extra requirements for orthonormal/unitary matrix generation
+    // ormbr
+    size_t size_ormbr = 0;
+
+    if(thinSVD && !fast_thinSVD && !leadvN)
+    {
+        size_t size_work_temp = 0;
+        rocsolver_ormbr_unmbr_getMemorySize_alt<BATCHED, T>(storev_lead, side, m, n, k, batch_count,
+                                                            &size_work_temp);
+        size_ormbr = std::max(size_ormbr, size_work_temp);
+    }
+    // orgbr
+    size_t size_orgbr = 0;
+
+    if(thinSVD)
+    {
+        if(!othervN)
+        {
+            size_t size_work_temp = 0;
+            rocsolver_orgbr_ungbr_getMemorySize_alt<BATCHED, T>(storev_other, k, k, k, batch_count,
+                                                                &size_work_temp);
+            size_orgbr = std::max(size_orgbr, size_work_temp);
+        }
+
+        if(fast_thinSVD && !leadvN)
+        {
+            size_t size_work_temp = 0;
+            rocsolver_orgbr_ungbr_getMemorySize_alt<BATCHED, T>(storev_lead, k, k, k, batch_count,
+                                                                &size_work_temp);
+            size_orgbr = std::max(size_orgbr, size_work_temp);
+        }
+    }
+    else
+    {
+        mn = (row && leftvS) ? n : m;
+        if(leftvS || leftvA)
+        {
+            size_t size_work_temp = 0;
+            rocsolver_orgbr_ungbr_getMemorySize_alt<BATCHED, T>(rocblas_column_wise, m, mn, n,
+                                                                batch_count, &size_work_temp);
+
+            size_orgbr = std::max(size_orgbr, size_work_temp);
+        }
+        else if(leftvO)
+        {
+            size_t size_work_temp = 0;
+            rocsolver_orgbr_ungbr_getMemorySize_alt<BATCHED, T>(rocblas_column_wise, m, k, n,
+                                                                batch_count, &size_work_temp);
+
+            size_orgbr = std::max(size_orgbr, size_work_temp);
+        }
+
+        mn = (!row && rightvS) ? m : n;
+        if(rightvS || rightvA)
+        {
+            size_t size_work_temp = 0;
+            rocsolver_orgbr_ungbr_getMemorySize_alt<BATCHED, T>(rocblas_row_wise, mn, n, m,
+                                                                batch_count, &size_work_temp);
+            size_orgbr = std::max(size_orgbr, size_work_temp);
+        }
+        else if(rightvO)
+        {
+            size_t size_work_temp = 0;
+            rocsolver_orgbr_ungbr_getMemorySize_alt<BATCHED, T>(rocblas_row_wise, k, n, m,
+                                                                batch_count, &size_work_temp);
+            size_orgbr = std::max(size_orgbr, size_work_temp);
+        }
+    }
+    // orgqr/orglq
+    size_t size_orgqr = 0;
+    size_t size_orglq = 0;
+
+    if(thinSVD && !leadvN)
+    {
+        if(leadvA)
+        {
+            if(row)
+            {
+                size_t size_work_temp = 0;
+                rocsolver_orgqr_ungqr_getMemorySize_alt<BATCHED, T>(kk, kk, k, batch_count,
+                                                                    &size_work_temp);
+                size_orgqr = std::max(size_orgqr, size_work_temp);
+            }
+            else
+            {
+                size_t size_work_temp = 0;
+                rocsolver_orglq_unglq_getMemorySize_alt<BATCHED, T>(kk, kk, k, batch_count,
+                                                                    &size_work_temp);
+                size_orglq = std::max(size_orglq, size_work_temp);
+            }
+        }
+        else
+        {
+            if(row)
+            {
+                size_t size_work_temp = 0;
+                rocsolver_orgqr_ungqr_getMemorySize_alt<BATCHED, T>(m, n, k, batch_count,
+                                                                    &size_work_temp);
+
+                size_orgqr = std::max(size_orgqr, size_work_temp);
+            }
+            else
+            {
+                size_t size_work_temp = 0;
+                rocsolver_orglq_unglq_getMemorySize_alt<BATCHED, T>(m, n, k, batch_count,
+                                                                    &size_work_temp);
+                size_orglq = std::max(size_orglq, size_work_temp);
+            }
+        }
+    }
+
+    // get max sizes
+    size_work_workArr = *std::max_element(std::begin(w), std::end(w));
+    size_Abyx_norms_tmptr_cmplt = *std::max_element(std::begin(a), std::end(a));
+    size_Abyx_norms_trfact_X = *std::max_element(std::begin(x), std::end(x));
+    size_diag_tmptr_Y = *std::max_element(std::begin(y), std::end(y));
+
+    adjust_for_alignment(size_tau_splits);
+
+    adjust_for_alignment(size_workArr);
+    adjust_for_alignment(size_Abyx_norms_tmptr_cmplt);
+    adjust_for_alignment(size_Abyx_norms_trfact_X);
+    adjust_for_alignment(size_diag_tmptr_Y);
+
+    adjust_for_alignment(size_tempArrayT);
+    adjust_for_alignment(size_tempArrayC);
+
+    adjust_for_alignment(size_gebrd);
+    adjust_for_alignment(size_bdsqr);
+    adjust_for_alignment(size_geqrf);
+    adjust_for_alignment(size_gelqf);
+
+    adjust_for_alignment(size_ormbr);
+    adjust_for_alignment(size_orgbr);
+    adjust_for_alignment(size_orgqr);
+    adjust_for_alignment(size_orglq);
+
+    // TODO: revisit  legacy shared array
+    size_gesvd += size_tau_splits;
+    size_gesvd += size_workArr;
+    size_gesvd += size_work_workArr;
+    size_gesvd += size_Abyx_norms_tmptr_cmplt;
+    size_gesvd += size_Abyx_norms_trfact_X;
+    size_gesvd += size_diag_tmptr_Y;
+    size_gesvd += size_tempArrayT;
+    size_gesvd += size_tempArrayC;
+
+    size_gesvd += size_gebrd;
+    size_gesvd += size_bdsqr;
+
+    size_gesvd += std::max(size_geqrf, size_gelqf);
+
+    size_gesvd += size_ormbr;
+    size_gesvd += size_orgbr;
+
+    size_gesvd += std::max(size_orgqr, size_orglq);
+
+    adjust_for_alignment(size_gesvd);
+    *p_size_gesvd = size_gesvd;
+}
+
+template <bool BATCHED, typename T, typename S>
+void rocsolver_gesvd_getMemorySize_alt_org(const rocblas_svect left_svect,
+                                           const rocblas_svect right_svect,
+                                           const rocblas_int m,
+                                           const rocblas_int n,
+                                           const rocblas_int batch_count,
+                                           const rocblas_workmode fast_alg,
+
+                                           size_t* p_size_gesvd)
 {
     size_t size_scalars = 0;
     size_t size_work_workArr = 0;

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -513,6 +513,10 @@ void rocsolver_gesvd_getMemorySize_alt(const rocblas_svect left_svect,
     if(thinSVD)
     {
         size_t size_work_temp = 0;
+
+        // --------------------------------------------------------------------
+        // assume X, Y are not scratch arrays but are arguments to be passed in
+        // --------------------------------------------------------------------
         rocsolver_gebrd_getMemorySize_alt<BATCHED, T>(k, k, batch_count, &size_work_temp);
 
         size_gebrd = std::max(size_gebrd, size_work_temp);
@@ -681,16 +685,21 @@ void rocsolver_gesvd_getMemorySize_alt(const rocblas_svect left_svect,
         adjust_for_alignment(size_tempArrayT);
         adjust_for_alignment(size_tempArrayC);
 
-        size_gesvd += size_tempArrayT;
-        size_gesvd += size_tempArrayC;
-
         adjust_for_alignment(size_tau_splits);
         adjust_for_alignment(size_Abyx_norms_trfact_X);
         adjust_for_alignment(size_diag_tmptr_Y);
 
+        size_gesvd += size_tempArrayT;
+        size_gesvd += size_tempArrayC;
+
         size_gesvd += size_tau_splits;
-        size_gesvd += size_diag_tmptr_Y;
-        size_gesvd += size_Abyx_norms_trfact_X;
+
+        // ----------------------------------------
+        // note: no need for temporary arrays
+        // Abyx_norms_trfact_X[] and diag_tmptr_Y[]
+        // ----------------------------------------
+        // size_gesvd += size_diag_tmptr_Y;
+        // size_gesvd += size_Abyx_norms_trfact_X;
     }
 
     {
@@ -714,26 +723,23 @@ void rocsolver_gesvd_getMemorySize_alt(const rocblas_svect left_svect,
         adjust_for_alignment(size_bdsqr);
         adjust_for_alignment(size_geqrf);
         adjust_for_alignment(size_gelqf);
-
-        size_gesvd += size_gebrd;
-        size_gesvd += size_bdsqr;
-
-        size_gesvd += std::max(size_geqrf, size_gelqf);
-    }
-
-    {
         adjust_for_alignment(size_ormbr);
         adjust_for_alignment(size_orgbr);
-
-        size_gesvd += size_ormbr;
-        size_gesvd += size_orgbr;
-    }
-
-    {
         adjust_for_alignment(size_orgqr);
         adjust_for_alignment(size_orglq);
 
-        size_gesvd += std::max(size_orgqr, size_orglq);
+        // clang-format off
+        size_gesvd += std::max( size_gebrd, 
+                      std::max( size_bdsqr,
+                      std::max( size_geqrf,
+                      std::max( size_gelqf,
+                      std::max( size_ormbr,
+                      std::max( size_orgbr,
+                      std::max( size_orgqr,
+                      std::max( size_orgqr,
+			        size_orglq ) ) ) ) ) ) ) );
+
+        // clang-format on
     }
 
     adjust_for_alignment(size_gesvd);
@@ -1471,6 +1477,16 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
         &size_scalars, &size_work_workArr, &size_Abyx_norms_tmptr_cmplt, &size_Abyx_norms_trfact_X,
         &size_diag_tmptr_Y, &size_tau_splits, &size_tempArrayT, &size_tempArrayC, &size_workArr);
 
+    {
+        // -----------------------------------------
+        // not need for temporary arrays
+        // diag_tmptr_Y[] and Abyx_norms_trfact_X[]
+        // -----------------------------------------
+
+        size_Abyx_norms_trfact_X = 0;
+        size_diag_tmptr_Y = 0;
+    }
+
     rocblas_status istat = rocblas_status_success;
 
     std::byte* const pwork = (std::byte*)work;
@@ -1686,9 +1702,11 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
 
                         tau_splits, k, (tau_splits + k * batch_count), k,
 
-                        X, shiftX, ldx, strideX,
+                        // X,
+                        shiftX, ldx, strideX,
 
-                        Y, shiftY, ldy, strideY,
+                        // Y,
+                        shiftY, ldy, strideY,
 
                         batch_count,
 
@@ -1849,13 +1867,19 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
                     T* const Y = (T*)diag_tmptr_Y;
 
                     istat = rocsolver_gebrd_template_alt<false, STRIDED>(
-                        handle, k, k, bufferT, shiftT, ldt, strideT, S, strideS, E, strideE,
+                        handle, k, k,
+
+                        bufferT, shiftT, ldt, strideT,
+
+                        S, strideS, E, strideE,
 
                         tau_splits, k, (tau_splits + k * batch_count), k,
 
-                        X, shiftX, ldx, strideX,
+                        // X,
+                        shiftX, ldx, strideX,
 
-                        Y, shiftY, ldy, strideY,
+                        // Y,
+                        shiftY, ldy, strideY,
 
                         batch_count,
 
@@ -2189,9 +2213,11 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
 
                             tau_splits, k, (tau_splits + k * batch_count), k,
 
-                            X, shiftX, ldx, strideX,
+                            // X,
+                            shiftX, ldx, strideX,
 
-                            Y, shiftY, ldy, strideY,
+                            // Y,
+                            shiftY, ldy, strideY,
 
                             batch_count,
 
@@ -2226,9 +2252,11 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
 
                             tau_splits, k, (tau_splits + k * batch_count), k,
 
-                            X, shiftX, ldx, strideX,
+                            // X,
+                            shiftX, ldx, strideX,
 
-                            Y, shiftY, ldy, strideY,
+                            // Y,
+                            shiftY, ldy, strideY,
 
                             batch_count,
 
@@ -2398,12 +2426,28 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
                 size_t const size_work_gebrd = (pwork + size_work) - pfree;
                 void* const work_gebrd = (void*)pfree;
 
+                T* const X = (T*)Abyx_norms_trfact_X;
+                T* const Y = (T*)diag_tmptr_Y;
+
                 istat = rocsolver_gebrd_template_alt<BATCHED, STRIDED>(
-                    handle, m, n, A, shiftA, lda, strideA, S, strideS, E, strideE, tau_splits, k,
-                    (tau_splits + k * batch_count), k, Abyx_norms_trfact_X, shiftX, ldx, strideX,
-                    diag_tmptr_Y, shiftY, ldy, strideY, batch_count,
+                    handle, m, n,
+
+                    A, shiftA, lda, strideA,
+
+                    S, strideS, E, strideE, tau_splits,
+
+                    k, (tau_splits + k * batch_count), k,
+
+                    // X,
+                    shiftX, ldx, strideX,
+
+                    // Y,
+                    shiftY, ldy, strideY,
+
+                    batch_count,
 
                     work_gebrd, size_work_gebrd);
+
                 if(istat != rocblas_status_success)
                 {
                     throw(istat);

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -47,7 +47,7 @@
 ROCSOLVER_BEGIN_NAMESPACE
 
 #ifndef USE_ORIGINAL
-#define USE_ORIGINAL true
+#define USE_ORIGINAL false
 #endif
 
 /** wrapper to xxGQR/xxGLQ_TEMPLATE **/

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -44,7 +44,9 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
-static bool constexpr use_original = false;
+#ifndef USE_ORIGINAL
+#define USE_ORIGINAL true
+#endif
 
 static inline void adjust_for_alignment(size_t& size_work)
 {
@@ -67,6 +69,7 @@ static inline void adjust_for_alignment(size_t* p_size_work)
 #define IS_POINTER_BATCHED(A, T) \
     (std::is_pointer_v<std::remove_cv_t<std::remove_cv_t<std::remove_reference_t<decltype((A)[0])>>>>)
 
+#ifndef MEM_CHECK
 #define MEM_CHECK(pfree)                                        \
     {                                                           \
         bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
@@ -75,7 +78,9 @@ static inline void adjust_for_alignment(size_t* p_size_work)
             return (rocblas_status_memory_error);               \
         }                                                       \
     }
+#endif
 
+#ifndef MEM_CHECK_THROW
 #define MEM_CHECK_THROW(pfree)                                  \
     {                                                           \
         bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
@@ -85,6 +90,7 @@ static inline void adjust_for_alignment(size_t* p_size_work)
             throw(istat);                                       \
         }                                                       \
     }
+#endif
 /** wrapper to xxGQR/xxGLQ_TEMPLATE **/
 template <bool BATCHED, bool STRIDED, typename T, typename U>
 void local_orgqrlq_ungqrlq_template(rocblas_handle handle,
@@ -144,6 +150,39 @@ void local_geqrlq_template(rocblas_handle handle,
                                                    strideP, batch_count, scalars, work_workArr,
                                                    Abyx_norms_trfact, diag_tmptr, workArr);
 }
+#if(0)
+template <bool BATCHED, bool STRIDED, typename T, typename U>
+void local_geqrlq_template_alt(rocblas_handle handle,
+                               const rocblas_int m,
+                               const rocblas_int n,
+                               U A,
+                               const rocblas_int shiftA,
+                               const rocblas_int lda,
+                               const rocblas_stride strideA,
+                               T* ipiv,
+                               const rocblas_stride strideP,
+                               const rocblas_int batch_count,
+                               const bool row,
+
+                               void* const work,
+                               size_t const size_work)
+{
+    if(row)
+    {
+        rocsolver_geqrf_template_alt<BATCHED, STRIDED>(handle, m, n, A, shiftA, lda, strideA, ipiv,
+                                                       strideP, batch_count,
+
+                                                       work, size_work);
+    }
+    else
+    {
+        rocsolver_gelqf_template_alt<BATCHED, STRIDED>(handle, m, n, A, shiftA, lda, strideA, ipiv,
+                                                       strideP, batch_count,
+
+                                                       work, size_work);
+    }
+}
+#endif
 
 /** Argument checking **/
 template <typename T, typename TT, typename W>

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -736,8 +736,7 @@ void rocsolver_gesvd_getMemorySize_alt(const rocblas_svect left_svect,
                       std::max( size_ormbr,
                       std::max( size_orgbr,
                       std::max( size_orgqr,
-                      std::max( size_orgqr,
-			        size_orglq ) ) ) ) ) ) ) );
+			        size_orglq ) ) ) ) ) ) ) ;
 
         // clang-format on
     }

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -1081,7 +1081,8 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
     size_t size_workArr = 0;
 
     {
-        rocsolver_gesvd_getMemorySize<BATCHED, T, T>(
+        using S = decltype(std::real(T{}));
+        rocsolver_gesvd_getMemorySize<BATCHED, T, S>(
             left_svect, right_svect, m, n, batch_count, fast_alg,
 
             &size_scalars, &size_work_workArr, &size_Abyx_norms_tmptr_cmplt,
@@ -1123,9 +1124,11 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
     pfree += size_workArr;
 
     {
-        bool const is_mem_ok = (pfree <= (pwork + size_work));
-        if(!is_mem_ok)
+        bool const is_mem_ok_ = (pfree <= (pwork + size_work));
+        if(!is_mem_ok_)
         {
+            printf("size_work = %ld, m = %d, n = %d, batch_count = %d\n", size_work, (int)m, (int)n,
+                   (int)batch_count);
             return (rocblas_status_memory_error);
         }
     }

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -44,6 +44,47 @@
 
 ROCSOLVER_BEGIN_NAMESPACE
 
+static bool constexpr use_original = false;
+
+static inline void adjust_for_alignment(size_t& size_work)
+{
+    constexpr int ialign = 256;
+
+    auto ceil = [](auto n, auto base) { return ((n - 1) / base + 1); };
+
+    size_work = ceil(size_work, ialign) * ialign;
+}
+
+static inline void adjust_for_alignment(size_t* p_size_work)
+{
+    size_t size_work = *p_size_work;
+
+    adjust_for_alignment(size_work);
+
+    *p_size_work = size_work;
+}
+
+#define IS_POINTER_BATCHED(A, T) \
+    (std::is_pointer_v<std::remove_cv_t<std::remove_cv_t<std::remove_reference_t<decltype((A)[0])>>>>)
+
+#define MEM_CHECK(pfree)                                        \
+    {                                                           \
+        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
+        if(!is_mem_ok_)                                         \
+        {                                                       \
+            return (rocblas_status_memory_error);               \
+        }                                                       \
+    }
+
+#define MEM_CHECK_THROW(pfree)                                  \
+    {                                                           \
+        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
+        if(!is_mem_ok_)                                         \
+        {                                                       \
+            istat = rocblas_status_memory_error;                \
+            throw(istat);                                       \
+        }                                                       \
+    }
 /** wrapper to xxGQR/xxGLQ_TEMPLATE **/
 template <bool BATCHED, bool STRIDED, typename T, typename U>
 void local_orgqrlq_ungqrlq_template(rocblas_handle handle,
@@ -177,17 +218,17 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
                                    size_t* size_workArr)
 {
     // if quick return, set workspace to zero
+    *size_scalars = 0;
+    *size_work_workArr = 0;
+    *size_Abyx_norms_tmptr_cmplt = 0;
+    *size_Abyx_norms_trfact_X = 0;
+    *size_diag_tmptr_Y = 0;
+    *size_tau_splits = 0;
+    *size_tempArrayT = 0;
+    *size_tempArrayC = 0;
+    *size_workArr = 0;
     if(n == 0 || m == 0 || batch_count == 0)
     {
-        *size_scalars = 0;
-        *size_work_workArr = 0;
-        *size_Abyx_norms_tmptr_cmplt = 0;
-        *size_Abyx_norms_trfact_X = 0;
-        *size_diag_tmptr_Y = 0;
-        *size_tau_splits = 0;
-        *size_tempArrayT = 0;
-        *size_tempArrayC = 0;
-        *size_workArr = 0;
         return;
     }
 
@@ -328,6 +369,63 @@ void rocsolver_gesvd_getMemorySize(const rocblas_svect left_svect,
     *size_Abyx_norms_tmptr_cmplt = *std::max_element(std::begin(a), std::end(a));
     *size_Abyx_norms_trfact_X = *std::max_element(std::begin(x), std::end(x));
     *size_diag_tmptr_Y = *std::max_element(std::begin(y), std::end(y));
+}
+
+template <bool BATCHED, typename T, typename S>
+void rocsolver_gesvd_getMemorySize_alt(const rocblas_svect left_svect,
+                                       const rocblas_svect right_svect,
+                                       const rocblas_int m,
+                                       const rocblas_int n,
+                                       const rocblas_int batch_count,
+                                       const rocblas_workmode fast_alg,
+
+                                       size_t* p_size_gesvd)
+{
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms_tmptr_cmplt = 0;
+    size_t size_Abyx_norms_trfact_X = 0;
+
+    size_t size_diag_tmptr_Y = 0;
+    size_t size_tau_splits = 0;
+    size_t size_tempArrayT = 0;
+    size_t size_tempArrayC = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_gesvd_getMemorySize<BATCHED, T, S>(
+        left_svect, right_svect, m, n, batch_count, fast_alg,
+
+        &size_scalars, &size_work_workArr, &size_Abyx_norms_tmptr_cmplt, &size_Abyx_norms_trfact_X,
+
+        &size_diag_tmptr_Y, &size_tau_splits, &size_tempArrayT, &size_tempArrayC, &size_workArr);
+
+    adjust_for_alignment(size_scalars);
+    adjust_for_alignment(size_work_workArr);
+    adjust_for_alignment(size_Abyx_norms_tmptr_cmplt);
+    adjust_for_alignment(size_Abyx_norms_trfact_X);
+
+    adjust_for_alignment(size_diag_tmptr_Y);
+    adjust_for_alignment(size_tau_splits);
+    adjust_for_alignment(size_tempArrayT);
+    adjust_for_alignment(size_tempArrayC);
+    adjust_for_alignment(size_workArr);
+
+    size_t size_gesvd = 0;
+
+    size_gesvd += size_scalars;
+    size_gesvd += size_work_workArr;
+    size_gesvd += size_Abyx_norms_tmptr_cmplt;
+    size_gesvd += size_Abyx_norms_trfact_X;
+
+    size_gesvd += size_diag_tmptr_Y;
+    size_gesvd += size_tau_splits;
+    size_gesvd += size_tempArrayT;
+    size_gesvd += size_tempArrayC;
+    size_gesvd += size_workArr;
+
+    adjust_for_alignment(size_gesvd);
+
+    *p_size_gesvd = size_gesvd;
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename TT, typename W>
@@ -941,6 +1039,106 @@ rocblas_status rocsolver_gesvd_template(rocblas_handle handle,
 
     rocblas_set_pointer_mode(handle, old_mode);
     return rocblas_status_success;
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename TT, typename W>
+rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
+                                            const rocblas_svect left_svect,
+                                            const rocblas_svect right_svect,
+                                            const rocblas_int m,
+                                            const rocblas_int n,
+                                            W A,
+                                            const rocblas_int shiftA,
+                                            const rocblas_int lda,
+                                            const rocblas_stride strideA,
+                                            TT* S,
+                                            const rocblas_stride strideS,
+                                            T* U,
+                                            const rocblas_int ldu,
+                                            const rocblas_stride strideU,
+                                            T* V,
+                                            const rocblas_int ldv,
+                                            const rocblas_stride strideV,
+                                            TT* E,
+                                            const rocblas_stride strideE,
+                                            const rocblas_workmode fast_alg,
+                                            rocblas_int* info,
+                                            const rocblas_int batch_count,
+
+                                            void* work,
+                                            size_t const size_work)
+
+{
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms_tmptr_cmplt = 0;
+    size_t size_Abyx_norms_trfact_X = 0;
+
+    size_t size_diag_tmptr_Y = 0;
+    size_t size_tau_splits = 0;
+    size_t size_tempArrayT = 0;
+    size_t size_tempArrayC = 0;
+    size_t size_workArr = 0;
+
+    {
+        rocsolver_gesvd_getMemorySize<BATCHED, T, T>(
+            left_svect, right_svect, m, n, batch_count, fast_alg,
+
+            &size_scalars, &size_work_workArr, &size_Abyx_norms_tmptr_cmplt,
+            &size_Abyx_norms_trfact_X,
+
+            &size_diag_tmptr_Y, &size_tau_splits, &size_tempArrayT, &size_tempArrayC, &size_workArr);
+    }
+
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    T* const scalars = (T*)pfree;
+    pfree += size_scalars;
+    if(size_scalars > 0)
+        init_scalars(handle, (T*)scalars);
+
+    void* const work_workArr = (void*)pfree;
+    pfree += size_work_workArr;
+
+    T* const Abyx_norms_tmptr_cmplt = (T*)pfree;
+    pfree += size_Abyx_norms_tmptr_cmplt;
+
+    T* const Abyx_norms_trfact_X = (T*)pfree;
+    pfree += size_Abyx_norms_trfact_X;
+
+    T* const diag_tmptr_Y = (T*)pfree;
+    pfree += size_diag_tmptr_Y;
+
+    T* const tau_splits = (T*)pfree;
+    pfree += size_tau_splits;
+
+    T* const tempArrayT = (T*)pfree;
+    pfree += size_tempArrayT;
+
+    T* const tempArrayC = (T*)pfree;
+    pfree += size_tempArrayC;
+
+    T** const workArr = (T**)pfree;
+    pfree += size_workArr;
+
+    {
+        bool const is_mem_ok = (pfree <= (pwork + size_work));
+        if(!is_mem_ok)
+        {
+            return (rocblas_status_memory_error);
+        }
+    }
+
+    rocblas_status istat = rocsolver_gesvd_template<BATCHED, STRIDED, T, TT, W>(
+        handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu, strideU,
+        V, ldv, strideV, E, strideE, fast_alg, info, batch_count,
+
+        scalars, work_workArr, Abyx_norms_tmptr_cmplt, Abyx_norms_trfact_X,
+
+        diag_tmptr_Y, tau_splits, tempArrayT, tempArrayC, workArr);
+
+    return (istat);
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -1123,15 +1123,7 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
     T** const workArr = (T**)pfree;
     pfree += size_workArr;
 
-    {
-        bool const is_mem_ok_ = (pfree <= (pwork + size_work));
-        if(!is_mem_ok_)
-        {
-            printf("size_work = %ld, m = %d, n = %d, batch_count = %d\n", size_work, (int)m, (int)n,
-                   (int)batch_count);
-            return (rocblas_status_memory_error);
-        }
-    }
+    MEM_CHECK(pfree);
 
     rocblas_status istat = rocsolver_gesvd_template<BATCHED, STRIDED, T, TT, W>(
         handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu, strideU,

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -42,55 +42,14 @@
 #include "rocsolver/rocsolver.h"
 #include "rocsolver_run_specialized_kernels.hpp"
 
+#include "mem_utils.hpp"
+
 ROCSOLVER_BEGIN_NAMESPACE
 
 #ifndef USE_ORIGINAL
 #define USE_ORIGINAL true
 #endif
 
-static inline void adjust_for_alignment(size_t& size_work)
-{
-    constexpr int ialign = 256;
-
-    auto ceil = [](auto n, auto base) { return ((n - 1) / base + 1); };
-
-    size_work = ceil(size_work, ialign) * ialign;
-}
-
-static inline void adjust_for_alignment(size_t* p_size_work)
-{
-    size_t size_work = *p_size_work;
-
-    adjust_for_alignment(size_work);
-
-    *p_size_work = size_work;
-}
-
-#define IS_POINTER_BATCHED(A, T) \
-    (std::is_pointer_v<std::remove_cv_t<std::remove_cv_t<std::remove_reference_t<decltype((A)[0])>>>>)
-
-#ifndef MEM_CHECK
-#define MEM_CHECK(pfree)                                        \
-    {                                                           \
-        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
-        if(!is_mem_ok_)                                         \
-        {                                                       \
-            return (rocblas_status_memory_error);               \
-        }                                                       \
-    }
-#endif
-
-#ifndef MEM_CHECK_THROW
-#define MEM_CHECK_THROW(pfree)                                  \
-    {                                                           \
-        bool const is_mem_ok_ = (pfree <= (pwork + size_work)); \
-        if(!is_mem_ok_)                                         \
-        {                                                       \
-            istat = rocblas_status_memory_error;                \
-            throw(istat);                                       \
-        }                                                       \
-    }
-#endif
 /** wrapper to xxGQR/xxGLQ_TEMPLATE **/
 template <bool BATCHED, bool STRIDED, typename T, typename U>
 void local_orgqrlq_ungqrlq_template(rocblas_handle handle,

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -82,34 +82,35 @@ void local_orgqrlq_ungqrlq_template(rocblas_handle handle,
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename U>
-void local_orgqrlq_ungqrlq_template_alt(rocblas_handle handle,
-                                        const rocblas_int m,
-                                        const rocblas_int n,
-                                        const rocblas_int k,
-                                        U A,
-                                        const rocblas_int shiftA,
-                                        const rocblas_int lda,
-                                        const rocblas_stride strideA,
-                                        T* ipiv,
-                                        const rocblas_stride strideP,
-                                        const rocblas_int batch_count,
-                                        const bool row,
+rocblas_status local_orgqrlq_ungqrlq_template_alt(rocblas_handle handle,
+                                                  const rocblas_int m,
+                                                  const rocblas_int n,
+                                                  const rocblas_int k,
+                                                  U A,
+                                                  const rocblas_int shiftA,
+                                                  const rocblas_int lda,
+                                                  const rocblas_stride strideA,
+                                                  T* ipiv,
+                                                  const rocblas_stride strideP,
+                                                  const rocblas_int batch_count,
+                                                  const bool row,
 
-                                        void* const work,
-                                        size_t const size_work)
+                                                  void* const work,
+                                                  size_t const size_work)
 {
     if(row)
     {
-        rocsolver_orgqr_ungqr_template_alt<BATCHED, STRIDED>(
-            handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count, work, size_work);
+        return (rocsolver_orgqr_ungqr_template_alt<BATCHED, STRIDED>(
+            handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count, work, size_work));
     }
     else
     {
-        rocsolver_orglq_unglq_template_alt<BATCHED, STRIDED>(handle, m, n, k, A, shiftA, lda,
-                                                             strideA, ipiv, strideP, batch_count,
+        return (rocsolver_orglq_unglq_template_alt<BATCHED, STRIDED>(
+            handle, m, n, k, A, shiftA, lda, strideA, ipiv, strideP, batch_count,
 
-                                                             work, size_work);
+            work, size_work));
     }
+    return (rocblas_status_success);
 }
 /** wrapper to GEQRF/GELQF_TEMPLATE **/
 template <bool BATCHED, bool STRIDED, typename T, typename U>
@@ -141,35 +142,36 @@ void local_geqrlq_template(rocblas_handle handle,
 }
 
 template <bool BATCHED, bool STRIDED, typename T, typename U>
-void local_geqrlq_template_alt(rocblas_handle handle,
-                               const rocblas_int m,
-                               const rocblas_int n,
-                               U A,
-                               const rocblas_int shiftA,
-                               const rocblas_int lda,
-                               const rocblas_stride strideA,
-                               T* ipiv,
-                               const rocblas_stride strideP,
-                               const rocblas_int batch_count,
-                               const bool row,
+rocblas_status local_geqrlq_template_alt(rocblas_handle handle,
+                                         const rocblas_int m,
+                                         const rocblas_int n,
+                                         U A,
+                                         const rocblas_int shiftA,
+                                         const rocblas_int lda,
+                                         const rocblas_stride strideA,
+                                         T* ipiv,
+                                         const rocblas_stride strideP,
+                                         const rocblas_int batch_count,
+                                         const bool row,
 
-                               void* const work,
-                               size_t const size_work)
+                                         void* const work,
+                                         size_t const size_work)
 {
     if(row)
     {
-        rocsolver_geqrf_template_alt<BATCHED, STRIDED>(handle, m, n, A, shiftA, lda, strideA, ipiv,
-                                                       strideP, batch_count,
+        return (rocsolver_geqrf_template_alt<BATCHED, STRIDED>(handle, m, n, A, shiftA, lda,
+                                                               strideA, ipiv, strideP, batch_count,
 
-                                                       work, size_work);
+                                                               work, size_work));
     }
     else
     {
-        rocsolver_gelqf_template_alt<BATCHED, STRIDED>(handle, m, n, A, shiftA, lda, strideA, ipiv,
-                                                       strideP, batch_count,
+        return (rocsolver_gelqf_template_alt<BATCHED, STRIDED>(handle, m, n, A, shiftA, lda,
+                                                               strideA, ipiv, strideP, batch_count,
 
-                                                       work, size_work);
+                                                               work, size_work));
     }
+    return (rocblas_status_success);
 }
 
 /** Argument checking **/
@@ -434,16 +436,33 @@ void rocsolver_gesvd_getMemorySize_alt(const rocblas_svect left_svect,
     size_t size_tempArrayC = 0;
     size_t size_workArr = 0;
 
+    //       ---------------------------------------------
+    // TODO: try to figure out how arrays tempArrayT[], tempArrayC[],
+    //       tau_splits[], Abyx_norms_tmptr_trfact_X[],  diag_tmptr_Y[]
+    //       are reused
+    //       ---------------------------------------------
+
+    {
+        rocsolver_gesvd_getMemorySize<BATCHED, T, S>(
+            left_svect, right_svect, m, n, batch_count, fast_alg,
+
+            &size_scalars, &size_work_workArr, &size_Abyx_norms_tmptr_cmplt,
+            &size_Abyx_norms_trfact_X, &size_diag_tmptr_Y, &size_tau_splits, &size_tempArrayT,
+            &size_tempArrayC, &size_workArr);
+    }
+
     if(n == 0 || m == 0 || batch_count == 0)
     {
         return;
     }
 
+#if(0)
     size_t w[6] = {0, 0, 0, 0, 0, 0};
     size_t a[6] = {0, 0, 0, 0, 0, 0};
     size_t x[6] = {0, 0, 0, 0, 0, 0};
     size_t y[3] = {0, 0, 0};
     size_t unused;
+#endif
 
     // booleans used to determine the path that the execution will follow:
     const bool row = (m >= n);
@@ -656,51 +675,66 @@ void rocsolver_gesvd_getMemorySize_alt(const rocblas_svect left_svect,
         }
     }
 
-    // get max sizes
-    size_work_workArr = *std::max_element(std::begin(w), std::end(w));
-    size_Abyx_norms_tmptr_cmplt = *std::max_element(std::begin(a), std::end(a));
-    size_Abyx_norms_trfact_X = *std::max_element(std::begin(x), std::end(x));
-    size_diag_tmptr_Y = *std::max_element(std::begin(y), std::end(y));
+    {
+        // TODO: revisit  legacy shared array
 
-    adjust_for_alignment(size_tau_splits);
+        adjust_for_alignment(size_tempArrayT);
+        adjust_for_alignment(size_tempArrayC);
 
-    adjust_for_alignment(size_workArr);
-    adjust_for_alignment(size_Abyx_norms_tmptr_cmplt);
-    adjust_for_alignment(size_Abyx_norms_trfact_X);
-    adjust_for_alignment(size_diag_tmptr_Y);
+        size_gesvd += size_tempArrayT;
+        size_gesvd += size_tempArrayC;
 
-    adjust_for_alignment(size_tempArrayT);
-    adjust_for_alignment(size_tempArrayC);
+        adjust_for_alignment(size_tau_splits);
+        adjust_for_alignment(size_Abyx_norms_trfact_X);
+        adjust_for_alignment(size_diag_tmptr_Y);
 
-    adjust_for_alignment(size_gebrd);
-    adjust_for_alignment(size_bdsqr);
-    adjust_for_alignment(size_geqrf);
-    adjust_for_alignment(size_gelqf);
+        size_gesvd += size_tau_splits;
+        size_gesvd += size_diag_tmptr_Y;
+        size_gesvd += size_Abyx_norms_trfact_X;
+    }
 
-    adjust_for_alignment(size_ormbr);
-    adjust_for_alignment(size_orgbr);
-    adjust_for_alignment(size_orgqr);
-    adjust_for_alignment(size_orglq);
+    {
+        // for GEMM
 
-    // TODO: revisit  legacy shared array
-    size_gesvd += size_tau_splits;
-    size_gesvd += size_workArr;
-    size_gesvd += size_work_workArr;
-    size_gesvd += size_Abyx_norms_tmptr_cmplt;
-    size_gesvd += size_Abyx_norms_trfact_X;
-    size_gesvd += size_diag_tmptr_Y;
-    size_gesvd += size_tempArrayT;
-    size_gesvd += size_tempArrayC;
+        adjust_for_alignment(size_workArr);
+        size_gesvd += size_workArr;
+    }
 
-    size_gesvd += size_gebrd;
-    size_gesvd += size_bdsqr;
+    {
+        // TODO: check whether these are still needed
+        adjust_for_alignment(size_work_workArr);
+        adjust_for_alignment(size_Abyx_norms_tmptr_cmplt);
 
-    size_gesvd += std::max(size_geqrf, size_gelqf);
+        size_gesvd += size_work_workArr;
+        size_gesvd += size_Abyx_norms_tmptr_cmplt;
+    }
 
-    size_gesvd += size_ormbr;
-    size_gesvd += size_orgbr;
+    {
+        adjust_for_alignment(size_gebrd);
+        adjust_for_alignment(size_bdsqr);
+        adjust_for_alignment(size_geqrf);
+        adjust_for_alignment(size_gelqf);
 
-    size_gesvd += std::max(size_orgqr, size_orglq);
+        size_gesvd += size_gebrd;
+        size_gesvd += size_bdsqr;
+
+        size_gesvd += std::max(size_geqrf, size_gelqf);
+    }
+
+    {
+        adjust_for_alignment(size_ormbr);
+        adjust_for_alignment(size_orgbr);
+
+        size_gesvd += size_ormbr;
+        size_gesvd += size_orgbr;
+    }
+
+    {
+        adjust_for_alignment(size_orgqr);
+        adjust_for_alignment(size_orglq);
+
+        size_gesvd += std::max(size_orgqr, size_orglq);
+    }
 
     adjust_for_alignment(size_gesvd);
     *p_size_gesvd = size_gesvd;
@@ -1400,8 +1434,1154 @@ rocblas_status rocsolver_gesvd_template_alt(rocblas_handle handle,
                                             rocblas_int* info,
                                             const rocblas_int batch_count,
 
-                                            void* work,
+                                            void* const work,
                                             size_t const size_work)
+
+{
+    ROCSOLVER_ENTER("gesvd", "leftsv:", left_svect, "rightsv:", right_svect, "m:", m, "n:", n,
+                    "shiftA:", shiftA, "lda:", lda, "ldu:", ldu, "ldv:", ldv, "mode:", fast_alg,
+                    "bc:", batch_count);
+
+    constexpr bool COMPLEX = rocblas_is_complex<T>;
+
+    // quick return
+    if(n == 0 || m == 0 || batch_count == 0)
+        return rocblas_status_success;
+
+    hipStream_t stream;
+    rocblas_get_stream(handle, &stream);
+
+    // ---------------------------------------------------------------------------------
+    // TODO: try to figure out how arrays diag_tmptr_Y, tau_splits, Abyx_norms_trfact_X
+    // are shared and reused
+    // ---------------------------------------------------------------------------------
+    size_t size_scalars = 0;
+    size_t size_work_workArr = 0;
+    size_t size_Abyx_norms_tmptr_cmplt = 0;
+    size_t size_Abyx_norms_trfact_X = 0;
+    size_t size_diag_tmptr_Y = 0;
+    size_t size_tau_splits = 0;
+    size_t size_tempArrayT = 0;
+    size_t size_tempArrayC = 0;
+    size_t size_workArr = 0;
+
+    rocsolver_gesvd_getMemorySize<BATCHED, T, TT>(
+        left_svect, right_svect, m, n, batch_count, fast_alg,
+
+        &size_scalars, &size_work_workArr, &size_Abyx_norms_tmptr_cmplt, &size_Abyx_norms_trfact_X,
+        &size_diag_tmptr_Y, &size_tau_splits, &size_tempArrayT, &size_tempArrayC, &size_workArr);
+
+    rocblas_status istat = rocblas_status_success;
+
+    std::byte* const pwork = (std::byte*)work;
+    std::byte* pfree = pwork;
+
+    T* const tau_splits = (T*)pfree;
+    pfree += size_tau_splits;
+
+    T* const Abyx_norms_trfact_X = (T*)pfree;
+    pfree += size_Abyx_norms_trfact_X;
+
+    T* const diag_tmptr_Y = (T*)pfree;
+    pfree += size_diag_tmptr_Y;
+
+    T* tempArrayC = (T*)pfree;
+    pfree += size_tempArrayC;
+
+    T* tempArrayT = (T*)pfree;
+    pfree += size_tempArrayT;
+
+    {
+        bool const is_mem_ok = (pfree <= (pwork + size_work));
+        if(!is_mem_ok)
+        {
+            istat = rocblas_status_memory_error;
+            return (istat);
+        }
+    }
+
+    // everything must be executed with scalars on the host
+    rocblas_pointer_mode old_mode;
+    rocblas_get_pointer_mode(handle, &old_mode);
+    rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
+
+    // -----------------------------------------
+    // use try/throw/catch to reset pointer mode
+    // in case of error
+    // -----------------------------------------
+    try
+    {
+        // constants to use when calling rocablas functions
+        T one = 1;
+        T zero = 0;
+
+        // booleans used to determine the path that the execution will follow:
+        const bool row = (m >= n);
+        const bool leftvS = (left_svect == rocblas_svect_singular);
+        const bool leftvO = (left_svect == rocblas_svect_overwrite);
+        const bool leftvA = (left_svect == rocblas_svect_all);
+        const bool leftvN = (left_svect == rocblas_svect_none);
+        const bool rightvS = (right_svect == rocblas_svect_singular);
+        const bool rightvO = (right_svect == rocblas_svect_overwrite);
+        const bool rightvA = (right_svect == rocblas_svect_all);
+        const bool rightvN = (right_svect == rocblas_svect_none);
+        const bool leadvS = row ? leftvS : rightvS;
+        const bool leadvO = row ? leftvO : rightvO;
+        const bool leadvA = row ? leftvA : rightvA;
+        const bool leadvN = row ? leftvN : rightvN;
+        const bool othervS = !row ? leftvS : rightvS;
+        const bool othervO = !row ? leftvO : rightvO;
+        const bool othervA = !row ? leftvA : rightvA;
+        const bool othervN = !row ? leftvN : rightvN;
+        const bool thinSVD = (m >= THIN_SVD_SWITCH * n || n >= THIN_SVD_SWITCH * m);
+        const bool fast_thinSVD = (thinSVD && fast_alg == rocblas_outofplace);
+
+        // auxiliary sizes and variables
+        const rocblas_int k = std::min(m, n);
+        const rocblas_int kk = std::max(m, n);
+        const rocblas_int shiftX = 0;
+        const rocblas_int shiftY = 0;
+        const rocblas_int shiftUV = 0;
+        const rocblas_int shiftT = 0;
+        const rocblas_int shiftC = 0;
+        const rocblas_int shiftU = 0;
+        const rocblas_int shiftV = 0;
+        const rocblas_int ldx = thinSVD ? k : m;
+        const rocblas_int ldy = thinSVD ? k : n;
+        const rocblas_stride strideX = ldx * GEBRD_BLOCKSIZE;
+        const rocblas_stride strideY = ldy * GEBRD_BLOCKSIZE;
+        T* bufferT = tempArrayT;
+        rocblas_int ldt = k;
+        rocblas_stride strideT = k * k;
+        T* bufferC = tempArrayC;
+        rocblas_int ldc = m;
+        rocblas_stride strideC = m * n;
+
+        T* UV;
+        rocblas_int lduv, mn, nu, nv;
+        rocblas_int offset_other, offset_lead;
+        rocblas_storev storev_other, storev_lead;
+        rocblas_stride strideUV;
+        rocblas_fill uplo;
+        rocblas_side side;
+        rocblas_operation trans;
+
+        nu = leftvN ? 0 : m;
+        nv = rightvN ? 0 : n;
+        if(row)
+        {
+            UV = U;
+            lduv = ldu;
+            strideUV = strideU;
+            uplo = rocblas_fill_upper;
+            storev_other = rocblas_row_wise;
+            storev_lead = rocblas_column_wise;
+            offset_other = k * batch_count;
+            offset_lead = 0;
+            if(othervS || othervA)
+            {
+                bufferC = V;
+                ldc = ldv;
+                strideC = strideV;
+                if(!fast_thinSVD)
+                {
+                    bufferT = V;
+                    ldt = ldv;
+                    strideT = strideV;
+                }
+            }
+            side = rocblas_side_right;
+            trans = rocblas_operation_none;
+        }
+        else
+        {
+            UV = V;
+            lduv = ldv;
+            strideUV = strideV;
+            uplo = rocblas_fill_lower;
+            storev_other = rocblas_column_wise;
+            storev_lead = rocblas_row_wise;
+            offset_other = 0;
+            offset_lead = k * batch_count;
+            if(othervS || othervA)
+            {
+                bufferC = U;
+                ldc = ldu;
+                strideC = strideU;
+                if(!fast_thinSVD)
+                {
+                    bufferT = U;
+                    ldt = ldu;
+                    strideT = strideU;
+                }
+            }
+            side = rocblas_side_left;
+            trans = COMPLEX ? rocblas_operation_conjugate_transpose : rocblas_operation_transpose;
+        }
+
+        // common block sizes and number of threads for internal kernels
+        constexpr rocblas_int thread_count = 32;
+        const rocblas_int blocks_m = (m - 1) / thread_count + 1;
+        const rocblas_int blocks_n = (n - 1) / thread_count + 1;
+        const rocblas_int blocks_k = (k - 1) / thread_count + 1;
+
+        /** A thin SVD could be computed for matrices with sufficiently more rows than
+        columns (or columns than rows) by starting with a QR factorization (or LQ
+        factorization) and working with the triangular factor afterwards. When
+        computing a thin SVD, a fast algorithm could be executed by doing some
+        computations out-of-place. **/
+
+        if(thinSVD)
+        /*******************************************/
+        /********** CASE: CHOOSE THIN-SVD **********/
+        /*******************************************/
+        {
+            if(leadvN)
+            /***** SUB-CASE: USE THIN-SVD WITH NO LEAD-DIMENSION VECTORS *****/
+            /*****************************************************************/
+            {
+                nu = leftvN ? 0 : k;
+                nv = rightvN ? 0 : k;
+
+                //*** STAGE 1: Row (or column) compression ***//
+                {
+                    size_t const size_geqrlq = (pwork + size_work) - pfree;
+                    void* work_geqrlq = (void*)pfree;
+
+                    istat = local_geqrlq_template_alt<BATCHED, STRIDED>(
+                        handle, m, n, A, shiftA, lda, strideA, tau_splits, k, batch_count, row,
+
+                        work_geqrlq, size_geqrlq);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 2: generate orthonormal/unitary matrix from row/column compression ***//
+                // N/A
+
+                //*** STAGE 3: Bidiagonalization ***//
+                // clean triangular factor
+                ROCSOLVER_LAUNCH_KERNEL(set_zero<T>, dim3(blocks_k, blocks_k, batch_count),
+                                        dim3(thread_count, thread_count, 1), 0, stream, k, k, A,
+                                        shiftA, lda, strideA, uplo);
+
+                {
+                    size_t const size_work_gebrd = (pwork + size_work) - pfree;
+                    void* const work_gebrd = (void*)pfree;
+
+                    // --------------------------------
+                    // TODO: are X, Y scratch arrays in gebrd ?
+                    // --------------------------------
+                    T* const X = (T*)Abyx_norms_trfact_X;
+                    T* const Y = (T*)diag_tmptr_Y;
+
+                    istat = rocsolver_gebrd_template_alt<BATCHED, STRIDED>(
+                        handle, k, k,
+
+                        A, shiftA, lda, strideA,
+
+                        S, strideS, E, strideE,
+
+                        tau_splits, k, (tau_splits + k * batch_count), k,
+
+                        X, shiftX, ldx, strideX,
+
+                        Y, shiftY, ldy, strideY,
+
+                        batch_count,
+
+                        work_gebrd, size_work_gebrd);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 4: generate orthonormal/unitary matrices from bidiagonalization ***//
+                if(!othervN)
+                {
+                    size_t const size_work_orgbr = (pwork + size_work) - pfree;
+                    void* const work_orgbr = (void*)pfree;
+
+                    istat = rocsolver_orgbr_ungbr_template_alt<BATCHED, STRIDED>(
+                        handle, storev_other, k, k, k, A, shiftA, lda, strideA,
+                        (tau_splits + offset_other), k, batch_count,
+
+                        work_orgbr, size_work_orgbr);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 5: Compute singular values and vectors from the bidiagonal form ***//
+                if(row)
+                {
+                    size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                    void* const work_bdsqr = (void*)pfree;
+
+                    istat = rocsolver_bdsqr_template_alt<T>(handle, rocblas_fill_upper, k, nv, nu,
+                                                            0, S, strideS, E, strideE, A, shiftA,
+                                                            lda, strideA, U, shiftU, ldu, strideU,
+                                                            (W) nullptr, 0, 1, 1, info, batch_count,
+
+                                                            work_bdsqr, size_work_bdsqr);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+                else
+                {
+                    size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                    void* const work_bdsqr = (void*)pfree;
+
+                    istat = rocsolver_bdsqr_template_alt<T>(handle, rocblas_fill_upper, k, nv, nu,
+                                                            0, S, strideS, E, strideE, V, shiftV,
+                                                            ldv, strideV, A, shiftA, lda, strideA,
+                                                            (W) nullptr, 0, 1, 1, info, batch_count,
+
+                                                            work_bdsqr, size_work_bdsqr);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 6: update vectors with orthonormal/unitary matrices ***//
+                if(othervS || othervA)
+                {
+                    mn = row ? n : m;
+                    ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_n, batch_count),
+                                            dim3(thread_count, thread_count, 1), 0, stream, mn, mn,
+                                            A, shiftA, lda, strideA, bufferC, shiftC, ldc, strideC);
+                }
+            }
+
+            else if(fast_thinSVD)
+            /***** SUB-CASE: USE FAST (OUT-OF-PLACE) THIN-SVD ALGORITHM *****/
+            /****************************************************************/
+            {
+                nu = leftvN ? 0 : k;
+                nv = rightvN ? 0 : k;
+
+                //*** STAGE 1: Row (or column) compression ***//
+                {
+                    size_t const size_work_geqrlq = (pwork + size_work) - pfree;
+                    void* const work_geqrlq = (void*)pfree;
+
+                    istat = local_geqrlq_template_alt<BATCHED, STRIDED>(
+                        handle, m, n, A, shiftA, lda, strideA, tau_splits, k, batch_count, row,
+
+                        work_geqrlq, size_work_geqrlq);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                if(leadvA)
+                {
+                    // copy factorization to U or V when needed
+                    ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_n, batch_count),
+                                            dim3(thread_count, thread_count, 1), 0, stream, m, n, A,
+                                            shiftA, lda, strideA, UV, shiftUV, lduv, strideUV);
+                }
+
+                // copy the triangular part to be used in the bidiagonalization
+                ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_k, blocks_k, batch_count),
+                                        dim3(thread_count, thread_count, 1), 0, stream, k, k, A,
+                                        shiftA, lda, strideA, bufferT, shiftT, ldt, strideT,
+                                        no_mask{}, uplo);
+
+                //*** STAGE 2: generate orthonormal/unitary matrix from row/column compression ***//
+                if(leadvA)
+                {
+                    size_t const size_work_orgqrlq = (pwork + size_work) - pfree;
+                    void* work_orgqrlq = (void*)pfree;
+
+                    istat = local_orgqrlq_ungqrlq_template_alt<false, STRIDED>(
+                        handle, kk, kk, k, UV, shiftUV, lduv, strideUV, tau_splits, k, batch_count,
+                        row,
+
+                        work_orgqrlq, size_work_orgqrlq);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+                else
+                {
+                    size_t const size_work_orgqrlq = (pwork + size_work) - pfree;
+                    void* work_orgqrlq = (void*)pfree;
+                    istat = local_orgqrlq_ungqrlq_template_alt<BATCHED, STRIDED>(
+                        handle, m, n, k, A, shiftA, lda, strideA, tau_splits, k, batch_count, row,
+
+                        work_orgqrlq, size_work_orgqrlq);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 3: Bidiagonalization ***//
+                // clean triangular factor
+                ROCSOLVER_LAUNCH_KERNEL(set_zero<T>, dim3(blocks_k, blocks_k, batch_count),
+                                        dim3(thread_count, thread_count, 1), 0, stream, k, k,
+                                        bufferT, shiftT, ldt, strideT, uplo);
+
+                {
+                    size_t const size_work_gebrd = (pwork + size_work) - pfree;
+                    void* const work_gebrd = (void*)pfree;
+
+                    // --------------------------------
+                    // TODO: are X, Y scratch arrays in gebrd ?
+                    // --------------------------------
+                    T* const X = (T*)Abyx_norms_trfact_X;
+                    T* const Y = (T*)diag_tmptr_Y;
+
+                    istat = rocsolver_gebrd_template_alt<false, STRIDED>(
+                        handle, k, k, bufferT, shiftT, ldt, strideT, S, strideS, E, strideE,
+
+                        tau_splits, k, (tau_splits + k * batch_count), k,
+
+                        X, shiftX, ldx, strideX,
+
+                        Y, shiftY, ldy, strideY,
+
+                        batch_count,
+
+                        work_gebrd, size_work_gebrd);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                if(!othervN)
+                {
+                    // copy results to generate non-lead vectors if required
+                    ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_k, blocks_k, batch_count),
+                                            dim3(thread_count, thread_count, 1), 0, stream, k, k,
+                                            bufferT, shiftT, ldt, strideT, bufferC, shiftC, ldc,
+                                            strideC);
+                }
+
+                //*** STAGE 4: generate orthonormal/unitary matrices from bidiagonalization ***//
+                // for lead-dimension vectors
+                {
+                    size_t const size_work_orgbr = (pfree + size_work) - pfree;
+                    void* const work_orgbr = (void*)pfree;
+
+                    istat = rocsolver_orgbr_ungbr_template_alt<false, STRIDED>(
+                        handle, storev_lead, k, k, k, bufferT, shiftT, ldt, strideT,
+                        (tau_splits + offset_lead), k, batch_count,
+
+                        work_orgbr, size_work_orgbr);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                // for the other-side vectors
+                if(!othervN)
+                {
+                    size_t const size_work_orgbr = (pfree + size_work) - pfree;
+                    void* const work_orgbr = (void*)pfree;
+
+                    istat = rocsolver_orgbr_ungbr_template_alt<false, STRIDED>(
+                        handle, storev_other, k, k, k, bufferC, shiftC, ldc, strideC,
+                        (tau_splits + offset_other), k, batch_count,
+
+                        work_orgbr, size_work_orgbr);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 5: Compute singular values and vectors from the bidiagonal form ***//
+                if(row)
+                {
+                    size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                    void* const work_bdsqr = (void*)pfree;
+
+                    istat = rocsolver_bdsqr_template_alt<T>(
+                        handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E, strideE, bufferC,
+                        shiftC, ldc, strideC, bufferT, shiftT, ldt, strideT, (T*)nullptr, 0, 1, 1,
+                        info, batch_count,
+
+                        work_bdsqr, size_work_bdsqr);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+                else
+                {
+                    size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                    void* const work_bdsqr = (void*)pfree;
+
+                    istat = rocsolver_bdsqr_template_alt<T>(
+                        handle, rocblas_fill_upper, k, nv, nu, 0, S, strideS, E, strideE, bufferT,
+                        shiftT, ldt, strideT, bufferC, shiftC, ldc, strideC, (T*)nullptr, 0, 1, 1,
+                        info, batch_count,
+
+                        work_bdsqr, size_work_bdsqr);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 6: update vectors with orthonormal/unitary matrices ***//
+                if(leadvO)
+                {
+                    bufferC = tempArrayC;
+                    ldc = m;
+                    strideC = m * n;
+
+                    // update
+                    if(row)
+                    {
+                        auto const pfree_saved = pfree;
+                        size_t const size_workArr = sizeof(T*) * batch_count;
+
+                        T** workArr = (T**)pfree;
+                        pfree += size_workArr;
+                        MEM_CHECK_THROW(pfree);
+
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, A, shiftA, lda, strideA, bufferT, shiftT, ldt,
+                                       strideT, &zero, bufferC, shiftC, ldc, strideC, batch_count,
+                                       workArr);
+
+                        pfree = pfree_saved;
+                    }
+                    else
+                    {
+                        auto const pfree_saved = pfree;
+                        size_t const size_workArr = sizeof(T*) * batch_count;
+                        T** workArr = (T**)pfree;
+                        pfree += size_workArr;
+                        MEM_CHECK_THROW(pfree);
+
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, bufferT, shiftT, ldt, strideT, A, shiftA, lda,
+                                       strideA, &zero, bufferC, shiftC, ldc, strideC, batch_count,
+                                       workArr);
+
+                        pfree = pfree_saved;
+                    }
+
+                    // copy to overwrite A
+                    ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_n, batch_count),
+                                            dim3(thread_count, thread_count, 1), 0, stream, m, n,
+                                            bufferC, shiftC, ldc, strideC, A, shiftA, lda, strideA);
+                }
+                else if(leadvS)
+                {
+                    // update
+                    if(row)
+                    {
+                        auto const pfree_saved = pfree;
+                        size_t const size_workArr = sizeof(T*) * batch_count;
+                        T** workArr = (T**)pfree;
+                        pfree += size_workArr;
+                        MEM_CHECK_THROW(pfree);
+
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, A, shiftA, lda, strideA, bufferT, shiftT, ldt,
+                                       strideT, &zero, UV, shiftUV, lduv, strideUV, batch_count,
+                                       workArr);
+
+                        pfree = pfree_saved;
+                    }
+                    else
+                    {
+                        auto const pfree_saved = pfree;
+                        size_t const size_workArr = sizeof(T*) * batch_count;
+                        T** workArr = (T**)pfree;
+                        pfree += size_workArr;
+                        MEM_CHECK_THROW(pfree);
+
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, bufferT, shiftT, ldt, strideT, A, shiftA, lda,
+                                       strideA, &zero, UV, shiftUV, lduv, strideUV, batch_count,
+                                       workArr);
+
+                        pfree = pfree_saved;
+                    }
+
+                    // overwrite A if required
+                    if(othervO)
+                        ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_k, blocks_k, batch_count),
+                                                dim3(thread_count, thread_count, 1), 0, stream, k,
+                                                k, bufferC, shiftC, ldc, strideC, A, shiftA, lda,
+                                                strideA);
+                }
+                else
+                {
+                    // update
+                    if(row)
+                    {
+                        auto const pfree_saved = pfree;
+                        size_t const size_workArr = sizeof(T*) * batch_count;
+                        T** workArr = (T**)pfree;
+                        pfree += size_workArr;
+                        MEM_CHECK_THROW(pfree);
+
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, UV, shiftUV, lduv, strideUV, bufferT, shiftT, ldt,
+                                       strideT, &zero, A, shiftA, lda, strideA, batch_count, workArr);
+                        pfree = pfree_saved;
+                    }
+                    else
+                    {
+                        auto const pfree_saved = pfree;
+                        size_t const size_workArr = sizeof(T*) * batch_count;
+                        T** workArr = (T**)pfree;
+                        pfree += size_workArr;
+                        MEM_CHECK_THROW(pfree);
+
+                        rocsolver_gemm(handle, rocblas_operation_none, rocblas_operation_none, m, n,
+                                       k, &one, bufferT, shiftT, ldt, strideT, UV, shiftUV, lduv,
+                                       strideUV, &zero, A, shiftA, lda, strideA, batch_count,
+                                       workArr);
+
+                        pfree = pfree_saved;
+                    }
+
+                    // copy back to U/V
+                    ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_n, batch_count),
+                                            dim3(thread_count, thread_count, 1), 0, stream, m, n, A,
+                                            shiftA, lda, strideA, UV, shiftUV, lduv, strideUV);
+
+                    // overwrite A if required
+                    if(othervO)
+                        ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_k, blocks_k, batch_count),
+                                                dim3(thread_count, thread_count, 1), 0, stream, k,
+                                                k, bufferC, shiftC, ldc, strideC, A, shiftA, lda,
+                                                strideA);
+                }
+            }
+
+            else
+            /************ SUB-CASE: USE IN-PLACE THIN-SVD ALGORITHM *******/
+            /**************************************************************/
+            {
+                /** (Note: A compression is not required when leadvO and othervN. We are
+                compressing matrix A here, albeit requiring extra workspace for the purpose of
+                testing. -See corresponding unit test for more details-) **/
+
+                //*** STAGE 1: Row (or column) compression ***//
+                {
+                    size_t const size_work_geqrlq = (pwork + size_work) - pfree;
+                    void* const work_geqrlq = pfree;
+
+                    istat = local_geqrlq_template_alt<BATCHED, STRIDED>(
+                        handle, m, n, A, shiftA, lda, strideA, tau_splits, k, batch_count, row,
+
+                        work_geqrlq, size_work_geqrlq);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                if(!leadvO)
+                {
+                    // copy factorization to U or V when needed
+                    ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_n, batch_count),
+                                            dim3(thread_count, thread_count, 1), 0, stream, m, n, A,
+                                            shiftA, lda, strideA, UV, shiftUV, lduv, strideUV);
+                }
+
+                if(othervS || othervA || (leadvO && othervN))
+                {
+                    // copy the triangular part
+                    ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_k, blocks_k, batch_count),
+                                            dim3(thread_count, thread_count, 1), 0, stream, k, k, A,
+                                            shiftA, lda, strideA, bufferT, shiftT, ldt, strideT,
+                                            no_mask{}, uplo);
+                }
+
+                //*** STAGE 2: generate orthonormal/unitary matrix from row/column compression ***//
+                if(leadvO)
+                {
+                    size_t const size_work_orgqrlq = (pwork + size_work) - pfree;
+                    void* const work_orgqrlq = (void*)pfree;
+
+                    istat = local_orgqrlq_ungqrlq_template_alt<BATCHED, STRIDED>(
+                        handle, m, n, k, A, shiftA, lda, strideA, tau_splits, k, batch_count, row,
+
+                        work_orgqrlq, size_work_orgqrlq);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+                else if(leadvA)
+                {
+                    size_t const size_work_orgqrlq = (pwork + size_work) - pfree;
+                    void* const work_orgqrlq = (void*)pfree;
+
+                    istat = local_orgqrlq_ungqrlq_template_alt<false, STRIDED>(
+                        handle, kk, kk, k, UV, shiftUV, lduv, strideUV, tau_splits, k, batch_count,
+                        row,
+
+                        work_orgqrlq, size_work_orgqrlq);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+                else
+                {
+                    size_t const size_work_orgqrlq = (pwork + size_work) - pfree;
+                    void* const work_orgqrlq = (void*)pfree;
+
+                    istat = local_orgqrlq_ungqrlq_template_alt<false, STRIDED>(
+                        handle, m, n, k, UV, shiftUV, lduv, strideUV, tau_splits, k, batch_count, row,
+
+                        work_orgqrlq, size_work_orgqrlq);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 3: Bidiagonalization ***//
+                if(othervS || othervA || (leadvO && othervN))
+                {
+                    // clean triangular factor
+                    ROCSOLVER_LAUNCH_KERNEL(set_zero<T>, dim3(blocks_k, blocks_k, batch_count),
+                                            dim3(thread_count, thread_count, 1), 0, stream, k, k,
+                                            bufferT, shiftT, ldt, strideT, uplo);
+
+                    {
+                        size_t const size_work_gebrd = (pwork + size_work) - pfree;
+                        void* const work_gebrd = (void*)pfree;
+
+                        // --------------------------------
+                        // TODO: are X, Y scratch arrays in gebrd ?
+                        // --------------------------------
+                        T* const X = (T*)Abyx_norms_trfact_X;
+                        T* const Y = (T*)diag_tmptr_Y;
+
+                        istat = rocsolver_gebrd_template_alt<false, STRIDED>(
+                            handle, k, k, bufferT, shiftT, ldt, strideT, S, strideS, E, strideE,
+
+                            tau_splits, k, (tau_splits + k * batch_count), k,
+
+                            X, shiftX, ldx, strideX,
+
+                            Y, shiftY, ldy, strideY,
+
+                            batch_count,
+
+                            work_gebrd, size_work_gebrd);
+                        if(istat != rocblas_status_success)
+                        {
+                            throw(istat);
+                        }
+                    }
+
+                    uplo = rocblas_fill_upper;
+                }
+                else
+                {
+                    // clean triangular factor
+                    ROCSOLVER_LAUNCH_KERNEL(set_zero<T>, dim3(blocks_k, blocks_k, batch_count),
+                                            dim3(thread_count, thread_count, 1), 0, stream, k, k, A,
+                                            shiftA, lda, strideA, uplo);
+
+                    {
+                        size_t const size_work_gebrd = (pwork + size_work) - pfree;
+                        void* const work_gebrd = (void*)pfree;
+
+                        // --------------------------------
+                        // TODO: are X, Y scratch arrays in gebrd ?
+                        // --------------------------------
+                        T* const X = (T*)Abyx_norms_trfact_X;
+                        T* const Y = (T*)diag_tmptr_Y;
+
+                        istat = rocsolver_gebrd_template_alt<BATCHED, STRIDED>(
+                            handle, k, k, A, shiftA, lda, strideA, S, strideS, E, strideE,
+
+                            tau_splits, k, (tau_splits + k * batch_count), k,
+
+                            X, shiftX, ldx, strideX,
+
+                            Y, shiftY, ldy, strideY,
+
+                            batch_count,
+
+                            work_gebrd, size_work_gebrd);
+                        if(istat != rocblas_status_success)
+                        {
+                            throw(istat);
+                        }
+                    }
+
+                    uplo = rocblas_fill_upper;
+                }
+
+                //*** STAGE 4: generate orthonormal/unitary matrices from bidiagonalization ***//
+                // for lead-dimension vectors
+                if(othervS || othervA || (leadvO && othervN))
+                {
+                    if(leadvO)
+                    {
+                        size_t const size_work_ormbr = (pwork + size_work) - pfree;
+                        void* const work_ormbr = (void*)pfree;
+
+                        istat = rocsolver_ormbr_unmbr_template_alt<BATCHED, STRIDED>(
+                            handle, storev_lead, side, trans, m, n, k, bufferT, shiftT, ldt, strideT,
+                            (tau_splits + offset_lead), k, A, shiftA, lda, strideA, batch_count,
+
+                            work_ormbr, size_work_ormbr);
+
+                        if(istat != rocblas_status_success)
+                        {
+                            throw(istat);
+                        }
+                    }
+                    else
+                    {
+                        size_t const size_work_ormbr = (pwork + size_work) - pfree;
+                        void* const work_ormbr = (void*)pfree;
+
+                        istat = rocsolver_ormbr_unmbr_template_alt<false, STRIDED>(
+                            handle, storev_lead, side, trans, m, n, k, bufferT, shiftT, ldt, strideT,
+                            (tau_splits + offset_lead), k, UV, shiftUV, lduv, strideUV, batch_count,
+
+                            work_ormbr, size_work_ormbr);
+
+                        if(istat != rocblas_status_success)
+                        {
+                            throw(istat);
+                        }
+                    }
+                }
+                else
+                {
+                    size_t const size_work_ormbr = (pwork + size_work) - pfree;
+                    void* const work_ormbr = (void*)pfree;
+
+                    istat = rocsolver_ormbr_unmbr_template_alt<BATCHED, STRIDED>(
+                        handle, storev_lead, side, trans, m, n, k, A, shiftA, lda, strideA,
+                        (tau_splits + offset_lead), k, UV, shiftUV, lduv, strideUV, batch_count,
+
+                        work_ormbr, size_work_ormbr);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                // for the other-side vectors
+                if(othervS || othervA)
+                {
+                    size_t const size_work_orgbr = (pwork + size_work) - pfree;
+                    void* const work_orgbr = (void*)pfree;
+
+                    istat = rocsolver_orgbr_ungbr_template_alt<false, STRIDED>(
+                        handle, storev_other, k, k, k, bufferT, shiftT, ldt, strideT,
+                        (tau_splits + offset_other), k, batch_count,
+
+                        work_orgbr, size_work_orgbr);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+                else if(othervO)
+                {
+                    size_t const size_work_orgbr = (pwork + size_work) - pfree;
+                    void* const work_orgbr = (void*)pfree;
+
+                    istat = rocsolver_orgbr_ungbr_template_alt<BATCHED, STRIDED>(
+                        handle, storev_other, k, k, k, A, shiftA, lda, strideA,
+                        (tau_splits + offset_other), k, batch_count,
+
+                        work_orgbr, size_work_orgbr);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 5: Compute singular values and vectors from the bidiagonal form ***//
+                uplo = rocblas_fill_upper;
+                if(!leftvO && !rightvO)
+                {
+                    size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                    void* const work_bdsqr = (void*)pfree;
+
+                    istat = rocsolver_bdsqr_template_alt<T>(
+                        handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V, shiftV, ldv, strideV,
+                        U, shiftU, ldu, strideU, (T*)nullptr, 0, 1, 1, info, batch_count,
+
+                        work_bdsqr, size_work_bdsqr);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+                else if(leftvO && !rightvO)
+                {
+                    size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                    void* const work_bdsqr = (void*)pfree;
+
+                    istat = rocsolver_bdsqr_template_alt<T>(
+                        handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V, shiftV, ldv, strideV,
+                        A, shiftA, lda, strideA, (W) nullptr, 0, 1, 1, info, batch_count,
+
+                        work_bdsqr, size_work_bdsqr);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+                else
+                {
+                    size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                    void* const work_bdsqr = (void*)pfree;
+
+                    istat = rocsolver_bdsqr_template_alt<T>(
+                        handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, A, shiftA, lda, strideA,
+                        U, shiftU, ldu, strideU, (W) nullptr, 0, 1, 1, info, batch_count,
+
+                        work_bdsqr, size_work_bdsqr);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+
+                //*** STAGE 6: update vectors with orthonormal/unitary matrices ***//
+                // N/A
+            }
+        }
+
+        else
+        /*********************************************/
+        /********** CASE: CHOOSE NORMAL SVD **********/
+        /*********************************************/
+        {
+            //*** STAGE 1: Row (or column) compression ***//
+            // N/A
+
+            //*** STAGE 2: generate orthonormal/unitary matrix from row/column compression ***//
+            // N/A
+
+            //*** STAGE 3: Bidiagonalization ***//
+            {
+                size_t const size_work_gebrd = (pwork + size_work) - pfree;
+                void* const work_gebrd = (void*)pfree;
+
+                istat = rocsolver_gebrd_template_alt<BATCHED, STRIDED>(
+                    handle, m, n, A, shiftA, lda, strideA, S, strideS, E, strideE, tau_splits, k,
+                    (tau_splits + k * batch_count), k, Abyx_norms_trfact_X, shiftX, ldx, strideX,
+                    diag_tmptr_Y, shiftY, ldy, strideY, batch_count,
+
+                    work_gebrd, size_work_gebrd);
+                if(istat != rocblas_status_success)
+                {
+                    throw(istat);
+                }
+            }
+
+            //*** STAGE 4: generate orthonormal/unitary matrices from bidiagonalization ***//
+            if(leftvS || leftvA)
+            {
+                // copy data to matrix U where orthogonal matrix will be generated
+                mn = (row && leftvS) ? n : m;
+                ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_m, blocks_k, batch_count),
+                                        dim3(thread_count, thread_count, 1), 0, stream, m, k, A,
+                                        shiftA, lda, strideA, U, shiftU, ldu, strideU);
+
+                {
+                    size_t const size_work_orgbr = (pwork + size_work) - pfree;
+                    void* const work_orgbr = (void*)pfree;
+
+                    istat = rocsolver_orgbr_ungbr_template_alt<false, STRIDED>(
+                        handle, rocblas_column_wise, m, mn, n, U, shiftU, ldu, strideU, tau_splits,
+                        k, batch_count,
+
+                        work_orgbr, size_work_orgbr);
+
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+            }
+
+            if(rightvS || rightvA)
+            {
+                // copy data to matrix V where othogonal matrix will be generated
+                mn = (!row && rightvS) ? m : n;
+                ROCSOLVER_LAUNCH_KERNEL(copy_mat<T>, dim3(blocks_k, blocks_n, batch_count),
+                                        dim3(thread_count, thread_count, 1), 0, stream, k, n, A,
+                                        shiftA, lda, strideA, V, shiftV, ldv, strideV);
+
+                {
+                    size_t const size_work_orgbr = (pwork + size_work) - pfree;
+                    void* const work_orgbr = (void*)pfree;
+
+                    istat = rocsolver_orgbr_ungbr_template_alt<false, STRIDED>(
+                        handle, rocblas_row_wise, mn, n, m, V, shiftV, ldv, strideV,
+                        (tau_splits + k * batch_count), k, batch_count,
+
+                        work_orgbr, size_work_orgbr);
+                    if(istat != rocblas_status_success)
+                    {
+                        throw(istat);
+                    }
+                }
+            }
+
+            if(leftvO)
+            {
+                size_t const size_work_orgbr = (pwork + size_work) - pfree;
+                void* const work_orgbr = (void*)pfree;
+
+                istat = rocsolver_orgbr_ungbr_template_alt<BATCHED, STRIDED>(
+                    handle, rocblas_column_wise, m, k, n, A, shiftA, lda, strideA, tau_splits, k,
+                    batch_count,
+
+                    work_orgbr, size_work_orgbr);
+
+                if(istat != rocblas_status_success)
+                {
+                    throw(istat);
+                }
+            }
+
+            if(rightvO)
+            {
+                size_t const size_work_orgbr = (pwork + size_work) - pfree;
+                void* const work_orgbr = (void*)pfree;
+
+                istat = rocsolver_orgbr_ungbr_template_alt<BATCHED, STRIDED>(
+                    handle, rocblas_row_wise, k, n, m, A, shiftA, lda, strideA,
+                    (tau_splits + k * batch_count), k, batch_count,
+
+                    work_orgbr, size_work_orgbr);
+                if(istat != rocblas_status_success)
+                {
+                    throw(istat);
+                }
+            }
+
+            //*** STAGE 5: Compute singular values and vectors from the bidiagonal form ***//
+            if(!leftvO && !rightvO)
+            {
+                size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                void* const work_bdsqr = (void*)pfree;
+
+                istat = rocsolver_bdsqr_template_alt<T>(
+                    handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V, shiftV, ldv, strideV, U,
+                    shiftU, ldu, strideU, (T*)nullptr, 0, 1, 1, info, batch_count,
+
+                    work_bdsqr, size_work_bdsqr);
+                if(istat != rocblas_status_success)
+                {
+                    throw(istat);
+                }
+            }
+
+            else if(leftvO && !rightvO)
+            {
+                size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                void* const work_bdsqr = (void*)pfree;
+
+                istat = rocsolver_bdsqr_template_alt<T>(
+                    handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, V, shiftV, ldv, strideV, A,
+                    shiftA, lda, strideA, (W) nullptr, 0, 1, 1, info, batch_count,
+
+                    work_bdsqr, size_work_bdsqr);
+                if(istat != rocblas_status_success)
+                {
+                    throw(istat);
+                }
+            }
+
+            else
+            {
+                size_t const size_work_bdsqr = (pwork + size_work) - pfree;
+                void* const work_bdsqr = (void*)pfree;
+
+                istat = rocsolver_bdsqr_template_alt<T>(
+                    handle, uplo, k, nv, nu, 0, S, strideS, E, strideE, A, shiftA, lda, strideA, U,
+                    shiftU, ldu, strideU, (W) nullptr, 0, 1, 1, info, batch_count,
+
+                    work_bdsqr, size_work_bdsqr);
+                if(istat != rocblas_status_success)
+                {
+                    throw(istat);
+                }
+            }
+
+            //*** STAGE 6: update vectors with orthonormal/unitary matrices ***//
+            // N/A
+        }
+
+        rocblas_set_pointer_mode(handle, old_mode);
+        return rocblas_status_success;
+    }
+    catch(rocblas_status istat)
+    {
+        rocblas_set_pointer_mode(handle, old_mode);
+        return istat;
+    }
+}
+
+template <bool BATCHED, bool STRIDED, typename T, typename TT, typename W>
+rocblas_status rocsolver_gesvd_template_alt_org(rocblas_handle handle,
+                                                const rocblas_svect left_svect,
+                                                const rocblas_svect right_svect,
+                                                const rocblas_int m,
+                                                const rocblas_int n,
+                                                W A,
+                                                const rocblas_int shiftA,
+                                                const rocblas_int lda,
+                                                const rocblas_stride strideA,
+                                                TT* S,
+                                                const rocblas_stride strideS,
+                                                T* U,
+                                                const rocblas_int ldu,
+                                                const rocblas_stride strideU,
+                                                T* V,
+                                                const rocblas_int ldv,
+                                                const rocblas_stride strideV,
+                                                TT* E,
+                                                const rocblas_stride strideE,
+                                                const rocblas_workmode fast_alg,
+                                                rocblas_int* info,
+                                                const rocblas_int batch_count,
+
+                                                void* work,
+                                                size_t const size_work)
 
 {
     size_t size_scalars = 0;

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd.hpp
@@ -42,7 +42,7 @@
 #include "rocsolver/rocsolver.h"
 #include "rocsolver_run_specialized_kernels.hpp"
 
-#include "mem_utils.hpp"
+#include "rocsolver_mem_utils.hpp"
 
 ROCSOLVER_BEGIN_NAMESPACE
 

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
@@ -85,7 +85,7 @@ rocblas_status rocsolver_gesvd_batched_impl(rocblas_handle handle,
     // size of array of pointers (only for batched case)
     size_t size_workArr;
 
-    if(use_original)
+    if(USE_ORIGINAL)
     {
         rocsolver_gesvd_getMemorySize<true, T, TT>(
             left_svect, right_svect, m, n, batch_count, fast_alg, &size_scalars, &size_work_workArr,

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd_batched.cpp
@@ -85,44 +85,80 @@ rocblas_status rocsolver_gesvd_batched_impl(rocblas_handle handle,
     // size of array of pointers (only for batched case)
     size_t size_workArr;
 
-    rocsolver_gesvd_getMemorySize<true, T, TT>(
-        left_svect, right_svect, m, n, batch_count, fast_alg, &size_scalars, &size_work_workArr,
-        &size_Abyx_norms_tmptr, &size_Abyx_norms_trfact_X, &size_diag_tmptr_Y, &size_tau_splits,
-        &size_tempArrayT, &size_tempArrayC, &size_workArr);
+    if(use_original)
+    {
+        rocsolver_gesvd_getMemorySize<true, T, TT>(
+            left_svect, right_svect, m, n, batch_count, fast_alg, &size_scalars, &size_work_workArr,
+            &size_Abyx_norms_tmptr, &size_Abyx_norms_trfact_X, &size_diag_tmptr_Y, &size_tau_splits,
+            &size_tempArrayT, &size_tempArrayC, &size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(
-            handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr, size_Abyx_norms_trfact_X,
-            size_diag_tmptr_Y, size_tau_splits, size_tempArrayT, size_tempArrayC, size_workArr);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr,
+                size_Abyx_norms_trfact_X, size_diag_tmptr_Y, size_tau_splits, size_tempArrayT,
+                size_tempArrayC, size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_tmptr, *Abyx_norms_trfact_X, *diag_tmptr_Y, *tau_splits;
-    void *tempArrayT, *tempArrayC, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr,
-                              size_Abyx_norms_trfact_X, size_diag_tmptr_Y, size_tau_splits,
-                              size_tempArrayT, size_tempArrayC, size_workArr);
+        // memory workspace allocation
+        void *scalars, *work_workArr, *Abyx_norms_tmptr, *Abyx_norms_trfact_X, *diag_tmptr_Y,
+            *tau_splits;
+        void *tempArrayT, *tempArrayC, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr,
+                                  size_Abyx_norms_trfact_X, size_diag_tmptr_Y, size_tau_splits,
+                                  size_tempArrayT, size_tempArrayC, size_workArr);
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_tmptr = mem[2];
-    Abyx_norms_trfact_X = mem[3];
-    diag_tmptr_Y = mem[4];
-    tau_splits = mem[5];
-    tempArrayT = mem[6];
-    tempArrayC = mem[7];
-    workArr = mem[8];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        scalars = mem[0];
+        work_workArr = mem[1];
+        Abyx_norms_tmptr = mem[2];
+        Abyx_norms_trfact_X = mem[3];
+        diag_tmptr_Y = mem[4];
+        tau_splits = mem[5];
+        tempArrayT = mem[6];
+        tempArrayC = mem[7];
+        workArr = mem[8];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
 
-    // execution
-    return rocsolver_gesvd_template<true, false, T>(
-        handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu, strideU,
-        V, ldv, strideV, E, strideE, fast_alg, info, batch_count, (T*)scalars, work_workArr,
-        (T*)Abyx_norms_tmptr, (T*)Abyx_norms_trfact_X, (T*)diag_tmptr_Y, (T*)tau_splits,
-        (T*)tempArrayT, (T*)tempArrayC, (T**)workArr);
+        // execution
+        return rocsolver_gesvd_template<true, false, T>(
+            handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu,
+            strideU, V, ldv, strideV, E, strideE, fast_alg, info, batch_count, (T*)scalars,
+            work_workArr, (T*)Abyx_norms_tmptr, (T*)Abyx_norms_trfact_X, (T*)diag_tmptr_Y,
+            (T*)tau_splits, (T*)tempArrayT, (T*)tempArrayC, (T**)workArr);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_gesvd_getMemorySize_alt<true, T, TT>(left_svect, right_svect, m, n, batch_count,
+                                                       fast_alg,
+
+                                                       &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = (void*)mem[0];
+
+        // ------------------------------------------------------------------
+        // note: initialization of scalars[] performed in roclapack_gesvd.hpp
+        // ------------------------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gesvd_template_alt<true, false, T>(
+            handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu,
+            strideU, V, ldv, strideV, E, strideE, fast_alg, info, batch_count,
+
+            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
@@ -83,7 +83,7 @@ rocblas_status rocsolver_gesvd_strided_batched_impl(rocblas_handle handle,
     size_t size_tempArrayT, size_tempArrayC;
     // size of array of pointers (only for batched case)
     size_t size_workArr;
-    if(use_original)
+    if(USE_ORIGINAL)
     {
         rocsolver_gesvd_getMemorySize<false, T, TT>(
             left_svect, right_svect, m, n, batch_count, fast_alg, &size_scalars, &size_work_workArr,

--- a/projects/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_gesvd_strided_batched.cpp
@@ -83,45 +83,80 @@ rocblas_status rocsolver_gesvd_strided_batched_impl(rocblas_handle handle,
     size_t size_tempArrayT, size_tempArrayC;
     // size of array of pointers (only for batched case)
     size_t size_workArr;
+    if(use_original)
+    {
+        rocsolver_gesvd_getMemorySize<false, T, TT>(
+            left_svect, right_svect, m, n, batch_count, fast_alg, &size_scalars, &size_work_workArr,
+            &size_Abyx_norms_tmptr, &size_Abyx_norms_trfact_X, &size_diag_tmptr_Y, &size_tau_splits,
+            &size_tempArrayT, &size_tempArrayC, &size_workArr);
 
-    rocsolver_gesvd_getMemorySize<false, T, TT>(
-        left_svect, right_svect, m, n, batch_count, fast_alg, &size_scalars, &size_work_workArr,
-        &size_Abyx_norms_tmptr, &size_Abyx_norms_trfact_X, &size_diag_tmptr_Y, &size_tau_splits,
-        &size_tempArrayT, &size_tempArrayC, &size_workArr);
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(
+                handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr,
+                size_Abyx_norms_trfact_X, size_diag_tmptr_Y, size_tau_splits, size_tempArrayT,
+                size_tempArrayC, size_workArr);
 
-    if(rocblas_is_device_memory_size_query(handle))
-        return rocblas_set_optimal_device_memory_size(
-            handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr, size_Abyx_norms_trfact_X,
-            size_diag_tmptr_Y, size_tau_splits, size_tempArrayT, size_tempArrayC, size_workArr);
+        // memory workspace allocation
+        void *scalars, *work_workArr, *Abyx_norms_tmptr, *Abyx_norms_trfact_X, *diag_tmptr_Y,
+            *tau_splits;
+        void *tempArrayT, *tempArrayC, *workArr;
+        rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr,
+                                  size_Abyx_norms_trfact_X, size_diag_tmptr_Y, size_tau_splits,
+                                  size_tempArrayT, size_tempArrayC, size_workArr);
 
-    // memory workspace allocation
-    void *scalars, *work_workArr, *Abyx_norms_tmptr, *Abyx_norms_trfact_X, *diag_tmptr_Y, *tau_splits;
-    void *tempArrayT, *tempArrayC, *workArr;
-    rocblas_device_malloc mem(handle, size_scalars, size_work_workArr, size_Abyx_norms_tmptr,
-                              size_Abyx_norms_trfact_X, size_diag_tmptr_Y, size_tau_splits,
-                              size_tempArrayT, size_tempArrayC, size_workArr);
+        if(!mem)
+            return rocblas_status_memory_error;
 
-    if(!mem)
-        return rocblas_status_memory_error;
+        scalars = mem[0];
+        work_workArr = mem[1];
+        Abyx_norms_tmptr = mem[2];
+        Abyx_norms_trfact_X = mem[3];
+        diag_tmptr_Y = mem[4];
+        tau_splits = mem[5];
+        tempArrayT = mem[6];
+        tempArrayC = mem[7];
+        workArr = mem[8];
+        if(size_scalars > 0)
+            init_scalars(handle, (T*)scalars);
 
-    scalars = mem[0];
-    work_workArr = mem[1];
-    Abyx_norms_tmptr = mem[2];
-    Abyx_norms_trfact_X = mem[3];
-    diag_tmptr_Y = mem[4];
-    tau_splits = mem[5];
-    tempArrayT = mem[6];
-    tempArrayC = mem[7];
-    workArr = mem[8];
-    if(size_scalars > 0)
-        init_scalars(handle, (T*)scalars);
+        // execution
+        return rocsolver_gesvd_template<false, true, T>(
+            handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu,
+            strideU, V, ldv, strideV, E, strideE, fast_alg, info, batch_count, (T*)scalars,
+            work_workArr, (T*)Abyx_norms_tmptr, (T*)Abyx_norms_trfact_X, (T*)diag_tmptr_Y,
+            (T*)tau_splits, (T*)tempArrayT, (T*)tempArrayC, (T**)workArr);
+    }
+    else
+    {
+        size_t size_work = 0;
+        rocsolver_gesvd_getMemorySize_alt<false, T, TT>(left_svect, right_svect, m, n, batch_count,
+                                                        fast_alg,
 
-    // execution
-    return rocsolver_gesvd_template<false, true, T>(
-        handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu, strideU,
-        V, ldv, strideV, E, strideE, fast_alg, info, batch_count, (T*)scalars, work_workArr,
-        (T*)Abyx_norms_tmptr, (T*)Abyx_norms_trfact_X, (T*)diag_tmptr_Y, (T*)tau_splits,
-        (T*)tempArrayT, (T*)tempArrayC, (T**)workArr);
+                                                        &size_work);
+
+        if(rocblas_is_device_memory_size_query(handle))
+            return rocblas_set_optimal_device_memory_size(handle, size_work);
+
+        // memory workspace allocation
+        rocblas_device_malloc mem(handle, size_work);
+
+        if(!mem)
+            return rocblas_status_memory_error;
+
+        void* const work = mem[0];
+
+        // ------------------------------------------------------------------
+        // note: initialization of scalars[] performed in roclapack_gesvd.hpp
+        // ------------------------------------------------------------------
+        // if(size_scalars > 0) init_scalars(handle, (T*)scalars);
+
+        // execution
+        return rocsolver_gesvd_template_alt<false, true, T>(
+            handle, left_svect, right_svect, m, n, A, shiftA, lda, strideA, S, strideS, U, ldu,
+            strideU, V, ldv, strideV, E, strideE, fast_alg, info, batch_count,
+
+            work, size_work);
+    }
 }
 
 ROCSOLVER_END_NAMESPACE


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The goals for this PR are: (1) to isolate design decisions related to the number and type of scratch arrays, (2) demonstrate the stack-based single array allocation is backward compatible with existing software and the conversion can be accomplished in a straight-forward manner.

## Technical Details

The current design of passing in all necessary scratch arrays exposes internal implementation designs. This makes it difficult to reuse software and requires extensive and error prone changes when the internal implementation changes.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Google tests for BDSQR, GEBRD, GELQF, GEQRF, GESVD, ORGBR, ORGLQ, ORGQR, ORMBR

## Test Result

<!-- Briefly summarize test outcomes. -->
The changes pass google tests.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
