### PR TITLE
[rocfft][fft shared] Fixes for multi-device, in-place transforms + enabling more tests thereof in `rocfft-test`

### DIFF
--- a/projects/hipfft/clients/hipfft_params.h
+++ b/projects/hipfft/clients/hipfft_params.h
@@ -836,10 +836,10 @@ public:
     }
 
     // call the hipFFT APIs to distribute data to multiple GPUs
-    void multi_gpu_prepare(std::vector<hostbuf>& cpu_input,
-                           std::vector<gpubuf>&  ibuffer,
-                           std::vector<void*>&   pibuffer,
-                           std::vector<void*>&   pobuffer) override
+    void multi_gpu_prepare(std::vector<hostbuf>& /* unused */,
+                           std::vector<gpubuf>& ibuffer,
+                           std::vector<void*>&  pibuffer,
+                           std::vector<void*>&  pobuffer) override
     {
         if(multiGPU <= 1)
             return;
@@ -919,9 +919,9 @@ public:
     }
 
     // call the hipFFT APIs to gather the data back from the multiple GPUs
-    virtual void multi_gpu_finalize(std::vector<hostbuf>& gpu_output,
-                                    std::vector<gpubuf>&  obuffer,
-                                    std::vector<void*>&   pobuffer) override
+    void multi_gpu_finalize(std::vector<hostbuf>& /* unused*/,
+                            std::vector<gpubuf>& obuffer,
+                            std::vector<void*>&  pobuffer) override
     {
         if(multiGPU <= 1)
             return;

--- a/projects/hipfft/clients/tests/multi_device_test.cpp
+++ b/projects/hipfft/clients/tests/multi_device_test.cpp
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 #include "../../shared/accuracy_test.h"
+#include "../../shared/fft_enums.h"
 #include "../../shared/params_gen.h"
 #include "../hipfft_params.h"
 #include <algorithm>

--- a/projects/hipfft/clients/tests/multi_device_test.cpp
+++ b/projects/hipfft/clients/tests/multi_device_test.cpp
@@ -187,8 +187,8 @@ std::vector<fft_params> param_generator_multi_gpu(const std::optional<SplitType>
                 }
 
                 p_dist.mp_lib = mp_lib;
-                p_dist.distribute_input(localDeviceCount, input_grid);
-                p_dist.distribute_output(localDeviceCount, output_grid);
+                p_dist.distribute_field<fft_io::fft_io_in>(localDeviceCount, input_grid);
+                p_dist.distribute_field<fft_io::fft_io_out>(localDeviceCount, output_grid);
 
                 // "placement" flag is meaningless if exactly one of
                 // input+output is a field.  So just add those cases if

--- a/projects/hipfft/shared/accuracy_test.h
+++ b/projects/hipfft/shared/accuracy_test.h
@@ -706,14 +706,7 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
     }
     ASSERT_EQ(plan_status, fft_status_success) << "plan creation failed";
 
-    fft_params contiguous_params;
-    contiguous_params.length         = params.length;
-    contiguous_params.precision      = params.precision;
-    contiguous_params.placement      = fft_placement_notinplace;
-    contiguous_params.transform_type = params.transform_type;
-    contiguous_params.nbatch         = params.nbatch;
-    contiguous_params.itype          = contiguous_itype(params.transform_type);
-    contiguous_params.otype          = contiguous_otype(contiguous_params.transform_type);
+    auto contiguous_params = params.make_params_for_reference_cpu();
 
     contiguous_params.validate();
 
@@ -1190,7 +1183,6 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
     {
         pobuffer[i] = obuffer->at(i).data();
     }
-
     // scatter data out to multi-GPUs if this is a multi-GPU test
     params.multi_gpu_prepare(cpu_input, ibuffer, pibuffer, pobuffer);
 

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -2376,6 +2376,12 @@ public:
     /**
      * @brief create one input (resp. output) field with as many bricks
      * as desired along every field dimension for the current object.
+     * The device assignment of the bricks is cycling though the total number
+     * of available devices (i.e., `gpusperrank * num_ranks`) starting from
+     * the `start_global_dev_idx` (global) device index.
+     * NOTE: The global device index `g` in `[0, gpusperrank * mp_ranks(`
+     * corresponds to device of local ID `g % gpusperrank` on process of rank
+     * `g / gpusperrank.
      * 
      * @tparam io enum flag specifying whether the input (`io == fft_io::fft_io_in`)
      * or output (`io == fft_io::fft_io_in`) field is being considered.
@@ -2385,11 +2391,11 @@ public:
      * bricks per dimension: `brick_count_along[i]` if the number of bricks
      * desired along the `i`-th field dimension.
      * @param[in] num_ranks number of processes used in the parallel computer
-     * (default value is one)
+     * (default value is 1)
+     * @param[in] start_global_dev_idx first (global) device ID to be considered
+     * in the cyclic assignment (default value is 0)
      * 
      * NOTES:
-     * - the input/output field is created only if an actual division is requested,
-     * i.e., if product(brick_count_along.begin(), brick_count_along.end()) > 1;
      * - data layouts within bricks are set to be compact, i.e., contiguous for
      * bricks in complex domain, padded in real domain for in-place operations
      * (only if the fastest dimension is not divided itself, i.e., if
@@ -2400,7 +2406,8 @@ public:
     template <fft_io io>
     void distribute_field(int                              gpusperrank,
                           const std::vector<unsigned int>& brick_count_along,
-                          int                              num_ranks = 1)
+                          int                              num_ranks            = 1,
+                          int                              start_global_dev_idx = 0)
     {
         static_assert(io == fft_io::fft_io_in || io == fft_io::fft_io_out);
 
@@ -2424,12 +2431,6 @@ public:
                 "number of available device(s) per process.");
 
         const auto total_bricks = product(brick_count_along.begin(), brick_count_along.end());
-        if(total_bricks == 1)
-        {
-            // nothing to split, no field required
-            iofields.clear();
-            return;
-        }
 
         struct length_division
         {
@@ -2490,8 +2491,10 @@ public:
                 }
             }
 
-            iobrick.device = b_idx % gpusperrank; // determine GPU within rank
-            iobrick.rank   = (b_idx / gpusperrank) % num_ranks; // determine MPI rank
+            iobrick.device
+                = (start_global_dev_idx + b_idx) % gpusperrank; // determine GPU within rank
+            iobrick.rank
+                = ((start_global_dev_idx + b_idx) / gpusperrank) % num_ranks; // determine MPI rank
         }
     }
 

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -2381,7 +2381,7 @@ public:
      * the `start_global_dev_idx` (global) device index.
      * NOTE: The global device index `g` in `[0, gpusperrank * mp_ranks(`
      * corresponds to device of local ID `g % gpusperrank` on process of rank
-     * `g / gpusperrank.
+     * `g / gpusperrank`.
      * 
      * @tparam io enum flag specifying whether the input (`io == fft_io::fft_io_in`)
      * or output (`io == fft_io::fft_io_in`) field is being considered.

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -2380,8 +2380,8 @@ public:
      * of available devices (i.e., `gpusperrank * num_ranks`) starting from
      * the `start_global_dev_idx` (global) device index.
      * NOTE: The global device index `g` in `[0, gpusperrank * mp_ranks(`
-     * corresponds to device of local ID `g % gpusperrank` on process of rank
-     * `g / gpusperrank`.
+     * corresponds to device of local ID `g / mp_ranks` on process of rank
+     * `g % mp_ranks`. This prioritize distributing layout across all processes.
      * 
      * @tparam io enum flag specifying whether the input (`io == fft_io::fft_io_in`)
      * or output (`io == fft_io::fft_io_in`) field is being considered.
@@ -2491,10 +2491,8 @@ public:
                 }
             }
 
-            iobrick.device
-                = (start_global_dev_idx + b_idx) % gpusperrank; // determine GPU within rank
-            iobrick.rank
-                = ((start_global_dev_idx + b_idx) / gpusperrank) % num_ranks; // determine MPI rank
+            iobrick.rank   = (start_global_dev_idx + b_idx) % num_ranks;
+            iobrick.device = ((start_global_dev_idx + b_idx) / num_ranks) % gpusperrank;
         }
     }
 

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -2373,125 +2373,126 @@ public:
     {
     }
 
-    // Create bricks in the specified field.  brick_grid has an
-    // integer per dimension (batch and FFT dimensions), with the
-    // number of bricks to split that dimension on.  Field length
-    // starts with batch dimension, followed by FFT dimensions
-    // slowest to fastest.
-    // num_ranks represents the number of ranks used in the parallel
-    // computer, which are assumed to have at least gpusperrank each
+    /**
+     * @brief create one input (resp. output) field with as many bricks
+     * as desired along every field dimension for the current object.
+     * 
+     * @tparam io enum flag specifying whether the input (`io == fft_io::fft_io_in`)
+     * or output (`io == fft_io::fft_io_in`) field is being considered.
+     * 
+     * @param[in] gpusperrank number of GPU devices available to each process
+     * @param[in] brick_count_along desired (strictly positive) numbers of
+     * bricks per dimension: `brick_count_along[i]` if the number of bricks
+     * desired along the `i`-th field dimension.
+     * @param[in] num_ranks number of processes used in the parallel computer
+     * (default value is one)
+     * 
+     * NOTES:
+     * - the input/output field is created only if an actual division is requested,
+     * i.e., if product(brick_count_along.begin(), brick_count_along.end()) > 1;
+     * - data layouts within bricks are set to be compact, i.e., contiguous for
+     * bricks in complex domain, padded in real domain for in-place operations
+     * (only if the fastest dimension is not divided itself, i.e., if
+     * brick_count_along.last() == 1)
+     * - if more bricks than available devices are requested, some bricks may be
+     * assigned to the same device.
+     */
+    template <fft_io io>
     void distribute_field(int                              gpusperrank,
-                          const std::vector<unsigned int>& brick_grid,
-                          std::vector<fft_field>&          fields,
-                          const std::vector<size_t>&       field_length,
-                          int                              num_ranks)
-    {
-        if(brick_grid.size() != field_length.size())
-            throw std::runtime_error(
-                "distribute field requires same number of dims for grid and field length");
-
-        // if nothing's actually split, don't bother making bricks
-        if(std::all_of(
-               brick_grid.begin(), brick_grid.end(), [](const unsigned int g) { return g == 1; }))
-            return;
-
-        size_t total_bricks = product(brick_grid.begin(), brick_grid.end());
-
-        auto& field = fields.emplace_back();
-
-        // Start with empty brick in field
-        field.bricks.reserve(total_bricks);
-        field.bricks.emplace_back();
-
-        // Go over the grid
-        for(size_t i = 0; i < brick_grid.size(); ++i)
-        {
-            std::vector<fft_brick> cur_bricks;
-            cur_bricks.swap(field.bricks);
-            field.bricks.reserve(total_bricks);
-
-            auto brick_count = brick_grid[i];
-            auto cur_length  = field_length[i];
-
-            // split current length, apply to all current bricks and
-            // append bricks to field
-            for(size_t ibrick = 0; ibrick < brick_count; ++ibrick)
-            {
-                for(const auto& b : cur_bricks)
-                {
-                    auto& new_brick = field.bricks.emplace_back(b);
-                    new_brick.lower.push_back(cur_length / brick_count * ibrick);
-                    // last brick needs to include the whole split len
-                    if(ibrick == brick_count - 1)
-                    {
-                        new_brick.upper.push_back(cur_length);
-                    }
-                    else
-                    {
-                        new_brick.upper.push_back(std::min(
-                            cur_length, new_brick.lower.back() + cur_length / brick_count));
-                    }
-                }
-            }
-        }
-
-        // Give all bricks contiguous strides
-        int brickIdx = 0;
-        for(auto& b : field.bricks)
-        {
-            b.stride.resize(b.upper.size());
-
-            // Fill strides from fastest to slowest
-            size_t brick_dist = 1;
-            for(size_t distIdx = 0; distIdx < b.upper.size(); ++distIdx)
-            {
-                *(b.stride.rbegin() + distIdx) = brick_dist;
-                brick_dist *= *(b.upper.rbegin() + distIdx) - *(b.lower.rbegin() + distIdx);
-            }
-
-            // Split across ranks for a multi-process transform,
-            // otherwise split across bricks.  assume there's one
-            // rank/device per brick
-            if(mp_lib == fft_mp_lib_none)
-            {
-                b.device = brickIdx;
-            }
-            else
-            {
-                int rank = brickIdx / gpusperrank; // determine MPI rank
-                int gpu  = brickIdx % gpusperrank; // determine GPU within rank
-
-                b.rank   = rank;
-                b.device = gpu;
-            }
-            brickIdx++;
-        }
-    }
-
-    // Distribute problem input among specified grid of devices/processors.
-    // Grid specifies number of bricks per dimension, starting with batch
-    // and ending with fastest FFT dimension. For single-proc single-proc
-    // multi-gpu, gpusperrank represents the number of GPUs to use;
-    // while for multi-proc it represents the number of GPUs on each rank.
-    void distribute_input(int                              gpusperrank,
-                          const std::vector<unsigned int>& brick_grid,
+                          const std::vector<unsigned int>& brick_count_along,
                           int                              num_ranks = 1)
     {
-        auto len = length;
-        len.insert(len.begin(), nbatch);
-        distribute_field(gpusperrank, brick_grid, ifields, len, num_ranks);
-    }
+        static_assert(io == fft_io::fft_io_in || io == fft_io::fft_io_out);
 
