### PR TITLE
[hipBLASLt-provider][ALMIOPEN-931] Matmul support

### DIFF
--- a/dnn-providers/hipblaslt-provider/CMakeLists.txt
+++ b/dnn-providers/hipblaslt-provider/CMakeLists.txt
@@ -104,6 +104,11 @@ add_library(
     HipblasltContainer.cpp
     HipblasltPlugin.cpp
     HipblasltUtils.cpp
+    # Matmul-related files
+    engines/plans/HipblasltMatmulPlan.cpp
+    engines/plans/HipblasltMatmulPlanBuilder.cpp
+    HipblasltMatmulDesc.cpp
+    HipblasltMatrixLayout.cpp
 )
 target_compile_definitions(
     hipblaslt_plugin_private PRIVATE COMPONENT_NAME="hipblaslt_plugin"
@@ -132,6 +137,14 @@ set_target_properties(
 
 if(NOT HIPDNN_SKIP_TESTS)
     add_subdirectory(tests)
+    add_subdirectory(integration_tests)
+
+    # Keep this after all build folders have been added so they have a chance to register their tests
+    # using add_*_test_target()
+    finalize_test_targets()
+
+    # For standalone builds we need to install the ctest files
+    install_hipblaslt_plugin_ctest_files()
 endif()
 
 install(TARGETS hipblaslt_plugin EXPORT hipblaslt-plugin

--- a/dnn-providers/hipblaslt-provider/HipblasltContainer.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltContainer.cpp
@@ -7,6 +7,7 @@
 #include "EngineManager.hpp"
 #include "HipblasltContainer.hpp"
 #include "engines/HipblasltEngine.hpp"
+#include "engines/plans/HipblasltMatmulPlanBuilder.hpp"
 
 namespace hipblaslt_plugin
 {
@@ -17,6 +18,9 @@ HipblasltContainer::HipblasltContainer()
 
     auto hipblasltEngine
         = std::make_unique<HipblasltEngine>(hipdnn_data_sdk::utilities::HIPBLASLT_ENGINE_ID);
+
+    auto matmulPlanBuilder = std::make_unique<HipblasltMatmulPlanBuilder>();
+    hipblasltEngine->addPlanBuilder(std::move(matmulPlanBuilder));
 
     _engineManager = std::make_unique<EngineManager>();
     _engineManager->addEngine(std::move(hipblasltEngine));

--- a/dnn-providers/hipblaslt-provider/HipblasltMatmulDesc.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltMatmulDesc.cpp
@@ -1,0 +1,66 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "HipblasltMatmulDesc.hpp"
+#include "HipblasltUtils.hpp"
+
+namespace hipblaslt_plugin
+{
+
+HipblasltMatmulDesc::HipblasltMatmulDesc(hipblasOperation_t transA,
+                                         hipblasOperation_t transB,
+                                         hipblasComputeType_t computeType,
+                                         hipDataType scaleType)
+{
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatmulDescCreate(&_desc, computeType, scaleType));
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatmulDescSetAttribute(
+        _desc, HIPBLASLT_MATMUL_DESC_TRANSA, &transA, sizeof(int32_t)));
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatmulDescSetAttribute(
+        _desc, HIPBLASLT_MATMUL_DESC_TRANSB, &transB, sizeof(int32_t)));
+
+    hipblasLtEpilogue_t epilogue = HIPBLASLT_EPILOGUE_DEFAULT;
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatmulDescSetAttribute(
+        _desc, HIPBLASLT_MATMUL_DESC_EPILOGUE, &epilogue, sizeof(epilogue)));
+}
+
+HipblasltMatmulDesc::HipblasltMatmulDesc(HipblasltMatmulDesc&& other) noexcept
+    : _desc(other._desc)
+{
+    other._desc = nullptr;
+}
+
+HipblasltMatmulDesc& HipblasltMatmulDesc::operator=(HipblasltMatmulDesc&& other) noexcept
+{
+    if(this != &other)
+    {
+        if(_desc != nullptr)
+        {
+            LOG_ON_HIPBLASLT_FAILURE(hipblasLtMatmulDescDestroy(_desc));
+        }
+
+        _desc = other._desc;
+        other._desc = nullptr;
+    }
+    return *this;
+}
+
+HipblasltMatmulDesc::~HipblasltMatmulDesc()
+{
+    if(_desc != nullptr)
+    {
+        LOG_ON_HIPBLASLT_FAILURE(hipblasLtMatmulDescDestroy(_desc));
+    }
+}
+
+hipblasLtMatmulDesc_t HipblasltMatmulDesc::matmulDesc() const
+{
+    return _desc;
+}
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/HipblasltMatmulDesc.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltMatmulDesc.hpp
@@ -1,0 +1,34 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipblaslt/hipblaslt.h>
+
+namespace hipblaslt_plugin
+{
+
+class HipblasltMatmulDesc
+{
+public:
+    HipblasltMatmulDesc() = default;
+    HipblasltMatmulDesc(hipblasOperation_t transA,
+                        hipblasOperation_t transB,
+                        hipblasComputeType_t computeType,
+                        hipDataType scaleType);
+
+    HipblasltMatmulDesc(const HipblasltMatmulDesc&) = delete;
+    HipblasltMatmulDesc& operator=(const HipblasltMatmulDesc&) = delete;
+
+    HipblasltMatmulDesc(HipblasltMatmulDesc&& other) noexcept;
+    HipblasltMatmulDesc& operator=(HipblasltMatmulDesc&& other) noexcept;
+
+    ~HipblasltMatmulDesc();
+
+    hipblasLtMatmulDesc_t matmulDesc() const;
+
+private:
+    hipblasLtMatmulDesc_t _desc = nullptr;
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.cpp
@@ -1,0 +1,118 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipblasltMatrixLayout.hpp"
+#include "HipblasltUtils.hpp"
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+namespace hipblaslt_plugin
+{
+
+HipblasltMatrixLayout::HipblasltMatrixLayout(
+    const hipdnn_plugin_sdk::TensorAttributesWrapper& tensor)
+    : _uid(tensor.uid())
+{
+    const auto& dims = tensor.dims();
+    const auto& strides = tensor.strides();
+    const auto rank = dims.size();
+
+    PLUGIN_THROW_IF_TRUE(rank < 2,
+                         HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                         "Tensor rank must be at least 2 for matrix layout. UID: "
+                             + std::to_string(_uid));
+
+    // Different types of matrices require different initialization of layout:
+    // - If this is column-major matrix (strides[rank-2] == 1):
+    //   we need to use the dimensions and the strides as-is since hipBLASLT expects column-major layout.
+    // - If this is row-major matrix (strides[rank-1] == 1):
+    //   we need to swap the dimensions and the strides.
+    uint64_t rows, cols;
+    int64_t ld;
+    if(strides[rank - 1] == 1) // row-major matrix
+    {
+        rows = static_cast<uint64_t>(dims[rank - 1]);
+        cols = static_cast<uint64_t>(dims[rank - 2]);
+        ld = strides[rank - 2]; // row stride
+    }
+    else if(strides[strides.size() - 2] == 1) // column-major matrix
+    {
+        rows = static_cast<uint64_t>(dims[rank - 2]);
+        cols = static_cast<uint64_t>(dims[rank - 1]);
+        ld = strides[rank - 1]; // column stride
+    }
+    else
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Unsupported matrix: only column major and row major matrices are supported");
+    }
+
+    THROW_ON_HIPBLASLT_FAILURE(
+        hipblasLtMatrixLayoutCreate(&_matrix_layout,
+                                    hipblaslt_utils::tensorDataTypeToHipDataType(tensor.dataType()),
+                                    rows,
+                                    cols,
+                                    ld));
+}
+
+HipblasltMatrixLayout::HipblasltMatrixLayout(HipblasltMatrixLayout&& other) noexcept
+    : _uid(other._uid)
+    , _matrix_layout(other._matrix_layout)
+{
+    other._matrix_layout = nullptr;
+}
+
+HipblasltMatrixLayout& HipblasltMatrixLayout::operator=(HipblasltMatrixLayout&& other) noexcept
+{
+    if(this != &other)
+    {
+        if(_matrix_layout != nullptr)
+        {
+            LOG_ON_HIPBLASLT_FAILURE(hipblasLtMatrixLayoutDestroy(_matrix_layout));
+        }
+
+        _uid = other._uid;
+        _matrix_layout = other._matrix_layout;
+
+        other._matrix_layout = nullptr;
+    }
+    return *this;
+}
+
+HipblasltMatrixLayout::~HipblasltMatrixLayout()
+{
+    if(_matrix_layout != nullptr)
+    {
+        LOG_ON_HIPBLASLT_FAILURE(hipblasLtMatrixLayoutDestroy(_matrix_layout));
+    }
+}
+
+int64_t HipblasltMatrixLayout::uid() const
+{
+    return _uid;
+}
+
+hipblasLtMatrixLayout_t HipblasltMatrixLayout::matrixLayout() const
+{
+    return _matrix_layout;
+}
+
+void HipblasltMatrixLayout::setBatchCount(int64_t count)
+{
+    PLUGIN_THROW_IF_NULL(_matrix_layout,
+                         HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                         "Failed to set batch count: matrixLayout is nullptr");
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatrixLayoutSetAttribute(
+        _matrix_layout, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &count, sizeof(count)));
+}
+
+void HipblasltMatrixLayout::setStridedBatchOffset(int64_t stride)
+{
+    PLUGIN_THROW_IF_NULL(_matrix_layout,
+                         HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                         "Failed to set strided batch offset: matrixLayout is nullptr");
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatrixLayoutSetAttribute(
+        _matrix_layout, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stride, sizeof(stride)));
+}
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.hpp
@@ -12,6 +12,7 @@ namespace hipblaslt_plugin
 class HipblasltMatrixLayout
 {
 public:
+    HipblasltMatrixLayout() = default;
     HipblasltMatrixLayout(const hipdnn_plugin_sdk::TensorAttributesWrapper& tensor);
 
     HipblasltMatrixLayout(const HipblasltMatrixLayout&) = delete;
@@ -30,7 +31,7 @@ public:
     void setStridedBatchOffset(int64_t stride);
 
 private:
-    int64_t _uid;
+    int64_t _uid{0};
     hipblasLtMatrixLayout_t _matrix_layout{nullptr};
 };
 

--- a/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltMatrixLayout.hpp
@@ -1,0 +1,37 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipblaslt/hipblaslt.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
+
+namespace hipblaslt_plugin
+{
+
+class HipblasltMatrixLayout
+{
+public:
+    HipblasltMatrixLayout(const hipdnn_plugin_sdk::TensorAttributesWrapper& tensor);
+
+    HipblasltMatrixLayout(const HipblasltMatrixLayout&) = delete;
+    HipblasltMatrixLayout& operator=(const HipblasltMatrixLayout&) = delete;
+
+    HipblasltMatrixLayout(HipblasltMatrixLayout&& other) noexcept;
+    HipblasltMatrixLayout& operator=(HipblasltMatrixLayout&& other) noexcept;
+
+    ~HipblasltMatrixLayout();
+
+    int64_t uid() const;
+
+    hipblasLtMatrixLayout_t matrixLayout() const;
+
+    void setBatchCount(int64_t count);
+    void setStridedBatchOffset(int64_t stride);
+
+private:
+    int64_t _uid;
+    hipblasLtMatrixLayout_t _matrix_layout{nullptr};
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/HipblasltUtils.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltUtils.cpp
@@ -28,4 +28,37 @@ hipDataType tensorDataTypeToHipDataType(const hipdnn_data_sdk::data_objects::Dat
     }
 }
 
+hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
+                                            const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                            uint32_t numDeviceBuffers)
+{
+    for(uint32_t i = 0; i < numDeviceBuffers; i++)
+    {
+        if(uid == deviceBuffers[i].uid)
+        {
+            return deviceBuffers[i];
+        }
+    }
+
+    throw hipdnn_plugin_sdk::HipdnnPluginException(
+        HIPDNN_PLUGIN_STATUS_INVALID_VALUE,
+        "Device buffer with the uid: " + std::to_string(uid)
+            + " not found in the provided device buffers.");
+}
+
+hipdnn_plugin_sdk::TensorAttributesWrapper findTensorAttributes(
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    int64_t uid)
+{
+    if(auto tensorAttr = tensorMap.find(uid); tensorAttr != tensorMap.end())
+    {
+        return hipdnn_plugin_sdk::TensorAttributesWrapper(tensorAttr->second);
+    }
+
+    throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                                                   "Failed to find tensor with UID in tensorMap: "
+                                                       + std::to_string(uid));
+}
+
 } // namespace hipblaslt_plugin::hipblaslt_utils

