### PR TITLE
fft: fix toolchain-windows.cmake typo

### DIFF
--- a/projects/hipfft/toolchain-windows.cmake
+++ b/projects/hipfft/toolchain-windows.cmake
@@ -44,7 +44,7 @@ set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DWIN32 -D_CRT_SECURE_NO_WARNI
 # flags for clang direct use
 
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wno-ignored-attributes)
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wno-ignored-attributes")
 set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DHIP_CLANG_HCC_COMPAT_MODE=1 -DNOMINMAX")
 
 # args also in hipcc.bat

--- a/projects/rocfft/toolchain-windows.cmake
+++ b/projects/rocfft/toolchain-windows.cmake
@@ -44,7 +44,7 @@ set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DWIN32 -D_CRT_SECURE_NO_WARNI
 # flags for clang direct use
 
 # -Wno-ignored-attributes to avoid warning: __declspec attribute 'dllexport' is not supported [-Wignored-attributes] which is used by msvc compiler
-set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wno-ignored-attributes)
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wno-ignored-attributes")
 set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -DHIP_CLANG_HCC_COMPAT_MODE=1 -DNOMINMAX")
 
 # args also in hipcc.bat


### PR DESCRIPTION
## Motivation

Fix a typo in toolchain-windows.cmake, where a quoted string was not correctly closed.

## Test Plan

Manual builds plus TheRock CI.

## Test Result

Builds succeed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
