### PR TITLE
[MIOpen] Add bfloat16 and NHWC support in BatchNormActivInfer kernels

### DIFF
--- a/projects/miopen/driver/CBAInferFusion_driver.hpp
+++ b/projects/miopen/driver/CBAInferFusion_driver.hpp
@@ -723,8 +723,8 @@ int CBAInferFusionDriver<Tgpu, Tref>::createRunningBuffers()
         runningVariance_dev = std::make_unique<GPUMem>(ctx, sb_sz, sizeof(float));
 
         // GPU host allocation
-        runningMean     = std::vector<float>(sb_sz, static_cast<float>(0));
-        runningVariance = std::vector<float>(sb_sz, static_cast<float>(0));
+        runningMean     = std::vector<float>(sb_sz, 0.0f);
+        runningVariance = std::vector<float>(sb_sz, 0.0f);
 
         // Populate
         for(int i = 0; i < sb_sz; i++)
@@ -809,8 +809,8 @@ int CBAInferFusionDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 
     if(useBatchNorm)
     {
-        scale       = std::vector<float>(sb_sz, static_cast<float>(0));
-        bias        = std::vector<float>(sb_sz, static_cast<float>(0));
+        scale       = std::vector<float>(sb_sz, 0.0f);
+        bias        = std::vector<float>(sb_sz, 0.0f);
         bn_res      = std::vector<Tgpu>(out_sz, static_cast<Tgpu>(0));
         bn_res_host = std::vector<Tref>(out_sz, static_cast<Tref>(0));
 

--- a/projects/miopen/driver/CBAInferFusion_driver.hpp
+++ b/projects/miopen/driver/CBAInferFusion_driver.hpp
@@ -249,12 +249,11 @@ private:
     std::vector<Tref> conv_res_host;
     std::vector<Tref> bn_res_host;
     std::vector<Tref> out_host;
-    std::vector<Tgpu> scale;
-    std::vector<Tgpu> bias;
+    std::vector<float> scale;
+    std::vector<float> bias;
     std::vector<Tref> bias_host;
-    std::vector<Tgpu> runningMean;
-    std::vector<Tgpu> runningVariance;
-
+    std::vector<float> runningMean;
+    std::vector<float> runningVariance;
     int createSaveBuffers();
     int createRunningBuffers();
 
@@ -720,12 +719,12 @@ int CBAInferFusionDriver<Tgpu, Tref>::createRunningBuffers()
         size_t sb_sz = GetTensorSize(biasScaleTensor);
 
         // GPU allocation
-        runningMean_dev     = std::make_unique<GPUMem>(ctx, sb_sz, sizeof(Tgpu));
-        runningVariance_dev = std::make_unique<GPUMem>(ctx, sb_sz, sizeof(Tgpu));
+        runningMean_dev     = std::make_unique<GPUMem>(ctx, sb_sz, sizeof(float));
+        runningVariance_dev = std::make_unique<GPUMem>(ctx, sb_sz, sizeof(float));
 
         // GPU host allocation
-        runningMean     = std::vector<Tgpu>(sb_sz, static_cast<Tgpu>(0));
-        runningVariance = std::vector<Tgpu>(sb_sz, static_cast<Tgpu>(0));
+        runningMean     = std::vector<float>(sb_sz, static_cast<float>(0));
+        runningVariance = std::vector<float>(sb_sz, static_cast<float>(0));
 
         // Populate
         for(int i = 0; i < sb_sz; i++)
@@ -734,8 +733,8 @@ int CBAInferFusionDriver<Tgpu, Tref>::createRunningBuffers()
             runningMean[i]     = 0.;
             runningVariance[i] = 1.;
 #else
-            runningMean[i]     = prng::gen_canonical<Tgpu>();
-            runningVariance[i] = prng::gen_canonical<Tgpu>();
+            runningMean[i]     = prng::gen_canonical<float>();
+            runningVariance[i] = prng::gen_canonical<float>();
 #endif
         }
 