--- a/dnn-providers/hipblaslt-provider/HipblasltUtils.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltUtils.hpp
@@ -7,6 +7,7 @@
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
 #include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
 #include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <string>
@@ -77,5 +78,14 @@ inline const char* hipblas_status_to_string(hipblasStatus_t status)
 }
 
 hipDataType tensorDataTypeToHipDataType(const hipdnn_data_sdk::data_objects::DataType& dataType);
+
+hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
+                                            const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                            uint32_t numDeviceBuffers);
+
+hipdnn_plugin_sdk::TensorAttributesWrapper findTensorAttributes(
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    int64_t uid);
 
 } // namespace hipblaslt_plugin::hipblaslt_utils

--- a/dnn-providers/hipblaslt-provider/cmake/Dependencies.cmake
+++ b/dnn-providers/hipblaslt-provider/cmake/Dependencies.cmake
@@ -4,26 +4,24 @@
 cmake_minimum_required(VERSION 3.25.2)
 
 # Only setup dependencies for standalone builds
-if(NOT BUILD_PLUGIN_AS_DEPENDENCY AND NOT HIPDNN_SKIP_TESTS)
-    include(FetchContent)
+include(FetchContent)
 
-    # Try to find GTest first
-    find_package(GTest CONFIG QUIET)
+# Try to find GTest first
+find_package(GTest CONFIG QUIET)
 
-    if(NOT GTest_FOUND)
-        message(STATUS "Fetching GTest for standalone plugin build")
+if(NOT GTest_FOUND)
+    message(STATUS "Fetching GTest for standalone plugin build")
 
