### PR TITLE
Update TheRock hash to 2026-01-21 branch with fixed MIOpen tests

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 6a91147f22b525b79b19e909ea832d4f21e71306 # 2026-01-14 commit
+          ref: e39ed88b1d9c35181b7e68fd48feb73d8afb019e # 2026-01-21 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 6a91147f22b525b79b19e909ea832d4f21e71306 # 2026-01-14 commit
+          ref: e39ed88b1d9c35181b7e68fd48feb73d8afb019e # 2026-01-21 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 6a91147f22b525b79b19e909ea832d4f21e71306 # 2026-01-14 commit
+          ref: e39ed88b1d9c35181b7e68fd48feb73d8afb019e # 2026-01-21 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 6a91147f22b525b79b19e909ea832d4f21e71306 # 2026-01-14 commit
+          ref: e39ed88b1d9c35181b7e68fd48feb73d8afb019e # 2026-01-21 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 6a91147f22b525b79b19e909ea832d4f21e71306 # 2026-01-14 commit
+          ref: e39ed88b1d9c35181b7e68fd48feb73d8afb019e # 2026-01-21 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: 6a91147f22b525b79b19e909ea832d4f21e71306 # 2026-01-14 commit
+          ref: e39ed88b1d9c35181b7e68fd48feb73d8afb019e # 2026-01-21 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 6a91147f22b525b79b19e909ea832d4f21e71306 # 2026-01-14 commit
+          ref: e39ed88b1d9c35181b7e68fd48feb73d8afb019e # 2026-01-21 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
## Motivation

Bump to the hash in TheRock where we've fixed the MIOpen tests taking so long problem.

## Technical Details

Issue was the removal of the positive tests for MIOpen brought in too many tests that are taking too long.  We reverted the change [here](https://github.com/ROCm/TheRock/pull/3007) which is the hash we're using in this bump.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