-    // Distribute problem output among specified grid of devices/processors.
-    // Grid specifies number of bricks per dimension, starting with batch
-    // and ending with fastest FFT dimension.
-    void distribute_output(int                              gpusperrank,
-                           const std::vector<unsigned int>& brick_grid,
-                           int                              num_ranks = 1)
-    {
-        auto len = olength();
-        len.insert(len.begin(), nbatch);
-        distribute_field(gpusperrank, brick_grid, ofields, len, num_ranks);
+        auto& iofields       = io == fft_io::fft_io_in ? ifields : ofields;
+        auto  iofield_length = io == fft_io::fft_io_in ? ilength() : olength();
+        iofield_length.insert(iofield_length.begin(), nbatch);
+        const auto field_size = iofield_length.size(); // --> field_size > 0
+        // arg validation
+        if(brick_count_along.size() != field_size)
+            throw std::runtime_error(
+                "fft_params::distribute_field inconsistent size between desired number of bricks "
+                "per dimension and number of dimensions");
+        if(std::any_of(
+               brick_count_along.begin(),
+               brick_count_along.end(),
+               [](const auto& brick_count_along_dim) { return brick_count_along_dim == 0; }))
+            throw std::invalid_argument("brick_count_per_dim must not be 0.");
+        if(gpusperrank < 1 || num_ranks < 1)
+            throw std::invalid_argument(
+                "fft_params::distribute_field requires strictly positive number of processes and "
+                "number of available device(s) per process.");
+
+        const auto total_bricks = product(brick_count_along.begin(), brick_count_along.end());
+        if(total_bricks == 1)
+        {
+            // nothing to split, no field required
+            iofields.clear();
+            return;
+        }
+
+        struct length_division
+        {
+            size_t min_length;
+            size_t remainder;
+        };
+        std::vector<length_division> field_division_along(field_size);
+        for(auto field_dim = field_size; field_dim-- > 0;)
+        {
+            field_division_along[field_dim].min_length
+                = iofield_length[field_dim] / brick_count_along[field_dim];
+            field_division_along[field_dim].remainder
+                = iofield_length[field_dim] % brick_count_along[field_dim];
+        }
+
+        // make ONE field with as many bricks as required along every field dimension
+        iofields.resize(1);
+        auto& iofield  = iofields[0];
+        auto& iobricks = iofield.bricks;
+        // Create the required number of bricks
+        iobricks.resize(total_bricks);
+        // define them
+        for(size_t b_idx = 0; b_idx < total_bricks; b_idx++)
+        {
+            auto&               iobrick = iobricks[b_idx];
+            std::vector<size_t> brick_dim_idx(field_size, 0);
+            iobrick.lower.resize(field_size);
+            iobrick.upper.resize(field_size);
+            iobrick.stride.resize(field_size);
+            auto tmp_idx = b_idx;
+            for(auto field_dim = field_size; field_dim-- > 0;
+                tmp_idx /= brick_count_along[field_dim])
+            {
+                const auto brick_idx_along_dim = tmp_idx % brick_count_along[field_dim];
+                const auto brick_length_along_dim
+                    = field_division_along[field_dim].min_length
+                      + (brick_idx_along_dim < field_division_along[field_dim].remainder ? 1 : 0);
+                iobrick.lower[field_dim]
+                    = brick_idx_along_dim * field_division_along[field_dim].min_length
+                      + std::min(brick_idx_along_dim, field_division_along[field_dim].remainder);
+                iobrick.upper[field_dim] = iobrick.lower[field_dim] + brick_length_along_dim;
+                if(field_dim == field_size - 1)
+                    iobrick.stride[field_dim] = 1; // contiguous along fastest dimension
+                else
+                {
+                    auto stride_multiplier
+                        = iobrick.upper[field_dim + 1] - iobrick.lower[field_dim + 1];
+                    if(field_dim == field_size - 2 && is_real()
+                       && placement == fft_placement_inplace
+                       && (is_forward() ^ (io == fft_io::fft_io_out)) /* <-- brick in real domain */
+                       && brick_count_along[field_size - 1] == 1)
+                    {
+                        // real in-place case with fastest dimension that is NOT divided
+                        // --> most likely use case is *with* padding
+                        stride_multiplier = 2 * (stride_multiplier / 2 + 1);
+                    }
+                    iobrick.stride[field_dim] = iobrick.stride[field_dim + 1] * stride_multiplier;
+                }
+            }
+
+            iobrick.device = b_idx % gpusperrank; // determine GPU within rank
+            iobrick.rank   = (b_idx / gpusperrank) % num_ranks; // determine MPI rank
+        }
     }
 
     // Apply load operations specified by this struct to the host-side

--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -2305,28 +2305,71 @@ public:
         scale_factor = 1 / params_forward.scale_factor;
     }
 
-    // prepare for multi-GPU transform.  cpu_input has contiguous
-    // input on the host, ibuffer has device input, which can be
-    // discarded if it's turned into multi-GPU bricks.  pibuffer,
-    // pobuffer are the pointers that will be passed to the FFT
-    // library's "execute" API.
-    virtual void multi_gpu_prepare(std::vector<hostbuf>& cpu_input,
-                                   std::vector<gpubuf>&  ibuffer,
-                                   std::vector<void*>&   pibuffer,
-                                   std::vector<void*>&   pobuffer)
+    /**
+     * @brief initialize the I/O device buffers as required for multi-device
+     * transforms described by this object. Device buffers are determined (created
+     * and allocated, if needed), and input buffers are data-initialized using the
+     * provided host-residing (resp. device-residing) reference data for the
+     * `rocfft_params` (resp. `hipfft_params`) derived class.
+     *
+     * TODO: unify data-initialization logic across derived classes and make all arguments
+     * relevant in all cases (remove ignore ones).
+     * 
+     * @param[in] input_data_host vector of (at least) one host buffer containing the
+     * input-initialization data to be considered for data-initialization of the
+     * device input buffers (this is unused by `hipfft_params` objects). If used,
+     * the data layout of `input_data_host[0]` must be consistent with `cpu_params.istride`,
+     * `cpu_params.idist`, etc. wherein `cpu_params = this->make_params_for_reference_cpu()`.
+     * @param[in] input_data_gpu vector of (at least) one device buffer containing the
+     * input-initialization data to be considered for data-initialization of the
+     * device input buffers (this is unused by `rocfft_params` objects). If used,
+     * the data layout of `input_data_gpu[0]` must be consistent with `this->istride`,
+     * `this->idist`, etc.
+     * @param[out] mgpu_ibuffers vector of raw pointers to input device allocations as
+     * needed for the multi-device transform that this object describes. The content
+     * of these device allocations is initialized with the (transposed) content of
+     * `input_data_host` (resp. `input_data_gpu`) by `rocfft_params` (resp. `hipfft_params`)
+     * objects. Upon return, the data layout in these device allocations is
+     * - as described by the corresponding input brick's for `rocfft_params` objects;
+     * - as implicitly-defined for `hipfft_params` objects.
+     * @param[out] mgpu_obuffers vector of raw pointers to output device allocations as
+     * needed for the multi-device transform that this object describes.
+     */
+    virtual void multi_gpu_prepare(std::vector<hostbuf>& input_data_host,
+                                   std::vector<gpubuf>&  input_data_gpu,
+                                   std::vector<void*>&   mgpu_ibuffers,
+                                   std::vector<void*>&   mgpu_obuffers)
     {
     }
 
-    // finalize multi-GPU transform.  pobuffers are the pointers
-    // provided to the FFT library's "execute" API.  obuffer is the
-    // normal GPU buffer that is used for single-device FFTs.
-    // gpu_output is the host buffer where transform output needs to
-    // go for validation
-    // Field is distributed among ranks and then among the number
-    // of GPUs per rank (which defaults to 1).
-    virtual void multi_gpu_finalize(std::vector<hostbuf>& gpu_output,
-                                    std::vector<gpubuf>&  obuffer,
-                                    std::vector<void*>&   pobuffer)
+    /**
+     * @brief gather the results of a multi-device transform to a unique host-residing
+     * buffer for `rocfft_params` objects (resp. device-residing buffer for
+     * `hipfft_params` objects).
+     * 
+     * TODO: unify data-gathering logic across derived classes and make all arguments
+     * relevant in all cases (remove ignore ones).
+     * 
+     * @param[out] gathered_results_host vector of (at least) one host buffer (ignored by
+     * `hipfft_params` objects). If not ignored, `gathered_results_host[0]` contains the
+     * gathered output data of the multi-device transform upon return.
+     * @param[out] gathered_results_device vector of (at least) one device buffer (ignored
+     * by `rocfft_params` objects). If not ignored, `gathered_results_device[0]` contains
+     * the gathered output data of the multi-device transform upon return.
+     * @param[in] mgpu_obuffers vector of raw pointers to output device allocations
+     * considered by the (previously-executed) multi-device transform described by this
+     * object.
+     * 
+     * Note 1: whichever gathering buffer that is considered (`gathered_results_host[0]`
+     * or `gathered_results_device[0]`) must be large enough for containing the
+     * gathered results when passed to this function: this function does NOT resize it.
+     * Note 2: the data layout in the considered gathered results is defined
+     * by the calling object's output data layout parameter, i.e., defined by
+     * `this->ostride`, `this->odist`, `this->otype`, etc.
+     */
+    virtual void multi_gpu_finalize(std::vector<hostbuf>& gathered_results_host,
+                                    std::vector<gpubuf>&  gathered_results_device,
+                                    std::vector<void*>&   mgpu_obuffers)
     {
     }
 
@@ -2604,6 +2647,36 @@ public:
             abort();
         }
 #endif
+    }
+
+    fft_params make_params_for_reference_cpu() const
+    {
+        fft_params ret;
+        ret.length         = length;
+        ret.precision      = precision;
+        ret.placement      = fft_placement_notinplace;
+        ret.transform_type = transform_type;
+        ret.nbatch         = nbatch;
+        ret.itype          = is_real() ? (is_forward() ? fft_array_type_real
+                                                       : fft_array_type_hermitian_interleaved)
+                                       : fft_array_type_complex_interleaved;
+        ret.otype          = is_real() ? (is_inverse() ? fft_array_type_real
+                                                       : fft_array_type_hermitian_interleaved)
+                                       : fft_array_type_complex_interleaved;
+        ret.istride
+            = default_strides(transform_type, fft_placement_notinplace, fft_io::fft_io_in, length);
+        ret.ostride
+            = default_strides(transform_type, fft_placement_notinplace, fft_io::fft_io_out, length);
+        ret.idist = default_distance(
+            transform_type, fft_placement_notinplace, fft_io::fft_io_in, length, nbatch);
+        ret.odist = default_distance(
+            transform_type, fft_placement_notinplace, fft_io::fft_io_out, length, nbatch);
+        ret.compute_isize();
+        ret.compute_osize();
+
+        // other ret's members should be irrelevant for cpu reference calculations
+        // (default values)
+        return ret;
     }
 };
 

--- a/projects/hipfft/shared/mpi_worker.h
+++ b/projects/hipfft/shared/mpi_worker.h
@@ -20,6 +20,7 @@
 * THE SOFTWARE.
 *******************************************************************************/
 
+#include "fft_enums.h"
 #include "fft_params.h"
 
 #include "CLI11.hpp"

