### PR TITLE
[hipDNN] Update bfp16 wrw tolerances to account for split-k non-deterministic results

### DIFF
--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuConvBackwardWeights.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuConvBackwardWeights.cpp
@@ -19,9 +19,9 @@ using namespace hipdnn_test_sdk::utilities;
 using namespace miopen_legacy_plugin::test_utilities;
 using namespace test_conv_common;
 
-// Using 4e-1 for bfloat16 tolerance instead of conv::getToleranceWrw<hip_bfloat16>()
-// due to non-deterministic kernel results from CK leading to a high tolerance requirement for MIOpen tests.
-#define WRW_BFP16_TOLERANCE 4e-1_bf
+// Workaround https://github.com/ROCm/rocm-libraries/issues/4010 by using 4e-1
+// for bfloat16 tolerance instead of conv::getToleranceWrw<hip_bfloat16>()
+#define WORKAROUND_GH_ISSUE_4010 4e-1_bf
 
 namespace
 {
@@ -104,12 +104,12 @@ TEST_P(IntegrationGpuConvWrwDataNcdhwFp32, Correctness)
 
 TEST_P(IntegrationGpuConvWrwDataNchwBfp16, Correctness)
 {
-    runGraphTest(WRW_BFP16_TOLERANCE, TensorLayout::NCHW);
+    runGraphTest(WORKAROUND_GH_ISSUE_4010, TensorLayout::NCHW);
 }
 
 TEST_P(IntegrationGpuConvWrwDataNcdhwBfp16, Correctness)
 {
-    runGraphTest(WRW_BFP16_TOLERANCE, TensorLayout::NCDHW);
+    runGraphTest(WORKAROUND_GH_ISSUE_4010, TensorLayout::NCDHW);
 }
 
 TEST_P(IntegrationGpuConvWrwDataNchwFp16, Correctness)
@@ -134,12 +134,12 @@ TEST_P(IntegrationGpuConvWrwDataNdhwcFp32, Correctness)
 
 TEST_P(IntegrationGpuConvWrwDataNhwcBfp16, Correctness)
 {
-    runGraphTest(WRW_BFP16_TOLERANCE, TensorLayout::NHWC);
+    runGraphTest(WORKAROUND_GH_ISSUE_4010, TensorLayout::NHWC);
 }
 
 TEST_P(IntegrationGpuConvWrwDataNdhwcBfp16, Correctness)
 {
-    runGraphTest(WRW_BFP16_TOLERANCE, TensorLayout::NDHWC);
+    runGraphTest(WORKAROUND_GH_ISSUE_4010, TensorLayout::NDHWC);
 }
 
 TEST_P(IntegrationGpuConvWrwDataNhwcFp16, Correctness)

--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuConvBackwardWeights.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuConvBackwardWeights.cpp
@@ -19,6 +19,10 @@ using namespace hipdnn_test_sdk::utilities;
 using namespace miopen_legacy_plugin::test_utilities;
 using namespace test_conv_common;
 
+// Using 4e-1 for bfloat16 tolerance instead of conv::getToleranceWrw<hip_bfloat16>()
+// due to non-deterministic kernel results from CK leading to a high tolerance requirement for MIOpen tests.
+#define WRW_BFP16_TOLERANCE 4e-1_bf
+
 namespace
 {
 
@@ -100,12 +104,12 @@ TEST_P(IntegrationGpuConvWrwDataNcdhwFp32, Correctness)
 
 TEST_P(IntegrationGpuConvWrwDataNchwBfp16, Correctness)
 {
-    runGraphTest(conv::getToleranceWrw<hip_bfloat16>(), TensorLayout::NCHW);
+    runGraphTest(WRW_BFP16_TOLERANCE, TensorLayout::NCHW);
 }
 
 TEST_P(IntegrationGpuConvWrwDataNcdhwBfp16, Correctness)
 {
-    runGraphTest(conv::getToleranceWrw<hip_bfloat16>(), TensorLayout::NCDHW);
+    runGraphTest(WRW_BFP16_TOLERANCE, TensorLayout::NCDHW);
 }
 
 TEST_P(IntegrationGpuConvWrwDataNchwFp16, Correctness)
@@ -130,12 +134,12 @@ TEST_P(IntegrationGpuConvWrwDataNdhwcFp32, Correctness)
 
 TEST_P(IntegrationGpuConvWrwDataNhwcBfp16, Correctness)
 {
-    runGraphTest(conv::getToleranceWrw<hip_bfloat16>(), TensorLayout::NHWC);
+    runGraphTest(WRW_BFP16_TOLERANCE, TensorLayout::NHWC);
 }
 
 TEST_P(IntegrationGpuConvWrwDataNdhwcBfp16, Correctness)
 {
-    runGraphTest(conv::getToleranceWrw<hip_bfloat16>(), TensorLayout::NDHWC);
+    runGraphTest(WRW_BFP16_TOLERANCE, TensorLayout::NDHWC);
 }
 
 TEST_P(IntegrationGpuConvWrwDataNhwcFp16, Correctness)

--- a/projects/hipdnn/samples/README.md
+++ b/projects/hipdnn/samples/README.md
@@ -10,11 +10,11 @@
      * ROCm / TheRock (includes AMD Clang compiler)
    - A ROCm-compatible GPU is required to run the samples
 
-   > [!IMPORTANT]
-   > **AMD Clang++ Requirement for Samples**
-   > **AMD Clang++ is required** to compile hipDNN samples and tests. These components utilize `Tensor.hpp` and reference validation implementations that depend on HIP device headers for GPU buffer allocation.
-   >
-   > **Note for API Consumers:** This requirement **does not** apply to standard usage of the `hipDNN` Frontend. Projects consuming the library API without using these specific `data_sdk` utilities for validation & GPU memory allocation do not require AMD Clang++.
+> [!IMPORTANT]
+> **AMD Clang++ Requirement for Samples**
+> **AMD Clang++ is required** to compile hipDNN samples and tests. These components utilize `Tensor.hpp` and reference validation implementations that depend on HIP device headers for GPU buffer allocation.
+>
+> **Note for API Consumers:** This requirement **does not** apply to standard usage of the `hipDNN` Frontend. Projects consuming the library API without using these specific `data_sdk` utilities for validation & GPU memory allocation do not require AMD Clang++.
 
 2. **Build Samples:** From this `samples` directory:
    ```bash


### PR DESCRIPTION
## Motivation

Tests in hipDNN started to break once heuristics were updated in MIOpen which changed kernel selection (issue #4010).
Issue appears to be due to split-k kernel having non-deterministic results.

## Technical Details

Update MIOpen integration tests to increase tolerance ranges to match closer with what MIOpen uses.

## Test Plan

CI is successful

## Test Result

Waiting for CI
