### PR TITLE
[hipDNN][hipBLASLt] Updated EngineID for hipblaslt-provider

### DIFF
--- a/dnn-providers/hipblaslt-provider/HipblasltContainer.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltContainer.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_data_sdk/utilities/EngineNames.hpp>
 
 #include "EngineManager.hpp"
 #include "HipblasltContainer.hpp"
@@ -14,8 +15,8 @@ HipblasltContainer::HipblasltContainer()
 {
     HIPDNN_LOG_INFO("Creating HipblasltContainer");
 
-    int64_t engineId = 1;
-    auto hipblasltEngine = std::make_unique<HipblasltEngine>(engineId++);
+    auto hipblasltEngine
+        = std::make_unique<HipblasltEngine>(hipdnn_data_sdk::utilities::HIPBLASLT_ENGINE_ID);
 
     _engineManager = std::make_unique<EngineManager>();
     _engineManager->addEngine(std::move(hipblasltEngine));

--- a/dnn-providers/hipblaslt-provider/HipblasltPlugin.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltPlugin.cpp
@@ -6,6 +6,7 @@
 #include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
 #include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_data_sdk/utilities/EngineNames.hpp>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_plugin_sdk/PluginApi.h>
 #include <hipdnn_plugin_sdk/PluginDataTypeHelpers.hpp>
@@ -110,8 +111,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
         }
         throwIfNull(numEngines);
 
