### PR TITLE
[rocWMMA] Fix up types passed to the mfma and wmma builtins

### DIFF
--- a/projects/rocwmma/library/include/rocwmma/internal/mfma_impl.hpp
+++ b/projects/rocwmma/library/include/rocwmma/internal/mfma_impl.hpp
@@ -52,13 +52,13 @@ namespace rocwmma
 
         // Enabler for all of gfx9, with binary condition.
         template <uint32_t TargetId, bool Cond = true>
-        using enable_gfx9_t
-            = enable_if_t<contains_number_v<uint32_t,
-                                            TargetId,
-                                            Constants::AMDGCN_ARCH_ID_GFX908,
-                                            Constants::AMDGCN_ARCH_ID_GFX90A,
-                                            Constants::AMDGCN_ARCH_ID_GFX942,
-                                            Constants::AMDGCN_ARCH_ID_GFX950> && Cond>;
+        using enable_gfx9_t = enable_if_t<contains_number_v<uint32_t,
+                                                            TargetId,
+                                                            Constants::AMDGCN_ARCH_ID_GFX908,
+                                                            Constants::AMDGCN_ARCH_ID_GFX90A,
+                                                            Constants::AMDGCN_ARCH_ID_GFX942,
+                                                            Constants::AMDGCN_ARCH_ID_GFX950>
+                                          && Cond>;
 
         /*! \class amdgcn_mfma
         *  \brief  Builtin wrapper for mfma instructions
@@ -249,14 +249,21 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of float16_t.
+                using TypeIn = VecT<float16_t, 4>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_mfma_f32_16x16x16f16(to_native_vector(regsA),
-                                                             to_native_vector(regsB),
-                                                             to_native_vector(regsC),
-                                                             (int)Cbsz,
-                                                             (int)Abid,
-                                                             (int)Blgp)};
+                to_native_vector(result) = {__builtin_amdgcn_mfma_f32_16x16x16f16(
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC),
+                    (int)Cbsz,
+                    (int)Abid,
+                    (int)Blgp)};
                 return result;
             }
         };
@@ -284,14 +291,22 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of float16_t.
+                using TypeIn = VecT<float16_t, 8>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_mfma_f32_16x16x32_f16(to_native_vector(regsA),
-                                                              to_native_vector(regsB),
-                                                              to_native_vector(regsC),
-                                                              (int)Cbsz,
-                                                              (int)Abid,
-                                                              (int)Blgp)};
+                to_native_vector(result) = {__builtin_amdgcn_mfma_f32_16x16x32_f16(
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC),
+                    (int)Cbsz,
+                    (int)Abid,
+                    (int)Blgp)};
                 return result;
             }
         };
@@ -350,14 +365,22 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of float16_t.
+                using TypeIn = VecT<float16_t, 4>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_mfma_f32_32x32x8f16(to_native_vector(regsA),
-                                                            to_native_vector(regsB),
-                                                            to_native_vector(regsC),
-                                                            (int)Cbsz,
-                                                            (int)Abid,
-                                                            (int)Blgp)};
+                to_native_vector(result) = {__builtin_amdgcn_mfma_f32_32x32x8f16(
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC),
+                    (int)Cbsz,
+                    (int)Abid,
+                    (int)Blgp)};
                 return result;
             }
         };
@@ -385,14 +408,22 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of float16_t.
+                using TypeIn = VecT<float16_t, 8>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_mfma_f32_32x32x16_f16(to_native_vector(regsA),
-                                                              to_native_vector(regsB),
-                                                              to_native_vector(regsC),
-                                                              (int)Cbsz,
-                                                              (int)Abid,
-                                                              (int)Blgp)};
+                to_native_vector(result) = {__builtin_amdgcn_mfma_f32_32x32x16_f16(
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC),
+                    (int)Cbsz,
+                    (int)Abid,
+                    (int)Blgp)};
                 return result;
             }
         };
@@ -542,14 +573,22 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of short.
+                using TypeIn = VecT<short, 4>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_mfma_f32_16x16x16bf16_1k(to_native_vector(regsA),
-                                                                 to_native_vector(regsB),
-                                                                 to_native_vector(regsC),
-                                                                 (int)Cbsz,
-                                                                 (int)Abid,
-                                                                 (int)Blgp)};
+                to_native_vector(result) = {__builtin_amdgcn_mfma_f32_16x16x16bf16_1k(
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC),
+                    (int)Cbsz,
+                    (int)Abid,
+                    (int)Blgp)};
                 return result;
             }
         };
@@ -577,14 +616,22 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of __bf16.
+                using TypeIn = __bf16 __attribute__((ext_vector_type(8)));
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_mfma_f32_16x16x32_bf16(to_native_vector(regsA),
-                                                               to_native_vector(regsB),
-                                                               to_native_vector(regsC),
-                                                               (int)Cbsz,
-                                                               (int)Abid,
-                                                               (int)Blgp)};
+                to_native_vector(result) = {__builtin_amdgcn_mfma_f32_16x16x32_bf16(
+                    (reinterpret_cast<TypeIn const&>(regsA)),
+                    (reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC),
+                    (int)Cbsz,
+                    (int)Abid,
+                    (int)Blgp)};
                 return result;
             }
         };
@@ -694,14 +741,22 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of short.
+                using TypeIn = VecT<short, 4>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_mfma_f32_32x32x8bf16_1k(to_native_vector(regsA),
-                                                                to_native_vector(regsB),
-                                                                to_native_vector(regsC),
-                                                                (int)Cbsz,
-                                                                (int)Abid,
-                                                                (int)Blgp)};
+                to_native_vector(result) = {__builtin_amdgcn_mfma_f32_32x32x8bf16_1k(
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC),
+                    (int)Cbsz,
+                    (int)Abid,
+                    (int)Blgp)};
                 return result;
             }
         };
@@ -729,14 +784,22 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of __bf16.
+                using TypeIn = __bf16 __attribute__((ext_vector_type(8)));
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_mfma_f32_32x32x16_bf16(to_native_vector(regsA),
-                                                               to_native_vector(regsB),
-                                                               to_native_vector(regsC),
-                                                               (int)Cbsz,
-                                                               (int)Abid,
-                                                               (int)Blgp)};
+                to_native_vector(result) = {__builtin_amdgcn_mfma_f32_32x32x16_bf16(
+                    (reinterpret_cast<TypeIn const&>(regsA)),
+                    (reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC),
+                    (int)Cbsz,
+                    (int)Abid,
+                    (int)Blgp)};
                 return result;
             }
         };

--- a/projects/rocwmma/library/include/rocwmma/internal/wmma_impl.hpp
+++ b/projects/rocwmma/library/include/rocwmma/internal/wmma_impl.hpp
@@ -43,25 +43,25 @@ namespace rocwmma
 
         // Enabler for all of gfx11
         template <uint32_t TargetId, bool Cond = true>
-        using enable_gfx11_t
-            = enable_if_t<contains_number_v<uint32_t,
-                                            TargetId,
-                                            Constants::AMDGCN_ARCH_ID_GFX1100,
-                                            Constants::AMDGCN_ARCH_ID_GFX1101,
-                                            Constants::AMDGCN_ARCH_ID_GFX1102,
-                                            Constants::AMDGCN_ARCH_ID_GFX1103,
-                                            Constants::AMDGCN_ARCH_ID_GFX1150,
-                                            Constants::AMDGCN_ARCH_ID_GFX1151,
-                                            Constants::AMDGCN_ARCH_ID_GFX1152,
-                                            Constants::AMDGCN_ARCH_ID_GFX1153> && Cond>;
+        using enable_gfx11_t = enable_if_t<contains_number_v<uint32_t,
+                                                             TargetId,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1100,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1101,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1102,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1103,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1150,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1151,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1152,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1153>
+                                           && Cond>;
 
         // Enabler for all of gfx12
         template <uint32_t TargetId, bool Cond = true>
-        using enable_gfx12_t
-            = enable_if_t<contains_number_v<uint32_t,
-                                            TargetId,
-                                            Constants::AMDGCN_ARCH_ID_GFX1200,
-                                            Constants::AMDGCN_ARCH_ID_GFX1201> && Cond>;
+        using enable_gfx12_t = enable_if_t<contains_number_v<uint32_t,
+                                                             TargetId,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1200,
+                                                             Constants::AMDGCN_ARCH_ID_GFX1201>
+                                           && Cond>;
 
         // Enabler for all of gfx11 and gfx12
         template <uint32_t TargetId, bool Cond = true>
@@ -77,7 +77,8 @@ namespace rocwmma
                                             Constants::AMDGCN_ARCH_ID_GFX1152,
                                             Constants::AMDGCN_ARCH_ID_GFX1153,
                                             Constants::AMDGCN_ARCH_ID_GFX1200,
-                                            Constants::AMDGCN_ARCH_ID_GFX1201> && Cond>;
+                                            Constants::AMDGCN_ARCH_ID_GFX1201>
+                          && Cond>;
 
         /*! \class amdgcn_wmma
         *  \brief  Builtin wrapper for wmma instructions
@@ -220,9 +221,19 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of float16.
+                using TypeIn = VecT<float16_t, 16>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
                 to_native_vector(result) = {__builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
-                    to_native_vector(regsA), to_native_vector(regsB), to_native_vector(regsC))};
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC))};
                 return result;
             }
         };
@@ -310,12 +321,26 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of float16.
+                using TypeIn  = VecT<float16_t, 16>;
+                using TypeOut = VecT<float16_t, 16>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsC)>),
+                              "Inconsistent data formats"); // some other thing
+                static_assert(sizeof(TypeOut) == sizeof(decay_t<DRegsT>),
+                              "Inconsistent data formats"); // some thing
+
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_wmma_f16_16x16x16_f16_w32(to_native_vector(regsA),
-                                                                  to_native_vector(regsB),
-                                                                  to_native_vector(regsC),
-                                                                  (bool)AccumBits)};
+                to_native_vector(reinterpret_cast<TypeOut&>(result))
+                    = {__builtin_amdgcn_wmma_f16_16x16x16_f16_w32(
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsC)),
+                        (bool)AccumBits)};
                 return result;
             }
         };
@@ -403,9 +428,19 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of short.
+                using TypeIn = VecT<short, 16>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
                 to_native_vector(result) = {__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(
-                    to_native_vector(regsA), to_native_vector(regsB), to_native_vector(regsC))};
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC))};
                 return result;
             }
         };
@@ -493,12 +528,26 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of short.
+                using TypeIn  = VecT<short, 16>;
+                using TypeOut = VecT<short, 16>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsC)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeOut) == sizeof(decay_t<DRegsT>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result)
-                    = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32(to_native_vector(regsA),
-                                                                    to_native_vector(regsB),
-                                                                    to_native_vector(regsC),
-                                                                    (bool)AccumBits)};
+                to_native_vector(reinterpret_cast<TypeOut&>(result))
+                    = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32(
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsC)),
+                        (bool)AccumBits)};
                 return result;
             }
         };
@@ -652,9 +701,19 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of float16_t.
+                using TypeIn = VecT<float16_t, 8>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
                 to_native_vector(result) = {__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(
-                    to_native_vector(regsA), to_native_vector(regsB), to_native_vector(regsC))};
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC))};
                 return result;
             }
         };
@@ -742,9 +801,25 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of float16_t.
+                using TypeIn  = VecT<float16_t, 8>;
+                using TypeOut = VecT<float16_t, 8>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsC)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeOut) == sizeof(decay_t<DRegsT>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result) = {__builtin_amdgcn_wmma_f16_16x16x16_f16_w32_gfx12(
-                    to_native_vector(regsA), to_native_vector(regsB), to_native_vector(regsC))};
+                to_native_vector(reinterpret_cast<TypeIn&>(result))
+                    = {__builtin_amdgcn_wmma_f16_16x16x16_f16_w32_gfx12(
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsC)))};
                 return result;
             }
         };
@@ -832,9 +907,19 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of short.
+                using TypeIn = VecT<short, 8>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
                 to_native_vector(result) = {__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(
-                    to_native_vector(regsA), to_native_vector(regsB), to_native_vector(regsC))};
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                    to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                    to_native_vector(regsC))};
                 return result;
             }
         };
@@ -922,9 +1007,25 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
+                // Built-in expects vector of short.
+                using TypeIn  = VecT<short, 8>;
+                using TypeOut = VecT<short, 8>;
+
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsC)>),
+                              "Inconsistent data formats");
+                static_assert(sizeof(TypeOut) == sizeof(decay_t<DRegsT>),
+                              "Inconsistent data formats");
+
                 DRegsT result;
-                to_native_vector(result) = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32_gfx12(
-                    to_native_vector(regsA), to_native_vector(regsB), to_native_vector(regsC))};
+                to_native_vector(reinterpret_cast<TypeOut&>(result))
+                    = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32_gfx12(
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsA)),
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsB)),
+                        to_native_vector(reinterpret_cast<TypeIn const&>(regsC)))};
                 return result;
             }
         };


### PR DESCRIPTION
## Motivation

An upstream change in LLVM means the builtin argument types are checked much more strictly.  Ensure we're passing the expected input types.
See https://github.com/llvm/llvm-project/pull/176033

## Technical Details

Cast the inputs to the expected types.

## Test Plan

Compile with latest AMD clang compiler with stricter builtin type checking.

## Test Result

Compiles fine with new rocWMMA changes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