-        fetchcontent_declare(
-            googletest URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
-                           DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-        )
+    fetchcontent_declare(
+        googletest URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
+                       DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
 
-        set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
-        set(INSTALL_GTEST OFF CACHE INTERNAL "")
-        set(BUILD_GMOCK ON CACHE INTERNAL "")
+    set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
+    set(INSTALL_GTEST OFF CACHE INTERNAL "")
+    set(BUILD_GMOCK ON CACHE INTERNAL "")
 
-        fetchcontent_makeavailable(googletest)
-    else()
-        message(STATUS "Found system GTest")
-    endif()
+    fetchcontent_makeavailable(googletest)
+else()
+    message(STATUS "Found system GTest")
 endif()

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.cpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.cpp
@@ -1,0 +1,237 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <array>
+#include <numeric>
+#include <string>
+
+#include <hipblaslt/hipblaslt.h>
+#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_data_sdk/utilities/ScopedResource.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "HipblasltMatmulPlan.hpp"
+#include "HipblasltUtils.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+
+namespace hipblaslt_plugin
+{
+namespace
+{
+inline int64_t getBatchCount(const std::vector<int64_t>& dims)
+{
+    PLUGIN_THROW_IF_TRUE(dims.size() < 2,
+                         HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                         "Failed to calculate batch count:expected at least 2 dimensions");
+    return std::accumulate(dims.begin(), dims.end() - 2, int64_t{1}, std::multiplies<int64_t>());
+}
+} // namespace
+
+hipblasOperation_t MatmulParams::getTrans(const hipdnn_plugin_sdk::TensorAttributesWrapper& t)
+{
+    const auto& strides = t.strides();
+    PLUGIN_THROW_IF_FALSE(strides.size() > 1,
+                          HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                          "Unsupported stride for input matrix: " + t.name());
+    // Row-major storage: dims are swapped in layout, no additional transpose
+    if(strides[strides.size() - 1] == 1)
+    {
+        return HIPBLAS_OP_N;
+    }
+    // Column-major storage: dims not swapped, need transpose
+    else if(strides[strides.size() - 2] == 1)
+    {
+        return HIPBLAS_OP_T;
+    }
+    throw hipdnn_plugin_sdk::HipdnnPluginException(
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM, "Unsupported stride for input matrix: " + t.name());
+}
+
+hipblasComputeType_t
+    MatmulParams::getComputeDataType(const hipdnn_plugin_sdk::TensorAttributesWrapper& tA,
+                                     const hipdnn_plugin_sdk::TensorAttributesWrapper& tB)
+{
+    auto hipDataTypeA = hipblaslt_utils::tensorDataTypeToHipDataType(tA.dataType());
+    auto hipDataTypeB = hipblaslt_utils::tensorDataTypeToHipDataType(tB.dataType());
+    if(hipDataTypeA == hipDataTypeB && hipDataTypeA == HIP_R_16F)
+    {
+        return HIPBLAS_COMPUTE_32F_FAST_16F;
+    }
+    else if(hipDataTypeA == hipDataTypeB && hipDataTypeA == HIP_R_16BF)
+    {
+        return HIPBLAS_COMPUTE_32F_FAST_16BF;
+    }
+    return HIPBLAS_COMPUTE_32F;
+}
+
+MatmulParams::MatmulParams(
+    const hipdnn_data_sdk::data_objects::MatmulAttributes& attributes,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+    : _matrixLayoutA(hipblaslt_utils::findTensorAttributes(tensorMap, attributes.a_tensor_uid()))
+    , _matrixLayoutB(hipblaslt_utils::findTensorAttributes(tensorMap, attributes.b_tensor_uid()))
+    , _matrixLayoutC(hipblaslt_utils::findTensorAttributes(tensorMap, attributes.c_tensor_uid()))
+{
+    const auto tA = hipblaslt_utils::findTensorAttributes(tensorMap, attributes.a_tensor_uid());
+    const auto tB = hipblaslt_utils::findTensorAttributes(tensorMap, attributes.b_tensor_uid());
+    const auto tC = hipblaslt_utils::findTensorAttributes(tensorMap, attributes.c_tensor_uid());
+    // Row-major BLAS trick: to compute C = A * B with row-major data,
+    // we compute C^T = B^T * A^T with column-major BLAS.
+    // So we swap the transpose operations: transA in desc = getTrans(B), transB in desc = getTrans(A)
+    _matmulDesc
+        = HipblasltMatmulDesc(getTrans(tB), getTrans(tA), getComputeDataType(tA, tB), HIP_R_32F);
+
+    const auto& aDims = tA.dims();
+    const auto& bDims = tB.dims();
+    const auto& cDims = tC.dims();
+    if(aDims.size() != bDims.size() || aDims.size() != cDims.size())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Unsupported input matrix ranks: they should be the same");
+    }
+
+    // Batch support: we flatten all batch dimensions (all except last two) into a single batch count.
+    // hipBLASLt uses a single strided batch offset, so we can only support uniform batch strides.
+    // Supported: [3, M, K] x [1, K, N] or [3, M, K] x [3, K, N] - single batch dimension, uniform stride.
+    // Not supported: [3, 1, M, K] x [1, 3, K, N] - would require non-uniform stride pattern for broadcasting.
+    const auto rank = aDims.size();
+    if(rank > 2)
+    {
+        const int64_t aBatch = getBatchCount(aDims);
+        const int64_t bBatch = getBatchCount(bDims);
+        const int64_t cBatch = getBatchCount(cDims);
+
+        if(aBatch != bBatch && aBatch != 1 && bBatch != 1)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Unsupported input matrix batch dimensions: they should be equal or one of them "
+                "should be 1");
+        }
+
+        if(cBatch != std::max(aBatch, bBatch))
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Unsupported matrix batch dimensions: output batch should be the same as the max "
+                "of the input batch dimensions");
+        }
+
+        if(cBatch > 1)
+        {
+            _matrixLayoutA.setBatchCount(cBatch);
+            _matrixLayoutB.setBatchCount(cBatch);
+            _matrixLayoutC.setBatchCount(cBatch);
+
+            if(aBatch > 1)
+            {
+                _matrixLayoutA.setStridedBatchOffset(tA.strides()[rank - 3]);
+            }
+            if(bBatch > 1)
+            {
+                _matrixLayoutB.setStridedBatchOffset(tB.strides()[rank - 3]);
+            }
+            _matrixLayoutC.setStridedBatchOffset(tC.strides()[rank - 3]);
+        }
+    }
+}
+
+const HipblasltMatrixLayout& MatmulParams::a() const
+{
+    return _matrixLayoutA;
+}
+
+const HipblasltMatrixLayout& MatmulParams::b() const
+{
+    return _matrixLayoutB;
+}
+
+const HipblasltMatrixLayout& MatmulParams::c() const
+{
+    return _matrixLayoutC;
+}
+
+const HipblasltMatmulDesc& MatmulParams::desc() const
+{
+    return _matmulDesc;
+}
+
+MatmulPlan::MatmulPlan(const HipdnnEnginePluginHandle& handle, MatmulParams&& params)
+    : _params(std::move(params))
+{
+    size_t max_workspace_size = 0;
+    hipblasLtMatmulPreference_t pref;
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatmulPreferenceCreate(&pref));
+    THROW_ON_HIPBLASLT_FAILURE(
+        hipblasLtMatmulPreferenceSetAttribute(pref,
+                                              HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                                              &max_workspace_size,
+                                              sizeof(max_workspace_size)));
+
+    // Row-major BLAS trick: swap A and B layouts
+    constexpr int request_solutions = 1;
+    hipblasLtMatmulHeuristicResult_t heuristicResult[request_solutions];
+    int returnedAlgoCount = 0;
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatmulAlgoGetHeuristic(handle.hipblasltHandle,
+                                                               _params.desc().matmulDesc(),
+                                                               _params.b().matrixLayout(),
+                                                               _params.a().matrixLayout(),
+                                                               _params.c().matrixLayout(),
+                                                               _params.c().matrixLayout(),
+                                                               pref,
+                                                               request_solutions,
+                                                               heuristicResult,
+                                                               &returnedAlgoCount));
+
+    PLUGIN_THROW_IF_FALSE(returnedAlgoCount > 0,
+                          HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                          "hipBLASLt has not found algorithm!");
+
+    _heuristicResult = heuristicResult[0];
+    _workspaceSize = _heuristicResult.workspaceSize;
+
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatmulPreferenceDestroy(pref));
+}
+
+size_t MatmulPlan::getWorkspaceSize([[maybe_unused]] const HipdnnEnginePluginHandle& handle) const
+{
+    return _workspaceSize;
+}
+
+void MatmulPlan::execute(const HipdnnEnginePluginHandle& handle,
+                         const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                         uint32_t numDeviceBuffers,
+                         void* workspace) const
+{
+    auto aBuffer
+        = hipblaslt_utils::findDeviceBuffer(_params.a().uid(), deviceBuffers, numDeviceBuffers);
+    auto bBuffer
+        = hipblaslt_utils::findDeviceBuffer(_params.b().uid(), deviceBuffers, numDeviceBuffers);
+    auto cBuffer
+        = hipblaslt_utils::findDeviceBuffer(_params.c().uid(), deviceBuffers, numDeviceBuffers);
+    // A, B and C matrices are row-major. But hipBLASLt works with column-major matrices
+    // To work with row-major matrices, we transpose them.
+    // This is done by changing the order of A and B matrices in arguments:
+    //  C = A * B => C^T = (A * B)^T => C^T = B^T * A^T
+    // Due to this formula, we changed the order of A and B matrices in arguments
+    THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatmul(handle.hipblasltHandle,
+                                               _params.desc().matmulDesc(),
+                                               &_alpha,
+                                               bBuffer.ptr,
+                                               _params.b().matrixLayout(),
+                                               aBuffer.ptr,
+                                               _params.a().matrixLayout(),
+                                               &_beta,
+                                               cBuffer.ptr,
+                                               _params.c().matrixLayout(),
+                                               cBuffer.ptr,
+                                               _params.c().matrixLayout(),
+                                               &_heuristicResult.algo,
+                                               workspace,
+                                               _workspaceSize,
+                                               handle.getStream()));
+}
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.cpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.cpp
@@ -69,13 +69,15 @@ MatmulParams::MatmulParams(
     const hipdnn_data_sdk::data_objects::MatmulAttributes& attributes,
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap)
-    : _matrixLayoutA(hipblaslt_utils::findTensorAttributes(tensorMap, attributes.a_tensor_uid()))
-    , _matrixLayoutB(hipblaslt_utils::findTensorAttributes(tensorMap, attributes.b_tensor_uid()))
-    , _matrixLayoutC(hipblaslt_utils::findTensorAttributes(tensorMap, attributes.c_tensor_uid()))
 {
     const auto tA = hipblaslt_utils::findTensorAttributes(tensorMap, attributes.a_tensor_uid());
     const auto tB = hipblaslt_utils::findTensorAttributes(tensorMap, attributes.b_tensor_uid());
     const auto tC = hipblaslt_utils::findTensorAttributes(tensorMap, attributes.c_tensor_uid());
+
+    _matrixLayoutA = HipblasltMatrixLayout(tA);
+    _matrixLayoutB = HipblasltMatrixLayout(tB);
+    _matrixLayoutC = HipblasltMatrixLayout(tC);
+
     // Row-major BLAS trick: to compute C = A * B with row-major data,
     // we compute C^T = B^T * A^T with column-major BLAS.
     // So we swap the transpose operations: transA in desc = getTrans(B), transB in desc = getTrans(A)

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.cpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier:  MIT
 
 #include <array>
+#include <limits>
 #include <numeric>
 #include <string>
 
@@ -163,7 +164,11 @@ const HipblasltMatmulDesc& MatmulParams::desc() const
 MatmulPlan::MatmulPlan(const HipdnnEnginePluginHandle& handle, MatmulParams&& params)
     : _params(std::move(params))
 {
-    size_t max_workspace_size = 0;
+    // hipBLASLt requests the max workspace size for the search algorithm
+    // so that it fits within the available memory size.
+    // So for better performance we set 128 MB here since
+    // it is enough to get the most performant solution from hipblaslt.
+    size_t max_workspace_size = 128 * 1024 * 1024; // 128MB
     hipblasLtMatmulPreference_t pref;
     THROW_ON_HIPBLASLT_FAILURE(hipblasLtMatmulPreferenceCreate(&pref));
     THROW_ON_HIPBLASLT_FAILURE(

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlan.hpp
@@ -1,0 +1,79 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+
+#include <hipblaslt/hipblaslt.h>
+#include <hipdnn_data_sdk/data_objects/matmul_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+
+#include "HipblasltMatmulDesc.hpp"
+#include "HipblasltMatrixLayout.hpp"
+#include "PlanInterface.hpp"
+
+namespace hipblaslt_plugin
+{
+
+class MatmulParams
+{
+public:
+    MatmulParams(
+        const hipdnn_data_sdk::data_objects::MatmulAttributes& attributes,
+        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+            tensorMap);
+
+    MatmulParams(const MatmulParams&) = delete;
+    MatmulParams& operator=(const MatmulParams&) = delete;
+
+    MatmulParams(MatmulParams&&) = default;
+    MatmulParams& operator=(MatmulParams&&) = default;
+
+    const HipblasltMatrixLayout& a() const;
+    const HipblasltMatrixLayout& b() const;
+    const HipblasltMatrixLayout& c() const;
+
+    const HipblasltMatmulDesc& desc() const;
+
+private:
+    static hipblasOperation_t getTrans(const hipdnn_plugin_sdk::TensorAttributesWrapper& t);
+    static hipblasComputeType_t
+        getComputeDataType(const hipdnn_plugin_sdk::TensorAttributesWrapper& tA,
+                           const hipdnn_plugin_sdk::TensorAttributesWrapper& tB);
+
+    HipblasltMatmulDesc _matmulDesc;
+    HipblasltMatrixLayout _matrixLayoutA;
+    HipblasltMatrixLayout _matrixLayoutB;
+    HipblasltMatrixLayout _matrixLayoutC;
+};
+
+class MatmulPlan : public IPlan
+{
+public:
+    MatmulPlan(const HipdnnEnginePluginHandle& handle, MatmulParams&& params);
+    ~MatmulPlan() override = default;
+
+    MatmulPlan(const MatmulPlan&) = delete;
+    MatmulPlan& operator=(const MatmulPlan&) = delete;
+
+    MatmulPlan(MatmulPlan&& other) = default;
+    MatmulPlan& operator=(MatmulPlan&& other) = default;
+
+    size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle) const override;
+
+    void execute(const HipdnnEnginePluginHandle& handle,
+                 const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                 uint32_t numDeviceBuffers,
+                 void* workspace = nullptr) const override;
+
+private:
+    MatmulParams _params;
+    hipblasLtMatmulHeuristicResult_t _heuristicResult;
+    size_t _workspaceSize = 0;
+
+    static constexpr float _alpha = 1.f;
+    static constexpr float _beta = 0.f;
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.cpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.cpp
@@ -1,0 +1,128 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <limits>
+#include <numeric>
+#include <string>
+
+#include <hipblaslt/hipblaslt.h>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "HipblasltMatmulPlan.hpp"
+#include "HipblasltMatmulPlanBuilder.hpp"
+
+namespace hipblaslt_plugin
+{
+namespace
+{
+bool checkDataTypes(const hipdnn_plugin_sdk::TensorAttributesWrapper& tA,
+                    const hipdnn_plugin_sdk::TensorAttributesWrapper& tB,
+                    const hipdnn_plugin_sdk::TensorAttributesWrapper& tC)
+{
+    const auto& aType = tA.dataType();
+    const auto& bType = tB.dataType();
+    const auto& cType = tC.dataType();
+
+    static constexpr std::array<hipdnn_data_sdk::data_objects::DataType, 3> validDataTypes
+        = {hipdnn_data_sdk::data_objects::DataType::FLOAT,
+           hipdnn_data_sdk::data_objects::DataType::HALF,
+           hipdnn_data_sdk::data_objects::DataType::BFLOAT16};
+    if(std::find(validDataTypes.begin(), validDataTypes.end(), aType) == validDataTypes.end()
+       || std::find(validDataTypes.begin(), validDataTypes.end(), bType) == validDataTypes.end()
+       || std::find(validDataTypes.begin(), validDataTypes.end(), cType) == validDataTypes.end())
+    {
+        HIPDNN_LOG_INFO("Matmul plan builder: only fp32, fp16 and bf16 are supported");
+        return false;
+    }
+
+    return true;
+}
+
+void validateGraphConfiguration(const hipdnn_plugin_sdk::IGraph& opGraph)
+{
+    if(opGraph.nodeCount() != 1)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Matmul plan builder supports only single node graphs. Graph has "
+                + std::to_string(opGraph.nodeCount()) + " nodes");
+    }
+
+    if(opGraph.getNode(0).attributes_type()
+       != hipdnn_data_sdk::data_objects::NodeAttributes::MatmulAttributes)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Matmul plan builder supports only MatmulAttributes nodes");
+    }
+
+    if(opGraph.getNode(0).compute_data_type() != hipdnn_data_sdk::data_objects::DataType::FLOAT)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Matmul plan builder only supports nodes with an fp32 compute_data_type");
+    }
+}
+
+} // namespace
+
+bool HipblasltMatmulPlanBuilder::isApplicable(const HipdnnEnginePluginHandle& handle,
+                                              const hipdnn_plugin_sdk::IGraph& opGraph) const
+{
+    try
+    {
+        validateGraphConfiguration(opGraph);
+
+        const auto& attr = opGraph.getNodeWrapper(0)
+                               .attributesAs<hipdnn_data_sdk::data_objects::MatmulAttributes>();
+
+        const auto& tensorMap = opGraph.getTensorMap();
+        auto aAttr = hipblaslt_utils::findTensorAttributes(tensorMap, attr.a_tensor_uid());
+        auto bAttr = hipblaslt_utils::findTensorAttributes(tensorMap, attr.b_tensor_uid());
+        auto cAttr = hipblaslt_utils::findTensorAttributes(tensorMap, attr.c_tensor_uid());
+        if(!checkDataTypes(aAttr, bAttr, cAttr))
+        {
+            return false;
+        }
+
+        MatmulParams params(attr, opGraph.getTensorMap());
+        MatmulPlan plan(handle, std::move(params));
+        return true;
+    }
+    catch(const std::exception& e)
+    {
+        HIPDNN_LOG_INFO(e.what());
+        return false;
+    }
+}
+
+size_t HipblasltMatmulPlanBuilder::getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                                                    const hipdnn_plugin_sdk::IGraph& opGraph) const
+{
+    validateGraphConfiguration(opGraph);
+
+    const auto& attr
+        = opGraph.getNodeWrapper(0).attributesAs<hipdnn_data_sdk::data_objects::MatmulAttributes>();
+    MatmulParams params(attr, opGraph.getTensorMap());
+    MatmulPlan plan(handle, std::move(params));
+    return plan.getWorkspaceSize(handle);
+}
+
+void HipblasltMatmulPlanBuilder::buildPlan(
+    const HipdnnEnginePluginHandle& handle,
+    const hipdnn_plugin_sdk::IGraph& opGraph,
+    HipdnnEnginePluginExecutionContext& executionContext) const
+{
+    validateGraphConfiguration(opGraph);
+
+    const auto& nodeWrapper = opGraph.getNodeWrapper(0);
+    HIPDNN_LOG_INFO("Building matmul plan for node: {}", nodeWrapper.name());
+
+    const auto& attr = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::MatmulAttributes>();
+    MatmulParams params(attr, opGraph.getTensorMap());
+    auto plan = std::make_unique<MatmulPlan>(handle, std::move(params));
+    executionContext.setPlan(std::move(plan));
+}
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.hpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.hpp
@@ -1,0 +1,33 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include "PlanBuilderInterface.hpp"
+#include <hipblaslt/hipblaslt.h>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hipblaslt_plugin
+{
+
+class HipblasltMatmulPlanBuilder : public IPlanBuilder
+{
+public:
+    HipblasltMatmulPlanBuilder() = default;
+    ~HipblasltMatmulPlanBuilder() override = default;
+
+    // Disallow copy and assignment
+    HipblasltMatmulPlanBuilder(const HipblasltMatmulPlanBuilder&) = delete;
+    HipblasltMatmulPlanBuilder& operator=(const HipblasltMatmulPlanBuilder&) = delete;
+
+    bool isApplicable(const HipdnnEnginePluginHandle& handle,
+                      const hipdnn_plugin_sdk::IGraph& opGraph) const override;
+    size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                            const hipdnn_plugin_sdk::IGraph& opGraph) const override;
+
+    void buildPlan(const HipdnnEnginePluginHandle& handle,
+                   const hipdnn_plugin_sdk::IGraph& opGraph,
+                   HipdnnEnginePluginExecutionContext& executionContext) const override;
+};
+
+} // namespace hipblaslt_plugin