--- a/projects/hipfft/shared/mpi_worker.h
+++ b/projects/hipfft/shared/mpi_worker.h
@@ -974,8 +974,8 @@ int mpi_worker_main(const char*                                               de
         // each node, GPUs are indexed 0,1,...,N
 
         // distribute input and output among the available number of ranks and GPUs per rank
-        params.distribute_input(ngpus, input_grid, mp_size);
-        params.distribute_output(ngpus, output_grid, mp_size);
+        params.distribute_field<fft_io::fft_io_in>(ngpus, input_grid, mp_size);
+        params.distribute_field<fft_io::fft_io_out>(ngpus, output_grid, mp_size);
 
         params.validate();
         token = params.token();

--- a/projects/hipfft/shared/rocfft_params.h
+++ b/projects/hipfft/shared/rocfft_params.h
@@ -21,6 +21,7 @@
 #ifndef ROCFFT_PARAMS_H
 #define ROCFFT_PARAMS_H
 
+#include "../shared/fft_enums.h"
 #include "../shared/fft_params.h"
 #include "../shared/gpubuf.h"
 #include "../shared/precision_type.h"

--- a/projects/hipfft/shared/rocfft_params.h
+++ b/projects/hipfft/shared/rocfft_params.h
@@ -175,22 +175,13 @@ public:
 
         if(rocfft.field_create(&rfield) != rocfft_status_success)
             throw std::runtime_error("rocfft_field_create failed");
+        const auto proc_rank = get_process_rank();
         for(const auto& b : f.bricks)
         {
             // if this is an MPI transform, only tell the current rank
             // about bricks for that rank
-            if(mp_lib == fft_mp_lib_mpi)
-            {
-#ifdef ROCFFT_MPI_ENABLE
-                int mpi_rank = 0;
-                MPI_Comm_rank(*static_cast<MPI_Comm*>(mp_comm), &mpi_rank);
-
-                if(mpi_rank != b.rank)
-                    continue;
-#else
-                throw std::runtime_error("MPI is not enabled");
-#endif
-            }
+            if(proc_rank != b.rank)
+                continue;
 
             // rocFFT wants column-major bricks and fft_params stores
             // row-major
@@ -363,13 +354,7 @@ public:
         if(fields.empty())
             return 1;
 
-        int mpi_rank = 0;
-#ifdef ROCFFT_MPI_ENABLE
-        if(mp_lib == fft_mp_lib_mpi)
-        {
-            MPI_Comm_rank(*static_cast<MPI_Comm*>(mp_comm), &mpi_rank);
-        }
-#endif
+        const int mpi_rank = get_process_rank();
 
         // count the number of bricks on this rank
         size_t expected_callbacks = 0;
@@ -425,98 +410,167 @@ public:
         return fft_status_from_rocfftparams(ret);
     }
 
-    // scatter data to multiple GPUs and adjust I/O buffers to match
-    virtual void multi_gpu_prepare(std::vector<hostbuf>& cpu_input,
-                                   std::vector<gpubuf>&  ibuffer,
-                                   std::vector<void*>&   pibuffer,
-                                   std::vector<void*>&   pobuffer) override
+    void multi_gpu_prepare(std::vector<hostbuf>& input_data_host,
+                           std::vector<gpubuf>& /* input_data_gpu (unused) */,
+                           std::vector<void*>& mgpu_ibuffers,
+                           std::vector<void*>& mgpu_obuffers) override
     {
-        auto alloc_fields = [&](const fft_params::fft_field& field,
-                                fft_array_type               array_type,
-                                std::vector<void*>&          pbuffer,
-                                bool                         copy_input) {
-            if(field.bricks.empty())
-                return;
+        if(ifields.empty() && ofields.empty())
+        {
+            // not a multi-device case
+            return;
+        }
 
-            // we have a field defined, clear the list of buffers as
-            // we'll be allocating new ones for each brick
-            pbuffer.clear();
+        if(input_data_host.empty())
+        {
+            throw std::invalid_argument(
+                "rocfft_params::multi_gpu_prepare: host-residing input buffer does not exist.");
+        }
+        const auto cpu_ref_params = make_params_for_reference_cpu();
+        if(cpu_ref_params.itype == fft_array_type_complex_planar
+           || cpu_ref_params.itype == fft_array_type_hermitian_planar)
+            throw std::logic_error("rocfft_params::multi_gpu_prepare: planar input data considered "
+                                   "by cpu reference calculation.");
+        const auto req_min_size = cpu_ref_params.ibuffer_sizes()[0];
+        if(input_data_host[0].size() < req_min_size)
+        {
+            std::ostringstream excpt_info;
+            excpt_info << "rocfft_params::multi_gpu_prepare: given host-residing input buffer is "
+                          "too small for scattering the multi-device transform inputs.\n"
+                       << "Buffer size is " << input_data_host[0].size()
+                       << ", required min size is " << req_min_size << ".";
+            throw std::invalid_argument(excpt_info.str());
+        }
 
-            const size_t elem_size_bytes = var_size<size_t>(precision, array_type);
-
-            for(const auto& b : field.bricks)
+        if(placement == fft_placement_inplace)
+        {
+            // validate test case configuration with respect to what we assume below (current
+            // limitations with respect to what we test for "in-place multi-device")
+            const std::runtime_error unmet_mgpu_inplace_requirement(
+                "rocfft_params::multi_gpu_prepare requires in-place tests to have the same total "
+                "number of fields and number of bricks per field on input and output. All bricks "
+                "should be assigned to the same devices, in the same order on input and output.");
+            if(ifields.size() != ofields.size())
+                throw unmet_mgpu_inplace_requirement;
+            for(size_t field_idx = 0; field_idx < ifields.size(); field_idx++)
             {
-                const size_t brick_size_elems = compute_ptrdiff(b.length(), b.stride);
-                const size_t brick_size_bytes = brick_size_elems * elem_size_bytes;
-
-                // set device for the alloc, but we want to return to the
-                // default device as the source of a following memcpy
+                const auto& ifield = ifields[field_idx];
+                const auto& ofield = ofields[field_idx];
+                if(ifield.bricks.size() != ofield.bricks.size())
+                    throw unmet_mgpu_inplace_requirement;
+                for(size_t b_idx = 0; b_idx < ifield.bricks.size(); b_idx++)
                 {
-                    rocfft_scoped_device dev(b.device);
-                    multi_gpu_data.emplace_back();
-                    if(multi_gpu_data.back().alloc(brick_size_bytes) != hipSuccess)
-                        throw std::runtime_error("device allocation failure");
-                    pbuffer.push_back(multi_gpu_data.back().data());
+                    const auto& ibrick = ifield.bricks[b_idx];
+                    const auto& obrick = ofield.bricks[b_idx];
+                    if(ibrick.rank != obrick.rank || ibrick.device != obrick.device)
+                        throw unmet_mgpu_inplace_requirement;
                 }
+            }
+        }
 
-                if(copy_input)
+        // I/O raw pointer(s) are left untouched if there is no corresponding field,
+        // i.e., no data decomposition
+        if(!ifields.empty())
+            mgpu_ibuffers.clear();
+        if(!ofields.empty())
+            mgpu_obuffers.clear();
+        const auto process_rank = get_process_rank();
+        for(size_t f_idx = 0; f_idx < std::max(ifields.size(), ofields.size()); f_idx++)
+        {
+            const auto* ifield = f_idx < ifields.size() ? &ifields[f_idx] : nullptr;
+            const auto* ofield = f_idx < ofields.size() ? &ofields[f_idx] : nullptr;
+            for(size_t b_idx = 0; b_idx < std::max(ifield ? ifield->bricks.size() : 0,
+                                                   ofield ? ofield->bricks.size() : 0);
+                b_idx++)
+            {
+                const auto* ibrick
+                    = ifield && b_idx < ifield->bricks.size() ? &ifield->bricks[b_idx] : nullptr;
+                const auto* obrick
+                    = ofield && b_idx < ofield->bricks.size() ? &ofield->bricks[b_idx] : nullptr;
+                for(const auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
                 {
-                    // get this brick's starting offset in the field
-                    const size_t brick_offset_elems = b.lower_field_offset(istride, idist);
-
-                    // transpose input data to the brick's shape in
-                    // host memory, then memcpy
-
-                    // alloc a host-side brick that's the right shape
-                    std::vector<hostbuf> host_brick(1);
-                    host_brick.front().alloc(brick_size_bytes);
-
-                    std::vector<size_t> istride_with_batch{idist};
-                    std::copy(
-                        istride.begin(), istride.end(), std::back_inserter(istride_with_batch));
-
-                    copy_buffers(cpu_input,
-                                 host_brick,
-                                 b.length(),
-                                 1,
-                                 precision,
-                                 array_type,
-                                 istride_with_batch,
-                                 0,
-                                 array_type,
-                                 b.stride,
-                                 0,
-                                 {brick_offset_elems},
-                                 {0});
-
-                    // memcpy the transposed brick to the device
-                    if(hipMemcpy(pbuffer.back(),
-                                 host_brick.front().data(),
-                                 brick_size_bytes,
-                                 hipMemcpyHostToDevice)
-                       != hipSuccess)
+                    if(placement == fft_placement_inplace && io == fft_io::fft_io_out)
                     {
-                        throw std::runtime_error("hipMemcpy failure");
+                        // outputs and input are set together (when the input is set)
+                        // for in-place operations
+                        continue;
+                    }
+                    const auto* io_brick = io == fft_io::fft_io_in ? ibrick : obrick;
+                    auto& io_buffer_vec  = io == fft_io::fft_io_in ? mgpu_ibuffers : mgpu_obuffers;
+                    if(!io_brick || io_brick->rank != process_rank)
+                        continue;
+                    // calculate byte size for device allocation:
+                    const auto array_type = io == fft_io::fft_io_in ? itype : otype;
+                    size_t     alloc_byte_size
+                        = var_size<size_t>(precision, array_type)
+                          * compute_ptrdiff(io_brick->length(), io_brick->stride);
+                    if(placement == fft_placement_inplace)
+                    {
+                        // The I/O buffers must be large enough for both input and output data.
+                        // NOTE: see above argument validation checks for testing "in-place". As
+                        // a consequence, if this point is reached, io_brick == ibrick,
+                        // obrick != nullptr, ibrick->rank == obrick->rank, and
+                        // ibrick->device == obrick->device.
+                        alloc_byte_size
+                            = std::max(alloc_byte_size,
+                                       var_size<size_t>(precision, otype)
+                                           * compute_ptrdiff(obrick->length(), obrick->stride));
+                    }
+
+                    // set device for the alloc, but we want to return to the
+                    // default device as the source of a following memcpy
+                    {
+                        rocfft_scoped_device dev(io_brick->device);
+                        multi_gpu_data.emplace_back();
+                        if(multi_gpu_data.back().alloc(alloc_byte_size) != hipSuccess)
+                            throw std::runtime_error(
+                                "rocfft_params::multi_gpu_prepare: device allocation failed");
+                        io_buffer_vec.push_back(multi_gpu_data.back().data());
+                        if(placement == fft_placement_inplace)
+                            mgpu_obuffers.push_back(multi_gpu_data.back().data());
+                    }
+                    if(io == fft_io::fft_io_in)
+                    {
+                        // copy cpu input data to device buffer(s)
+                        const auto input_data_host_offset = io_brick->lower_field_offset(
+                            cpu_ref_params.istride, cpu_ref_params.idist);
+
+                        // transpose input data to the brick's shape in host memory, then
+                        // memcpy (as is) into allocated device buffer
+                        std::vector<hostbuf> host_tmp(1);
+                        host_tmp.front().alloc(alloc_byte_size);
+
+                        std::vector<size_t> cpu_istrides_with_idist(cpu_ref_params.istride);
+                        cpu_istrides_with_idist.insert(cpu_istrides_with_idist.begin(),
+                                                       cpu_ref_params.idist);
+
+                        copy_buffers(input_data_host,
+                                     host_tmp,
+                                     io_brick->length(),
+                                     /* "nbatch" = */ 1,
+                                     cpu_ref_params.precision,
+                                     cpu_ref_params.itype,
+                                     cpu_istrides_with_idist,
+                                     /* "idist" = */ 0,
+                                     array_type,
+                                     io_brick->stride,
+                                     /* "odist" =  */ 0,
+                                     {input_data_host_offset},
+                                     /* "ooffset" = */ {0});
+
+                        // memcpy the transposed brick to the device
+                        if(hipMemcpy(io_buffer_vec.back(),
+                                     host_tmp.front().data(),
+                                     alloc_byte_size,
+                                     hipMemcpyHostToDevice)
+                           != hipSuccess)
+                        {
+                            throw std::runtime_error(
+                                "rocfft_params::multi_gpu_prepare: hipMemcpy failed");
+                        }
                     }
                 }
             }
-
-            // if we copied the input to all the other devices, and
-            // this is an out-of-place transform, we no longer
-            // need the original input
-            if(copy_input && placement == fft_placement_notinplace)
-                ibuffer.clear();
-        };
-
-        // assume one input, one output field for simple cases
-        if(!ifields.empty())
-            alloc_fields(ifields.front(), itype, pibuffer, true);
-        if(!ofields.empty())
-        {
-            if(!ifields.empty() && placement == fft_placement_inplace)
-                pobuffer = pibuffer;
-            else
-                alloc_fields(ofields.front(), otype, pobuffer, false);
         }
     }
 
@@ -524,59 +578,91 @@ public:
     // on each GPU.  This vector remembers all of those allocations.
     std::vector<gpubuf> multi_gpu_data;
 
-    // gather data after multi-GPU FFT for verification
-    void multi_gpu_finalize(std::vector<hostbuf>& gpu_output,
-                            std::vector<gpubuf>&  obuffer,
-                            std::vector<void*>&   pobuffer) override
+    void multi_gpu_finalize(std::vector<hostbuf>& gathered_results_host,
+                            std::vector<gpubuf>& /* gathered_results_device (unused) */,
+                            std::vector<void*>& mgpu_obuffers) override
     {
         if(ofields.empty())
-            return;
-
-        const size_t elem_size_bytes = var_size<size_t>(precision, otype);
-
-        for(size_t i = 0; i < pobuffer.size(); ++i)
         {
-            const auto& b = ofields.front().bricks[i];
-
-            const size_t brick_size_elems = compute_ptrdiff(b.length(), b.stride);
-            const size_t brick_size_bytes = brick_size_elems * elem_size_bytes;
-
-            // get this brick's starting offset in the field
-            const size_t brick_offset_elems = b.lower_field_offset(ostride, odist);
-
-            // switch device to where we're copying from
-            rocfft_scoped_device dev(b.device);
-
-            // copy the brick to host, then copy to output
-            std::vector<hostbuf> host_brick(1);
-            host_brick.front().alloc(brick_size_bytes);
-            if(hipMemcpy(
-                   host_brick.front().data(), pobuffer[i], brick_size_bytes, hipMemcpyDeviceToHost)
-               != hipSuccess)
-            {
-                throw std::runtime_error("hipMemcpy failed");
-            }
-
-            std::vector<size_t> ostride_with_batch{odist};
-            std::copy(ostride.begin(), ostride.end(), std::back_inserter(ostride_with_batch));
-
-            copy_buffers(host_brick,
-                         gpu_output,
-                         b.length(),
-                         1,
-                         precision,
-                         otype,
-                         b.stride,
-                         0,
-                         otype,
-                         ostride_with_batch,
-                         0,
-                         {0},
-                         {brick_offset_elems});
+            // not multi-device, no data gathering to be done
+            return;
         }
-        // set pobuffer back to a single-device transform
-        pobuffer.clear();
-        pobuffer.push_back(obuffer.front().data());
+        if(gathered_results_host.empty())
+        {
+            throw std::invalid_argument(
+                "rocfft_params::multi_gpu_finalize: given host-residing buffer does not exist.");
+        }
+        if(otype == fft_array_type_complex_planar || otype == fft_array_type_hermitian_planar)
+            throw std::logic_error("rocfft_params::multi_gpu_finalize: planar output data "
+                                   "considered by current object.");
+        const auto req_min_size = obuffer_sizes()[0];
+        if(gathered_results_host[0].size() < req_min_size)
+        {
+            throw std::invalid_argument(
+                "rocfft_params::multi_gpu_finalize: given host-residing buffer does not exist or "
+                "is too small for gathering the multi-device transform results.");
+            std::ostringstream excpt_info;
+            excpt_info << "rocfft_params::multi_gpu_finalize: given host-residing buffer is is too "
+                          "small for gathering the multi-device transform results.\n"
+                       << "Buffer size is " << gathered_results_host[0].size()
+                       << ", required min size is " << req_min_size << ".";
+            throw std::invalid_argument(excpt_info.str());
+        }
+
+        const auto          process_rank = get_process_rank();
+        std::vector<size_t> ostrides_with_odist(ostride);
+        ostrides_with_odist.insert(ostrides_with_odist.begin(), odist);
+
+        size_t obuffer_idx = 0;
+        for(const auto& ofield : ofields)
+        {
+            for(const auto& obrick : ofield.bricks)
+            {
+                if(obrick.rank != process_rank)
+                    continue;
+                if(obuffer_idx >= mgpu_obuffers.size())
+                {
+                    throw std::invalid_argument(
+                        "rocfft_params::multi_gpu_finalize: not as many device output buffers as "
+                        "expected when gathering the multi-device transform results.");
+                }
+
+                const size_t brick_byte_size = var_size<size_t>(precision, otype)
+                                               * compute_ptrdiff(obrick.length(), obrick.stride);
+
+                const auto offset_in_gathered_results_host
+                    = obrick.lower_field_offset(ostride, odist);
+
+                // switch device to where we're copying from
+                rocfft_scoped_device dev(obrick.device);
+
+                // copy the device results to host, then copy to gathered_results
+                std::vector<hostbuf> host_tmp(1);
+                host_tmp.front().alloc(brick_byte_size);
+                if(hipMemcpy(host_tmp.front().data(),
+                             mgpu_obuffers[obuffer_idx++],
+                             brick_byte_size,
+                             hipMemcpyDeviceToHost)
+                   != hipSuccess)
+                {
+                    throw std::runtime_error("rocfft_params::multi_gpu_finalize: hipMemcpy failed");
+                }
+
+                copy_buffers(host_tmp,
+                             gathered_results_host,
+                             obrick.length(),
+                             /* "nbatch" =  */ 1,
+                             precision,
+                             otype,
+                             obrick.stride,
+                             /* "idist" = */ 0,
+                             otype,
+                             ostrides_with_odist,
+                             /* "odist" =  */ 0,
+                             /* "ioffset" =  */ {0},
+                             {offset_in_gathered_results_host});
+            }
+        }
     }
 
 private:
@@ -608,6 +694,28 @@ private:
             throw std::runtime_error("too many split dimensions");
         }
         return splitDims;
+    }
+
+    int get_process_rank() const
+    {
+        int process_rank = -1; // invalid initialization
+        if(mp_lib == fft_mp_lib_mpi)
+        {
+#ifdef ROCFFT_MPI_ENABLE
+            if(!mp_comm)
+                throw std::runtime_error("Multi-process communicator is not defined");
+            auto ret = MPI_Comm_rank(*static_cast<MPI_Comm*>(mp_comm), &process_rank);
+            if(ret != MPI_SUCCESS || process_rank < 0)
+                throw std::runtime_error("Rank of current process couldn't be set");
+#else
+            throw std::runtime_error("MPI is not enabled");
+#endif
+        }
+        else
+        {
+            process_rank = 0;
+        }
+        return process_rank;
     }
 };
 

--- a/projects/rocfft/CHANGELOG.md
+++ b/projects/rocfft/CHANGELOG.md
@@ -37,6 +37,7 @@ Documentation for rocFFT is available at
 * Fixed incorrect results on some strided real-complex FFTs on gfx90a.
 * Fixed incorrect results on some even-length real FFTs that have odd-length strides on higher dimensions.
 * Fixed callbacks on MPI transforms, when not all ranks have the same number of data bricks.
+* Fixed functional issues for multi-device, in-place real transforms.
 
 ## rocFFT 1.0.36 for ROCm 7.2.0
 

--- a/projects/rocfft/clients/bench/bench.cpp
+++ b/projects/rocfft/clients/bench/bench.cpp
@@ -25,6 +25,7 @@
 
 #include "../../shared/CLI11.hpp"
 #include "../../shared/arithmetic.h"
+#include "../../shared/fft_enums.h"
 #include "../../shared/gpubuf.h"
 #include "../../shared/hip_object_wrapper.h"
 #include "../../shared/rocfft_params.h"

--- a/projects/rocfft/clients/bench/bench.cpp
+++ b/projects/rocfft/clients/bench/bench.cpp
@@ -218,8 +218,8 @@ int main(int argc, char* argv[])
             std::copy(ingrid.begin(), ingrid.end(), input_grid.begin() + 1);
             std::copy(outgrid.begin(), outgrid.end(), output_grid.begin() + 1);
 
-            params.distribute_input(localDeviceCount, input_grid);
-            params.distribute_output(localDeviceCount, output_grid);
+            params.distribute_field<fft_io::fft_io_in>(localDeviceCount, input_grid);
+            params.distribute_field<fft_io::fft_io_out>(localDeviceCount, output_grid);
         }
 
         if(*opt_not_in_place)

--- a/projects/rocfft/clients/bench/dyna-bench.cpp
+++ b/projects/rocfft/clients/bench/dyna-bench.cpp
@@ -49,6 +49,7 @@ namespace std
 #endif
 
 #include "../../shared/CLI11.hpp"
+#include "../../shared/fft_enums.h"
 #include "../../shared/gpubuf.h"
 #include "../../shared/hip_object_wrapper.h"
 #include "../../shared/rocfft_params.h"

