### PR TITLE
fix(rocprim): implement hotfix to workaround missing operators when '__HIP_NO_HALF_OPERATORS__' is set in internal 'compare_nan_sensitive' functio

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -626,19 +626,53 @@ auto compare_nan_sensitive(const T& a, const T& b) ->
     // when making changes to this function.
 
     static constexpr auto sign_bit = ::rocprim::traits::get<T>().float_bit_mask().sign_bit;
-    using bit_key_type             = decltype(sign_bit);
+    using bit_key_type             = std::remove_cv_t<decltype(sign_bit)>;
 
-    // convert -0.0 to +0.0
-    // It was concerned that when the flags -fno-signed-zeros or -funsafe-math-optimizations
-    // (or -ffast-math which controls these two) is enabled then it is optimized away, but
-    // the compiler also seems to correctly model this and does not optimize away the addition
-    // when testing with the compile flags.
-    const T zero{0};
-    const T a_plus = a + zero;
-    const T b_plus = b + zero;
+#if __HIP_NO_HALF_OPERATORS__ || __HIP_NO_HALF_CONVERSIONS__
+    // There are cases where downstream users compile with '__HIP_NO_HALF_OPERATORS__' or
+    // '__HIP_NO_HALF_CONVERSIONS__' set. This means that '__half::operator+' does not work
+    // and we can't apply our trick to convert -0.0 to +0.0. We must fall back to a potentially
+    // slower bit flipping/masking method.
+    //
+    // Ideally we would use C++20 concepts to check if operator+ is valid for this type.
+    // Alternatively we could use some utility provided by libhipcxx. That way, we can catch
+    // other weird cases.
+    constexpr bool has_operator_plus = !std::is_same_v<T, __half>;
+#else
+    constexpr bool has_operator_plus = true;
+#endif
 
-    auto a_bits = ::rocprim::detail::bit_cast<bit_key_type>(a_plus);
-    auto b_bits = ::rocprim::detail::bit_cast<bit_key_type>(b_plus);
+    bit_key_type a_bits;
+    bit_key_type b_bits;
+    if constexpr(has_operator_plus)
+    {
+        // Convert -0.0 to +0.0 using floating point trick.
+        // It was concerned that when the flags -fno-signed-zeros or -funsafe-math-optimizations
+        // (or -ffast-math which controls these two) is enabled then it is optimized away, but
+        // the compiler also seems to correctly model this and does not optimize away the addition
+        // when testing with the compile flags.
+        const T zero{0};
+        const T a_plus = a + zero;
+        const T b_plus = b + zero;
+
+        a_bits = ::rocprim::detail::bit_cast<bit_key_type>(a_plus);
+        b_bits = ::rocprim::detail::bit_cast<bit_key_type>(b_plus);
+    }
+    else
+    {
+        a_bits = ::rocprim::detail::bit_cast<bit_key_type>(a);
+        b_bits = ::rocprim::detail::bit_cast<bit_key_type>(b);
+
+        // Convert -0.0 to +0.0 by flipping the sign bit. If value with the flipped signbit
+        // is all zeroes, then we have to return +0.0.
+        // input           : flipped  : bool : result
+        // 0...0000 : +0.0 : 1...0000 : true : 0...0000 : +0.0
+        // 1...0000 : -0.0 : 0...0000 : false: 0...0000 : +0.0
+        // 0...1111 : +x.y : 1...1111 : true : 0...1111 : +x.y
+        // 1...1111 : -x.y : 0...1111 : true : 0...1111 : -x.y
+        a_bits = a_bits == sign_bit ? 0 : a_bits;
+        b_bits = b_bits == sign_bit ? 0 : b_bits;
+    }
 
     // invert negatives, put 1 into sign bit for positives
     a_bits ^= (sign_bit & a_bits ? bit_key_type(-1) : 0) | sign_bit;


### PR DESCRIPTION
## Motivation

Closes https://github.com/ROCm/rocm-libraries/issues/4024.

## Technical Details

TheRock compiles PyTorch with `__HIP_NO_HALF_OPERATORS__` and `__HIP_NO_HALF_CONVERSIONS__` set. This breaks our -0.0 to +0.0 conversion trick. When these are not set, we must fall back to a slightly less optimal implementation using bit checks.

## Test Plan

Configure and compile rocPRIM with `-D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1`.

## Test Result

Compiles & test successful.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
