### PR TITLE
[hipblaslt] Improve readability of if with initializer statement in rocroller host and add comment

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
@@ -503,8 +503,8 @@ rocblaslt_status
 
     // Check if scale type is not F32 while limiting scope of scale_type
     if(auto scale_type = hipDataType_to_rocRoller_type(prob.scale_type);
-        scale_type != rocRoller::DataType::None &&
-        scale_type != rocRoller::DataType::Float)
+       scale_type != rocRoller::DataType::None &&
+       scale_type != rocRoller::DataType::Float)
     {
         std::cerr << "rocRoller only supports F32 as scale type not " << scale_type << std::endl;
         return rocblaslt_status_invalid_value;

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
@@ -501,8 +501,10 @@ rocblaslt_status
         return rocblaslt_status_invalid_value;
     }
 
+    // Check if scale type is not F32 while limiting scope of scale_type
     if(auto scale_type = hipDataType_to_rocRoller_type(prob.scale_type);
-       scale_type != rocRoller::DataType::None && scale_type != rocRoller::DataType::Float)
+        scale_type != rocRoller::DataType::None &&
+        scale_type != rocRoller::DataType::Float)
     {
         std::cerr << "rocRoller only supports F32 as scale type not " << scale_type << std::endl;
         return rocblaslt_status_invalid_value;

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
@@ -501,10 +501,8 @@ rocblaslt_status
         return rocblaslt_status_invalid_value;
     }
 
-    // Check if scale type is not F32 while limiting scope of scale_type
-    if(auto scale_type = hipDataType_to_rocRoller_type(prob.scale_type);
-       scale_type != rocRoller::DataType::None &&
-       scale_type != rocRoller::DataType::Float)
+    auto scale_type = hipDataType_to_rocRoller_type(prob.scale_type);
+    if(scale_type != rocRoller::DataType::None && scale_type != rocRoller::DataType::Float)
     {
         std::cerr << "rocRoller only supports F32 as scale type not " << scale_type << std::endl;
         return rocblaslt_status_invalid_value;


### PR DESCRIPTION
## Motivation
The modified snippet was potentially confusing to read, and had been raised as an issue in rocroller. This PR improves readability without changing the functionality of the codr.

## Technical Details
Moved declaration of `scale_type` outside of `if` statement. This does not change functionality of code.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