@@ -810,23 +809,23 @@ int CBAInferFusionDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 
     if(useBatchNorm)
     {
-        scale       = std::vector<Tgpu>(sb_sz, static_cast<Tgpu>(0));
-        bias        = std::vector<Tgpu>(sb_sz, static_cast<Tgpu>(0));
+        scale       = std::vector<float>(sb_sz, static_cast<float>(0));
+        bias        = std::vector<float>(sb_sz, static_cast<float>(0));
         bn_res      = std::vector<Tgpu>(out_sz, static_cast<Tgpu>(0));
         bn_res_host = std::vector<Tref>(out_sz, static_cast<Tref>(0));
 
         bn_res_dev = std::make_unique<GPUMem>(ctx, out_sz, sizeof(Tgpu));
-        scale_dev  = std::make_unique<GPUMem>(ctx, sb_sz, sizeof(Tgpu));
-        bias_dev   = std::make_unique<GPUMem>(ctx, sb_sz, sizeof(Tgpu));
+        scale_dev  = std::make_unique<GPUMem>(ctx, sb_sz, sizeof(float));
+        bias_dev   = std::make_unique<GPUMem>(ctx, sb_sz, sizeof(float));
         // Using random beta and gamma
         for(int i = 0; i < sb_sz; i++)
         {
 #if(CBA_DEBUG_VALUES == 1)
-            scale[i] = 1.; // prng::gen_canonical<Tgpu>(); // 1.0;
+            scale[i] = 1.; // prng::gen_canonical<float>(); // 1.0;
             bias[i]  = 10.;
 #else
-            scale[i]           = prng::gen_canonical<Tgpu>();
-            bias[i]            = prng::gen_canonical<Tgpu>();
+            scale[i]           = prng::gen_canonical<float>();
+            bias[i]            = prng::gen_canonical<float>();
 #endif
         }
         status |= scale_dev->ToGPU(q, scale.data());

--- a/projects/miopen/driver/miopen_ConvBatchNormActivHost.hpp
+++ b/projects/miopen/driver/miopen_ConvBatchNormActivHost.hpp
@@ -49,6 +49,7 @@ int miopenBNSpatialFwdInferHost(miopenTensorDescriptor_t& inputTensor,
 {
     int nIn, cIn, hIn, wIn;
     miopenGet4dTensorDescriptorLengths(inputTensor, &nIn, &cIn, &hIn, &wIn);
+    auto tensorLayout = miopen::deref(inputTensor).GetLayout_t();
 
     int n_batchs = nIn;
     int channels = cIn;
@@ -76,7 +77,9 @@ int miopenBNSpatialFwdInferHost(miopenTensorDescriptor_t& inputTensor,
         { // via rows
             for(int column = 0; column < width; column++)
             { // via columns
-                adjIndex = in_cstride * cidx + width * row + column;
+                adjIndex = (tensorLayout == miopenTensorNCHW)
+                               ? in_cstride * cidx + width * row + column
+                               : width * channels * row + channels * column + cidx;
                 for(int bidx = 0; bidx < n_batchs; bidx++)
                 { // via mini_batch
                     index          = in_nstride * bidx + adjIndex;
@@ -103,6 +106,7 @@ int miopenBNPerActivFwdInferHost(miopenTensorDescriptor_t& inputTensor,
 
     int nIn, cIn, hIn, wIn;
     miopenGet4dTensorDescriptorLengths(inputTensor, &nIn, &cIn, &hIn, &wIn);
+    auto tensorLayout = miopen::deref(inputTensor).GetLayout_t();
 
     int n_batchs = nIn;
     int channels = cIn;
@@ -128,7 +132,9 @@ int miopenBNPerActivFwdInferHost(miopenTensorDescriptor_t& inputTensor,
         { // via rows
             for(int column = 0; column < width; column++)
             { // via columns
-                adjIndex          = in_cstride * cidx + width * row + column;
+                adjIndex = (tensorLayout == miopenTensorNCHW)
+                               ? in_cstride * cidx + width * row + column
+                               : width * channels * row + channels * column + cidx;
                 mean              = estimatedMean[adjIndex];
                 variance          = estimatedVariance[adjIndex];
                 double elemInvVar = 1.0 / double(sqrt(variance + epsilon));

--- a/projects/miopen/driver/miopen_ConvBatchNormActivHost.hpp
+++ b/projects/miopen/driver/miopen_ConvBatchNormActivHost.hpp
@@ -49,7 +49,7 @@ int miopenBNSpatialFwdInferHost(miopenTensorDescriptor_t& inputTensor,
 {
     int nIn, cIn, hIn, wIn;
     miopenGet4dTensorDescriptorLengths(inputTensor, &nIn, &cIn, &hIn, &wIn);
-    auto tensorLayout = miopen::deref(inputTensor).GetLayout_t();
+    const auto tensorLayout = miopen::deref(inputTensor).GetLayout_t();
 
     int n_batchs = nIn;
     int channels = cIn;
@@ -106,7 +106,7 @@ int miopenBNPerActivFwdInferHost(miopenTensorDescriptor_t& inputTensor,
 
     int nIn, cIn, hIn, wIn;
     miopenGet4dTensorDescriptorLengths(inputTensor, &nIn, &cIn, &hIn, &wIn);
-    auto tensorLayout = miopen::deref(inputTensor).GetLayout_t();
+    const auto tensorLayout = miopen::deref(inputTensor).GetLayout_t();
 
     int n_batchs = nIn;
     int channels = cIn;

--- a/projects/miopen/driver/miopen_ConvBatchNormActivHost.hpp
+++ b/projects/miopen/driver/miopen_ConvBatchNormActivHost.hpp
@@ -132,9 +132,9 @@ int miopenBNPerActivFwdInferHost(miopenTensorDescriptor_t& inputTensor,
         { // via rows
             for(int column = 0; column < width; column++)
             { // via columns
-                adjIndex = (tensorLayout == miopenTensorNCHW)
-                               ? in_cstride * cidx + width * row + column
-                               : width * channels * row + channels * column + cidx;
+                adjIndex          = (tensorLayout == miopenTensorNCHW)
+                                        ? in_cstride * cidx + width * row + column
+                                        : width * channels * row + channels * column + cidx;
                 mean              = estimatedMean[adjIndex];
                 variance          = estimatedVariance[adjIndex];
                 double elemInvVar = 1.0 / double(sqrt(variance + epsilon));

--- a/projects/miopen/src/include/miopen/fusion/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/fusion/problem_description.hpp
@@ -56,8 +56,14 @@ struct FusionDescription : ProblemDescriptionBase
     {
         const auto& input_desc  = fusion_plan_desc->input_desc;
         const auto& output_desc = fusion_plan_desc->output_desc;
-        ss << input_desc.ToString() << ((input_desc.GetType() == miopenHalf) ? "FP16" : "FP32");
-        ss << output_desc.ToString() << ((output_desc.GetType() == miopenHalf) ? "FP16" : "FP32");
+        ss << input_desc.ToString()
+           << ((input_desc.GetType() == miopenFloat)  ? "FP32"
+               : (input_desc.GetType() == miopenHalf) ? "FP16"
+                                                      : "BFP16");
+        ss << output_desc.ToString()
+           << ((output_desc.GetType() == miopenFloat)  ? "FP32"
+               : (output_desc.GetType() == miopenHalf) ? "FP16"
+                                                       : "BFP16");
         GetNetworkConfig(ss);
     }
 
@@ -94,17 +100,28 @@ struct FusionDescription : ProblemDescriptionBase
 
     bool IsFp16() const { return (fusion_plan_desc->input_desc).GetType() == miopenHalf; }
 
+    bool IsBFp16() const { return (fusion_plan_desc->input_desc).GetType() == miopenBFloat16; }
+
     bool Is2D() const { return (fusion_plan_desc->input_desc).GetLengths().size() == 4; }
 
-    bool IsLayoutContiguous() const
+    bool IsLayoutNCHW() const
     {
-        // determine input and output layouts
         const auto in_layout  = fusion_plan_desc->input_desc.GetLayout_str();
         const auto out_layout = fusion_plan_desc->output_desc.GetLayout_str();
 
         return fusion_plan_desc->input_desc.GetLengths().size() == 4
                    ? ((in_layout == "NCHW") && (out_layout == "NCHW"))
                    : ((in_layout == "NCDHW") && (out_layout == "NCDHW"));
+    }
+
+    bool IsLayoutNHWC() const
+    {
+        const auto in_layout  = fusion_plan_desc->input_desc.GetLayout_str();
+        const auto out_layout = fusion_plan_desc->output_desc.GetLayout_str();
+
+        return fusion_plan_desc->input_desc.GetLengths().size() == 4
+                   ? ((in_layout == "NHWC") && (out_layout == "NHWC"))
+                   : ((in_layout == "NDHWC") && (out_layout == "NDHWC"));
     }
 
     // This and the following method should be moved to the Ops once the return type can be unified

--- a/projects/miopen/src/include/miopen/op_kernel_args.hpp
+++ b/projects/miopen/src/include/miopen/op_kernel_args.hpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include <cstdint>
 #include <half/half.hpp>
+#include <miopen/bfloat16.hpp>
 #include <boost/container/small_vector.hpp>
 
 struct OpKernelArg
@@ -17,7 +18,8 @@ struct OpKernelArg
     template <typename T>
     OpKernelArg(T arg) : buffer(sizeof(T))
     {
-        static_assert(std::is_trivial<T>{} || std::is_same<T, half_float::half>{},
+        static_assert(std::is_trivial<T>{} || std::is_same<T, half_float::half>{} ||
+                          std::is_same<T, bfloat16>{},
                       "Only for trivial types");
         *(reinterpret_cast<T*>(buffer.data())) = arg;
     }

--- a/projects/miopen/src/kernels/MIOpenBatchNormActivInferHIP.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormActivInferHIP.cpp
@@ -62,16 +62,60 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
 
-    unsigned int c_i      = tidy;
-    unsigned int hw_i     = tidx;
-    unsigned int c_offset = c_i * MIO_BN_HW;
+    unsigned int c_i, hw_i, c_offset, hw_offset;
+    if constexpr(MIO_LAYOUT_NHWC)
+    {
+        c_i       = tidx;
+        hw_i      = tidy;
+        c_offset  = c_i * MIOPEN_READ_UNIT;
+        hw_offset = hw_i * MIO_BN_C;
+    }
+    else
+    {
+        c_i       = tidy;
+        hw_i      = tidx;
+        c_offset  = c_i * MIO_BN_HW;
+        hw_offset = hw_i * MIOPEN_READ_UNIT;
+    }
 
     // load the mean, variance, scale, and bias
-    const FLOAT_ACCUM pmean       = estimatedMean[c_i];
-    const FLOAT_ACCUM pvar        = estimatedVariance[c_i];
-    const FLOAT_ACCUM pscale      = scale[c_i];
-    const FLOAT_ACCUM pbias       = bias[c_i];
-    const FLOAT_ACCUM invVariance = rsqrt(pvar + static_cast<FLOAT_ACCUM>(epsilon));
+    FLOAT_ACCUM pmean[MIOPEN_READ_UNIT];
+    FLOAT_ACCUM pvar[MIOPEN_READ_UNIT];
+    FLOAT_ACCUM pscale[MIOPEN_READ_UNIT];
+    FLOAT_ACCUM pbias[MIOPEN_READ_UNIT];
+    FLOAT_ACCUM invVariance[MIOPEN_READ_UNIT];
+    if constexpr(MIO_LAYOUT_NHWC)
+    {
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pmean)) = *(
+            reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedMean + c_i * MIOPEN_READ_UNIT));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pvar)) =
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedVariance +
+                                                            c_i * MIOPEN_READ_UNIT));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pscale)) =
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(scale + c_i * MIOPEN_READ_UNIT));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pbias)) =
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(bias + c_i * MIOPEN_READ_UNIT));
+    }
+    else // NCHW layout
+    {
+        const auto mean_val  = estimatedMean[c_i];
+        const auto var_val   = estimatedVariance[c_i];
+        const auto scale_val = scale[c_i];
+        const auto bias_val  = bias[c_i];
+#pragma unroll
+        for(unsigned int i = 0; i < MIOPEN_READ_UNIT; ++i)
+        {
+            pmean[i]  = mean_val;
+            pvar[i]   = var_val;
+            pscale[i] = scale_val;
+            pbias[i]  = bias_val;
+        }
+    }
+#pragma unroll
+    for(unsigned int i = 0; i < MIOPEN_READ_UNIT; ++i)
+    {
+        invVariance[i] = rsqrt(pvar[i] + static_cast<FLOAT_ACCUM>(epsilon));
+    }
 
     FLOAT data[MIOPEN_READ_UNIT];
     FLOAT_ACCUM bnRes[MIOPEN_READ_UNIT];
@@ -80,7 +124,7 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 #pragma unroll 2
     for(unsigned int n_i = 0; n_i < MIO_BN_N; ++n_i)
     {
-        const unsigned int index = n_i * MIO_BN_CHW + c_offset + hw_i * MIOPEN_READ_UNIT;
+        const unsigned int index = n_i * MIO_BN_CHW + c_offset + hw_offset;
 
         // load the input data
         *(reinterpret_cast<FLOAT_VEC_TYPE*>(data)) =
@@ -90,7 +134,8 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 #pragma unroll
         for(unsigned int i = 0; i < MIOPEN_READ_UNIT; ++i)
         {
-            bnRes[i] = pscale * (CVT_FLOAT2ACCUM(data[i]) - pmean) * invVariance + pbias;
+            bnRes[i] =
+                pscale[i] * (CVT_FLOAT2ACCUM(data[i]) - pmean[i]) * invVariance[i] + pbias[i];
         }
         ActivationFunction(
             actRes, bnRes, CVT_FLOAT2ACCUM(gamma), CVT_FLOAT2ACCUM(beta), CVT_FLOAT2ACCUM(alpha));

--- a/projects/miopen/src/kernels/MIOpenBatchNormActivInferHIP.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormActivInferHIP.cpp
@@ -86,15 +86,14 @@ extern "C" __global__ void __launch_bounds__(blockSize)
     FLOAT_ACCUM invVariance[MIOPEN_READ_UNIT];
     if constexpr(MIO_LAYOUT_NHWC)
     {
-        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pmean)) = *(
-            reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedMean + c_i * MIOPEN_READ_UNIT));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pmean)) =
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedMean + c_offset));
         *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pvar)) =
