### PR TITLE
Raise exception instead of segfaulting

### DIFF
--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -60,8 +60,6 @@
 #include <cstddef>
 #include <memory>
 
-namespace po = boost::program_options;
-
 namespace TensileLite
 {
     namespace Client
@@ -629,7 +627,11 @@ int main(int argc, const char* argv[])
     auto        hardware = GetHardware(args);
     hipStream_t stream   = GetStream(args);
 
-    auto                              library = LoadSolutionLibrary(args);
+    std::shared_ptr<MasterSolutionLibrary<ContractionProblemGemm>> library
+        = LoadSolutionLibrary(args);
+    if(!library)
+        throw std::runtime_error("Failed to load solution library");
+
     TensileLite::hip::SolutionAdapter adapter;
     LoadCodeObjects(args, adapter);
 


### PR DESCRIPTION
## Motivation

Faster problem diagnostic when failure. 

## Technical Details

Throw exception if library is nullptr.

## Test 

Before:

```
TensileLibrary.yaml:181:31: error: invalid boolean
    customMainLoopScheduling: 0
                              ^
[Lots of logging]

Segmentation fault     
+ ERR2=139
+ ERR=0
```

After:

```
TensileLibrary.yaml:181:31: error: invalid boolean
    customMainLoopScheduling: 0

terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to load solution library

+ ERR2=134
+ ERR=0
```