--- a/dnn-providers/hipblaslt-provider/integration_tests/CMakeLists.txt
+++ b/dnn-providers/hipblaslt-provider/integration_tests/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+find_package(Threads REQUIRED)
+find_package(hipdnn_test_sdk CONFIG REQUIRED)
+find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+
+add_executable(
+    hipblaslt_plugin_integration_tests
+    main.cpp
+    IntegrationGpuMatmul.cpp
+)
+
+target_compile_options(hipblaslt_plugin_integration_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+
+# To use the build tree plugin, we use the path relative to the test binary instead of the installed
+# libhipdnn_backend.so HIPDNN_PLUGIN_ENGINE_SUBDIR is provided by the sdk
+target_compile_definitions(
+    hipblaslt_plugin_integration_tests
+    PRIVATE
+        PLUGIN_PATH="../$<IF:$<PLATFORM_ID:Windows>,bin,lib>/${HIPDNN_PLUGIN_ENGINE_SUBDIR}/hipblaslt_plugin"
+)
+
+target_link_libraries(
+    hipblaslt_plugin_integration_tests PUBLIC GTest::gtest hip::host hipdnn_test_sdk hipdnn_plugin_sdk Threads::Threads
+)
+
+# Ensure that the hipblaslt_plugin is built before the hipblaslt_plugin_integration_tests, as the
+# integration tests depend on the hipBLASLt Provider Plugin
+add_dependencies(hipblaslt_plugin_integration_tests hipblaslt_plugin)
+
+add_integration_test_target(hipblaslt_plugin_integration_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/dnn-providers/hipblaslt-provider/integration_tests/IntegrationGpuMatmul.cpp
+++ b/dnn-providers/hipblaslt-provider/integration_tests/IntegrationGpuMatmul.cpp
@@ -1,0 +1,106 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <filesystem>
+#include <random>
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "../tests/common/MatmulCommon.hpp"
+#include "IntegrationGraphVerificationHarness.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipblaslt_plugin::test_utilities;
+using namespace test_matmul_common;
+
+namespace
+{
+
+template <typename DataType>
+class IntegrationGpuMatmul : public IntegrationGraphVerificationHarness<DataType, MatmulTestCase>
+{
+protected:
+    void runGraphTest(DataType tolerance) override
+    {
+        const MatmulTestCase& testCase = this->GetParam();
+
+        hipdnn_frontend::graph::Graph graphObj;
+        graphObj.set_name("MatmulTest");
+
+        auto dataType = getDataTypeEnumFromType<DataType>();
+        graphObj.set_intermediate_data_type(dataType)
+            .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+            .set_io_data_type(dataType);
+
+        auto aAttr = graph::makeTensorAttributes(
+            "a", testCase.aDims, generateInputStrideOrder(testCase.aDims, testCase.transA));
+        auto aTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(aAttr));
+
+        auto bAttr = graph::makeTensorAttributes(
+            "b", testCase.bDims, generateInputStrideOrder(testCase.bDims, testCase.transB));
+        auto bTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(bAttr));
+
+        graph::MatmulAttributes matmulAttrs;
+
+        auto cAttr = graphObj.matmul(aTensorAttr, bTensorAttr, matmulAttrs);
+
+        cAttr->set_output(true);
+
+        this->registerValidator(cAttr, tolerance);
+
+        this->verifyGraph(graphObj, testCase.seed);
+    }
+
+protected:
+    static std::vector<int64_t> generateInputStrideOrder(const std::vector<int64_t>& dims,
+                                                         bool transpose)
+    {
+        std::vector<int64_t> strides = generateStrides(dims);
+        if(transpose)
+        {
+            const size_t rank = dims.size();
+            strides[rank - 1] = dims[rank - 2];
+            strides[rank - 2] = 1;
+        }
+        return strides;
+    }
+};
+
+using IntegrationGpuMatmulFp32 = IntegrationGpuMatmul<float>;
+using IntegrationGpuMatmulFp16 = IntegrationGpuMatmul<half>;
+using IntegrationGpuMatmulBf16 = IntegrationGpuMatmul<hip_bfloat16>;
+
+} // namespace
+
+TEST_P(IntegrationGpuMatmulFp32, Correctness)
+{
+    runGraphTest(matmul::getTolerance<float>());
+}
+
+TEST_P(IntegrationGpuMatmulFp16, Correctness)
+{
+    runGraphTest(matmul::getTolerance<half>());
+}
+
+TEST_P(IntegrationGpuMatmulBf16, Correctness)
+{
+    runGraphTest(matmul::getTolerance<hip_bfloat16>());
+}
+
+INSTANTIATE_TEST_SUITE_P(IntegrationGpuMatmul,
+                         IntegrationGpuMatmulFp32,
+                         testing::ValuesIn(getMatmulTestCases()));
+
+INSTANTIATE_TEST_SUITE_P(IntegrationGpuMatmul,
+                         IntegrationGpuMatmulFp16,
+                         testing::ValuesIn(getMatmulTestCases()));
+
+INSTANTIATE_TEST_SUITE_P(IntegrationGpuMatmul,
+                         IntegrationGpuMatmulBf16,
+                         testing::ValuesIn(getMatmulTestCases()));

--- a/dnn-providers/hipblaslt-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/hipblaslt-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -1,0 +1,233 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/utilities/Workspace.hpp>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/Utilities.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+#include <hipdnn_frontend/node/Node.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceMiopenRmsValidation.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/VectorLoggingUtils.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp>
+
+#include <hipdnn_data_sdk/utilities/TensorView.hpp>
+
+#include <functional>
+#include <optional>
+#include <string_view>
+
+namespace hipblaslt_plugin::test_utilities
+{
+
+// NOLINTBEGIN (portability-template-virtual-member-function)
+template <typename DataType, typename TestCaseType>
+class IntegrationGraphVerificationHarness : public ::testing::TestWithParam<TestCaseType>
+{
+protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+
+        // Initialize HIP
+        ASSERT_EQ(hipInit(0), hipSuccess);
+        ASSERT_EQ(hipGetDevice(&_deviceId), hipSuccess);
+
+        // Note: The plugin paths has to be set before we create the hipdnn handle.
+        auto pluginPath = std::filesystem::weakly_canonical(
+            hipdnn_data_sdk::utilities::getCurrentExecutableDirectory() / PLUGIN_PATH);
+        const std::string pluginPathStr = pluginPath.string();
+        const std::array<const char*, 1> paths = {pluginPathStr.c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+
+        // Create handle and stream
+        ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
+        ASSERT_EQ(hipStreamCreate(&_stream), hipSuccess);
+        ASSERT_EQ(hipdnnSetStream(_handle, _stream), HIPDNN_STATUS_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        if(_handle != nullptr)
+        {
+            ASSERT_EQ(hipdnnDestroy(_handle), HIPDNN_STATUS_SUCCESS);
+        }
+        if(_stream != nullptr)
+        {
+            ASSERT_EQ(hipStreamDestroy(_stream), hipSuccess);
+        }
+    }
+
+    virtual void runGraphTest(DataType tolerance) = 0;
+
+protected:
+    void verifyGraph(hipdnn_frontend::graph::Graph& graph, unsigned int seed)
+    {
+        hipdnn_test_sdk::utilities::GraphTensorBundle gpuBundle, cpuBundle;
+        std::vector<int64_t> outputTensorIds;
+
+        auto result = graph.build(_handle);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        generateBundles(graph, cpuBundle, gpuBundle, outputTensorIds);
+
+        initializeBundle(graph, gpuBundle, seed);
+        initializeBundle(graph, cpuBundle, seed);
+
+        ASSERT_NO_FATAL_FAILURE(executeGpuGraph(_handle, graph, gpuBundle));
+        executeCpuGraph(graph, cpuBundle);
+
+        ASSERT_GE(outputTensorIds.size(), 1)
+            << "At least one output tensor id must be specified for "
+               "validation.";
+
+        HIPDNN_LOG_INFO("Validating {} output tensors", outputTensorIds);
+
+        // Lazily register validators after graph execution since tensor Ids and types may be inferred during graph finalization
+        for(const auto& registerValidator : _deferredValidators)
+        {
+            registerValidator();
+        }
+
+        for(const auto& tensorId : outputTensorIds)
+        {
+            auto& cpuTensor = cpuBundle.tensors.at(tensorId);
+            auto& gpuTensor = gpuBundle.tensors.at(tensorId);
+
+            // This tells the tensor that its data has been modified on the device side
+            // All frontend graph knows is a (void*) pointer to device memory, so we need to inform the tensor
+            // that the data there is now valid so that it knows to copy from device to host when requested
+            // by the validation step.
+            gpuTensor->markDeviceModified();
+
+            if(_tensorIdToValidatorMap.find(tensorId) == _tensorIdToValidatorMap.end())
+            {
+                FAIL() << "No validator registered for tensor with id: " << tensorId
+                       << ", name: " << getOutputTensorName(tensorId);
+            }
+
+            bool valid = _tensorIdToValidatorMap.at(tensorId)->allClose(*cpuTensor, *gpuTensor);
+            ASSERT_TRUE(valid) << "Mismatch found in tensor with id: " << tensorId
+                               << ", name: " << _tensorIdToNameMap.at(tensorId);
+        }
+    }
+
+    void registerValidator(const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes> attr,
+                           float tolerance)
+    {
+        registerValidator(attr, tolerance, tolerance);
+    }
+
+    void registerValidator(const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes> attr,
+                           float absoluteTolerance,
+                           float relativeTolerance)
+    {
+        // Since the graph can infer properties + Ids, we defer validator registration until right before validation in verifyGraph
+        _deferredValidators.emplace_back([=]() {
+            _tensorIdToValidatorMap.insert(
+                {attr->get_uid(),
+                 hipdnn_test_sdk::utilities::createAllCloseValidator(
+                     toSdkType(attr->get_data_type()), absoluteTolerance, relativeTolerance)});
+            _tensorIdToNameMap.insert({attr->get_uid(), attr->get_name()});
+        });
+    }
+
+    virtual void generateBundles(hipdnn_frontend::graph::Graph& graph,
+                                 hipdnn_test_sdk::utilities::GraphTensorBundle& cpuBundle,
+                                 hipdnn_test_sdk::utilities::GraphTensorBundle& gpuBundle,
+                                 std::vector<int64_t>& outputTensorIds)
+    {
+        graph.visit([&](const hipdnn_frontend::graph::INode& node) {
+            for(const auto& tensorAttr : node.getNodeOutputTensorAttributes())
+            {
+                if(tryAddTensorToBundles(tensorAttr, cpuBundle, gpuBundle))
+                {
+                    outputTensorIds.push_back(tensorAttr->get_uid());
+                }
+            }
+            for(const auto& tensorAttr : node.getNodeInputTensorAttributes())
+            {
+                tryAddTensorToBundles(tensorAttr, cpuBundle, gpuBundle);
+            }
+        });
+    }
+
+    virtual void initializeBundle([[maybe_unused]] const hipdnn_frontend::graph::Graph& graph,
+                                  hipdnn_test_sdk::utilities::GraphTensorBundle& bundle,
+                                  unsigned int seed)
+    {
+        for(auto& tensorPair : bundle.tensors)
+        {
+            bundle.randomizeTensor(tensorPair.first, -1.0f, 1.0f, seed);
+        }
+    }
+
+private:
+    void executeGpuGraph(hipdnnHandle_t handle,
+                         hipdnn_frontend::graph::Graph& graph,
+                         hipdnn_test_sdk::utilities::GraphTensorBundle& bundle)
+    {
+        int64_t workspaceSize;
+        auto result = graph.get_workspace_size(workspaceSize);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+        ASSERT_GE(workspaceSize, 0) << result.err_msg;
+        hipdnn_data_sdk::utilities::Workspace workspace(static_cast<size_t>(workspaceSize));
+
+        auto variantPack = bundle.toDeviceVariantPack();
+        result = graph.execute(handle, variantPack, workspace.get());
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+    }
+
+    void executeCpuGraph(hipdnn_frontend::graph::Graph& graph,
+                         hipdnn_test_sdk::utilities::GraphTensorBundle& bundle)
+    {
+        auto flatbufferGraph = graph.buildFlatbufferOperationGraph();
+
+        hipdnn_test_sdk::utilities::CpuReferenceGraphExecutor().execute(
+            flatbufferGraph.data(), flatbufferGraph.size(), bundle.toHostVariantPack());
+    }
+
+    std::string getOutputTensorName(int64_t tensorId)
+    {
+        return _tensorIdToNameMap.at(tensorId);
+    }
+
+    bool tryAddTensorToBundles(
+        const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes>& tensorAttr,
+        hipdnn_test_sdk::utilities::GraphTensorBundle& cpuBundle,
+        hipdnn_test_sdk::utilities::GraphTensorBundle& gpuBundle)
+    {
+        int64_t tensorId = tensorAttr->get_uid();
+
+        if(tensorAttr->get_is_virtual()
+           || cpuBundle.tensors.find(tensorId) != cpuBundle.tensors.end())
+        {
+            return false;
+        }
+
+        cpuBundle.tensors.insert({tensorId, createTensorFromAttribute(*tensorAttr)});
+        gpuBundle.tensors.insert({tensorId, createTensorFromAttribute(*tensorAttr)});
+        _tensorIdToNameMap.insert({tensorId, tensorAttr->get_name()});
+
+        return true;
+    }
+
+    hipdnnHandle_t _handle = nullptr;
+    hipStream_t _stream = nullptr;
+    int _deviceId = 0;
+    std::unordered_map<int64_t, std::string> _tensorIdToNameMap;
+    std::unordered_map<int64_t, std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>>
+        _tensorIdToValidatorMap;
+    std::vector<std::function<void()>> _deferredValidators;
+};
+
+// NOLINTEND (portability-template-virtual-member-function)
+
+} // namespace hipblaslt_plugin::test_utilities

--- a/dnn-providers/hipblaslt-provider/integration_tests/main.cpp
+++ b/dnn-providers/hipblaslt-provider/integration_tests/main.cpp
@@ -1,0 +1,25 @@
+/*
+Copyright © Advanced Micro Devices, Inc., or its affiliates.
+SPDX-License-Identifier: MIT
+*/
+
+#include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
+#include <hipdnn_frontend.hpp>
+#include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    hipdnn_frontend::initializeFrontendLogging();
+
+    // Register HipErrorHandler to check and clear HIP errors after each test
+    testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+    listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
+
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
+}

