### PR TITLE
[hipblaslt][CMS] Change LocalRead.needed_by to use ValidatorInstruction

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1698,7 +1698,7 @@ def _transform_index_standard(
     is_lr0: bool,
     use_f32x_emulation: bool,
     mfma_reorder: list[int],
-    num_vmfma: int,
+    num_vmfma: int
 ) -> int:
     """
     Convert column-major linear index into needed_by mfma index when ForceUnrollSubIter is disabled.
@@ -1706,7 +1706,7 @@ def _transform_index_standard(
     if use_f32x_emulation:  # Each tile requires 3 MFMAs
         needed_by *= 3
     
-    if is_lr0:  # LR0 reads data for 2nd half of this iteration
+    if is_lr0:  # LR0 reads data for 2nd half of this iteration (when present)
         needed_by += num_vmfma // 2
     
     if mfma_reorder:
@@ -1752,12 +1752,14 @@ def lr_needed_by_mfma(
     n_tiles_per_lra = n_tiles_a / n_local_reads_a
     n_tiles_per_lrb = n_tiles_b / n_local_reads_b
 
-    if force_unroll_sub_iter:
+    mfma_per_tile = 3 if use_f32x_emulation else 1
+    single_sub_iter = num_vmfma == n_tiles_a * n_tiles_b * mfma_per_tile
+    if force_unroll_sub_iter or single_sub_iter:
         # Without the unroll, the LRs are for half of the vmfmas.
         # But the number of vmfmas == 2 * n_tiles_a * n_tiles_b.
         # So each LR loads n_tiles tiles.
-        # For force_unroll_sub_iter, there are only n_tiles_a * n_tiles_b vmfmas.
-        # So each LR only loads half as many tiles.
+        # For force_unroll_sub_iter (and single-sub-iter schedules), there are only
+        # n_tiles_a * n_tiles_b vmfmas. So each LR only loads half as many tiles.
         n_tiles_per_lra /= 2
         n_tiles_per_lrb /= 2
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -337,7 +337,7 @@ class LocalRead(ValidatorInstruction):
     # The index in the list of Local Read instructions provided by a CMS schedule.
     # Needed to properly calculate must_start_after for Packs.
     issue_index: int
-    needed_by: Union[int, float] = float('inf')
+    needed_by: ValidatorInstruction = field(default_factory=lambda: MFMA(float('inf')))
     guaranteed_by: Union[int, float] = float('inf')
 
     def done_idx(self) -> Union[int, float]:
@@ -345,35 +345,32 @@ class LocalRead(ValidatorInstruction):
 
     def validate(self) -> Optional[str]:
         # For when local reads are not being guaranteed by a particular pass.
-        if self.needed_by == float('inf'):
+        if self.needed_by.issued_at == float('inf'):
             return None
 
         # Needs to be guaranteed BEFORE the index at which it's needed since the
         # SWaitCnt is issued AFTER the vmfma.
-        if self.guaranteed_by < self.needed_by:
+        if self.guaranteed_by < self.needed_by.issued_at:
             return None
 
         guaranteed_by = self.guaranteed_by
         # Modulo for LRs that finish in next iteration.
-        needed_by = self.needed_by % self.num_vmfma
+        needed_by = int(self.needed_by.issued_at) % self.num_vmfma
         issued_at = floor(self.issued_at) % self.num_vmfma
         if guaranteed_by == float('inf'):
-            message = f"{self.name} at index {issued_at} is not valid. " + \
-                        "There are no guarantees on when it will be done."
+            return f"{self.name} @ idx={issued_at} is not valid. There are no guarantees on when it will be done."
+        
+        if self.num_vmfma - 1 + 0.5 <= (guaranteed_by % self.num_vmfma) < self.num_vmfma:
+            # Special case to handle idx=-1 which is in the range of [numVMFMA + 0.5, numVMFMA)
+            guaranteed_by = -1
         else:
-            if self.num_vmfma - 1 + 0.5 <= (guaranteed_by % self.num_vmfma) < self.num_vmfma:
-                # Special case to handle idx=-1 which is in the range of [numVMFMA + 0.5, numVMFMA)
-                guaranteed_by = -1
-            else:
-                guaranteed_by = floor(guaranteed_by) % self.num_vmfma
-            
-            context_str = ""
-            if self.needed_by > self.num_vmfma:
-                context_str = " (of next iteration)"
+            guaranteed_by = floor(guaranteed_by) % self.num_vmfma
+        
+        context_str = ""
+        if self.needed_by.issued_at > self.num_vmfma:
+            context_str = " (of next iteration)"
 
-            message = f"{self.name} at index {issued_at} is not valid. " + \
-                        f"Needed before index {needed_by}{context_str}, but only guaranteed at index {guaranteed_by}."
-        return message
+        return f"{self.name} @ idx={issued_at} issued too late, must be guaranteed before {self.needed_by.name} @ idx={needed_by}{context_str} but only guaranteed @ idx={guaranteed_by}."
 
 @dataclass
 class MFMA(ValidatorInstruction):
@@ -898,6 +895,10 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution', mfma_reor
     n_local_reads_a = len(timeline.get_instructions("LRA0", MAIN_LOOP))
     n_local_reads_b = len(timeline.get_instructions("LRB0", MAIN_LOOP))
 
+    mfmas_by_index: dict[int, MFMA] = {
+        int(mfma.issued_at): mfma for _, mfma in timeline.get_instructions_combined("MFMA")
+    }
+
     for i_loop, loop in enumerate(timeline.loops):
         loop_offset = timeline.num_vmfma * i_loop
         for instruction_name in timeline.get_instruction_names():
@@ -915,7 +916,7 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution', mfma_reor
                     n_local_reads_b=n_local_reads_b,
                     force_unroll_sub_iter=kernel.get("ForceUnrollSubIter", False),
                     use_f32x_emulation=kernel.get("UseF32XEmulation", False))                
-                lr.needed_by = needed_by + loop_offset
+                lr.needed_by = mfmas_by_index[needed_by + loop_offset]
 
 
 def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) -> None:
@@ -1599,31 +1600,19 @@ def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
 
     # Build helper lookup
     index_for_inst_id = {id(inst): i for i, inst in enumerate(timeline.combined_timeline)}
-    
-    # TODO: Needed by LR, pointing to MFMA by index. Redo implementation of LR.
-    mfma_for_mfma_index = {
-        inst.issued_at: inst 
-        for inst in timeline.combined_timeline 
-        if isinstance(inst, MFMA)
-    }
 
     # Precompute issue times
     issue_times = precompute_issue_times(timeline.combined_timeline, kernel.get("UseMFMAF32XEmulation", False))
         
     # Estimate number of quad-cycles between being issued and result being used
     for i_instruction, instruction in enumerate(timeline.combined_timeline):
-        # TODO: Get rid of the float("inf") check once LocalRead uses the new needed_by version.
-        if not hasattr(instruction, "needed_by") or instruction.needed_by is None or instruction.needed_by is float("inf"):
+        if not hasattr(instruction, "needed_by") or instruction.needed_by is None or instruction.needed_by.issued_at == float("inf"):
             continue
         
         if not hasattr(instruction, "min_quad_cycles_before_result_used") or instruction.min_quad_cycles_before_result_used == 0:
             continue
 
         needed_by = instruction.needed_by
-        if not isinstance(instruction.needed_by, ValidatorInstruction):
-            needed_by = mfma_for_mfma_index.get(instruction.needed_by)
-            if needed_by is None:
-                continue
         
         i_needed_by = index_for_inst_id.get(id(needed_by))
         estimate = estimate_quad_cycles_precomputed(i_instruction, i_needed_by, issue_times)

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -615,6 +615,7 @@ class TestCustomScheduleTF32:
         })
         kernel.update({
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
+            "ForceUnrollSubIter": True,
             "MacroTile0": 128, "MacroTile1": 192, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
             "DirectToLds": True,
@@ -640,6 +641,7 @@ class TestCustomScheduleTF32:
         })
         kernel.update({
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
+            "ForceUnrollSubIter": True,
             "MacroTile0": 192, "MacroTile1": 128, "DepthU": 32,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
             "DirectToLds": True,

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -53,14 +53,14 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         optSchedule["LRA0"] = [[1, 6]]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "LRA0 at index 6 is not valid. Needed before index 5, but only guaranteed at index 3."
+            "LRA0 @ idx=6 issued too late, must be guaranteed before MFMA @ idx=5 but only guaranteed @ idx=3."
         )
 
         optSchedule["LRA0"] = [[1, 2]]
         optSchedule["LRB0"] = [[3, 6]]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "LRB0 at index 3 is not valid. Needed before index 4, but only guaranteed at index 3."
+            "LRB0 @ idx=3 issued too late, must be guaranteed before MFMA @ idx=4 but only guaranteed @ idx=3."
         )
 
     def test_simple_LR0_w_LR1(self):
@@ -169,7 +169,7 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "LRA1 at index 4 is not valid. Needed before index 0, but only guaranteed at index 1."
+            "LRA1 @ idx=4 issued too late, must be guaranteed before MFMA @ idx=0 but only guaranteed @ idx=1."
         )
 
     def test_complex_LR1(self):
@@ -196,7 +196,7 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         optSchedule["LRA1"] = [[4, 5]]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "LRA1 at index 5 is not valid. Needed before index 1 (of next iteration), but only guaranteed at index 1."
+            "LRA1 @ idx=5 issued too late, must be guaranteed before MFMA @ idx=1 (of next iteration) but only guaranteed @ idx=1."
         )
 
     def test_more_LRs(self):
@@ -243,7 +243,7 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         # Failure case 1: Don't wait for any LRA0
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "LRA0 at index 1 is not valid. Needed before index 4, but only guaranteed at index 4."
+            "LRA0 @ idx=1 issued too late, must be guaranteed before MFMA @ idx=4 but only guaranteed @ idx=4."
         )
 
         # Failure case 2: Wait for only 1/4 LRA0 (need at least 2/4 LRA0) to do VMFMA 4.
@@ -251,7 +251,7 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         syncCode[0].comment = "Wait for LRB0 and 1/4 LRA0"
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "LRA0 at index 1 is not valid. Needed before index 4, but only guaranteed at index 4."
+            "LRA0 @ idx=1 issued too late, must be guaranteed before MFMA @ idx=4 but only guaranteed @ idx=4."
         )
 
         # Passing case: Correctly SWaitCnt for 2/4 LRA0 (i.e. 1/2 As) in time for VMFMA 4.
@@ -288,7 +288,7 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         optSchedule["SYNC"][0][0] = 8
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "LRB1 at index 19 is not valid. Needed before index 8 (of next iteration), but only guaranteed at index 8."
+            "LRB1 @ idx=19 issued too late, must be guaranteed before MFMA @ idx=8 (of next iteration) but only guaranteed @ idx=8."
         )
 
     def test_handling_instruction_order(self):
@@ -313,7 +313,7 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         }
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "LRA0 at index 3 is not valid. Needed before index 4, but only guaranteed at index 7."
+            "LRA0 @ idx=3 issued too late, must be guaranteed before MFMA @ idx=4 but only guaranteed @ idx=7."
         )
 
         # 2. SwaitCnt after LR0s but before LR1s
@@ -327,7 +327,7 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         }
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "LRA1 at index 7 is not valid. Needed before index 0, but only guaranteed at index 3."
+            "LRA1 @ idx=7 issued too late, must be guaranteed before MFMA @ idx=0 but only guaranteed @ idx=3."
         )
 
         # 3. SwaitCnt after all LRs
@@ -396,7 +396,7 @@ class TestValidateLRsCompleteBeforeVMFMA_tf32(CMSValidationTestBase):
             SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="LRA0"),
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LRB0"),
         ]
-        self.validate(optSchedule, syncCode, 1, None, None, 0, "LRA0 at index 0 is not valid. Needed before index 3, but only guaranteed at index 3.")
+        self.validate(optSchedule, syncCode, 1, None, None, 0, "LRA0 @ idx=0 issued too late, must be guaranteed before MFMA @ idx=3 but only guaranteed @ idx=3.")
     
     def test_LR0s_fail2(self):
         """