--- a/projects/rocfft/clients/bench/dyna-bench.cpp
+++ b/projects/rocfft/clients/bench/dyna-bench.cpp
@@ -471,8 +471,8 @@ int main(int argc, char* argv[])
             std::copy(ingrid.begin(), ingrid.end(), input_grid.begin() + 1);
             std::copy(outgrid.begin(), outgrid.end(), output_grid.begin() + 1);
 
-            params.distribute_input(localDeviceCount, input_grid);
-            params.distribute_output(localDeviceCount, output_grid);
+            params.distribute_field<fft_io::fft_io_in>(localDeviceCount, input_grid);
+            params.distribute_field<fft_io::fft_io_out>(localDeviceCount, output_grid);
         }
 
         if(*opt_not_in_place)

--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -40,6 +40,7 @@
 #include "../../shared/concurrency.h"
 #include "../../shared/device_properties.h"
 #include "../../shared/environment.h"
+#include "../../shared/fft_enums.h"
 #include "../../shared/hostbuf.h"
 #include "../../shared/rocfft_accuracy_test.h"
 #include "../../shared/sys_mem.h"

--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -799,8 +799,8 @@ TEST(manual, vs_fftw) // MANUAL TESTS HERE
         std::vector<unsigned int> deviceGrid(params.length.size() + 1, 1);
         deviceGrid[1] = manual_devices;
 
-        params.distribute_input(manual_devices, deviceGrid);
-        params.distribute_output(manual_devices, deviceGrid);
+        params.distribute_field<fft_io::fft_io_in>(manual_devices, deviceGrid);
+        params.distribute_field<fft_io::fft_io_out>(manual_devices, deviceGrid);
     }
 
     // Run an individual test using the provided command-line parameters.

--- a/projects/rocfft/clients/tests/multi_device_test.cpp
+++ b/projects/rocfft/clients/tests/multi_device_test.cpp
@@ -85,30 +85,19 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
 
     for(auto run_callbacks : {false, true})
     {
-        auto params = param_generator_complex(test_prob,
-                                              multi_gpu_sizes,
-                                              precision_range_sp_dp,
-                                              multi_gpu_batch_range,
-                                              stride_generator(stride_range),
-                                              stride_generator(stride_range),
-                                              ioffset_range_zero,
-                                              ooffset_range_zero,
-                                              {fft_placement_inplace, fft_placement_notinplace},
-                                              false,
-                                              run_callbacks);
-        std::copy(params.begin(), params.end(), std::back_inserter(params_single));
-
-        params = param_generator_real(test_prob,
-                                      multi_gpu_sizes,
-                                      precision_range_sp_dp,
-                                      multi_gpu_batch_range,
-                                      stride_generator(stride_range),
-                                      stride_generator(stride_range),
-                                      ioffset_range_zero,
-                                      ooffset_range_zero,
-                                      {fft_placement_notinplace},
-                                      false,
-                                      run_callbacks);
+        auto params = param_generator_base(test_prob,
+                                           trans_type_range_full,
+                                           multi_gpu_sizes,
+                                           precision_range_sp_dp,
+                                           multi_gpu_batch_range,
+                                           generate_types,
+                                           stride_generator(stride_range),
+                                           stride_generator(stride_range),
+                                           ioffset_range_zero,
+                                           ooffset_range_zero,
+                                           place_range,
+                                           false,
+                                           run_callbacks);
         std::copy(params.begin(), params.end(), std::back_inserter(params_single));
     }
 

--- a/projects/rocfft/clients/tests/multi_device_test.cpp
+++ b/projects/rocfft/clients/tests/multi_device_test.cpp
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 #include "../../shared/accuracy_test.h"
+#include "../../shared/fft_enums.h"
 #include "../../shared/params_gen.h"
 #include "../../shared/rocfft_params.h"
 #include <gtest/gtest.h>

--- a/projects/rocfft/clients/tests/multi_device_test.cpp
+++ b/projects/rocfft/clients/tests/multi_device_test.cpp
@@ -25,6 +25,7 @@
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 
+extern size_t                 random_seed;
 extern fft_params::fft_mp_lib mp_lib;
 extern int                    mp_ranks;
 
@@ -53,16 +54,18 @@ enum SplitType
     PENCIL_3D,
     // split I/O as (single-process) hipfft would implicitly do for the
     // considered number of devices
-    IMPLICIT_HIPFFT
+    IMPLICIT_HIPFFT,
+    // different I/O devices but no decomposition
+    DIFFERENT_IO_DEVICES
 };
 
 std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const int ngpus)
 {
-    int localDeviceCount = 0;
+    int gpusperrank = 0;
     if(ngpus <= 0)
     {
         // Use the command-line option as a priority
-        if(hipGetDeviceCount(&localDeviceCount) != hipSuccess)
+        if(hipGetDeviceCount(&gpusperrank) != hipSuccess)
         {
             throw std::runtime_error("hipGetDeviceCount failed");
         }
@@ -70,15 +73,15 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
         // Limit local device testing to 16 GPUs, as we have some
         // bottlenecks with larger device counts that unreasonably slow
         // down plan creation
-        localDeviceCount = std::min<int>(16, localDeviceCount);
+        gpusperrank = std::min<int>(16, gpusperrank);
     }
     else
     {
-        localDeviceCount = ngpus;
+        gpusperrank = ngpus;
     }
 
     // need multiple devices or multiprocessing to test anything
-    if(localDeviceCount < 2 && mp_lib == fft_params::fft_mp_lib_none)
+    if(gpusperrank < 2 && mp_lib == fft_params::fft_mp_lib_none)
         return {};
 
     static const std::vector<std::vector<size_t>> stride_range = {{1}};
@@ -108,13 +111,17 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
     std::vector<fft_params> all_params;
 
     auto distribute_params = [=, &all_params](const std::vector<fft_params>& params) {
-        int brickCount = mp_lib == fft_params::fft_mp_lib_none ? localDeviceCount : mp_ranks;
+        int brickCount = mp_lib == fft_params::fft_mp_lib_none ? gpusperrank : mp_ranks;
 
         for(auto& p : params)
         {
             // start with all-ones in grids
-            std::vector<unsigned int> input_grid(p.length.size() + 1, 1);
-            std::vector<unsigned int> output_grid(p.length.size() + 1, 1);
+            std::vector<unsigned int>          input_grid(p.length.size() + 1, 1);
+            std::vector<unsigned int>          output_grid(p.length.size() + 1, 1);
+            int                                start_global_dev_id_input  = 0;
+            int                                start_global_dev_id_output = 0;
+            static std::ranlux24_base          gen(random_seed);
+            std::uniform_int_distribution<int> dev_rng(0, gpusperrank * mp_ranks);
 
             auto p_dist = p;
             switch(type)
@@ -190,13 +197,25 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
                     }
                 }
                 break;
+            case DIFFERENT_IO_DEVICES:
+                if(p.placement == fft_placement_inplace || mp_ranks * gpusperrank == 1)
+                    continue; // only out-of-place with more than one device available
+                if(p.run_callbacks)
+                    continue; // known issue to fix w/ callbacks
+                start_global_dev_id_input  = dev_rng(gen);
+                start_global_dev_id_output = dev_rng(gen);
+                while(start_global_dev_id_input == start_global_dev_id_output)
+                    start_global_dev_id_output = dev_rng(gen);
+                break;
             default:
                 throw std::invalid_argument("param_generator_multi_gpu: unkonwn split type");
             }
 
             p_dist.mp_lib = mp_lib;
-            p_dist.distribute_field<fft_io::fft_io_in>(localDeviceCount, input_grid);
-            p_dist.distribute_field<fft_io::fft_io_out>(localDeviceCount, output_grid);
+            p_dist.distribute_field<fft_io::fft_io_in>(
+                gpusperrank, input_grid, mp_ranks, start_global_dev_id_input);
+            p_dist.distribute_field<fft_io::fft_io_out>(
+                gpusperrank, input_grid, mp_ranks, start_global_dev_id_output);
 
             // "placement" flag is meaningless if exactly one of
             // input+output is a field.  So just add those cases if
@@ -251,6 +270,13 @@ INSTANTIATE_TEST_SUITE_P(multi_gpu_3d_pencils,
 INSTANTIATE_TEST_SUITE_P(multi_gpu_implicit_hipfft,
                          accuracy_test,
                          ::testing::ValuesIn(param_generator_multi_gpu(IMPLICIT_HIPFFT, ngpus)),
+                         accuracy_test::TestName);
+
+// input data on one device, output data on another
+INSTANTIATE_TEST_SUITE_P(multi_gpu_different_io_devices,
+                         accuracy_test,
+                         ::testing::ValuesIn(param_generator_multi_gpu(DIFFERENT_IO_DEVICES,
+                                                                       ngpus)),
                          accuracy_test::TestName);
 
 TEST(multi_gpu_validate, catch_validation_errors)

--- a/projects/rocfft/clients/tests/multi_device_test.cpp
+++ b/projects/rocfft/clients/tests/multi_device_test.cpp
@@ -50,6 +50,9 @@ enum SplitType
     // and another dimension contiguous on output, remaining dims are
     // both split
     PENCIL_3D,
+    // split I/O as (single-process) hipfft would implicitly do for the
+    // considered number of devices
+    IMPLICIT_HIPFFT
 };
 
 std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const int ngpus)
@@ -155,6 +158,39 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
                 output_grid[1] = input_grid[1];
                 output_grid[3] = input_grid[2];
                 break;
+            case IMPLICIT_HIPFFT:
+                // unbatched 1D cases are irrelevant at the moment
+                if(p.length.size() < 2 && p.nbatch <= 1)
+                    continue;
+                if(p.nbatch == 1 && p.placement != fft_placement_inplace)
+                    continue; // only in-place is relevant for unbatched cases
+
+                if(p.nbatch > 1)
+                {
+                    // only the batch dimension is split
+                    input_grid[0] = output_grid[0]
+                        = std::min(p.nbatch, static_cast<size_t>(brickCount));
+                }
+                else
+                {
+                    // Slowest nonbatch dimension is split on input (resp. output)
+                    // of forward (resp. inverse) transforms. Second-slowest nonbatch
+                    // dimension is split on output (resp. input) of forward (resp.
+                    // inverse) transforms
+                    if(p.is_forward())
+                    {
+                        input_grid[1]  = brickCount;
+                        output_grid[2] = brickCount;
+                    }
+                    else
+                    {
+                        input_grid[2]  = brickCount;
+                        output_grid[1] = brickCount;
+                    }
+                }
+                break;
+            default:
+                throw std::invalid_argument("param_generator_multi_gpu: unkonwn split type");
             }
 
             p_dist.mp_lib = mp_lib;
@@ -210,15 +246,16 @@ INSTANTIATE_TEST_SUITE_P(multi_gpu_3d_pencils,
                          ::testing::ValuesIn(param_generator_multi_gpu(PENCIL_3D, ngpus)),
                          accuracy_test::TestName);
 
+// decompositions as hipFFT would define under the hood
+INSTANTIATE_TEST_SUITE_P(multi_gpu_implicit_hipfft,
+                         accuracy_test,
+                         ::testing::ValuesIn(param_generator_multi_gpu(IMPLICIT_HIPFFT, ngpus)),
+                         accuracy_test::TestName);
+
 TEST(multi_gpu_validate, catch_validation_errors)
 {
-    const auto all_split_types = {
-        SLOW_INOUT,
-        SLOW_IN,
-        SLOW_OUT,
-        SLOW_IN_FAST_OUT,
-        PENCIL_3D,
-    };
+    const auto all_split_types
+        = {SLOW_INOUT, SLOW_IN, SLOW_OUT, SLOW_IN_FAST_OUT, PENCIL_3D, IMPLICIT_HIPFFT};
 
     for(auto type : all_split_types)
     {

--- a/projects/rocfft/clients/tests/multi_device_test.cpp
+++ b/projects/rocfft/clients/tests/multi_device_test.cpp
@@ -136,6 +136,8 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
                 // fields.
                 if(mp_lib != fft_params::fft_mp_lib_none)
                     continue;
+                if(p_dist.placement == fft_placement_inplace)
+                    continue;
                 input_grid[1] = brickCount;
                 break;
             case SLOW_OUT:
@@ -143,6 +145,8 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
                 // field, but multi-process transforms require both
                 // fields.
                 if(mp_lib != fft_params::fft_mp_lib_none)
+                    continue;
+                if(p_dist.placement == fft_placement_inplace)
                     continue;
                 output_grid[1] = brickCount;
                 break;
@@ -215,15 +219,7 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
             p_dist.distribute_field<fft_io::fft_io_in>(
                 gpusperrank, input_grid, mp_ranks, start_global_dev_id_input);
             p_dist.distribute_field<fft_io::fft_io_out>(
-                gpusperrank, input_grid, mp_ranks, start_global_dev_id_output);
-
-            // "placement" flag is meaningless if exactly one of
-            // input+output is a field.  So just add those cases if
-            // the flag is "out-of-place", since "in-place" is
-            // exactly the same test case.
-            if(p_dist.placement == fft_placement_inplace
-               && p_dist.ifields.empty() != p_dist.ofields.empty())
-                continue;
+                gpusperrank, output_grid, mp_ranks, start_global_dev_id_output);
 
             all_params.push_back(p_dist);
             // also test result scaling for multi-GPU plans

--- a/projects/rocfft/clients/tests/multi_device_test.cpp
+++ b/projects/rocfft/clients/tests/multi_device_test.cpp
@@ -80,8 +80,13 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
         gpusperrank = ngpus;
     }
 
-    // need multiple devices or multiprocessing to test anything
-    if(gpusperrank < 2 && mp_lib == fft_params::fft_mp_lib_none)
+    if(mp_lib == fft_params::fft_mp_lib_none && mp_ranks != 1)
+        throw std::runtime_error("Unexpected value of mp_ranks (" + std::to_string(mp_ranks)
+                                 + ") without a multi-process library.");
+
+    // need more than one device overall, of course
+    const auto total_num_devices = mp_ranks * gpusperrank;
+    if(total_num_devices < 2)
         return {};
 
     static const std::vector<std::vector<size_t>> stride_range = {{1}};