--- a/dnn-providers/hipblaslt-provider/tests/CMakeLists.txt
+++ b/dnn-providers/hipblaslt-provider/tests/CMakeLists.txt
@@ -4,14 +4,13 @@
 add_compile_definitions(__HIP_PLATFORM_AMD__)
 find_package(hip REQUIRED)
 find_package(Threads REQUIRED)
-
-if(NOT BUILD_PLUGIN_AS_DEPENDENCY)
-    find_package(hipdnn_test_sdk CONFIG REQUIRED)
-    find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
-endif()
+find_package(hipdnn_test_sdk CONFIG REQUIRED)
+find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
 
 add_executable(
     hipblaslt_plugin_tests
+    engines/plans/TestHipblasltMatmulPlan.cpp
+    engines/plans/TestHipblasltMatmulPlanBuilder.cpp
     engines/TestHipblasltEngine.cpp
     main.cpp
     TestHipblasltEngineManager.cpp
@@ -19,6 +18,8 @@ add_executable(
     TestHipblasltHandleFactory.cpp
     TestHipblasltHipdnnEnginePluginHandle.cpp
     TestHipblasltHipdnnPluginExecutionContext.cpp
+    TestHipblasltMatmulDesc.cpp
+    TestHipblasltMatrixLayout.cpp
     TestHipblasltPluginApi.cpp
     TestHipblasltUtils.cpp
 )

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltMatmulDesc.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltMatmulDesc.cpp
@@ -1,0 +1,16 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipblasltMatmulDesc.hpp"
+#include <gtest/gtest.h>
+#include <hipblaslt/hipblaslt.h>
+
+using namespace hipblaslt_plugin;
+
+TEST(TestHipblasltMatmulDesc, CanCreateAndDestroy)
+{
+    EXPECT_NO_THROW({
+        HipblasltMatmulDesc desc(HIPBLAS_OP_N, HIPBLAS_OP_N, HIPBLAS_COMPUTE_32F, HIP_R_32F);
+        EXPECT_NE(desc.matmulDesc(), nullptr);
+    });
+}

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltMatrixLayout.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltMatrixLayout.cpp
@@ -42,6 +42,15 @@ TEST(TestHipblasltMatrixLayout, TensorDescriptorIsValid)
     EXPECT_NE(matLayout.matrixLayout(), nullptr);
 }
 
+TEST(TestHipblasltMatrixLayout, CanCreateAndDestroyDefaultMatrix)
+{
+    EXPECT_NO_THROW({
+        HipblasltMatrixLayout matLayout;
+        EXPECT_EQ(matLayout.uid(), 0);
+        EXPECT_EQ(matLayout.matrixLayout(), nullptr);
+    });
+}
+
 TEST(TestHipblasltMatrixLayout, TensorWithEmptyShape)
 {
     std::vector<int64_t> strides = {1};

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltMatrixLayout.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltMatrixLayout.cpp
@@ -1,0 +1,143 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipblasltMatrixLayout.hpp"
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+
+using namespace hipblaslt_plugin;
+
+TEST(TestHipblasltMatrixLayout, CanCreateAndDestroy)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidMatmulGraph();
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& tensorMap = graph.getTensorMap();
+    ASSERT_FALSE(tensorMap.empty());
+    const auto* tensorAttr = tensorMap.begin()->second;
+    ASSERT_NE(tensorAttr, nullptr);
+
+    EXPECT_NO_THROW({
+        hipdnn_plugin_sdk::TensorAttributesWrapper tensorWrapper(tensorAttr);
+        HipblasltMatrixLayout matLayout(tensorWrapper);
+        EXPECT_EQ(matLayout.uid(), tensorWrapper.uid());
+        EXPECT_NE(matLayout.matrixLayout(), nullptr);
+    });
+}
+
+TEST(TestHipblasltMatrixLayout, TensorDescriptorIsValid)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidMatmulGraph();
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& tensorMap = graph.getTensorMap();
+    ASSERT_FALSE(tensorMap.empty());
+    hipdnn_plugin_sdk::TensorAttributesWrapper tensorWrapper(tensorMap.begin()->second);
+    HipblasltMatrixLayout matLayout(tensorWrapper);
+
+    // The descriptor should be non-null and can be used in HipBLASLt API calls
+    EXPECT_NE(matLayout.matrixLayout(), nullptr);
+}
+
+TEST(TestHipblasltMatrixLayout, TensorWithEmptyShape)
+{
+    std::vector<int64_t> strides = {1};
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, &strides, nullptr);
+    builder.Finish(attrOffset);
+
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+        builder.GetBufferPointer());
+
+    hipdnn_plugin_sdk::TensorAttributesWrapper tensorWrapper(attrPtr);
+    EXPECT_THROW(HipblasltMatrixLayout matLayout(tensorWrapper), std::invalid_argument);
+}
+
+TEST(TestHipblasltMatrixLayout, TensorWithEmptyStride)
+{
+    std::vector<int64_t> dims = {10, 16};
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, nullptr, &dims);
+    builder.Finish(attrOffset);
+
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+        builder.GetBufferPointer());
+
+    hipdnn_plugin_sdk::TensorAttributesWrapper tensorWrapper(attrPtr);
+    EXPECT_THROW(HipblasltMatrixLayout matLayout(tensorWrapper), std::invalid_argument);
+}
+
+TEST(TestHipblasltMatrixLayout, TensorWithInvalidShapeRank)
+{
+    std::vector<int64_t> dims = {10};
+    std::vector<int64_t> strides = {1};
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, &strides, &dims);
+    builder.Finish(attrOffset);
+
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+        builder.GetBufferPointer());
+
+    hipdnn_plugin_sdk::TensorAttributesWrapper tensorWrapper(attrPtr);
+    EXPECT_THROW(HipblasltMatrixLayout matLayout(tensorWrapper),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestHipblasltMatrixLayout, TensorWithInvalidMatrixType)
+{
+    std::vector<int64_t> dims = {8, 2, 4};
+    std::vector<int64_t> strides = {1, 8, 16};
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto attrOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "", hipdnn_data_sdk::data_objects::DataType::UNSET, &strides, &dims);
+    builder.Finish(attrOffset);
+
+    auto attrPtr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+        builder.GetBufferPointer());
+
+    hipdnn_plugin_sdk::TensorAttributesWrapper tensorWrapper(attrPtr);
+    EXPECT_THROW(HipblasltMatrixLayout matLayout(tensorWrapper),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestHipblasltMatrixLayout, SetBatchCount)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidMatmulGraph();
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& tensorMap = graph.getTensorMap();
+    ASSERT_FALSE(tensorMap.empty());
+    const auto* tensorAttr = tensorMap.begin()->second;
+
+    EXPECT_NO_THROW({
+        hipdnn_plugin_sdk::TensorAttributesWrapper tensorWrapper(tensorAttr);
+        HipblasltMatrixLayout matLayout(tensorWrapper);
+        matLayout.setBatchCount(2);
+    });
+}
+
+TEST(TestHipblasltMatrixLayout, setStridedBatchOffset)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidMatmulGraph();
+    hipdnn_plugin_sdk::GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& tensorMap = graph.getTensorMap();
+    ASSERT_FALSE(tensorMap.empty());
+    const auto* tensorAttr = tensorMap.begin()->second;
+
+    EXPECT_NO_THROW({
+        hipdnn_plugin_sdk::TensorAttributesWrapper tensorWrapper(tensorAttr);
+        HipblasltMatrixLayout matLayout(tensorWrapper);
+        matLayout.setStridedBatchOffset(2);
+    });
+}

--- a/dnn-providers/hipblaslt-provider/tests/TestHipblasltUtils.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/TestHipblasltUtils.cpp
@@ -28,3 +28,54 @@ TEST(TestHipblasltUtils, TensorDataTypeToHipblasltDataTypeThrowsOnUnsupported)
                      static_cast<hipdnn_data_sdk::data_objects::DataType>(-1)),
                  hipdnn_plugin_sdk::HipdnnPluginException);
 }
