### PR TITLE
miopen:fix:disable tf32 on gfx950

### DIFF
--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -927,7 +927,7 @@ if(MIOPEN_USE_COMPOSABLEKERNEL)
         # Use the aliased targets when we pull CK from /opt/rocm or other place on disc.
         set(MIOPEN_CK_LINK_FLAGS composable_kernel::device_conv_operations hip::host)
     endif()
-    if(GPU_TARGETS MATCHES "gfx942" OR GPU_TARGETS MATCHES "gfx950")
+    if(GPU_TARGETS MATCHES "gfx942")
         target_compile_definitions(MIOpen PRIVATE CK_ENABLE_TF32)
     endif()
 endif()

--- a/projects/miopen/test/gtest/unit_conv_solver.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver.cpp
@@ -450,8 +450,7 @@ void RunSolverFwd(const miopen::solver::conv::ConvSolverInterface& solv,
     }();
 
     auto device_name = ctx.GetStream().GetDeviceName();
-    if(!(miopen::StartsWith(device_name, "gfx942")) &&
-       conv_config.GetXDataType() == miopenFloat &&
+    if(!(miopen::StartsWith(device_name, "gfx942")) && conv_config.GetXDataType() == miopenFloat &&
        conv_config.GetConv().GetMathType() == miopenMathDefault)
     {
         GTEST_SKIP() << "TF32 test is not supported on this device";

--- a/projects/miopen/test/gtest/unit_conv_solver.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver.cpp
@@ -450,7 +450,7 @@ void RunSolverFwd(const miopen::solver::conv::ConvSolverInterface& solv,
     }();
 
     auto device_name = ctx.GetStream().GetDeviceName();
-    if(!(miopen::StartsWith(device_name, "gfx942") || miopen::StartsWith(device_name, "gfx950")) &&
+    if(!(miopen::StartsWith(device_name, "gfx942")) &&
        conv_config.GetXDataType() == miopenFloat &&
        conv_config.GetConv().GetMathType() == miopenMathDefault)
     {

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemm3DGroupBwdXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemm3DGroupBwdXdlops.cpp
@@ -64,7 +64,7 @@ const auto& GetTestParams()
         }
         else if constexpr(type == TestDataType::TF32)
         {
-            supportedDevices = Gpu::gfx94X | Gpu::gfx950;
+            supportedDevices = Gpu::gfx94X;
         }else{
             supportedDevices = Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X | Gpu::gfx950 | Gpu::gfx110X | Gpu::gfx115X | Gpu::gfx120X;
         }

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemm3DGroupFwdXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemm3DGroupFwdXdlops.cpp
@@ -75,7 +75,7 @@ const auto& GetTestParams()
         }
         else if constexpr(type == TestDataType::TF32)
         {
-            supportedDevices = Gpu::gfx94X | Gpu::gfx950;
+            supportedDevices = Gpu::gfx94X;
         }
         else
         {

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemm3DGroupWrwXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemm3DGroupWrwXdlops.cpp
@@ -73,9 +73,13 @@ const auto& GetTestParams()
         {
             supportedDevices = Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X | Gpu::gfx950;
         }
-        else if constexpr(type == TestDataType::TF32 || type == TestDataType::BF16)
+        else if constexpr(type == TestDataType::BF16)
         {
             supportedDevices = Gpu::gfx94X | Gpu::gfx950;
+        }
+        else if constexpr(type == TestDataType::TF32)
+        {
+            supportedDevices = Gpu::gfx94X;
         }
         else
         {

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupBwdXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupBwdXdlops.cpp
@@ -75,7 +75,7 @@ const auto& GetTestParams()
         }
         else if constexpr(type == TestDataType::TF32)
         {
-            supportedDevices = Gpu::gfx94X | Gpu::gfx950;
+            supportedDevices = Gpu::gfx94X;
         }
         else
         {

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupFwdXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupFwdXdlops.cpp
@@ -75,7 +75,7 @@ const auto& GetTestParams()
         }
         else if constexpr(type == TestDataType::TF32)
         {
-            supportedDevices = Gpu::gfx94X | Gpu::gfx950;
+            supportedDevices = Gpu::gfx94X;
         }
         else
         {

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupWrwXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupWrwXdlops.cpp
@@ -76,7 +76,8 @@ const auto& GetTestParams()
         {
             supportedDevices = Gpu::gfx94X | Gpu::gfx950;
         }
-        else if constexpr(type == TestDataType::TF32){
+        else if constexpr(type == TestDataType::TF32)
+        {
             supportedDevices = Gpu::gfx94X;
         }
         else

--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupWrwXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupWrwXdlops.cpp
@@ -72,9 +72,12 @@ const auto& GetTestParams()
         {
             supportedDevices = Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X | Gpu::gfx950;
         }
-        else if constexpr(type == TestDataType::TF32 || type == TestDataType::BF16)
+        else if constexpr(type == TestDataType::BF16)
         {
             supportedDevices = Gpu::gfx94X | Gpu::gfx950;
+        }
+        else if constexpr(type == TestDataType::TF32){
+            supportedDevices = Gpu::gfx94X;
         }
         else
         {


### PR DESCRIPTION
## Motivation

Tf32 tests failed on gfx950, see [action log](https://github.com/ROCm/rocm-libraries/actions/runs/21201334033/job/60994684179?pr=3556). Disable TF32 on gfx950 temporarily.

## Technical Details

Disable all TF32 features on gfx950.
RC is CK use different template configs on gfx950 and gfx942([CK-PR](https://github.com/ROCm/composable_kernel/pull/3248/changes)). But MIopen still apply gfx942 configs on gfx950 which doesn't have this instance. Will find a solution later.
```cpp
#if defined(__gfx950__)
constexpr auto _k_per_block = 32;
#else
constexpr auto _k_per_block = 16;
#endif
```


## Test Plan

Run all the solver tests related to TF32.
` ./bin/miopen_gtest --gtest_filter="*/GPU_UnitTestConvSolverImplicitGemm*Xdlops_TF32.*"`

## Test Result

<img width="1365" height="1950" alt="image" src="https://github.com/user-attachments/assets/2c0a19cb-16e9-423d-94b3-10ba1f1caaa2" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