@@ -111,8 +116,6 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
     std::vector<fft_params> all_params;
 
     auto distribute_params = [=, &all_params](const std::vector<fft_params>& params) {
-        int brickCount = mp_lib == fft_params::fft_mp_lib_none ? gpusperrank : mp_ranks;
-
         for(auto& p : params)
         {
             // start with all-ones in grids
@@ -121,51 +124,51 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
             int                                start_global_dev_id_input  = 0;
             int                                start_global_dev_id_output = 0;
             static std::ranlux24_base          gen(random_seed);
-            std::uniform_int_distribution<int> dev_rng(0, gpusperrank * mp_ranks);
+            std::uniform_int_distribution<int> dev_rng(0, total_num_devices);
 
             auto p_dist = p;
             switch(type)
             {
             case SLOW_INOUT:
-                input_grid[1]  = brickCount;
-                output_grid[1] = brickCount;
+                input_grid[1]  = total_num_devices;
+                output_grid[1] = total_num_devices;
                 break;
             case SLOW_IN:
                 // this type only specifies input field and no output
                 // field, but multi-process transforms require both
                 // fields.
-                if(mp_lib != fft_params::fft_mp_lib_none)
+                if(mp_ranks > 1)
                     continue;
                 if(p_dist.placement == fft_placement_inplace)
                     continue;
-                input_grid[1] = brickCount;
+                input_grid[1] = total_num_devices;
                 break;
             case SLOW_OUT:
                 // this type only specifies output field and no input
                 // field, but multi-process transforms require both
                 // fields.
-                if(mp_lib != fft_params::fft_mp_lib_none)
+                if(mp_ranks > 1)
                     continue;
                 if(p_dist.placement == fft_placement_inplace)
                     continue;
-                output_grid[1] = brickCount;
+                output_grid[1] = total_num_devices;
                 break;
             case SLOW_IN_FAST_OUT:
                 // requires at least rank-2 FFT
                 if(p.length.size() < 2)
                     continue;
-                input_grid[1]      = brickCount;
-                output_grid.back() = brickCount;
+                input_grid[1]      = total_num_devices;
+                output_grid.back() = total_num_devices;
                 break;
             case PENCIL_3D:
                 // need at least 2 bricks per split dimension, or 4 devices.
                 // also needs to be a 3D problem.
-                if(brickCount < 4 || p.length.size() != 3)
+                if(total_num_devices < 4 || p.length.size() != 3)
                     continue;
 
                 // make fast dimension contiguous on input
-                input_grid[1] = static_cast<unsigned int>(sqrt(brickCount));
-                input_grid[2] = brickCount / input_grid[1];
+                input_grid[1] = static_cast<unsigned int>(sqrt(total_num_devices));
+                input_grid[2] = total_num_devices / input_grid[1];
                 // make middle dimension contiguous on output
                 output_grid[1] = input_grid[1];
                 output_grid[3] = input_grid[2];
@@ -176,12 +179,11 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
                     continue;
                 if(p.nbatch == 1 && p.placement != fft_placement_inplace)
                     continue; // only in-place is relevant for unbatched cases
-
                 if(p.nbatch > 1)
                 {
                     // only the batch dimension is split
                     input_grid[0] = output_grid[0]
-                        = std::min(p.nbatch, static_cast<size_t>(brickCount));
+                        = std::min(p.nbatch, static_cast<size_t>(total_num_devices));
                 }
                 else
                 {
@@ -191,19 +193,19 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
                     // inverse) transforms
                     if(p.is_forward())
                     {
-                        input_grid[1]  = brickCount;
-                        output_grid[2] = brickCount;
+                        input_grid[1]  = total_num_devices;
+                        output_grid[2] = total_num_devices;
                     }
                     else
                     {
-                        input_grid[2]  = brickCount;
-                        output_grid[1] = brickCount;
+                        input_grid[2]  = total_num_devices;
+                        output_grid[1] = total_num_devices;
                     }
                 }
                 break;
             case DIFFERENT_IO_DEVICES:
-                if(p.placement == fft_placement_inplace || mp_ranks * gpusperrank == 1)
-                    continue; // only out-of-place with more than one device available
+                if(p.placement == fft_placement_inplace)
+                    continue; // only out-of-place
                 if(p.run_callbacks)
                     continue; // known issue to fix w/ callbacks
                 start_global_dev_id_input  = dev_rng(gen);
@@ -220,6 +222,26 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
                 gpusperrank, input_grid, mp_ranks, start_global_dev_id_input);
             p_dist.distribute_field<fft_io::fft_io_out>(
                 gpusperrank, output_grid, mp_ranks, start_global_dev_id_output);
+
+            if(mp_ranks > 1)
+            {
+                std::set<int> used_ranks;
+                for(const auto& io_fields : {p_dist.ifields, p_dist.ofields})
+                {
+                    if(io_fields.empty())
+                        used_ranks.insert(0); // implicit "current" rank
+                    for(const auto& io_field : io_fields)
+                    {
+                        for(const auto& b : io_field.bricks)
+                            used_ranks.insert(b.rank);
+                    }
+                }
+                if(used_ranks.size() < static_cast<size_t>(mp_ranks))
+                {
+                    // some ranks have nothing to do...
+                    continue;
+                }
+            }
 
             all_params.push_back(p_dist);
             // also test result scaling for multi-GPU plans

--- a/projects/rocfft/clients/tests/multi_device_test.cpp
+++ b/projects/rocfft/clients/tests/multi_device_test.cpp
@@ -169,8 +169,8 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
             }
 
             p_dist.mp_lib = mp_lib;
-            p_dist.distribute_input(localDeviceCount, input_grid);
-            p_dist.distribute_output(localDeviceCount, output_grid);
+            p_dist.distribute_field<fft_io::fft_io_in>(localDeviceCount, input_grid);
+            p_dist.distribute_field<fft_io::fft_io_out>(localDeviceCount, output_grid);
 
             // "placement" flag is meaningless if exactly one of
             // input+output is a field.  So just add those cases if

--- a/projects/rocfft/library/src/include/plan.h
+++ b/projects/rocfft/library/src/include/plan.h
@@ -123,8 +123,7 @@ struct rocfft_brick_t
     std::vector<size_t> contiguous_strides() const;
 
     // return true if this brick is contiguous in the specified field
-    bool is_contiguous_in_field(const std::vector<size_t>& field_length,
-                                const std::vector<size_t>& field_stride) const;
+    bool is_contiguous_in_field(const std::vector<size_t>& field_length) const;
 
     // compute offset of this brick, given the field's stride
     size_t offset_in_field(const std::vector<size_t>& fieldStride) const;

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -310,7 +310,7 @@ bool rocfft_plan_t::is_contiguous_input()
 }
 bool rocfft_plan_t::is_contiguous_output()
 {
-    return is_contiguous(lengths, desc.outStrides, desc.outDist);
+    return is_contiguous(outputLengths, desc.outStrides, desc.outDist);
 }
 
 size_t rocfft_plan_t::AddMultiPlanItem(std::unique_ptr<MultiPlanItem>&& item,
@@ -578,17 +578,17 @@ bool rocfft_brick_t::is_contiguous() const
     return true;
 }
 
