### PR TITLE
[WIP] Use asm developed externally in hipblaslt

### DIFF
--- a/projects/hipblaslt/clients/common/include/allclose.hpp
+++ b/projects/hipblaslt/clients/common/include/allclose.hpp
@@ -50,9 +50,10 @@
 template <typename T>
 bool allclose(size_t* N, T* a, T* b, double atol, double rtol, bool equal_nan = false)
 {
+
     for(size_t i = 0; i < *N; i++)
     {
-        //Returning ture immediately if 2 elements are identical.
+        //Returning true immediately if 2 elements are identical.
         //This also can handle inf == inf case
         if(a[i] == b[i])
             continue;
@@ -73,9 +74,9 @@ bool allclose(size_t* N, T* a, T* b, double atol, double rtol, bool equal_nan = 
 template <
     typename T,
     std::enable_if_t<!(std::is_same<T, hipblaslt_f8_fnuz>{} || std::is_same<T, hipblaslt_bf8_fnuz>{}
-                       || std::is_same<T, hipblaslt_f8>{} || std::is_same<T, hipblaslt_bf8>{}
-                       ),
-                     int> = 0>
+                       || std::is_same<T, hipblaslt_f8>{} || std::is_same<T, hipblaslt_bf8>{}),
+                     int>
+    = 0>
 bool allclose_check_general(char    allclose_type,
                             int64_t M,
                             int64_t N,
@@ -85,6 +86,7 @@ bool allclose_check_general(char    allclose_type,
                             double& hipblaslt_atol,
                             double& hipblaslt_rtol)
 {
+
     if(M * N == 0)
         return 0;
     size_t              size = N * (size_t)lda;
@@ -100,6 +102,39 @@ bool allclose_check_general(char    allclose_type,
             hGPU_double[idx] = double(hGPU[idx]);
         }
     }
+
+    auto dH = std::min<int>(20, N);
+    auto dW = std::min<int>(20, M);
+
+    auto print = [&](auto& X) {
+        std::cout << "[DIRECT ASSEMBLY DEBUG] Top left:\n";
+        for(int64_t i = 0; i < dH; i++)
+        {
+            for(int64_t j = 0; j < dW; j++)
+            {
+                size_t idx = j + i * (size_t)lda;
+                std::cout << X[idx] << " ";
+            }
+            std::cout << std::endl;
+        }
+
+        std::cout << "[DIRECT ASSEMBLY DEBUG] Bottom right:\n";
+        for(int64_t i = N - dH; i < N; i++)
+        {
+            for(int64_t j = M - dW; j < M; j++)
+            {
+                size_t idx = j + i * (size_t)lda;
+                std::cout << X[idx] << " ";
+            }
+            std::cout << std::endl;
+        }
+    };
+
+    std::cout << "\n\n[DIRECT ASSEMBLY DEBUG] CPU reference" << std::endl;
+    print(hCPU_double);
+
+    std::cout << "\n\n[DIRECT ASSEMBLY DEBUG] GPU observation" << std::endl;
+    print(hGPU_double);
 
     std::vector<double> atols{1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
     std::vector<double> rtols{1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
@@ -131,7 +166,8 @@ bool allclose_check_general(char    allclose_type,
 template <typename T,
           std::enable_if_t<(std::is_same<T, hipblaslt_f8_fnuz>{}
                             || std::is_same<T, hipblaslt_bf8_fnuz>{}),
-                           int> = 0>
+                           int>
+          = 0>
 bool allclose_check_general(char    allclose_type,
                             int64_t M,
                             int64_t N,
@@ -184,9 +220,10 @@ bool allclose_check_general(char    allclose_type,
     return true;
 }
 
-template <typename T,
-          std::enable_if_t<(std::is_same<T, hipblaslt_f8>{} || std::is_same<T, hipblaslt_bf8>{}),
-                           int> = 0>
+template <
+    typename T,
+    std::enable_if_t<(std::is_same<T, hipblaslt_f8>{} || std::is_same<T, hipblaslt_bf8>{}), int>
+    = 0>
 bool allclose_check_general(char    allclose_type,
                             int64_t M,
                             int64_t N,
@@ -239,10 +276,10 @@ bool allclose_check_general(char    allclose_type,
     return true;
 }
 // For BF16 and half, we convert the results to double first
-template <
-    typename T,
-    typename VEC,
-    std::enable_if_t<std::is_same<T, hipblasLtHalf>{} || std::is_same<T, hip_bfloat16>{}, int> = 0>
+template <typename T,
+          typename VEC,
+          std::enable_if_t<std::is_same<T, hipblasLtHalf>{} || std::is_same<T, hip_bfloat16>{}, int>
+          = 0>
 bool allclose_check_general(char    allclose_type,
                             int64_t M,
                             int64_t N,
@@ -316,6 +353,7 @@ bool allclose_check_general(char    allclose_type,
                             double& hipblaslt_atol,
                             double& hipblaslt_rtol)
 {
+
     if(M * N == 0)
         return 0;
 
@@ -373,6 +411,8 @@ bool allclose_check_general(char        allclose_type,
     switch(type)
     {
     case HIP_R_32F:
+    {
+
         return allclose_check_general<float>(allclose_type,
                                              M,
                                              N,
@@ -383,7 +423,9 @@ bool allclose_check_general(char        allclose_type,
                                              batch_count,
                                              hipblaslt_atol,
                                              hipblaslt_rtol);
+    }
     case HIP_R_64F:
+    {
         return allclose_check_general<double>(allclose_type,
                                               M,
                                               N,
@@ -394,7 +436,10 @@ bool allclose_check_general(char        allclose_type,
                                               batch_count,
                                               hipblaslt_atol,
                                               hipblaslt_rtol);
+    }
     case HIP_R_16F:
+    {
+
         return allclose_check_general<hipblasLtHalf>(allclose_type,
                                                      M,
                                                      N,
@@ -405,7 +450,12 @@ bool allclose_check_general(char        allclose_type,
                                                      batch_count,
                                                      hipblaslt_atol,
                                                      hipblaslt_rtol);
+    }
     case HIP_R_16BF:
+    {
+
+        std::cout << "[DIRECT ASSEMBLY DEBUG] allclose_check_general: HIP_R_16BF case."
+                  << std::endl;
         return allclose_check_general<hip_bfloat16>(allclose_type,
                                                     M,
                                                     N,
@@ -416,7 +466,9 @@ bool allclose_check_general(char        allclose_type,
                                                     batch_count,
                                                     hipblaslt_atol,
                                                     hipblaslt_rtol);
+    }
     case HIP_R_8F_E4M3_FNUZ:
+    {
         return allclose_check_general<hipblaslt_f8_fnuz>(allclose_type,
                                                          M,
                                                          N,
@@ -427,6 +479,7 @@ bool allclose_check_general(char        allclose_type,
                                                          batch_count,
                                                          hipblaslt_atol,
                                                          hipblaslt_rtol);
+    }
     case HIP_R_8F_E5M2_FNUZ:
         return allclose_check_general<hipblaslt_bf8_fnuz>(allclose_type,
                                                           M,
@@ -439,6 +492,7 @@ bool allclose_check_general(char        allclose_type,
                                                           hipblaslt_atol,
                                                           hipblaslt_rtol);
     case HIP_R_8F_E4M3:
+    {
         return allclose_check_general<hipblaslt_f8>(allclose_type,
                                                     M,
                                                     N,
@@ -449,7 +503,10 @@ bool allclose_check_general(char        allclose_type,
                                                     batch_count,
                                                     hipblaslt_atol,
                                                     hipblaslt_rtol);
+    }
     case HIP_R_8F_E5M2:
+    {
+
         return allclose_check_general<hipblaslt_bf8>(allclose_type,
                                                      M,
                                                      N,
@@ -460,7 +517,9 @@ bool allclose_check_general(char        allclose_type,
                                                      batch_count,
                                                      hipblaslt_atol,
                                                      hipblaslt_rtol);
+    }
     case HIP_R_32I:
+    {
         return allclose_check_general<int32_t>(allclose_type,
                                                M,
                                                N,
@@ -471,7 +530,9 @@ bool allclose_check_general(char        allclose_type,
                                                batch_count,
                                                hipblaslt_atol,
                                                hipblaslt_rtol);
+    }
     case HIP_R_8I:
+    {
         return allclose_check_general<hipblasLtInt8>(allclose_type,
                                                      M,
                                                      N,
@@ -482,6 +543,7 @@ bool allclose_check_general(char        allclose_type,
                                                      batch_count,
                                                      hipblaslt_atol,
                                                      hipblaslt_rtol);
+    }
     default:
         hipblaslt_cerr << "Error type in allclose_check_general" << std::endl;
         return false;

--- a/projects/hipblaslt/clients/common/src/mxDataGen.cpp
+++ b/projects/hipblaslt/clients/common/src/mxDataGen.cpp
@@ -25,10 +25,9 @@
  *******************************************************************************/
 
 #include "mxDataGen.hpp"
+#include <cblas.h>
 #include <mxDataGenerator/DataGenerator.hpp>
 #include <mxDataGenerator/PreSwizzle.hpp>
-#include <cblas.h>
-
 
 template <typename DT>
 std::vector<uint8_t> unpackData(std::vector<uint8_t> const& dataBytes)
@@ -223,6 +222,20 @@ std::vector<float> generateData(T                           dgen,
                                 std::vector<size_t> const&  preSwizzleTile,
                                 std::vector<size_t> const&  preTile)
 {
+
+    using namespace DGen;
+
+    if(isMatrixA)
+    {
+        std::cout << "[DIRECT ASSEMBLY DEBUG] In generate data for A, customizing." << isMatrixA << std::endl;
+        opt.initMode = DataInitMode(Ones{});
+    }
+    else
+    {
+        std::cout << "[DIRECT ASSEMBLY DEBUG] In generate data for (not) A, customizing." << isMatrixA << std::endl;
+        opt.initMode = DataInitMode(Identity{});
+    }
+
     dgen.setSeed(seed);
     dgen.generate(sizes, strides, opt);
 
@@ -301,6 +314,7 @@ std::vector<float> generateData(T                           dgen,
  *
  * @return float values of generated MX type data
  */
+
 std::vector<float> generateMXInput(hipDataType                dataType,
                                    void*                      data,
                                    void*                      scale,
@@ -337,7 +351,6 @@ std::vector<float> generateMXInput(hipDataType                dataType,
     strides.push_back(stride);
 
     auto const elementsPerMXBlock = scaleBlockRowSize * scaleBlockColSize;
-
     if(dataType == HIP_R_8F_E5M2)
     {
         DGen::DataGenerator<DGen::ocp_e5m2_mxfp8> dgen;
@@ -404,6 +417,7 @@ std::vector<float> generateMXInput(hipDataType                dataType,
     }
     else if(static_cast<hipDataType>(dataType) == HIP_R_4F_E2M1_EXT)
     {
+        std::cout << "[CUSTOM ASSEMBLY DEBUG] Generating data for ocp_e2m1_mxfp4." << std::endl;
         DGen::DataGenerator<DGen::ocp_e2m1_mxfp4> dgen;
         return generateData<decltype(dgen), DGen::ocp_e2m1_mxfp4>(dgen,
                                                                   data,

--- a/projects/hipblaslt/for_demo/poc_co.cpp
+++ b/projects/hipblaslt/for_demo/poc_co.cpp
@@ -1,0 +1,40 @@
+// Compile with :
+//  hipcc --genco --offload-arch=gfx942 -O3 poc_co.cpp -o poc_co.co
+// Above assumes MI300X.
+
+#include <hip/hip_runtime.h>
+
+extern "C" __global__ void SimpleGemm(float*       D,
+                                      const float* A,
+                                      const float* B,
+                                      const float* C,
+                                      float        alpha,
+                                      float        beta,
+                                      int          m,
+                                      int          n,
+                                      int          k)
+{
+    // Launch a 1D grid covering the output matrix C (M x N)
+    int tx  = threadIdx.x;
+    int bx  = blockIdx.x;
+    int idx = bx * blockDim.x + tx;
+
+    // Boundary check
+    if(idx >= m * n)
+        return;
+
+    int row = idx % m;
+    int col = idx / m;
+
+    float sum = 0.0f;
+    for(int i = 0; i < k; ++i)
+    {
+        float a_val = A[row + i * m];
+        float b_val = B[i + col * k];
+        sum += a_val * b_val;
+    }
+
+    // 4. Write Result
+    float c_val = C[idx];
+    D[idx]      = alpha * sum + beta * c_val;
+}

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -92,6 +92,130 @@
 namespace
 {
 
+    // This struct exactly matches the one defined by AITER, see:
+    // https://github.com/newling/aiter/blob/b5a9d77e353175f08e87be5912dfd67fa4f3a467/csrc/py_itfs_cu/asm_gemm_a4w4.cu#L12
+    struct p3
+    {
+        uint32_t _p0, _p1, _p2;
+    };
+    struct p2
+    {
+        uint32_t _p0, _p1;
+    };
+    struct __attribute__((packed)) F4GemmKernelArgs
+    {
+        void*    ptr_D;
+        p2       _p0;
+        void*    ptr_C;
+        p2       _p1;
+        void*    ptr_A;
+        p2       _p2;
+        void*    ptr_B;
+        p2       _p3;
+        float    alpha;
+        p3       _p4;
+        float    beta;
+        p3       _p5;
+        uint32_t stride_D0;
+        p3       _p6;
+        uint32_t stride_D1;
+        p3       _p7;
+        uint32_t stride_C0;
+        p3       _p8;
+        uint32_t stride_C1;
+        p3       _p9;
+        uint32_t stride_A0;
+        p3       _p10;
+        uint32_t stride_A1;
+        p3       _p11;
+        uint32_t stride_B0;
+        p3       _p12;
+        uint32_t stride_B1;
+        p3       _p13;
+        uint32_t M;
+        p3       _p14;
+        uint32_t N;
+        p3       _p15;
+        uint32_t K;
+        p3       _p16;
+        void*    ptr_ScaleA;
+        p2       _p17;
+        void*    ptr_ScaleB;
+        p2       _p18;
+        uint32_t stride_ScaleA0;
+        p3       _p19;
+        uint32_t stride_ScaleA1;
+        p3       _p20;
+        uint32_t stride_ScaleB0;
+        p3       _p21;
+        uint32_t stride_ScaleB1;
+        p3       _p22;
+        int      log2_k_split;
+    };
+
+    void printKernelArgs(const F4GemmKernelArgs& args)
+    {
+
+        const unsigned char* bytes = reinterpret_cast<const unsigned char*>(&args);
+        size_t               size  = sizeof(args);
+
+        std::cout << "Offset | 00 01 02 03 04 05 06 07 | 08 09 0A 0B 0C 0D 0E 0F" << std::endl;
+        std::cout << "-------|-------------------------|-------------------------" << std::endl;
+
+        for(size_t i = 0; i < size; i += 16)
+        {
+            std::cout << std::setw(4) << std::setfill('0') << std::dec << i << "   | ";
+            for(size_t j = 0; j < 16; ++j)
+            {
+                if(i + j < size)
+                {
+                    std::cout << std::hex << std::setw(2) << std::setfill('0') << (int)bytes[i + j]
+                              << " ";
+                }
+                else
+                {
+                    std::cout << "   ";
+                }
+                if(j == 7)
+                    std::cout << "| ";
+            }
+            std::cout << std::endl;
+        }
+        std::cout << "=======================================\n" << std::endl;
+
+        std::cout << "\n========== [DIRECT ASSEMBLY REPLICATION DATA] ==========" << std::endl;
+
+        std::cout << "\n--- KernelArgs Struct Content ---" << std::endl;
+        std::cout << std::hex;
+        std::cout << "ptr_D        : " << args.ptr_D << std::endl;
+        std::cout << "ptr_C        : " << args.ptr_C << std::endl;
+        std::cout << "ptr_A        : " << args.ptr_A << std::endl;
+        std::cout << "ptr_B        : " << args.ptr_B << std::endl;
+        std::cout << "ptr_ScaleA   : " << args.ptr_ScaleA << std::endl;
+        std::cout << "ptr_ScaleB   : " << args.ptr_ScaleB << std::endl;
+        std::cout << std::dec;
+        std::cout << "alpha        : " << args.alpha << std::endl;
+        std::cout << "beta         : " << args.beta << std::endl;
+        std::cout << "M            : " << args.M << std::endl;
+        std::cout << "N            : " << args.N << std::endl;
+        std::cout << "K            : " << args.K << std::endl;
+        std::cout << "\n[Strides]" << std::endl;
+        std::cout << "stride_D0 (Out)   : " << args.stride_D0 << std::endl;
+        std::cout << "stride_D1         : " << args.stride_D1 << std::endl;
+        std::cout << "stride_C0 (Bias)  : " << args.stride_C0 << std::endl;
+        std::cout << "stride_C1         : " << args.stride_C1 << std::endl;
+        std::cout << "stride_A0 (In A)  : " << args.stride_A0 << std::endl;
+        std::cout << "stride_A1         : " << args.stride_A1 << std::endl;
+        std::cout << "stride_B0 (In B)  : " << args.stride_B0 << std::endl;
+        std::cout << "stride_B1         : " << args.stride_B1 << std::endl;
+        std::cout << "stride_ScaleA0    : " << args.stride_ScaleA0 << std::endl;
+        std::cout << "stride_ScaleA1    : " << args.stride_ScaleA1 << std::endl;
+        std::cout << "stride_ScaleB0    : " << args.stride_ScaleB0 << std::endl;
+        std::cout << "stride_ScaleB1    : " << args.stride_ScaleB1 << std::endl;
+        std::cout << "========== [DIRECT ASSEMBLY DATA END] ==========\n" << std::endl;
+    }
+
+
     /**
       * @brief Singleton manager for direct assembly kernels.
       * Handles rule selection, module loading, and kernel launching.
@@ -220,6 +344,7 @@ namespace
                                       static_cast<int>(p.n),
                                       static_cast<int>(p.k)};
 
+
                          size_t argsSize = sizeof(args);
 
                          void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
@@ -243,8 +368,98 @@ namespace
                                                                 1,
                                                                 0, // Shared Mem
                                                                 p.stream, // Stream
-                                                                NULL,
+                                                                nullptr,
                                                                 config);
+
+                         if(err != hipSuccess)
+                         {
+                             std::cerr
+                                 << "[DirectAssembly] Launch failed: " << hipGetErrorString(err)
+                                 << std::endl;
+                             return false;
+                         }
+                         return true;
+                     }}};
+        }
+
+        // Rule: F4Gemm Custom (Matches AITER 256x256 Log)
+        static RegistryEntry entryF4Gemm()
+        {
+
+            // To enable the use of these assembly kernels, ensure that the following environment variables have been exported.
+            //
+            //  1) To look for an assembly kernel that matches the workload:
+            //  export HIPBLASLT_ENABLE_DIRECT_ASSEMBLY=1
+            //
+            //  2) The directory to look for the assembly kernel:
+            //  export HIPBLASLT_CUSTOM_ASM_DIR=/home/jnewling/workspace/aiter/hsa/gfx950/f4gemm
+            //
+            //  The assembly kernel can either be downloaded following the ticket:
+            //    https://amd-hub.atlassian.net/browse/AIROCROLL-1511
+            //    https://github.com/ROCm/aiter/blob/545afc9462ebdd59b296e2d48bb41fbdbb951a5c/csrc/py_itfs_cu/asm_gemm_a4w4.cu#L161
+            //
+            //  Or by generating them in AITER directly. See the branch
+            //  TODO(newling).
+            //
+
+            constexpr const static char* const coName
+                //  = "f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256.co";
+                = "f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256.co";
+            //  = "f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128.co";
+
+            const int macroTileM = 256;
+            const int macroTileN = 256;
+
+            constexpr const static char* const fName
+                // = "_ZN5aiter44f4gemm_bf16_per1x32Fp4_noBpreShuffle_256x256E";
+                // = "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_192x128E";
+                // = "_ZN5aiter44f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E";
+                // = "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E";
+                = "_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E";
+            return {"F4Gemm_Custom_256x256",
+                    [](rocblaslt_handle, const RocblasltContractionProblem& p) -> bool {
+                        bool typesMatch = (p.a_type == HIP_R_4F_E2M1_EXT); // etc
+                        return typesMatch;
+                    },
+                    {getCoPath(coName),
+                     fName,
+                     [](hipFunction_t func, const RocblasltContractionProblem& p) -> bool {
+                         F4GemmKernelArgs args;
+                         std::memset(&args, 0, sizeof(args));
+
+                         args.ptr_D          = p.D;
+                         args.ptr_A          = const_cast<void*>(p.A);
+                         args.ptr_B          = const_cast<void*>(p.B);
+                         args.ptr_ScaleA     = const_cast<void*>(p.scaleA);
+                         args.ptr_ScaleB     = const_cast<void*>(p.scaleB);
+                         args.alpha          = *(static_cast<const float*>(p.alpha));
+                         args.beta           = *(static_cast<const float*>(p.beta));
+                         args.M              = static_cast<int>(p.m);
+                         args.N              = static_cast<int>(p.n);
+                         args.K              = static_cast<int>(p.k);
+                         args.log2_k_split   = 0;
+                         args.stride_C0      = p.col_stride_c;
+                         args.stride_A0      = p.col_stride_a;
+                         args.stride_B0      = p.col_stride_b;
+                         args.stride_ScaleA0 = p.col_stride_a / 32;
+                         args.stride_ScaleB0 = p.col_stride_b / 32;
+                         size_t argsSize     = sizeof(args);
+                         void*  config[]     = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
+                                                &args,
+                                                HIP_LAUNCH_PARAM_BUFFER_SIZE,
+                                                &argsSize,
+                                                HIP_LAUNCH_PARAM_END};
+
+                         printKernelArgs(args);
+
+                         // See the AITER logic in asm_gemm_a4w4.cu
+                         auto gdM = (macroTileM + args.M - 1) / macroTileM;
+                         auto gdN = (macroTileN + args.N - 1) / macroTileN;
+
+                         std::cout << "[DIRECT ASSEMBLY DEBUG] Launched with [" << gdN << ", "
+                                   << gdM << ", 1, 256, 1, 1]" << std::endl;
+                         hipError_t err = hipModuleLaunchKernel(
+                             func, gdN, gdM, 1, 256, 1, 1, 0, p.stream, nullptr, config);
 
                          if(err != hipSuccess)
                          {
@@ -259,11 +474,9 @@ namespace
 
         static const std::vector<RegistryEntry>& getRegistry()
         {
-            static std::vector<RegistryEntry> registry = {
-                // Register your rules here:
-                entrySimpleGemmPoC(),
-                // entryLargeProblem(),
-            };
+            static std::vector<RegistryEntry> registry = {// Register your rules here:
+                                                          entrySimpleGemmPoC(),
+                                                          entryF4Gemm()};
             return registry;
         }
 

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -71,6 +71,14 @@
 #include <type_traits>
 #include <vector>
 
+#define HIPBLASLT_LIB_PATH "/opt/rocm/lib"
+
+#ifdef ENABLE_ROCTX
+#include <roctracer/roctx.h>
+#endif
+
+#define INTERNAL_HIPHOSTMEM_SIZE 32768
+
 #define CHECK_HIP_DRV(cmd)                                                              \
     {                                                                                   \
         hipError_t error = cmd;                                                         \
@@ -81,13 +89,224 @@
         }                                                                               \
     }
 
-#define HIPBLASLT_LIB_PATH "/opt/rocm/lib"
+namespace
+{
 
-#ifdef ENABLE_ROCTX
-#include <roctracer/roctx.h>
-#endif
+    /**
+      * @brief Singleton manager for direct assembly kernels.
+      * Handles rule selection, module loading, and kernel launching.
+      */
+    class DirectAssembly
+    {
+    public:
+        static bool isEnabled()
+        {
+            static bool enabled = []() {
+                const char* env = getenv("HIPBLASLT_ENABLE_DIRECT_ASSEMBLY");
+                if(env && (std::string(env) == "1" || std::string(env) == "TRUE"))
+                {
+                    return true;
+                }
+                return false;
+            }();
+            return enabled;
+        }
 
-#define INTERNAL_HIPHOSTMEM_SIZE 32768
+        static std::string getCoPath(const std::string& filename)
+        {
+            const char* env = std::getenv("HIPBLASLT_CUSTOM_ASM_DIR");
+            if(env)
+            {
+                std::string path = env;
+                // Ensure trailing slash
+                if(!path.empty() && path.back() != '/')
+                {
+                    path += "/";
+                }
+                return path + filename;
+            }
+
+            // Fallback: Use current directory or a specific hardcoded path for safety
+            return "./" + filename;
+        }
+        // The function signature for checking if a kernel applies to a problem.
+        using KernelSelector
+            = std::function<bool(rocblaslt_handle, const RocblasltContractionProblem&)>;
+
+        // The function signature for launching the kernel.
+        using KernelLauncher
+            = std::function<bool(hipFunction_t, const RocblasltContractionProblem&)>;
+
+        struct KernelInfo
+        {
+            std::string    coPath;
+            std::string    funcName;
+            KernelLauncher launcher;
+        };
+
+        struct RegistryEntry
+        {
+            std::string    name;
+            KernelSelector selector;
+            KernelInfo     info;
+        };
+
+        // Main Entry Point
+        static bool dispatch(rocblaslt_handle                   handle,
+                             const KernelInfo&                  info,
+                             const RocblasltContractionProblem& prob)
+        {
+            hipFunction_t func = getFunction(info);
+            if(!func)
+            {
+                std::cerr << "[DirectAssembly] Failed to get GPU function handle." << std::endl;
+                return false;
+            }
+
+            // 3. Execute launcher
+            return info.launcher(func, prob);
+        }
+
+        static const KernelInfo* findKernel(rocblaslt_handle                   handle,
+                                            const RocblasltContractionProblem& prob)
+        {
+            for(const auto& entry : getRegistry())
+            {
+                if(entry.selector(handle, prob))
+                {
+                    return &entry.info;
+                }
+            }
+            return nullptr;
+        }
+
+    private:
+        // Rule 1: Simple GEMM PoC
+        static RegistryEntry entrySimpleGemmPoC()
+        {
+            return {"SimpleGemm_PoC", // Name
+                    [](rocblaslt_handle, const RocblasltContractionProblem& p) -> bool {
+                        // 1. Check Dimensions
+                        bool dimsMatch = (p.m == 128 && p.n == 64 && p.k == 256);
+
+                        // 2. Check Data Types (All F32)
+                        // Assuming standard hipBLASLt enum names:
+                        bool typesMatch = (p.a_type == HIP_R_32F && p.b_type == HIP_R_32F
+                                           && p.c_type == HIP_R_32F && p.d_type == HIP_R_32F);
+
+                        return dimsMatch && typesMatch;
+                    },
+                    // Info & Launcher
+                    {getCoPath("poc_co.co"),
+                     "SimpleGemm", // Symbol
+                     [](hipFunction_t func, const RocblasltContractionProblem& p) -> bool {
+                         std::cout << "[DirectAssembly] Launching SimpleGemm" << std::endl;
+
+                         struct Args
+                         {
+                             void*       D;
+                             const void *A, *B, *C;
+                             float       alpha, beta;
+                             int         m, n, k;
+                         };
+
+                         Args args = {p.D,
+                                      p.A,
+                                      p.B,
+                                      p.C,
+                                      *(float*)p.alpha,
+                                      *(float*)p.beta,
+                                      static_cast<int>(p.m),
+                                      static_cast<int>(p.n),
+                                      static_cast<int>(p.k)};
+
+                         size_t argsSize = sizeof(args);
+
+                         void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
+                                           &args,
+                                           HIP_LAUNCH_PARAM_BUFFER_SIZE,
+                                           &argsSize,
+                                           HIP_LAUNCH_PARAM_END};
+
+                         // Grid: 1 thread per element, 256 threads per block
+                         // For M=128, N=64 -> 8192 threads -> 32 blocks
+                         int threads   = static_cast<int>(p.m * p.n);
+                         int blockSize = 256;
+                         int blocks    = (threads + blockSize - 1) / blockSize;
+
+                         hipError_t err = hipModuleLaunchKernel(func,
+                                                                blocks,
+                                                                1,
+                                                                1, // Grid
+                                                                blockSize, // Block
+                                                                1,
+                                                                1,
+                                                                0, // Shared Mem
+                                                                p.stream, // Stream
+                                                                NULL,
+                                                                config);
+
+                         if(err != hipSuccess)
+                         {
+                             std::cerr
+                                 << "[DirectAssembly] Launch failed: " << hipGetErrorString(err)
+                                 << std::endl;
+                             return false;
+                         }
+                         return true;
+                     }}};
+        }
+
+        static const std::vector<RegistryEntry>& getRegistry()
+        {
+            static std::vector<RegistryEntry> registry = {
+                // Register your rules here:
+                entrySimpleGemmPoC(),
+                // entryLargeProblem(),
+            };
+            return registry;
+        }
+
+        static hipFunction_t getFunction(const KernelInfo& info)
+        {
+            // Static variables for caching (Singleton-like behavior)
+            static std::mutex                                     mutex;
+            static std::unordered_map<std::string, hipFunction_t> funcMap;
+            static std::vector<hipModule_t>                       modules; // Keep alive
+
+            std::lock_guard<std::mutex> lock(mutex);
+
+            std::string key = info.coPath + "::" + info.funcName;
+
+            if(funcMap.count(key))
+            {
+                return funcMap[key];
+            }
+
+            std::cout << "[DirectAssembly] Loading module: " << info.coPath << std::endl;
+
+            hipModule_t module;
+            if(hipModuleLoad(&module, info.coPath.c_str()) != hipSuccess)
+            {
+                std::cerr << "[DirectAssembly] Failed to load module: " << info.coPath << std::endl;
+                return nullptr;
+            }
+
+            hipFunction_t func;
+            if(hipModuleGetFunction(&func, module, info.funcName.c_str()) != hipSuccess)
+            {
+                std::cerr << "[DirectAssembly] Failed to find symbol: " << info.funcName
+                          << std::endl;
+                return nullptr;
+            }
+
+            modules.push_back(module);
+            funcMap[key] = func;
+            return func;
+        }
+    };
+
+} // End anonymous namespace
 
 RocblasltContractionProblem::RocblasltContractionProblem(hipblasOperation_t     trans_a,
                                                          hipblasOperation_t     trans_b,
@@ -2536,243 +2755,6 @@ bool useRocRoller(rocblaslt_handle handle, const RocblasltContractionProblem& pr
 }
 #endif
 
-namespace
-{
-
-    static bool isDirectAssemblyEnabled()
-    {
-        static bool enabled = []() {
-            const char* env = getenv("HIPBLASLT_ENABLE_DIRECT_ASSEMBLY");
-            if(env && (std::string(env) == "1" || std::string(env) == "TRUE"))
-            {
-                return true;
-            }
-            return false;
-        }();
-        return enabled;
-    }
-
-    static std::string getCustomCoPath(const std::string& filename)
-    {
-        const char* env = std::getenv("HIPBLASLT_CUSTOM_ASM_DIR");
-        if(env)
-        {
-            std::string path = env;
-            // Ensure trailing slash
-            if(!path.empty() && path.back() != '/')
-            {
-                path += "/";
-            }
-            return path + filename;
-        }
-
-        // Fallback: Use current directory or a specific hardcoded path for safety
-        return "./" + filename;
-    }
-
-    /**
-      * @brief Singleton manager for direct assembly kernels.
-      * Handles rule selection, module loading, and kernel launching.
-      */
-    class DirectAssembly
-    {
-    public:
-        // The function signature for checking if a kernel applies to a problem.
-        using KernelSelector
-            = std::function<bool(rocblaslt_handle, const RocblasltContractionProblem&)>;
-
-        // The function signature for launching the kernel.
-        using KernelLauncher
-            = std::function<bool(hipFunction_t, const RocblasltContractionProblem&)>;
-
-        struct KernelInfo
-        {
-            std::string    coPath;
-            std::string    funcName;
-            KernelLauncher launcher;
-        };
-
-        struct RegistryEntry
-        {
-            std::string    name;
-            KernelSelector selector;
-            KernelInfo     info;
-        };
-
-        // Main Entry Point
-        static bool dispatch(rocblaslt_handle                   handle,
-                             const rocblaslt_matmul_algo*       algo,
-                             const RocblasltContractionProblem& prob)
-        {
-            // 1. Find matching kernel info
-            const auto* info = findKernel(handle, prob);
-            if(!info)
-            {
-                return false;
-            }
-
-            // 2. Get cached GPU function handle
-            hipFunction_t func = getFunction(*info);
-            if(!func)
-            {
-                std::cerr << "[DirectAssembly] Failed to get GPU function handle." << std::endl;
-                return false;
-            }
-
-            // 3. Execute launcher
-            return info->launcher(func, prob);
-        }
-
-    private:
-        // Rule 1: Simple GEMM PoC
-        static RegistryEntry entrySimpleGemmPoC()
-        {
-            return {"SimpleGemm_PoC", // Name
-                    [](rocblaslt_handle, const RocblasltContractionProblem& p) -> bool {
-                        // 1. Check Dimensions
-                        bool dimsMatch = (p.m == 128 && p.n == 64 && p.k == 256);
-
-                        // 2. Check Data Types (All F32)
-                        // Assuming standard hipBLASLt enum names:
-                        bool typesMatch = (p.a_type == HIP_R_32F && p.b_type == HIP_R_32F
-                                           && p.c_type == HIP_R_32F && p.d_type == HIP_R_32F);
-
-                        return dimsMatch && typesMatch;
-                    },
-                    // Info & Launcher
-                    {getCustomCoPath("poc_co.co"),
-                     "SimpleGemm", // Symbol
-                     [](hipFunction_t func, const RocblasltContractionProblem& p) -> bool {
-                         std::cout << "[DirectAssembly] Launching SimpleGemm..." << std::endl;
-
-                         struct Args
-                         {
-                             void*       D;
-                             const void *A, *B, *C;
-                             float       alpha, beta;
-                             int         m, n, k;
-                         };
-
-                         Args args = {p.D,
-                                      p.A,
-                                      p.B,
-                                      p.C,
-                                      *(float*)p.alpha,
-                                      *(float*)p.beta,
-                                      static_cast<int>(p.m),
-                                      static_cast<int>(p.n),
-                                      static_cast<int>(p.k)};
-
-                         size_t argsSize = sizeof(args);
-
-                         void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
-                                           &args,
-                                           HIP_LAUNCH_PARAM_BUFFER_SIZE,
-                                           &argsSize,
-                                           HIP_LAUNCH_PARAM_END};
-
-                         // Grid: 1 thread per element, 256 threads per block
-                         // For M=128, N=64 -> 8192 threads -> 32 blocks
-                         int threads   = static_cast<int>(p.m * p.n);
-                         int blockSize = 256;
-                         int blocks    = (threads + blockSize - 1) / blockSize;
-
-                         hipError_t err = hipModuleLaunchKernel(func,
-                                                                blocks,
-                                                                1,
-                                                                1, // Grid
-                                                                blockSize, // Block
-                                                                1,
-                                                                1,
-                                                                0, // Shared Mem
-                                                                p.stream, // Stream
-                                                                NULL,
-                                                                config);
-
-                         if(err != hipSuccess)
-                         {
-                             std::cerr
-                                 << "[DirectAssembly] Launch failed: " << hipGetErrorString(err)
-                                 << std::endl;
-                             return false;
-                         }
-                         return true;
-                     }}};
-        }
-
-        static const std::vector<RegistryEntry>& getRegistry()
-        {
-            static std::vector<RegistryEntry> registry = {
-                // Register your rules here:
-                entrySimpleGemmPoC(),
-                // entryLargeProblem(),
-            };
-            return registry;
-        }
-
-        static const KernelInfo* findKernel(rocblaslt_handle                   handle,
-                                            const RocblasltContractionProblem& prob)
-        {
-            for(const auto& entry : getRegistry())
-            {
-                if(entry.selector(handle, prob))
-                {
-                    std::cout << "[DirectAssembly] Match found: " << entry.name << std::endl;
-                    return &entry.info;
-                }
-            }
-            return nullptr;
-        }
-
-        static hipFunction_t getFunction(const KernelInfo& info)
-        {
-            // Static variables for caching (Singleton-like behavior)
-            static std::mutex                                     mutex;
-            static std::unordered_map<std::string, hipFunction_t> funcMap;
-            static std::vector<hipModule_t>                       modules; // Keep alive
-
-            std::lock_guard<std::mutex> lock(mutex);
-
-            std::string key = info.coPath + "::" + info.funcName;
-
-            if(funcMap.count(key))
-            {
-                return funcMap[key];
-            }
-
-            std::cout << "[DirectAssembly] Loading module: " << info.coPath << std::endl;
-
-            hipModule_t module;
-            if(hipModuleLoad(&module, info.coPath.c_str()) != hipSuccess)
-            {
-                std::cerr << "[DirectAssembly] Failed to load module: " << info.coPath << std::endl;
-                return nullptr;
-            }
-
-            hipFunction_t func;
-            if(hipModuleGetFunction(&func, module, info.funcName.c_str()) != hipSuccess)
-            {
-                std::cerr << "[DirectAssembly] Failed to find symbol: " << info.funcName
-                          << std::endl;
-                return nullptr;
-            }
-
-            modules.push_back(module);
-            funcMap[key] = func;
-            return func;
-        }
-    };
-
-    // Returns true if GEMM was run with direct assembly, false otherwise.
-    bool useDirectAssembly(rocblaslt_handle                   handle,
-                           const rocblaslt_matmul_algo*       algo,
-                           const RocblasltContractionProblem& prob)
-    {
-        return DirectAssembly::dispatch(handle, algo, prob);
-    }
-
-} // End anonymous namespace
-
 /******************************************************************************
  * runContractionProblem calls Tensile to run a contraction problem described *
  * by RocblasltContractionProblem *
@@ -2787,13 +2769,17 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
 
     try
     {
-
-        // Check if the environment variable to enable direct assembly is set.
-        // If it is, try and run the problem using direct assembly kernels.
-        // If you succeed, continue. Otherwise fall through to normal roc-roller + tensilelite paths.
-        if(isDirectAssemblyEnabled() && useDirectAssembly(handle, algo, prob))
+        if(DirectAssembly::isEnabled())
         {
-            return rocblaslt_status_success;
+            const auto* kernel = DirectAssembly::findKernel(handle, prob);
+            if(kernel)
+            {
+                if(DirectAssembly::dispatch(handle, *kernel, prob))
+                {
+                    return rocblaslt_status_success;
+                }
+                throw std::runtime_error("Failed to run Direct Assembly kernel.");
+            }
         }
 
 #ifdef HIPBLASLT_USE_ROCROLLER
@@ -3841,6 +3827,26 @@ rocblaslt_status getBestSolutions(RocblasltContractionProblem const& prob,
                                   int*                               returnAlgoCount,
                                   size_t                             maxWorkSpaceBytes)
 {
+
+    // If direct assembly is enabled (environment variable), and there is a direct assembly kernel that can perform prob,
+    // set the returnAlgoCount to 1 and return success.
+    if(!DirectAssembly::isEnabled())
+    {
+        std::cout << "[DirectAssembly] Direct assembly not enabled" << std::endl;
+    }
+    else if(DirectAssembly::findKernel(handle, prob))
+    {
+
+        std::cout << "[DirectAssembly] Match found" << std::endl;
+        *returnAlgoCount = 1;
+        return rocblaslt_status_success;
+    }
+    else
+    {
+        std::cout << "[DirectAssembly] Direct assembly enabled but no matching kernel found"
+                  << std::endl;
+    }
+
 #ifdef HIPBLASLT_USE_ROCROLLER
     if(useRocRoller(handle, prob))
         return getRocRollerBestSolutions(handle,

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -26,7 +26,8 @@
 
 // The implementation of the rocblaslt<->Tensile interface layer.
 
-#include "rocblaslt.h"
+#include <hip/hip_runtime.h>
+#include <iostream>
 
 /*****************************************************************************
  * This is the only file in rocblaslt which should #include Tensile headers    *
@@ -35,7 +36,6 @@
 
 #include "Debug.hpp"
 #include "rocblaslt-types.h"
-#include "rocblaslt_mat_utils.hpp"
 #include "tensile_host.hpp"
 
 #ifdef HIPBLASLT_USE_ROCROLLER
@@ -52,21 +52,34 @@
 #include <Tensile/hip/HipHardware.hpp>
 #include <Tensile/hip/HipSolutionAdapter.hpp>
 #include <Tensile/hip/HipUtils.hpp>
+#include <functional>
+#include <hip/hip_runtime.h>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include <atomic>
-#include <complex>
 #include <exception>
 #include <filesystem>
-#include <iomanip>
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <regex>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <type_traits>
 #include <vector>
+
+#define CHECK_HIP_DRV(cmd)                                                              \
+    {                                                                                   \
+        hipError_t error = cmd;                                                         \
+        if(error != hipSuccess)                                                         \
+        {                                                                               \
+            std::cerr << "HIP Driver Error: " << hipGetErrorString(error) << std::endl; \
+            return false;                                                               \
+        }                                                                               \
+    }
 
 #define HIPBLASLT_LIB_PATH "/opt/rocm/lib"
 
@@ -2523,6 +2536,243 @@ bool useRocRoller(rocblaslt_handle handle, const RocblasltContractionProblem& pr
 }
 #endif
 
+namespace
+{
+
+    static bool isDirectAssemblyEnabled()
+    {
+        static bool enabled = []() {
+            const char* env = getenv("HIPBLASLT_ENABLE_DIRECT_ASSEMBLY");
+            if(env && (std::string(env) == "1" || std::string(env) == "TRUE"))
+            {
+                return true;
+            }
+            return false;
+        }();
+        return enabled;
+    }
+
+    static std::string getCustomCoPath(const std::string& filename)
+    {
+        const char* env = std::getenv("HIPBLASLT_CUSTOM_ASM_DIR");
+        if(env)
+        {
+            std::string path = env;
+            // Ensure trailing slash
+            if(!path.empty() && path.back() != '/')
+            {
+                path += "/";
+            }
+            return path + filename;
+        }
+
+        // Fallback: Use current directory or a specific hardcoded path for safety
+        return "./" + filename;
+    }
+
+    /**
+      * @brief Singleton manager for direct assembly kernels.
+      * Handles rule selection, module loading, and kernel launching.
+      */
+    class DirectAssembly
+    {
+    public:
+        // The function signature for checking if a kernel applies to a problem.
+        using KernelSelector
+            = std::function<bool(rocblaslt_handle, const RocblasltContractionProblem&)>;
+
+        // The function signature for launching the kernel.
+        using KernelLauncher
+            = std::function<bool(hipFunction_t, const RocblasltContractionProblem&)>;
+
+        struct KernelInfo
+        {
+            std::string    coPath;
+            std::string    funcName;
+            KernelLauncher launcher;
+        };
+
+        struct RegistryEntry
+        {
+            std::string    name;
+            KernelSelector selector;
+            KernelInfo     info;
+        };
+
+        // Main Entry Point
+        static bool dispatch(rocblaslt_handle                   handle,
+                             const rocblaslt_matmul_algo*       algo,
+                             const RocblasltContractionProblem& prob)
+        {
+            // 1. Find matching kernel info
+            const auto* info = findKernel(handle, prob);
+            if(!info)
+            {
+                return false;
+            }
+
+            // 2. Get cached GPU function handle
+            hipFunction_t func = getFunction(*info);
+            if(!func)
+            {
+                std::cerr << "[DirectAssembly] Failed to get GPU function handle." << std::endl;
+                return false;
+            }
+
+            // 3. Execute launcher
+            return info->launcher(func, prob);
+        }
+
+    private:
+        // Rule 1: Simple GEMM PoC
+        static RegistryEntry entrySimpleGemmPoC()
+        {
+            return {"SimpleGemm_PoC", // Name
+                    [](rocblaslt_handle, const RocblasltContractionProblem& p) -> bool {
+                        // 1. Check Dimensions
+                        bool dimsMatch = (p.m == 128 && p.n == 64 && p.k == 256);
+
+                        // 2. Check Data Types (All F32)
+                        // Assuming standard hipBLASLt enum names:
+                        bool typesMatch = (p.a_type == HIP_R_32F && p.b_type == HIP_R_32F
+                                           && p.c_type == HIP_R_32F && p.d_type == HIP_R_32F);
+
+                        return dimsMatch && typesMatch;
+                    },
+                    // Info & Launcher
+                    {getCustomCoPath("poc_co.co"),
+                     "SimpleGemm", // Symbol
+                     [](hipFunction_t func, const RocblasltContractionProblem& p) -> bool {
+                         std::cout << "[DirectAssembly] Launching SimpleGemm..." << std::endl;
+
+                         struct Args
+                         {
+                             void*       D;
+                             const void *A, *B, *C;
+                             float       alpha, beta;
+                             int         m, n, k;
+                         };
+
+                         Args args = {p.D,
+                                      p.A,
+                                      p.B,
+                                      p.C,
+                                      *(float*)p.alpha,
+                                      *(float*)p.beta,
+                                      static_cast<int>(p.m),
+                                      static_cast<int>(p.n),
+                                      static_cast<int>(p.k)};
+
+                         size_t argsSize = sizeof(args);
+
+                         void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER,
+                                           &args,
+                                           HIP_LAUNCH_PARAM_BUFFER_SIZE,
+                                           &argsSize,
+                                           HIP_LAUNCH_PARAM_END};
+
+                         // Grid: 1 thread per element, 256 threads per block
+                         // For M=128, N=64 -> 8192 threads -> 32 blocks
+                         int threads   = static_cast<int>(p.m * p.n);
+                         int blockSize = 256;
+                         int blocks    = (threads + blockSize - 1) / blockSize;
+
+                         hipError_t err = hipModuleLaunchKernel(func,
+                                                                blocks,
+                                                                1,
+                                                                1, // Grid
+                                                                blockSize, // Block
+                                                                1,
+                                                                1,
+                                                                0, // Shared Mem
+                                                                p.stream, // Stream
+                                                                NULL,
+                                                                config);
+
+                         if(err != hipSuccess)
+                         {
+                             std::cerr
+                                 << "[DirectAssembly] Launch failed: " << hipGetErrorString(err)
+                                 << std::endl;
+                             return false;
+                         }
+                         return true;
+                     }}};
+        }
+
+        static const std::vector<RegistryEntry>& getRegistry()
+        {
+            static std::vector<RegistryEntry> registry = {
+                // Register your rules here:
+                entrySimpleGemmPoC(),
+                // entryLargeProblem(),
+            };
+            return registry;
+        }
+
+        static const KernelInfo* findKernel(rocblaslt_handle                   handle,
+                                            const RocblasltContractionProblem& prob)
+        {
+            for(const auto& entry : getRegistry())
+            {
+                if(entry.selector(handle, prob))
+                {
+                    std::cout << "[DirectAssembly] Match found: " << entry.name << std::endl;
+                    return &entry.info;
+                }
+            }
+            return nullptr;
+        }
+
+        static hipFunction_t getFunction(const KernelInfo& info)
+        {
+            // Static variables for caching (Singleton-like behavior)
+            static std::mutex                                     mutex;
+            static std::unordered_map<std::string, hipFunction_t> funcMap;
+            static std::vector<hipModule_t>                       modules; // Keep alive
+
+            std::lock_guard<std::mutex> lock(mutex);
+
+            std::string key = info.coPath + "::" + info.funcName;
+
+            if(funcMap.count(key))
+            {
+                return funcMap[key];
+            }
+
+            std::cout << "[DirectAssembly] Loading module: " << info.coPath << std::endl;
+
+            hipModule_t module;
+            if(hipModuleLoad(&module, info.coPath.c_str()) != hipSuccess)
+            {
+                std::cerr << "[DirectAssembly] Failed to load module: " << info.coPath << std::endl;
+                return nullptr;
+            }
+
+            hipFunction_t func;
+            if(hipModuleGetFunction(&func, module, info.funcName.c_str()) != hipSuccess)
+            {
+                std::cerr << "[DirectAssembly] Failed to find symbol: " << info.funcName
+                          << std::endl;
+                return nullptr;
+            }
+
+            modules.push_back(module);
+            funcMap[key] = func;
+            return func;
+        }
+    };
+
+    // Returns true if GEMM was run with direct assembly, false otherwise.
+    bool useDirectAssembly(rocblaslt_handle                   handle,
+                           const rocblaslt_matmul_algo*       algo,
+                           const RocblasltContractionProblem& prob)
+    {
+        return DirectAssembly::dispatch(handle, algo, prob);
+    }
+
+} // End anonymous namespace
+
 /******************************************************************************
  * runContractionProblem calls Tensile to run a contraction problem described *
  * by RocblasltContractionProblem *
@@ -2532,9 +2782,20 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
                                        const RocblasltContractionProblem& prob,
                                        std::shared_ptr<void>              gemmData)
 {
+
     rocblaslt_status status = rocblaslt_status_internal_error;
+
     try
     {
+
+        // Check if the environment variable to enable direct assembly is set.
+        // If it is, try and run the problem using direct assembly kernels.
+        // If you succeed, continue. Otherwise fall through to normal roc-roller + tensilelite paths.
+        if(isDirectAssemblyEnabled() && useDirectAssembly(handle, algo, prob))
+        {
+            return rocblaslt_status_success;
+        }
+
 #ifdef HIPBLASLT_USE_ROCROLLER
         if(useRocRoller(handle, prob))
             return runRocRollerContractionProblem(handle, algo, prob);
@@ -2620,7 +2881,9 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
                                                   false);
         }
 
-        auto solution = library->getSolutionByIndex(data->problem, *hardware, *solutionIndex);
+        // Print the data problem:
+        std::shared_ptr<TensileLite::ContractionSolution> solution
+            = library->getSolutionByIndex(data->problem, *hardware, *solutionIndex);
         if(prob.workspaceSize < solution->requiredWorkspaceSize(data->problem, *hardware))
         {
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
@@ -2696,7 +2959,9 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
             // set XCC=1 to param when this is a fallback solution
             data->problem.setParams().setWGMXCC((isCUFallback ? 1 : 0));
 
-            auto kernels = solution->solve(data->problem, GetTensileInputs(prob), *hardware);
+            std::vector<TensileLite::KernelInvocation> kernels
+                = solution->solve(data->problem, GetTensileInputs(prob), *hardware);
+
             // Remove this after supports getting comgr buffers from hip.
             bool isPreloaded = false;
             if(rocblaslt::Debug::Instance().preload())
@@ -3626,7 +3891,8 @@ rocblaslt_status getBestSolutions(RocblasltContractionProblem const& prob,
         for(size_t i = 0; i < algoCount; ++i)
         {
             auto& solution = solutions[i];
-            msg << "getBestSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
+            msg << "getBestSolutions(): sol-idx = " << solution->index
+                << ", sol-tag = " << solution->matchingTag() << std::endl;
         }
         log_info(__func__, msg.str());
     }
@@ -3702,7 +3968,7 @@ rocblaslt_status getAllSolutions(MyProblem&                                     
 
     heuristicResults.resize(solutions.size());
 
-    int i = 0;
+    int i                 = 0;
     int duplicated_counts = 0;
     for(auto solution : solutions)
     {
@@ -3731,7 +3997,8 @@ rocblaslt_status getAllSolutions(MyProblem&                                     
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
         {
             std::ostringstream msg;
-            msg << "getAllSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
+            msg << "getAllSolutions(): sol-idx = " << solution->index
+                << ", sol-tag = " << solution->matchingTag() << std::endl;
             log_info(__func__, msg.str());
         }
 
@@ -4218,7 +4485,8 @@ rocblaslt_status getBestSolutions(rocblaslt_handle       handle,
             for(size_t i = 0; i < algoCount; ++i)
             {
                 auto& solution = solutions[i];
-                msg << "getBestSolutions(): sol-idx = " << solution->index << ", sol-tag = " << solution->matchingTag() << std::endl;
+                msg << "getBestSolutions(): sol-idx = " << solution->index
+                    << ", sol-tag = " << solution->matchingTag() << std::endl;
             }
             log_info(__func__, msg.str());
         }

--- a/shared/mxdatagenerator/lib/include/mxDataGenerator/DataGenerator.hpp
+++ b/shared/mxdatagenerator/lib/include/mxDataGenerator/DataGenerator.hpp
@@ -354,13 +354,47 @@ namespace DGen
     template <typename DTYPE>
     std::vector<uint8_t> DataGenerator<DTYPE>::getDataBytes() const
     {
-        return DataGenerator::packArray(m_dataDesc, m_dataBytes);
+        auto dataBytes = DataGenerator::packArray(m_dataDesc, m_dataBytes);
+        std::cout << "[DIRECT ASSEMBLY DEBUG] return data bytes of size " << dataBytes.size() << std::endl;
+        // for(uint64_t i = 0; i < 200; ++i)
+        // {
+        //     std::cout << " " << int(dataBytes[i]);
+        //     if((i + 1) % 20 == 0)
+        //     {
+        //         std::cout << std::endl;
+        //     }
+        // }
+        // std::cout << std::endl;
+        //  for (auto x : dataBytes){
+        //    if (x != dataBytes[0]){
+        //      std::cout << "[DIRECT ASSEMBLY DEBUG] Different data!" << std::endl;
+        //      std::abort();
+        //    }
+        //  }
+        return dataBytes;
     }
 
     template <typename DTYPE>
     std::vector<uint8_t> DataGenerator<DTYPE>::getScaleBytes() const
     {
-        return DataGenerator::packArray(m_scaleDesc, m_scaleBytes);
+        auto scaleBytes = DataGenerator::packArray(m_scaleDesc, m_scaleBytes);
+        std::cout << "[DIRECT ASSEMBLY DEBUG] return scale bytes of size " << scaleBytes.size() << std::endl;
+        // for(uint64_t i = 0; i < 200; ++i)
+        // {
+        //     std::cout << " " << int(scaleBytes[i]);
+        //     if((i + 1) % 20 == 0)
+        //     {
+        //         std::cout << std::endl;
+        //     }
+        // }
+        // std::cout << std::endl;
+        //  for (auto x : scaleBytes){
+        //    if (x != scaleBytes[0]){
+        //      std::cout << "[DIRECT ASSEMBLY DEBUG] Different scale!" << std::endl;
+        //      std::abort();
+        //    }
+        //  }
+        return scaleBytes;
     }
 
     template <typename DTYPE>


### PR DESCRIPTION
## Goal of this PR

We have been provided with an AITER .co file that we want to use instead of RocRoller's generated kernel, but only when Origami predicts that the best macro-tile size is 256x256 (see task description [here](https://amd-hub.atlassian.net/browse/AIROCROLL-1511)).


## Summary of PR

Currently (before this PR), the approach hipblaslt takes is, at a high-level 

```python
if canRunRocRoller: 
  return useRocroller()
return useTensilelite()
```

This PR changes this to 

```python
if canUseAssemblyDirect:
   return useAssemblyDirect()
if canRunRocRoller: 
  return useRocroller()
return useTensilelite()
```

Another PR being worked on by @awhittle3 and others uses a cleaner approach for packaging external kernels, and it will use the approach: 

```python
if canRunRocRoller: 
  # origami logic runs here
  if canUseAssemblyDirect:
     return useAssemblyDirect()
  return useRocroller()
return useTensilelite()
```

Where the difference above is that the Origami logic can be used more cleanly is deciding whether to use the externel kernel ('assembly direct'). 

This current PR has 2 environment variables, set as:

```bash
 export HIPBLASLT_CUSTOM_ASM_DIR=/path/to/custom/file.co
 export HIPBLASLT_ENABLE_DIRECT_ASSEMBLY=1
 ```
 
The first of these is hacky -- these .co files should be packaged correctly within the install of hipblaslt in production. 
 
I have generated a toy .co file (see poc_co.cpp in this PR) for doing single precision gemm. To use 
 
 1) Compile it to a .co file, and put it in the directory ${HIPBLASLT_CUSTOM_ASM_DIR}, and then 
 2) Add the glue to register it in hipblaslt (already in this PR) 
 
 Running hipblaslt-bench, I see the following logging which shows that the custom kernel ran:
  
 ```bash
 ./clients/hipblaslt-bench  -m 128 -n 64 -k 256 -r f32_r --verify --alpha 1 --beta 1
[...]
[DirectAssembly] Match found: SimpleGemm_PoC
[DirectAssembly] Loading module: /home/jnewling/workspace/amd-experiments/hip_hipblaslt_standalone/poc_co.co
[DirectAssembly] Launching SimpleGemm...
[DirectAssembly] Match found: SimpleGemm_PoC
[DirectAssembly] Launching SimpleGemm...
[...]
[0]:transA,transB,grouped_gemm,batch_count,m,n,k,alpha,lda,stride_a,beta,ldb,stride_b,ldc,stride_c,ldd,stride_d,a_type,b_type,c_type,d_type,compute_type,scaleA,scaleB,scaleC,scaleD,amaxD,swizzle_a,swizzle_b,activation_type,bias_vector,bias_type,aux_type,rotating_buffer,flush,use_gpu_timer,hipblaslt-Gflops,hipblaslt-GB/s,us,CPU-Gflops,CPU-us,norm_error,atol,rtol
    N,N,0,1,128,64,256,1,128,32768,1,256,16384,128,8192,128,8192,f32_r,f32_r,f32_r,f32_r,f32_r,0,0,0,0,0,0,0,none,0,f32_r,f32_r,0,0,0,119.156,6.93581,35.2,0.220278,19041,2.94527e-07,1e-06,1e-05
```

If I disable the environment variable with 

`export HIPBLASLT_ENABLE_DIRECT_ASSEMBLY=0`,  the custom kernel is not used. 

## Integrating the AITER kernel

For the production .co that we want to use, we need to get information from running the kernel through AITER. Below I describe this (this step will be dependent on the source of the kernel).

Building AITER: My approach was 

0) Get AITER at https://github.com/ROCm/aiter
1) create a venv
2) wget https://download.pytorch.org/whl/rocm7.1/torch-2.10.0%2Brocm7.1-cp310-cp310-manylinux_2_28_x86_64.whl
3) pip3 install ./torch-2.10.0+rocm7.1-cp310-cp310-manylinux_2_28_x86_64.whl torchvision --index-url https://download.pytorch.org/whl/rocm7.1
4) pip install the 2 mentioned deps on https://github.com/ROCm/aiter

Run the test that exercises the kernel:
```
python3 op_tests/test_gemm_a4w4.py
```
Kernels are cached after compilation. To remove the cache (important if the printing / kernel changes) I did:

```
rm -rf aiter/jit
git checkout main aiter/jit
```

For figuring out kernel arguments, the branch is https://github.com/newling/aiter/tree/printing_for_kernel_arg_debug. I dumped the kernel arguments as bytes to help verify that intergration glue into hipblaslt is correct. 

```
Offset | 00 01 02 03 04 05 06 07 | 08 09 0A 0B 0C 0D 0E 0F
-------|-------------------------|-------------------------
0000   | 00 00 20 6d ab 7f 00 00 | 00 00 00 00 00 00 00 00 
0016   | 00 00 00 00 00 00 00 00 | 00 00 00 00 00 00 00 00 
[...]
0336   | 80 00 00 00 00 00 00 00 | 00 00 00 00 00 00 00 00 
0352   | 00 00 00 00 00 00 00 00 | 00 00 00 00 00 00 00 00 
0368   | 00 00 00 00             |                         
```

Important to note: Getting the kernel arguments matching was not enough for this specific kernel, the scale values needed to have a special layout (tiling) in HBM. That was the trickiest part of getting the kernel to give numerically correct results in hipblaslt (thanks to @bethune-bryant and @bnemanich for decoding the AITER logic). 