@@ -413,7 +413,7 @@ class TestValidateLRsCompleteBeforeVMFMA_tf32(CMSValidationTestBase):
             SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="LRA0"),
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="LRB0"),
         ]
-        self.validate(optSchedule, syncCode, 1, None, None, 0, "LRB0 at index 1 is not valid. Needed before index 6, but only guaranteed at index 6.")
+        self.validate(optSchedule, syncCode, 1, None, None, 0, "LRB0 @ idx=1 issued too late, must be guaranteed before MFMA @ idx=6 but only guaranteed @ idx=6.")
 
     def test_LR3s_pass(self):
         """
@@ -592,7 +592,7 @@ class TestValidateLRsCompleteBeforeVMFMA_ForceUnrollSubIter(CMSValidationTestBas
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="For LR0s"),
         ]
 
-        self.validate(optSchedule, syncCode, 1, None, None, 0, "LRA3 at index 7 is not valid. Needed before index 0, but only guaranteed at index 3.")
+        self.validate(optSchedule, syncCode, 1, None, None, 0, "LRA3 @ idx=7 issued too late, must be guaranteed before MFMA @ idx=0 but only guaranteed @ idx=3.")
 
 
 class TestIndexForForceUnrollSubIter:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -642,6 +642,42 @@ class TestLRNeededByMFMA:
         for lr_name, expected_indices in expected_results.items():
             actual_indices = [lr_needed_by_mfma(lr_name, lr_idx, num_vmfma, mfma_reorder, n_tiles_a, n_tiles_b, n_local_reads_a, n_local_reads_b, force_unroll_sub_iter, use_f32x_emulation=False) for lr_idx in range(len(expected_indices))]
             assert actual_indices == expected_indices
+
+    def test_single_sub_iter_bf16(self):
+        """
+        Non-force-unroll case where MFMAs only cover a single sub-iteration.
+        """
+        n_tiles_a, n_tiles_b = 8, 8
+        n_local_reads_a, n_local_reads_b = 8, 8
+        num_vmfma = n_tiles_a * n_tiles_b
+
+        force_unroll_sub_iter = False
+        mfma_reorder = []
+
+        expected_results = {
+            "LRA0": [32, 32, 33, 33, 34, 34, 35, 35],
+            "LRB0": [32, 32, 40, 40, 48, 48, 56, 56],
+            "LRA1": [64, 64, 65, 65, 66, 66, 67, 67],
+            "LRB1": [64, 64, 72, 72, 80, 80, 88, 88],
+        }
+
+        for lr_name, expected_indices in expected_results.items():
+            actual_indices = [
+                lr_needed_by_mfma(
+                    lr_name,
+                    lr_idx,
+                    num_vmfma,
+                    mfma_reorder,
+                    n_tiles_a,
+                    n_tiles_b,
+                    n_local_reads_a,
+                    n_local_reads_b,
+                    force_unroll_sub_iter,
+                    use_f32x_emulation=False,
+                )
+                for lr_idx in range(len(expected_indices))
+            ]
+            assert actual_indices == expected_indices
     
     def test_simple_tf32(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -102,7 +102,7 @@ class TestValidateNll(CMSValidationTestBase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
         ]
         self.validate(optSchedule, syncCode, 1, None, None, 0,
-                                         "Loop NLL: LRB0 at index 0 is not valid. Needed before index 6 (of next iteration), but only guaranteed at index 7.")
+                                         "Loop NLL: LRB0 @ idx=0 issued too late, must be guaranteed before MFMA @ idx=6 (of next iteration) but only guaranteed @ idx=7.")
 
     def test_lr0_swait_depends_on_lr1_realistic(self, useZeroDscnt: bool=False):
         """