-bool rocfft_brick_t::is_contiguous_in_field(const std::vector<size_t>& field_length,
-                                            const std::vector<size_t>& field_stride) const
+bool rocfft_brick_t::is_contiguous_in_field(const std::vector<size_t>& field_length) const
 {
     const auto brick_len = length();
 
     // a contiguous brick in a field is shorter than field length
-    // only on the highest dimension, ignoring dimensions of
-    // length-1, and strides must match the field for all those
-    // dimensions.
-    size_t shortDim       = std::numeric_limits<size_t>::max();
-    size_t highestNot1Dim = std::numeric_limits<size_t>::max();
+    // only on the highest dimension (ignoring dimensions of
+    // length-1), and its strides must be consistent with contiguous
+    // storage of the field.
+    size_t shortDim        = std::numeric_limits<size_t>::max();
+    size_t highestNot1Dim  = std::numeric_limits<size_t>::max();
+    size_t expected_stride = 1;
     for(size_t i = 0; i < brick_len.size(); ++i)
     {
         if(field_length[i] == 1)
@@ -602,6 +602,9 @@ bool rocfft_brick_t::is_contiguous_in_field(const std::vector<size_t>& field_len
                 return false;
             shortDim = i;
         }
+        if(stride[i] != expected_stride)
+            return false;
+        expected_stride *= field_length[i];
     }
 
     return shortDim == highestNot1Dim;
@@ -1342,8 +1345,7 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
     BufferPtr  gatherDest;
     const bool gatherToTemp
         = std::any_of(bricks.begin(), bricks.end(), [&](const rocfft_brick_t& brick) {
-              return !brick.is_contiguous()
-                     || !brick.is_contiguous_in_field(field_length, field_stride);
+              return !brick.is_contiguous() || !brick.is_contiguous_in_field(field_length);
           });
     if(gatherToTemp)
     {
@@ -1428,7 +1430,7 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
         // if brick is not contiguous in the field, it was packed to
         // be contiguous for communication.  unpack it so it's
         // contiguous in the field.
-        if(!brick.is_contiguous() || !brick.is_contiguous_in_field(field_length, field_stride))
+        if(!brick.is_contiguous() || !brick.is_contiguous_in_field(field_length))
         {
             std::string description = "unpack brick " + std::to_string(brickIdx) + " after gather";
 
@@ -1481,7 +1483,7 @@ std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t       
     BufferPtr  scatterSrc;
     const bool scatterFromTemp
         = std::any_of(bricks.begin(), bricks.end(), [&](const rocfft_brick_t& b) {
-              return !b.is_contiguous_in_field(field_length, field_stride);
+              return !b.is_contiguous_in_field(field_length);
           });
     if(scatterFromTemp)
     {
@@ -1515,7 +1517,7 @@ std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t       
     {
         const auto& brick = bricks[brickIdx];
 
-        if(brick.is_contiguous_in_field(field_length, field_stride))
+        if(brick.is_contiguous_in_field(field_length))
         {
             // contiguous brick, just copy the data
             scatter->AddOperation(
@@ -1645,14 +1647,14 @@ void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& ex
     std::shared_ptr<TempBufferLease> fftBuf;
     std::shared_ptr<TempBufferLease> fftOutBuf;
 
-    // Gather to temp buf if infields were specified and output is not contiguous or is also a field
     BufferPtr gatherBuf;
     {
-        if(!desc.inFields.empty() && (!is_contiguous_output() || !desc.outFields.empty()))
+        if(!desc.inFields.empty() && desc.outFields.empty() && is_contiguous_output()
+           && execPlan->rootPlan->placement == rocfft_placement_inplace)
         {
-            fftBuf = std::make_shared<TempBufferLease>(
-                tempBuffers, local_comm_rank, execPlanPtr->location, in_elem_count, in_elem_size);
-            gatherBuf = BufferPtr::temp(fftBuf->data());
+            // We can gather directly to the output buffer and will operate in-place
+            // thereafter
+            gatherBuf = BufferPtr::user_output(0, 0);
         }
         else if(desc.inFields.empty())
         {
@@ -1660,14 +1662,15 @@ void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& ex
         }
         else
         {
-            // Else, we can gather directly to the output buffer
-            gatherBuf = BufferPtr::user_output(0, 0);
+            fftBuf = std::make_shared<TempBufferLease>(
+                tempBuffers, local_comm_rank, execPlanPtr->location, in_elem_count, in_elem_size);
+            gatherBuf = BufferPtr::temp(fftBuf->data());
         }
     }
 
     // Allocate another temp buf if FFT is not-in-place and outfield was specified
     // TODO: this only needs to be done if there are multiple bricks in the output field.
-    if(placement == rocfft_placement_notinplace && !desc.outFields.empty())
+    if(execPlan->rootPlan->placement == rocfft_placement_notinplace && !desc.outFields.empty())
     {
         const auto   out_elem_size  = element_size(precision, desc.outArrayType);
         const size_t out_elem_count = compute_ptrdiff(
@@ -1719,7 +1722,7 @@ void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& ex
         auto fieldStrideWithBatch = desc.outStrides;
         fieldStrideWithBatch.push_back(desc.outDist);
 
-        auto fieldLengthWithBatch = lengths;
+        auto fieldLengthWithBatch = outputLengths;
         fieldLengthWithBatch.push_back(batch);
 
         auto scatterSrcBuf = execPlan->rootPlan->placement == rocfft_placement_notinplace

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -1338,7 +1338,7 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
     std::vector<TempBufferLease>   gatherPackBufs;
     std::optional<TempBufferLease> gatherDestBuf;
 
-    std::vector<BufferPtr> outputBufs = GatherUserBuffers(BufferPtr::user_input, bricks);
+    std::vector<BufferPtr> inputBufs = GatherUserBuffers(BufferPtr::user_input, bricks);
 
     const auto local_comm_rank = get_local_comm_rank();
 
@@ -1391,9 +1391,12 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
         if(brick.is_contiguous())
         {
             // Contiguous brick, just copy the data
-            gather->AddOperation(
-                local_comm_rank,
-                {brick.location, outputBufs[brickIdx], 0, gatherOffset, brick.count_elems()});
+            gather->AddOperation(local_comm_rank,
+                                 {brick.location,
+                                  inputBufs[brickIdx],
+                                  0,
+                                  gatherToTemp ? gatherOffset : brick.offset_in_field(field_stride),
+                                  brick.count_elems()});
         }
         else
         {
@@ -1409,7 +1412,7 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
                                                    brick.length(),
                                                    precision,
                                                    arrayType,
-                                                   outputBufs[brickIdx],
+                                                   inputBufs[brickIdx],
                                                    0,
                                                    brick.stride,
                                                    BufferPtr::temp(gatherPackBufs.back().data()),
@@ -1522,7 +1525,11 @@ std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t       
             // contiguous brick, just copy the data
             scatter->AddOperation(
                 local_comm_rank,
-                {brick.location, outputBufs[brickIdx], scatterOffset, 0, brick.count_elems()});
+                {brick.location,
+                 outputBufs[brickIdx],
+                 scatterFromTemp ? scatterOffset : brick.offset_in_field(field_stride),
+                 0,
+                 brick.count_elems()});
         }
         else
         {

--- a/projects/rocfft/shared/accuracy_test.h
+++ b/projects/rocfft/shared/accuracy_test.h
@@ -706,14 +706,7 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
     }
     ASSERT_EQ(plan_status, fft_status_success) << "plan creation failed";
 
-    fft_params contiguous_params;
-    contiguous_params.length         = params.length;
-    contiguous_params.precision      = params.precision;
-    contiguous_params.placement      = fft_placement_notinplace;
-    contiguous_params.transform_type = params.transform_type;
-    contiguous_params.nbatch         = params.nbatch;
-    contiguous_params.itype          = contiguous_itype(params.transform_type);
-    contiguous_params.otype          = contiguous_otype(contiguous_params.transform_type);
+    auto contiguous_params = params.make_params_for_reference_cpu();
 
     contiguous_params.validate();
 
@@ -1190,7 +1183,6 @@ inline void fft_vs_reference_impl(Tparams& params, bool round_trip)
     {
         pobuffer[i] = obuffer->at(i).data();
     }
-
     // scatter data out to multi-GPUs if this is a multi-GPU test
     params.multi_gpu_prepare(cpu_input, ibuffer, pibuffer, pobuffer);
 

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -2376,6 +2376,12 @@ public:
     /**
      * @brief create one input (resp. output) field with as many bricks
      * as desired along every field dimension for the current object.
+     * The device assignment of the bricks is cycling though the total number
+     * of available devices (i.e., `gpusperrank * num_ranks`) starting from
+     * the `start_global_dev_idx` (global) device index.
+     * NOTE: The global device index `g` in `[0, gpusperrank * mp_ranks(`
+     * corresponds to device of local ID `g % gpusperrank` on process of rank
+     * `g / gpusperrank.
      * 
      * @tparam io enum flag specifying whether the input (`io == fft_io::fft_io_in`)
      * or output (`io == fft_io::fft_io_in`) field is being considered.
@@ -2385,11 +2391,11 @@ public:
      * bricks per dimension: `brick_count_along[i]` if the number of bricks
      * desired along the `i`-th field dimension.
      * @param[in] num_ranks number of processes used in the parallel computer
-     * (default value is one)
+     * (default value is 1)
+     * @param[in] start_global_dev_idx first (global) device ID to be considered
+     * in the cyclic assignment (default value is 0)
      * 
      * NOTES:
-     * - the input/output field is created only if an actual division is requested,
-     * i.e., if product(brick_count_along.begin(), brick_count_along.end()) > 1;
      * - data layouts within bricks are set to be compact, i.e., contiguous for
      * bricks in complex domain, padded in real domain for in-place operations
      * (only if the fastest dimension is not divided itself, i.e., if
@@ -2400,7 +2406,8 @@ public:
     template <fft_io io>
     void distribute_field(int                              gpusperrank,
                           const std::vector<unsigned int>& brick_count_along,
-                          int                              num_ranks = 1)
+                          int                              num_ranks            = 1,
+                          int                              start_global_dev_idx = 0)
     {
         static_assert(io == fft_io::fft_io_in || io == fft_io::fft_io_out);
 
@@ -2424,12 +2431,6 @@ public:
                 "number of available device(s) per process.");
 
         const auto total_bricks = product(brick_count_along.begin(), brick_count_along.end());
-        if(total_bricks == 1)
-        {
-            // nothing to split, no field required
-            iofields.clear();
-            return;
-        }
 
         struct length_division
         {
@@ -2490,8 +2491,10 @@ public:
                 }
             }
 
-            iobrick.device = b_idx % gpusperrank; // determine GPU within rank
-            iobrick.rank   = (b_idx / gpusperrank) % num_ranks; // determine MPI rank
+            iobrick.device
+                = (start_global_dev_idx + b_idx) % gpusperrank; // determine GPU within rank
+            iobrick.rank
+                = ((start_global_dev_idx + b_idx) / gpusperrank) % num_ranks; // determine MPI rank
         }
     }
 

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -2381,7 +2381,7 @@ public:
      * the `start_global_dev_idx` (global) device index.
      * NOTE: The global device index `g` in `[0, gpusperrank * mp_ranks(`
      * corresponds to device of local ID `g % gpusperrank` on process of rank
-     * `g / gpusperrank.
+     * `g / gpusperrank`.
      * 
      * @tparam io enum flag specifying whether the input (`io == fft_io::fft_io_in`)
      * or output (`io == fft_io::fft_io_in`) field is being considered.

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -2380,8 +2380,8 @@ public:
      * of available devices (i.e., `gpusperrank * num_ranks`) starting from
      * the `start_global_dev_idx` (global) device index.
      * NOTE: The global device index `g` in `[0, gpusperrank * mp_ranks(`
-     * corresponds to device of local ID `g % gpusperrank` on process of rank
-     * `g / gpusperrank`.
+     * corresponds to device of local ID `g / mp_ranks` on process of rank
+     * `g % mp_ranks`. This prioritize distributing layout across all processes.
      * 
      * @tparam io enum flag specifying whether the input (`io == fft_io::fft_io_in`)
      * or output (`io == fft_io::fft_io_in`) field is being considered.
@@ -2491,10 +2491,8 @@ public:
                 }
             }
 
-            iobrick.device
-                = (start_global_dev_idx + b_idx) % gpusperrank; // determine GPU within rank
-            iobrick.rank
-                = ((start_global_dev_idx + b_idx) / gpusperrank) % num_ranks; // determine MPI rank
+            iobrick.rank   = (start_global_dev_idx + b_idx) % num_ranks;
+            iobrick.device = ((start_global_dev_idx + b_idx) / num_ranks) % gpusperrank;
         }
     }
 

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -2373,125 +2373,126 @@ public:
     {
     }
 
-    // Create bricks in the specified field.  brick_grid has an
-    // integer per dimension (batch and FFT dimensions), with the
-    // number of bricks to split that dimension on.  Field length
-    // starts with batch dimension, followed by FFT dimensions
-    // slowest to fastest.
-    // num_ranks represents the number of ranks used in the parallel
-    // computer, which are assumed to have at least gpusperrank each
+    /**
+     * @brief create one input (resp. output) field with as many bricks
+     * as desired along every field dimension for the current object.
+     * 
+     * @tparam io enum flag specifying whether the input (`io == fft_io::fft_io_in`)
+     * or output (`io == fft_io::fft_io_in`) field is being considered.
+     * 
+     * @param[in] gpusperrank number of GPU devices available to each process
+     * @param[in] brick_count_along desired (strictly positive) numbers of
+     * bricks per dimension: `brick_count_along[i]` if the number of bricks
+     * desired along the `i`-th field dimension.
+     * @param[in] num_ranks number of processes used in the parallel computer
+     * (default value is one)
+     * 
+     * NOTES:
+     * - the input/output field is created only if an actual division is requested,
+     * i.e., if product(brick_count_along.begin(), brick_count_along.end()) > 1;
+     * - data layouts within bricks are set to be compact, i.e., contiguous for
+     * bricks in complex domain, padded in real domain for in-place operations
+     * (only if the fastest dimension is not divided itself, i.e., if
+     * brick_count_along.last() == 1)
+     * - if more bricks than available devices are requested, some bricks may be
+     * assigned to the same device.
+     */
+    template <fft_io io>
     void distribute_field(int                              gpusperrank,
-                          const std::vector<unsigned int>& brick_grid,
-                          std::vector<fft_field>&          fields,
-                          const std::vector<size_t>&       field_length,
-                          int                              num_ranks)
-    {
-        if(brick_grid.size() != field_length.size())
-            throw std::runtime_error(
-                "distribute field requires same number of dims for grid and field length");
-
-        // if nothing's actually split, don't bother making bricks
-        if(std::all_of(
-               brick_grid.begin(), brick_grid.end(), [](const unsigned int g) { return g == 1; }))
-            return;
-
-        size_t total_bricks = product(brick_grid.begin(), brick_grid.end());
-
-        auto& field = fields.emplace_back();
-
-        // Start with empty brick in field
-        field.bricks.reserve(total_bricks);
-        field.bricks.emplace_back();
-
-        // Go over the grid
-        for(size_t i = 0; i < brick_grid.size(); ++i)
-        {
-            std::vector<fft_brick> cur_bricks;
-            cur_bricks.swap(field.bricks);
-            field.bricks.reserve(total_bricks);
-
-            auto brick_count = brick_grid[i];
-            auto cur_length  = field_length[i];
-
-            // split current length, apply to all current bricks and
-            // append bricks to field
-            for(size_t ibrick = 0; ibrick < brick_count; ++ibrick)
-            {
-                for(const auto& b : cur_bricks)
-                {
-                    auto& new_brick = field.bricks.emplace_back(b);
-                    new_brick.lower.push_back(cur_length / brick_count * ibrick);
-                    // last brick needs to include the whole split len
-                    if(ibrick == brick_count - 1)
-                    {
-                        new_brick.upper.push_back(cur_length);
-                    }
-                    else
-                    {
-                        new_brick.upper.push_back(std::min(
-                            cur_length, new_brick.lower.back() + cur_length / brick_count));
-                    }
-                }
-            }
-        }
-
-        // Give all bricks contiguous strides
-        int brickIdx = 0;
-        for(auto& b : field.bricks)
-        {
-            b.stride.resize(b.upper.size());
-
-            // Fill strides from fastest to slowest
-            size_t brick_dist = 1;
-            for(size_t distIdx = 0; distIdx < b.upper.size(); ++distIdx)
-            {
-                *(b.stride.rbegin() + distIdx) = brick_dist;
-                brick_dist *= *(b.upper.rbegin() + distIdx) - *(b.lower.rbegin() + distIdx);
-            }
-
-            // Split across ranks for a multi-process transform,
-            // otherwise split across bricks.  assume there's one
-            // rank/device per brick
-            if(mp_lib == fft_mp_lib_none)
-            {
-                b.device = brickIdx;
-            }
-            else
-            {
-                int rank = brickIdx / gpusperrank; // determine MPI rank
-                int gpu  = brickIdx % gpusperrank; // determine GPU within rank
-
-                b.rank   = rank;
-                b.device = gpu;
-            }
-            brickIdx++;
-        }
-    }
-
-    // Distribute problem input among specified grid of devices/processors.
-    // Grid specifies number of bricks per dimension, starting with batch
-    // and ending with fastest FFT dimension. For single-proc single-proc
-    // multi-gpu, gpusperrank represents the number of GPUs to use;
-    // while for multi-proc it represents the number of GPUs on each rank.
-    void distribute_input(int                              gpusperrank,
-                          const std::vector<unsigned int>& brick_grid,
+                          const std::vector<unsigned int>& brick_count_along,
                           int                              num_ranks = 1)
     {
-        auto len = length;
-        len.insert(len.begin(), nbatch);
-        distribute_field(gpusperrank, brick_grid, ifields, len, num_ranks);
-    }
+        static_assert(io == fft_io::fft_io_in || io == fft_io::fft_io_out);
 
-    // Distribute problem output among specified grid of devices/processors.
-    // Grid specifies number of bricks per dimension, starting with batch
-    // and ending with fastest FFT dimension.
-    void distribute_output(int                              gpusperrank,
-                           const std::vector<unsigned int>& brick_grid,
-                           int                              num_ranks = 1)
-    {
-        auto len = olength();
-        len.insert(len.begin(), nbatch);
-        distribute_field(gpusperrank, brick_grid, ofields, len, num_ranks);
+        auto& iofields       = io == fft_io::fft_io_in ? ifields : ofields;
+        auto  iofield_length = io == fft_io::fft_io_in ? ilength() : olength();
+        iofield_length.insert(iofield_length.begin(), nbatch);
+        const auto field_size = iofield_length.size(); // --> field_size > 0
+        // arg validation
+        if(brick_count_along.size() != field_size)
+            throw std::runtime_error(
+                "fft_params::distribute_field inconsistent size between desired number of bricks "
+                "per dimension and number of dimensions");
+        if(std::any_of(
+               brick_count_along.begin(),
+               brick_count_along.end(),
+               [](const auto& brick_count_along_dim) { return brick_count_along_dim == 0; }))
+            throw std::invalid_argument("brick_count_per_dim must not be 0.");
+        if(gpusperrank < 1 || num_ranks < 1)
+            throw std::invalid_argument(
+                "fft_params::distribute_field requires strictly positive number of processes and "
+                "number of available device(s) per process.");
+
+        const auto total_bricks = product(brick_count_along.begin(), brick_count_along.end());
+        if(total_bricks == 1)
+        {
+            // nothing to split, no field required
+            iofields.clear();
+            return;
+        }
+
+        struct length_division
+        {
+            size_t min_length;
+            size_t remainder;
+        };
+        std::vector<length_division> field_division_along(field_size);
+        for(auto field_dim = field_size; field_dim-- > 0;)
+        {
+            field_division_along[field_dim].min_length
+                = iofield_length[field_dim] / brick_count_along[field_dim];
+            field_division_along[field_dim].remainder
+                = iofield_length[field_dim] % brick_count_along[field_dim];
+        }
+
+        // make ONE field with as many bricks as required along every field dimension
+        iofields.resize(1);
+        auto& iofield  = iofields[0];
+        auto& iobricks = iofield.bricks;
+        // Create the required number of bricks
+        iobricks.resize(total_bricks);
+        // define them
+        for(size_t b_idx = 0; b_idx < total_bricks; b_idx++)
+        {
+            auto&               iobrick = iobricks[b_idx];
+            std::vector<size_t> brick_dim_idx(field_size, 0);
+            iobrick.lower.resize(field_size);
+            iobrick.upper.resize(field_size);
+            iobrick.stride.resize(field_size);
+            auto tmp_idx = b_idx;
+            for(auto field_dim = field_size; field_dim-- > 0;
+                tmp_idx /= brick_count_along[field_dim])
+            {
+                const auto brick_idx_along_dim = tmp_idx % brick_count_along[field_dim];
+                const auto brick_length_along_dim
+                    = field_division_along[field_dim].min_length
+                      + (brick_idx_along_dim < field_division_along[field_dim].remainder ? 1 : 0);
+                iobrick.lower[field_dim]
+                    = brick_idx_along_dim * field_division_along[field_dim].min_length
+                      + std::min(brick_idx_along_dim, field_division_along[field_dim].remainder);
+                iobrick.upper[field_dim] = iobrick.lower[field_dim] + brick_length_along_dim;
+                if(field_dim == field_size - 1)
+                    iobrick.stride[field_dim] = 1; // contiguous along fastest dimension
+                else
+                {
+                    auto stride_multiplier
+                        = iobrick.upper[field_dim + 1] - iobrick.lower[field_dim + 1];
+                    if(field_dim == field_size - 2 && is_real()
+                       && placement == fft_placement_inplace
+                       && (is_forward() ^ (io == fft_io::fft_io_out)) /* <-- brick in real domain */
+                       && brick_count_along[field_size - 1] == 1)
+                    {
+                        // real in-place case with fastest dimension that is NOT divided
+                        // --> most likely use case is *with* padding
+                        stride_multiplier = 2 * (stride_multiplier / 2 + 1);
+                    }
+                    iobrick.stride[field_dim] = iobrick.stride[field_dim + 1] * stride_multiplier;
+                }
+            }
+
+            iobrick.device = b_idx % gpusperrank; // determine GPU within rank
+            iobrick.rank   = (b_idx / gpusperrank) % num_ranks; // determine MPI rank
+        }
     }
 
     // Apply load operations specified by this struct to the host-side

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -2305,28 +2305,71 @@ public:
         scale_factor = 1 / params_forward.scale_factor;
     }
 
-    // prepare for multi-GPU transform.  cpu_input has contiguous
-    // input on the host, ibuffer has device input, which can be
-    // discarded if it's turned into multi-GPU bricks.  pibuffer,
-    // pobuffer are the pointers that will be passed to the FFT
-    // library's "execute" API.
-    virtual void multi_gpu_prepare(std::vector<hostbuf>& cpu_input,
-                                   std::vector<gpubuf>&  ibuffer,
-                                   std::vector<void*>&   pibuffer,
-                                   std::vector<void*>&   pobuffer)
+    /**
+     * @brief initialize the I/O device buffers as required for multi-device
+     * transforms described by this object. Device buffers are determined (created
+     * and allocated, if needed), and input buffers are data-initialized using the
+     * provided host-residing (resp. device-residing) reference data for the
+     * `rocfft_params` (resp. `hipfft_params`) derived class.
+     *
+     * TODO: unify data-initialization logic across derived classes and make all arguments
+     * relevant in all cases (remove ignore ones).
+     * 
+     * @param[in] input_data_host vector of (at least) one host buffer containing the
+     * input-initialization data to be considered for data-initialization of the
+     * device input buffers (this is unused by `hipfft_params` objects). If used,
+     * the data layout of `input_data_host[0]` must be consistent with `cpu_params.istride`,
+     * `cpu_params.idist`, etc. wherein `cpu_params = this->make_params_for_reference_cpu()`.
+     * @param[in] input_data_gpu vector of (at least) one device buffer containing the
+     * input-initialization data to be considered for data-initialization of the
+     * device input buffers (this is unused by `rocfft_params` objects). If used,
+     * the data layout of `input_data_gpu[0]` must be consistent with `this->istride`,
+     * `this->idist`, etc.
+     * @param[out] mgpu_ibuffers vector of raw pointers to input device allocations as
+     * needed for the multi-device transform that this object describes. The content
+     * of these device allocations is initialized with the (transposed) content of
+     * `input_data_host` (resp. `input_data_gpu`) by `rocfft_params` (resp. `hipfft_params`)
+     * objects. Upon return, the data layout in these device allocations is
+     * - as described by the corresponding input brick's for `rocfft_params` objects;
+     * - as implicitly-defined for `hipfft_params` objects.
+     * @param[out] mgpu_obuffers vector of raw pointers to output device allocations as
+     * needed for the multi-device transform that this object describes.
+     */
+    virtual void multi_gpu_prepare(std::vector<hostbuf>& input_data_host,
+                                   std::vector<gpubuf>&  input_data_gpu,
+                                   std::vector<void*>&   mgpu_ibuffers,
+                                   std::vector<void*>&   mgpu_obuffers)
     {
     }
 
-    // finalize multi-GPU transform.  pobuffers are the pointers
-    // provided to the FFT library's "execute" API.  obuffer is the
-    // normal GPU buffer that is used for single-device FFTs.
-    // gpu_output is the host buffer where transform output needs to
-    // go for validation
-    // Field is distributed among ranks and then among the number
-    // of GPUs per rank (which defaults to 1).
-    virtual void multi_gpu_finalize(std::vector<hostbuf>& gpu_output,
-                                    std::vector<gpubuf>&  obuffer,
-                                    std::vector<void*>&   pobuffer)
+    /**
+     * @brief gather the results of a multi-device transform to a unique host-residing
+     * buffer for `rocfft_params` objects (resp. device-residing buffer for
+     * `hipfft_params` objects).
+     * 
+     * TODO: unify data-gathering logic across derived classes and make all arguments
+     * relevant in all cases (remove ignore ones).
+     * 
+     * @param[out] gathered_results_host vector of (at least) one host buffer (ignored by
+     * `hipfft_params` objects). If not ignored, `gathered_results_host[0]` contains the
+     * gathered output data of the multi-device transform upon return.
+     * @param[out] gathered_results_device vector of (at least) one device buffer (ignored
+     * by `rocfft_params` objects). If not ignored, `gathered_results_device[0]` contains
+     * the gathered output data of the multi-device transform upon return.
+     * @param[in] mgpu_obuffers vector of raw pointers to output device allocations
+     * considered by the (previously-executed) multi-device transform described by this
+     * object.
+     * 
+     * Note 1: whichever gathering buffer that is considered (`gathered_results_host[0]`
+     * or `gathered_results_device[0]`) must be large enough for containing the
+     * gathered results when passed to this function: this function does NOT resize it.
+     * Note 2: the data layout in the considered gathered results is defined
+     * by the calling object's output data layout parameter, i.e., defined by
+     * `this->ostride`, `this->odist`, `this->otype`, etc.
+     */
+    virtual void multi_gpu_finalize(std::vector<hostbuf>& gathered_results_host,
+                                    std::vector<gpubuf>&  gathered_results_device,
+                                    std::vector<void*>&   mgpu_obuffers)
     {
     }
 
@@ -2604,6 +2647,36 @@ public:
             abort();
         }
 #endif
+    }
+
+    fft_params make_params_for_reference_cpu() const
+    {
+        fft_params ret;
+        ret.length         = length;
+        ret.precision      = precision;
+        ret.placement      = fft_placement_notinplace;
+        ret.transform_type = transform_type;
+        ret.nbatch         = nbatch;
+        ret.itype          = is_real() ? (is_forward() ? fft_array_type_real
+                                                       : fft_array_type_hermitian_interleaved)
+                                       : fft_array_type_complex_interleaved;
+        ret.otype          = is_real() ? (is_inverse() ? fft_array_type_real
+                                                       : fft_array_type_hermitian_interleaved)
+                                       : fft_array_type_complex_interleaved;
+        ret.istride
+            = default_strides(transform_type, fft_placement_notinplace, fft_io::fft_io_in, length);
+        ret.ostride
+            = default_strides(transform_type, fft_placement_notinplace, fft_io::fft_io_out, length);
+        ret.idist = default_distance(
+            transform_type, fft_placement_notinplace, fft_io::fft_io_in, length, nbatch);
+        ret.odist = default_distance(
+            transform_type, fft_placement_notinplace, fft_io::fft_io_out, length, nbatch);
+        ret.compute_isize();
+        ret.compute_osize();
+
+        // other ret's members should be irrelevant for cpu reference calculations
+        // (default values)
+        return ret;
     }
 };
 

--- a/projects/rocfft/shared/mpi_worker.h
+++ b/projects/rocfft/shared/mpi_worker.h
@@ -23,6 +23,7 @@
 #include "fft_params.h"
 
 #include "CLI11.hpp"
+#include "fft_enums.h"
 #include "gpubuf.h"
 #include "hostbuf.h"
 #include "ptrdiff.h"

--- a/projects/rocfft/shared/mpi_worker.h
+++ b/projects/rocfft/shared/mpi_worker.h
@@ -32,6 +32,8 @@
 #include "test_callbacks.h"
 #include <chrono>
 #include <mpi.h>
+#include <optional>
+#include <stdexcept>
 
 static MPI_Datatype get_mpi_type(size_t elem_size)
 {
@@ -365,30 +367,53 @@ static void gather_field(MPI_Comm                                  mpi_comm,
 // Allocate device buffer(s) to hold all of the bricks for this rank.
 // A rank can have N bricks on it but this will allocate one
 // contiguous buffer per device and return pointers to each of the N bricks.
-static void alloc_local_bricks(int                                       mpi_rank,
-                               const std::vector<fft_params::fft_brick>& bricks,
-                               size_t                                    elem_size,
-                               std::map<int, gpubuf>&                    buffers,
-                               std::vector<void*>&                       buffer_ptrs)
+static void
+    alloc_local_bricks(int                                       mpi_rank,
+                       const std::vector<fft_params::fft_brick>& bricks,
+                       size_t                                    elem_size,
+                       std::map<int, gpubuf>&                    buffers,
+                       std::vector<void*>&                       buffer_ptrs,
+                       const std::vector<fft_params::fft_brick>* corresponding_in_place_bricks
+                       = nullptr,
+                       size_t corresponding_in_place_elem_size = 0)
 {
     // Get bricks that are local to this rank
     auto local_range = std::equal_range(bricks.begin(), bricks.end(), mpi_rank, match_rank());
+    if(corresponding_in_place_bricks)
+    {
+        if(corresponding_in_place_elem_size == 0)
+            throw std::invalid_argument("Invalid element size for corresponding in-place I/O data");
+
+        for(auto brick = local_range.first; brick != local_range.second; ++brick)
+        {
+            const size_t brick_idx = std::distance(bricks.begin(), brick);
+            if(brick_idx >= corresponding_in_place_bricks->size()
+               || corresponding_in_place_bricks->at(brick_idx).rank != mpi_rank
+               || corresponding_in_place_bricks->at(brick_idx).device != brick->device)
+                throw std::invalid_argument("Invalid configuration for in-place operations");
+        }
+    }
 
     // Do one pass over these bricks to work out how big of a buffer
     // we need to allocate on each device
-    std::map<int, size_t> buffer_sizes;
+    std::map<int, size_t> buffer_byte_sizes;
     for(auto brick = local_range.first; brick != local_range.second; ++brick)
     {
-        buffer_sizes.insert({brick->device, static_cast<size_t>(0)}).first->second
-            += compute_ptrdiff(brick->length(), brick->stride);
+        const size_t brick_idx = std::distance(bricks.begin(), brick);
+        buffer_byte_sizes.insert({brick->device, static_cast<size_t>(0)}).first->second
+            += std::max(compute_ptrdiff(brick->length(), brick->stride) * elem_size,
+                        corresponding_in_place_bricks
+                            ? compute_ptrdiff(corresponding_in_place_bricks->at(brick_idx).length(),
+                                              corresponding_in_place_bricks->at(brick_idx).stride)
+                                  * corresponding_in_place_elem_size
+                            : 0);
     }
 
     // Alloc buffers for each device
-    for(const auto buffer_size : buffer_sizes)
+    for(const auto buffer_size : buffer_byte_sizes)
     {
         rocfft_scoped_device dev(buffer_size.first);
-        if(buffers.emplace(buffer_size.first, gpubuf{})
-               .first->second.alloc(buffer_size.second * elem_size)
+        if(buffers.emplace(buffer_size.first, gpubuf{}).first->second.alloc(buffer_size.second)
            != hipSuccess)
         {
             throw std::runtime_error("Failed to allocate buffer on device "
@@ -399,14 +424,20 @@ static void alloc_local_bricks(int                                       mpi_ran
     // Return pointers for each brick
     for(auto brick = local_range.first; brick != local_range.second; ++brick)
     {
-        auto& buf = buffers[brick->device];
+        const size_t brick_idx = std::distance(bricks.begin(), brick);
+        auto&        buf       = buffers[brick->device];
 
-        // Use buffer_sizes to count down bricks for each device
-        auto& remaining_size = buffer_sizes[brick->device];
-        auto  offset_elems   = (buf.size() / elem_size) - remaining_size;
-        remaining_size -= compute_ptrdiff(brick->length(), brick->stride);
-
-        buffer_ptrs.push_back(buf.data_offset(offset_elems * elem_size));
+        // Use buffer_byte_sizes to count down bricks for each device
+        auto& remaining_byte_size = buffer_byte_sizes[brick->device];
+        auto  offset_bytes        = buf.size() - remaining_byte_size;
+        remaining_byte_size
+            -= std::max(compute_ptrdiff(brick->length(), brick->stride) * elem_size,
+                        corresponding_in_place_bricks
+                            ? compute_ptrdiff(corresponding_in_place_bricks->at(brick_idx).length(),
+                                              corresponding_in_place_bricks->at(brick_idx).stride)
+                                  * corresponding_in_place_elem_size
+                            : 0);
+        buffer_ptrs.push_back(buf.data_offset(offset_bytes));
     }
 }
 
@@ -517,8 +548,14 @@ void exec_testcases(std::function<AllParams(const std::vector<std::string>&)> ma
     const auto  out_elem_size = var_size<size_t>(params.precision, params.otype);
 
     // allocate and initialize input buffers
-    alloc_local_bricks(
-        mpi_rank, params.ifields.back().bricks, in_elem_size, local_inputs, local_input_ptrs);
+    alloc_local_bricks(mpi_rank,
+                       params.ifields.back().bricks,
+                       in_elem_size,
+                       local_inputs,
+                       local_input_ptrs,
+                       params.placement == fft_placement_inplace ? &params.ofields.back().bricks
+                                                                 : nullptr,
+                       out_elem_size);
 
     init_local_input<decltype(params), gpubuf>(
         mpi_rank, params, params.ifields.back().bricks, in_elem_size, local_input_ptrs);

--- a/projects/rocfft/shared/mpi_worker.h
+++ b/projects/rocfft/shared/mpi_worker.h
@@ -974,8 +974,8 @@ int mpi_worker_main(const char*                                               de
         // each node, GPUs are indexed 0,1,...,N
 
         // distribute input and output among the available number of ranks and GPUs per rank
-        params.distribute_input(ngpus, input_grid, mp_size);
-        params.distribute_output(ngpus, output_grid, mp_size);
+        params.distribute_field<fft_io::fft_io_in>(ngpus, input_grid, mp_size);
+        params.distribute_field<fft_io::fft_io_out>(ngpus, output_grid, mp_size);
 
         params.validate();
         token = params.token();

--- a/projects/rocfft/shared/rocfft_params.h
+++ b/projects/rocfft/shared/rocfft_params.h
@@ -21,6 +21,7 @@
 #ifndef ROCFFT_PARAMS_H
 #define ROCFFT_PARAMS_H
 
+#include "../shared/fft_enums.h"
 #include "../shared/fft_params.h"
 #include "../shared/gpubuf.h"
 #include "../shared/precision_type.h"

--- a/projects/rocfft/shared/rocfft_params.h
+++ b/projects/rocfft/shared/rocfft_params.h
@@ -175,22 +175,13 @@ public:
 
         if(rocfft.field_create(&rfield) != rocfft_status_success)
             throw std::runtime_error("rocfft_field_create failed");
+        const auto proc_rank = get_process_rank();
         for(const auto& b : f.bricks)
         {
             // if this is an MPI transform, only tell the current rank
             // about bricks for that rank
-            if(mp_lib == fft_mp_lib_mpi)
-            {
-#ifdef ROCFFT_MPI_ENABLE
-                int mpi_rank = 0;
-                MPI_Comm_rank(*static_cast<MPI_Comm*>(mp_comm), &mpi_rank);
-
-                if(mpi_rank != b.rank)
-                    continue;
-#else
-                throw std::runtime_error("MPI is not enabled");
-#endif
-            }
+            if(proc_rank != b.rank)
+                continue;
 
             // rocFFT wants column-major bricks and fft_params stores
             // row-major
@@ -363,13 +354,7 @@ public:
         if(fields.empty())
             return 1;
 
-        int mpi_rank = 0;
-#ifdef ROCFFT_MPI_ENABLE
-        if(mp_lib == fft_mp_lib_mpi)
-        {
-            MPI_Comm_rank(*static_cast<MPI_Comm*>(mp_comm), &mpi_rank);
-        }
-#endif
+        const int mpi_rank = get_process_rank();
 
         // count the number of bricks on this rank
         size_t expected_callbacks = 0;
@@ -425,98 +410,167 @@ public:
         return fft_status_from_rocfftparams(ret);
     }
 
-    // scatter data to multiple GPUs and adjust I/O buffers to match
-    virtual void multi_gpu_prepare(std::vector<hostbuf>& cpu_input,
-                                   std::vector<gpubuf>&  ibuffer,
-                                   std::vector<void*>&   pibuffer,
-                                   std::vector<void*>&   pobuffer) override
+    void multi_gpu_prepare(std::vector<hostbuf>& input_data_host,
+                           std::vector<gpubuf>& /* input_data_gpu (unused) */,
+                           std::vector<void*>& mgpu_ibuffers,
+                           std::vector<void*>& mgpu_obuffers) override
     {
-        auto alloc_fields = [&](const fft_params::fft_field& field,
-                                fft_array_type               array_type,
-                                std::vector<void*>&          pbuffer,
-                                bool                         copy_input) {
-            if(field.bricks.empty())
-                return;
+        if(ifields.empty() && ofields.empty())
+        {
+            // not a multi-device case
+            return;
+        }
 
-            // we have a field defined, clear the list of buffers as
-            // we'll be allocating new ones for each brick
-            pbuffer.clear();
+        if(input_data_host.empty())
+        {
+            throw std::invalid_argument(
+                "rocfft_params::multi_gpu_prepare: host-residing input buffer does not exist.");
+        }
+        const auto cpu_ref_params = make_params_for_reference_cpu();
+        if(cpu_ref_params.itype == fft_array_type_complex_planar
+           || cpu_ref_params.itype == fft_array_type_hermitian_planar)
+            throw std::logic_error("rocfft_params::multi_gpu_prepare: planar input data considered "
+                                   "by cpu reference calculation.");
+        const auto req_min_size = cpu_ref_params.ibuffer_sizes()[0];
+        if(input_data_host[0].size() < req_min_size)
+        {
+            std::ostringstream excpt_info;
+            excpt_info << "rocfft_params::multi_gpu_prepare: given host-residing input buffer is "
+                          "too small for scattering the multi-device transform inputs.\n"
+                       << "Buffer size is " << input_data_host[0].size()
+                       << ", required min size is " << req_min_size << ".";
+            throw std::invalid_argument(excpt_info.str());
+        }
 
-            const size_t elem_size_bytes = var_size<size_t>(precision, array_type);
-
-            for(const auto& b : field.bricks)
+        if(placement == fft_placement_inplace)
+        {
+            // validate test case configuration with respect to what we assume below (current
+            // limitations with respect to what we test for "in-place multi-device")
+            const std::runtime_error unmet_mgpu_inplace_requirement(
+                "rocfft_params::multi_gpu_prepare requires in-place tests to have the same total "
+                "number of fields and number of bricks per field on input and output. All bricks "
+                "should be assigned to the same devices, in the same order on input and output.");
+            if(ifields.size() != ofields.size())
+                throw unmet_mgpu_inplace_requirement;
+            for(size_t field_idx = 0; field_idx < ifields.size(); field_idx++)
             {
-                const size_t brick_size_elems = compute_ptrdiff(b.length(), b.stride);
-                const size_t brick_size_bytes = brick_size_elems * elem_size_bytes;
-
-                // set device for the alloc, but we want to return to the
-                // default device as the source of a following memcpy
+                const auto& ifield = ifields[field_idx];
+                const auto& ofield = ofields[field_idx];
+                if(ifield.bricks.size() != ofield.bricks.size())
+                    throw unmet_mgpu_inplace_requirement;
+                for(size_t b_idx = 0; b_idx < ifield.bricks.size(); b_idx++)
                 {
-                    rocfft_scoped_device dev(b.device);
-                    multi_gpu_data.emplace_back();
-                    if(multi_gpu_data.back().alloc(brick_size_bytes) != hipSuccess)
-                        throw std::runtime_error("device allocation failure");
-                    pbuffer.push_back(multi_gpu_data.back().data());
+                    const auto& ibrick = ifield.bricks[b_idx];
+                    const auto& obrick = ofield.bricks[b_idx];
+                    if(ibrick.rank != obrick.rank || ibrick.device != obrick.device)
+                        throw unmet_mgpu_inplace_requirement;
                 }
+            }
+        }
 
-                if(copy_input)
+        // I/O raw pointer(s) are left untouched if there is no corresponding field,
+        // i.e., no data decomposition
+        if(!ifields.empty())
+            mgpu_ibuffers.clear();
+        if(!ofields.empty())
+            mgpu_obuffers.clear();
+        const auto process_rank = get_process_rank();
+        for(size_t f_idx = 0; f_idx < std::max(ifields.size(), ofields.size()); f_idx++)
+        {
+            const auto* ifield = f_idx < ifields.size() ? &ifields[f_idx] : nullptr;
+            const auto* ofield = f_idx < ofields.size() ? &ofields[f_idx] : nullptr;
+            for(size_t b_idx = 0; b_idx < std::max(ifield ? ifield->bricks.size() : 0,
+                                                   ofield ? ofield->bricks.size() : 0);
+                b_idx++)
+            {
+                const auto* ibrick
+                    = ifield && b_idx < ifield->bricks.size() ? &ifield->bricks[b_idx] : nullptr;
+                const auto* obrick
+                    = ofield && b_idx < ofield->bricks.size() ? &ofield->bricks[b_idx] : nullptr;
+                for(const auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
                 {
-                    // get this brick's starting offset in the field
-                    const size_t brick_offset_elems = b.lower_field_offset(istride, idist);
-
-                    // transpose input data to the brick's shape in
-                    // host memory, then memcpy
-
-                    // alloc a host-side brick that's the right shape
-                    std::vector<hostbuf> host_brick(1);
-                    host_brick.front().alloc(brick_size_bytes);
-
-                    std::vector<size_t> istride_with_batch{idist};
-                    std::copy(
-                        istride.begin(), istride.end(), std::back_inserter(istride_with_batch));
-
-                    copy_buffers(cpu_input,
-                                 host_brick,
-                                 b.length(),
-                                 1,
-                                 precision,
-                                 array_type,
-                                 istride_with_batch,
-                                 0,
-                                 array_type,
-                                 b.stride,
-                                 0,
-                                 {brick_offset_elems},
-                                 {0});
-
-                    // memcpy the transposed brick to the device
-                    if(hipMemcpy(pbuffer.back(),
-                                 host_brick.front().data(),
-                                 brick_size_bytes,
-                                 hipMemcpyHostToDevice)
-                       != hipSuccess)
+                    if(placement == fft_placement_inplace && io == fft_io::fft_io_out)
                     {
-                        throw std::runtime_error("hipMemcpy failure");
+                        // outputs and input are set together (when the input is set)
+                        // for in-place operations
+                        continue;
+                    }
+                    const auto* io_brick = io == fft_io::fft_io_in ? ibrick : obrick;
+                    auto& io_buffer_vec  = io == fft_io::fft_io_in ? mgpu_ibuffers : mgpu_obuffers;
+                    if(!io_brick || io_brick->rank != process_rank)
+                        continue;
+                    // calculate byte size for device allocation:
+                    const auto array_type = io == fft_io::fft_io_in ? itype : otype;
+                    size_t     alloc_byte_size
+                        = var_size<size_t>(precision, array_type)
+                          * compute_ptrdiff(io_brick->length(), io_brick->stride);
+                    if(placement == fft_placement_inplace)
+                    {
+                        // The I/O buffers must be large enough for both input and output data.
+                        // NOTE: see above argument validation checks for testing "in-place". As
+                        // a consequence, if this point is reached, io_brick == ibrick,
+                        // obrick != nullptr, ibrick->rank == obrick->rank, and
+                        // ibrick->device == obrick->device.
+                        alloc_byte_size
+                            = std::max(alloc_byte_size,
+                                       var_size<size_t>(precision, otype)
+                                           * compute_ptrdiff(obrick->length(), obrick->stride));
+                    }
+
+                    // set device for the alloc, but we want to return to the
+                    // default device as the source of a following memcpy
+                    {
+                        rocfft_scoped_device dev(io_brick->device);
+                        multi_gpu_data.emplace_back();
+                        if(multi_gpu_data.back().alloc(alloc_byte_size) != hipSuccess)
+                            throw std::runtime_error(
+                                "rocfft_params::multi_gpu_prepare: device allocation failed");
+                        io_buffer_vec.push_back(multi_gpu_data.back().data());
+                        if(placement == fft_placement_inplace)
+                            mgpu_obuffers.push_back(multi_gpu_data.back().data());
+                    }
+                    if(io == fft_io::fft_io_in)
+                    {
+                        // copy cpu input data to device buffer(s)
+                        const auto input_data_host_offset = io_brick->lower_field_offset(
+                            cpu_ref_params.istride, cpu_ref_params.idist);
+
+                        // transpose input data to the brick's shape in host memory, then
+                        // memcpy (as is) into allocated device buffer
+                        std::vector<hostbuf> host_tmp(1);
+                        host_tmp.front().alloc(alloc_byte_size);
+
+                        std::vector<size_t> cpu_istrides_with_idist(cpu_ref_params.istride);
+                        cpu_istrides_with_idist.insert(cpu_istrides_with_idist.begin(),
+                                                       cpu_ref_params.idist);
+
+                        copy_buffers(input_data_host,
+                                     host_tmp,
+                                     io_brick->length(),
+                                     /* "nbatch" = */ 1,
+                                     cpu_ref_params.precision,
+                                     cpu_ref_params.itype,
+                                     cpu_istrides_with_idist,
+                                     /* "idist" = */ 0,
+                                     array_type,
+                                     io_brick->stride,
+                                     /* "odist" =  */ 0,
+                                     {input_data_host_offset},
+                                     /* "ooffset" = */ {0});
+
+                        // memcpy the transposed brick to the device
+                        if(hipMemcpy(io_buffer_vec.back(),
+                                     host_tmp.front().data(),
+                                     alloc_byte_size,
+                                     hipMemcpyHostToDevice)
+                           != hipSuccess)
+                        {
+                            throw std::runtime_error(
+                                "rocfft_params::multi_gpu_prepare: hipMemcpy failed");
+                        }
                     }
                 }
             }
-
-            // if we copied the input to all the other devices, and
-            // this is an out-of-place transform, we no longer
-            // need the original input
-            if(copy_input && placement == fft_placement_notinplace)
-                ibuffer.clear();
-        };
-
-        // assume one input, one output field for simple cases
-        if(!ifields.empty())
-            alloc_fields(ifields.front(), itype, pibuffer, true);
-        if(!ofields.empty())
-        {
-            if(!ifields.empty() && placement == fft_placement_inplace)
-                pobuffer = pibuffer;
-            else
-                alloc_fields(ofields.front(), otype, pobuffer, false);
         }
     }
 
@@ -524,59 +578,91 @@ public:
     // on each GPU.  This vector remembers all of those allocations.
     std::vector<gpubuf> multi_gpu_data;
 
-    // gather data after multi-GPU FFT for verification
-    void multi_gpu_finalize(std::vector<hostbuf>& gpu_output,
-                            std::vector<gpubuf>&  obuffer,
-                            std::vector<void*>&   pobuffer) override
+    void multi_gpu_finalize(std::vector<hostbuf>& gathered_results_host,
+                            std::vector<gpubuf>& /* gathered_results_device (unused) */,
+                            std::vector<void*>& mgpu_obuffers) override
     {
         if(ofields.empty())
-            return;
-
-        const size_t elem_size_bytes = var_size<size_t>(precision, otype);
-
-        for(size_t i = 0; i < pobuffer.size(); ++i)
         {
-            const auto& b = ofields.front().bricks[i];
-
-            const size_t brick_size_elems = compute_ptrdiff(b.length(), b.stride);
-            const size_t brick_size_bytes = brick_size_elems * elem_size_bytes;
-
-            // get this brick's starting offset in the field
-            const size_t brick_offset_elems = b.lower_field_offset(ostride, odist);
-
-            // switch device to where we're copying from
-            rocfft_scoped_device dev(b.device);
-
-            // copy the brick to host, then copy to output
-            std::vector<hostbuf> host_brick(1);
-            host_brick.front().alloc(brick_size_bytes);
-            if(hipMemcpy(
-                   host_brick.front().data(), pobuffer[i], brick_size_bytes, hipMemcpyDeviceToHost)
-               != hipSuccess)
-            {
-                throw std::runtime_error("hipMemcpy failed");
-            }
-
-            std::vector<size_t> ostride_with_batch{odist};
-            std::copy(ostride.begin(), ostride.end(), std::back_inserter(ostride_with_batch));
-
-            copy_buffers(host_brick,
-                         gpu_output,
-                         b.length(),
-                         1,
-                         precision,
-                         otype,
-                         b.stride,
-                         0,
-                         otype,
-                         ostride_with_batch,
-                         0,
-                         {0},
-                         {brick_offset_elems});
+            // not multi-device, no data gathering to be done
+            return;
         }
-        // set pobuffer back to a single-device transform
-        pobuffer.clear();
-        pobuffer.push_back(obuffer.front().data());
+        if(gathered_results_host.empty())
+        {
+            throw std::invalid_argument(
+                "rocfft_params::multi_gpu_finalize: given host-residing buffer does not exist.");
+        }
+        if(otype == fft_array_type_complex_planar || otype == fft_array_type_hermitian_planar)
+            throw std::logic_error("rocfft_params::multi_gpu_finalize: planar output data "
+                                   "considered by current object.");
+        const auto req_min_size = obuffer_sizes()[0];
+        if(gathered_results_host[0].size() < req_min_size)
+        {
+            throw std::invalid_argument(
+                "rocfft_params::multi_gpu_finalize: given host-residing buffer does not exist or "
+                "is too small for gathering the multi-device transform results.");
+            std::ostringstream excpt_info;
+            excpt_info << "rocfft_params::multi_gpu_finalize: given host-residing buffer is is too "
+                          "small for gathering the multi-device transform results.\n"
+                       << "Buffer size is " << gathered_results_host[0].size()
+                       << ", required min size is " << req_min_size << ".";
+            throw std::invalid_argument(excpt_info.str());
+        }
+
+        const auto          process_rank = get_process_rank();
+        std::vector<size_t> ostrides_with_odist(ostride);
+        ostrides_with_odist.insert(ostrides_with_odist.begin(), odist);
+
+        size_t obuffer_idx = 0;
+        for(const auto& ofield : ofields)
+        {
+            for(const auto& obrick : ofield.bricks)
+            {
+                if(obrick.rank != process_rank)
+                    continue;
+                if(obuffer_idx >= mgpu_obuffers.size())
+                {
+                    throw std::invalid_argument(
+                        "rocfft_params::multi_gpu_finalize: not as many device output buffers as "
+                        "expected when gathering the multi-device transform results.");
+                }
+
+                const size_t brick_byte_size = var_size<size_t>(precision, otype)
+                                               * compute_ptrdiff(obrick.length(), obrick.stride);
+
+                const auto offset_in_gathered_results_host
+                    = obrick.lower_field_offset(ostride, odist);
+
+                // switch device to where we're copying from
+                rocfft_scoped_device dev(obrick.device);
+
+                // copy the device results to host, then copy to gathered_results
+                std::vector<hostbuf> host_tmp(1);
+                host_tmp.front().alloc(brick_byte_size);
+                if(hipMemcpy(host_tmp.front().data(),
+                             mgpu_obuffers[obuffer_idx++],
+                             brick_byte_size,
+                             hipMemcpyDeviceToHost)
+                   != hipSuccess)
+                {
+                    throw std::runtime_error("rocfft_params::multi_gpu_finalize: hipMemcpy failed");
+                }
+
+                copy_buffers(host_tmp,
+                             gathered_results_host,
+                             obrick.length(),
+                             /* "nbatch" =  */ 1,
+                             precision,
+                             otype,
+                             obrick.stride,
+                             /* "idist" = */ 0,
+                             otype,
+                             ostrides_with_odist,
+                             /* "odist" =  */ 0,
+                             /* "ioffset" =  */ {0},
+                             {offset_in_gathered_results_host});
+            }
+        }
     }
 
 private:
@@ -608,6 +694,28 @@ private:
             throw std::runtime_error("too many split dimensions");
         }
         return splitDims;
+    }
+
+    int get_process_rank() const
+    {
+        int process_rank = -1; // invalid initialization
+        if(mp_lib == fft_mp_lib_mpi)
+        {
+#ifdef ROCFFT_MPI_ENABLE
+            if(!mp_comm)
+                throw std::runtime_error("Multi-process communicator is not defined");
+            auto ret = MPI_Comm_rank(*static_cast<MPI_Comm*>(mp_comm), &process_rank);
+            if(ret != MPI_SUCCESS || process_rank < 0)
+                throw std::runtime_error("Rank of current process couldn't be set");
+#else
+            throw std::runtime_error("MPI is not enabled");
+#endif
+        }
+        else
+        {
+            process_rank = 0;
+        }
+        return process_rank;
     }
 };
 


### PR DESCRIPTION
## Motivation

Address functional issues with multi-device, real in-place transforms and enable testing thereof.

## Technical Details

### Changes in `rocfft/library`
- Revised logic deciding what to use as destination buffer for the gather step to make it consistent with how the `rootPlan` is set to operate.
- Addressed suspected typos/bugs/incorrect arguments used in contiguity checks.
- Revised logic of `rocfft_brick_t::is_contiguous_in_field` to account for brick's strides w.r.t. expected strides for contiguous data (chunks) in corresponding field.
- Revised offsets used in gather/scatter operations when the source/destination buffers are not temporary buffers.

### Other changes
- Revisions to `rocfft_params::multi_gpu_prepare` to correctly set input buffer sizes in case of in-place operations and improve data initialization of input device buffers: fixes are required for real in-place cases enabled herein (and for non-default input strides, more generally), since data layout parameters differ between input data layout for reference CPU calculations and object's (non-distributed) input data layout.
- Revisions to `rocfft_params::multi_gpu_finalize` were motivated by the revisions to `rocfft_params::multi_gpu_prepare` (see above) for alignment and account for possibly many output fields.
- Revised implementation of `distribute_field` to better account for other object's parameters (_e.g._, `placement`) that may be relevant to the definition of brick's strides for (real) in-place operations. Specifically, when the fastest dimension is not split in real domain, padding is used as that'd be recommended usage (_e.g._, typically set so by default in library-defined decompositions);
- Thorough documentation was added to `fft_params::multi_gpu_prepare`, `fft_params::multi_gpu_finalize` and (templated) `fft_params::distribute_field`.
- Expanded unit tests to cover all combinations of transform directions, transform types, and placement for the data decompositions of interest.

## Test Plan

Tests were added to the `multi_gpu*` test suites. Said tests cover and motivate the suggested changes.

## Test Result

All tests (new and pre-existing ones) pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
