### PR TITLE
[MIOpen] BatchNorm Forward Inference: add z-dimension blocks for batch parallelism

### DIFF
--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdInferPerActHIP.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdInferPerActHIP.cpp
@@ -52,7 +52,7 @@ __device__ __forceinline__ void BNFwdInferPerActivationImpl(unsigned int adjInde
     FLOAT value[MIO_BN_VEC_SIZE];
 
     // loop over the batches
-    for(unsigned int n = 0; n < batchSize; ++n)
+    for(unsigned int n = blockIdx.z; n < batchSize; n += gridDim.z)
     {
         // load input value
         const unsigned int batchIndex = (n * batchStride) + adjIndex;
@@ -91,13 +91,14 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+    unsigned int tidz = blockIdx.z * MIO_BN_GRP2 + threadIdx.z;
 
     // decide vector sizes based on problem layout
     constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
     constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
 
     // skip execution for out-of-bound threads
-    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw)
+    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw || tidz >= batchSize)
     {
         return;
     }
@@ -147,13 +148,14 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+    unsigned int tidz = blockIdx.z * MIO_BN_GRP2 + threadIdx.z;
 
     // decide vector sizes based on problem layout
     constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
     constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
 
     // skip execution for out-of-bound threads
-    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw)
+    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw || tidz >= batchSize)
     {
         return;
     }

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdInferPerActHIP.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdInferPerActHIP.cpp
@@ -52,6 +52,9 @@ __device__ __forceinline__ void BNFwdInferPerActivationImpl(unsigned int adjInde
     FLOAT value[MIO_BN_VEC_SIZE];
 
     // loop over the batches
+    // NOTE: We use zlocalsize = 1 and zgridsize = min(batchSize, maxGridSizeToFillTheGPU). So the
+    // idea here is to use the blocks in z-dimension to cover the batch dimension first, and then
+    // each block will loop over the remaining batches with stride of gridDim.z if necessary.
     for(unsigned int n = blockIdx.z; n < batchSize; n += gridDim.z)
     {
         // load input value
@@ -91,7 +94,7 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
-    unsigned int tidz = blockIdx.z * MIO_BN_GRP2 + threadIdx.z;
+    unsigned int tidz = blockIdx.z;
 
     // decide vector sizes based on problem layout
     constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
@@ -148,7 +151,7 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
-    unsigned int tidz = blockIdx.z * MIO_BN_GRP2 + threadIdx.z;
+    unsigned int tidz = blockIdx.z;
 
     // decide vector sizes based on problem layout
     constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdInferSpatialHIP.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdInferSpatialHIP.cpp
@@ -59,7 +59,7 @@ __device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
     FLOAT value[MIO_BN_VEC_SIZE];
 
     // loop over the batches
-    for(unsigned int n = 0; n < batchSize; ++n)
+    for(unsigned int n = blockIdx.z; n < batchSize; n += gridDim.z)
     {
         // load input value
         const unsigned int batchIndex =
@@ -104,13 +104,14 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+    unsigned int tidz = blockIdx.z * MIO_BN_GRP2 + threadIdx.z;
 
     // decide vector sizes based on problem layout
     constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
     constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
 
     // skip execution for out-of-bound threads
-    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw)
+    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw || tidz >= batchSize)
     {
         return;
     }
@@ -192,13 +193,14 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+    unsigned int tidz = blockIdx.z * MIO_BN_GRP2 + threadIdx.z;
 
     // decide vector sizes based on problem layout
     constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
     constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
 
     // skip execution for out-of-bound threads
-    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw)
+    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw || tidz >= batchSize)
     {
         return;
     }

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdInferSpatialHIP.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdInferSpatialHIP.cpp
@@ -59,6 +59,9 @@ __device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
     FLOAT value[MIO_BN_VEC_SIZE];
 
     // loop over the batches
+    // NOTE: We use zlocalsize = 1 and zgridsize = min(batchSize, maxGridSizeToFillTheGPU). So the
+    // idea here is to use the blocks in z-dimension to cover the batch dimension first, and then
+    // each block will loop over the remaining batches with stride of gridDim.z if necessary.
     for(unsigned int n = blockIdx.z; n < batchSize; n += gridDim.z)
     {
         // load input value
@@ -104,7 +107,7 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
-    unsigned int tidz = blockIdx.z * MIO_BN_GRP2 + threadIdx.z;
+    unsigned int tidz = blockIdx.z;
 
     // decide vector sizes based on problem layout
     constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
@@ -193,7 +196,7 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
-    unsigned int tidz = blockIdx.z * MIO_BN_GRP2 + threadIdx.z;
+    unsigned int tidz = blockIdx.z;
 
     // decide vector sizes based on problem layout
     constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;

--- a/projects/miopen/src/solver/batchnorm/forward_inference.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_inference.cpp
@@ -108,13 +108,24 @@ ConvSolution BnFwdInference::GetSolution(const ExecutionContext& context,
             ylocalsize = max_localsize;
             ygridsize  = AlignUp(size_t{in_cstride / vectorsize}, ylocalsize);
         }
-        zlocalsize = 1;
-        zgridsize  = std::min(size_t{n}, size_t{65535}); // do not exceed max grid size in z
 
         // HIP runtime does not support non-uniform blocks
         // Adjust the global worker sizes accordingly
         xgridsize = AlignUp(xgridsize, xlocalsize);
         ygridsize = AlignUp(ygridsize, ylocalsize);
+
+        zlocalsize                = 1;
+        size_t active_threads_xy  = xgridsize * ygridsize;
+        size_t max_active_threads = handle.GetMaxComputeUnits() * 32 *
+                                    handle.GetWavefrontWidth(); // considering max 32 waves per CU
+        if(active_threads_xy < max_active_threads)
+        {
+            zgridsize = std::min(size_t{(max_active_threads / active_threads_xy)}, size_t{n});
+        }
+        else
+        {
+            zgridsize = 1;
+        }
 
         auto kernel = KernelInfo{};
 

--- a/projects/miopen/src/solver/batchnorm/forward_inference.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_inference.cpp
@@ -109,7 +109,7 @@ ConvSolution BnFwdInference::GetSolution(const ExecutionContext& context,
             ygridsize  = AlignUp(size_t{in_cstride / vectorsize}, ylocalsize);
         }
         zlocalsize = 1;
-        zgridsize  = 1;
+        zgridsize  = std::min(size_t{n}, size_t{65535}); // do not exceed max grid size in z
 
         // HIP runtime does not support non-uniform blocks
         // Adjust the global worker sizes accordingly


### PR DESCRIPTION
## Motivation

This PR aims to improve the performance of BatchNorm forward inference kernels by adding blocks in the z-dimension to parallelize the computations across the batch dimension.

## Technical Details

- Updates the `MIOpenBatchNormFwdInferSpatialEst` and `MIOpenBatchNormFwdInferPerActivationEst` kernels to parallelize batch computations by using z-dimension blocks, rather than having a single xy-block process the entire batch.
- The `BnFwdInference` solver is modified to try and launch as many blocks as possible in the z-dimension based on the batch size in an attempt to maximize the occupancy of the GPU.

## Test Plan

Changes can be verified with `test_bn_fwd_infer` and through the `MIOpenDriver` with the following options:
`bnorm[fp16|bfp16] --layout [NCHW|NHWC] --forw 2 --run 1`.

## Test Result

Tests pass on gfx90a and gfx942.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