@@ -146,7 +146,7 @@ class TestValidateNll(CMSValidationTestBase):
         }
         # We need to set nglshift and nllshift for the vlcnt adjustments
         num_gr = 2  # 2 GRs total (1 GRA + 1 GRB, but we only count the actual reads not the increments)
-        expected_error_message = None if useZeroDscnt else "Loop NLL: LRB0 at index 3 is not valid. Needed before index 28 (of next iteration), but only guaranteed at index 31."
+        expected_error_message = None if useZeroDscnt else "Loop NLL: LRB0 @ idx=3 issued too late, must be guaranteed before MFMA @ idx=28 (of next iteration) but only guaranteed @ idx=31."
         self.validate(optSchedule, syncTable[1::2], 1, num_gr, num_gr, 0, expected_error_message, nllZeroDscnt=useZeroDscnt)
 
     def test_lr0_swait_depends_on_lr1_realistic_zero_dscnt(self):


### PR DESCRIPTION
## Motivation

Currently LocalReads use a number for needed_by, but this makes it impossible to cleanly specify why a given LocalRead is issued to late. By changing it to a ValidatorInstruction (i.e. copying the approach from Packs) the error message will be able to indicate which instruction sets this needed_by constraint on the LocalRead.

## Technical Details

1. Change needed_by to ValidatorInstruction and change error messages to match.
2. Fix bug in test_CustomSchedule where 2 tests were missing the require `ForceUnrollSubIter` arg.
3. Fix bug in _transform_index_standard

## Test Plan

Run existing tests. Add new tests to exercise issue found.

## Test Result

New and existing tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
