### PR TITLE
[hipDNN]: Remove the int knob ids from Knob and KnobSetting as the string is enough

### DIFF
--- a/dnn-providers/miopen-provider/engines/MiopenEngine.cpp
+++ b/dnn-providers/miopen-provider/engines/MiopenEngine.cpp
@@ -44,16 +44,8 @@ void MiopenEngine::getDetails(HipdnnEnginePluginHandle& handle,
 {
     flatbuffers::FlatBufferBuilder builder;
 
-    auto knob
-        = hipdnn_plugin_sdk::KnobFactory::createIntKnob(builder,
-                                                        hipdnn_plugin_sdk::benchmarking_KNOB_ID,
-                                                        hipdnn_plugin_sdk::benchmarking_KNOB_NAME,
-                                                        "Enable benchmarking",
-                                                        0,
-                                                        0,
-                                                        1,
-                                                        1,
-                                                        {});
+    auto knob = hipdnn_plugin_sdk::KnobFactory::createIntKnob(
+        builder, hipdnn_plugin_sdk::BENCHMARKING_KNOB_NAME, "Enable benchmarking", 0, 0, 1, 1, {});
 
     std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>> knobsVector;
     knobsVector.push_back(knob);
@@ -90,10 +82,10 @@ void MiopenEngine::initializeExecutionContext(
 {
     if(engineConfig.isValid())
     {
-        if(engineConfig.hasKnobSetting(hipdnn_plugin_sdk::benchmarking_KNOB_ID))
+        if(engineConfig.hasKnobSetting(hipdnn_plugin_sdk::BENCHMARKING_KNOB_NAME))
         {
             const auto& knobSetting
-                = engineConfig.getKnobSettingById(hipdnn_plugin_sdk::benchmarking_KNOB_ID);
+                = engineConfig.getKnobSettingByName(hipdnn_plugin_sdk::BENCHMARKING_KNOB_NAME);
             if(knobSetting.valueType() == hipdnn_data_sdk::data_objects::KnobValue::IntValue)
             {
                 auto value = knobSetting.valueAs<hipdnn_data_sdk::data_objects::IntValue>().value();

--- a/dnn-providers/miopen-provider/tests/engines/TestMiopenEngine.cpp
+++ b/dnn-providers/miopen-provider/tests/engines/TestMiopenEngine.cpp
@@ -202,12 +202,13 @@ TEST(TestMiopenEngine, InitializeExecutionContextSetsBenchmarkingEnabled)
     MockHipdnnEnginePluginExecutionContext ctx;
 
     flatbuffers::FlatBufferBuilder builder;
+    auto knobIdOffset = builder.CreateString("global.benchmarking");
     auto knobValue = hipdnn_data_sdk::data_objects::CreateIntValue(builder, 1);
-    auto knobSetting = hipdnn_data_sdk::data_objects::CreateKnobSetting(
-        builder,
-        static_cast<int64_t>(hipdnn_data_sdk::utilities::fnv1aHash("global.benchmarking")),
-        hipdnn_data_sdk::data_objects::KnobValue::IntValue,
-        knobValue.Union());
+    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
+    knobSettingBuilder.add_knob_id(knobIdOffset);
+    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value(knobValue.Union());
+    auto knobSetting = knobSettingBuilder.Finish();
 
     std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);
@@ -232,13 +233,14 @@ TEST(TestMiopenEngine, InitializeExecutionContextSetsBenchmarkingDisabled)
     MockHipdnnEnginePluginExecutionContext ctx;
 
     flatbuffers::FlatBufferBuilder builder;
+    auto knobIdOffset = builder.CreateString("global.benchmarking");
     auto knobValue
         = hipdnn_data_sdk::data_objects::CreateIntValue(builder, static_cast<int64_t>(0));
-    auto knobSetting = hipdnn_data_sdk::data_objects::CreateKnobSetting(
-        builder,
-        static_cast<int64_t>(hipdnn_data_sdk::utilities::fnv1aHash("global.benchmarking")),
-        hipdnn_data_sdk::data_objects::KnobValue::IntValue,
-        knobValue.Union());
+    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
+    knobSettingBuilder.add_knob_id(knobIdOffset);
+    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value(knobValue.Union());
+    auto knobSetting = knobSettingBuilder.Finish();
 
     std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
     knobsVector.push_back(knobSetting);

--- a/projects/hipdnn/backend/tests/TestBackendEnumStringUtils.cpp
+++ b/projects/hipdnn/backend/tests/TestBackendEnumStringUtils.cpp
@@ -155,6 +155,11 @@ TEST(TestBackendEnumStringUtils, GetBackendAttributeName)
                  "HIPDNN_ATTR_DEVICEPROP_HANDLE");
     EXPECT_STREQ(hipdnnGetAttributeNameString(HIPDNN_ATTR_DEVICEPROP_JSON_REPRESENTATION),
                  "HIPDNN_ATTR_DEVICEPROP_JSON_REPRESENTATION");
+
+    EXPECT_STREQ(hipdnnGetAttributeNameString(HIPDNN_ATTR_KNOB_INFO_SERIALIZED_VALUE_EXT),
+                 "HIPDNN_ATTR_KNOB_INFO_SERIALIZED_VALUE_EXT");
+    EXPECT_STREQ(hipdnnGetAttributeNameString(HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT),
+                 "HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT");
 }
 
 TEST(TestBackendEnumStringUtils, GetStatusString)

--- a/projects/hipdnn/backend/tests/descriptors/TestEngineConfigDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestEngineConfigDescriptor.cpp
@@ -286,12 +286,17 @@ TEST_F(TestEngineConfigDescriptor, GetEngineDescriptorMaxWorkspaceSize)
 }
 
 // Helper function to create a serialized KnobSetting
-static flatbuffers::DetachedBuffer createSerializedKnobSetting(int64_t knobId, int64_t value)
+static flatbuffers::DetachedBuffer createSerializedKnobSetting(const std::string& knobId,
+                                                               int64_t value)
 {
     flatbuffers::FlatBufferBuilder builder;
+    auto knobIdOffset = builder.CreateString(knobId);
     auto intValue = hipdnn_data_sdk::data_objects::CreateIntValue(builder, value);
     auto knobSetting = hipdnn_data_sdk::data_objects::CreateKnobSetting(
-        builder, knobId, hipdnn_data_sdk::data_objects::KnobValue::IntValue, intValue.Union());
+        builder,
+        knobIdOffset,
+        hipdnn_data_sdk::data_objects::KnobValue::IntValue,
+        intValue.Union());
     builder.Finish(knobSetting);
     return builder.Release();
 }
@@ -300,7 +305,7 @@ TEST_F(TestEngineConfigDescriptor, SetKnobChoiceInvalidType)
 {
     auto engineConfig = getEngineConfigDescriptor();
 
-    auto knobBuffer = createSerializedKnobSetting(100, 42);
+    auto knobBuffer = createSerializedKnobSetting("test_knob_100", 42);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     // Wrong attribute type
@@ -314,7 +319,7 @@ TEST_F(TestEngineConfigDescriptor, SetKnobChoiceInvalidCount)
 {
     auto engineConfig = getEngineConfigDescriptor();
 
-    auto knobBuffer = createSerializedKnobSetting(100, 42);
+    auto knobBuffer = createSerializedKnobSetting("test_knob_100", 42);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     // Element count < 1
@@ -356,7 +361,7 @@ TEST_F(TestEngineConfigDescriptor, SetKnobChoiceZeroSize)
 {
     auto engineConfig = getEngineConfigDescriptor();
 
-    auto knobBuffer = createSerializedKnobSetting(100, 42);
+    auto knobBuffer = createSerializedKnobSetting("test_knob_100", 42);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), 0};
 
     ASSERT_THROW_HIPDNN_STATUS(
@@ -379,7 +384,7 @@ TEST_F(TestEngineConfigDescriptor, SetKnobChoiceSuccess)
         HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mockEngineWrapper));
 
     // Now set a knob choice
-    auto knobBuffer = createSerializedKnobSetting(100, 42);
+    auto knobBuffer = createSerializedKnobSetting("test_knob_100", 42);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     ASSERT_NO_THROW(engineConfig->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
@@ -400,8 +405,8 @@ TEST_F(TestEngineConfigDescriptor, SetKnobChoiceMultipleKnobs)
         HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mockEngineWrapper));
 
     // Create multiple knob settings
-    auto knobBuffer1 = createSerializedKnobSetting(100, 42);
-    auto knobBuffer2 = createSerializedKnobSetting(101, 84);
+    auto knobBuffer1 = createSerializedKnobSetting("test_knob_100", 42);
+    auto knobBuffer2 = createSerializedKnobSetting("test_knob_101", 84);
 
     std::vector<hipdnnBackendFlatbufferData_t> knobDataArray
         = {{knobBuffer1.data(), knobBuffer1.size()}, {knobBuffer2.data(), knobBuffer2.size()}};
@@ -417,7 +422,7 @@ TEST_F(TestEngineConfigDescriptor, SetKnobChoiceOnFinalizedDescriptor)
     auto engineConfig = getEngineConfigDescriptor();
     makeEngineConfigFinalized();
 
-    auto knobBuffer = createSerializedKnobSetting(100, 42);
+    auto knobBuffer = createSerializedKnobSetting("test_knob_100", 42);
     hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
 
     ASSERT_THROW_HIPDNN_STATUS(

--- a/projects/hipdnn/backend/tests/descriptors/TestEngineDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestEngineDescriptor.cpp
@@ -379,7 +379,6 @@ protected:
 
             auto knob = hipdnn_data_sdk::data_objects::CreateKnob(
                 builder,
-                static_cast<int64_t>(i + 100), // knob_id
                 knobIdStr,
                 description,
                 hipdnn_data_sdk::data_objects::KnobValue::IntValue,
@@ -515,7 +514,7 @@ TEST_F(TestEngineDescriptorWithKnobs, GetKnobInfoReturnsSerializedKnobs)
         ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_data_sdk::data_objects::Knob>());
 
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
-        ASSERT_EQ(knob->knob_id(), static_cast<int64_t>(i + 100));
+        ASSERT_EQ(knob->knob_id_str()->str(), "test_knob_" + std::to_string(i));
     }
 }
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/engine_config_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/engine_config_generated.h
@@ -33,7 +33,7 @@ bool operator!=(const EngineConfigT &lhs, const EngineConfigT &rhs);
 
 struct KnobSettingT : public ::flatbuffers::NativeTable {
   typedef KnobSetting TableType;
-  int64_t knob_id = 0;
+  std::string knob_id{};
   hipdnn_data_sdk::data_objects::KnobValueUnion value{};
 };
 
