### PR TITLE
[miopen-provider] Add miopen-provider to therock_matrix.py

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -48,20 +48,10 @@ project_map = {
         "cmake_options": [
             "-DTHEROCK_ENABLE_MIOPEN=ON",
             "-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON",
+            "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
+            "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
+            "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
         ],
-        "additional_flags": {
-            # As composable_kernel is not enabled for Windows, we only enable these flags during Linux builds
-            "linux": [
-                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
-            ],
-            "windows": [
-                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
-            ],
-        },
         "project_to_test": ["miopen", "miopen_plugin"],
     },
     "fft": {
@@ -69,37 +59,21 @@ project_map = {
         "project_to_test": ["hipfft", "rocfft"],
     },
     "hipdnn": {  # due to MIOpen plugin project being inside the hipDNN directory, we cannot have the MIOpen plugin project as a separate project for now https://github.com/ROCm/rocm-libraries/issues/2316
-        "cmake_options": ["-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON"],
-        "additional_flags": {
-            # As composable_kernel is not enabled for Windows, we only enable these flags during Linux builds
-            "linux": [
-                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
-            ],
-            "windows": [
-                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
-            ],
-        },
+        "cmake_options": [
+            "-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON",
+            "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
+            "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
+            "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
+        ],
         "project_to_test": ["hipdnn", "miopen_plugin"],
     },
     "miopen-provider": {
-        "cmake_options": ["-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON"],
-        "additional_flags": {
-            # As composable_kernel is not enabled for Windows, we only enable these flags during Linux builds
-            "linux": [
-                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
-            ],
-            "windows": [
-                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
-                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
-            ],
-        },
+        "cmake_options": [
+            "-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON",
+            "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
+            "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
+            "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
+        ],
         "project_to_test": ["miopen_plugin"],
     },
     "rocwmma": {

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -5,6 +5,7 @@ This dictionary is used to map specific file directory changes to the correspond
 import os
 
 subtree_to_project_map = {
+    "dnn-providers/miopen-provider": "miopen-provider",
     "projects/hipblas": "blas",
     "projects/hipblas-common": "blas",
     "projects/hipblaslt": "blas",
@@ -83,6 +84,23 @@ project_map = {
             ],
         },
         "project_to_test": ["hipdnn", "miopen_plugin"],
+    },
+    "miopen-provider": {
+        "cmake_options": ["-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON"],
+        "additional_flags": {
+            # As composable_kernel is not enabled for Windows, we only enable these flags during Linux builds
+            "linux": [
+                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
+                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
+                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
+            ],
+            "windows": [
+                "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
+                "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
+                "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
+            ],
+        },
+        "project_to_test": ["miopen_plugin"],
     },
     "rocwmma": {
         "cmake_options": ["-DTHEROCK_ENABLE_ROCWMMA=ON"],


### PR DESCRIPTION
## Motivation

With the label changes in #3945, and the miopen-provider plugin being separated out from hipDNN with #3671, the miopen-provider was no longer triggering CI correctly.

This adds miopen-provider as a separate project to the matrix, and will now run CI automatically when the label is applied.

## Technical Details

Add miopen-provider project.
Remove identical additional flags between platforms and unify.

## Test Plan

Verify miopen-provider CI runs when label is applied.

## Test Result

Waiting on CI