+
+TEST(TestHipblasltUtils, FindDeviceBufferReturnsCorrectBuffer)
+{
+    std::vector<hipdnnPluginDeviceBuffer_t> buffers
+        = {{42, reinterpret_cast<void*>(0x1234)}, {99, reinterpret_cast<void*>(0x5678)}};
+
+    auto result = hipblaslt_utils::findDeviceBuffer(99, buffers.data(), 2);
+    EXPECT_EQ(result.uid, 99);
+    EXPECT_EQ(result.ptr, reinterpret_cast<void*>(0x5678));
+}
+
+TEST(TestHipblasltUtils, FindDeviceBufferThrowsIfNotFound)
+{
+    std::vector<hipdnnPluginDeviceBuffer_t> buffers = {{1, reinterpret_cast<void*>(0x1111)}};
+
+    EXPECT_THROW(
+        hipblaslt_utils::findDeviceBuffer(2, buffers.data(), static_cast<uint32_t>(buffers.size())),
+        hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestHipblasltUtils, FindTensorAttributesReturnsCorrectValue)
+{
+    flatbuffers::FlatBufferBuilder builder1;
+    auto attrOffset1 = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder1, 1);
+    builder1.Finish(attrOffset1);
+
+    flatbuffers::FlatBufferBuilder builder2;
+    auto attrOffset2 = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder2, 2);
+    builder2.Finish(attrOffset2);
+
+    auto attrPtr1 = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+        builder1.GetBufferPointer());
+    auto attrPtr2 = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+        builder2.GetBufferPointer());
+
+    auto attrMap
+        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{
+            {1, attrPtr1}, {2, attrPtr2}};
+
+    EXPECT_EQ(hipblaslt_utils::findTensorAttributes(attrMap, 1).uid(), 1);
+    EXPECT_EQ(hipblaslt_utils::findTensorAttributes(attrMap, 2).uid(), 2);
+}
+
+TEST(TestHipblasltUtils, FindTensorAttributesThrowsIfNotFound)
+{
+    auto attrMap
+        = std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>{};
+
+    EXPECT_THROW(hipblaslt_utils::findTensorAttributes(attrMap, 1),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}

--- a/dnn-providers/hipblaslt-provider/tests/common/MatmulCommon.hpp
+++ b/dnn-providers/hipblaslt-provider/tests/common/MatmulCommon.hpp
@@ -1,0 +1,170 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <cstdint>
+#include <ostream>
+#include <vector>
+
+#include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+#include <hipdnn_test_sdk/utilities/Seeds.hpp>
+
+namespace test_matmul_common
+{
+
+struct MatmulTestCase
+{
+    std::vector<int64_t> aDims;
+    std::vector<int64_t> bDims;
+    std::vector<int64_t> cDims;
+    bool transA;
+    bool transB;
+    unsigned seed;
+
+    MatmulTestCase(std::vector<int64_t>&& aDimsLocal,
+                   std::vector<int64_t>&& bDimsLocal,
+                   bool transALocal,
+                   bool transBLocal,
+                   unsigned seedLocal)
+        : aDims(std::move(aDimsLocal))
+        , bDims(std::move(bDimsLocal))
+        , transA(transALocal)
+        , transB(transBLocal)
+        , seed(seedLocal)
+    {
+        if(aDims.size() != bDims.size())
+        {
+            throw std::invalid_argument("aDims and bDims must have the same number of dimensions.");
+        }
+
+        const auto rank = aDims.size();
+        if(rank < 2)
+        {
+            throw std::invalid_argument("Tensor rank must have at least 2 dimensions.");
+        }
+
+        const auto batchDims = rank - 2;
+        cDims = std::vector<int64_t>(rank, 1);
+
+        for(size_t i = 0; i < batchDims; ++i)
+        {
+            const auto aDimVal = aDims[i];
+            const auto bDimVal = bDims[i];
+
+            if(aDimVal <= 0 || bDimVal <= 0)
+            {
+                throw std::invalid_argument("Dimensions must be positive.");
+            }
+
+            if(aDimVal % bDimVal != 0 && bDimVal % aDimVal != 0)
+            {
+                throw std::invalid_argument("Batch dimensions must be broadcastable.");
+            }
+
+            cDims[i] = std::max(aDimVal, bDimVal);
+        }
+
+        // Matrix dimensions:
+        // A[..., M, K] x B[..., K, N] -> C[..., M, N]
+        if(aDims[batchDims + 1] != bDims[batchDims])
+        {
+            throw std::invalid_argument("Matmul shape mismatch: A.K must equal B.K");
+        }
+
+        cDims[batchDims] = aDims[batchDims];
+        cDims[batchDims + 1] = bDims[batchDims + 1];
+    }
+
+    friend std::ostream& operator<<(std::ostream& ss, const MatmulTestCase& tc)
+    {
+        using namespace hipdnn_data_sdk::utilities;
+
+        ss << "(a:";
+        vecToStream(ss, tc.aDims);
+        ss << " b:";
+        vecToStream(ss, tc.bDims);
+        ss << " c:";
+        vecToStream(ss, tc.cDims);
+        ss << " transA:";
+        ss << tc.transA;
+        ss << " transB:";
+        ss << tc.transB;
+        ss << " seed:" << tc.seed;
+        ss << ")";
+
+        return ss;
+    }
+};
+
+inline std::vector<MatmulTestCase> getMatmulTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        // Basic
+        {{16, 32}, {32, 128}, false, false, seed},
+        // Transpose A matrix
+        {{16, 32}, {32, 128}, true, false, seed},
+        // Transpose B matrix
+        {{16, 32}, {32, 128}, false, true, seed},
+        // Transpose both matrices
+        {{16, 32}, {32, 128}, true, true, seed},
+
+        // Basic
+        {{1, 16, 32}, {1, 32, 128}, false, false, seed},
+        // Not unit batch
+        {{3, 16, 32}, {3, 32, 128}, false, false, seed},
+        // Broadcasted A batch
+        {{1, 16, 32}, {3, 32, 128}, false, false, seed},
+        // Broadcasted B batch
+        {{3, 16, 32}, {1, 32, 128}, false, false, seed},
+        // Transpose A matrix (matching batch)
+        {{3, 16, 32}, {3, 32, 128}, true, false, seed},
+        // Broadcasted A batch
+        {{1, 16, 32}, {3, 32, 128}, true, false, seed},
+        // Broadcasted B batch
+        {{3, 16, 32}, {1, 32, 128}, true, false, seed},
+        // Transpose B matrix (matching batch)
+        {{3, 16, 32}, {3, 32, 128}, false, true, seed},
+        // Broadcasted A batch
+        {{1, 16, 32}, {3, 32, 128}, false, true, seed},
+        // Broadcasted B batch
+        {{3, 16, 32}, {1, 32, 128}, false, true, seed},
+        // Transpose both matrices (matching batch)
+        {{3, 16, 32}, {3, 32, 128}, true, true, seed},
+        // Broadcasted A batch
+        {{1, 16, 32}, {3, 32, 128}, true, true, seed},
+        // Broadcasted B batch
+        {{3, 16, 32}, {1, 32, 128}, true, true, seed},
+
+        // Basic single batch
+        {{1, 1, 16, 32}, {1, 1, 32, 128}, false, false, seed},
+        // Matching batch
+        {{2, 3, 16, 32}, {2, 3, 32, 128}, false, false, seed},
+        // Broadcasted A batch
+        {{1, 1, 16, 32}, {2, 3, 32, 128}, false, false, seed},
+        // Broadcasted B batch
+        {{2, 3, 16, 32}, {1, 1, 32, 128}, false, false, seed},
+        // Transpose A matrix (matching batch)
+        {{2, 3, 16, 32}, {2, 3, 32, 128}, true, false, seed},
+        // Broadcasted A batch
+        {{1, 1, 16, 32}, {2, 3, 32, 128}, true, false, seed},
+        // Broadcasted B batch
+        {{2, 3, 16, 32}, {1, 1, 32, 128}, true, false, seed},
+        // Transpose B matrix (matching batch)
+        {{2, 3, 16, 32}, {2, 3, 32, 128}, false, true, seed},
+        // Broadcasted A batch
+        {{1, 1, 16, 32}, {2, 3, 32, 128}, false, true, seed},
+        // Broadcasted B batch
+        {{2, 3, 16, 32}, {1, 1, 32, 128}, false, true, seed},
+        // Transpose both matrices (matching batch)
+        {{2, 3, 16, 32}, {2, 3, 32, 128}, true, true, seed},
+        // Broadcasted A batch
+        {{1, 1, 16, 32}, {2, 3, 32, 128}, true, true, seed},
+        // Broadcasted B batch
+        {{2, 3, 16, 32}, {1, 1, 32, 128}, true, true, seed},
+    };
+}
+
+} // namespace test_matmul_common