@@ -45,11 +45,11 @@ struct KnobSetting FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_VALUE_TYPE = 6,
     VT_VALUE = 8
   };
-  int64_t knob_id() const {
-    return GetField<int64_t>(VT_KNOB_ID, 0);
+  const ::flatbuffers::String *knob_id() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_KNOB_ID);
   }
-  bool mutate_knob_id(int64_t _knob_id = 0) {
-    return SetField<int64_t>(VT_KNOB_ID, _knob_id, 0);
+  ::flatbuffers::String *mutable_knob_id() {
+    return GetPointer<::flatbuffers::String *>(VT_KNOB_ID);
   }
   hipdnn_data_sdk::data_objects::KnobValue value_type() const {
     return static_cast<hipdnn_data_sdk::data_objects::KnobValue>(GetField<uint8_t>(VT_VALUE_TYPE, 0));
@@ -72,7 +72,8 @@ struct KnobSetting FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<int64_t>(verifier, VT_KNOB_ID, 8) &&
+           VerifyOffset(verifier, VT_KNOB_ID) &&
+           verifier.VerifyString(knob_id()) &&
            VerifyField<uint8_t>(verifier, VT_VALUE_TYPE, 1) &&
            VerifyOffset(verifier, VT_VALUE) &&
            VerifyKnobValue(verifier, value(), value_type()) &&
@@ -99,8 +100,8 @@ struct KnobSettingBuilder {
   typedef KnobSetting Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_knob_id(int64_t knob_id) {
-    fbb_.AddElement<int64_t>(KnobSetting::VT_KNOB_ID, knob_id, 0);
+  void add_knob_id(::flatbuffers::Offset<::flatbuffers::String> knob_id) {
+    fbb_.AddOffset(KnobSetting::VT_KNOB_ID, knob_id);
   }
   void add_value_type(hipdnn_data_sdk::data_objects::KnobValue value_type) {
     fbb_.AddElement<uint8_t>(KnobSetting::VT_VALUE_TYPE, static_cast<uint8_t>(value_type), 0);
@@ -121,14 +122,27 @@ struct KnobSettingBuilder {
 
 inline ::flatbuffers::Offset<KnobSetting> CreateKnobSetting(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    int64_t knob_id = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> knob_id = 0,
     hipdnn_data_sdk::data_objects::KnobValue value_type = hipdnn_data_sdk::data_objects::KnobValue::NONE,
     ::flatbuffers::Offset<void> value = 0) {
   KnobSettingBuilder builder_(_fbb);
-  builder_.add_knob_id(knob_id);
   builder_.add_value(value);
+  builder_.add_knob_id(knob_id);
   builder_.add_value_type(value_type);
   return builder_.Finish();
+}
+
+inline ::flatbuffers::Offset<KnobSetting> CreateKnobSettingDirect(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    const char *knob_id = nullptr,
+    hipdnn_data_sdk::data_objects::KnobValue value_type = hipdnn_data_sdk::data_objects::KnobValue::NONE,
+    ::flatbuffers::Offset<void> value = 0) {
+  auto knob_id__ = knob_id ? _fbb.CreateString(knob_id) : 0;
+  return hipdnn_data_sdk::data_objects::CreateKnobSetting(
+      _fbb,
+      knob_id__,
+      value_type,
+      value);
 }
 
 ::flatbuffers::Offset<KnobSetting> CreateKnobSetting(::flatbuffers::FlatBufferBuilder &_fbb, const KnobSettingT *_o, const ::flatbuffers::rehasher_function_t *_rehasher = nullptr);
@@ -240,7 +254,7 @@ inline KnobSettingT *KnobSetting::UnPack(const ::flatbuffers::resolver_function_
 inline void KnobSetting::UnPackTo(KnobSettingT *_o, const ::flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = knob_id(); _o->knob_id = _e; }
+  { auto _e = knob_id(); if (_e) _o->knob_id = _e->str(); }
   { auto _e = value_type(); _o->value.type = _e; }
   { auto _e = value(); if (_e) _o->value.value = hipdnn_data_sdk::data_objects::KnobValueUnion::UnPack(_e, value_type(), _resolver); }
 }
@@ -253,7 +267,7 @@ inline ::flatbuffers::Offset<KnobSetting> CreateKnobSetting(::flatbuffers::FlatB
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const KnobSettingT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _knob_id = _o->knob_id;
+  auto _knob_id = _o->knob_id.empty() ? 0 : _fbb.CreateString(_o->knob_id);
   auto _value_type = _o->value.type;
   auto _value = _o->value.Pack(_fbb);
   return hipdnn_data_sdk::data_objects::CreateKnobSetting(

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/knob_value_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/knob_value_generated.h
@@ -812,7 +812,6 @@ inline ::flatbuffers::Offset<StringConstraint> CreateStringConstraintDirect(
 
 struct KnobT : public ::flatbuffers::NativeTable {
   typedef Knob TableType;
-  int64_t knob_id = 0;
   std::string knob_id_str{};
   std::string description{};
   hipdnn_data_sdk::data_objects::KnobValueUnion default_value{};
@@ -824,21 +823,14 @@ struct Knob FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef KnobT NativeTableType;
   typedef KnobBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_KNOB_ID = 4,
-    VT_KNOB_ID_STR = 6,
-    VT_DESCRIPTION = 8,
-    VT_DEFAULT_VALUE_TYPE = 10,
-    VT_DEFAULT_VALUE = 12,
-    VT_CONSTRAINT_TYPE = 14,
-    VT_CONSTRAINT = 16,
-    VT_DEPRECATED = 18
+    VT_KNOB_ID_STR = 4,
+    VT_DESCRIPTION = 6,
+    VT_DEFAULT_VALUE_TYPE = 8,
+    VT_DEFAULT_VALUE = 10,
+    VT_CONSTRAINT_TYPE = 12,
+    VT_CONSTRAINT = 14,
+    VT_DEPRECATED = 16
   };
-  int64_t knob_id() const {
-    return GetField<int64_t>(VT_KNOB_ID, 0);
-  }
-  bool mutate_knob_id(int64_t _knob_id = 0) {
-    return SetField<int64_t>(VT_KNOB_ID, _knob_id, 0);
-  }
   const ::flatbuffers::String *knob_id_str() const {
     return GetPointer<const ::flatbuffers::String *>(VT_KNOB_ID_STR);
   }
@@ -897,7 +889,6 @@ struct Knob FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<int64_t>(verifier, VT_KNOB_ID, 8) &&
            VerifyOffset(verifier, VT_KNOB_ID_STR) &&
            verifier.VerifyString(knob_id_str()) &&
            VerifyOffset(verifier, VT_DESCRIPTION) &&
@@ -944,9 +935,6 @@ struct KnobBuilder {
   typedef Knob Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_knob_id(int64_t knob_id) {
-    fbb_.AddElement<int64_t>(Knob::VT_KNOB_ID, knob_id, 0);
-  }
   void add_knob_id_str(::flatbuffers::Offset<::flatbuffers::String> knob_id_str) {
     fbb_.AddOffset(Knob::VT_KNOB_ID_STR, knob_id_str);
   }
@@ -981,7 +969,6 @@ struct KnobBuilder {
 
 inline ::flatbuffers::Offset<Knob> CreateKnob(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    int64_t knob_id = 0,
     ::flatbuffers::Offset<::flatbuffers::String> knob_id_str = 0,
     ::flatbuffers::Offset<::flatbuffers::String> description = 0,
     hipdnn_data_sdk::data_objects::KnobValue default_value_type = hipdnn_data_sdk::data_objects::KnobValue::NONE,
@@ -990,7 +977,6 @@ inline ::flatbuffers::Offset<Knob> CreateKnob(
     ::flatbuffers::Offset<void> constraint = 0,
     bool deprecated = false) {
   KnobBuilder builder_(_fbb);
-  builder_.add_knob_id(knob_id);
   builder_.add_constraint(constraint);
   builder_.add_default_value(default_value);
   builder_.add_description(description);
@@ -1003,7 +989,6 @@ inline ::flatbuffers::Offset<Knob> CreateKnob(
 
 inline ::flatbuffers::Offset<Knob> CreateKnobDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    int64_t knob_id = 0,
     const char *knob_id_str = nullptr,
     const char *description = nullptr,
     hipdnn_data_sdk::data_objects::KnobValue default_value_type = hipdnn_data_sdk::data_objects::KnobValue::NONE,
@@ -1015,7 +1000,6 @@ inline ::flatbuffers::Offset<Knob> CreateKnobDirect(
   auto description__ = description ? _fbb.CreateString(description) : 0;
   return hipdnn_data_sdk::data_objects::CreateKnob(
       _fbb,
-      knob_id,
       knob_id_str__,
       description__,
       default_value_type,
@@ -1272,7 +1256,6 @@ inline ::flatbuffers::Offset<StringConstraint> CreateStringConstraint(::flatbuff
 
 inline bool operator==(const KnobT &lhs, const KnobT &rhs) {
   return
-      (lhs.knob_id == rhs.knob_id) &&
       (lhs.knob_id_str == rhs.knob_id_str) &&
       (lhs.description == rhs.description) &&
       (lhs.default_value == rhs.default_value) &&
@@ -1294,7 +1277,6 @@ inline KnobT *Knob::UnPack(const ::flatbuffers::resolver_function_t *_resolver) 
 inline void Knob::UnPackTo(KnobT *_o, const ::flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = knob_id(); _o->knob_id = _e; }
   { auto _e = knob_id_str(); if (_e) _o->knob_id_str = _e->str(); }
   { auto _e = description(); if (_e) _o->description = _e->str(); }
   { auto _e = default_value_type(); _o->default_value.type = _e; }
@@ -1312,7 +1294,6 @@ inline ::flatbuffers::Offset<Knob> CreateKnob(::flatbuffers::FlatBufferBuilder &
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const KnobT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _knob_id = _o->knob_id;
   auto _knob_id_str = _o->knob_id_str.empty() ? 0 : _fbb.CreateString(_o->knob_id_str);
   auto _description = _o->description.empty() ? 0 : _fbb.CreateString(_o->description);
   auto _default_value_type = _o->default_value.type;
@@ -1322,7 +1303,6 @@ inline ::flatbuffers::Offset<Knob> CreateKnob(::flatbuffers::FlatBufferBuilder &
   auto _deprecated = _o->deprecated;
   return hipdnn_data_sdk::data_objects::CreateKnob(
       _fbb,
-      _knob_id,
       _knob_id_str,
       _description,
       _default_value_type,

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp
@@ -28,13 +28,9 @@ public:
         knobSettingWrappers() const
         = 0;
     virtual const hipdnn_data_sdk::flatbuffer_utilities::IKnobSetting&
-        getKnobSettingById(int64_t knobId) const
-        = 0;
-    virtual const hipdnn_data_sdk::flatbuffer_utilities::IKnobSetting&
         getKnobSettingByName(const std::string& knobName) const
         = 0;
 
-    virtual bool hasKnobSetting(int64_t knobId) const = 0;
     virtual bool hasKnobSetting(const std::string& knobName) const = 0;
 };
 
@@ -94,38 +90,25 @@ public:
     }
 
     const hipdnn_data_sdk::flatbuffer_utilities::IKnobSetting&
-        getKnobSettingById(int64_t knobId) const override
+        getKnobSettingByName(const std::string& knobName) const override
     {
         throwIfNotValid();
         populateKnobSettingWrappers();
 
-        auto it = _knobSettingIdToIndex.find(knobId);
-        if(it == _knobSettingIdToIndex.end())
+        auto it = _knobSettingNameToIndex.find(knobName);
+        if(it == _knobSettingNameToIndex.end())
         {
-            throw std::out_of_range("KnobSetting with id " + std::to_string(knobId) + " not found");
+            throw std::out_of_range("KnobSetting with name '" + knobName + "' not found");
         }
 
         return *_knobSettingWrappers[it->second];
     }
 
-    const hipdnn_data_sdk::flatbuffer_utilities::IKnobSetting&
-        getKnobSettingByName(const std::string& knobName) const override
-    {
-        auto knobId = static_cast<int64_t>(hipdnn_data_sdk::utilities::fnv1aHash(knobName));
-        return getKnobSettingById(knobId);
-    }
-
-    bool hasKnobSetting(int64_t knobId) const override
+    bool hasKnobSetting(const std::string& knobName) const override
     {
         throwIfNotValid();
         populateKnobSettingWrappers();
-        return _knobSettingIdToIndex.find(knobId) != _knobSettingIdToIndex.end();
-    }
-
-    bool hasKnobSetting(const std::string& knobName) const override
-    {
-        auto knobId = static_cast<int64_t>(hipdnn_data_sdk::utilities::fnv1aHash(knobName));
-        return hasKnobSetting(knobId);
+        return _knobSettingNameToIndex.find(knobName) != _knobSettingNameToIndex.end();
     }
 
 private:
@@ -154,8 +137,8 @@ private:
                 auto wrapper
                     = std::make_unique<hipdnn_data_sdk::flatbuffer_utilities::KnobSettingWrapper>(
                         knob);
-                auto knobId = wrapper->knobId();
-                _knobSettingIdToIndex[knobId] = i;
+                auto knobName = wrapper->knobId();
+                _knobSettingNameToIndex[knobName] = i;
                 _knobSettingWrappers.push_back(std::move(wrapper));
             }
         }
@@ -169,7 +152,7 @@ private:
     // Lazily populated cache of knob setting wrappers
     mutable std::vector<std::unique_ptr<hipdnn_data_sdk::flatbuffer_utilities::IKnobSetting>>
         _knobSettingWrappers;
-    mutable std::unordered_map<int64_t, size_t> _knobSettingIdToIndex;
+    mutable std::unordered_map<std::string, size_t> _knobSettingNameToIndex;
     mutable bool _knobSettingsPopulated = false;
 };
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp
@@ -27,8 +27,6 @@ public:
     virtual const std::vector<std::unique_ptr<hipdnn_data_sdk::flatbuffer_utilities::IKnob>>&
         knobWrappers() const
         = 0;
-    virtual const hipdnn_data_sdk::flatbuffer_utilities::IKnob& getKnobById(int64_t knobId) const
-        = 0;
     virtual const hipdnn_data_sdk::flatbuffer_utilities::IKnob&
         getKnobByName(const std::string& knobName) const
         = 0;
@@ -93,25 +91,19 @@ public:
         return _knobWrappers;
     }
 
-    const hipdnn_data_sdk::flatbuffer_utilities::IKnob& getKnobById(int64_t knobId) const override
+    const hipdnn_data_sdk::flatbuffer_utilities::IKnob&
+        getKnobByName(const std::string& knobName) const override
     {
         throwIfNotValid();
         populateKnobWrappers();
 
-        auto it = _knobIdToIndex.find(knobId);
-        if(it == _knobIdToIndex.end())
+        auto it = _knobNameToIndex.find(knobName);
+        if(it == _knobNameToIndex.end())
         {
-            throw std::out_of_range("Knob with id " + std::to_string(knobId) + " not found");
+            throw std::out_of_range("Knob with name '" + knobName + "' not found");
         }
 
         return *_knobWrappers[it->second];
-    }
-
-    const hipdnn_data_sdk::flatbuffer_utilities::IKnob&
-        getKnobByName(const std::string& knobName) const override
-    {
-        auto knobId = static_cast<int64_t>(hipdnn_data_sdk::utilities::fnv1aHash(knobName));
-        return getKnobById(knobId);
     }
 
 private:
@@ -139,8 +131,8 @@ private:
                 auto knob = knobs->Get(i);
                 auto wrapper
                     = std::make_unique<hipdnn_data_sdk::flatbuffer_utilities::KnobWrapper>(knob);
-                auto knobId = wrapper->knobId();
-                _knobIdToIndex[knobId] = i;
+                auto knobName = wrapper->knobIdStr();
+                _knobNameToIndex[knobName] = i;
                 _knobWrappers.push_back(std::move(wrapper));
             }
         }
@@ -154,7 +146,7 @@ private:
     // Lazily populated cache of knob wrappers
     mutable std::vector<std::unique_ptr<hipdnn_data_sdk::flatbuffer_utilities::IKnob>>
         _knobWrappers;
-    mutable std::unordered_map<int64_t, size_t> _knobIdToIndex;
+    mutable std::unordered_map<std::string, size_t> _knobNameToIndex;
     mutable bool _knobsPopulated = false;
 };
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/KnobSettingWrapper.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/KnobSettingWrapper.hpp
@@ -20,7 +20,7 @@ public:
 
     virtual const hipdnn_data_sdk::data_objects::KnobSetting& getKnobSetting() const = 0;
     virtual bool isValid() const = 0;
-    virtual int64_t knobId() const = 0;
+    virtual std::string knobId() const = 0;
     virtual hipdnn_data_sdk::data_objects::KnobValue valueType() const = 0;
     virtual const std::type_info& valueClassType() const = 0;
 
@@ -79,10 +79,11 @@ public:
         return _shallowKnobSetting != nullptr;
     }
 
-    int64_t knobId() const override
+    std::string knobId() const override
     {
         throwIfNotValid();
-        return _shallowKnobSetting->knob_id();
+        auto knobIdPtr = _shallowKnobSetting->knob_id();
+        return knobIdPtr != nullptr ? knobIdPtr->str() : "";
     }
 
     hipdnn_data_sdk::data_objects::KnobValue valueType() const override
@@ -113,7 +114,8 @@ public:
         throwIfNotValid();
 
         auto knobSettingT = std::make_unique<hipdnn_data_sdk::data_objects::KnobSettingT>();
-        knobSettingT->knob_id = _shallowKnobSetting->knob_id();
+        auto knobIdPtr = _shallowKnobSetting->knob_id();
+        knobSettingT->knob_id = knobIdPtr != nullptr ? knobIdPtr->str() : "";
 
         auto knobValueType = _shallowKnobSetting->value_type();
         auto knobValuePtr = _shallowKnobSetting->value();

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/KnobWrapper.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/KnobWrapper.hpp
@@ -20,7 +20,6 @@ public:
 
     virtual const hipdnn_data_sdk::data_objects::Knob& getKnob() const = 0;
     virtual bool isValid() const = 0;
-    virtual int64_t knobId() const = 0;
     virtual std::string knobIdStr() const = 0;
     virtual std::string description() const = 0;
     virtual bool isDeprecated() const = 0;
@@ -104,12 +103,6 @@ public:
     bool isValid() const override
     {
         return _shallowKnob != nullptr;
-    }
-
-    int64_t knobId() const override
-    {
-        throwIfNotValid();
-        return _shallowKnob->knob_id();
     }
 
     std::string knobIdStr() const override

--- a/projects/hipdnn/data_sdk/schemas/engine_config.fbs
+++ b/projects/hipdnn/data_sdk/schemas/engine_config.fbs
@@ -6,7 +6,7 @@ include "knob_value.fbs";
 namespace hipdnn_data_sdk.data_objects;
 
 table KnobSetting {
-    knob_id: int64;
+    knob_id: string;
     value: KnobValue;
 }
 

--- a/projects/hipdnn/data_sdk/schemas/knob_value.fbs
+++ b/projects/hipdnn/data_sdk/schemas/knob_value.fbs
@@ -48,7 +48,6 @@ union KnobConstraint {
 
 // Knob metadata
 table Knob {
-    knob_id: int64;               // Hashed from knob_id_str
     knob_id_str: string;          // Unique identifier (namespaced by plugin)
     description: string;          // Help text
     default_value: KnobValue;     // Default setting

--- a/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestEngineConfigWrapper.cpp
+++ b/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestEngineConfigWrapper.cpp
@@ -17,9 +17,8 @@ flatbuffers::FlatBufferBuilder buildValidEngineConfigBuffer(int64_t engineId)
     return builder;
 }
 
-flatbuffers::FlatBufferBuilder
-    buildEngineConfigWithKnobSettings(int64_t engineId,
-                                      const std::vector<std::pair<int64_t, int64_t>>& knobIdValues)
+flatbuffers::FlatBufferBuilder buildEngineConfigWithKnobSettings(
+    int64_t engineId, const std::vector<std::pair<std::string, int64_t>>& knobIdValues)
 {
     flatbuffers::FlatBufferBuilder builder;
 
@@ -28,9 +27,10 @@ flatbuffers::FlatBufferBuilder
 
     for(const auto& [knobId, value] : knobIdValues)
     {
+        auto knobIdOffset = builder.CreateString(knobId);
         auto intValue = hipdnn_data_sdk::data_objects::CreateIntValue(builder, value);
         hipdnn_data_sdk::data_objects::KnobSettingBuilder settingBuilder(builder);
-        settingBuilder.add_knob_id(knobId);
+        settingBuilder.add_knob_id(knobIdOffset);
         settingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
         settingBuilder.add_value(intValue.Union());
         knobSettings.push_back(settingBuilder.Finish());
@@ -78,7 +78,8 @@ TEST(TestEngineConfigWrapper, KnobSettingCountEmpty)
 
 TEST(TestEngineConfigWrapper, KnobSettingCountNonEmpty)
 {
-    auto builder = buildEngineConfigWithKnobSettings(42, {{1, 100}, {2, 200}, {3, 300}});
+    auto builder = buildEngineConfigWithKnobSettings(
+        42, {{"knob_1", 100}, {"knob_2", 200}, {"knob_3", 300}});
     EngineConfigWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
     EXPECT_TRUE(wrapper.isValid());
     EXPECT_EQ(wrapper.knobSettingCount(), 3u);
@@ -94,50 +95,30 @@ TEST(TestEngineConfigWrapper, KnobSettingWrappersEmpty)
 
 TEST(TestEngineConfigWrapper, KnobSettingWrappersPopulated)
 {
-    auto builder = buildEngineConfigWithKnobSettings(42, {{1, 100}, {2, 200}});
+    auto builder = buildEngineConfigWithKnobSettings(42, {{"knob_1", 100}, {"knob_2", 200}});
     EngineConfigWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
     const auto& wrappers = wrapper.knobSettingWrappers();
     EXPECT_EQ(wrappers.size(), 2u);
-    EXPECT_EQ(wrappers[0]->knobId(), 1);
-    EXPECT_EQ(wrappers[1]->knobId(), 2);
-}
-
-TEST(TestEngineConfigWrapper, GetKnobSettingByIdFound)
-{
-    auto builder = buildEngineConfigWithKnobSettings(42, {{100, 1000}, {200, 2000}});
-    EngineConfigWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
-
-    const auto& knobSetting = wrapper.getKnobSettingById(100);
-    EXPECT_EQ(knobSetting.knobId(), 100);
-
-    const auto& knobSetting2 = wrapper.getKnobSettingById(200);
-    EXPECT_EQ(knobSetting2.knobId(), 200);
-}
-
-TEST(TestEngineConfigWrapper, GetKnobSettingByIdNotFound)
-{
-    auto builder = buildEngineConfigWithKnobSettings(42, {{100, 1000}});
-    EngineConfigWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
-
-    EXPECT_THROW(wrapper.getKnobSettingById(999), std::out_of_range);
+    EXPECT_EQ(wrappers[0]->knobId(), "knob_1");
+    EXPECT_EQ(wrappers[1]->knobId(), "knob_2");
 }
 
 TEST(TestEngineConfigWrapper, GetKnobSettingByNameFound)
 {
-    // Use fnv1aHash to generate a known knob ID from a name
-    auto knobName = "TEST_KNOB";
-    auto knobId = static_cast<int64_t>(hipdnn_data_sdk::utilities::fnv1aHash(knobName));
-
-    auto builder = buildEngineConfigWithKnobSettings(42, {{knobId, 500}});
+    auto builder
+        = buildEngineConfigWithKnobSettings(42, {{"test_knob_100", 1000}, {"test_knob_200", 2000}});
     EngineConfigWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
 
-    const auto& knobSetting = wrapper.getKnobSettingByName(knobName);
-    EXPECT_EQ(knobSetting.knobId(), knobId);
+    const auto& knobSetting = wrapper.getKnobSettingByName("test_knob_100");
+    EXPECT_EQ(knobSetting.knobId(), "test_knob_100");
+
+    const auto& knobSetting2 = wrapper.getKnobSettingByName("test_knob_200");
+    EXPECT_EQ(knobSetting2.knobId(), "test_knob_200");
 }
 
 TEST(TestEngineConfigWrapper, GetKnobSettingByNameNotFound)
 {
-    auto builder = buildEngineConfigWithKnobSettings(42, {{100, 1000}});
+    auto builder = buildEngineConfigWithKnobSettings(42, {{"test_knob_100", 1000}});
     EngineConfigWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
 
     EXPECT_THROW(wrapper.getKnobSettingByName("NONEXISTENT_KNOB"), std::out_of_range);
@@ -150,30 +131,17 @@ TEST(TestEngineConfigWrapper, KnobSettingMethodsOnInvalidWrapperThrow)
 
     EXPECT_THROW(wrapper.knobSettingCount(), std::invalid_argument);
     EXPECT_THROW(wrapper.knobSettingWrappers(), std::invalid_argument);
-    EXPECT_THROW(wrapper.getKnobSettingById(1), std::invalid_argument);
     EXPECT_THROW(wrapper.getKnobSettingByName("test"), std::invalid_argument);
-    EXPECT_THROW(wrapper.hasKnobSetting(1), std::invalid_argument);
     EXPECT_THROW(wrapper.hasKnobSetting("test"), std::invalid_argument);
-}
-
-TEST(TestEngineConfigWrapper, HasKnobSettingById)
-{
-    auto builder = buildEngineConfigWithKnobSettings(42, {{100, 1000}, {200, 2000}});
-    EngineConfigWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
-
-    EXPECT_TRUE(wrapper.hasKnobSetting(100));
-    EXPECT_TRUE(wrapper.hasKnobSetting(200));
-    EXPECT_FALSE(wrapper.hasKnobSetting(300));
 }
 
 TEST(TestEngineConfigWrapper, HasKnobSettingByName)
 {
-    auto knobName = "TEST_KNOB";
-    auto knobId = static_cast<int64_t>(hipdnn_data_sdk::utilities::fnv1aHash(knobName));
-
-    auto builder = buildEngineConfigWithKnobSettings(42, {{knobId, 500}});
+    auto builder
+        = buildEngineConfigWithKnobSettings(42, {{"test_knob_100", 1000}, {"test_knob_200", 2000}});
     EngineConfigWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
 
-    EXPECT_TRUE(wrapper.hasKnobSetting(knobName));
-    EXPECT_FALSE(wrapper.hasKnobSetting("NONEXISTENT_KNOB"));
+    EXPECT_TRUE(wrapper.hasKnobSetting("test_knob_100"));
+    EXPECT_TRUE(wrapper.hasKnobSetting("test_knob_200"));
+    EXPECT_FALSE(wrapper.hasKnobSetting("test_knob_300"));
 }

--- a/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestEngineDetailsWrapper.cpp
+++ b/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestEngineDetailsWrapper.cpp
@@ -19,21 +19,19 @@ flatbuffers::FlatBufferBuilder buildValidEngineDetailsBuffer(int64_t engineId)
 }
 
 flatbuffers::FlatBufferBuilder
-    buildEngineDetailsWithKnobs(int64_t engineId,
-                                const std::vector<std::pair<int64_t, std::string>>& knobIdAndNames)
+    buildEngineDetailsWithKnobs(int64_t engineId, const std::vector<std::string>& knobNames)
 {
     flatbuffers::FlatBufferBuilder builder;
 
     std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>> knobs;
-    knobs.reserve(knobIdAndNames.size());
+    knobs.reserve(knobNames.size());
 
-    for(const auto& [knobId, knobIdStr] : knobIdAndNames)
+    for(const auto& knobIdStr : knobNames)
     {
         auto knobIdStrOffset = builder.CreateString(knobIdStr);
         auto descOffset = builder.CreateString("Description for " + knobIdStr);
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id(knobId);
         knobBuilder.add_knob_id_str(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobs.push_back(knobBuilder.Finish());
@@ -82,7 +80,7 @@ TEST(TestEngineDetailsWrapper, KnobCountEmpty)
 
 TEST(TestEngineDetailsWrapper, KnobCountNonEmpty)
 {
-    auto builder = buildEngineDetailsWithKnobs(42, {{1, "KNOB_1"}, {2, "KNOB_2"}, {3, "KNOB_3"}});
+    auto builder = buildEngineDetailsWithKnobs(42, {"KNOB_1", "KNOB_2", "KNOB_3"});
     EngineDetailsWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
     EXPECT_TRUE(wrapper.isValid());
     EXPECT_EQ(wrapper.knobCount(), 3u);
@@ -98,55 +96,29 @@ TEST(TestEngineDetailsWrapper, KnobWrappersEmpty)
 
 TEST(TestEngineDetailsWrapper, KnobWrappersPopulated)
 {
-    auto builder = buildEngineDetailsWithKnobs(42, {{100, "KNOB_A"}, {200, "KNOB_B"}});
+    auto builder = buildEngineDetailsWithKnobs(42, {"KNOB_A", "KNOB_B"});
     EngineDetailsWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
     const auto& wrappers = wrapper.knobWrappers();
     EXPECT_EQ(wrappers.size(), 2u);
-    EXPECT_EQ(wrappers[0]->knobId(), 100);
     EXPECT_EQ(wrappers[0]->knobIdStr(), "KNOB_A");
-    EXPECT_EQ(wrappers[1]->knobId(), 200);
     EXPECT_EQ(wrappers[1]->knobIdStr(), "KNOB_B");
-}
-
-TEST(TestEngineDetailsWrapper, GetKnobByIdFound)
-{
-    auto builder = buildEngineDetailsWithKnobs(42, {{100, "FIRST_KNOB"}, {200, "SECOND_KNOB"}});
-    EngineDetailsWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
-
-    const auto& knob = wrapper.getKnobById(100);
-    EXPECT_EQ(knob.knobId(), 100);
-    EXPECT_EQ(knob.knobIdStr(), "FIRST_KNOB");
-
-    const auto& knob2 = wrapper.getKnobById(200);
-    EXPECT_EQ(knob2.knobId(), 200);
-    EXPECT_EQ(knob2.knobIdStr(), "SECOND_KNOB");
-}
-
-TEST(TestEngineDetailsWrapper, GetKnobByIdNotFound)
-{
-    auto builder = buildEngineDetailsWithKnobs(42, {{100, "TEST_KNOB"}});
-    EngineDetailsWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
-
-    EXPECT_THROW(wrapper.getKnobById(999), std::out_of_range);
 }
 
 TEST(TestEngineDetailsWrapper, GetKnobByNameFound)
 {
-    // Use fnv1aHash to generate a known knob ID from a name
-    auto knobName = "MY_TEST_KNOB";
-    auto knobId = static_cast<int64_t>(hipdnn_data_sdk::utilities::fnv1aHash(knobName));
-
-    auto builder = buildEngineDetailsWithKnobs(42, {{knobId, knobName}});
+    auto builder = buildEngineDetailsWithKnobs(42, {"FIRST_KNOB", "SECOND_KNOB"});
     EngineDetailsWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
 
-    const auto& knob = wrapper.getKnobByName(knobName);
-    EXPECT_EQ(knob.knobId(), knobId);
-    EXPECT_EQ(knob.knobIdStr(), knobName);
+    const auto& knob = wrapper.getKnobByName("FIRST_KNOB");
+    EXPECT_EQ(knob.knobIdStr(), "FIRST_KNOB");
+
+    const auto& knob2 = wrapper.getKnobByName("SECOND_KNOB");
+    EXPECT_EQ(knob2.knobIdStr(), "SECOND_KNOB");
 }
 
 TEST(TestEngineDetailsWrapper, GetKnobByNameNotFound)
 {
-    auto builder = buildEngineDetailsWithKnobs(42, {{100, "SOME_KNOB"}});
+    auto builder = buildEngineDetailsWithKnobs(42, {"SOME_KNOB"});
     EngineDetailsWrapper wrapper(builder.GetBufferPointer(), builder.GetSize());
 
     EXPECT_THROW(wrapper.getKnobByName("NONEXISTENT_KNOB"), std::out_of_range);
@@ -159,6 +131,5 @@ TEST(TestEngineDetailsWrapper, KnobMethodsOnInvalidWrapperThrow)
 
     EXPECT_THROW(wrapper.knobCount(), std::invalid_argument);
     EXPECT_THROW(wrapper.knobWrappers(), std::invalid_argument);
-    EXPECT_THROW(wrapper.getKnobById(1), std::invalid_argument);
     EXPECT_THROW(wrapper.getKnobByName("test"), std::invalid_argument);
 }

--- a/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestKnobSettingWrapper.cpp
+++ b/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestKnobSettingWrapper.cpp
@@ -13,16 +13,17 @@ using namespace hipdnn_data_sdk::flatbuffer_utilities;
 class TestKnobSettingWrapper : public ::testing::Test
 {
 protected:
-    static flatbuffers::DetachedBuffer createKnobSetting(int64_t knobId, int64_t value)
+    static flatbuffers::DetachedBuffer createKnobSetting(const std::string& knobId, int64_t value)
     {
         flatbuffers::FlatBufferBuilder builder;
 
+        auto knobIdOffset = builder.CreateString(knobId);
         // Create the value
         auto intValue = hipdnn_data_sdk::data_objects::CreateIntValue(builder, value);
 
         // Create the knob setting
         hipdnn_data_sdk::data_objects::KnobSettingBuilder settingBuilder(builder);
-        settingBuilder.add_knob_id(knobId);
+        settingBuilder.add_knob_id(knobIdOffset);
         settingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
         settingBuilder.add_value(intValue.Union());
 
@@ -32,16 +33,17 @@ protected:
         return builder.Release();
     }
 
-    static flatbuffers::DetachedBuffer createKnobSettingWithString(int64_t knobId,
+    static flatbuffers::DetachedBuffer createKnobSettingWithString(const std::string& knobId,
                                                                    const std::string& value)
     {
         flatbuffers::FlatBufferBuilder builder;
 
+        auto knobIdOffset = builder.CreateString(knobId);
         auto strOffset = builder.CreateString(value);
         auto stringValue = hipdnn_data_sdk::data_objects::CreateStringValue(builder, strOffset);
 
         hipdnn_data_sdk::data_objects::KnobSettingBuilder settingBuilder(builder);
-        settingBuilder.add_knob_id(knobId);
+        settingBuilder.add_knob_id(knobIdOffset);
         settingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::StringValue);
         settingBuilder.add_value(stringValue.Union());
 
@@ -51,14 +53,16 @@ protected:
         return builder.Release();
     }
 
-    static flatbuffers::DetachedBuffer createKnobSettingWithFloat(int64_t knobId, double value)
+    static flatbuffers::DetachedBuffer createKnobSettingWithFloat(const std::string& knobId,
+                                                                  double value)
     {
         flatbuffers::FlatBufferBuilder builder;
 
+        auto knobIdOffset = builder.CreateString(knobId);
         auto floatValue = hipdnn_data_sdk::data_objects::CreateFloatValue(builder, value);
 
         hipdnn_data_sdk::data_objects::KnobSettingBuilder settingBuilder(builder);
-        settingBuilder.add_knob_id(knobId);
+        settingBuilder.add_knob_id(knobIdOffset);
         settingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
         settingBuilder.add_value(floatValue.Union());
 
@@ -71,22 +75,22 @@ protected:
 
 TEST_F(TestKnobSettingWrapper, ConstructFromFlatbufferPointer)
 {
-    auto buffer = createKnobSetting(42, 100);
+    auto buffer = createKnobSetting("test_knob_42", 100);
     auto setting = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::KnobSetting>(buffer.data());
 
     KnobSettingWrapper wrapper(setting);
     EXPECT_TRUE(wrapper.isValid());
-    EXPECT_EQ(wrapper.knobId(), 42);
+    EXPECT_EQ(wrapper.knobId(), "test_knob_42");
     EXPECT_EQ(wrapper.valueType(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
 }
 
 TEST_F(TestKnobSettingWrapper, ConstructFromBuffer)
 {
-    auto buffer = createKnobSetting(42, 100);
+    auto buffer = createKnobSetting("test_knob_42", 100);
 
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
     EXPECT_TRUE(wrapper.isValid());
-    EXPECT_EQ(wrapper.knobId(), 42);
+    EXPECT_EQ(wrapper.knobId(), "test_knob_42");
     EXPECT_EQ(wrapper.valueType(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
 }
 
@@ -112,14 +116,14 @@ TEST_F(TestKnobSettingWrapper, ConstructFromInvalidBuffer)
 
 TEST_F(TestKnobSettingWrapper, GetKnobIdFromValidWrapper)
 {
-    auto buffer = createKnobSetting(999, 123);
+    auto buffer = createKnobSetting("test_knob_999", 123);
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
-    EXPECT_EQ(wrapper.knobId(), 999);
+    EXPECT_EQ(wrapper.knobId(), "test_knob_999");
 }
 
 TEST_F(TestKnobSettingWrapper, ValueAsIntValue)
 {
-    auto buffer = createKnobSetting(42, 100);
+    auto buffer = createKnobSetting("test_knob_42", 100);
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
     EXPECT_EQ(wrapper.valueType(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
 
@@ -129,7 +133,7 @@ TEST_F(TestKnobSettingWrapper, ValueAsIntValue)
 
 TEST_F(TestKnobSettingWrapper, ValueAsStringValue)
 {
-    auto buffer = createKnobSettingWithString(42, "test_value");
+    auto buffer = createKnobSettingWithString("test_knob_42", "test_value");
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
     EXPECT_EQ(wrapper.valueType(), hipdnn_data_sdk::data_objects::KnobValue::StringValue);
 
@@ -139,7 +143,7 @@ TEST_F(TestKnobSettingWrapper, ValueAsStringValue)
 
 TEST_F(TestKnobSettingWrapper, ValueAsFloatValue)
 {
-    auto buffer = createKnobSettingWithFloat(42, 3.14159);
+    auto buffer = createKnobSettingWithFloat("test_knob_42", 3.14159);
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
     EXPECT_EQ(wrapper.valueType(), hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
 
@@ -149,7 +153,7 @@ TEST_F(TestKnobSettingWrapper, ValueAsFloatValue)
 
 TEST_F(TestKnobSettingWrapper, ValueAsTypeMismatchThrows)
 {
-    auto buffer = createKnobSetting(42, 100);
+    auto buffer = createKnobSetting("test_knob_42", 100);
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
 
     // Value is IntValue, trying to get as FloatValue should throw
@@ -161,7 +165,7 @@ TEST_F(TestKnobSettingWrapper, ValueAsTypeMismatchThrows)
 
 TEST_F(TestKnobSettingWrapper, GetKnobSettingFromValidWrapper)
 {
-    auto buffer = createKnobSetting(42, 100);
+    auto buffer = createKnobSetting("test_knob_42", 100);
     auto setting = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::KnobSetting>(buffer.data());
 
     KnobSettingWrapper wrapper(setting);
@@ -182,53 +186,52 @@ TEST_F(TestKnobSettingWrapper, AccessMethodsOnInvalidWrapperThrow)
 TEST_F(TestKnobSettingWrapper, MultipleDifferentKnobSettings)
 {
     // Test that wrapper correctly handles different knob settings
-    auto buffer1 = createKnobSetting(1, 100);
-    auto buffer2 = createKnobSettingWithString(2, "config_value");
-    auto buffer3 = createKnobSettingWithFloat(3, 2.718);
+    auto buffer1 = createKnobSetting("knob_1", 100);
+    auto buffer2 = createKnobSettingWithString("knob_2", "config_value");
+    auto buffer3 = createKnobSettingWithFloat("knob_3", 2.718);
 
     KnobSettingWrapper wrapper1(buffer1.data(), buffer1.size());
     KnobSettingWrapper wrapper2(buffer2.data(), buffer2.size());
     KnobSettingWrapper wrapper3(buffer3.data(), buffer3.size());
 
-    EXPECT_EQ(wrapper1.knobId(), 1);
+    EXPECT_EQ(wrapper1.knobId(), "knob_1");
     EXPECT_EQ(wrapper1.valueType(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
 
-    EXPECT_EQ(wrapper2.knobId(), 2);
+    EXPECT_EQ(wrapper2.knobId(), "knob_2");
     EXPECT_EQ(wrapper2.valueType(), hipdnn_data_sdk::data_objects::KnobValue::StringValue);
 
-    EXPECT_EQ(wrapper3.knobId(), 3);
+    EXPECT_EQ(wrapper3.knobId(), "knob_3");
     EXPECT_EQ(wrapper3.valueType(), hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
 }
 
-TEST_F(TestKnobSettingWrapper, LargeKnobId)
+TEST_F(TestKnobSettingWrapper, EmptyKnobId)
 {
-    int64_t largeId = INT64_MAX - 1;
-    auto buffer = createKnobSetting(largeId, 42);
+    auto buffer = createKnobSetting("", 42);
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.isValid());
-    EXPECT_EQ(wrapper.knobId(), largeId);
+    EXPECT_EQ(wrapper.knobId(), "");
 }
 
-TEST_F(TestKnobSettingWrapper, NegativeKnobId)
+TEST_F(TestKnobSettingWrapper, LongKnobId)
 {
-    int64_t negativeId = -999;
-    auto buffer = createKnobSetting(negativeId, 42);
+    std::string longKnobId = "this.is.a.very.long.knob.id.with.many.parts.for.testing";
+    auto buffer = createKnobSetting(longKnobId, 42);
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.isValid());
-    EXPECT_EQ(wrapper.knobId(), negativeId);
+    EXPECT_EQ(wrapper.knobId(), longKnobId);
 }
 
 TEST_F(TestKnobSettingWrapper, ToKnobSettingTWithIntValue)
 {
-    auto buffer = createKnobSetting(42, 100);
+    auto buffer = createKnobSetting("test_knob_42", 100);
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
 
     auto knobSettingT = wrapper.toKnobSettingT();
 
     ASSERT_NE(knobSettingT, nullptr);
-    EXPECT_EQ(knobSettingT->knob_id, 42);
+    EXPECT_EQ(knobSettingT->knob_id, "test_knob_42");
     EXPECT_EQ(knobSettingT->value.type, hipdnn_data_sdk::data_objects::KnobValue::IntValue);
     ASSERT_NE(knobSettingT->value.AsIntValue(), nullptr);
     EXPECT_EQ(knobSettingT->value.AsIntValue()->value, 100);
@@ -236,13 +239,13 @@ TEST_F(TestKnobSettingWrapper, ToKnobSettingTWithIntValue)
 
 TEST_F(TestKnobSettingWrapper, ToKnobSettingTWithStringValue)
 {
-    auto buffer = createKnobSettingWithString(99, "test_string_value");
+    auto buffer = createKnobSettingWithString("test_knob_99", "test_string_value");
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
 
     auto knobSettingT = wrapper.toKnobSettingT();
 
     ASSERT_NE(knobSettingT, nullptr);
-    EXPECT_EQ(knobSettingT->knob_id, 99);
+    EXPECT_EQ(knobSettingT->knob_id, "test_knob_99");
     EXPECT_EQ(knobSettingT->value.type, hipdnn_data_sdk::data_objects::KnobValue::StringValue);
     ASSERT_NE(knobSettingT->value.AsStringValue(), nullptr);
     EXPECT_EQ(knobSettingT->value.AsStringValue()->value, "test_string_value");
@@ -250,13 +253,13 @@ TEST_F(TestKnobSettingWrapper, ToKnobSettingTWithStringValue)
 
 TEST_F(TestKnobSettingWrapper, ToKnobSettingTWithFloatValue)
 {
-    auto buffer = createKnobSettingWithFloat(123, 3.14159);
+    auto buffer = createKnobSettingWithFloat("test_knob_123", 3.14159);
     KnobSettingWrapper wrapper(buffer.data(), buffer.size());
 
     auto knobSettingT = wrapper.toKnobSettingT();
 
     ASSERT_NE(knobSettingT, nullptr);
-    EXPECT_EQ(knobSettingT->knob_id, 123);
+    EXPECT_EQ(knobSettingT->knob_id, "test_knob_123");
     EXPECT_EQ(knobSettingT->value.type, hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
     ASSERT_NE(knobSettingT->value.AsFloatValue(), nullptr);
     EXPECT_DOUBLE_EQ(knobSettingT->value.AsFloatValue()->value, 3.14159);

--- a/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestKnobWrapper.cpp
+++ b/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestKnobWrapper.cpp
@@ -13,8 +13,7 @@ using namespace hipdnn_data_sdk::flatbuffer_utilities;
 class TestKnobWrapper : public ::testing::Test
 {
 protected:
-    static flatbuffers::DetachedBuffer createKnob(int64_t knobId,
-                                                  const std::string& knobIdStr,
+    static flatbuffers::DetachedBuffer createKnob(const std::string& knobIdStr,
                                                   const std::string& description,
                                                   bool deprecated = false,
                                                   bool withDefaultValue = true,
@@ -50,7 +49,6 @@ protected:
         }
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id(knobId);
         knobBuilder.add_knob_id_str(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobBuilder.add_deprecated(deprecated);
@@ -73,17 +71,17 @@ protected:
         return builder.Release();
     }
 
-    static flatbuffers::DetachedBuffer createKnobWithFloatValue(int64_t knobId, double defaultValue)
+    static flatbuffers::DetachedBuffer createKnobWithFloatValue(const std::string& knobIdStr,
+                                                                double defaultValue)
     {
         flatbuffers::FlatBufferBuilder builder;
 
-        auto knobIdStrOffset = builder.CreateString("FLOAT_KNOB");
+        auto knobIdStrOffset = builder.CreateString(knobIdStr);
         auto descOffset = builder.CreateString("Float knob");
 
         auto floatVal = hipdnn_data_sdk::data_objects::CreateFloatValue(builder, defaultValue);
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id(knobId);
         knobBuilder.add_knob_id_str(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobBuilder.add_default_value_type(hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
@@ -95,12 +93,13 @@ protected:
         return builder.Release();
     }
 
-    static flatbuffers::DetachedBuffer
-        createKnobWithFloatConstraint(int64_t knobId, double minValue, double maxValue)
+    static flatbuffers::DetachedBuffer createKnobWithFloatConstraint(const std::string& knobIdStr,
+                                                                     double minValue,
+                                                                     double maxValue)
     {
         flatbuffers::FlatBufferBuilder builder;
 
-        auto knobIdStrOffset = builder.CreateString("FLOAT_CONSTRAINT_KNOB");
+        auto knobIdStrOffset = builder.CreateString(knobIdStr);
         auto descOffset = builder.CreateString("Knob with float constraint");
 
         auto floatVal = hipdnn_data_sdk::data_objects::CreateFloatValue(builder, 1.0);
@@ -108,7 +107,6 @@ protected:
             = hipdnn_data_sdk::data_objects::CreateFloatConstraint(builder, minValue, maxValue);
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id(knobId);
         knobBuilder.add_knob_id_str(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobBuilder.add_default_value_type(hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
@@ -123,12 +121,14 @@ protected:
         return builder.Release();
     }
 
-    static flatbuffers::DetachedBuffer createKnobWithStringConstraint(
-        int64_t knobId, int32_t maxLength, const std::vector<std::string>& validValues)
+    static flatbuffers::DetachedBuffer
+        createKnobWithStringConstraint(const std::string& knobIdStr,
+                                       int32_t maxLength,
+                                       const std::vector<std::string>& validValues)
     {
         flatbuffers::FlatBufferBuilder builder;
 
-        auto knobIdStrOffset = builder.CreateString("STRING_CONSTRAINT_KNOB");
+        auto knobIdStrOffset = builder.CreateString(knobIdStr);
         auto descOffset = builder.CreateString("Knob with string constraint");
 
         auto strVal = builder.CreateString("default_val");
@@ -145,7 +145,6 @@ protected:
             builder, maxLength, validValuesVector);
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id(knobId);
         knobBuilder.add_knob_id_str(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobBuilder.add_default_value_type(hipdnn_data_sdk::data_objects::KnobValue::StringValue);
@@ -163,23 +162,21 @@ protected:
 
 TEST_F(TestKnobWrapper, ConstructFromFlatbufferPointer)
 {
-    auto buffer = createKnob(42, "KNOB_42", "Test knob");
+    auto buffer = createKnob("KNOB_42", "Test knob");
     auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(buffer.data());
 
     KnobWrapper wrapper(knob);
     EXPECT_TRUE(wrapper.isValid());
-    EXPECT_EQ(wrapper.knobId(), 42);
     EXPECT_EQ(wrapper.knobIdStr(), "KNOB_42");
     EXPECT_EQ(wrapper.description(), "Test knob");
 }
 
 TEST_F(TestKnobWrapper, ConstructFromBuffer)
 {
-    auto buffer = createKnob(42, "KNOB_42", "Test knob");
+    auto buffer = createKnob("KNOB_42", "Test knob");
 
     KnobWrapper wrapper(buffer.data(), buffer.size());
     EXPECT_TRUE(wrapper.isValid());
-    EXPECT_EQ(wrapper.knobId(), 42);
     EXPECT_EQ(wrapper.knobIdStr(), "KNOB_42");
     EXPECT_EQ(wrapper.description(), "Test knob");
 }
@@ -204,60 +201,53 @@ TEST_F(TestKnobWrapper, ConstructFromInvalidBuffer)
     EXPECT_FALSE(wrapper.isValid());
 }
 
-TEST_F(TestKnobWrapper, GetKnobIdFromValidWrapper)
-{
-    auto buffer = createKnob(999, "KNOB_999", "Test");
-    KnobWrapper wrapper(buffer.data(), buffer.size());
-    EXPECT_EQ(wrapper.knobId(), 999);
-}
-
 TEST_F(TestKnobWrapper, GetKnobIdStrFromValidWrapper)
 {
-    auto buffer = createKnob(42, "CUSTOM_KNOB_NAME", "Test");
+    auto buffer = createKnob("CUSTOM_KNOB_NAME", "Test");
     KnobWrapper wrapper(buffer.data(), buffer.size());
     EXPECT_EQ(wrapper.knobIdStr(), "CUSTOM_KNOB_NAME");
 }
 
 TEST_F(TestKnobWrapper, GetDescriptionFromValidWrapper)
 {
-    auto buffer = createKnob(42, "KNOB_42", "This is a detailed description");
+    auto buffer = createKnob("KNOB_42", "This is a detailed description");
     KnobWrapper wrapper(buffer.data(), buffer.size());
     EXPECT_EQ(wrapper.description(), "This is a detailed description");
 }
 
 TEST_F(TestKnobWrapper, GetDefaultValueType)
 {
-    auto buffer = createKnob(42, "KNOB_42", "Test");
+    auto buffer = createKnob("KNOB_42", "Test");
     KnobWrapper wrapper(buffer.data(), buffer.size());
     EXPECT_EQ(wrapper.defaultValueType(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
 }
 
 TEST_F(TestKnobWrapper, IsDeprecated)
 {
-    auto buffer1 = createKnob(42, "KNOB_42", "Test", false);
+    auto buffer1 = createKnob("KNOB_42", "Test", false);
     KnobWrapper wrapper1(buffer1.data(), buffer1.size());
     EXPECT_FALSE(wrapper1.isDeprecated());
 
-    auto buffer2 = createKnob(42, "KNOB_42", "Test", true);
+    auto buffer2 = createKnob("KNOB_42", "Test", true);
     KnobWrapper wrapper2(buffer2.data(), buffer2.size());
     EXPECT_TRUE(wrapper2.isDeprecated());
 }
 
 TEST_F(TestKnobWrapper, HasDefaultValue)
 {
-    auto buffer1 = createKnob(42, "KNOB_42", "Test", false, true);
+    auto buffer1 = createKnob("KNOB_42", "Test", false, true);
     KnobWrapper wrapper1(buffer1.data(), buffer1.size());
     EXPECT_TRUE(wrapper1.hasDefaultValue());
     EXPECT_EQ(wrapper1.defaultValueType(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
 
-    auto buffer2 = createKnob(42, "KNOB_42", "Test", false, false);
+    auto buffer2 = createKnob("KNOB_42", "Test", false, false);
     KnobWrapper wrapper2(buffer2.data(), buffer2.size());
     EXPECT_FALSE(wrapper2.hasDefaultValue());
 }
 
 TEST_F(TestKnobWrapper, DefaultValueAsIntValue)
 {
-    auto buffer = createKnob(42, "KNOB_42", "Test", false, true, false);
+    auto buffer = createKnob("KNOB_42", "Test", false, true, false);
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.hasDefaultValue());
@@ -267,7 +257,7 @@ TEST_F(TestKnobWrapper, DefaultValueAsIntValue)
 
 TEST_F(TestKnobWrapper, DefaultValueAsFloatValue)
 {
-    auto buffer = createKnobWithFloatValue(42, 3.14159);
+    auto buffer = createKnobWithFloatValue("FLOAT_KNOB", 3.14159);
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.hasDefaultValue());
@@ -278,7 +268,7 @@ TEST_F(TestKnobWrapper, DefaultValueAsFloatValue)
 
 TEST_F(TestKnobWrapper, DefaultValueAsTypeMismatchThrows)
 {
-    auto buffer = createKnob(42, "KNOB_42", "Test", false, true, false);
+    auto buffer = createKnob("KNOB_42", "Test", false, true, false);
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     // Default value is IntValue, trying to get as FloatValue should throw
@@ -290,20 +280,20 @@ TEST_F(TestKnobWrapper, DefaultValueAsTypeMismatchThrows)
 
 TEST_F(TestKnobWrapper, HasConstraints)
 {
-    auto buffer1 = createKnob(42, "KNOB_42", "Test", false, true, true);
+    auto buffer1 = createKnob("KNOB_42", "Test", false, true, true);
     KnobWrapper wrapper1(buffer1.data(), buffer1.size());
     EXPECT_TRUE(wrapper1.hasConstraint());
     EXPECT_EQ(wrapper1.constraintType(),
               hipdnn_data_sdk::data_objects::KnobConstraint::IntConstraint);
 
-    auto buffer2 = createKnob(42, "KNOB_42", "Test", false, true, false);
+    auto buffer2 = createKnob("KNOB_42", "Test", false, true, false);
     KnobWrapper wrapper2(buffer2.data(), buffer2.size());
     EXPECT_FALSE(wrapper2.hasConstraint());
 }
 
 TEST_F(TestKnobWrapper, ConstraintsAsIntConstraint)
 {
-    auto buffer = createKnob(42, "KNOB_42", "Test", false, true, true);
+    auto buffer = createKnob("KNOB_42", "Test", false, true, true);
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.hasConstraint());
@@ -316,7 +306,7 @@ TEST_F(TestKnobWrapper, ConstraintsAsIntConstraint)
 
 TEST_F(TestKnobWrapper, ConstraintsAsTypeMismatchThrows)
 {
-    auto buffer = createKnob(42, "KNOB_42", "Test", false, true, true);
+    auto buffer = createKnob("KNOB_42", "Test", false, true, true);
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     // Constraint is IntConstraint, trying to get as FloatConstraint should throw
@@ -328,7 +318,7 @@ TEST_F(TestKnobWrapper, ConstraintsAsTypeMismatchThrows)
 
 TEST_F(TestKnobWrapper, GetKnobFromValidWrapper)
 {
-    auto buffer = createKnob(42, "KNOB_42", "Test");
+    auto buffer = createKnob("KNOB_42", "Test");
     auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(buffer.data());
 
     KnobWrapper wrapper(knob);
@@ -341,7 +331,6 @@ TEST_F(TestKnobWrapper, AccessMethodsOnInvalidWrapperThrow)
     KnobWrapper wrapper(nullptr, 0);
     EXPECT_FALSE(wrapper.isValid());
 
-    EXPECT_THROW(wrapper.knobId(), std::invalid_argument);
     EXPECT_THROW(wrapper.knobIdStr(), std::invalid_argument);
     EXPECT_THROW(wrapper.description(), std::invalid_argument);
     EXPECT_THROW(wrapper.defaultValueType(), std::invalid_argument);
@@ -355,7 +344,7 @@ TEST_F(TestKnobWrapper, AccessMethodsOnInvalidWrapperThrow)
 TEST_F(TestKnobWrapper, EmptyStringsHandling)
 {
     // Create a knob with empty strings
-    auto buffer = createKnob(42, "", "", false);
+    auto buffer = createKnob("", "", false);
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.isValid());
@@ -366,25 +355,25 @@ TEST_F(TestKnobWrapper, EmptyStringsHandling)
 TEST_F(TestKnobWrapper, MultipleDifferentKnobs)
 {
     // Test that wrapper correctly handles different knob configurations
-    auto buffer1 = createKnob(1, "KNOB_1", "First", false, true, false);
-    auto buffer2 = createKnob(2, "KNOB_2", "Second", true, false, false);
-    auto buffer3 = createKnob(3, "KNOB_3", "Third", false, true, true);
+    auto buffer1 = createKnob("KNOB_1", "First", false, true, false);
+    auto buffer2 = createKnob("KNOB_2", "Second", true, false, false);
+    auto buffer3 = createKnob("KNOB_3", "Third", false, true, true);
 
     KnobWrapper wrapper1(buffer1.data(), buffer1.size());
     KnobWrapper wrapper2(buffer2.data(), buffer2.size());
     KnobWrapper wrapper3(buffer3.data(), buffer3.size());
 
-    EXPECT_EQ(wrapper1.knobId(), 1);
+    EXPECT_EQ(wrapper1.knobIdStr(), "KNOB_1");
     EXPECT_TRUE(wrapper1.hasDefaultValue());
     EXPECT_FALSE(wrapper1.hasConstraint());
     EXPECT_FALSE(wrapper1.isDeprecated());
 
-    EXPECT_EQ(wrapper2.knobId(), 2);
+    EXPECT_EQ(wrapper2.knobIdStr(), "KNOB_2");
     EXPECT_FALSE(wrapper2.hasDefaultValue());
     EXPECT_FALSE(wrapper2.hasConstraint());
     EXPECT_TRUE(wrapper2.isDeprecated());
 
-    EXPECT_EQ(wrapper3.knobId(), 3);
+    EXPECT_EQ(wrapper3.knobIdStr(), "KNOB_3");
     EXPECT_TRUE(wrapper3.hasDefaultValue());
     EXPECT_TRUE(wrapper3.hasConstraint());
     EXPECT_FALSE(wrapper3.isDeprecated());
@@ -392,7 +381,7 @@ TEST_F(TestKnobWrapper, MultipleDifferentKnobs)
 
 TEST_F(TestKnobWrapper, HasFloatConstraint)
 {
-    auto buffer = createKnobWithFloatConstraint(42, 0.0, 100.0);
+    auto buffer = createKnobWithFloatConstraint("FLOAT_CONSTRAINT_KNOB", 0.0, 100.0);
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.isValid());
@@ -403,7 +392,7 @@ TEST_F(TestKnobWrapper, HasFloatConstraint)
 
 TEST_F(TestKnobWrapper, ConstraintAsFloatConstraint)
 {
-    auto buffer = createKnobWithFloatConstraint(42, -10.5, 50.75);
+    auto buffer = createKnobWithFloatConstraint("FLOAT_CONSTRAINT_KNOB", -10.5, 50.75);
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.hasConstraint());
@@ -415,7 +404,7 @@ TEST_F(TestKnobWrapper, ConstraintAsFloatConstraint)
 
 TEST_F(TestKnobWrapper, FloatConstraintTypeMismatchThrows)
 {
-    auto buffer = createKnobWithFloatConstraint(42, 0.0, 100.0);
+    auto buffer = createKnobWithFloatConstraint("FLOAT_CONSTRAINT_KNOB", 0.0, 100.0);
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     // Constraint is FloatConstraint, trying to get as IntConstraint should throw
@@ -427,7 +416,8 @@ TEST_F(TestKnobWrapper, FloatConstraintTypeMismatchThrows)
 
 TEST_F(TestKnobWrapper, HasStringConstraint)
 {
-    auto buffer = createKnobWithStringConstraint(42, 256, {"option1", "option2", "option3"});
+    auto buffer = createKnobWithStringConstraint(
+        "STRING_CONSTRAINT_KNOB", 256, {"option1", "option2", "option3"});
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.isValid());
@@ -438,7 +428,8 @@ TEST_F(TestKnobWrapper, HasStringConstraint)
 
 TEST_F(TestKnobWrapper, ConstraintAsStringConstraint)
 {
-    auto buffer = createKnobWithStringConstraint(42, 128, {"alpha", "beta", "gamma"});
+    auto buffer
+        = createKnobWithStringConstraint("STRING_CONSTRAINT_KNOB", 128, {"alpha", "beta", "gamma"});
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.hasConstraint());
@@ -454,7 +445,7 @@ TEST_F(TestKnobWrapper, ConstraintAsStringConstraint)
 
 TEST_F(TestKnobWrapper, StringConstraintTypeMismatchThrows)
 {
-    auto buffer = createKnobWithStringConstraint(42, 100, {"opt1", "opt2"});
+    auto buffer = createKnobWithStringConstraint("STRING_CONSTRAINT_KNOB", 100, {"opt1", "opt2"});
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     // Constraint is StringConstraint, trying to get as IntConstraint should throw
@@ -466,7 +457,7 @@ TEST_F(TestKnobWrapper, StringConstraintTypeMismatchThrows)
 
 TEST_F(TestKnobWrapper, StringConstraintEmptyValidValues)
 {
-    auto buffer = createKnobWithStringConstraint(42, 64, {});
+    auto buffer = createKnobWithStringConstraint("STRING_CONSTRAINT_KNOB", 64, {});
     KnobWrapper wrapper(buffer.data(), buffer.size());
 
     EXPECT_TRUE(wrapper.hasConstraint());

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/GlobalKnobDefines.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/GlobalKnobDefines.hpp
@@ -3,11 +3,7 @@
 
 #pragma once
 
-#include <hipdnn_plugin_sdk/KnobFactory.hpp>
-
 namespace hipdnn_plugin_sdk
 {
-
-DEFINE_HIPDNN_KNOB_NAMED(benchmarking, "global.benchmarking")
-
+static constexpr const char* BENCHMARKING_KNOB_NAME = "global.benchmarking";
 }

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/KnobFactory.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/KnobFactory.hpp
@@ -13,19 +13,11 @@
 namespace hipdnn_plugin_sdk
 {
 
-#define DEFINE_HIPDNN_KNOB_NAMED(VAR_NAME, STRING_NAME)              \
-    static constexpr const char* VAR_NAME##_KNOB_NAME = STRING_NAME; \
-    static const int64_t VAR_NAME##_KNOB_ID                          \
-        = static_cast<int64_t>(hipdnn_data_sdk::utilities::fnv1aHash(STRING_NAME));
-
-#define DEFINE_HIPDNN_KNOB(NAME) DEFINE_HIPDNN_KNOB_NAMED(NAME, #NAME)
-
 class KnobFactory
 {
 public:
     static flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>
         createIntKnob(flatbuffers::FlatBufferBuilder& builder,
-                      int64_t id,
                       const std::string& name,
                       const std::string& description,
                       int64_t defaultValue,
@@ -44,7 +36,6 @@ public:
 
         return hipdnn_data_sdk::data_objects::CreateKnob(
             builder,
-            id,
             knobIdStr,
             descStr,
             hipdnn_data_sdk::data_objects::KnobValue::IntValue,
@@ -56,7 +47,6 @@ public:
 
     static flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>
         createFloatKnob(flatbuffers::FlatBufferBuilder& builder,
-                        int64_t id,
                         const std::string& name,
                         const std::string& description,
                         float defaultValue,
@@ -72,7 +62,6 @@ public:
 
         return hipdnn_data_sdk::data_objects::CreateKnob(
             builder,
-            id,
             knobIdStr,
             descStr,
             hipdnn_data_sdk::data_objects::KnobValue::FloatValue,
@@ -84,7 +73,6 @@ public:
 
     static flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>
         createStringKnob(flatbuffers::FlatBufferBuilder& builder,
-                         int64_t id,
                          const std::string& name,
                          const std::string& description,
                          const std::string& defaultValue,
@@ -108,7 +96,6 @@ public:
 
         return hipdnn_data_sdk::data_objects::CreateKnob(
             builder,
-            id,
             knobIdStr,
             descStr,
             hipdnn_data_sdk::data_objects::KnobValue::StringValue,

--- a/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
@@ -11,13 +11,12 @@ TEST(TestKnobFactory, CreateIntKnob)
     flatbuffers::FlatBufferBuilder builder;
     std::vector<int64_t> options = {10, 20, 30};
     auto knob
-        = KnobFactory::createIntKnob(builder, 1, "int_knob", "description", 10, 0, 100, 1, options);
+        = KnobFactory::createIntKnob(builder, "int_knob", "description", 10, 0, 100, 1, options);
     builder.Finish(knob);
 
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_EQ(root->knob_id(), 1);
     EXPECT_STREQ(root->knob_id_str()->c_str(), "int_knob");
     EXPECT_STREQ(root->description()->c_str(), "description");
     EXPECT_EQ(root->default_value_type(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
@@ -39,13 +38,12 @@ TEST(TestKnobFactory, CreateFloatKnob)
 {
     flatbuffers::FlatBufferBuilder builder;
     auto knob
-        = KnobFactory::createFloatKnob(builder, 2, "float_knob", "description", 1.5f, 0.0f, 10.0f);
+        = KnobFactory::createFloatKnob(builder, "float_knob", "description", 1.5f, 0.0f, 10.0f);
     builder.Finish(knob);
 
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_EQ(root->knob_id(), 2);
     EXPECT_STREQ(root->knob_id_str()->c_str(), "float_knob");
     EXPECT_STREQ(root->description()->c_str(), "description");
     EXPECT_EQ(root->default_value_type(), hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
@@ -60,14 +58,13 @@ TEST(TestKnobFactory, CreateStringKnob)
 {
     flatbuffers::FlatBufferBuilder builder;
     std::vector<std::string> options = {"option1", "option2"};
-    auto knob = KnobFactory::createStringKnob(
-        builder, 3, "string_knob", "description", "option1", options);
+    auto knob
+        = KnobFactory::createStringKnob(builder, "string_knob", "description", "option1", options);
     builder.Finish(knob);
 
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_EQ(root->knob_id(), 3);
     EXPECT_STREQ(root->knob_id_str()->c_str(), "string_knob");
     EXPECT_STREQ(root->description()->c_str(), "description");
     EXPECT_EQ(root->default_value_type(), hipdnn_data_sdk::data_objects::KnobValue::StringValue);
@@ -79,11 +76,4 @@ TEST(TestKnobFactory, CreateStringKnob)
     ASSERT_EQ(validValues->size(), 2);
     EXPECT_STREQ(validValues->Get(0)->c_str(), "option1");
     EXPECT_STREQ(validValues->Get(1)->c_str(), "option2");
-}
-
-TEST(TestKnobFactory, DefineMacro)
-{
-    DEFINE_HIPDNN_KNOB(test_knob);
-    EXPECT_STREQ(test_knob_KNOB_NAME, "test_knob");
-    EXPECT_EQ(test_knob_KNOB_ID, hipdnn_data_sdk::utilities::fnv1aHash("test_knob"));
 }

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/MockEngineConfig.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/MockEngineConfig.hpp
@@ -26,14 +26,9 @@ public:
         (),
         (const, override));
     MOCK_METHOD(const hipdnn_data_sdk::flatbuffer_utilities::IKnobSetting&,
-                getKnobSettingById,
-                (int64_t knobId),
-                (const, override));
-    MOCK_METHOD(const hipdnn_data_sdk::flatbuffer_utilities::IKnobSetting&,
                 getKnobSettingByName,
                 (const std::string& knobName),
                 (const, override));
-    MOCK_METHOD(bool, hasKnobSetting, (int64_t knobId), (const, override));
     MOCK_METHOD(bool, hasKnobSetting, (const std::string& knobName), (const, override));
 };
 


### PR DESCRIPTION
## Motivation

We dont need to add the complexity of having a knob id string and knob id int.  We can simplify to just having a string id.

## Technical Details


## Test Plan

Test pass

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
