### PR TITLE
[dnn-providers] Add missing dnn-providers to repos-config.json

### DIFF
--- a/.github/repos-config.json
+++ b/.github/repos-config.json
@@ -224,6 +224,24 @@
       "auto_subtree_pull": false,
       "auto_subtree_push": true,
       "monorepo_source_of_truth": true
+    },
+    {
+      "name": "miopen-provider",
+      "url": "ROCm/MIOpen-Provider",
+      "branch": "develop",
+      "category": "dnn-providers",
+      "auto_subtree_pull": false,
+      "auto_subtree_push": false,
+      "monorepo_source_of_truth": true
+    },
+    {
+      "name": "hipblaslt-provider",
+      "url": "ROCm/hipBLASLt-Provider",
+      "branch": "develop",
+      "category": "dnn-providers",
+      "auto_subtree_pull": false,
+      "auto_subtree_push": false,
+      "monorepo_source_of_truth": true
     }
   ]
 }


### PR DESCRIPTION
## Motivation

#4006 added the updates to track projects and schedule the workflows, but since the project wasn't in repos-config.json this was getting skipped.

Adding the new hipdnn-provider projects to the json to ensure that can be picked up by CI automation.

## Testing plan

Test draft [PR](https://github.com/ROCm/rocm-libraries/pull/4067) here to confirm this is now working.