### PR TITLE
[rocRoller] Add more division and modulo expression simplifications

### DIFF
--- a/shared/rocroller/lib/source/ExpressionTransformations/Simplify.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/Simplify.cpp
@@ -792,6 +792,224 @@ namespace rocRoller
                 return std::make_shared<Expression>(Expr({lhs, rhs, expr.comment}));
             }
 
+            // Helper: returns true if the value is positive
+            static bool isPositiveValue(ExpressionPtr const& expr)
+            {
+                auto type = resultVariableType(expr);
+                if(type.dataType == DataType::UInt32 || type.dataType == DataType::UInt64)
+                    return true;
+
+                if(evaluationTimes(expr)[EvaluationTime::Translate])
+                {
+                    auto val = evaluate(expr);
+                    return std::visit(
+                        [](auto&& v) -> bool {
+                            using T = std::decay_t<decltype(v)>;
+                            if constexpr(CIntegral<T>)
+                                return v > T(0);
+                            return false;
+                        },
+                        val);
+                }
+
+                return false;
+            }
+
+            ExpressionPtr operator()(Divide const& expr) const
+            {
+                auto resultVarType = resultVariableType(expr);
+
+                auto lhs = call(expr.lhs);
+                auto rhs = call(expr.rhs);
+
+                bool eval_lhs = evaluationTimes(lhs)[EvaluationTime::Translate];
+                bool eval_rhs = evaluationTimes(rhs)[EvaluationTime::Translate];
+
+                // Simplification: a / a = 1 (when expressions are identical)
+                if(identical(lhs, rhs))
+                {
+                    auto rv = literal(1, resultVarType);
+                    copyComment(rv, expr);
+                    return rv;
+                }
+
+                // Apply constant-based simplifications
+                auto simplifier = SimplifyByConstant<Divide>{resultVarType};
+
+                ExpressionPtr rv = nullptr;
+
+                if(eval_lhs && eval_rhs)
+                {
+                    rv = literal(evaluate(Divide({lhs, rhs})));
+                }
+                else if(eval_lhs)
+                {
+                    auto simplifierLHS = SimplifyByConstantLHS<Divide>{resultVarType};
+                    rv                 = simplifierLHS.call(evaluate(lhs), rhs);
+                }
+                else if(eval_rhs)
+                {
+                    rv = simplifier.call(lhs, evaluate(rhs));
+                }
+
+                if(rv != nullptr)
+                {
+                    if(resultVariableType(rv) != resultVarType)
+                    {
+                        AssertFatal(!resultVarType.isPointer(),
+                                    ShowValue(expr),
+                                    ShowValue(rv),
+                                    ShowValue(resultVarType));
+                        rv = convert(resultVarType.dataType, rv);
+                    }
+                    copyComment(rv, expr);
+                    return rv;
+                }
+
+                // Simplification: (a / b) / c = a / (b * c) (divide chain flattening)
+                // Valid for integers when both b and c are positive
+                if(lhs && std::holds_alternative<Divide>(*lhs))
+                {
+                    auto const& innerDiv = std::get<Divide>(*lhs);
+
+                    if(isPositiveValue(innerDiv.rhs) && isPositiveValue(rhs))
+                    {
+                        auto rv = innerDiv.lhs / (innerDiv.rhs * rhs);
+                        copyComment(rv, expr);
+                        return call(rv); // Recursively simplify in case of deeper chains
+                    }
+                }
+
+                // Simplification: (a * b) / b = a or (a * b) / a = b
+                if(lhs && std::holds_alternative<Multiply>(*lhs))
+                {
+                    auto const& mul = std::get<Multiply>(*lhs);
+                    if(identical(mul.rhs, rhs))
+                    {
+                        auto rv = mul.lhs;
+                        copyComment(rv, expr);
+                        return rv;
+                    }
+                    if(identical(mul.lhs, rhs))
+                    {
+                        auto rv = mul.rhs;
+                        copyComment(rv, expr);
+                        return rv;
+                    }
+                }
+
+                return std::make_shared<Expression>(Divide({lhs, rhs, expr.comment}));
+            }
+
+            ExpressionPtr operator()(Modulo const& expr) const
+            {
+                auto resultVarType = resultVariableType(expr);
+
+                auto lhs = call(expr.lhs);
+                auto rhs = call(expr.rhs);
+
+                bool eval_lhs = evaluationTimes(lhs)[EvaluationTime::Translate];
+                bool eval_rhs = evaluationTimes(rhs)[EvaluationTime::Translate];
+
+                // Simplification: a % a = 0 (when expressions are identical)
+                if(identical(lhs, rhs))
+                {
+                    auto rv = literal(0, resultVarType);
+                    copyComment(rv, expr);
+                    return rv;
+                }
+
+                // Simplification: (a * b) % b = 0 or (a * b) % a = 0
+                if(lhs && std::holds_alternative<Multiply>(*lhs))
+                {
+                    auto const& mul = std::get<Multiply>(*lhs);
+                    if(identical(mul.rhs, rhs) || identical(mul.lhs, rhs))
+                    {
+                        auto rv = literal(0, resultVarType);
+                        copyComment(rv, expr);
+                        return rv;
+                    }
+                }
+
+                // Apply constant-based simplifications
+                auto simplifier = SimplifyByConstant<Modulo>{resultVarType};
+
+                ExpressionPtr rv = nullptr;
+
+                if(eval_lhs && eval_rhs)
+                {
+                    rv = literal(evaluate(Modulo({lhs, rhs})));
+                }
+                else if(eval_rhs)
+                {
+                    rv = simplifier.call(lhs, evaluate(rhs));
+                }
+                else if(eval_lhs)
+                {
+                    auto simplifierLHS = SimplifyByConstantLHS<Modulo>{resultVarType};
+                    rv                 = simplifierLHS.call(evaluate(lhs), rhs);
+                }
+
+                if(rv != nullptr)
+                {
+                    if(resultVariableType(rv) != resultVarType)
+                    {
+                        AssertFatal(!resultVarType.isPointer(),
+                                    ShowValue(expr),
+                                    ShowValue(rv),
+                                    ShowValue(resultVarType));
+                        rv = convert(resultVarType.dataType, rv);
+                    }
+                    copyComment(rv, expr);
+                    return rv;
+                }
+
+                // Simplification: (a % b) % b = a % b (double modulo by same value)
+                if(lhs && std::holds_alternative<Modulo>(*lhs))
+                {
+                    auto const& innerMod = std::get<Modulo>(*lhs);
+                    if(identical(innerMod.rhs, rhs))
+                    {
+                        copyComment(lhs, expr);
+                        return lhs;
+                    }
+
+                    // Simplification: (a % b) % c = a % c when c divides b
+                    // Valid for integers: if b = k*c for integer k, then (a % b) % c = a % c
+                    // Proof: a % b gives remainder r where 0 <= r < b
+                    //        r % c = (a - q*b) % c = (a - q*k*c) % c = a % c
+                    if(evaluationTimes(innerMod.rhs)[EvaluationTime::Translate]
+                       && evaluationTimes(rhs)[EvaluationTime::Translate])
+                    {
+                        auto b_val = evaluate(innerMod.rhs);
+                        auto c_val = evaluate(rhs);
+
+                        // Check if both are integral types and c divides b
+                        bool canSimplify = std::visit(
+                            [](auto&& b, auto&& c) -> bool {
+                                using B_Type = std::decay_t<decltype(b)>;
+                                using C_Type = std::decay_t<decltype(c)>;
+
+                                if constexpr(CIntegral<B_Type> && CIntegral<C_Type>)
+                                    return c != C_Type(0) && b % c == B_Type(0);
+                                return false;
+                            },
+                            b_val,
+                            c_val);
+
+                        if(canSimplify)
+                        {
+                            auto rv = innerMod.lhs % rhs;
+                            copyComment(rv, expr);
+                            // Recursively simplify in case of deeper nesting
+                            return call(rv);
+                        }
+                    }
+                }
+
+                return std::make_shared<Expression>(Modulo({lhs, rhs, expr.comment}));
+            }
+
             ExpressionPtr operator()(BitfieldCombine const& expr) const
             {
                 auto cpy        = expr;

--- a/shared/rocroller/test/catch/ExpressionTransformationTest.cpp
+++ b/shared/rocroller/test/catch/ExpressionTransformationTest.cpp
@@ -79,6 +79,30 @@ TEST_CASE("Simplify ExpressionTransformation works", "[expression][expression-tr
         CHECK_THAT(simplify(v / one), IdenticalTo(v));
         CHECK_THAT(simplify(v / a), IdenticalTo(v / a));
         CHECK_THAT(simplify(b / v), IdenticalTo(b / v));
+
+        // 0 / a = 0
+        CHECK_THAT(simplify(zero / v), IdenticalTo(zero));
+        CHECK_THAT(simplify(zero / a), IdenticalTo(zero));
+
+        // a / a = 1
+        CHECK_THAT(simplify(v / v), IdenticalTo(one));
+        CHECK_THAT(simplify(a / a), IdenticalTo(one));
+
+        // (a / b) / c = a / (b * c) - division chain flattening
+        CHECK_THAT(simplify((v / a) / b), IdenticalTo(v / literal(3300)));
+        CHECK_THAT(simplify((v / literal(3)) / literal(11)), IdenticalTo(v / literal(33)));
+
+        // Division chain flattening should NOT occur with negative constants (signed types)
+        auto negTwo = literal(-2);
+        CHECK_THAT(simplify((v / a) / negTwo), IdenticalTo((v / a) / negTwo));
+
+        // (a * b) / b = a
+        CHECK_THAT(simplify((v * a) / a), IdenticalTo(v));
+        CHECK_THAT(simplify((a * v) / a), IdenticalTo(v));
+
+        // (a * b) / a = b
+        CHECK_THAT(simplify((v * a) / v), IdenticalTo(a));
+        CHECK_THAT(simplify((a * v) / v), IdenticalTo(a));
     }
 
     SECTION("Modulo")
@@ -87,6 +111,40 @@ TEST_CASE("Simplify ExpressionTransformation works", "[expression][expression-tr
         CHECK_THAT(simplify(v % one), IdenticalTo(zero));
         CHECK_THAT(simplify(v % a), IdenticalTo(v % a));
         CHECK_THAT(simplify(b % v), IdenticalTo(b % v));
+
+        // 0 % a = 0
+        CHECK_THAT(simplify(zero % v), IdenticalTo(zero));
+        CHECK_THAT(simplify(zero % a), IdenticalTo(zero));
+
+        // a % a = 0
+        CHECK_THAT(simplify(v % v), IdenticalTo(zero));
+        CHECK_THAT(simplify(a % a), IdenticalTo(zero));
+
+        // (a * b) % b = 0
+        CHECK_THAT(simplify((v * a) % a), IdenticalTo(zero));
+        CHECK_THAT(simplify((a * v) % a), IdenticalTo(zero));
+
+        // (a * b) % a = 0
+        CHECK_THAT(simplify((v * a) % v), IdenticalTo(zero));
+        CHECK_THAT(simplify((a * v) % v), IdenticalTo(zero));
+
+        // (a % b) % b = a % b - redundant double modulo
+        CHECK_THAT(simplify((v % a) % a), IdenticalTo(v % a));
+        CHECK_THAT(simplify((a % v) % v), IdenticalTo(a % v));
+
+        // (a % b) % c = a % c when c divides b
+        // Example: (v % 12) % 3 = v % 3  (since 3 divides 12)
+        auto twelve = literal(12);
+        auto three  = literal(3);
+        auto four   = literal(4);
+        auto six    = literal(6);
+        CHECK_THAT(simplify((v % twelve) % three), IdenticalTo(v % three));
+        CHECK_THAT(simplify((v % twelve) % four), IdenticalTo(v % four));
+        CHECK_THAT(simplify((v % twelve) % six), IdenticalTo(v % six));
+
+        // When c does NOT divide b, no simplification
+        auto five = literal(5);
+        CHECK_THAT(simplify((v % twelve) % five), IdenticalTo((v % twelve) % five));
     }
 
     SECTION("Bitwise And")


### PR DESCRIPTION
## Motivation

Division and modulo operations are very expensive and can add kernel arguments due to magic numbers. This PR adds more simplifications to avoid these operations.

## Technical Details

The following simplifications are now supported:

Division:
  - `a / a = 1` (self-division)
  - `(a * b) / b = a` and `(a * b) / a = b` (multiply-divide cancellation)
  - `(a / b) / c = a / (b * c)` (division chain flattening, when b and c are positive)

Modulo:
  - `a % a = 0` (self-modulo)
  - `(a * b) % b = 0` and `(a * b) % a = 0` (multiply-modulo cancellation)
  - `(a % b) % b = a % b` (redundant double modulo)
  - `(a % b) % c = a % c` when c divides b (modulo reduction)

## Test Plan

Tests added to "Simplify ExpressionTransformation works"

## Test Result

All tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
