### PR TITLE
[rocSOLVER] Add overflow check utility function and modify argCheck

### DIFF
--- a/projects/rocsolver/clients/common/lapack/testing_getf2_getrf.hpp
+++ b/projects/rocsolver/clients/common/lapack/testing_getf2_getrf.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -383,6 +383,11 @@ void testing_getf2_getrf(Arguments& argus)
 
     I bc = argus.batch_count;
     int hot_calls = argus.iters;
+
+    // uncomment to test overflow check
+    EXPECT_ROCBLAS_STATUS(rocsolver_getf2_getrf(STRIDED, GETRF, handle, m, n, (T*)nullptr, lda, stA,
+                                                (I*)nullptr, stP, (I*)nullptr, bc),
+                          rocblas_status_success);
 
     rocblas_stride stARes = (argus.unit_check || argus.norm_check || argus.hash_check) ? stA : 0;
     rocblas_stride stPRes = (argus.unit_check || argus.norm_check || argus.hash_check) ? stP : 0;

--- a/projects/rocsolver/library/src/include/lib_host_helpers.hpp
+++ b/projects/rocsolver/library/src/include/lib_host_helpers.hpp
@@ -1,5 +1,5 @@
 /* **************************************************************************
- * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 #include <hip/hip_runtime.h>
+#include <limits>
 #include <rocblas/rocblas.h>
 
 ROCSOLVER_BEGIN_NAMESPACE
@@ -48,6 +49,41 @@ ROCSOLVER_BEGIN_NAMESPACE
 __device__ __host__ inline int64_t idx2D(const int64_t i, const int64_t j, const int64_t lda)
 {
     return j * lda + i;
+}
+
+// for an m x n matrix with leading dimension lda, the maximum index is: (m - 1) + (n - 1) * lda
+// check if that overflows for given type I
+template <typename I>
+__host__ inline bool matrix_index_overflow(const I m, const I n, const I lda)
+{
+    if(m <= 0 || n <= 0)
+        return false;
+
+    // calculate max index: (m - 1) + (n - 1) * lda
+    // while checking for overflow at each step
+    if(n > 1)
+    {
+        I n_minus_1 = n - 1;
+        if(lda > std::numeric_limits<I>::max() / n_minus_1)
+            return true;
+    }
+
+    I col_offset = (n > 1) ? (n - 1) * lda : I(0);
+
+    I row_max = m - 1;
+    if(row_max > std::numeric_limits<I>::max() - col_offset)
+        return true;
+
+    return false;
+}
+
+// simple wrapper that returns rocblas_status code for matrix index overflow results
+template <typename I>
+__host__ inline rocblas_status check_matrix_index_overflow(const I m, const I n, const I lda)
+{
+    return matrix_index_overflow(m, n, lda)
+        ? rocblas_status_invalid_size // TODO: is rocblas_invalid_size appropriate for overflow?
+        : rocblas_status_continue;
 }
 
 __device__ __host__ inline int64_t

--- a/projects/rocsolver/library/src/lapack/roclapack_getf2.hpp
+++ b/projects/rocsolver/library/src/lapack/roclapack_getf2.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -534,6 +534,14 @@ rocblas_status rocsolver_getf2_getrf_argCheck(rocblas_handle handle,
     // 2. invalid size
     if(m < 0 || n < 0 || lda < m || batch_count < 0)
         return rocblas_status_invalid_size;
+
+    // 2b. check for index overflow: (m-1) + (n-1)*lda must fit in type I
+    // This prevents undefined behavior when indexing large matrices
+    if(matrix_index_overflow(m, n, lda))
+    {
+        printf("index overflow\n"); // uncomment to test overflow check correctly detects
+        return rocblas_status_invalid_size; // TODO: is rocblas_invalid_size appropriate for overflow?
+    }
 
     // skip pointer check if querying memory size
     if(rocblas_is_device_memory_size_query(handle))


### PR DESCRIPTION
## Motivation

Users of rocSOLVER can unknowingly cause integer overflow. We want to communicate to the user when these errors occur. This draft PR proposes one implementation of such a check.

## Technical Details

By invoking rocSOLVER routines on matrices of a size > INT_MAX, users can cause integer overflow upon the routine trying to index elements of the matrix. 

This PR is a *draft* intended to invite review and discussion. I have implemented a proposed utility function, and applied it for a single routine in it's argCheck method. I have added an additional test to the `testing_getf2_getrf.hpp` file to provoke the integer overflow, and an extra print statement in order to convey to reviewers that would like to test this implementation to see that it does indeed work.

## Future Work

In order to extend this to all of rocSOLVER's API, we will need to create a similar utility function for any routine that operates on a vector rather than a matrix.

Additionally, we may want to return a distinctive rocblas_status that indicated integer overflow, or discuss the possibility of invoking the 64 bit routine if it avoids overflow.

## Test Plan

Run `./rocsolver-bench -f getf2 -m 46342` and check if integer overflow is detected by checking for print statement. 46342**2 > INT_MAX for signed 32 bit integers, so indexing 

## Test Result

`./rocsolver-bench -f getf2 -m 46342` produces the print statement indicating integer overflow is detected while indexing last element of matrix, and program exits.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
