### PR TITLE
[rocfft-test] update and fix rocfft_UnitTest.log_multithreading

### DIFF
--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -350,7 +350,7 @@ TEST(rocfft_UnitTest, log_multithreading)
     // now verify that the trace log has one message per line, with nothing garbled
     std::ifstream trace_log(TRACE_FILE);
     std::string   line;
-    std::regex    validator("^rocfft_(setup,[0-9]+.[0-9]+.[0-9]+.[0-9a-fA-F]+|cleanup|plan_"
+    std::regex    validator("^rocfft_(setup,[0-9]+.[0-9]+.[0-9]+.([0-9a-fA-F]+)?|cleanup|plan_"
                             "description_(create|destroy),description,[x0-9a-fA-F]+)$");
     while(std::getline(trace_log, line))
     {

--- a/projects/rocfft/clients/tests/unit_test.cpp
+++ b/projects/rocfft/clients/tests/unit_test.cpp
@@ -350,8 +350,8 @@ TEST(rocfft_UnitTest, log_multithreading)
     // now verify that the trace log has one message per line, with nothing garbled
     std::ifstream trace_log(TRACE_FILE);
     std::string   line;
-    std::regex    validator("^rocfft_(setup|cleanup|plan_description_(create|destroy),"
-                         "description,[x0-9a-fA-F]+)$");
+    std::regex    validator("^rocfft_(setup,[0-9]+.[0-9]+.[0-9]+.[0-9a-fA-F]+|cleanup|plan_"
+                            "description_(create|destroy),description,[x0-9a-fA-F]+)$");
     while(std::getline(trace_log, line))
     {
         bool res = std::regex_match(line, validator);


### PR DESCRIPTION
## Motivation

This test update was omitted in https://github.com/ROCm/rocm-libraries/pull/3954

## Technical Details

Updated the regex validator to match the updated log pattern.

## Test Plan + Test Result

"rocfft_UnitTest.log_multithreading" test instance was executed manually and no longer fails.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
