### PR TITLE
fix(rocrand): nvcc build

### DIFF
--- a/projects/rocrand/benchmark/custom_csv_formater.hpp
+++ b/projects/rocrand/benchmark/custom_csv_formater.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,8 +20,10 @@
 
 #pragma once
 
+#include <array>
 #include <benchmark/benchmark.h>
 #include <vector>
+
 namespace benchmark
 {
 

--- a/projects/rocrand/benchmark/custom_csv_formater.hpp
+++ b/projects/rocrand/benchmark/custom_csv_formater.hpp
@@ -137,9 +137,8 @@ inline void customCSVReporter::ReportRuns(const std::vector<Run>& reports)
                     continue;
 
                 // benchmark::internal::GetNullLogInstance()
-                *nullLog << "All counters must be present in each run. "
-                         << "Counter named \"" << cnt.first
-                         << "\" was not in a run after being added to the header";
+                *nullLog << "All counters must be present in each run. " << "Counter named \""
+                         << cnt.first << "\" was not in a run after being added to the header";
             }
         }
     }
@@ -157,7 +156,7 @@ inline void customCSVReporter::PrintRunData(const Run& run)
     std::ostream& Err = GetErrorStream();
 
     //get the name of the engine and distribution:
-    std::string temp = run.benchmark_name();
+    std::string temp       = run.benchmark_name();
     std::string deviceName = std::string(temp.begin(), temp.begin() + temp.find("<"));
     temp.erase(0, temp.find("<") + 1);
     std::string engineName = std::string(temp.begin(), temp.begin() + temp.find(","));
@@ -170,7 +169,7 @@ inline void customCSVReporter::PrintRunData(const Run& run)
         temp.erase(0, temp.find(",") + 1);
     }
     std::string disName = std::string(temp.begin(), temp.begin() + temp.find(">"));
-    std::string lambda = "";
+    std::string lambda  = "";
 
     size_t ePos = disName.find("=");
     if(ePos <= disName.size())

--- a/projects/rocrand/library/src/rng/mt19937_octo_engine.hpp
+++ b/projects/rocrand/library/src/rng/mt19937_octo_engine.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -168,19 +168,31 @@ struct mt19937_octo_engine
     /// Returns \p val from thread <tt>tid mod 8</tt>.
     static __forceinline__ __device__ unsigned int shuffle(unsigned int val, unsigned int tid)
     {
+#if defined(__HIP_PLATFORM_AMD__)
         return __shfl(val, tid, 8);
+#elif defined(__HIP_PLATFORM_NVCC__)
+        return __shfl_sync(-1 /*mask 0xffffffff*/, val, tid, 8);
+#endif
     }
 
     /// For thread i, returns \p val from thread <tt>(i + 1) mod 8</tt>
     static __forceinline__ __device__ unsigned int shuffle_down(unsigned int val)
     {
+#if defined(__HIP_PLATFORM_AMD__)
         return __shfl_down(val, 1, 8);
+#elif defined(__HIP_PLATFORM_NVCC__)
+        return __shfl_down_sync(-1 /*mask 0xffffffff*/, val, 1, 8);
+#endif
     }
 
     /// For thread i, returns \p val from thread <tt>(i - 1) mod 8</tt>
     static __forceinline__ __device__ unsigned int shuffle_up(unsigned int val)
     {
+#if defined(__HIP_PLATFORM_AMD__)
         return __shfl_up(val, 1, 8);
+#elif defined(__HIP_PLATFORM_NVCC__)
+        return __shfl_up_sync(-1 /*mask 0xffffffff*/, val, 1, 8);
+#endif
     }
     /// Calculates value of index \p i using values <tt>i</tt>, <tt>(i + 1) % n</tt>, and <tt>(i + m) % n</tt>.
     static __forceinline__ __device__ __host__

--- a/projects/rocrand/library/src/rng/mt19937_octo_engine.hpp
+++ b/projects/rocrand/library/src/rng/mt19937_octo_engine.hpp
@@ -166,7 +166,8 @@ struct mt19937_octo_engine
     }
 
     /// Returns \p val from thread <tt>tid mod 8</tt>.
-    static __forceinline__ __device__ unsigned int shuffle(unsigned int val, unsigned int tid)
+    static __forceinline__ __device__
+    unsigned int shuffle(unsigned int val, unsigned int tid)
     {
 #if defined(__HIP_PLATFORM_AMD__)
         return __shfl(val, tid, 8);
@@ -176,7 +177,8 @@ struct mt19937_octo_engine
     }
 
     /// For thread i, returns \p val from thread <tt>(i + 1) mod 8</tt>