-        // For now, we will just return a single engine ID.
-        auto allEngineIds = std::vector<int64_t>({1});
+        auto allEngineIds = std::vector<int64_t>({hipdnn_data_sdk::utilities::HIPBLASLT_ENGINE_ID});
         if(allEngineIds.size() > std::numeric_limits<uint32_t>::max())
         {
             throw HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltEnginePluginApi.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltEnginePluginApi.cpp
@@ -5,6 +5,7 @@
 
 #include <HipblasltPlugin.hpp>
 #include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
+#include <hipdnn_data_sdk/utilities/EngineNames.hpp>
 #include <hipdnn_plugin_sdk/EnginePluginApi.h>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <hipdnn_plugin_sdk/PluginGraphTestUtils.hpp>
@@ -14,6 +15,8 @@
 #include "HipdnnEnginePluginExecutionContext.hpp"
 #include "HipdnnEnginePluginHandle.hpp"
 #include "mocks/MockHipdnnEnginePluginExecutionContext.hpp"
+
+using namespace hipdnn_data_sdk::utilities;
 
 TEST(TestHipblasltEnginePluginApi, GetAllEngineIdsNull)
 {
@@ -40,7 +43,7 @@ TEST(TestHipblasltEnginePluginApi, GetAllEngineIdsValid)
 
     EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
     EXPECT_EQ(numEngines, 1u);
-    EXPECT_EQ(engineIds[0], 1u);
+    EXPECT_EQ(engineIds[0], HIPBLASLT_ENGINE_ID);
 
     status = hipdnnEnginePluginGetAllEngineIdsImpl(nullptr, 0, &numEngines);
 
@@ -291,13 +294,14 @@ TEST(TestGpuHipblasltEnginePluginApi, GetEngineDetailsValid)
     hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
     hipdnnPluginConstData_t engineDetailsOut;
 
-    auto status = hipdnnEnginePluginGetEngineDetailsImpl(handle, 1, &opGraph, &engineDetailsOut);
+    auto status = hipdnnEnginePluginGetEngineDetailsImpl(
+        handle, HIPBLASLT_ENGINE_ID, &opGraph, &engineDetailsOut);
 
     hipdnn_plugin_sdk::EngineDetailsWrapper engineDetails(engineDetailsOut.ptr,
                                                           engineDetailsOut.size);
 
     EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
-    EXPECT_EQ(engineDetails.engineId(), 1);
+    EXPECT_EQ(engineDetails.engineId(), HIPBLASLT_ENGINE_ID);
 
     // Clean up
     EXPECT_EQ(hipdnnEnginePluginDestroyEngineDetailsImpl(handle, &engineDetailsOut),
@@ -316,7 +320,8 @@ TEST(TestGpuHipblasltEnginePluginApi, GetWorkspaceSizeValid)
     auto serializedGraph = builder.Release();
     hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
 
-    auto engineConfigBuilder = hipdnn_test_sdk::utilities::createValidEngineConfig(1);
+    auto engineConfigBuilder
+        = hipdnn_test_sdk::utilities::createValidEngineConfig(HIPBLASLT_ENGINE_ID);
     auto serializedEngineConfig = engineConfigBuilder.Release();
     hipdnnPluginConstData_t engineConfig
         = hipdnn_plugin_sdk::createValidConstDataEngineConfig(serializedEngineConfig);
@@ -341,7 +346,8 @@ TEST(TestGpuHipblasltEnginePluginApi, CreateExecutionContextValid)
     auto serializedGraph = builder.Release();
     hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
 
-    auto engineConfigBuilder = hipdnn_test_sdk::utilities::createValidEngineConfig(1);
+    auto engineConfigBuilder
+        = hipdnn_test_sdk::utilities::createValidEngineConfig(HIPBLASLT_ENGINE_ID);
     auto serializedEngineConfig = engineConfigBuilder.Release();
     hipdnnPluginConstData_t engineConfig
         = hipdnn_plugin_sdk::createValidConstDataEngineConfig(serializedEngineConfig);

--- a/dnn-providers/hipblaslt-provider/tests/engines/TestHipblasltEngine.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/engines/TestHipblasltEngine.cpp
@@ -7,6 +7,7 @@
 
 #include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
+#include <hipdnn_data_sdk/utilities/EngineNames.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/MockGraph.hpp>
 
@@ -156,14 +157,14 @@ TEST(TestHipblasltEngine, IsApplicableReturnsFalseIfNoPlanBuilderApplicable)
 
 TEST(TestHipblasltEngine, GetDetailsReturnsSerializedEngineDetails)
 {
-    HipblasltEngine engine(1);
+    HipblasltEngine engine(hipdnn_data_sdk::utilities::HIPBLASLT_ENGINE_ID);
     HipdnnEnginePluginHandle dummyHandle;
 
     hipdnnPluginConstData_t result;
     engine.getDetails(dummyHandle, result);
 
     hipdnn_plugin_sdk::EngineDetailsWrapper engineDetails(result.ptr, result.size);
-    EXPECT_EQ(engineDetails.engineId(), 1);
+    EXPECT_EQ(engineDetails.engineId(), hipdnn_data_sdk::utilities::HIPBLASLT_ENGINE_ID);
 }
 
 TEST(TestHipblasltEngine, InitializeExecutionContextInvokesFirstApplicablePlanBuilder)

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
@@ -125,5 +125,6 @@ struct EngineRegistrar
 
 // Define all engines using the macro
 HIPDNN_REGISTER_ENGINE(MIOPEN_ENGINE, "MIOPEN_ENGINE")
+HIPDNN_REGISTER_ENGINE(HIPBLASLT_ENGINE, "HIPBLASLT_ENGINE")
 
 } // namespace hipdnn_data_sdk::utilities

--- a/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
@@ -18,9 +18,11 @@ TEST_F(TestEngineNames, MacroGeneratesCorrectConstants)
 {
     // Check that the string constants are defined
     EXPECT_STREQ(MIOPEN_ENGINE_NAME, "MIOPEN_ENGINE");
+    EXPECT_STREQ(HIPBLASLT_ENGINE_NAME, "HIPBLASLT_ENGINE");
 
     // Check that the ID constants are defined and match the hash function
     EXPECT_EQ(MIOPEN_ENGINE_ID, engineNameToId("MIOPEN_ENGINE"));
+    EXPECT_EQ(HIPBLASLT_ENGINE_ID, engineNameToId("HIPBLASLT_ENGINE"));
 }
 
 TEST_F(TestEngineNames, EngineIdToNameMappingConsistent)
@@ -42,6 +44,7 @@ TEST_F(TestEngineNames, IsEngineNameRegistered)
 {
     // Test with known registered names
     EXPECT_TRUE(isEngineNameRegistered(MIOPEN_ENGINE_NAME));
+    EXPECT_TRUE(isEngineNameRegistered(HIPBLASLT_ENGINE_NAME));
 
     // Test with unregistered names
     EXPECT_FALSE(isEngineNameRegistered("UNKNOWN_ENGINE"));
@@ -53,6 +56,7 @@ TEST_F(TestEngineNames, GetEngineNameFromId)
 {
     // Test with registered engines
     EXPECT_EQ(getEngineNameFromId(MIOPEN_ENGINE_ID), "MIOPEN_ENGINE");
+    EXPECT_EQ(getEngineNameFromId(HIPBLASLT_ENGINE_ID), "HIPBLASLT_ENGINE");
 
     // Test with non-existent ID - should throw
     int64_t nonExistentId = 0xDEADBEEF;
@@ -79,10 +83,21 @@ TEST_F(TestEngineNames, EngineCountMatches)
 
 TEST_F(TestEngineNames, EnsureAllEngineNameToIdsBehaveTheSame)
 {
-    auto engineIdCString = engineNameToId(MIOPEN_ENGINE_NAME);
-    auto engineIdString = engineNameToId(std::string(MIOPEN_ENGINE_NAME));
-    auto engineIdStringView = engineNameToId(std::string_view(MIOPEN_ENGINE_NAME));
+    {
+        auto engineIdCString = engineNameToId(MIOPEN_ENGINE_NAME);
+        auto engineIdString = engineNameToId(std::string(MIOPEN_ENGINE_NAME));
+        auto engineIdStringView = engineNameToId(std::string_view(MIOPEN_ENGINE_NAME));
 
-    EXPECT_EQ(engineIdCString, engineIdString);
-    EXPECT_EQ(engineIdCString, engineIdStringView);
+        EXPECT_EQ(engineIdCString, engineIdString);
+        EXPECT_EQ(engineIdCString, engineIdStringView);
+    }
+
+    {
+        auto engineIdCString = engineNameToId(HIPBLASLT_ENGINE_NAME);
+        auto engineIdString = engineNameToId(std::string(HIPBLASLT_ENGINE_NAME));
+        auto engineIdStringView = engineNameToId(std::string_view(HIPBLASLT_ENGINE_NAME));
+
+        EXPECT_EQ(engineIdCString, engineIdString);
+        EXPECT_EQ(engineIdCString, engineIdStringView);
+    }
 }


### PR DESCRIPTION
## Motivation

Set generated `HIPBLASLT_ENGINE_ID` value to `engineID` in hipblaslt provider plugin. This is needed to differs it from miopen provider plugin.

The follow-up PR for https://github.com/ROCm/rocm-libraries/pull/3914

## Technical Details

The value `HIPBLASLT_ENGINE_ID` is generated from hash function by value `HIPBLASLT_ENGINE` - it guarantees unique ID (hash algorithm minimizes collision risk) for the engine plugin. More information is [here](https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipdnn/docs/PluginDevelopment.md#engine-ids).

## Test Plan

Updated existing tests in hipblaslt-provider and hipdnn.

## Test Result

The tests in hipblaslt-provider and hipdnn are successfully passed.
```
/opt/rocm-libraries-full/dnn-providers/hipblaslt-provider/build# ./bin/hipblaslt_plugin_tests 
[==========] Running 65 tests from 10 test suites.
[----------] Global test environment set-up.
...
[----------] Global test environment tear-down
[==========] 65 tests from 10 test suites ran. (290 ms total)
[  PASSED  ] 65 tests.
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