--- a/dnn-providers/hipblaslt-provider/tests/engines/plans/TestHipblasltMatmulPlan.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/engines/plans/TestHipblasltMatmulPlan.cpp
@@ -1,0 +1,449 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <hipblaslt/hipblaslt.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "HipdnnEnginePluginHandle.hpp"
+#include "engines/plans/HipblasltMatmulPlan.hpp"
+
+using namespace hipblaslt_plugin;
+using namespace hipdnn_plugin_sdk;
+using namespace hipdnn_test_sdk::utilities;
+
+class TestGpuMatmulPlan : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+        ASSERT_EQ(hipblasLtCreate(&_handle.hipblasltHandle), HIPBLAS_STATUS_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        if(_handle.hipblasltHandle != nullptr)
+        {
+            EXPECT_EQ(hipblasLtDestroy(_handle.hipblasltHandle), HIPBLAS_STATUS_SUCCESS);
+        }
+    }
+
+    HipdnnEnginePluginHandle _handle;
+};
+
+TEST(TestMatmulParams, InitializesAllTensorsFromValidGraph)
+{
+    // Create a valid matmul graph
+    auto builder = createValidMatmulGraph();
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    // Get the matmul node and attributes
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Construct params
+    MatmulParams params(*attrs, graph.getTensorMap());
+
+    // All required tensors should be accessible
+    EXPECT_NO_THROW(params.a());
+    EXPECT_NO_THROW(params.b());
+    EXPECT_NO_THROW(params.c());
+    EXPECT_NO_THROW(params.desc());
+}
+
+TEST(TestMatmulParams, RowMajor)
+{
+    // Row-major storage has stride[last] == 1
+    std::vector<int64_t> aDims = {4, 8};
+    std::vector<int64_t> aStrides = {8, 1}; // Row-major
+    std::vector<int64_t> bDims = {8, 5};
+    std::vector<int64_t> bStrides = {5, 1}; // Row-major
+    std::vector<int64_t> cDims = {4, 5};
+    std::vector<int64_t> cStrides = {5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should not throw for valid row-major strides
+    EXPECT_NO_THROW(MatmulParams(*attrs, graph.getTensorMap()));
+}
+
+TEST(TestMatmulParams, ColumnMajor)
+{
+    // Column-major storage has stride[last-1] == 1
+    std::vector<int64_t> aDims = {4, 8};
+    std::vector<int64_t> aStrides = {1, 4}; // Column-major
+    std::vector<int64_t> bDims = {8, 5};
+    std::vector<int64_t> bStrides = {1, 8}; // Column-major
+    std::vector<int64_t> cDims = {4, 5};
+    std::vector<int64_t> cStrides = {5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should not throw for valid column-major strides
+    EXPECT_NO_THROW(MatmulParams(*attrs, graph.getTensorMap()));
+}
+
+TEST(TestMatmulParams, BatchBroadcastWithABatchOne)
+{
+    // [1, M, K] x [2, K, N] -> [2, M, N]
+    std::vector<int64_t> aDims = {1, 4, 8};
+    std::vector<int64_t> aStrides = {32, 8, 1};
+    std::vector<int64_t> bDims = {2, 8, 5};
+    std::vector<int64_t> bStrides = {40, 5, 1};
+    std::vector<int64_t> cDims = {2, 4, 5};
+    std::vector<int64_t> cStrides = {20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should not throw for valid broadcast configuration
+    EXPECT_NO_THROW(MatmulParams(*attrs, graph.getTensorMap()));
+}
+
+TEST(TestMatmulParams, BatchBroadcastWithBBatchOne)
+{
+    // [3, M, K] x [1, K, N] -> [3, M, N]
+    std::vector<int64_t> aDims = {3, 4, 8};
+    std::vector<int64_t> aStrides = {32, 8, 1};
+    std::vector<int64_t> bDims = {1, 8, 5};
+    std::vector<int64_t> bStrides = {40, 5, 1};
+    std::vector<int64_t> cDims = {3, 4, 5};
+    std::vector<int64_t> cStrides = {20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should not throw for valid broadcast configuration
+    EXPECT_NO_THROW(MatmulParams(*attrs, graph.getTensorMap()));
+}
+
+TEST(TestMatmulParams, ThrowsOnDifferentRanks)
+{
+    // [M, K] x [2, K, N] -> [2, M, N]
+    std::vector<int64_t> aDims = {4, 8};
+    std::vector<int64_t> aStrides = {8, 1};
+    std::vector<int64_t> bDims = {2, 8, 5};
+    std::vector<int64_t> bStrides = {40, 5, 1};
+    std::vector<int64_t> cDims = {2, 4, 5};
+    std::vector<int64_t> cStrides = {20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should throw due to mismatched ranks
+    EXPECT_THROW(MatmulParams(*attrs, graph.getTensorMap()), HipdnnPluginException);
+}
+
+TEST(TestMatmulParams, ThrowsOnIncompatibleBatchDimensions)
+{
+    // [2, M, K] x [3, K, N] -> [3, M, N]
+    std::vector<int64_t> aDims = {2, 4, 8};
+    std::vector<int64_t> aStrides = {32, 8, 1};
+    std::vector<int64_t> bDims = {3, 8, 5};
+    std::vector<int64_t> bStrides = {40, 5, 1};
+    std::vector<int64_t> cDims = {3, 4, 5};
+    std::vector<int64_t> cStrides = {20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should throw due to incompatible batch dimensions
+    EXPECT_THROW(MatmulParams(*attrs, graph.getTensorMap()), HipdnnPluginException);
+}
+
+TEST(TestMatmulParams, ThrowsOnOutputBatchMismatch)
+{
+    // [2, M, K] x [2, K, N] -> [3, M, N]
+    std::vector<int64_t> aDims = {2, 4, 8};
+    std::vector<int64_t> aStrides = {32, 8, 1};
+    std::vector<int64_t> bDims = {2, 8, 5};
+    std::vector<int64_t> bStrides = {40, 5, 1};
+    std::vector<int64_t> cDims = {3, 4, 5};
+    std::vector<int64_t> cStrides = {20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should throw due to output batch mismatch
+    EXPECT_THROW(MatmulParams(*attrs, graph.getTensorMap()), HipdnnPluginException);
+}
+
+TEST(TestMatmulParams, ThrowsOnOutputBatchSmallerThanMax)
+{
+    // [1, M, K] x [3, K, N] -> [2, M, N]
+    std::vector<int64_t> aDims = {1, 4, 8};
+    std::vector<int64_t> aStrides = {32, 8, 1};
+    std::vector<int64_t> bDims = {3, 8, 5};
+    std::vector<int64_t> bStrides = {40, 5, 1};
+    std::vector<int64_t> cDims = {2, 4, 5};
+    std::vector<int64_t> cStrides = {20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    EXPECT_THROW(MatmulParams(*attrs, graph.getTensorMap()), HipdnnPluginException);
+}
+
+TEST(TestMatmulParams, Tensor4DBroadcastWithUnitBatchB)
+{
+    // [3, 3, m, k] x [1, 1, k, n] -> [3, 3, m, n]
+    std::vector<int64_t> aDims = {3, 3, 4, 8};
+    std::vector<int64_t> aStrides = {96, 32, 8, 1};
+    std::vector<int64_t> bDims = {1, 1, 8, 5};
+    std::vector<int64_t> bStrides = {40, 40, 5, 1};
+    std::vector<int64_t> cDims = {3, 3, 4, 5};
+    std::vector<int64_t> cStrides = {60, 20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should not throw - B batch is all 1s, broadcasting is valid
+    EXPECT_NO_THROW(MatmulParams(*attrs, graph.getTensorMap()));
+}
+
+TEST(TestMatmulParams, Tensor4DThrowsOnIncompatibleBatch)
+{
+    // [3, 3, m, k] x [1, 3, k, n] -> [3, 3, m, n]
+    std::vector<int64_t> aDims = {3, 3, 4, 8};
+    std::vector<int64_t> aStrides = {96, 32, 8, 1};
+    std::vector<int64_t> bDims = {1, 3, 8, 5};
+    std::vector<int64_t> bStrides = {120, 40, 5, 1};
+    std::vector<int64_t> cDims = {3, 3, 4, 5};
+    std::vector<int64_t> cStrides = {60, 20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should throw - batch dimensions are incompatible (9 vs 3, neither is 1)
+    EXPECT_THROW(MatmulParams(*attrs, graph.getTensorMap()), HipdnnPluginException);
+}
+
+TEST(TestMatmulParams, Tensor4DThrowsOnOutputBatchMismatch)
+{
+    // [3, 1, m, k] x [1, 3, k, n] -> [3, 3, m, n]
+    std::vector<int64_t> aDims = {3, 1, 4, 8};
+    std::vector<int64_t> aStrides = {32, 32, 8, 1};
+    std::vector<int64_t> bDims = {1, 3, 8, 5};
+    std::vector<int64_t> bStrides = {120, 40, 5, 1};
+    std::vector<int64_t> cDims = {3, 3, 4, 5};
+    std::vector<int64_t> cStrides = {60, 20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should throw - strided input batches
+    EXPECT_THROW(MatmulParams(*attrs, graph.getTensorMap()), HipdnnPluginException);
+}
+
+TEST_F(TestGpuMatmulPlan, CreatesPlanWithValidGraph)
+{
+    // Create a valid matmul graph
+    auto builder = createValidMatmulGraph();
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    // Get the matmul node and attributes
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Construct params
+    MatmulParams params(*attrs, graph.getTensorMap());
+
+    // Create plan - should not throw
+    EXPECT_NO_THROW(MatmulPlan(_handle, std::move(params)));
+}
+
+TEST_F(TestGpuMatmulPlan, PlanReturnsValidWorkspaceSize)
+{
+    // Create a valid matmul graph
+    auto builder = createValidMatmulGraph();
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    MatmulParams params(*attrs, graph.getTensorMap());
+    MatmulPlan plan(_handle, std::move(params));
+
+    // Workspace size should be >= 0
+    EXPECT_GE(plan.getWorkspaceSize(_handle), 0u);
+}
+
+TEST_F(TestGpuMatmulPlan, CreatesPlanWithColumnMajorInputs)
+{
+    // Column-major strides
+    std::vector<int64_t> aDims = {4, 8};
+    std::vector<int64_t> aStrides = {1, 4}; // Column-major
+    std::vector<int64_t> bDims = {8, 5};
+    std::vector<int64_t> bStrides = {1, 8}; // Column-major
+    std::vector<int64_t> cDims = {4, 5};
+    std::vector<int64_t> cStrides = {5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    MatmulParams params(*attrs, graph.getTensorMap());
+
+    // Create plan - should not throw for column-major inputs
+    EXPECT_NO_THROW(MatmulPlan(_handle, std::move(params)));
+}
+
+TEST_F(TestGpuMatmulPlan, CreatesPlanWithLargerMatrices)
+{
+    // Larger matrices for testing
+    std::vector<int64_t> aDims = {64, 128};
+    std::vector<int64_t> aStrides = {128, 1};
+    std::vector<int64_t> bDims = {128, 256};
+    std::vector<int64_t> bStrides = {256, 1};
+    std::vector<int64_t> cDims = {64, 256};
+    std::vector<int64_t> cStrides = {256, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    MatmulParams params(*attrs, graph.getTensorMap());
+
+    // Create plan - should not throw
+    EXPECT_NO_THROW(MatmulPlan(_handle, std::move(params)));
+}
+
+TEST_F(TestGpuMatmulPlan, CreatesPlanWithBatchedMatmul)
+{
+    // Batched matmul: [batch, M, K] x [batch, K, N] -> [batch, M, N]
+    std::vector<int64_t> aDims = {2, 4, 8};
+    std::vector<int64_t> aStrides = {32, 8, 1};
+    std::vector<int64_t> bDims = {2, 8, 5};
+    std::vector<int64_t> bStrides = {40, 5, 1};
+    std::vector<int64_t> cDims = {2, 4, 5};
+    std::vector<int64_t> cStrides = {20, 5, 1};
+
+    auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    MatmulParams params(*attrs, graph.getTensorMap());
+
+    // Create plan - should not throw
+    EXPECT_NO_THROW(MatmulPlan(_handle, std::move(params)));
+}
+
+TEST_F(TestGpuMatmulPlan, CreatesPlanWithHalfPrecision)
+{
+    // Half precision matmul
+    std::vector<int64_t> aDims = {16, 32};
+    std::vector<int64_t> aStrides = {32, 1};
+    std::vector<int64_t> bDims = {32, 64};
+    std::vector<int64_t> bStrides = {64, 1};
+    std::vector<int64_t> cDims = {16, 64};
+    std::vector<int64_t> cStrides = {64, 1};
+
+    auto builder = createValidMatmulGraph(aDims,
+                                          aStrides,
+                                          bDims,
+                                          bStrides,
+                                          cDims,
+                                          cStrides,
+                                          hipdnn_data_sdk::data_objects::DataType::HALF);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    MatmulParams params(*attrs, graph.getTensorMap());
+
+    // Create plan - should not throw
+    EXPECT_NO_THROW(MatmulPlan(_handle, std::move(params)));
+}
+
+TEST_F(TestGpuMatmulPlan, CreatesPlanWithBFloat16)
+{
+    // BFloat16 matmul
+    std::vector<int64_t> aDims = {16, 32};
+    std::vector<int64_t> aStrides = {32, 1};
+    std::vector<int64_t> bDims = {32, 64};
+    std::vector<int64_t> bStrides = {64, 1};
+    std::vector<int64_t> cDims = {16, 64};
+    std::vector<int64_t> cStrides = {64, 1};
+
+    auto builder = createValidMatmulGraph(aDims,
+                                          aStrides,
+                                          bDims,
+                                          bStrides,
+                                          cDims,
+                                          cStrides,
+                                          hipdnn_data_sdk::data_objects::DataType::BFLOAT16);
+    GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_MatmulAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    MatmulParams params(*attrs, graph.getTensorMap());
+
+    // Create plan - should not throw
+    EXPECT_NO_THROW(MatmulPlan(_handle, std::move(params)));
+}

--- a/dnn-providers/hipblaslt-provider/tests/engines/plans/TestHipblasltMatmulPlanBuilder.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/engines/plans/TestHipblasltMatmulPlanBuilder.cpp
@@ -1,0 +1,202 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <hipblaslt/hipblaslt.h>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "HipdnnEnginePluginHandle.hpp"
+#include "engines/plans/HipblasltMatmulPlanBuilder.hpp"
+
+using namespace hipblaslt_plugin;
+using namespace hipdnn_plugin_sdk;
+using namespace hipdnn_test_sdk::utilities;
+
+class TestHipblasltMatmulPlanBuilder : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+        ASSERT_EQ(hipblasLtCreate(&_handle.hipblasltHandle), HIPBLAS_STATUS_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        if(_handle.hipblasltHandle != nullptr)
+        {
+            EXPECT_EQ(hipblasLtDestroy(_handle.hipblasltHandle), HIPBLAS_STATUS_SUCCESS);
+        }
+    }
+
+    HipblasltMatmulPlanBuilder _planBuilder;
+    HipdnnEnginePluginHandle _handle;
+};
+
+TEST_F(TestHipblasltMatmulPlanBuilder, IsApplicable)
+{
+    // MultiNode Graph
+    {
+        MockGraph mockGraph;
+        EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(2));
+        EXPECT_FALSE(_planBuilder.isApplicable(_handle, mockGraph));
+    }
+
+    // Unsupported Graph with batchnorm
+    {
+        auto builder = createValidBatchnormInferenceGraph();
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+        EXPECT_FALSE(_planBuilder.isApplicable(_handle, graph));
+    }
+
+    // Supported broadcastable batch dimensions
+    {
+        std::vector<int64_t> aDims = {2, 4, 8};
+        std::vector<int64_t> aStrides = {32, 8, 1};
+        std::vector<int64_t> bDims = {1, 8, 5};
+        std::vector<int64_t> bStrides = {40, 5, 1};
+        std::vector<int64_t> cDims = {2, 4, 5};
+        std::vector<int64_t> cStrides = {20, 5, 1};
+
+        auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+        EXPECT_TRUE(_planBuilder.isApplicable(_handle, graph));
+    }
+
+    // Different tensor ranks
+    {
+        std::vector<int64_t> aDims = {2, 4, 8};
+        std::vector<int64_t> aStrides = {32, 8, 1};
+        std::vector<int64_t> bDims = {8, 5};
+        std::vector<int64_t> bStrides = {5, 1};
+        std::vector<int64_t> cDims = {2, 4, 5};
+        std::vector<int64_t> cStrides = {20, 5, 1};
+
+        auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+        EXPECT_FALSE(_planBuilder.isApplicable(_handle, graph));
+    }
+
+    // Incorrect C batch dimension
+    {
+        std::vector<int64_t> aDims = {2, 4, 8};
+        std::vector<int64_t> aStrides = {32, 8, 1};
+        std::vector<int64_t> bDims = {3, 8, 5};
+        std::vector<int64_t> bStrides = {40, 5, 1};
+        std::vector<int64_t> cDims = {6, 4, 5};
+        std::vector<int64_t> cStrides = {20, 5, 1};
+
+        auto builder = createValidMatmulGraph(aDims, aStrides, bDims, bStrides, cDims, cStrides);
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+        EXPECT_FALSE(_planBuilder.isApplicable(_handle, graph));
+    }
+
+    // Unsupported data type
+    {
+        std::vector<int64_t> aDims = {2, 4, 8};
+        std::vector<int64_t> aStrides = {32, 8, 1};
+        std::vector<int64_t> bDims = {2, 8, 5};
+        std::vector<int64_t> bStrides = {40, 5, 1};
+        std::vector<int64_t> cDims = {2, 4, 5};
+        std::vector<int64_t> cStrides = {20, 5, 1};
+
+        auto builder = createValidMatmulGraph(aDims,
+                                              aStrides,
+                                              bDims,
+                                              bStrides,
+                                              cDims,
+                                              cStrides,
+                                              hipdnn_data_sdk::data_objects::DataType::INT32);
+
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+        EXPECT_FALSE(_planBuilder.isApplicable(_handle, graph));
+    }
+
+    // Unsupported compute data type
+    {
+        flatbuffers::FlatBufferBuilder builder = createValidMatmulGraph();
+
+        auto mutableGraph
+            = hipdnn_data_sdk::data_objects::GetMutableGraph(builder.GetBufferPointer());
+        mutableGraph->mutable_nodes()->GetMutableObject(0)->mutate_compute_data_type(
+            hipdnn_data_sdk::data_objects::DataType::HALF);
+
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+        EXPECT_FALSE(_planBuilder.isApplicable(_handle, graph));
+    }
+
+    // Supported graph with matmul
+    {
+        auto builder = createValidMatmulGraph();
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+        EXPECT_TRUE(_planBuilder.isApplicable(_handle, graph));
+    }
+}
+
+TEST_F(TestHipblasltMatmulPlanBuilder, GetWorkspaceSize)
+{
+    // MultiNode Graph
+    {
+        MockGraph mockGraph;
+        EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(2));
+
+        EXPECT_THROW(_planBuilder.getWorkspaceSize(_handle, mockGraph), HipdnnPluginException);
+    }
+
+    // Unsupported Graph with batchnorm
+    {
+        auto builder = createValidBatchnormInferenceGraph();
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+        EXPECT_THROW(_planBuilder.getWorkspaceSize(_handle, graph), HipdnnPluginException);
+    }
+
+    // Supported Graph
+    {
+        auto builder = createValidMatmulGraph();
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+
+        EXPECT_NO_THROW(_planBuilder.getWorkspaceSize(_handle, graph));
+    }
+}
+
+TEST_F(TestHipblasltMatmulPlanBuilder, BuildPlan)
+{
+    // MultiNode Graph
+    {
+        MockGraph mockGraph;
+        EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(2));
+        HipdnnEnginePluginExecutionContext ctx;
+
+        EXPECT_THROW(_planBuilder.buildPlan(_handle, mockGraph, ctx), HipdnnPluginException);
+        EXPECT_FALSE(ctx.hasValidPlan());
+    }
+
+    // Unsupported Graph with batchnorm
+    {
+        auto builder = createValidBatchnormInferenceGraph();
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+        HipdnnEnginePluginExecutionContext ctx;
+
+        EXPECT_THROW(_planBuilder.buildPlan(_handle, graph, ctx), HipdnnPluginException);
+        EXPECT_FALSE(ctx.hasValidPlan());
+    }
+
+    // Supported Graph with matmul
+    {
+        auto builder = createValidMatmulGraph();
+        GraphWrapper graph(builder.GetBufferPointer(), builder.GetSize());
+        HipdnnEnginePluginExecutionContext ctx;
+
+        EXPECT_NO_THROW(_planBuilder.buildPlan(_handle, graph, ctx));
+        EXPECT_TRUE(ctx.hasValidPlan());
+    }
+}

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp
@@ -1,0 +1,162 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <flatbuffers/flatbuffers.h>
+
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+
+namespace hipdnn_plugin_sdk
+{
+
+class ITensorAttributesWrapper
+{
+public:
+    virtual ~ITensorAttributesWrapper() = default;
+    virtual bool isValid() const = 0;
+    virtual const hipdnn_data_sdk::data_objects::TensorAttributes& tensorAttributes() const = 0;
+
+    virtual int64_t uid() const = 0;
+    virtual std::string name() const = 0;
+    virtual hipdnn_data_sdk::data_objects::DataType dataType() const = 0;
+    virtual const std::type_info& dataClassType() const = 0;
+    virtual std::vector<int64_t> strides() const = 0;
+    virtual std::vector<int64_t> dims() const = 0;
+    virtual bool isVirtual() const = 0;
+    virtual hipdnn_data_sdk::data_objects::TensorValue valueType() const = 0;
+    virtual const void* value() const = 0;
+
+    template <typename T>
+    const T& valueAs() const
+    {
+        if(dataClassType() != typeid(T))
+        {
+            throw std::invalid_argument("Value of tensor attributes is not of the expected type");
+        }
+
+        auto* v = value();
+        if(v == nullptr)
+        {
+            throw std::invalid_argument("Value of tensor attributes is null");
+        }
+
+        return *static_cast<const T*>(v);
+    }
+};
+
+class TensorAttributesWrapper : public ITensorAttributesWrapper
+{
+public:
+    explicit TensorAttributesWrapper(const hipdnn_data_sdk::data_objects::TensorAttributes* t)
+        : _shallowTensor(t)
+    {
+        throwIfNotValid();
+    }
+
+    bool isValid() const override
+    {
+        return _shallowTensor != nullptr;
+    }
+
+    const hipdnn_data_sdk::data_objects::TensorAttributes& tensorAttributes() const override
+    {
+        throwIfNotValid();
+        return *_shallowTensor;
+    }
+
+    int64_t uid() const override
+    {
+        throwIfNotValid();
+        return _shallowTensor->uid();
+    }
+
+    std::string name() const override
+    {
+        throwIfNotValid();
+        const auto& t = tensorAttributes();
+        return t.name() != nullptr ? t.name()->str() : "";
+    }
+
+    hipdnn_data_sdk::data_objects::DataType dataType() const override
+    {
+        throwIfNotValid();
+        return _shallowTensor->data_type();
+    }
+
+    std::vector<int64_t> strides() const override
+    {
+        throwIfNotValid();
+        const auto* strides = _shallowTensor->strides();
+        if(strides == nullptr)
+        {
+            throw std::invalid_argument("TensorAttribute has null strides");
+        }
+
+        return {strides->cbegin(), strides->cend()};
+    }
+
+    std::vector<int64_t> dims() const override
+    {
+        throwIfNotValid();
+        const auto* dims = _shallowTensor->dims();
+        if(dims == nullptr)
+        {
+            throw std::invalid_argument("TensorAttribute has null dims");
+        }
+
+        return {dims->cbegin(), dims->cend()};
+    }
+
+    bool isVirtual() const override
+    {
+        throwIfNotValid();
+        return _shallowTensor->virtual_();
+    }
+
+    hipdnn_data_sdk::data_objects::TensorValue valueType() const override
+    {
+        throwIfNotValid();
+        return _shallowTensor->value_type();
+    }
+
+    const void* value() const override
+    {
+        throwIfNotValid();
+        return _shallowTensor->value();
+    }
+
+    const std::type_info& dataClassType() const override
+    {
+        throwIfNotValid();
+        switch(valueType())
+        {
+        case hipdnn_data_sdk::data_objects::TensorValue::Float32Value:
+            return typeid(hipdnn_data_sdk::data_objects::Float32Value);
+        case hipdnn_data_sdk::data_objects::TensorValue::Float16Value:
+            return typeid(hipdnn_data_sdk::data_objects::Float16Value);
+        case hipdnn_data_sdk::data_objects::TensorValue::BFloat16Value:
+            return typeid(hipdnn_data_sdk::data_objects::BFloat16Value);
+        case hipdnn_data_sdk::data_objects::TensorValue::Float8Value:
+            return typeid(hipdnn_data_sdk::data_objects::Float8Value);
+        case hipdnn_data_sdk::data_objects::TensorValue::Int32Value:
+            return typeid(hipdnn_data_sdk::data_objects::Int32Value);
+        case hipdnn_data_sdk::data_objects::TensorValue::Float64Value:
+            return typeid(hipdnn_data_sdk::data_objects::Float64Value);
+        default:
+            throw std::invalid_argument("Value type in tensor attributes is not recognized");
+        }
+    }
+
+private:
+    void throwIfNotValid() const
+    {
+        if(!isValid())
+        {
+            throw std::invalid_argument("TensorAttribute is null");
+        }
+    }
+
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _shallowTensor = nullptr;
+};
+} // namespace hipdnn_plugin_sdk

--- a/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestTensorAttributesWrapper.cpp
+++ b/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestTensorAttributesWrapper.cpp
@@ -1,0 +1,55 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <flatbuffers/flatbuffers.h>
+#include <gtest/gtest.h>
+#include <set>
+
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/TensorAttributesWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+
+using namespace hipdnn_plugin_sdk;
+using namespace hipdnn_data_sdk::data_objects;
+
+TEST(TestTensorAttributesWrapper, NullBufferIsInvalid)
+{
+    EXPECT_THROW(TensorAttributesWrapper wrapper(nullptr), std::invalid_argument);
+}
+
+TEST(TestTensorAttributesWrapper, EnsureTheTensorAttributesIsWrappedCorrectly)
+{
+    const int64_t uid = 1;
+    const std::string name = "x";
+    const DataType dataType = DataType::FLOAT;
+    const std::vector<int64_t> dims = {10, 2};
+    const std::vector<int64_t> strides = {2, 1};
+    const bool isVirtual = false;
+    const TensorValue valueType = TensorValue::Float32Value;
+    const float value = 1.0f;
+
+    flatbuffers::FlatBufferBuilder builder;
+    Float32Value floatValue(value);
+    auto valueOffset = builder.CreateStruct(floatValue).Union();
+    auto attributeOffset = CreateTensorAttributesDirect(
+        builder, uid, name.c_str(), dataType, &strides, &dims, isVirtual, valueType, valueOffset);
+    builder.Finish(attributeOffset);
+
+    auto shallowTensorAttributes
+        = flatbuffers::GetRoot<TensorAttributes>(builder.GetBufferPointer());
+
+    TensorAttributesWrapper wrapper(shallowTensorAttributes);
+
+    EXPECT_TRUE(wrapper.isValid());
+    EXPECT_EQ(wrapper.uid(), uid);
+    EXPECT_EQ(wrapper.name(), name);
+    EXPECT_EQ(wrapper.dataType(), dataType);
+    EXPECT_EQ(wrapper.dims(), dims);
+    EXPECT_EQ(wrapper.strides(), strides);
+    EXPECT_EQ(wrapper.isVirtual(), isVirtual);
+    EXPECT_EQ(wrapper.valueType(), valueType);
+    EXPECT_EQ(wrapper.dataClassType(), typeid(Float32Value));
+    EXPECT_NO_THROW(wrapper.valueAs<Float32Value>());
+    EXPECT_EQ(wrapper.valueAs<Float32Value>().value(), value);
+    EXPECT_THROW(wrapper.valueAs<Float64Value>(), std::invalid_argument);
+}

--- a/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
@@ -46,7 +46,7 @@ TEST(TestKnobFactory, CreateIntKnobDeprecated)
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_STREQ(root->knob_id_str()->c_str(), "deprecated_int_knob");
+    EXPECT_STREQ(root->knob_id()->c_str(), "deprecated_int_knob");
     EXPECT_TRUE(root->deprecated());
 }
 
@@ -81,7 +81,7 @@ TEST(TestKnobFactory, CreateFloatKnobDeprecated)
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_STREQ(root->knob_id_str()->c_str(), "deprecated_float_knob");
+    EXPECT_STREQ(root->knob_id()->c_str(), "deprecated_float_knob");
     EXPECT_TRUE(root->deprecated());
 }
 
@@ -121,6 +121,6 @@ TEST(TestKnobFactory, CreateStringKnobDeprecated)
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_STREQ(root->knob_id_str()->c_str(), "deprecated_string_knob");
+    EXPECT_STREQ(root->knob_id()->c_str(), "deprecated_string_knob");
     EXPECT_TRUE(root->deprecated());
 }

--- a/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
@@ -156,7 +156,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateIntKnob)
 
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
 
-        if(knob->knob_id_str()->str() == "test.int_knob")
+        if(knob->knob_id()->str() == "test.int_knob")
         {
             foundIntKnob = true;
 
@@ -217,7 +217,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateFloatKnob)
     {
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
 
-        if(knob->knob_id_str()->str() == "test.float_knob")
+        if(knob->knob_id()->str() == "test.float_knob")
         {
             foundFloatKnob = true;
 
@@ -277,7 +277,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateStringKnob)
     {
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
 
-        if(knob->knob_id_str()->str() == "test.string_knob")
+        if(knob->knob_id()->str() == "test.string_knob")
         {
             foundStringKnob = true;
 
@@ -347,7 +347,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateDeprecatedKnob)
     {
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
 
-        if(knob->knob_id_str()->str() == "test.deprecated_knob")
+        if(knob->knob_id()->str() == "test.deprecated_knob")
         {
             foundDeprecatedKnob = true;
 


### PR DESCRIPTION
## Motivation

Implemented Matmul support to hipBLASLt-provider - now the plugin provides impl for Matmul in hipDNN library.

## Technical Details

The current limitations:
- Supported only fp32, fp16, bf16 (the support of other data types (fp8) should be in the separate PR)
- Supported only single node (the support of post-ops should be in the separate PR)
- Supported input matrices with broadcastable batch dimensions only if batch has unit stride.

Also implemented class-wrappers on C-style hipblaslt classes: `HipblasltMatmulDesc` and `HipblasltMatrixLayout` to control their life cycle.

## Test Plan

Added unit tests for added classes `HipblasltMatmulDesc`, `HipblasltMatrixLayout`, `HipblasltMatmulPlan` and `HipblasltMatmulPlanBuilder`. Also the integration tests for Matmul (fp32, bf16, fp16) are implemented.

## Test Result

The unit and integration tests are successfully passed.
```
/opt/rocm-libraries-full/dnn-providers/hipblaslt-provider/build# ./bin/hipblaslt_plugin_tests 
[==========] Running 89 tests from 16 test suites.
...
[==========] 89 tests from 16 test suites ran. (521 ms total)
[  PASSED  ] 89 tests.

/opt/rocm-libraries-full/dnn-providers/hipblaslt-provider/build# ./bin/hipblaslt_plugin_integration_tests 
[==========] Running 42 tests from 3 test suites.
...
[==========] 42 tests from 3 test suites ran. (60907 ms total)
[  PASSED  ] 42 tests.
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
