### PR TITLE
[Ex CI] Disable sparse-related Azure pipelines

### DIFF
--- a/.github/scripts/azure_resolve_subtree_deps.py
+++ b/.github/scripts/azure_resolve_subtree_deps.py
@@ -86,11 +86,6 @@ def main(argv=None) -> None:
         "projects/hipblaslt": {"projects/hipblas-common"},
         "projects/rocblas": {"projects/hipblaslt"},
         "projects/rocsolver": {"projects/rocprim", "projects/rocblas"},
-        "projects/rocsparse": {"projects/rocprim", "projects/rocblas"},
-        "projects/hipblas": {"projects/rocsolver"},
-        "projects/hipsolver": {"projects/rocsolver", "projects/rocsparse"},
-        "projects/hipsparse": {"projects/rocsparse"},
-        "projects/hipsparselt": {"projects/hipsparse"},
         "projects/hiptensor": {},
     }
     # Azure pipeline IDs for each project, to be populated as projects are enabled
@@ -107,11 +102,6 @@ def main(argv=None) -> None:
         "projects/hipblaslt": 301,
         "projects/rocblas": 302,
         "projects/rocsolver": 303,
-        "projects/rocsparse": 314,
-        "projects/hipblas": 317,
-        "projects/hipsolver": 322,
-        "projects/hipsparse": 315,
-        "projects/hipsparselt": 309,
         "shared/origami": 364,
         "projects/rocwmma": 370,
         "projects/hiptensor": 374,


### PR DESCRIPTION
Disabling the following pipelines from rocm-libraries:
- projects/rocsparse (ID: 314)
- projects/hipsparse (ID: 315)
- projects/hipsparselt (ID: 309)
- projects/hipblas (ID: 317)
- projects/hipsolver (ID: 322)

These components depend on sparse libraries and are being disabled as part of the sparse pipeline disablement effort.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