-            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedVariance +
-                                                            c_i * MIOPEN_READ_UNIT));
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedVariance + c_offset));
         *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pscale)) =
-            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(scale + c_i * MIOPEN_READ_UNIT));
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(scale + c_offset));
         *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pbias)) =
-            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(bias + c_i * MIOPEN_READ_UNIT));
+            *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(bias + c_offset));
     }
     else // NCHW layout
     {

--- a/projects/miopen/src/kernels/float_types.h
+++ b/projects/miopen/src/kernels/float_types.h
@@ -119,7 +119,7 @@
 #endif
 #endif // MIOPEN_USE_DOUBLE_ACCUM
 
-#if (MIOPEN_USE_FP16 == 1) || (MIOPEN_USE_FPMIX == 1)
+#if(MIOPEN_USE_FP16 == 1) || (MIOPEN_USE_FPMIX == 1)
 #ifdef __HIP_PLATFORM_AMD__
 #define FLOAT _Float16
 #else // __HIP_PLATFORM_AMD__
@@ -150,7 +150,7 @@
 #endif
 #endif // MIOPEN_USE_FP32
 
-#if (MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
+#if(MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
 #ifdef __HIP_PLATFORM_AMD__
 #define FLOAT ushort
 #else
@@ -161,7 +161,7 @@
 #define MAX_VAL 0x7F7F
 #endif // MIOPEN_USE_BFP16 || MIOPEN_USE_BFPMIX
 
-#if (MIOPEN_USE_FP16 == 1) || (MIOPEN_USE_FPMIX == 1)
+#if(MIOPEN_USE_FP16 == 1) || (MIOPEN_USE_FPMIX == 1)
 #ifdef __HIP_PLATFORM_AMD__
 #define CVT_FLOAT2ACCUM(x) (static_cast<FLOAT_ACCUM>(x))
 #define CVT_ACCUM2FLOAT(x) (static_cast<FLOAT>(x))
@@ -205,7 +205,7 @@
 #define CVT_ACCUM2FP32(x) (x)
 #endif // MIOPEN_USE_FP32
 
-#if (MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
+#if(MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
 #ifdef __HIP_PLATFORM_AMD__
 #define CVT_FLOAT2ACCUM(x) (bfloat16_to_float(x))
 #define CVT_ACCUM2FLOAT(x) (float_to_bfloat16(x))
@@ -262,7 +262,7 @@
 
 #undef CVT_INTEGRAL2ACCUM
 #ifdef __HIP_PLATFORM_AMD__
-#if (MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
+#if(MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
 // No direct conversion from integral types to BF16 is available.
 // WARNING: Precision loss when integral type is wider than 16 bits.
 #define CVT_INTEGRAL2ACCUM(x) (float_to_bfloat16(static_cast<float>(x)))
@@ -270,7 +270,7 @@
 #define CVT_INTEGRAL2ACCUM(x) (static_cast<FLOAT>(x))
 #endif
 #else
-#if (MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
+#if(MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
 // No direct conversion from integral types to BF16 is available.
 // WARNING: Precision loss when integral type is wider than 16 bits.
 #define CVT_INTEGRAL2ACCUM(x) (float_to_bfloat16(static_cast<float>(x)))

--- a/projects/miopen/src/kernels/float_types.h
+++ b/projects/miopen/src/kernels/float_types.h
@@ -119,7 +119,7 @@
 #endif
 #endif // MIOPEN_USE_DOUBLE_ACCUM
 
-#if MIOPEN_USE_FP16 == 1
+#if (MIOPEN_USE_FP16 == 1) || (MIOPEN_USE_FPMIX == 1)
 #ifdef __HIP_PLATFORM_AMD__
 #define FLOAT _Float16
 #else // __HIP_PLATFORM_AMD__
@@ -133,7 +133,7 @@
 #else
 #define MAX_VAL HALF_MAX
 #endif
-#endif // MIOPEN_USE_FP16
+#endif // MIOPEN_USE_FP16 || MIOPEN_USE_FPMIX
 
 #if MIOPEN_USE_FP32 == 1
 #ifdef __HIP_PLATFORM_AMD__
@@ -150,7 +150,7 @@
 #endif
 #endif // MIOPEN_USE_FP32
 
-#if MIOPEN_USE_BFP16 == 1
+#if (MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
 #ifdef __HIP_PLATFORM_AMD__
 #define FLOAT ushort
 #else
@@ -159,9 +159,9 @@
 #define SIZEOF_FLOAT 2
 // Max value for the main datatype
 #define MAX_VAL 0x7F7F
-#endif // MIOPEN_USE_BFP16
+#endif // MIOPEN_USE_BFP16 || MIOPEN_USE_BFPMIX
 
-#if MIOPEN_USE_FP16 == 1
+#if (MIOPEN_USE_FP16 == 1) || (MIOPEN_USE_FPMIX == 1)
 #ifdef __HIP_PLATFORM_AMD__
 #define CVT_FLOAT2ACCUM(x) (static_cast<FLOAT_ACCUM>(x))
 #define CVT_ACCUM2FLOAT(x) (static_cast<FLOAT>(x))
@@ -180,7 +180,7 @@
 #define CVT_FP32_2ACCUM(x) (x)
 #define CVT_FLOAT2FP32(x) (CVT_FLOAT2ACCUM(x))
 #define CVT_ACCUM2FP32(x) (x)
-#endif // MIOPEN_USE_FP16
+#endif // MIOPEN_USE_FP16 || MIOPEN_USE_FPMIX
 
 #if MIOPEN_USE_FP32 == 1
 /// \todo Basically, conversions from float to accum and vice versa
@@ -205,7 +205,7 @@
 #define CVT_ACCUM2FP32(x) (x)
 #endif // MIOPEN_USE_FP32
 
-#if MIOPEN_USE_BFP16 == 1
+#if (MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
 #ifdef __HIP_PLATFORM_AMD__
 #define CVT_FLOAT2ACCUM(x) (bfloat16_to_float(x))
 #define CVT_ACCUM2FLOAT(x) (float_to_bfloat16(x))
@@ -262,7 +262,7 @@
 
 #undef CVT_INTEGRAL2ACCUM
 #ifdef __HIP_PLATFORM_AMD__
-#if MIOPEN_USE_BFP16 == 1
+#if (MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
 // No direct conversion from integral types to BF16 is available.
 // WARNING: Precision loss when integral type is wider than 16 bits.
 #define CVT_INTEGRAL2ACCUM(x) (float_to_bfloat16(static_cast<float>(x)))
@@ -270,7 +270,7 @@
 #define CVT_INTEGRAL2ACCUM(x) (static_cast<FLOAT>(x))
 #endif
 #else
-#if MIOPEN_USE_BFP16 == 1
+#if (MIOPEN_USE_BFP16 == 1) || (MIOPEN_USE_BFPMIX == 1)
 // No direct conversion from integral types to BF16 is available.
 // WARNING: Precision loss when integral type is wider than 16 bits.
 #define CVT_INTEGRAL2ACCUM(x) (float_to_bfloat16(static_cast<float>(x)))

--- a/projects/miopen/src/solver/batchnorm/forward_inference_fused.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_inference_fused.cpp
@@ -68,7 +68,7 @@ bool BnFwdInferActivationFused::IsApplicable(const FusionContext& /*context*/,
     return true;
 }
 
-ConvSolution BnFwdInferActivationFused::GetSolution(const FusionContext& context,
+ConvSolution BnFwdInferActivationFused::GetSolution(const FusionContext&,
                                                     const FusionDescription& problem) const
 {
     const auto bn_problem = problem.GetBnProblem(0, miopen::batchnorm::Direction::ForwardInference);

--- a/projects/miopen/src/solver/batchnorm/forward_inference_fused.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_inference_fused.cpp
@@ -56,9 +56,14 @@ bool BnFwdInferActivationFused::IsApplicable(const FusionContext& /*context*/,
         return false;
     if(desc.op_map.at(1)->kind() != miopenFusionOpActivForward)
         return false;
-    if(!(problem.IsFp32() || problem.IsFp16()))
+    if(!(problem.IsFp32() || problem.IsFp16() || problem.IsBFp16()))
         return false;
-    if(!(problem.Is2D() && problem.IsLayoutContiguous()))
+    if(!(problem.Is2D()))
+        return false;
+    if(!(problem.IsLayoutNCHW() || problem.IsLayoutNHWC()))
+        return false;
+    const auto bn_problem = problem.GetBnProblem(0, miopen::batchnorm::Direction::ForwardInference);
+    if(!IsOCLInferTypeValid(bn_problem))
         return false;
     return true;
 }
@@ -130,15 +135,14 @@ ConvSolution BnFwdInferActivationFused::GetSolution(const FusionContext& context
         {"MIOPEN_READ_UNIT", static_cast<int>(read_unit)},
         {"MIOPEN_SBN_BOUNDS", static_cast<unsigned int>(read_len / read_unit)},
         {"MIOPEN_NRN_OP_ID", static_cast<int>(activ_op.activMode)},
-        {"MIOPEN_USE_FP16", static_cast<int>(input_desc.GetType() == miopenHalf)},
+        {"MIOPEN_USE_BFPMIX", static_cast<int>(input_desc.GetType() == miopenBFloat16)},
+        {"MIOPEN_USE_FPMIX", static_cast<int>(input_desc.GetType() == miopenHalf)},
         {"MIOPEN_USE_FP32", static_cast<int>(input_desc.GetType() == miopenFloat)}};
     kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
     if(bn_problem.GetMode() == miopenBNSpatial)
         kernel.comp_options += " -DSPATIAL_BN";
     else
         kernel.comp_options += " -DPERACT_BN";
-    if(input_desc.GetType() == miopenHalf)
-        kernel.comp_options += " -DMIOPEN_USE_FPMIX=1";
 
     result.construction_params.push_back(kernel);
 

--- a/projects/miopen/src/solver/batchnorm/forward_inference_fused.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_inference_fused.cpp
@@ -164,6 +164,12 @@ ConvSolution BnFwdInferActivationFused::GetSolution(const FusionContext& context
                 kern_args.push_back({static_cast<half_float::half>(activ_beta)});
                 kern_args.push_back({static_cast<half_float::half>(activ_gamma)});
             }
+            else if(input_type == miopenBFloat16)
+            {
+                kern_args.push_back({static_cast<bfloat16>(activ_alpha)});
+                kern_args.push_back({static_cast<bfloat16>(activ_beta)});
+                kern_args.push_back({static_cast<bfloat16>(activ_gamma)});
+            }
             else
                 MIOPEN_THROW("Unsupported Precision");
             kern_args.push_back(bn_invoke.epsilon);

--- a/projects/miopen/src/solver/batchnorm/forward_inference_fused.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_inference_fused.cpp
@@ -87,37 +87,25 @@ ConvSolution BnFwdInferActivationFused::GetSolution(const FusionContext& context
     { // PER ACTIVATION
         kernel.kernel_name += "PerActEst";
     }
-    kernel.l_wk.push_back(256);
-    kernel.l_wk.push_back(1);
-    kernel.l_wk.push_back(1);
 
     int n, c, h, w;
     const auto& input_desc = bn_problem.GetXDesc();
     std::tie(n, c, h, w)   = tien<4>(input_desc.GetLengths());
 
-    size_t read_unit = 1;
-    size_t read_len  = (mode == miopenBNSpatial) ? h * w : c * h * w;
-    read_unit        = (read_len % 4 == 0) ? 4 : (read_len % 2 == 0) ? 2 : 1;
+    bool is_layout_NHWC  = (input_desc.GetLayout_t() == miopenTensorNHWC);
+    size_t read_len      = (mode == miopenBNSpatial) ? (is_layout_NHWC ? c : h * w) : c * h * w;
+    size_t read_unit     = (read_len % 4 == 0) ? 4 : (read_len % 2 == 0) ? 2 : 1;
+    size_t max_localsize = 256;
+    size_t xlocalsize    = std::min(size_t{read_len / read_unit}, max_localsize);
+    size_t xgridsize     = AlignUp(size_t{read_len / read_unit}, xlocalsize);
+    size_t ylocalsize    = 1;
+    size_t ygridsize     = (mode == miopenBNSpatial) ? size_t{is_layout_NHWC ? h * w : c} : 1;
+    size_t zlocalsize    = 1;
+    size_t zgridsize     = 1;
 
-    size_t xlocalsize = 256;
-    size_t xgridsize  = read_len / read_unit;
-    size_t ygridsize  = (mode == miopenBNSpatial) ? size_t(c) : 1;
-    size_t zgridsize  = 1;
-
-    // HIP runtime does not support non-uniform blocks
-    // Adjust the xlocalsize and xgridsize accordingly
-    if(xgridsize < xlocalsize)
-    {
-        // round up the xlocalsize to the nearest wavefront size
-        xlocalsize = AlignUp(xgridsize, context.GetStream().GetWavefrontWidth());
-        // launch only one block
-        xgridsize = xlocalsize;
-    }
-    else
-    {
-        xgridsize = AlignUp(xgridsize, xlocalsize);
-    }
-    kernel.l_wk[0] = xlocalsize;
+    kernel.l_wk.push_back(xlocalsize);
+    kernel.l_wk.push_back(ylocalsize);
+    kernel.l_wk.push_back(zlocalsize);
 
     kernel.g_wk.push_back(xgridsize);
     kernel.g_wk.push_back(ygridsize);
@@ -129,9 +117,11 @@ ConvSolution BnFwdInferActivationFused::GetSolution(const FusionContext& context
         {"MIO_BN_CHW", static_cast<int>(c * h * w)},
         {"MIO_BN_HW", static_cast<int>(h * w)},
         {"MIO_BN_N", static_cast<int>(n)},
-        {"MIO_BN_GRP0", kernel.l_wk[0]},
-        {"MIO_BN_GRP1", static_cast<int>(1)},
-        {"MIO_BN_GRP2", static_cast<int>(1)},
+        {"MIO_BN_C", static_cast<int>(c)},
+        {"MIO_BN_GRP0", static_cast<int>(xlocalsize)},
+        {"MIO_BN_GRP1", static_cast<int>(ylocalsize)},
+        {"MIO_BN_GRP2", static_cast<int>(zlocalsize)},
+        {"MIO_LAYOUT_NHWC", static_cast<int>(is_layout_NHWC)},
         {"MIOPEN_READ_UNIT", static_cast<int>(read_unit)},
         {"MIOPEN_SBN_BOUNDS", static_cast<unsigned int>(read_len / read_unit)},
         {"MIOPEN_NRN_OP_ID", static_cast<int>(activ_op.activMode)},

--- a/projects/miopen/test/gtest/bn_activ_infer.cpp
+++ b/projects/miopen/test/gtest/bn_activ_infer.cpp
@@ -62,34 +62,19 @@ void BatchNormInferenceGPU(const miopen::Handle& handle,
     int n, c, h, w;
     std::tie(n, c, h, w) = miopen::tien<4>(xDesc.GetLengths());
 
-    size_t read_unit = 1;
-    size_t read_len  = (bn_mode == miopenBNSpatial) ? h * w : c * h * w;
-    // read unit size for vectorized loads/stores
-    read_unit = (read_len % 4 == 0) ? 4 : (read_len % 2 == 0) ? 2 : 1;
+    // Setup the kernel launch parameters
+    bool is_layout_NHWC = (xDesc.GetLayout_t() == miopenTensorNHWC);
+    size_t read_len     = (bn_mode == miopenBNSpatial) ? (is_layout_NHWC ? c : h * w) : c * h * w;
+    size_t read_unit    = (read_len % 4 == 0) ? 4 : (read_len % 2 == 0) ? 2 : 1;
     // For vectorized r/rw of the input/output data
     std::string READ_TYPE = (read_unit == 1) ? "_FLOAT" : "_FLOAT" + std::to_string(read_unit);
-    // Setup the kernel launch parameters
-    size_t xlocalsize = 256;
-    size_t xgridsize  = read_len / read_unit;
-    // HIP runtime does not support non-uniform blocks
-    if(use_hip)
-    {
-        if(xgridsize < xlocalsize)
-        {
-            // round up the xlocalsize to the nearest wavefront size
-            xlocalsize = AlignUp(xgridsize, handle.GetWavefrontWidth());
-            // Set xgridsize to the xlocalsize, to launch only one block
-            xgridsize = xlocalsize;
-        }
-        else
-        {
-            xgridsize = AlignUp(xgridsize, xlocalsize);
-        }
-    }
-    size_t ylocalsize = 1;
-    size_t ygridsize  = (bn_mode == miopenBNSpatial) ? size_t(c) : 1;
-    size_t zlocalsize = 1;
-    size_t zgridsize  = 1;
+    size_t max_localsize  = 256;
+    size_t xlocalsize     = std::min(size_t{read_len / read_unit}, max_localsize);
+    size_t xgridsize      = AlignUp(size_t{read_len / read_unit}, xlocalsize);
+    size_t ylocalsize     = 1;
+    size_t ygridsize      = (bn_mode == miopenBNSpatial) ? size_t{is_layout_NHWC ? h * w : c} : 1;
+    size_t zlocalsize     = 1;
+    size_t zgridsize      = 1;
 
     const std::vector<size_t> vgd{xgridsize, ygridsize, zgridsize};
     const std::vector<size_t> vld{xlocalsize, ylocalsize, zlocalsize};
@@ -98,15 +83,17 @@ void BatchNormInferenceGPU(const miopen::Handle& handle,
         {"MIO_BN_CHW", static_cast<unsigned>(c * h * w)},
         {"MIO_BN_HW", static_cast<unsigned>(h * w)},
         {"MIO_BN_N", static_cast<unsigned>(n)},
+        {"MIO_BN_C", static_cast<unsigned>(c)},
         {"MIO_BN_GRP0", xlocalsize},
         {"MIO_BN_GRP1", ylocalsize},
         {"MIO_BN_GRP2", zlocalsize},
+        {"MIO_LAYOUT_NHWC", static_cast<int>(is_layout_NHWC)},
         {"MIOPEN_READ_UNIT", static_cast<int>(read_unit)},
         {"MIOPEN_SBN_BOUNDS", static_cast<unsigned int>(read_len / read_unit)},
         {"MIOPEN_READ_TYPE", READ_TYPE},
         {"MIOPEN_NRN_OP_ID", static_cast<int>(activ_mode)},
-        {use_hip ? "MIOPEN_USE_FP16" : "MIOPEN_USE_FPMIX",
-         static_cast<int>(xDesc.GetType() == miopenHalf)},
+        {"MIOPEN_USE_BFPMIX", static_cast<int>(xDesc.GetType() == miopenBFloat16)},
+        {"MIOPEN_USE_FPMIX", static_cast<int>(xDesc.GetType() == miopenHalf)},
         {"MIOPEN_USE_FP32", static_cast<int>(xDesc.GetType() == miopenFloat)}};
 
     std::string kernel_file =
@@ -128,6 +115,7 @@ void BatchNormInferenceGPU(const miopen::Handle& handle,
     // Generate the network config
     std::ostringstream ss;
     ss << (use_hip ? "hip" : "ocl");
+    ss << "bfp16" << static_cast<int>(xDesc.GetType() == miopenBFloat16);
     ss << "fp16" << static_cast<int>(xDesc.GetType() == miopenHalf);
     ss << "fp32" << static_cast<int>(xDesc.GetType() == miopenFloat);
     ss << "mode" << bn_mode;
@@ -179,6 +167,23 @@ void BatchNormInferenceGPU(const miopen::Handle& handle,
                                  estimatedMean,
                                  estimatedVariance);
         }
+        else if(xDesc.GetType() == miopenBFloat16)
+        {
+            perf_helper.perfTest(handle,
+                                 kernel_name,
+                                 network_config,
+                                 use_hip,
+                                 static_cast<bfloat16>(activ_alpha),
+                                 static_cast<bfloat16>(activ_beta),
+                                 static_cast<bfloat16>(activ_gamma),
+                                 static_cast<double>(epsilon),
+                                 x,
+                                 y,
+                                 bnBias,
+                                 bnScale,
+                                 estimatedMean,
+                                 estimatedVariance);
+        }
     }
     else
     {
@@ -201,6 +206,19 @@ void BatchNormInferenceGPU(const miopen::Handle& handle,
             kernelInvoke(static_cast<_Float16>(activ_alpha),
                          static_cast<_Float16>(activ_beta),
                          static_cast<_Float16>(activ_gamma),
+                         static_cast<double>(epsilon),
+                         x,
+                         y,
+                         bnBias,
+                         bnScale,
+                         estimatedMean,
+                         estimatedVariance);
+        }
+        else if(xDesc.GetType() == miopenBFloat16)
+        {
+            kernelInvoke(static_cast<bfloat16>(activ_alpha),
+                         static_cast<bfloat16>(activ_beta),
+                         static_cast<bfloat16>(activ_gamma),
                          static_cast<double>(epsilon),
                          x,
                          y,
@@ -286,6 +304,16 @@ struct GPU_bn_activ_infer_per_act_FP16
 {
 };
 
+struct GPU_bn_activ_infer_spatial_BFP16
+    : BatchNormActivInferTester<bfloat16, bfloat16, float, float, float>
+{
+};
+
+struct GPU_bn_activ_infer_per_act_BFP16
+    : BatchNormActivInferTester<bfloat16, bfloat16, float, float, float>
+{
+};
+
 std::vector<miopenActivationMode_t> ActivationConfigs()
 {
     return {miopenActivationPASTHRU,
@@ -363,31 +391,69 @@ TEST_P(GPU_bn_activ_infer_per_act_FP16, PortTest)
     Verify();
 };
 
+TEST_P(GPU_bn_activ_infer_spatial_BFP16, PortTest)
+{
+    // Not sure if the OpenCL path works well for BFP16
+    // So, not running the COMPARE_WITH_OPENCL path here
+    // Run the CPU implementation
+    RunTestCPU();
+    // Run the HIP implementation
+    RunTestGPU();
+    // Compare the outputs
+    Verify();
+};
+
+TEST_P(GPU_bn_activ_infer_per_act_BFP16, PortTest)
+{
+    // Not sure if the OpenCL path works well for BFP16
+    // So, not running the COMPARE_WITH_OPENCL path here
+    // Run the CPU implementation
+    RunTestCPU();
+    // Run the HIP implementation
+    RunTestGPU();
+    // Compare the outputs
+    Verify();
+};
+
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
     GPU_bn_activ_infer_spatial_FP32,
     testing::Combine(testing::ValuesIn(ActivationConfigs()),
                      testing::ValuesIn(BNInferTestConfigs<float>(miopenBNSpatial)),
-                     testing::ValuesIn({miopenTensorNCHW})),
+                     testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC})),
     TestNameGenerator());
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
     GPU_bn_activ_infer_per_act_FP32,
     testing::Combine(testing::ValuesIn(ActivationConfigs()),
                      testing::ValuesIn(BNInferTestConfigs<float>(miopenBNPerActivation)),
-                     testing::ValuesIn({miopenTensorNCHW})),
+                     testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC})),
     TestNameGenerator());
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
     GPU_bn_activ_infer_spatial_FP16,
     testing::Combine(testing::ValuesIn(ActivationConfigs()),
                      testing::ValuesIn(BNInferTestConfigs<half_float::half>(miopenBNSpatial)),
-                     testing::ValuesIn({miopenTensorNCHW})),
+                     testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC})),
     TestNameGenerator());
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
     GPU_bn_activ_infer_per_act_FP16,
     testing::Combine(testing::ValuesIn(ActivationConfigs()),
                      testing::ValuesIn(BNInferTestConfigs<half_float::half>(miopenBNPerActivation)),
-                     testing::ValuesIn({miopenTensorNCHW})),
+                     testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC})),
+    TestNameGenerator());
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_bn_activ_infer_spatial_BFP16,
+    testing::Combine(testing::ValuesIn(ActivationConfigs()),
+                     testing::ValuesIn(BNInferTestConfigs<bfloat16>(miopenBNSpatial)),
+                     testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC})),
+    TestNameGenerator());
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_bn_activ_infer_per_act_BFP16,
+    testing::Combine(testing::ValuesIn(ActivationConfigs()),
+                     testing::ValuesIn(BNInferTestConfigs<bfloat16>(miopenBNPerActivation)),
+                     testing::ValuesIn({miopenTensorNCHW, miopenTensorNHWC})),
     TestNameGenerator());


### PR DESCRIPTION
## Motivation

This PR extends the `MIOpenBatchNormActivInferSpatialEst` and `MIOpenBatchNormActivInferPerActEst` kernels to support the `bfloat16` data type and the `NHWC` tensor layout.

## Technical Details

- Updated `MIOpenBatchNormActivInferSpatialEst` to support `NHWC` layout.
- Modified the batchnorm/forward_inference_fused solver to enable computations with bfloat16 data types and correctly configure and launch workgroups required for `NHWC` layout.
- Extended the `test_bn_activ_infer` test suite to include `bfloat16` and `NHWC` test cases across all configurations.
- Added utility functions in `fusion/problem_description.hpp` to support modifications in `forward_inference_fused` solver.
- Made consistency updates in `driver/CBAInferFusion_driver.hpp` to align with recent `BatchNormActivInfer` kernel changes.

## Test Plan

Changes can be verified with `test_bn_activ_infer` and through the `MIOpenDriver` with the following options:
`CBAInfer[fp16|bfp16] --fusion_mode 2 --in_layout [NCHW|NHWC] --out_layout [NCHW|NHWC]`.

## Test Result

Tests pass on gfx90a and gfx942.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
