### PR TITLE
Add cstring header to texture_cache_iterator.hpp

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -23,6 +23,7 @@
 
 #include <iterator>
 #include <cstddef>
+#include <cstring>
 #include <type_traits>
 
 #include "../config.hpp"


### PR DESCRIPTION
## Motivation

The header file refers to memset but is missing include of cstring. The issue comes up after the removal of standard headers like cstring from hip runtime headers.

## Technical Details

Add cstring header back to texture_cache_iterator.hpp.

## Test Plan

CI testing

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
