### PR TITLE
[hipdnn]: disable some hipdnn sample tests on windows due to missing solvers

### DIFF
--- a/projects/hipdnn/samples/CMakeLists.txt
+++ b/projects/hipdnn/samples/CMakeLists.txt
@@ -82,8 +82,11 @@ endfunction()
 add_hipdnn_sample_test(conv_fprop)
 add_hipdnn_sample_test(conv_dgrad)
 add_hipdnn_sample_test(conv_wgrad)
-add_hipdnn_sample_test(fused_conv_fprop_activ)
-add_hipdnn_sample_test(fused_conv_fprop_bias_activ)
+
+if(NOT WIN32)
+    add_hipdnn_sample_test(fused_conv_fprop_activ)
+    add_hipdnn_sample_test(fused_conv_fprop_bias_activ)
+endif()
 
 # Register batchnorm samples as tests
 add_hipdnn_sample_test(bn_inference)

--- a/projects/hipdnn/samples/CMakeLists.txt
+++ b/projects/hipdnn/samples/CMakeLists.txt
@@ -84,6 +84,7 @@ add_hipdnn_sample_test(conv_dgrad)
 add_hipdnn_sample_test(conv_wgrad)
 
 if(NOT WIN32)
+    # Some fused conv samples are not supported on windows due to lack of CK support
     add_hipdnn_sample_test(fused_conv_fprop_activ)
     add_hipdnn_sample_test(fused_conv_fprop_bias_activ)
 endif()


### PR DESCRIPTION
## Motivation

Some solvers on gfx1151 on windows are currently unavailable.  Disable the tests for the time being. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
