### PR TITLE
rocfft: log version to trace log during rocfft_setup

### DIFF
--- a/projects/rocfft/library/src/auxiliary.cpp
+++ b/projects/rocfft/library/src/auxiliary.cpp
@@ -25,6 +25,7 @@
 #include "../../shared/rocfft_hip.h"
 #include "logging.h"
 #include "repo.h"
+#include "rocfft/rocfft-version.h"
 #include "rocfft/rocfft.h"
 #include "rocfft_exception.h"
 #include "rocfft_ostream.hpp"
@@ -45,6 +46,8 @@ int log_kernelio_fd = -1;
 int log_rtc_fd      = -1;
 int log_tuning_fd   = -1;
 int log_graph_fd    = -1;
+
+extern const char* ROCFFT_VERSION_STRING;
 
 /**
  *  @brief Logging function
@@ -142,7 +145,7 @@ try
     solution_map::get_solution_map().setup(arch_name);
     TuningBenchmarker::GetSingleton().Setup();
 
-    log_trace(__func__);
+    log_trace(__func__, ROCFFT_VERSION_STRING);
     return rocfft_status_success;
 }
 catch(...)

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -62,10 +62,10 @@
 #define TO_STR(x) TO_STR2(x)
 
 // clang-format off
-#define ROCFFT_VERSION_STRING (TO_STR(rocfft_version_major) "." \
-                               TO_STR(rocfft_version_minor) "." \
-                               TO_STR(rocfft_version_patch) "." \
-                               TO_STR(rocfft_version_tweak) )
+const char* ROCFFT_VERSION_STRING = (TO_STR(rocfft_version_major) "." \
+                                     TO_STR(rocfft_version_minor) "." \
+                                     TO_STR(rocfft_version_patch) "." \
+                                     TO_STR(rocfft_version_tweak) );
 // clang-format on
 
 rocfft_status rocfft_plan_description_set_scale_factor(rocfft_plan_description description,
@@ -3780,12 +3780,13 @@ ROCFFT_EXPORT rocfft_status rocfft_get_version_string(char* buf, const size_t le
 try
 {
     log_trace(__func__, "buf", static_cast<void*>(buf), "len", len);
-    static constexpr char v[] = ROCFFT_VERSION_STRING;
+    // include nul terminator
+    const auto version_len = strlen(ROCFFT_VERSION_STRING) + 1;
     if(!buf)
         return rocfft_status_failure;
-    if(len < sizeof(v))
+    if(len < version_len)
         return rocfft_status_invalid_arg_value;
-    memcpy(buf, v, sizeof(v));
+    memcpy(buf, ROCFFT_VERSION_STRING, version_len);
     return rocfft_status_success;
 }
 catch(...)

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -45,6 +45,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <functional>
+#include <cstring>
 #include <iterator>
 #include <limits>
 #include <map>
@@ -3781,12 +3782,12 @@ try
 {
     log_trace(__func__, "buf", static_cast<void*>(buf), "len", len);
     // include nul terminator
-    const auto version_len = strlen(ROCFFT_VERSION_STRING) + 1;
+    const auto version_len = std::strlen(ROCFFT_VERSION_STRING) + 1;
     if(!buf)
         return rocfft_status_failure;
     if(len < version_len)
         return rocfft_status_invalid_arg_value;
-    memcpy(buf, ROCFFT_VERSION_STRING, version_len);
+    std::memcpy(buf, ROCFFT_VERSION_STRING, version_len);
     return rocfft_status_success;
 }
 catch(...)


### PR DESCRIPTION
## Motivation

Make troubleshooting a little bit easier by logging the rocFFT version to the trace log.

## Technical Details

Turn the version string into an internal symbol and link to it from rocfft_setup.

## Test Plan

Run regression tests.

## Test Result

Tests pass, and version is reported properly from rocfft-test.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
