### PR TITLE
[rocfft + shared] use only 2 args for compute_ptrdiff when no more needed

### DIFF
--- a/projects/rocfft/library/src/assignment_policy.cpp
+++ b/projects/rocfft/library/src/assignment_policy.cpp
@@ -962,7 +962,7 @@ static void PadStride(std::vector<size_t>&       stride,
     // to give us a number that doesn't make sense in that case.  but
     // if so, assume it's contiguous so that all the math works out.
     if(batch == 1)
-        dist = compute_ptrdiff(length, stride, 1, 1);
+        dist = compute_ptrdiff(length, stride);
 
     // sort lengths, treat batch dimension as another dim
     std::vector<LengthStrideSort<size_t>> cur;

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -4052,8 +4052,8 @@ void init_local_input(int                                       comm_rank,
         auto contiguous_dist   = params.compute_idist();
 
         std::vector<Tbuff> bufvec(1);
-        size_t brick_size_bytes = compute_ptrdiff(brick->length(), brick->stride, 0, 0) * elem_size
-                                  / (is_planar ? 2 : 1);
+        size_t             brick_size_bytes
+            = compute_ptrdiff(brick->length(), brick->stride) * elem_size / (is_planar ? 2 : 1);
         bufvec.back() = Tbuff::make_nonowned(input_ptrs[ptr_idx], brick_size_bytes);
         // grab a second pointer for planar
         if(is_planar)


### PR DESCRIPTION
## Motivation

Self-explanatory title, some use cases were missed in https://github.com/ROCm/rocm-libraries/pull/3898

## Technical Details

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
