### PR TITLE
Softmax: tuning support

### DIFF
--- a/projects/miopen/src/hip/handlehip.cpp
+++ b/projects/miopen/src/hip/handlehip.cpp
@@ -405,13 +405,17 @@ Allocator::ManageDataPtr Handle::Create(std::size_t sz) const
 Allocator::ManageDataPtr&
 Handle::WriteTo(const void* data, Allocator::ManageDataPtr& ddata, std::size_t sz) const
 {
+    WriteTo(data, ddata.get(), sz);
+    return ddata;
+}
+
+void Handle::WriteTo(const void* data, Data_t ddata, std::size_t sz) const
+{
     MIOPEN_HANDLE_LOCK
     this->Finish();
-    auto status =
-        hipMemcpyWithStream(ddata.get(), data, sz, hipMemcpyHostToDevice, this->GetStream());
+    auto status = hipMemcpyWithStream(ddata, data, sz, hipMemcpyHostToDevice, this->GetStream());
     if(status != hipSuccess)
         MIOPEN_THROW_HIP_STATUS(status, "Hip error writing to buffer: ");
-    return ddata;
 }
 
 void Handle::ReadTo(void* data, const Allocator::ManageDataPtr& ddata, std::size_t sz) const

--- a/projects/miopen/src/include/miopen/generic_search.hpp
+++ b/projects/miopen/src/include/miopen/generic_search.hpp
@@ -524,6 +524,8 @@ auto GenericSearch(const Solver s,
         size_t last_imprv      = 0;
         auto threads_remaining = total_threads;
         std::vector<float> samples;
+        float tuning_tolerance =
+            1.0f + static_cast<float>(env::value(MIOPEN_TUNING_FOLLOWUP_TOLERANCE_PCT)) / 100.0f;
         while(true)
         {
             if(n_current >= n_runs_total)
@@ -616,19 +618,18 @@ auto GenericSearch(const Solver s,
                 }
 
                 // Smooth the jitter of measurements:
-                // If the 1st probe is NOT too bad (measured time <= 1.10 * worst sample of the best
-                // config), then gather 9 more samples, and remove positive z-score outliers. Use
-                // the mean value with outliers removed for calculating best config.
-                constexpr int N_RUNS = 10;
+                // If the 1st probe is NOT too bad (measured time <= tuning_tolerance * worst sample
+                // of the best config), then gather more samples, and remove positive z-score
+                // outliers. Use the mean value with outliers removed for calculating best config.
                 last_imprv++;
-                if(elapsed_time < worst_time * 1.10f && elapsed_time < skip_time)
+                if(elapsed_time < worst_time * tuning_tolerance && elapsed_time < skip_time)
                 {
                     MIOPEN_LOG_I2("Finding average for: " << elapsed_time << " / " << best_time
                                                           << " = " << (elapsed_time / best_time));
 
                     try
                     {
-                        for(int i = 1; i < N_RUNS; ++i)
+                        for(int i = 1; i < env::value(MIOPEN_TUNING_ITERATIONS); ++i)
                         {
                             invoker(profile_h, invoke_ctx);
                             samples.push_back(profile_h.GetKernelTime());

--- a/projects/miopen/src/include/miopen/generic_search_controls.hpp
+++ b/projects/miopen/src/include/miopen/generic_search_controls.hpp
@@ -27,7 +27,6 @@
 #pragma once
 #include <miopen/env.hpp>
 #include <miopen/config.h>
-#include <chrono>
 #include <limits>
 #include <thread>
 
@@ -41,6 +40,10 @@ const size_t MIOPEN_DEFAULT_TUNING_PATIENCE = std::numeric_limits<std::size_t>::
 MIOPEN_DECLARE_ENV_VAR_UINT64(
     MIOPEN_TUNING_PATIENCE,
     MIOPEN_DEFAULT_TUNING_PATIENCE) // End tuning if no improvement in X iterations
+
+MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_TUNING_FOLLOWUP_TOLERANCE_PCT, 10)
+
+MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_TUNING_ITERATIONS, 10)
 
 #if MIOPEN_USE_COMGR
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_COMPILE_PARALLEL_LEVEL, 1) // COMGR is not parallelizable

--- a/projects/miopen/src/include/miopen/handle.hpp
+++ b/projects/miopen/src/include/miopen/handle.hpp
@@ -184,6 +184,7 @@ struct MIOPEN_EXPORT Handle : miopenHandle
     Allocator::ManageDataPtr Create(std::size_t sz) const;
     Allocator::ManageDataPtr&
     WriteTo(const void* data, Allocator::ManageDataPtr& ddata, std::size_t sz) const;
+    void WriteTo(const void* data, Data_t ddata, std::size_t sz) const;
     void ReadTo(void* data, const Allocator::ManageDataPtr& ddata, std::size_t sz) const;
     void ReadTo(void* data, ConstData_t ddata, std::size_t sz) const;
     shared<Data_t> CreateSubBuffer(Data_t data, std::size_t offset, std::size_t size) const;

--- a/projects/miopen/src/include/miopen/softmax/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/softmax/problem_description.hpp
@@ -3,7 +3,10 @@
 
 #pragma once
 
-#include "miopen/sqlite_db.hpp"
+#include <miopen/config.h>
+#if MIOPEN_ENABLE_SQLITE
+#include <miopen/sqlite_db.hpp>
+#endif
 #include <miopen/problem_description_base.hpp>
 #include <miopen/tensor.hpp>
 #include <miopen/mlo_internal.hpp>
@@ -133,8 +136,8 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
     // This declaration marks softmax as a primitive with tuning enabled.
     // Any tunable solver would be able pick it and fetch a db instance in ExecutePrimitive.
     // It has to be discoverable via ADL from problem description.
-    friend auto GetDb(const ExecutionContext& context, const ProblemDescriptionTag&)
-        -> PerformanceDb;
+    friend auto GetDb(const ExecutionContext& context,
+                      const ProblemDescriptionTag&) -> PerformanceDb;
 
 private:
     void CheckAndAssignAlphaBeta(const void* alpha_, const void* beta_)

--- a/projects/miopen/src/include/miopen/softmax/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/softmax/problem_description.hpp
@@ -1,33 +1,12 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 
+#include "miopen/sqlite_db.hpp"
 #include <miopen/problem_description_base.hpp>
 #include <miopen/tensor.hpp>
+#include <miopen/mlo_internal.hpp>
 
 namespace miopen {
 
@@ -35,7 +14,16 @@ struct NetworkConfig;
 
 namespace softmax {
 
-struct ProblemDescription : ProblemDescriptionBase
+struct ProblemDescriptionTag
+{
+};
+
+struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
+                                                    ProblemDescriptionTag
+#if MIOPEN_ENABLE_SQLITE
+    ,
+                                                    SQLiteSerializable<ProblemDescription>
+#endif
 {
     // softmax forward constructor
     ProblemDescription(const void* alpha_,
@@ -110,7 +98,43 @@ struct ProblemDescription : ProblemDescriptionBase
     const TensorDescriptor& GetdYDesc() const { return dyDesc; }
     const TensorDescriptor& GetdXDesc() const { return xdxDesc; }
 
+    void Serialize(std::ostream& stream) const { stream << MakeNetworkConfig().ToString(); }
+
     NetworkConfig MakeNetworkConfig() const override;
+
+    template <class Self>
+    static void Visit(Self&& self, std::function<void(int64_t, std::string)> f)
+    {
+        // The column names match the driver command line argument names
+        f(static_cast<uint64_t>(self.isForward), "forw");
+        f(self.GetBatchSize(), "batchsize");
+        f(self.GetChannels(), "in_channels");
+        f(self.GetHeight(), "in_h");
+        f(self.GetWidth(), "in_w");
+        f(static_cast<uint64_t>(self.algorithm), "algorithm");
+        f(static_cast<uint64_t>(self.mode), "mode");
+    }
+
+    template <class Self>
+    static void Visit(Self&& self, std::function<void(std::string, std::string)> f)
+    {
+        f(GetDataTypeName(self.yDesc.GetType()), "data_type");
+        f(self.GetLayout(), "layout");
+    }
+
+    template <class Self, class Visitor>
+    static void VisitAll(Self&& self, const Visitor& f)
+    {
+        Visit(std::forward<Self>(self), [&](int64_t value, std::string name) { f(value, name); });
+        Visit(std::forward<Self>(self),
+              [&](std::string value, std::string name) { f(value, name); });
+    }
+
+    // This declaration marks softmax as a primitive with tuning enabled.
+    // Any tunable solver would be able pick it and fetch a db instance in ExecutePrimitive.
+    // It has to be discoverable via ADL from problem description.
+    friend auto GetDb(const ExecutionContext& context, const ProblemDescriptionTag&)
+        -> PerformanceDb;
 
 private:
     void CheckAndAssignAlphaBeta(const void* alpha_, const void* beta_)
@@ -141,6 +165,12 @@ private:
 
     const miopenSoftmaxAlgorithm_t algorithm;
     const miopenSoftmaxMode_t mode;
+
+    std::size_t GetBatchSize() const { return yDesc.GetLengths()[0]; }
+    std::size_t GetChannels() const { return yDesc.GetLengths()[1]; }
+    std::size_t GetHeight() const { return yDesc.GetLengths()[2]; }
+    std::size_t GetWidth() const { return yDesc.GetLengths()[3]; }
+    std::string GetLayout() const { return yDesc.GetLayout_str(); }
 };
 
 } // namespace softmax

--- a/projects/miopen/src/include/miopen/softmax/solvers.hpp
+++ b/projects/miopen/src/include/miopen/softmax/solvers.hpp
@@ -68,35 +68,39 @@ struct Softmax final : SoftmaxTunableSolver<PerformanceConfigSoftmax>
         // Forward y and backward dx are both an input and an output, so we need to restore them
         // after tuning to make sure tuning doesn't affect the output
         auto invoke_context_softmax = invoke_context.CastTo<miopen::softmax::InvokeParams>();
-        Allocator::ManageDataPtr data_backup;
+        std::vector<unsigned char> data_backup;
         if(invoke_context_softmax.forward_y != nullptr)
         {
-            data_backup = context.GetStream().Create(invoke_context_softmax.yDesc.GetNumBytes());
-            context.GetStream().Copy(invoke_context_softmax.forward_y,
-                                     data_backup.get(),
-                                     invoke_context_softmax.yDesc.GetNumBytes());
+            auto y_bytepointer = reinterpret_cast<unsigned char*>(invoke_context_softmax.forward_y);
+            data_backup        = std::vector<unsigned char>(
+                y_bytepointer, y_bytepointer + invoke_context_softmax.yDesc.GetNumBytes());
+            context.GetStream().ReadTo(data_backup.data(),
+                                       invoke_context_softmax.forward_y,
+                                       invoke_context_softmax.yDesc.GetNumBytes());
         }
-        else if(invoke_context_softmax.dx != nullptr)
+        if(invoke_context_softmax.dx != nullptr)
         {
-            data_backup = context.GetStream().Create(invoke_context_softmax.xdxDesc.GetNumBytes());
-            context.GetStream().Copy(invoke_context_softmax.dx,
-                                     data_backup.get(),
-                                     invoke_context_softmax.yDesc.GetNumBytes());
+            auto dx_bytepointer = reinterpret_cast<unsigned char*>(invoke_context_softmax.dx);
+            data_backup         = std::vector<unsigned char>(
+                dx_bytepointer, dx_bytepointer + invoke_context_softmax.xdxDesc.GetNumBytes());
+            context.GetStream().ReadTo(invoke_context_softmax.dx,
+                                       data_backup.data(),
+                                       invoke_context_softmax.xdxDesc.GetNumBytes());
         }
 
         auto result = GenericSearch(*this, context, problem, invoke_context);
 
         if(invoke_context_softmax.forward_y != nullptr)
         {
-            context.GetStream().Copy(data_backup.get(),
-                                     invoke_context_softmax.forward_y,
-                                     invoke_context_softmax.yDesc.GetNumBytes());
+            context.GetStream().WriteTo(data_backup.data(),
+                                        invoke_context_softmax.forward_y,
+                                        invoke_context_softmax.yDesc.GetNumBytes());
         }
         if(invoke_context_softmax.dx != nullptr)
         {
-            context.GetStream().Copy(data_backup.get(),
-                                     invoke_context_softmax.dx,
-                                     invoke_context_softmax.xdxDesc.GetNumBytes());
+            context.GetStream().WriteTo(data_backup.data(),
+                                        invoke_context_softmax.dx,
+                                        invoke_context_softmax.xdxDesc.GetNumBytes());
         }
 
         return result;

--- a/projects/miopen/src/include/miopen/softmax/solvers.hpp
+++ b/projects/miopen/src/include/miopen/softmax/solvers.hpp
@@ -1,31 +1,13 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2023 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #pragma once
 
+#include "miopen/execution_context.hpp"
+#include "miopen/invoke_params.hpp"
+#include "miopen/generic_search.hpp"
+#include "miopen/softmax/invoke_params.hpp"
+#include "miopen/tensor.hpp"
 #include <miopen/solver.hpp>
 #include <miopen/softmax/problem_description.hpp>
 
@@ -37,16 +19,95 @@ namespace softmax {
 
 using SoftmaxSolver = NonTunableSolverBase<ExecutionContext, miopen::softmax::ProblemDescription>;
 
-struct Softmax final : SoftmaxSolver
+template <class PerformanceConfig>
+using SoftmaxTunableSolver =
+    TunableSolverMixin<ExecutionContext, miopen::softmax::ProblemDescription, PerformanceConfig>;
+
+struct PerformanceConfigSoftmax : PerfConfigBase<PerformanceConfigSoftmax>
+{
+    int local_size;
+    bool initialized = false;
+    PerformanceConfigSoftmax(int _local_size) : local_size(_local_size) {}
+    PerformanceConfigSoftmax() : local_size(static_cast<int>(1)) {}
+    PerformanceConfigSoftmax(bool) : local_size(static_cast<int>(1)) {}
+    void HeuristicInit(const miopen::softmax::ProblemDescription& problem);
+    bool SetNextValue(const miopen::softmax::ProblemDescription& problem);
+    bool IsValidValue() const;
+    bool IsValid(const ExecutionContext& context,
+                 const miopen::softmax::ProblemDescription& problem) const;
+
+    template <typename Self, typename F>
+    static void Visit(Self&& s, F f)
+    {
+        f(s.local_size, "local_size");
+    }
+    bool operator==(const PerformanceConfigSoftmax& other) const;
+
+public:
+    static constexpr auto default_local_size = 1024;
+    static constexpr auto max_local_size     = 1024;
+    static constexpr auto start_local_size   = 1;
+};
+
+struct Softmax final : SoftmaxTunableSolver<PerformanceConfigSoftmax>
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<Softmax>(); }
-
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::softmax::ProblemDescription& problem) const override;
+    bool IsDynamic() const override { return true; }
+    PerformanceConfigSoftmax
+    GetDefaultPerformanceConfig(const ExecutionContext& context,
+                                const miopen::softmax::ProblemDescription& problem) const override;
+    bool IsValidPerformanceConfig(const ExecutionContext& context,
+                                  const miopen::softmax::ProblemDescription& problem,
+                                  const PerformanceConfigSoftmax& config) const override;
+    PerformanceConfigSoftmax Search(const ExecutionContext& context,
+                                    const miopen::softmax::ProblemDescription& problem,
+                                    const AnyInvokeParams& invoke_context) const override
+    {
+        // Forward y and backward dx are both an input and an output, so we need to restore them
+        // after tuning to make sure tuning doesn't affect the output
+        auto invoke_context_softmax = invoke_context.CastTo<miopen::softmax::InvokeParams>();
+        std::vector<unsigned char> data_backup;
+        if(invoke_context_softmax.forward_y != nullptr)
+        {
+            auto y_bytepointer = reinterpret_cast<unsigned char*>(invoke_context_softmax.forward_y);
+            data_backup        = std::vector<unsigned char>(
+                y_bytepointer, y_bytepointer + invoke_context_softmax.yDesc.GetNumBytes());
+            context.GetStream().Copy(invoke_context_softmax.forward_y,
+                                     data_backup.data(),
+                                     invoke_context_softmax.yDesc.GetNumBytes());
+        }
+        else if(invoke_context_softmax.dx != nullptr)
+        {
+            auto dx_bytepointer = reinterpret_cast<unsigned char*>(invoke_context_softmax.dx);
+            data_backup         = std::vector<unsigned char>(
+                dx_bytepointer, dx_bytepointer + invoke_context_softmax.xdxDesc.GetNumBytes());
+            context.GetStream().Copy(invoke_context_softmax.dx,
+                                     data_backup.data(),
+                                     invoke_context_softmax.yDesc.GetNumBytes());
+        }
 
+        auto result = GenericSearch(*this, context, problem, invoke_context);
+
+        if(invoke_context_softmax.forward_y != nullptr)
+        {
+            context.GetStream().Copy(data_backup.data(),
+                                     invoke_context_softmax.forward_y,
+                                     invoke_context_softmax.yDesc.GetNumBytes());
+        }
+        if(invoke_context_softmax.dx != nullptr)
+        {
+            context.GetStream().Copy(data_backup.data(),
+                                     invoke_context_softmax.dx,
+                                     invoke_context_softmax.xdxDesc.GetNumBytes());
+        }
+
+        return result;
+    }
     ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::softmax::ProblemDescription& problem) const override;
-
+                             const miopen::softmax::ProblemDescription& problem,
+                             const PerformanceConfigSoftmax& config) const override;
     std::size_t GetWorkspaceSize(const ExecutionContext&,
                                  const miopen::softmax::ProblemDescription&) const override
     {

--- a/projects/miopen/src/include/miopen/softmax/solvers.hpp
+++ b/projects/miopen/src/include/miopen/softmax/solvers.hpp
@@ -28,8 +28,8 @@ struct PerformanceConfigSoftmax : PerfConfigBase<PerformanceConfigSoftmax>
     int local_size;
     bool initialized = false;
     PerformanceConfigSoftmax(int _local_size) : local_size(_local_size) {}
-    PerformanceConfigSoftmax() : local_size(static_cast<int>(1)) {}
-    PerformanceConfigSoftmax(bool) : local_size(static_cast<int>(1)) {}
+    PerformanceConfigSoftmax() : local_size(start_local_size) {}
+    PerformanceConfigSoftmax(bool) : local_size(start_local_size) {}
     void HeuristicInit(const miopen::softmax::ProblemDescription& problem);
     bool SetNextValue(const miopen::softmax::ProblemDescription& problem);
     bool IsValidValue() const;
@@ -69,34 +69,30 @@ struct Softmax final : SoftmaxTunableSolver<PerformanceConfigSoftmax>
         // after tuning to make sure tuning doesn't affect the output
         auto invoke_context_softmax = invoke_context.CastTo<miopen::softmax::InvokeParams>();
         std::vector<unsigned char> data_backup;
-        if(invoke_context_softmax.forward_y != nullptr)
+        if(problem.IsForward() && invoke_context_softmax.forward_y != nullptr)
         {
-            auto y_bytepointer = reinterpret_cast<unsigned char*>(invoke_context_softmax.forward_y);
-            data_backup        = std::vector<unsigned char>(
-                y_bytepointer, y_bytepointer + invoke_context_softmax.yDesc.GetNumBytes());
+            data_backup = std::vector<unsigned char>(invoke_context_softmax.yDesc.GetNumBytes());
             context.GetStream().ReadTo(data_backup.data(),
                                        invoke_context_softmax.forward_y,
                                        invoke_context_softmax.yDesc.GetNumBytes());
         }
-        if(invoke_context_softmax.dx != nullptr)
+        else if(!problem.IsForward() && invoke_context_softmax.dx != nullptr)
         {
-            auto dx_bytepointer = reinterpret_cast<unsigned char*>(invoke_context_softmax.dx);
-            data_backup         = std::vector<unsigned char>(
-                dx_bytepointer, dx_bytepointer + invoke_context_softmax.xdxDesc.GetNumBytes());
-            context.GetStream().ReadTo(invoke_context_softmax.dx,
-                                       data_backup.data(),
+            data_backup = std::vector<unsigned char>(invoke_context_softmax.xdxDesc.GetNumBytes());
+            context.GetStream().ReadTo(data_backup.data(),
+                                       invoke_context_softmax.dx,
                                        invoke_context_softmax.xdxDesc.GetNumBytes());
         }
 
         auto result = GenericSearch(*this, context, problem, invoke_context);
 
-        if(invoke_context_softmax.forward_y != nullptr)
+        if(problem.IsForward() && invoke_context_softmax.forward_y != nullptr)
         {
             context.GetStream().WriteTo(data_backup.data(),
                                         invoke_context_softmax.forward_y,
                                         invoke_context_softmax.yDesc.GetNumBytes());
         }
-        if(invoke_context_softmax.dx != nullptr)
+        else if(!problem.IsForward() && invoke_context_softmax.dx != nullptr)
         {
             context.GetStream().WriteTo(data_backup.data(),
                                         invoke_context_softmax.dx,

--- a/projects/miopen/src/include/miopen/softmax/solvers.hpp
+++ b/projects/miopen/src/include/miopen/softmax/solvers.hpp
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include "miopen/execution_context.hpp"
-#include "miopen/invoke_params.hpp"
-#include "miopen/generic_search.hpp"
-#include "miopen/softmax/invoke_params.hpp"
-#include "miopen/tensor.hpp"
+#include <miopen/execution_context.hpp>
+#include <miopen/invoke_params.hpp>
+#include <miopen/generic_search.hpp>
+#include <miopen/softmax/invoke_params.hpp>
+#include <miopen/tensor.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/softmax/problem_description.hpp>
 
@@ -68,23 +68,19 @@ struct Softmax final : SoftmaxTunableSolver<PerformanceConfigSoftmax>
         // Forward y and backward dx are both an input and an output, so we need to restore them
         // after tuning to make sure tuning doesn't affect the output
         auto invoke_context_softmax = invoke_context.CastTo<miopen::softmax::InvokeParams>();
-        std::vector<unsigned char> data_backup;
+        Allocator::ManageDataPtr data_backup;
         if(invoke_context_softmax.forward_y != nullptr)
         {
-            auto y_bytepointer = reinterpret_cast<unsigned char*>(invoke_context_softmax.forward_y);
-            data_backup        = std::vector<unsigned char>(
-                y_bytepointer, y_bytepointer + invoke_context_softmax.yDesc.GetNumBytes());
+            data_backup = context.GetStream().Create(invoke_context_softmax.yDesc.GetNumBytes());
             context.GetStream().Copy(invoke_context_softmax.forward_y,
-                                     data_backup.data(),
+                                     data_backup.get(),
                                      invoke_context_softmax.yDesc.GetNumBytes());
         }
         else if(invoke_context_softmax.dx != nullptr)
         {
-            auto dx_bytepointer = reinterpret_cast<unsigned char*>(invoke_context_softmax.dx);
-            data_backup         = std::vector<unsigned char>(
-                dx_bytepointer, dx_bytepointer + invoke_context_softmax.xdxDesc.GetNumBytes());
+            data_backup = context.GetStream().Create(invoke_context_softmax.xdxDesc.GetNumBytes());
             context.GetStream().Copy(invoke_context_softmax.dx,
-                                     data_backup.data(),
+                                     data_backup.get(),
                                      invoke_context_softmax.yDesc.GetNumBytes());
         }
 
@@ -92,13 +88,13 @@ struct Softmax final : SoftmaxTunableSolver<PerformanceConfigSoftmax>
 
         if(invoke_context_softmax.forward_y != nullptr)
         {
-            context.GetStream().Copy(data_backup.data(),
+            context.GetStream().Copy(data_backup.get(),
                                      invoke_context_softmax.forward_y,
                                      invoke_context_softmax.yDesc.GetNumBytes());
         }
         if(invoke_context_softmax.dx != nullptr)
         {
-            context.GetStream().Copy(data_backup.data(),
+            context.GetStream().Copy(data_backup.get(),
                                      invoke_context_softmax.dx,
                                      invoke_context_softmax.xdxDesc.GetNumBytes());
         }

--- a/projects/miopen/src/problem.cpp
+++ b/projects/miopen/src/problem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
 #include <miopen/problem.hpp>
@@ -563,39 +563,37 @@ Problem::FindSolutionsImpl(const Handle& handle,
     static solver::softmax::AttnSoftmax attnSoftmaxSolver;
     static solver::softmax::Softmax regularSoftmaxSolver;
 
-    std::vector<solver::softmax::SoftmaxSolver*> solvers;
-
-    solvers.push_back(&attnSoftmaxSolver);
-    solvers.push_back(&regularSoftmaxSolver);
-
-    for(auto solver : solvers)
+    auto check_solver = [&]<typename Solver>(const Solver* solver)
     {
+        if(ret.size() >= max_solutions)
+        {
+            return;
+        }
+
         if(!solver->IsApplicable(ctx, problem_description))
         {
             MIOPEN_LOG_I2(solver->SolverDbId() << ": Not applicable");
-            continue;
+            return;
         }
 
         auto solution = Solution();
 
         /// \todo time measurement will be done later. For now we set less time for attention
         /// softmax and slightly bigger for regular
-        solution.SetTime(solver == &attnSoftmaxSolver ? 1.0f : 2.0f);
+        solution.SetTime(std::is_same_v<Solver, solver::softmax::AttnSoftmax> ? 1.0f : 2.0f);
         solution.SetWorkspaceSize(solver->GetWorkspaceSize(ctx, problem_description));
         solution.SetSolver(solver->SolverDbId());
         solution.SetProblem({*this});
 
-        MIOPEN_LOG_I("Found solution: " << solution.GetSolver().ToString() << " , "
+        MIOPEN_LOG_I("Found solution: " << solution.GetSolver().ToString() << ", "
                                         << solution.GetWorkspaceSize() << ", "
                                         << solution.GetTime());
 
         ret.emplace_back(std::move(solution));
+    };
 
-        if(ret.size() >= max_solutions)
-        {
-            break;
-        }
-    }
+    check_solver(&attnSoftmaxSolver);
+    check_solver(&regularSoftmaxSolver);
 
     return ret;
 }

--- a/projects/miopen/src/problem.cpp
+++ b/projects/miopen/src/problem.cpp
@@ -563,8 +563,7 @@ Problem::FindSolutionsImpl(const Handle& handle,
     static solver::softmax::AttnSoftmax attnSoftmaxSolver;
     static solver::softmax::Softmax regularSoftmaxSolver;
 
-    auto check_solver = [&]<typename Solver>(const Solver* solver)
-    {
+    auto check_solver = [&]<typename Solver>(const Solver* solver) {
         if(ret.size() >= max_solutions)
         {
             return;

--- a/projects/miopen/src/softmax.cpp
+++ b/projects/miopen/src/softmax.cpp
@@ -1,28 +1,7 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+#include "miopen/execution_context.hpp"
+#include "miopen/softmax/problem_description.hpp"
 #include <miopen/kernel_cache.hpp>
 #include <miopen/softmax.hpp>
 #include <miopen/float_equal.hpp>
@@ -36,6 +15,13 @@
 #include <nlohmann/json.hpp>
 
 namespace miopen {
+
+namespace softmax {
+miopen::PerformanceDb GetDb(const miopen::ExecutionContext& context, const miopen::softmax::ProblemDescriptionTag&)
+{
+    return {DbKinds::PerfDb, context.GetPerfDbPath("softmax"), context.GetUserPerfDbPath("softmax")};
+}
+} // namespace softmax
 
 extern "C" miopenStatus_t miopenCreateSoftmaxDescriptor(miopenSoftmaxDescriptor_t* softmaxDesc)
 {

--- a/projects/miopen/src/softmax.cpp
+++ b/projects/miopen/src/softmax.cpp
@@ -17,9 +17,11 @@
 namespace miopen {
 
 namespace softmax {
-miopen::PerformanceDb GetDb(const miopen::ExecutionContext& context, const miopen::softmax::ProblemDescriptionTag&)
+miopen::PerformanceDb GetDb(const miopen::ExecutionContext& context,
+                            const miopen::softmax::ProblemDescriptionTag&)
 {
-    return {DbKinds::PerfDb, context.GetPerfDbPath("softmax"), context.GetUserPerfDbPath("softmax")};
+    return {
+        DbKinds::PerfDb, context.GetPerfDbPath("softmax"), context.GetUserPerfDbPath("softmax")};
 }
 } // namespace softmax
 

--- a/projects/miopen/src/solution.cpp
+++ b/projects/miopen/src/solution.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
 #include <miopen/solution.hpp>
@@ -19,6 +19,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "miopen/conv/db_getter.hpp"
 #include "miopen/fusion/problem_description.hpp"
 #include "miopen/fusion/context.hpp"
 
@@ -519,8 +520,9 @@ void Solution::RunImpl(const Handle& handle,
     if(!kernels.empty())
     {
         const auto ctx              = ExecutionContext{&handle};
+        auto db_getter = MakeConvDbGetter(ctx);
         const auto softmax_solution = GetSolver() == regularSoftmax.SolverDbId()
-                                          ? regularSoftmax.GetSolution(ctx, problem_description)
+                                          ? solver::FindSolution(regularSoftmax, ctx, problem_description, db_getter, invoke_ctx)
                                           : attnSoftmax.GetSolution(ctx, problem_description);
         auto kernel_handles         = std::vector<Kernel>{std::begin(kernels), std::end(kernels)};
 
@@ -547,9 +549,9 @@ void Solution::RunImpl(const Handle& handle,
     }
 
     auto ctx = ExecutionContext{&handle};
-
+    auto db_getter = MakeConvDbGetter(ctx);
     const auto softmax_solution = GetSolver() == regularSoftmax.SolverDbId()
-                                      ? regularSoftmax.GetSolution(ctx, problem_description)
+                                      ? solver::FindSolution(regularSoftmax, ctx, problem_description, db_getter, invoke_ctx)
                                       : attnSoftmax.GetSolution(ctx, problem_description);
 
     if(softmax_solution.invoker_factory.has_value())

--- a/projects/miopen/src/solution.cpp
+++ b/projects/miopen/src/solution.cpp
@@ -519,12 +519,14 @@ void Solution::RunImpl(const Handle& handle,
 
     if(!kernels.empty())
     {
-        const auto ctx              = ExecutionContext{&handle};
+        const auto ctx = ExecutionContext{&handle};
         auto db_getter = MakeConvDbGetter(ctx);
-        const auto softmax_solution = GetSolver() == regularSoftmax.SolverDbId()
-                                          ? solver::FindSolution(regularSoftmax, ctx, problem_description, db_getter, invoke_ctx)
-                                          : attnSoftmax.GetSolution(ctx, problem_description);
-        auto kernel_handles         = std::vector<Kernel>{std::begin(kernels), std::end(kernels)};
+        const auto softmax_solution =
+            GetSolver() == regularSoftmax.SolverDbId()
+                ? solver::FindSolution(
+                      regularSoftmax, ctx, problem_description, db_getter, invoke_ctx)
+                : attnSoftmax.GetSolution(ctx, problem_description);
+        auto kernel_handles = std::vector<Kernel>{std::begin(kernels), std::end(kernels)};
 
         if(softmax_solution.invoker_factory.has_value())
         {
@@ -548,11 +550,12 @@ void Solution::RunImpl(const Handle& handle,
         return;
     }
 
-    auto ctx = ExecutionContext{&handle};
+    auto ctx       = ExecutionContext{&handle};
     auto db_getter = MakeConvDbGetter(ctx);
-    const auto softmax_solution = GetSolver() == regularSoftmax.SolverDbId()
-                                      ? solver::FindSolution(regularSoftmax, ctx, problem_description, db_getter, invoke_ctx)
-                                      : attnSoftmax.GetSolution(ctx, problem_description);
+    const auto softmax_solution =
+        GetSolver() == regularSoftmax.SolverDbId()
+            ? solver::FindSolution(regularSoftmax, ctx, problem_description, db_getter, invoke_ctx)
+            : attnSoftmax.GetSolution(ctx, problem_description);
 
     if(softmax_solution.invoker_factory.has_value())
     {

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -91,7 +91,7 @@ bool Softmax::IsApplicable(
 }
 
 PerformanceConfigSoftmax
-Softmax::GetDefaultPerformanceConfig(const ExecutionContext& context,
+Softmax::GetDefaultPerformanceConfig(const ExecutionContext&,
                                      const miopen::softmax::ProblemDescription& problem) const
 {
     PerformanceConfigSoftmax config;

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -1,6 +1,9 @@
-// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
+#include "miopen/execution_context.hpp"
+#include "miopen/miopen.h"
+#include "miopen/softmax/problem_description.hpp"
 #include <miopen/env.hpp>
 #include <miopen/softmax/solvers.hpp>
 
@@ -10,8 +13,6 @@
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/target_properties.hpp>
 #include <miopen/float_equal.hpp>
-
-#define LOCAL_SIZE 256
 
 namespace miopen {
 
@@ -89,8 +90,23 @@ bool Softmax::IsApplicable(
     return true;
 }
 
+PerformanceConfigSoftmax Softmax::GetDefaultPerformanceConfig(const ExecutionContext& context, const miopen::softmax::ProblemDescription& problem) const
+{
+    PerformanceConfigSoftmax config;
+    config.HeuristicInit(problem);
+    config.local_size = PerformanceConfigSoftmax::default_local_size;
+    MIOPEN_LOG_I(config.ToString());
+    return config;
+}
+
+bool Softmax::IsValidPerformanceConfig(const ExecutionContext& context, const miopen::softmax::ProblemDescription& problem, const PerformanceConfigSoftmax& config) const
+{
+    return config.IsValid(context, problem);
+}
+
 ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& context,
-                                  const miopen::softmax::ProblemDescription& problem) const
+                                  const miopen::softmax::ProblemDescription& problem,
+                                  const PerformanceConfigSoftmax& config) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
@@ -106,14 +122,14 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     auto spatial_dim = mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? 1 : lengths[2] * lengths[3];
     auto vector_size =
         mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? lengths[1] * lengths[2] * lengths[3] : lengths[1];
-    auto num_batch    = vector_size < LOCAL_SIZE ? nextPow2(LOCAL_SIZE / vector_size) : 1;
+    auto num_batch    = vector_size < config.local_size ? nextPow2(config.local_size / vector_size) : 1;
     auto workgroups   = num_batch == 1               ? grid_size
                         : grid_size % num_batch == 0 ? grid_size / num_batch
                                                      : grid_size / num_batch + 1;
-    auto batch_size   = LOCAL_SIZE / num_batch;
+    auto batch_size   = config.local_size / num_batch;
     auto u_batch_size = vector_size > batch_size ? nextPow2(vector_size / batch_size) : 1;
 
-    size_t xlocalsize = LOCAL_SIZE;
+    size_t xlocalsize = config.local_size;
     size_t xgridsize  = workgroups * xlocalsize;
     size_t ylocalsize = 1;
     size_t ygridsize  = 1;
@@ -141,7 +157,7 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
                               {"C_STRIDE", strides[1]},
                               {"H_STRIDE", strides[2]},
                               {"W_STRIDE", strides[3]},
-                              {"LOCAL_SIZE", LOCAL_SIZE},
+                              {"LOCAL_SIZE", config.local_size},
                               {"WORKGROUPS", workgroups},
                               {"GRID_SIZE", grid_size},
                               {"SPATIAL_DIM", spatial_dim},
@@ -202,6 +218,81 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     }
 
     return result;
+}
+
+void PerformanceConfigSoftmax::HeuristicInit(const miopen::softmax::ProblemDescription& problem)
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+#else
+    switch(problem.GetYDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat:
+    case miopenBFloat16: local_size = PerformanceConfigSoftmax::start_local_size; break;
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+#endif
+    initialized = true;
+}
+
+bool PerformanceConfigSoftmax::SetNextValue(const miopen::softmax::ProblemDescription& problem)
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+    return false;
+#else
+    if(!initialized)
+    {
+        HeuristicInit(problem);
+    }
+    if(local_size <= 0)
+    {
+        MIOPEN_THROW(miopenStatusInvalidValue, "Local size zero or negative");
+    }
+    local_size *= 2;
+    return local_size <= max_local_size;
+#endif
+}
+
+bool PerformanceConfigSoftmax::IsValidValue() const
+{
+    return local_size > 0 && local_size <= max_local_size;
+}
+
+bool PerformanceConfigSoftmax::IsValid(const ExecutionContext&,
+                                       const miopen::softmax::ProblemDescription& problem) const
+{
+#if !MIOPEN_BACKEND_HIP
+    std::ignore = problem;
+    return false;
+#else
+    switch(problem.GetXDesc().GetType())
+    {
+    case miopenHalf:
+    case miopenFloat:
+    case miopenBFloat16: return true;
+    case miopenDouble:
+    case miopenFloat8_fnuz:
+    case miopenBFloat8_fnuz:
+    case miopenInt8:
+    case miopenInt32:
+    case miopenInt64:
+    default: MIOPEN_THROW("Unsupported datatype");
+    }
+    return false;
+#endif
+}
+
+bool PerformanceConfigSoftmax::operator==(const PerformanceConfigSoftmax& other) const
+{
+    return local_size == other.local_size;
 }
 
 } // namespace softmax

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -17,7 +17,7 @@
 namespace miopen {
 
 namespace {
-constexpr int nextPow2(int v)
+constexpr uint64_t nextPow2(uint64_t v)
 {
     if(v == 1)
     {
@@ -31,6 +31,7 @@ constexpr int nextPow2(int v)
         v |= v >> 4;
         v |= v >> 8;
         v |= v >> 16;
+        v |= v >> 32;
         v++;
         return v;
     }
@@ -128,9 +129,7 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
         mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? lengths[1] * lengths[2] * lengths[3] : lengths[1];
     auto num_batch =
         vector_size < config.local_size ? nextPow2(config.local_size / vector_size) : 1;
-    auto workgroups   = num_batch == 1               ? grid_size
-                        : grid_size % num_batch == 0 ? grid_size / num_batch
-                                                     : grid_size / num_batch + 1;
+    auto workgroups   = num_batch == 1 ? grid_size : (grid_size + num_batch - 1) / num_batch;
     auto batch_size   = config.local_size / num_batch;
     auto u_batch_size = vector_size > batch_size ? nextPow2(vector_size / batch_size) : 1;
 
@@ -146,34 +145,34 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     kernel.kernel_file = "MIOpenSoftmax.cpp";
     kernel.kernel_name = problem.IsForward() ? "SoftmaxFwd" : "SoftmaxBwd";
 
-    const auto build_params =
-        KernelBuildParameters{{"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
-                              {"MIOPEN_USE_FP32", static_cast<int>(dtype == miopenFloat)},
-                              {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
-                              {"DATA_TYPE", data_dtype == "bfloat16" ? "ushort" : data_dtype},
-                              {"USE_SOFTMAX_FAST", algorithm == MIOPEN_SOFTMAX_FAST},
-                              {"USE_SOFTMAX_ACCURATE", algorithm == MIOPEN_SOFTMAX_ACCURATE},
-                              {"USE_SOFTMAX_LOG", algorithm == MIOPEN_SOFTMAX_LOG},
-                              {"USE_SOFTMAX_MODE_INSTANCE", mode == MIOPEN_SOFTMAX_MODE_INSTANCE},
-                              {"USE_SOFTMAX_MODE_CHANNEL", mode == MIOPEN_SOFTMAX_MODE_CHANNEL},
-                              {"HEIGHT", lengths[2]},
-                              {"WIDTH", lengths[3]},
-                              {"N_STRIDE", strides[0]},
-                              {"C_STRIDE", strides[1]},
-                              {"H_STRIDE", strides[2]},
-                              {"W_STRIDE", strides[3]},
-                              {"LOCAL_SIZE", config.local_size},
-                              {"WORKGROUPS", workgroups},
-                              {"GRID_SIZE", grid_size},
-                              {"SPATIAL_DIM", spatial_dim},
-                              {"VECTOR_SIZE", vector_size},
-                              {"NUM_BATCH", num_batch},
-                              {"BATCH_SIZE", batch_size},
-                              {"U_BATCH_SIZE", u_batch_size},
-                              {"IS_INPUT_CONTIGUOUS", problem.GetXDesc().IsContiguous()},
-                              {"IS_OUTPUT_CONTIGUOUS", problem.GetYDesc().IsContiguous()},
-                              {"IS_DINPUT_CONTIGUOUS", problem.GetdXDesc().IsContiguous()},
-                              {"IS_DOUTPUT_CONTIGUOUS", problem.GetdYDesc().IsContiguous()}};
+    const auto build_params = KernelBuildParameters{
+        {"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
+        {"MIOPEN_USE_FP32", static_cast<int>(dtype == miopenFloat)},
+        {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
+        {"DATA_TYPE", data_dtype == "bfloat16" ? "ushort" : data_dtype},
+        {"USE_SOFTMAX_FAST", algorithm == MIOPEN_SOFTMAX_FAST},
+        {"USE_SOFTMAX_ACCURATE", algorithm == MIOPEN_SOFTMAX_ACCURATE},
+        {"USE_SOFTMAX_LOG", algorithm == MIOPEN_SOFTMAX_LOG},
+        {"USE_SOFTMAX_MODE_INSTANCE", mode == MIOPEN_SOFTMAX_MODE_INSTANCE},
+        {"USE_SOFTMAX_MODE_CHANNEL", mode == MIOPEN_SOFTMAX_MODE_CHANNEL},
+        {"HEIGHT", lengths[2]},
+        {"WIDTH", lengths[3]},
+        {"N_STRIDE", strides[0]},
+        {"C_STRIDE", strides[1]},
+        {"H_STRIDE", strides[2]},
+        {"W_STRIDE", strides[3]},
+        {"LOCAL_SIZE", config.local_size},
+        {"WORKGROUPS", workgroups},
+        {"GRID_SIZE", grid_size},
+        {"SPATIAL_DIM", spatial_dim},
+        {"VECTOR_SIZE", vector_size},
+        {"NUM_BATCH", num_batch},
+        {"BATCH_SIZE", batch_size},
+        {"U_BATCH_SIZE", u_batch_size},
+        {"IS_INPUT_CONTIGUOUS", problem.IsForward() && problem.GetXDesc().IsContiguous()},
+        {"IS_OUTPUT_CONTIGUOUS", problem.GetYDesc().IsContiguous()},
+        {"IS_DINPUT_CONTIGUOUS", !problem.IsForward() && problem.GetdXDesc().IsContiguous()},
+        {"IS_DOUTPUT_CONTIGUOUS", !problem.IsForward() && problem.GetdYDesc().IsContiguous()}};
 
     kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
 
@@ -291,7 +290,6 @@ bool PerformanceConfigSoftmax::IsValid(const ExecutionContext&,
     case miopenInt64:
     default: MIOPEN_THROW("Unsupported datatype");
     }
-    return false;
 #endif
 }
 

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -90,7 +90,9 @@ bool Softmax::IsApplicable(
     return true;
 }
 
-PerformanceConfigSoftmax Softmax::GetDefaultPerformanceConfig(const ExecutionContext& context, const miopen::softmax::ProblemDescription& problem) const
+PerformanceConfigSoftmax
+Softmax::GetDefaultPerformanceConfig(const ExecutionContext& context,
+                                     const miopen::softmax::ProblemDescription& problem) const
 {
     PerformanceConfigSoftmax config;
     config.HeuristicInit(problem);
@@ -99,7 +101,9 @@ PerformanceConfigSoftmax Softmax::GetDefaultPerformanceConfig(const ExecutionCon
     return config;
 }
 
-bool Softmax::IsValidPerformanceConfig(const ExecutionContext& context, const miopen::softmax::ProblemDescription& problem, const PerformanceConfigSoftmax& config) const
+bool Softmax::IsValidPerformanceConfig(const ExecutionContext& context,
+                                       const miopen::softmax::ProblemDescription& problem,
+                                       const PerformanceConfigSoftmax& config) const
 {
     return config.IsValid(context, problem);
 }
@@ -122,7 +126,8 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     auto spatial_dim = mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? 1 : lengths[2] * lengths[3];
     auto vector_size =
         mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? lengths[1] * lengths[2] * lengths[3] : lengths[1];
-    auto num_batch    = vector_size < config.local_size ? nextPow2(config.local_size / vector_size) : 1;
+    auto num_batch =
+        vector_size < config.local_size ? nextPow2(config.local_size / vector_size) : 1;
     auto workgroups   = num_batch == 1               ? grid_size
                         : grid_size % num_batch == 0 ? grid_size / num_batch
                                                      : grid_size / num_batch + 1;


### PR DESCRIPTION
## Motivation

This PR adds tuning support to Softmax and extends Generic Search a bit to allow for more control.

## Technical Details

- Add tuning support to Softmax.
- Added the envvar `MIOPEN_TUNING_FOLLOWUP_TOLERANCE_PCT` to Generic Search, which will allow a user to set the tolerance of the initial iteration of a config, after which a passing config will be followed up with more iterations. The default value is 10, which matches previous behaviour.
- Added the envvar `MIOPEN_TUNING_ITERATIONS` to Generic Search, which will allow a user to set a different number of iterations to run when following up a config during tuning. The default value is 10, which matches previous behaviour.

## Test Plan

Build and run the test target `test_soft_max` and `test_softmax_find20`.

## Test Result

All tests should pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
