### PR TITLE
rocrand/docs: fix invalid Doxygen settings that break docs build

### DIFF
--- a/projects/rocrand/docs/doxygen/Doxyfile
+++ b/projects/rocrand/docs/doxygen/Doxyfile
@@ -1674,7 +1674,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NONE
+GENERATE_TREEVIEW      = NO
 
 # When both GENERATE_TREEVIEW and DISABLE_INDEX are set to YES, then the
 # FULL_SIDEBAR option determines if the side bar is limited to only the treeview
@@ -1971,7 +1971,7 @@ COMPACT_LATEX          = NO
 # The default value is: a4.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = a4
 
 # The EXTRA_PACKAGES tag can be used to specify one or more LaTeX package names
 # that should be included in the LaTeX output. The package can be specified just


### PR DESCRIPTION
When building on newer Ubuntu (26.04 pre-release with doxygen 1.9.8 in this case), there are some settings in rocrand's Doxyfile which cause the building of those docs to fail.

This is a simple patch which changes those settings to values which continue to be valid and are similar, if not identical to the existing behavior.

## Motivation

This PR fixes build errors for rocrand on at least Ubuntu 26.04

## Technical Details

There's not much to this patch - there are errors when building docs on Ubuntu 26.04 due to settings which doxygen flags as invalid. This changes those settings to values which doxygen considers to be valid while minimizing any changes to the doxygen output.

The only behavior change will be the print output which is changed from 'a4wide' which is not a commonly used size and a size that doxygen no longer accepts to the far more common 'a4'.

## Test Plan

Build docs with the patch

## Test Result

Building docs without this patch ends with errors from doxygen.
Building docs on ubuntu 26.04 with this patch is successful. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