-    static __forceinline__ __device__ unsigned int shuffle_down(unsigned int val)
+    static __forceinline__ __device__
+    unsigned int shuffle_down(unsigned int val)
     {
 #if defined(__HIP_PLATFORM_AMD__)
         return __shfl_down(val, 1, 8);
@@ -186,7 +188,8 @@ struct mt19937_octo_engine
     }
 
     /// For thread i, returns \p val from thread <tt>(i - 1) mod 8</tt>
-    static __forceinline__ __device__ unsigned int shuffle_up(unsigned int val)
+    static __forceinline__ __device__
+    unsigned int shuffle_up(unsigned int val)
     {
 #if defined(__HIP_PLATFORM_AMD__)
         return __shfl_up(val, 1, 8);
@@ -211,10 +214,11 @@ struct mt19937_octo_engine
     /// \p idx_m is the local address of <tt>m</tt>: <tt>i + ipt * tid + m</tt>.
     /// \p last_dep_tid_7 is the value of <tt>i + ipt * (tid + 1)</tt>, which is
     /// required as it is the only value not owned by thread <tt>pid</tt>.
-    __forceinline__ __device__ void comp_vector(unsigned int tid,
-                                                unsigned int idx_i,
-                                                unsigned int idx_m,
-                                                unsigned int last_dep_tid_7)
+    __forceinline__ __device__
+    void comp_vector(unsigned int tid,
+                     unsigned int idx_i,
+                     unsigned int idx_m,
+                     unsigned int last_dep_tid_7)
     {
         // communicate the dependency for the last value
         unsigned int last_dep = shuffle_down(m_state.mt[idx_i]);
@@ -268,7 +272,8 @@ struct mt19937_octo_engine
     }
 
     /// Eights threads collaborate in computing the n next values.
-    __forceinline__ __device__ void gen_next_n()
+    __forceinline__ __device__
+    void gen_next_n()
     {
         const unsigned int tid = threadIdx.x & 7U;
 
@@ -590,7 +595,8 @@ private:
 template<unsigned int stride>
 struct mt19937_octo_engine_accessor
 {
-    __forceinline__ __device__ __host__ explicit mt19937_octo_engine_accessor(unsigned int* _engines)
+    __forceinline__ __device__ __host__
+    explicit mt19937_octo_engine_accessor(unsigned int* _engines)
         : engines(_engines)
     {}
 

--- a/projects/rocrand/test/internal/test_rocrand_host_prng.hpp
+++ b/projects/rocrand/test/internal/test_rocrand_host_prng.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -168,7 +168,7 @@ void normal_floating_point_host_test(rocrand_ordering ordering)
                                               data + size,
                                               0.0,
                                               [mean](double acc, double x)
-                                              { return acc + std::powf((x - mean), 2); })
+                                              { return acc + std::pow((x - mean), 2); })
                               / size);
 
     EXPECT_NEAR(2.0, mean, 0.4); // 20%
@@ -216,7 +216,7 @@ void log_normal_floating_point_host_test(rocrand_ordering ordering)
                                               data + size,
                                               0.0,
                                               [mean](double acc, double x)
-                                              { return acc + std::powf((x - mean), 2); })
+                                              { return acc + std::pow((x - mean), 2); })
                               / size);
 
     EXPECT_NEAR(log_normal_mean, mean, log_normal_mean * 0.2); // 20%
@@ -256,7 +256,7 @@ TYPED_TEST_P(generator_prng_host_tests, poisson_test)
         = std::accumulate(data,
                           data + size,
                           0.0,
-                          [mean](double acc, double x) { return acc + std::powf(x - mean, 2); })
+                          [mean](double acc, double x) { return acc + std::pow(x - mean, 2); })
           / size;
 
     EXPECT_NEAR(mean, 5.5, std::max(1.0, 5.5 * 1e-2));


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
As of now, the develop branch fails the nvcc build on our internal CI.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- There's a missing header in the custom csv formatter from the benchmarks
- A new test added for coverage ([test/internal/test_rocrand_host_prng.hpp](https://github.com/ROCm/rocm-libraries/blob/6037b77b3a40154506db3e3ee904d9af4f1d5b16/projects/rocrand/test/internal/test_rocrand_host_prng.hpp)) is using powf (not necessarily in std) instead of pow (guaranteed in std)
- Error related to the non-sync versions of warp shuffles not being available

## Test Plan

Run our internal CI.

## Test Result

Our internal CI build jobs for nvcc pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
