### PR TITLE
[rocfft] Improve robustness for multi-device plans with unifying logic for partial and full data layouts

### DIFF
--- a/projects/rocfft/CHANGELOG.md
+++ b/projects/rocfft/CHANGELOG.md
@@ -39,6 +39,7 @@ Documentation for rocFFT is available at
 * Fixed callbacks on MPI transforms, when not all ranks have the same number of data bricks.
 * Fixed functional issues for multi-device, in-place real transforms.
 * Fixed functional issues for multi-dimensional, multi-device transforms involving some unit length(s).
+* Fixed functional issues for multi-device transforms involving data divisions along the slowest-varying axis (only) for some bricks but not all.
 
 ## rocFFT 1.0.36 for ROCm 7.2.0
 

--- a/projects/rocfft/clients/tests/multi_device_test.cpp
+++ b/projects/rocfft/clients/tests/multi_device_test.cpp
@@ -46,6 +46,10 @@ static const std::vector<size_t>        multi_gpu_batch_range = {4, 1};
 static std::vector<std::vector<size_t>> ioffset_range_zero    = {{0, 0}};
 static std::vector<std::vector<size_t>> ooffset_range_zero    = {{0, 0}};
 
+// Limit local device testing to 16 GPUs, as we have some bottlenecks with
+// larger device counts that unreasonably slow down plan creation
+static constexpr int max_num_gpus_per_rank = 16;
+
 enum SplitType
 {
     // split both input and output on slow FFT dimension
@@ -77,11 +81,7 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
         {
             throw std::runtime_error("hipGetDeviceCount failed");
         }
-
-        // Limit local device testing to 16 GPUs, as we have some
-        // bottlenecks with larger device counts that unreasonably slow
-        // down plan creation
-        gpusperrank = std::min<int>(16, gpusperrank);
+        gpusperrank = std::min<int>(max_num_gpus_per_rank, gpusperrank);
     }
     else
     {
@@ -437,10 +437,7 @@ std::vector<fft_params> param_generator_multi_gpu_adhoc()
             throw std::runtime_error("hipGetDeviceCount failed");
         }
 
-        // Limit local device testing to 16 GPUs, as we have some
-        // bottlenecks with larger device counts that unreasonably slow
-        // down plan creation
-        localDeviceCount = std::min<int>(16, localDeviceCount);
+        localDeviceCount = std::min<int>(max_num_gpus_per_rank, localDeviceCount);
     }
     else
     {
@@ -505,4 +502,188 @@ std::vector<fft_params> param_generator_multi_gpu_adhoc()
 INSTANTIATE_TEST_SUITE_P(multi_gpu_adhoc_token,
                          accuracy_test,
                          ::testing::ValuesIn(param_generator_multi_gpu_adhoc()),
+                         accuracy_test::TestName);
+
+std::vector<fft_params> param_generator_some_continuous_brick()
+{
+    int gpusperrank = 0;
+    if(ngpus <= 0)
+    {
+        // Use the command-line option as a priority
+        if(hipGetDeviceCount(&gpusperrank) != hipSuccess)
+        {
+            throw std::runtime_error("hipGetDeviceCount failed");
+        }
+        gpusperrank = std::min<int>(max_num_gpus_per_rank, gpusperrank);
+    }
+    else
+    {
+        gpusperrank = ngpus;
+    }
+
+    if(mp_lib == fft_params::fft_mp_lib_none && mp_ranks != 1)
+        throw std::runtime_error("Unexpected value of mp_ranks (" + std::to_string(mp_ranks)
+                                 + ") without a multi-process library.");
+    if(mp_ranks < 0 || gpusperrank < 0)
+        return {}; // underflow protection
+
+    const size_t     total_num_devices  = mp_ranks * gpusperrank;
+    constexpr size_t min_slow_axis_ncut = 2;
+    // need at least min_slow_axis_ncut +1 devices
+    if(total_num_devices < min_slow_axis_ncut + 1)
+        return {};
+
+    std::vector<fft_params> params = param_generator_base(test_prob,
+                                                          trans_type_range_full,
+                                                          multi_gpu_sizes,
+                                                          precision_range_sp_dp,
+                                                          multi_gpu_batch_range,
+                                                          generate_types,
+                                                          stride_generator({{1}}),
+                                                          stride_generator({{1}}),
+                                                          ioffset_range_zero,
+                                                          ooffset_range_zero,
+                                                          place_range,
+                                                          false /* : planar */);
+
+    auto get_full_range = [](const fft_params& p, fft_io io) {
+        auto ret = io == fft_io::fft_io_in ? p.ilength() : p.olength();
+        ret.insert(ret.begin(), p.nbatch);
+        return ret;
+    };
+    auto get_full_strides = [](const fft_params& p, fft_io io) {
+        auto ret  = default_strides(p.transform_type, p.placement, io, p.length);
+        auto dist = default_distance(p.transform_type, p.placement, io, p.length, p.nbatch);
+        ret.insert(ret.begin(), dist);
+        return ret;
+    };
+
+    const size_t slowest_axis_ncut = std::max(min_slow_axis_ncut, total_num_devices / 2);
+    for(auto p = params.begin(); p != params.end();)
+    {
+        if((p->nbatch != 1 && p->nbatch < slowest_axis_ncut)
+           || (p->nbatch == 1 && p->length[0] < slowest_axis_ncut)
+           || p->length.back() < (total_num_devices - slowest_axis_ncut))
+        {
+            // no can do with this one
+            p = params.erase(p);
+            continue;
+        }
+        const size_t slowest_brick_axis = p->nbatch == 1 ? 1 : 0;
+        if(slowest_brick_axis == p->dim())
+        {
+            // too few dimensions
+            p = params.erase(p);
+            continue;
+        }
+        // initialize field size and bricks
+        for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+        {
+            auto& fields = io == fft_io::fft_io_in ? p->ifields : p->ofields;
+            fields.resize(1);
+            fields[0].bricks.clear();
+        }
+        // make slowest_axis_ncut bricks cutting the slowest axis in the layout
+        for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+        {
+            auto& bricks = io == fft_io::fft_io_in ? p->ifields[0].bricks : p->ofields[0].bricks;
+            const auto full_range   = get_full_range(*p, io);
+            const auto full_strides = get_full_strides(*p, io);
+            for(size_t b_idx = 0; b_idx < slowest_axis_ncut; b_idx++)
+            {
+                fft_params::fft_brick brick;
+                brick.lower.resize(p->dim() + 1);
+                brick.upper.resize(p->dim() + 1);
+                brick.stride.resize(p->dim() + 1);
+                for(size_t axis = p->dim() + 1; axis-- > 0;)
+                {
+                    if(axis == slowest_brick_axis)
+                    {
+                        brick.lower[axis] = b_idx * (full_range[axis] / slowest_axis_ncut);
+                        brick.upper[axis]
+                            = b_idx < slowest_axis_ncut - 1
+                                  ? (b_idx + 1) * (full_range[axis] / slowest_axis_ncut)
+                                  : full_range[axis];
+                    }
+                    else
+                    {
+                        brick.lower[axis] = 0;
+                        brick.upper[axis] = full_range[axis];
+                    }
+                    if(axis > slowest_brick_axis)
+                        brick.stride[axis] = full_strides[axis];
+                    else
+                        brick.stride[axis] = brick.stride[axis + 1]
+                                             * (brick.upper[axis + 1] - brick.lower[axis + 1]);
+                }
+                bricks.emplace_back(brick);
+            }
+            // randomly pick one of the bricks created so far as one that we won't divide anymore
+            static std::ranlux24_base             gen(random_seed);
+            std::uniform_int_distribution<size_t> dev_rng(0, slowest_axis_ncut - 1);
+            const auto                            const_brick_idx = dev_rng(gen);
+            while(bricks.size() < total_num_devices)
+            {
+                std::uniform_int_distribution<size_t> rnd(0, bricks.size() - 1);
+
+                size_t split_brick_idx = rnd(gen);
+                while(split_brick_idx == const_brick_idx)
+                    split_brick_idx = rnd(gen);
+                auto& split_brick = bricks[split_brick_idx];
+                if(split_brick.upper.back() - split_brick.lower.back() <= 1)
+                {
+                    if(verbose)
+                        std::cout << "Unexpected small last-axis length encountered in "
+                                     "param_generator_some_continuous_brick"
+                                  << std::endl;
+                    break;
+                }
+                // split bricks along the last axis, start with a simple copy
+                auto other_half = split_brick;
+                split_brick.upper.back()
+                    = split_brick.lower.back()
+                      + (split_brick.upper.back() - split_brick.lower.back()) / 2;
+                other_half.lower.back() = split_brick.upper.back();
+                // reset each split brick's strides to be contiguous
+                split_brick.stride.back() = 1;
+                other_half.stride.back()  = 1;
+                for(size_t axis = p->dim(); axis-- > 0;)
+                {
+                    split_brick.stride[axis]
+                        = split_brick.stride[axis + 1]
+                          * (split_brick.upper[axis + 1] - split_brick.lower[axis + 1]);
+                    other_half.stride[axis]
+                        = other_half.stride[axis + 1]
+                          * (other_half.upper[axis + 1] - other_half.lower[axis + 1]);
+                }
+                bricks.emplace_back(other_half);
+            }
+        }
+        if(p->ifields.size() != 1 || p->ifields[0].bricks.size() != total_num_devices
+           || p->ofields.size() != 1 || p->ofields[0].bricks.size() != total_num_devices)
+        {
+            // unexpected issue encountered while splitting
+            p = params.erase(p);
+            continue;
+        }
+        // assign ranks and devices, cycle through ranks first for make sure
+        // all processes have something to do
+        for(auto io : {fft_io::fft_io_in, fft_io::fft_io_out})
+        {
+            auto& bricks = io == fft_io::fft_io_in ? p->ifields[0].bricks : p->ofields[0].bricks;
+            for(size_t b_idx = 0; b_idx < bricks.size(); b_idx++)
+            {
+                bricks[b_idx].rank   = b_idx % mp_ranks;
+                bricks[b_idx].device = (b_idx / mp_ranks) % gpusperrank;
+            }
+        }
+        p->mp_lib = mp_lib;
+        p++;
+    }
+    return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(multi_gpu_some_continuous_brick,
+                         accuracy_test,
+                         ::testing::ValuesIn(param_generator_some_continuous_brick()),
                          accuracy_test::TestName);

--- a/projects/rocfft/library/src/data_layout.cpp
+++ b/projects/rocfft/library/src/data_layout.cpp
@@ -46,6 +46,19 @@ namespace
     }
 }
 
+io_data_label other(io_data_label io)
+{
+    switch(io)
+    {
+    case io_data_label::INPUT:
+        return io_data_label::OUTPUT;
+    case io_data_label::OUTPUT:
+        return io_data_label::INPUT;
+    default:
+        throw std::invalid_argument("Unknown io data label given to " + ROCFFT_CURRENT_FUNCTION);
+    }
+}
+
 std::string to_str(io_data_label io)
 {
     switch(io)
@@ -118,6 +131,32 @@ data_layout_t::data_layout_t(const std::vector<size_t>& lower,
         (*this)[dim].inbuffer_stride = strides[dim];
         (*this)[dim].is_partial      = is_partial;
     }
+}
+
+data_layout_t data_layout_t::full_layout(const std::vector<size_t>& lengths,
+                                         const std::vector<size_t>& strides,
+                                         size_t                     batch,
+                                         size_t                     distance)
+{
+    return data_layout_t{std::vector<size_t>(lengths.size() + 1, 0),
+                         concatenate(lengths, batch),
+                         concatenate(strides, distance),
+                         1,
+                         false /* : is_partial */};
+}
+
+data_layout_t data_layout_t::default_full_layout(const std::vector<size_t>& lengths,
+                                                 size_t                     batch,
+                                                 bool                       real_case_with_padding)
+{
+    data_layout_t             ret;
+    const std::vector<size_t> empty_for_default_strides_and_dist = {};
+    ret.full_range_reset(lengths,
+                         empty_for_default_strides_and_dist,
+                         {batch},
+                         empty_for_default_strides_and_dist,
+                         real_case_with_padding);
+    return ret;
 }
 
 size_t data_layout_t::get_len_rank() const
@@ -484,4 +523,70 @@ void data_layout_t::full_range_reset(const std::vector<size_t>& lengths,
 bool data_layout_t::is_dimensionally_consistent_with(const data_layout_t& other) const
 {
     return get_batch_rank() == other.get_batch_rank() && get_len_rank() == other.get_len_rank();
+}
+
+bool data_layout_t::has_some_partial_length_axis() const
+{
+    return std::any_of(
+        len_axes.begin(), len_axes.end(), [](const auto& len_axis) { return len_axis.is_partial; });
+}
+
+std::optional<data_layout_t>
+    data_layout_t::get_other_inplace_layout_for(io_data_label         other_io,
+                                                rocfft_transform_type fft_type,
+                                                bool other_innermost_length_is_odd) const
+{
+    if(other_io != io_data_label::INPUT && other_io != io_data_label::OUTPUT)
+        throw std::invalid_argument("Unknown I/O data label given to " + ROCFFT_CURRENT_FUNCTION);
+
+    if(is_empty())
+        throw std::logic_error(ROCFFT_CURRENT_FUNCTION + " queried on an empty layout");
+
+    if(has_some_partial_length_axis())
+        throw std::logic_error(ROCFFT_CURRENT_FUNCTION
+                               + " queried on a layout involving partial lengths");
+
+    if(fft_type == rocfft_transform_type_complex_forward
+       || fft_type == rocfft_transform_type_complex_inverse)
+    {
+        // simple copy
+        return std::make_optional<data_layout_t>(*this);
+    }
+    else if(fft_type != rocfft_transform_type_real_forward
+            && fft_type != rocfft_transform_type_real_inverse)
+    {
+        throw std::invalid_argument("Unknown type of transform given to "
+                                    + ROCFFT_CURRENT_FUNCTION);
+    }
+
+    // real transform: unit stride is required along the innermost axis
+    if((*this)[0].logical_span() > 1 && (*this)[0].inbuffer_stride != 1)
+        return std::nullopt;
+    const bool other_is_hermitian_domain
+        = (other_io == io_data_label::INPUT) ^ (fft_type == rocfft_transform_type_real_forward);
+    if(other_is_hermitian_domain)
+    {
+        bool strides_are_consistent = true;
+        for(size_t dim = 1; strides_are_consistent && dim < get_full_rank(); dim++)
+        {
+            if((*this)[dim].logical_span() == 1)
+                continue;
+            strides_are_consistent
+                &= (*this)[dim].inbuffer_stride % 2 == 0
+                   && (*this)[dim].inbuffer_stride >= 2 * ((*this)[0].logical_span() / 2 + 1);
+        }
+        if(!strides_are_consistent)
+            return std::nullopt;
+    }
+    // copy layout and modify what needs be
+    auto ret        = std::make_optional<data_layout_t>(*this);
+    (*ret)[0].upper = other_is_hermitian_domain ? (*this)[0].logical_span() / 2 + 1
+                                                : 2 * ((*this)[0].logical_span() - 1)
+                                                      + (other_innermost_length_is_odd ? 1 : 0);
+    for(size_t dim = 1; dim < ret->get_full_rank(); dim++)
+    {
+        (*ret)[dim].inbuffer_stride = other_is_hermitian_domain ? (*this)[dim].inbuffer_stride / 2
+                                                                : 2 * (*this)[dim].inbuffer_stride;
+    }
+    return ret;
 }

--- a/projects/rocfft/library/src/include/data_layout.h
+++ b/projects/rocfft/library/src/include/data_layout.h
@@ -24,6 +24,7 @@
 #include "rocfft/rocfft.h"
 
 #include <cstring>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -34,6 +35,13 @@ enum class io_data_label
     INPUT,
     OUTPUT
 };
+
+/**
+  * @return `io_data_label::OUTPUT` for the argument value `io_data_label::INPUT` and vice versa. 
+  * @throw An `std::invalid_argument` is thrown if `io` is not `io_data_label::INPUT` 
+  * nor `io_data_label::OUTPUT`.
+  */
+io_data_label other(io_data_label io);
 
 /**
  * @return An `std::string` of value "input" (resp. "output") if `io` is
@@ -60,7 +68,7 @@ std::string to_str(io_data_label io);
 struct data_layout_t
 {
     /**
-     * @brief Construct a new `data_layout_t` object with explicit member values.
+     * @brief Constructs a new `data_layout_t` object with explicit member values.
      * 
      * @param[in] lower lower bounds along all axes of the logical index range
      * (lower bounds are included).
@@ -94,6 +102,40 @@ struct data_layout_t
                   const std::vector<size_t>& strides,
                   size_t                     batch_rank = 1,
                   bool                       is_partial = true);
+
+    /**
+     * @brief Constructs a new `data_layout_t` object capturing a full range of logical
+     * indices with one batch axis.
+     * 
+     * @param[in] lengths spans of the logical index range along all length axes.
+     * @param[in] strides in-buffer strides associated with all length axes.
+     * @param[in] batch span of the logical index range along its batch axis.
+     * @param[in] distance in-buffer stride associated with the batch axis.
+     * 
+     * @throw An `std::invalid_argument` is thrown if `lengths` or `strides`
+     * are empty or have different sizes.
+     */
+    static data_layout_t full_layout(const std::vector<size_t>& lengths,
+                                     const std::vector<size_t>& strides,
+                                     size_t                     batch,
+                                     size_t                     distance);
+
+    /**
+     * @brief Constructs a new `data_layout_t` object capturing a full range of logical
+     * indices with one batch axis, and default in-buffer strides (enforcing in-buffer
+     * contiguity for the innermost length axis).
+     * 
+     * @param[in] lengths spans of the logical index range along all length axes.
+     * @param[in] batch span of the logical index range along its batch axis.
+     * @param[in] real_case_with_padding flag setting the in-buffer stride of the
+     * layout's first non-contiguous axis to the value that is required in real
+     * domain for real, in-place Discrete Fourier Transforms.
+     * 
+     * @throw An `std::invalid_argument` is thrown if `lengths` is empty.
+     */
+    static data_layout_t default_full_layout(const std::vector<size_t>& lengths,
+                                             size_t                     batch,
+                                             bool real_case_with_padding = false);
 
     /**
      * @return The number of length axes.
@@ -251,6 +293,10 @@ struct data_layout_t
      * @return `true` if this data layout is dimensionally consistent with `other` 
      */
     bool is_dimensionally_consistent_with(const data_layout_t& other) const;
+    /**
+     * @return `true` if any length axis covers a partial range.
+     */
+    bool has_some_partial_length_axis() const;
 
     /**
      * @brief Reports the order of length axis indices if sorting them by increasing
@@ -264,6 +310,40 @@ struct data_layout_t
      * if `i` < `j` (excluding `i == 0` and `j == 0` if `pin_innermost_axis` is true)
      */
     std::vector<size_t> length_axes_by_increasing_strides(bool pin_innermost_axis) const;
+
+    /**
+     * @brief Verifies whether this object's layout is consistent as input
+     * (resp. output) for specific types of in-place Discrete Fourier Transforms
+     * along its full lengths axes and, if so, returns the corresponding output
+     * (resp. input) layout.
+     * 
+     * @param[in] other_io I/O label for the data layout to be returned. Explicitly,
+     * the calling object's layout is considered an input (resp. output) layout
+     * if the argument value is `io_data_label::OUTPUT` (resp. `io_data_label::INPUT`)
+     * @param[in] fft_type intended type of (in-place) Fourier Transform
+     * @param[in] other_innermost_length_is_odd flag indicating whether the
+     * logical span of the innermost length axis in the corresponding layout is
+     * odd (if `true`) or not (if `false`). This is ignored (and can be safely
+     * omitted in calls) *unless* the data layout to be returned corresponds to
+     * the input of a real forward transform or the output of a real inverse
+     * transform.
+     * 
+     * @return An `std::optional<data_layout_t>` object which has a value set
+     * iff a corresponding layout for in-place operation does actually exist.
+     * 
+     * @note This function does not verify if either layout is self-aliasing and
+     * ignores offsets as `data_layout_t` objects do not capture them.
+     * 
+     * @throw An `std::logic_error` is thrown if the current object is an empty
+     * layout or involves some partial length axes. An `std::invalid_argument` is
+     * thrown if `fft_type` is not an expected value or if `other_io` is not an
+     * expected value.
+     * 
+     */
+    std::optional<data_layout_t> get_other_inplace_layout_for(io_data_label         other_io,
+                                                              rocfft_transform_type fft_type,
+                                                              bool other_innermost_length_is_odd
+                                                              = false) const;
 
     //-------------------------------------------------------------------------
     //                        DEFAULT COPIES AND MOVES
@@ -336,7 +416,7 @@ private:
     size_t slowest_varying_axis() const;
 
     /**
-     * @brief Empty all layout axes.
+     * @brief Empties all layout axes.
      */
     void clear();
 
@@ -353,7 +433,7 @@ private:
     void reorder_length_axes(const std::vector<size_t>& len_axis_order);
 
     /**
-     * @brief Reset the object's state to capture a full range of logical
+     * @brief Resets the object's state to capture a full range of logical
      * indices with either prescribed or default strides and/or distance.
      * 
      * @param[in] lengths spans of the logical index range along all length axes.

--- a/projects/rocfft/library/src/include/plan.h
+++ b/projects/rocfft/library/src/include/plan.h
@@ -113,8 +113,8 @@ struct rocfft_field_t
     data_layout_t get_full_data_range() const;
 
     /**
-     * @brief Finalize all the field's bricks, i.e., sort them by increasing rank (stable
-     * sort) and set the `is_partial` flags for all axes of their layouts.
+     * @brief Finalizes all the field's bricks, i.e., sorts them by increasing rank (stable
+     * sort) and sets the `is_partial` flags for all axes of their layouts.
      */
     void finalize();
 
@@ -171,7 +171,7 @@ struct rocfft_plan_description_t
     rocfft_location_t get_current_location() const;
 
     /**
-     * @brief Finalize the plan description by
+     * @brief Finalizes the plan description by
      * 
      * - assigning default values for structure members that have not been explicitly set yet;
      * 
@@ -193,13 +193,19 @@ struct rocfft_plan_description_t
      * 
      * - Input and output fields are both set for multi-process usage;
      * 
+     * - Usage of multiple I/O fields in descriptors is reported as unsupported;
+     * 
      * - I/O array types are not planar if the corresponding field(s) are set;
      * 
      * - I/O array types are consistent with the expected data types;
      * 
-     * - I/O array types are consistent for in-place transforms (if requested);
-     *
+     * - I/O array types are consistent for in-place transforms (if in-place is requested);
      * 
+     * - locations of I/O buffers are consistent for in-place transforms (if in-place is requested);
+     * 
+     * - I/O data layouts and offsets (unless ignored) are consistent with in-place usage
+     *   for single-device transforms (if in-place is requested);
+     *
      * @param[in] dft_type user-provided type of transform for the owning plan.
      * @param[in] placement user-provided placement of transform results for the owning plan.
      * @param[in] user_lengths user-provided lengths of the transform for the owning plan.
@@ -215,6 +221,41 @@ struct rocfft_plan_description_t
                                             const size_t*           user_lengths,
                                             const size_t            len_rank,
                                             const size_t            number_of_transforms);
+
+    /**
+     * @brief Verifies if the description has undistributed input/output data and,
+     * if so, returns the location thereof.
+     * 
+     * @param[in] io input (resp. output) data sets are considered for argument value
+     * `io_data_label::INPUT` (resp. `io_data_label::OUTPUT`)
+     * @return An `std::optional<rocfft_location_t>` object which has a value set to
+     * the expected location of the input (resp. output) data, if undistributed. 
+     * @throw An `std::invalid_argument` exception is thrown if `io` is not an
+     * expected value.
+     */
+    std::optional<rocfft_location_t> expected_undistributed_location_for(io_data_label io) const;
+
+    /**
+     * @return `true` if the description is consistent with single-device
+     * operations on the current location.
+     */
+    bool has_undistributed_io_on_current_location() const;
+
+    /**
+     * @brief Returns a read accessor for the input (resp. output) data layout that must take
+     * precedence. If a lone-brick input (resp. output) field is used, this returns a (const)
+     * reference to that brick's layout. Otherwise, a (const) reference to `input_layout`
+     * (resp. `output_layout`) is returned.
+     * 
+     * @param[in] io input (resp. output) data set(s) are considered for argument
+     * value `io_data_label::INPUT` (resp. `io_data_label::OUTPUT`)
+     * 
+     * @throw An `std::logic_error` is thrown if this description involves more than one brick
+     * on input (resp. output), i.e., if this description does not have an undistributed data
+     * layout on input (resp. output). An `std::invalid_argument` exception is thrown if `io`
+     * is not an expected value.
+     */
+    const data_layout_t& undistributed_layout_for(io_data_label io) const;
 
     // Count the number of pointers required for either input or output
     // - planar data requires two pointers, real + complex require one.
@@ -275,13 +316,6 @@ struct rocfft_plan_t
 
     size_t WorkBufBytes() const;
 
-    // Insert core execPlan into multi-item plan, surrounding it with
-    // sufficient items to gather/scatter to/from a single device if
-    // the plan needs it.  Gathering all the data to a single device is
-    // suboptimal but is a first step towards proper multi-device
-    // logic.
-    void GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& execPlan);
-
     // Construct an optimized multi-device plan for the FFT
     // parameters in *this.  Returns false if:
     // - multiple devices are not requested for this FFT, or
@@ -307,6 +341,13 @@ struct rocfft_plan_t
      * therefore *NOT* returned by this function.
      */
     std::vector<size_t> get_user_facing_lengths() const;
+    /**
+     * @brief Creates a plan execution item capable of tackling the plan's task
+     * via a single-device execution (the current-locaton device, implicitly). If
+     * the plan was not configured for single-device executions, the required
+     * input-gathering and output-scattering execution items are also created.
+     */
+    void MakeSingleDevPlanWithGatherScatterIfNeeded();
 
 private:
     // Multi-node or multi-GPU plan is built up from a vector of plan
@@ -338,25 +379,35 @@ private:
     // plan items can have void*'s that point to these buffers.
     std::multimap<rocfft_location_t, std::shared_ptr<InternalTempBuffer>> tempBuffers;
 
-    // gather a set of bricks to a field on the current device
-    std::vector<size_t> GatherBricksToField(rocfft_location_t                  destLocation,
-                                            const std::vector<rocfft_brick_t>& bricks,
-                                            rocfft_precision                   precision,
-                                            rocfft_array_type                  arrayType,
-                                            const data_layout_t&               gathering_layout,
-                                            BufferPtr                          output,
-                                            const std::vector<size_t>&         antecedents,
-                                            size_t                             elem_size);
+    /**
+     * @brief Creates the plan items required to gather the input data buffer(s) of a
+     * multi-device transform into the input buffer of the (single-device) execution
+     * plan (abiding by the input data layout set for that execution plan).
+     * 
+     * @param[in] execution_plan single-device execution plan.
+     * @param[in] antecedents indices of the plan items that must complete before
+     * the gather steps may be initiated.
+     * @return An `std::vector<size_t>` of indices of the created plan items. When these
+     * items complete, the execution plan's input buffer is set for computing the desired
+     * transform.
+     */
+    std::vector<size_t> CreateInputGatheringItems(const ExecPlan&            execution_plan,
+                                                  const std::vector<size_t>& antecedents = {});
 
-    // scatter a field on the current device to a set of bricks
-    std::vector<size_t> ScatterFieldToBricks(rocfft_location_t                  srcLocation,
-                                             BufferPtr                          input,
-                                             rocfft_precision                   precision,
-                                             rocfft_array_type                  arrayType,
-                                             const data_layout_t&               layout_to_scatter,
-                                             const std::vector<rocfft_brick_t>& bricks,
-                                             const std::vector<size_t>&         antecedents,
-                                             size_t                             elem_size);
+    /**
+     * @brief Creates the plan items required to scatter the output buffer of the (single-device)
+     * execution plan (observing the output data layout set for that execution plan) into the
+     * output data buffer(s) of a multi-device transform.
+     * 
+     * @param[in] execution_plan single-device execution plan.
+     * @param[in] antecedents indices of the plan items that must complete before
+     * the scatter steps may be initiated. 
+     * @return An `std::vector<size_t>` of indices of the created plan items. When these items
+     * complete, the user's output buffers are set with the corresponding portions of the
+     * transform's results.
+     */
+    std::vector<size_t> CreateOutputScatteringItems(const ExecPlan&            execution_plan,
+                                                    const std::vector<size_t>& antecedents);
 
     // Transpose the input field to the output field by adding work items
     // to the plan.  Antecedents are provided as a vector of item
@@ -415,6 +466,22 @@ private:
                   const std::optional<StoreOps>& storeOps,
                   const std::vector<size_t>&     inputAntecedents,
                   std::vector<size_t>&           outputItems);
+
+    /**
+     * @brief Creates and returns the metadata configuring the single-device
+     * execution plan item used for tackling the plan's task. If the plan's
+     * task cannot be handled by a single-device execution item operating on
+     * the current device, the returned object parameterizes an execution plan
+     * item configured to
+     * - read (resp. write) directly from (resp. into) the user's input (resp.
+     *   output) data buffer, if that data is undistribued and expected on the
+     *   current device at execution. If not, default packed layouts for in-place
+     *   operations are set on input and output;
+     * 
+     * - operate in-place, unless the above made that impossible or if the
+     *   plan's configuration does not guarantee that it is safe to do so.
+     */
+    NodeMetaData get_single_dev_exec_plan_metadata() const;
 };
 
 bool PlanPowX(ExecPlan& execPlan);

--- a/projects/rocfft/library/src/include/tree_node.h
+++ b/projects/rocfft/library/src/include/tree_node.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -38,12 +39,14 @@
 #include "../device/kernels/common.h"
 #include "callback_map.h"
 #include "compute_scheme.h"
+#include "data_layout.h"
 #include "enum_printer.h"
 #include "function_map_key.h"
 #include "function_pool.h"
 #include "kargs.h"
 #include "load_store_ops.h"
 #include "logging.h"
+#include "rocfft_current_function.h"
 #include "rocfft_mpi.h"
 #include "rtc_kernel.h"
 #include <hip/hip_runtime_api.h>
@@ -316,6 +319,45 @@ public:
 
     // Distance between consecutive batch members:
     size_t iDist = 0, oDist = 0;
+
+    // TODO: `batch`, `dimension`, `length`, `outputLength` `inStride`,
+    // `outStride`, `iDist`, and `oDist` could (and should) be replaced
+    // by two data_layout_t member objects instead.
+    inline data_layout_t layout_for(io_data_label io) const
+    {
+        switch(io)
+        {
+        case io_data_label::INPUT:
+            return data_layout_t::full_layout(length, inStride, batch, iDist);
+        case io_data_label::OUTPUT:
+            return data_layout_t::full_layout(outputLength, outStride, batch, oDist);
+        default:
+            throw std::invalid_argument("Unknown io data label given to "
+                                        + ROCFFT_CURRENT_FUNCTION);
+        }
+    };
+
+    inline size_t expected_buffer_size_for(io_data_label io) const
+    {
+        if(io != io_data_label::INPUT && io != io_data_label::OUTPUT)
+            throw std::invalid_argument("Invalid value given to " + ROCFFT_CURRENT_FUNCTION);
+
+        const auto layout = layout_for(io);
+        auto       ret
+            = layout.buffer_element_count()
+              * element_size(precision, io == io_data_label::INPUT ? inArrayType : outArrayType);
+        if(placement == rocfft_placement_inplace)
+        {
+            const auto other_layout = layout_for(other(io));
+
+            ret = std::max(
+                ret,
+                other_layout.buffer_element_count()
+                    * element_size(precision,
+                                   other(io) == io_data_label::INPUT ? inArrayType : outArrayType));
+        }
+        return ret;
+    }
 
     // Distance between consecutive batch members in fused Bluestein nodes
     size_t iDistBlue = 0, oDistBlue = 0;

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -96,6 +96,48 @@ static size_t offset_count(rocfft_array_type type)
                : 1;
 }
 
+std::optional<rocfft_location_t>
+    rocfft_plan_description_t::expected_undistributed_location_for(io_data_label io) const
+{
+    if(io != io_data_label::INPUT && io != io_data_label::OUTPUT)
+        throw std::invalid_argument("Invalid argument value given to " + ROCFFT_CURRENT_FUNCTION);
+    const auto& io_fields = io == io_data_label::INPUT ? inFields : outFields;
+    if(io_fields.empty())
+        return get_current_location();
+    // Undistributed I/O data iff only one brick per field.
+    std::optional<rocfft_location_t> ret;
+    if(io_fields.size() == 1 && io_fields[0].bricks.size() == 1)
+        ret = std::make_optional<rocfft_location_t>(io_fields[0].bricks[0].location);
+    return ret;
+}
+
+bool rocfft_plan_description_t::has_undistributed_io_on_current_location() const
+{
+    const auto input_loc = expected_undistributed_location_for(io_data_label::INPUT);
+    if(!input_loc)
+        return false;
+    const auto output_loc = expected_undistributed_location_for(io_data_label::OUTPUT);
+    if(!output_loc || *output_loc != *input_loc)
+        return false;
+    return *input_loc == get_current_location();
+}
+
+const data_layout_t& rocfft_plan_description_t::undistributed_layout_for(io_data_label io) const
+{
+    if(io != io_data_label::INPUT && io != io_data_label::OUTPUT)
+        throw std::invalid_argument("Invalid argument value given to " + ROCFFT_CURRENT_FUNCTION);
+
+    const auto& io_field = io == io_data_label::INPUT ? inFields : outFields;
+    if(io_field.size() > 1 || (io_field.size() == 1 && io_field[0].bricks.size() > 1))
+        throw std::logic_error(ROCFFT_CURRENT_FUNCTION
+                               + " cannot be used with multi-field or multi-brick descriptions.");
+
+    if(io_field.size() == 1 && io_field[0].bricks.size() == 1)
+        return io_field[0].bricks[0].layout;
+
+    return io == io_data_label::INPUT ? input_layout : output_layout;
+}
+
 bool rocfft_plan_description_t::multiple_devices_in_rank(const rocfft_field_t& field)
 {
     // map ranks to a set of distinct devices
@@ -551,76 +593,7 @@ rocfft_location_t rocfft_plan_description_t::get_current_location() const
     return current_loc;
 }
 
-// Given a rocfft_plan with validated parameters, set the transform parameters for the root of the
-// tree plan.
-void set_rootplan_params(const rocfft_plan plan, NodeMetaData& planData)
-{
-    planData.dimension    = plan->desc.rank();
-    planData.batch        = plan->desc.batch();
-    planData.length       = plan->desc.input_layout.lengths();
-    planData.outputLength = plan->desc.output_layout.lengths();
-    planData.inStride     = plan->desc.input_layout.strides();
-    planData.outStride    = plan->desc.output_layout.strides();
-    planData.iDist        = plan->desc.input_layout.distance();
-    planData.oDist        = plan->desc.output_layout.distance();
-    planData.placement    = plan->placement;
-
-    // If in+out fields are specified, currently that means we're
-    // gathering the data to one device and doing FFT there.  So
-    // the FFT becomes in-place.
-    // TODO: if we have no bricks, or just one brick which is the entire FFT, then we can
-    // just do a normal FFT.
-    if(!plan->desc.inFields.empty() && !plan->desc.outFields.empty())
-    {
-        // c2c can be inplace so both input/output can be
-        // contiguous without needing extra buffers
-        if(plan->transformType == rocfft_transform_type_complex_forward
-           || plan->transformType == rocfft_transform_type_complex_inverse)
-        {
-            planData.placement = rocfft_placement_inplace;
-        }
-        // real-complex would require non-contiguous data to be
-        // inplace (which likely means more packing/unpacking and
-        // extra temp buffer usage anyway), so make it
-        // not-in-place instead
-        else
-        {
-            planData.placement = rocfft_placement_notinplace;
-        }
-    }
-    // If we only have outfield, then there's no need to gather.  But we can't assume we can
-    // overwrite input, so the FFT will be outplace to a temp buf
-    else if(plan->desc.inFields.empty() && !plan->desc.outFields.empty())
-    {
-        planData.placement = rocfft_placement_notinplace;
-    }
-    // If we only have infield, then we must gather.
-    else if(!plan->desc.inFields.empty() && plan->desc.outFields.empty())
-    {
-        // If output is contiguous and this is c2c then we can
-        // gather to the output buf and do an inplace FFT.
-        if(plan->desc.output_layout.is_contiguous()
-           && (plan->transformType == rocfft_transform_type_complex_forward
-               || plan->transformType == rocfft_transform_type_complex_inverse))
-            planData.placement = rocfft_placement_inplace;
-        // Otherwise we must gather to a temp buf and do outplace FFT to output
-        else
-            planData.placement = rocfft_placement_notinplace;
-    }
-
-    planData.precision = plan->precision;
-    planData.direction = ((plan->transformType == rocfft_transform_type_complex_forward)
-                          || (plan->transformType == rocfft_transform_type_real_forward))
-                             ? -1
-                             : 1;
-
-    planData.inArrayType  = plan->desc.inArrayType;
-    planData.outArrayType = plan->desc.outArrayType;
-    planData.rootIsC2C    = (planData.inArrayType != rocfft_array_type_real)
-                         && (planData.outArrayType != rocfft_array_type_real);
-}
-
-void set_bluestein_strides(const rocfft_plan plan, NodeMetaData& planData)
+static void set_bluestein_strides(const rocfft_plan_t* plan, NodeMetaData& planData)
 {
     std::array<size_t, 3> inStridesBlue  = {0, 0, 0};
     std::array<size_t, 3> outStridesBlue = {0, 0, 0};
@@ -734,6 +707,133 @@ void set_bluestein_strides(const rocfft_plan plan, NodeMetaData& planData)
     }
     planData.iDistBlue = inDistBlue;
     planData.oDistBlue = outDistBlue;
+}
+
+NodeMetaData rocfft_plan_t::get_single_dev_exec_plan_metadata() const
+{
+    NodeMetaData root_plan(nullptr);
+    root_plan.dimension    = desc.rank();
+    root_plan.batch        = desc.batch();
+    root_plan.precision    = precision;
+    root_plan.direction    = ((transformType == rocfft_transform_type_complex_forward)
+                           || (transformType == rocfft_transform_type_real_forward))
+                                 ? -1
+                                 : 1;
+    root_plan.inArrayType  = desc.inArrayType;
+    root_plan.outArrayType = desc.outArrayType;
+    root_plan.rootIsC2C    = (root_plan.inArrayType != rocfft_array_type_real)
+                          && (root_plan.outArrayType != rocfft_array_type_real);
+    // root plan's data layouts and placement may be different than the calling plan's
+    std::unique_ptr<data_layout_t> root_plan_input_layout, root_plan_output_layout;
+    if(desc.has_undistributed_io_on_current_location())
+    {
+        // "true" single-device usage (no I/O field used or glorified version using
+        // lone bricks for some reason): use the calling plan's own parameters
+        root_plan_input_layout
+            = std::make_unique<data_layout_t>(desc.undistributed_layout_for(io_data_label::INPUT));
+        root_plan_output_layout
+            = std::make_unique<data_layout_t>(desc.undistributed_layout_for(io_data_label::OUTPUT));
+        root_plan.placement = placement;
+    }
+    else
+    {
+        // The root plan parameters define the single-device execution plan
+        // being used in a gather-scatter path. That single-device execution
+        // plan always operates on the current device.
+        const auto current_loc = desc.get_current_location();
+
+        // Single-device plan can always operate out-of-place, but that may trigger
+        // undesirable additional costs such as extra temporary buffer required for
+        // output results (and/or unfriendly gather/scatter extra steps in case of
+        // real transforms). If possible (and allowed) or likely preferrable,
+        // in-place operations are used instead.
+        for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
+        {
+            auto& root_plan_io_layout
+                = io == io_data_label::INPUT ? root_plan_input_layout : root_plan_output_layout;
+            if(root_plan_io_layout)
+                continue; // layout already set
+            const auto io_loc = desc.expected_undistributed_location_for(io);
+            if(io_loc && *io_loc == current_loc)
+            {
+                // The execution plan can access the user's undistributed data directly
+                root_plan_io_layout
+                    = std::make_unique<data_layout_t>(desc.undistributed_layout_for(io));
+                // other io layout to be set for the execution plan:
+                auto&      root_plan_other_io_layout = other(io) == io_data_label::INPUT
+                                                           ? root_plan_input_layout
+                                                           : root_plan_output_layout;
+                const auto other_lengths             = other(io) == io_data_label::INPUT
+                                                           ? desc.input_layout.lengths()
+                                                           : desc.output_layout.lengths();
+                auto       tmp = root_plan_io_layout->get_other_inplace_layout_for(
+                    other(io), transformType, other_lengths[0] % 2 == 1);
+                // If tmp has a value set, in-place operations can be done using that layout
+                // - if the plan was configured in-place by the user
+                // - or if the execution plan can operate entirely in the user's (undistributed)
+                //   output data buffer without risking overwriting anything it shouldn't touch
+                //   (i.e., if contiguous data is expected therein), *and* without risking writing
+                //   past the buffer's bounds.
+                if(tmp
+                   && (placement == rocfft_placement_inplace
+                       || (io == io_data_label::OUTPUT && root_plan_io_layout->is_contiguous()
+                           && transformType != rocfft_transform_type_real_inverse)))
+                {
+                    // execution plan may and can operate in-place.
+                    root_plan_other_io_layout = std::make_unique<data_layout_t>(std::move(*tmp));
+                    root_plan.placement       = rocfft_placement_inplace;
+                }
+                else
+                {
+                    // in-place is not allowed or it can't be done or it would require a larger buffer
+                    // than what's safe to expect from user. Pack results contiguously in a temporary
+                    // buffer and work out of place.
+                    root_plan_other_io_layout = std::make_unique<data_layout_t>(
+                        data_layout_t::default_full_layout(other_lengths, desc.batch()));
+                    root_plan.placement = rocfft_placement_notinplace;
+                }
+            }
+        }
+    }
+
+    if(!root_plan_input_layout && !root_plan_output_layout)
+    {
+        // Input and output data are distributed or none of them are directly accessible
+        // from the current location. Temporary buffers on current device are used for input
+        // and output of the execution plan. In-place default layout operations are
+        // used to minimizing the library's memory footprint.
+        root_plan.placement    = rocfft_placement_inplace;
+        root_plan_input_layout = std::make_unique<data_layout_t>(data_layout_t::default_full_layout(
+            desc.input_layout.lengths(),
+            desc.input_layout.batch(),
+            transformType == rocfft_transform_type_real_forward));
+        root_plan_output_layout
+            = std::make_unique<data_layout_t>(data_layout_t::default_full_layout(
+                desc.output_layout.lengths(),
+                desc.output_layout.batch(),
+                transformType == rocfft_transform_type_real_inverse));
+    }
+    // I/O layouts should both set at this point
+    for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
+    {
+        const auto& root_plan_io_layout
+            = io == io_data_label::INPUT ? root_plan_input_layout : root_plan_output_layout;
+        if(!root_plan_io_layout)
+            throw std::logic_error(ROCFFT_CURRENT_FUNCTION + " failed to define the " + to_str(io)
+                                   + " layout of the single-device execution plan item");
+    }
+
+    root_plan.length       = root_plan_input_layout->lengths();
+    root_plan.inStride     = root_plan_input_layout->strides();
+    root_plan.iDist        = root_plan_input_layout->distance();
+    root_plan.outputLength = root_plan_output_layout->lengths();
+    root_plan.outStride    = root_plan_output_layout->strides();
+    root_plan.oDist        = root_plan_output_layout->distance();
+
+    root_plan.deviceProp = get_curr_device_prop();
+    set_bluestein_strides(this, root_plan);
+
+    return root_plan;
 }
 
 // return an ExecPlan that transposes a brick
@@ -1032,6 +1132,13 @@ rocfft_status
         }
     }
 
+    if(inFields.size() > 1 || outFields.size() > 1)
+    {
+        // This would warrant a dedicated error code, e.g., rocfft_status_unsupported. For now,
+        // throw an std::runtime_error so that ROCFFT_LAYER reports something insightful
+        throw std::runtime_error("Multi-field transforms are not supported yet");
+    }
+
     // -------------------------------------------------------------------------------
     // Remove trivial axes of unit lengths from layouts (and from all bricks' layouts,
     // too) and sort length axes by increasing strides (in corresponding bricks, too)
@@ -1220,14 +1327,130 @@ rocfft_status
             throw std::invalid_argument("Unexpected type of transform given to "
                                         + ROCFFT_CURRENT_FUNCTION);
         }
-        // MORE TO BE DONE:
-        // - layout consistency requirements for single-device usage (including
-        //   offset values, if not ignored)
-        // - identical locations for I/O data buffers if fields are not empty
-        // - ...
-        // Will be integrated when more unifying logic is added (e.g., when
-        // unifying code paths between empty-fields usage and
-        // single-io-fields-with-lone-bricks-on-current-device usage)
+        // ----------------------------------------------------------------------
+        //   Consistency of data locations for multi-device in-place operations
+        // ----------------------------------------------------------------------
+        if(!inFields.empty() || !outFields.empty())
+        {
+            // Verify that input and output locations match
+            if(inFields.empty() || outFields.empty())
+            {
+                const auto& first_corresponding_brick
+                    = inFields.empty() ? outFields[0].bricks[0] : inFields[0].bricks[0];
+                if(first_corresponding_brick.location != get_current_location())
+                {
+                    // This would warrant a dedicated error code, e.g.,
+                    // "rocfft_status_invalid_description". For now, throw an std::runtime_error
+                    // so that ROCFFT_LAYER reports something insightful
+                    throw std::runtime_error(
+                        "If only one field is used and in-place operations are required, the first "
+                        "brick on the first field must be located on the current device");
+                }
+            }
+            else
+            {
+                // Fields are used for both input and output, parse all bricks in
+                // parallel and verify per-rank consistency of locations
+                const auto local_rank = get_local_comm_rank();
+                for(size_t field_idx = 0; field_idx < std::min(inFields.size(), outFields.size());
+                    field_idx++)
+                {
+                    const auto& ibricks = inFields[field_idx].bricks;
+                    const auto& obricks = outFields[field_idx].bricks;
+                    auto        ibrick  = std::find_if(
+                        ibricks.begin(), ibricks.end(), [&local_rank](const auto& brick) {
+                            return brick.location.comm_rank == local_rank;
+                        });
+                    auto obrick = std::find_if(
+                        obricks.begin(), obricks.end(), [&local_rank](const auto& brick) {
+                            return brick.location.comm_rank == local_rank;
+                        });
+                    while(ibrick != inFields[field_idx].bricks.end()
+                          && obrick != outFields[field_idx].bricks.end()
+                          && ibrick->location.comm_rank == local_rank
+                          && obrick->location.comm_rank == local_rank)
+                    {
+                        if(ibrick->location.device != obrick->location.device)
+                        {
+                            throw std::runtime_error(
+                                "Inconsistent brick locations for in-place operations: input brick "
+                                + ibrick->str() + " and output brick " + obrick->str()
+                                + " were expected on the same device");
+                        }
+                        ibrick++;
+                        obrick++;
+                    }
+                }
+            }
+        }
+        // -------------------------------------------------------------------
+        //          Consistency of data layouts for in-place operations
+        // -------------------------------------------------------------------
+        if(has_undistributed_io_on_current_location())
+        {
+            // Actual single-device usage (possibly with lone bricks, though).
+            // Lone bricks' layouts take precedence, if used
+            const auto& in_layout           = undistributed_layout_for(io_data_label::INPUT);
+            const auto& out_layout          = undistributed_layout_for(io_data_label::OUTPUT);
+            const auto  out_lengths         = output_layout.lengths();
+            const auto  expected_out_layout = in_layout.get_other_inplace_layout_for(
+                io_data_label::OUTPUT, dft_type, out_lengths[0] % 2 == 1);
+            if(!expected_out_layout)
+                throw std::runtime_error(
+                    "Undistributed input layout is incompatible with in-place operations.");
+            if(*expected_out_layout != out_layout)
+                throw std::runtime_error("Undistributed input and output layout are not compatible "
+                                         "for single-device in-place transforms.");
+            // Check offsets if they're not to be ignored
+            if(inFields.empty() && outFields.empty())
+            {
+                if(dft_type == rocfft_transform_type_complex_forward
+                   || dft_type == rocfft_transform_type_complex_inverse)
+                {
+                    if(inOffset[0] != outOffset[0]
+                       || (array_type_is_planar(inArrayType) && inOffset[1] != outOffset[1]))
+                        throw std::runtime_error("Identical offsets are required for single-device "
+                                                 "in-place complex transforms.");
+                }
+                else
+                {
+                    const auto& real_offset
+                        = dft_type == rocfft_transform_type_real_forward ? inOffset : outOffset;
+                    const auto& hermitian_offset
+                        = dft_type == rocfft_transform_type_real_forward ? outOffset : inOffset;
+                    if(real_offset[0] != 2 * hermitian_offset[0])
+                        throw std::runtime_error(
+                            "Inconsistent offsets for single-device in-place real transforms.");
+                }
+            }
+            else if((inFields.empty() && inOffset[0] != 0 && !outFields.empty())
+                    || (outFields.empty() && outOffset[0] != 0 && !inFields.empty()))
+            {
+                // If input (resp. output) is a lone-brick field while output (resp. input) has
+                // no field set, the input (resp. output) offset values will be ignored and nonzero
+                // offset values on output (resp. input) cannot be accepted (note: planar array
+                // types not supported if any I/O field is set)
+                throw std::runtime_error("Nonzero input (resp. output) offset values cannot be "
+                                         "used for in-place operations if the output (resp. input) "
+                                         "layout is dictated by a lone-brick field.");
+            }
+        }
+        //else
+        //{
+        //    // TBD
+        //    // "in-place" operations with non-trivial fields used on both inputs and outputs, so
+        //    // offsets are ignored since brick layouts take precedence in that case.
+        //    // TODO: parse input and output fields' bricks: for any brick that covers a non-partial
+        //    // (i.e., full) length dimension that may be processed in-place, the corresponding
+        //    // layout's requirements must be satisfied.
+        //    // More developments required in data_layout_t for those purposes, e.g., sthg like
+        //    // -----------------------------------------------------------------------------------------------
+        //    // data_layout_t data_layout_t::extract_full_length_axes_for(rocfft_transform_type dft_type);
+        //    // -----------------------------------------------------------------------------------------------
+        //    // then continue if empty or query the returned object's get_other_inplace_layout_for and throw if
+        //    // the returned optional has no value...
+        //    //
+        //}
     }
     return rocfft_status_success;
 }
@@ -1241,8 +1464,7 @@ struct TempBufferLease
         std::multimap<rocfft_location_t, std::shared_ptr<InternalTempBuffer>>& _tempBuffers,
         int                                                                    local_comm_rank,
         rocfft_location_t                                                      _location,
-        size_t                                                                 _elems,
-        size_t                                                                 _elem_size)
+        size_t                                                                 byte_size)
         : location(_location)
         , tempBuffers(&_tempBuffers)
     {
@@ -1256,12 +1478,11 @@ struct TempBufferLease
         }
 
         // return an existing buffer that's big enough, if one exists
-        const size_t alloc_size = _elems * _elem_size;
-        auto         i          = tempBuffers->lower_bound(location);
+        auto i = tempBuffers->lower_bound(location);
         if(i != tempBuffers->upper_bound(location))
         {
             // found a buffer, ensure it's big enough
-            i->second->set_size_bytes(alloc_size);
+            i->second->set_size_bytes(byte_size);
 
             // leasing out this temp buffer, remove it from the map
             buf = i->second;
@@ -1270,7 +1491,7 @@ struct TempBufferLease
         }
         // no buffer was found, allocate a new one
         buf = std::make_shared<InternalTempBuffer>(local_comm_rank);
-        buf->set_size_bytes(alloc_size);
+        buf->set_size_bytes(byte_size);
     }
     ~TempBufferLease()
     {
@@ -1385,295 +1606,6 @@ static std::vector<BufferPtr> GatherUserBuffers(BufferPtrConstruct              
     return ret;
 }
 
-std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t currentLocation,
-                                                       const std::vector<rocfft_brick_t>& bricks,
-                                                       rocfft_precision                   precision,
-                                                       rocfft_array_type                  arrayType,
-                                                       const data_layout_t&       gathering_layout,
-                                                       BufferPtr                  output,
-                                                       const std::vector<size_t>& antecedents,
-                                                       size_t                     elem_size)
-{
-    std::vector<size_t>            outputPlanItems;
-    std::vector<TempBufferLease>   gatherPackBufs;
-    std::optional<TempBufferLease> gatherDestBuf;
-
-    std::vector<BufferPtr> inputBufs = GatherUserBuffers(BufferPtr::user_input, bricks);
-
-    const auto local_comm_rank = desc.get_local_comm_rank();
-
-    BufferPtr  gatherDest;
-    const bool gatherToTemp
-        = std::any_of(bricks.begin(), bricks.end(), [&](const rocfft_brick_t& brick) {
-              return !brick.layout.is_contiguous()
-                     || !brick.layout.is_continuous_in(gathering_layout);
-          });
-    if(gatherToTemp)
-    {
-        // this is from source-rank to source-rank, before MPI comm.
-        gatherDestBuf = std::make_optional<TempBufferLease>(tempBuffers,
-                                                            local_comm_rank,
-                                                            currentLocation,
-                                                            gathering_layout.logical_count(),
-                                                            elem_size);
-        gatherDest    = BufferPtr::temp(gatherDestBuf->data());
-    }
-    else
-    {
-        gatherDest = output;
-    }
-
-    // Create gather operation
-    auto gatherPtr = std::make_unique<CommGather>(
-        local_comm_rank, precision, arrayType, currentLocation, gatherDest);
-    auto gather         = gatherPtr.get();
-    gather->description = "Gather " + std::to_string(bricks.size()) + " bricks";
-
-    // Add gather to the plan first - we will add operations to it later
-    size_t gatherIdx = AddMultiPlanItem(std::move(gatherPtr), antecedents);
-
-    // We'll be packing the brick data contiguously into the output,
-    // so keep track of how much of the output we've filled up.
-    // Track offset per location since we have one temp buffer per
-    // location.
-    std::map<rocfft_location_t, size_t> packOffsets;
-    size_t                              gatherOffset = 0;
-    for(size_t brickIdx = 0; brickIdx < bricks.size(); ++brickIdx)
-    {
-        const auto& brick = bricks[brickIdx];
-
-        // init offset for this location if it's not already
-        // initialized, and get a reference to this location's
-        // offset.
-        size_t& packOffset
-            = packOffsets.emplace(brick.location, static_cast<size_t>(0)).first->second;
-
-        if(brick.layout.is_contiguous())
-        {
-            // Contiguous brick, just copy the data
-            gather->AddOperation(
-                local_comm_rank,
-                {brick.location,
-                 inputBufs[brickIdx],
-                 0,
-                 gatherToTemp ? gatherOffset : brick.layout.offset_in(gathering_layout),
-                 brick.layout.logical_count()});
-        }
-        else
-        {
-            // Allocate temp memory for the pack
-            gatherPackBufs.emplace_back(tempBuffers,
-                                        local_comm_rank,
-                                        brick.location,
-                                        brick.layout.logical_count(),
-                                        elem_size);
-
-            // Brick is not contiguous, insert a pack node on the brick's device
-            std::string description = "pack brick " + std::to_string(brickIdx) + " before gather";
-            auto        packIdx
-                = AddMultiPlanItem(transpose_brick(local_comm_rank,
-                                                   brick.location,
-                                                   brick.layout.lengths_and_batches(),
-                                                   precision,
-                                                   arrayType,
-                                                   inputBufs[brickIdx],
-                                                   0,
-                                                   brick.layout.strides_and_distances(),
-                                                   BufferPtr::temp(gatherPackBufs.back().data()),
-                                                   packOffset,
-                                                   brick.layout.contiguous_strides_and_distances(),
-                                                   std::move(description)),
-                                   antecedents);
-            AddAntecedent(gatherIdx, packIdx);
-
-            gather->AddOperation(local_comm_rank,
-                                 {brick.location,
-                                  BufferPtr::temp(gatherPackBufs.back().data()),
-                                  0,
-                                  gatherOffset,
-                                  brick.layout.logical_count()});
-        }
-
-        // if brick is not contiguous in the field, it was packed to
-        // be contiguous for communication.  unpack it so it's
-        // contiguous in the field.
-        if(!brick.layout.is_contiguous() || !brick.layout.is_continuous_in(gathering_layout))
-        {
-            std::string description = "unpack brick " + std::to_string(brickIdx) + " after gather";
-
-            outputPlanItems.push_back(
-                AddMultiPlanItem(transpose_brick(local_comm_rank,
-                                                 currentLocation,
-                                                 brick.layout.lengths_and_batches(),
-                                                 precision,
-                                                 arrayType,
-                                                 BufferPtr::temp(gatherDestBuf->data()),
-                                                 gatherOffset,
-                                                 brick.layout.contiguous_strides_and_distances(),
-                                                 output,
-                                                 brick.layout.offset_in(gathering_layout),
-                                                 gathering_layout.strides_and_distances(),
-                                                 std::move(description)),
-                                 {gatherIdx}));
-        }
-
-        packOffset += brick.layout.logical_count();
-        gatherOffset += brick.layout.logical_count();
-    }
-
-    if(outputPlanItems.empty())
-    {
-        // following items in the plan just depend on the gather completing
-        outputPlanItems.push_back(gatherIdx);
-    }
-    return outputPlanItems;
-}
-
-std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t    currentLocation,
-                                                        BufferPtr            input,
-                                                        rocfft_precision     precision,
-                                                        rocfft_array_type    arrayType,
-                                                        const data_layout_t& layout_to_scatter,
-                                                        const std::vector<rocfft_brick_t>& bricks,
-                                                        const std::vector<size_t>& antecedents,
-                                                        size_t                     elem_size)
-{
-    std::vector<size_t>            outputPlanItems;
-    std::vector<TempBufferLease>   scatterPackBufs;
-    std::optional<TempBufferLease> scatterSrcBuf;
-
-    std::vector<BufferPtr> outputBufs = GatherUserBuffers(BufferPtr::user_output, bricks);
-
-    const auto local_comm_rank = desc.get_local_comm_rank();
-
-    BufferPtr  scatterSrc;
-    const bool scatterFromTemp
-        = std::any_of(bricks.begin(), bricks.end(), [&](const rocfft_brick_t& b) {
-              return !b.layout.is_contiguous() || !b.layout.is_continuous_in(layout_to_scatter);
-          });
-    if(scatterFromTemp)
-    {
-        scatterSrcBuf = std::make_optional<TempBufferLease>(tempBuffers,
-                                                            local_comm_rank,
-                                                            currentLocation,
-                                                            layout_to_scatter.logical_count(),
-                                                            elem_size);
-        scatterSrc    = BufferPtr::temp(scatterSrcBuf->data());
-    }
-    else
-    {
-        scatterSrc = input;
-    }
-
-    // create scatter operation
-    auto scatterPtr
-        = std::make_unique<CommScatter>(precision, arrayType, currentLocation, scatterSrc);
-    auto scatter         = scatterPtr.get();
-    scatter->description = "Scatter " + std::to_string(bricks.size()) + " bricks";
-
-    // add scatter to the multi-plan first, add operations afterwards
-    auto scatterIdx = AddMultiPlanItem(std::move(scatterPtr), antecedents);
-
-    // we'll be packing the brick data contiguously into the output,
-    // so keep track of how much of the output we've filled up
-    size_t scatterOffset = 0;
-
-    for(size_t brickIdx = 0; brickIdx < bricks.size(); ++brickIdx)
-    {
-        const auto& brick = bricks[brickIdx];
-
-        if(brick.layout.is_contiguous() && brick.layout.is_continuous_in(layout_to_scatter))
-        {
-            // contiguous brick, just copy the data
-            scatter->AddOperation(
-                local_comm_rank,
-                {brick.location,
-                 outputBufs[brickIdx],
-                 scatterFromTemp ? scatterOffset : brick.layout.offset_in(layout_to_scatter),
-                 0,
-                 brick.layout.logical_count()});
-        }
-        else
-        {
-            // pack data to be contiguous
-            std::string description = "pack brick " + std::to_string(brickIdx) + " before scatter";
-
-            auto packIdx
-                = AddMultiPlanItem(transpose_brick(local_comm_rank,
-                                                   currentLocation,
-                                                   brick.layout.lengths_and_batches(),
-                                                   precision,
-                                                   arrayType,
-                                                   input,
-                                                   brick.layout.offset_in(layout_to_scatter),
-                                                   layout_to_scatter.strides_and_distances(),
-                                                   BufferPtr::temp(scatterSrcBuf->data()),
-                                                   scatterOffset,
-                                                   brick.layout.contiguous_strides_and_distances(),
-                                                   std::move(description)),
-                                   antecedents);
-            AddAntecedent(scatterIdx, packIdx);
-
-            // Bricks are packed to be contiguous - if output is the
-            // same shape, then there's no need for unpacking
-            if(brick.layout.is_contiguous())
-            {
-                scatter->AddOperation(local_comm_rank,
-                                      {brick.location,
-                                       outputBufs[brickIdx],
-                                       scatterOffset,
-                                       0,
-                                       brick.layout.logical_count()});
-            }
-            else
-            {
-                // allocate memory for packed data
-                scatterPackBufs.emplace_back(tempBuffers,
-                                             local_comm_rank,
-                                             brick.location,
-                                             brick.layout.logical_count(),
-                                             elem_size);
-
-                // send the data
-                scatter->AddOperation(local_comm_rank,
-                                      {brick.location,
-                                       BufferPtr::temp(scatterPackBufs.back().data()),
-                                       scatterOffset,
-                                       0,
-                                       brick.layout.logical_count()});
-
-                // unpack data after sending
-                description = "unpack brick " + std::to_string(brickIdx) + " after scatter";
-
-                outputPlanItems.push_back(AddMultiPlanItem(
-                    transpose_brick(local_comm_rank,
-                                    brick.location,
-                                    brick.layout.lengths_and_batches(),
-                                    precision,
-                                    arrayType,
-                                    BufferPtr::temp(scatterPackBufs.back().data()),
-                                    0,
-                                    brick.layout.contiguous_strides_and_distances(),
-                                    outputBufs[brickIdx],
-                                    0,
-                                    brick.layout.strides_and_distances(),
-                                    std::move(description)),
-                    {scatterIdx}));
-            }
-        }
-        scatterOffset += brick.layout.logical_count();
-    }
-
-    // following items in the plan just depend on the scatter
-    // completing if no unpacking was required
-    if(outputPlanItems.empty())
-    {
-        outputPlanItems.push_back(scatterIdx);
-    }
-
-    return outputPlanItems;
-}
-
 // test if the specified dimension is split up across separate bricks
 // in the field
 static bool DimensionSplitInField(size_t length, size_t dimIdx, const rocfft_field_t& field)
@@ -1682,122 +1614,6 @@ static bool DimensionSplitInField(size_t length, size_t dimIdx, const rocfft_fie
         if(b.layout.lengths_and_batches()[dimIdx] != length)
             return true;
     return false;
-}
-
-// Construct a single-device execPlan - fill out the provided
-// execPlan with nodes to implement the FFT.
-void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& execPlanPtr)
-{
-    // The smart pointer will be moved into the multi-plan during this
-    // function, so keep a plain non-owning pointer
-    auto execPlan = execPlanPtr.get();
-
-    // If we have no input/output fields, then the single ExecPlan is
-    // exactly what we need to do
-    if(desc.inFields.empty() && desc.outFields.empty())
-    {
-        AddMultiPlanItem(std::move(execPlanPtr), {});
-        return;
-    }
-
-    // Code below this line is only required for multi-device plans
-    execPlan->mgpuPlan    = true;
-    execPlan->description = "FFT gathered data";
-
-    // Ensure fields are real or interleaved - planar is not supported
-    if((!desc.inFields.empty() && array_type_is_planar(desc.inArrayType))
-       || (!desc.outFields.empty() && array_type_is_planar(desc.outArrayType)))
-    {
-        throw std::runtime_error("fields must be not be planar");
-    }
-
-    const auto in_elem_size = element_size(precision, desc.inArrayType);
-    // We do in-place transforms here, so allocate a buffer for the
-    // complex side of real-complex transforms, since it's bigger.
-    const size_t in_elem_count = desc.input_layout.buffer_element_count();
-
-    const auto local_comm_rank = desc.get_local_comm_rank();
-
-    // May need buffer(s) to do the actual FFT
-    std::shared_ptr<TempBufferLease> fftBuf;
-    std::shared_ptr<TempBufferLease> fftOutBuf;
-
-    BufferPtr gatherBuf;
-    {
-        if(!desc.inFields.empty() && desc.outFields.empty() && desc.output_layout.is_contiguous()
-           && execPlan->rootPlan->placement == rocfft_placement_inplace)
-        {
-            // We can gather directly to the output buffer and will operate in-place
-            // thereafter
-            gatherBuf = BufferPtr::user_output(0, 0);
-        }
-        else if(desc.inFields.empty())
-        {
-            gatherBuf = BufferPtr::user_input(0, 0);
-        }
-        else
-        {
-            fftBuf = std::make_shared<TempBufferLease>(
-                tempBuffers, local_comm_rank, execPlanPtr->location, in_elem_count, in_elem_size);
-            gatherBuf = BufferPtr::temp(fftBuf->data());
-        }
-    }
-
-    // Allocate another temp buf if FFT is not-in-place and outfield was specified
-    // TODO: this only needs to be done if there are multiple bricks in the output field.
-    if(execPlan->rootPlan->placement == rocfft_placement_notinplace && !desc.outFields.empty())
-    {
-        const auto   out_elem_size  = element_size(precision, desc.outArrayType);
-        const size_t out_elem_count = desc.output_layout.buffer_element_count();
-        fftOutBuf                   = std::make_shared<TempBufferLease>(
-            tempBuffers, local_comm_rank, execPlanPtr->location, out_elem_count, out_elem_size);
-    }
-
-    std::vector<size_t> gatherIndexes;
-    {
-        for(const auto& inField : desc.inFields)
-        {
-            auto curIndexes = GatherBricksToField(execPlan->location,
-                                                  inField.bricks,
-                                                  precision,
-                                                  desc.inArrayType,
-                                                  desc.input_layout,
-                                                  gatherBuf,
-                                                  {},
-                                                  element_size(precision, desc.inArrayType));
-            std::copy(curIndexes.begin(), curIndexes.end(), std::back_inserter(gatherIndexes));
-        }
-
-        // Data is gathered and unpacked (if necessary), run the core FFT plan we started with
-        if(gatherBuf)
-            execPlan->inputPtr = gatherBuf;
-        else
-            execPlan->inputPtr = BufferPtr::user_input(0, 0);
-
-        if(execPlan->rootPlan->placement == rocfft_placement_inplace)
-            execPlan->outputPtr = execPlan->inputPtr;
-        else if(fftOutBuf)
-            execPlan->outputPtr = BufferPtr::temp(fftOutBuf->data());
-    }
-    auto fftIdx = AddMultiPlanItem(std::move(execPlanPtr), gatherIndexes);
-
-    // Scatter data back out
-    for(const auto& outField : desc.outFields)
-    {
-        // brick indexes include batch so create a set of comparable field strides
-        auto scatterSrcBuf = execPlan->rootPlan->placement == rocfft_placement_notinplace
-                                 ? fftOutBuf->data()
-                                 : fftBuf->data();
-
-        ScatterFieldToBricks(execPlan->location,
-                             BufferPtr::temp(scatterSrcBuf),
-                             execPlan->rootPlan->precision,
-                             execPlan->rootPlan->outArrayType,
-                             desc.output_layout,
-                             outField.bricks,
-                             {fftIdx},
-                             element_size(precision, execPlan->rootPlan->outArrayType));
-    }
 }
 
 // Construct a single-device execPlan - fill out the provided
@@ -1915,6 +1731,393 @@ static std::unique_ptr<ExecPlan> BuildSingleDevicePlan(NodeMetaData&         roo
             PrintNode(*LogSingleton::GetInstance().GetPlanOS(), execPlan);
         throw;
     }
+}
+
+std::vector<size_t> rocfft_plan_t::CreateInputGatheringItems(const ExecPlan& execution_plan,
+                                                             const std::vector<size_t>& antecedents)
+{
+    std::vector<size_t> gather_plan_items;
+    if(execution_plan.inputPtr.ptr_type() == BufferPtr::PtrType::PTR_USER_IN)
+    {
+        // no need to gather, input data is readily available to the single-device execution plan
+        return gather_plan_items;
+    }
+    if(!execution_plan.inputPtr)
+    {
+        throw std::invalid_argument(
+            ROCFFT_CURRENT_FUNCTION
+            + " requires the given single-device execution plan's input pointer to be defined");
+    }
+
+    if(desc.inFields.size() != 1)
+        throw std::logic_error(ROCFFT_CURRENT_FUNCTION
+                               + " expected a unique input field but encountered "
+                               + std::to_string(desc.inFields.size()));
+
+    const auto& input_bricks    = desc.inFields[0].bricks;
+    const auto  local_comm_rank = desc.get_local_comm_rank();
+    const auto  input_buffers   = GatherUserBuffers(BufferPtr::user_input, input_bricks);
+    const auto  input_elem_size = element_size(precision, desc.inArrayType);
+    // data layout to be observed by the final results of the data-gathering steps
+    const auto single_dev_input_layout = execution_plan.rootPlan->layout_for(io_data_label::INPUT);
+
+    // Create node that captures data-gathering steps
+    std::unique_ptr<CommGather> gather_node;
+    if(std::all_of(input_bricks.begin(), input_bricks.end(), [&](const rocfft_brick_t& ibrick) {
+           return ibrick.layout.is_continuous_in(single_dev_input_layout)
+                  && (execution_plan.inputPtr.ptr_type() == BufferPtr::PtrType::PTR_TEMP
+                      || ibrick.layout.is_contiguous());
+       }))
+    {
+        // All inputs may and can be copied directly into the execution plan's input buffer
+        gather_node              = std::make_unique<CommGather>(local_comm_rank,
+                                                   precision,
+                                                   desc.inArrayType,
+                                                   execution_plan.location,
+                                                   execution_plan.inputPtr);
+        gather_node->description = "Gather input data of " + std::to_string(input_bricks.size())
+                                   + " bricks directly into single-device plan's input buffer";
+        for(size_t b_idx = 0; b_idx < input_bricks.size(); ++b_idx)
+        {
+            const auto& ibrick = input_bricks[b_idx];
+            gather_node->AddOperation(local_comm_rank,
+                                      {ibrick.location,
+                                       input_buffers[b_idx],
+                                       0 /* : srcOffset */,
+                                       ibrick.layout.offset_in(single_dev_input_layout),
+                                       ibrick.layout.buffer_element_count()});
+        }
+        gather_plan_items.push_back(AddMultiPlanItem(std::move(gather_node), antecedents));
+    }
+    else
+    {
+        // At least one of the inputs cannot be copied directly into the execution plan's
+        // input buffer. A temporary buffer is used to pack input buffers locally before
+        // transposing it to match the data layout that's expected by the execution plan.
+        const data_layout_t packed_layout = data_layout_t::default_full_layout(
+            single_dev_input_layout.lengths(), single_dev_input_layout.batch());
+        TempBufferLease packing_temp_buffer(tempBuffers,
+                                            local_comm_rank,
+                                            execution_plan.location,
+                                            packed_layout.logical_count() * input_elem_size);
+        gather_node = std::make_unique<CommGather>(local_comm_rank,
+                                                   precision,
+                                                   desc.inArrayType,
+                                                   execution_plan.location,
+                                                   BufferPtr::temp(packing_temp_buffer.data()));
+
+        gather_node->description = "Gather contiguously-packed input data chunks for "
+                                   + std::to_string(input_bricks.size()) + " bricks";
+        // save the raw pointer as gather_node will be moved below
+        auto gather_node_raw_ptr = gather_node.get();
+        // Add gather_node to the plan, operations are added to it below
+        const auto gatherIdx = AddMultiPlanItem(std::move(gather_node), antecedents);
+        // Devices may need to pack their data (locally) before having it transferred
+        // to packing_temp_buffer
+        std::vector<TempBufferLease> local_packed_chunk;
+        size_t                       packed_offset = 0;
+        for(size_t b_idx = 0; b_idx < input_bricks.size(); ++b_idx)
+        {
+            const auto& ibrick = input_bricks[b_idx];
+
+            if(ibrick.layout.is_contiguous())
+            {
+                // a direct copy into packing_temp_buffer may be done
+                gather_node_raw_ptr->AddOperation(local_comm_rank,
+                                                  {ibrick.location,
+                                                   input_buffers[b_idx],
+                                                   0 /* : srcOffset */,
+                                                   packed_offset,
+                                                   ibrick.layout.logical_count()});
+            }
+            else
+            {
+                // Pre-pack data locally on the brick's device before transferring it
+                // to packing_temp_buffer
+                std::string local_pack_description
+                    = "pack brick " + std::to_string(b_idx) + "'s input data on device "
+                      + std::to_string(ibrick.location.device) + " (rank "
+                      + std::to_string(ibrick.location.comm_rank) + ") before gather";
+                local_packed_chunk.emplace_back(tempBuffers,
+                                                local_comm_rank,
+                                                ibrick.location,
+                                                ibrick.layout.logical_count() * input_elem_size);
+                const auto packIdx = AddMultiPlanItem(
+                    transpose_brick(local_comm_rank,
+                                    ibrick.location,
+                                    ibrick.layout.lengths_and_batches(),
+                                    precision,
+                                    desc.inArrayType,
+                                    input_buffers[b_idx],
+                                    0 /* : offsetIn */,
+                                    ibrick.layout.strides_and_distances(),
+                                    BufferPtr::temp(local_packed_chunk.back().data()),
+                                    0 /* : offsetOut */,
+                                    ibrick.layout.contiguous_strides_and_distances(),
+                                    std::move(local_pack_description)),
+                    antecedents);
+                AddAntecedent(gatherIdx, packIdx);
+
+                gather_node_raw_ptr->AddOperation(
+                    local_comm_rank,
+                    {ibrick.location,
+                     BufferPtr::temp(local_packed_chunk.back().data()),
+                     0 /* : srcOffset */,
+                     packed_offset,
+                     ibrick.layout.logical_count()});
+            }
+            std::string description
+                = "unpack brick " + std::to_string(b_idx)
+                  + "'s contiguous data chunk into single-device plan's input buffer";
+            gather_plan_items.push_back(
+                AddMultiPlanItem(transpose_brick(local_comm_rank,
+                                                 execution_plan.location,
+                                                 ibrick.layout.lengths_and_batches(),
+                                                 precision,
+                                                 desc.inArrayType,
+                                                 BufferPtr::temp(packing_temp_buffer.data()),
+                                                 packed_offset,
+                                                 ibrick.layout.contiguous_strides_and_distances(),
+                                                 execution_plan.inputPtr,
+                                                 ibrick.layout.offset_in(single_dev_input_layout),
+                                                 single_dev_input_layout.strides_and_distances(),
+                                                 std::move(description)),
+                                 {gatherIdx}));
+            packed_offset += ibrick.layout.logical_count();
+        }
+    }
+    return gather_plan_items;
+}
+
+std::vector<size_t>
+    rocfft_plan_t::CreateOutputScatteringItems(const ExecPlan&            execution_plan,
+                                               const std::vector<size_t>& antecedents)
+{
+    std::vector<size_t> scatter_plan_items;
+    if(execution_plan.outputPtr.ptr_type() == BufferPtr::PtrType::PTR_USER_OUT)
+    {
+        // no need to scatter, output data is written directly the single-device execution plan
+        return scatter_plan_items;
+    }
+    if(!execution_plan.outputPtr)
+    {
+        throw std::invalid_argument(
+            ROCFFT_CURRENT_FUNCTION
+            + " requires the given single-device execution plan's output pointer to be defined");
+    }
+
+    if(desc.outFields.size() != 1)
+        throw std::logic_error(ROCFFT_CURRENT_FUNCTION
+                               + " expected a unique output field but encountered "
+                               + std::to_string(desc.outFields.size()));
+
+    const auto& output_bricks    = desc.outFields[0].bricks;
+    const auto  local_comm_rank  = desc.get_local_comm_rank();
+    const auto  output_buffers   = GatherUserBuffers(BufferPtr::user_output, output_bricks);
+    const auto  output_elem_size = element_size(precision, desc.outArrayType);
+    // data layout of the results to be scattered
+    const auto single_dev_output_layout
+        = execution_plan.rootPlan->layout_for(io_data_label::OUTPUT);
+
+    // Create node that captures data-scattering steps
+    std::unique_ptr<CommScatter> scatter_node;
+    if(std::all_of(output_bricks.begin(), output_bricks.end(), [&](const rocfft_brick_t& obrick) {
+           return obrick.layout.is_continuous_in(single_dev_output_layout)
+                  && obrick.layout.is_contiguous();
+       }))
+    {
+        // All outputs are continuous chunks of the execution plan's output buffer and the
+        // chunks may be transferred directly
+        scatter_node = std::make_unique<CommScatter>(
+            precision, desc.outArrayType, execution_plan.location, execution_plan.outputPtr);
+        scatter_node->description = "Scatter single-device plan's output buffer directly to "
+                                    + std::to_string(output_bricks.size()) + " bricks";
+        for(size_t b_idx = 0; b_idx < output_bricks.size(); ++b_idx)
+        {
+            const auto& obrick = output_bricks[b_idx];
+            scatter_node->AddOperation(local_comm_rank,
+                                       {obrick.location,
+                                        output_buffers[b_idx],
+                                        obrick.layout.offset_in(single_dev_output_layout),
+                                        0 /* : destOffset*/,
+                                        obrick.layout.buffer_element_count()});
+        }
+        scatter_plan_items.push_back(AddMultiPlanItem(std::move(scatter_node), antecedents));
+    }
+    else
+    {
+        // At least one of the outputs cannot be copied directly from the execution plan's
+        // output buffer. A temporary buffer is used to pack the successive output chunks
+        // contiguously. These (contiguous) chunks are then scattered and unpacked into their
+        // the respective destinations.
+        const data_layout_t packed_layout = data_layout_t::default_full_layout(
+            single_dev_output_layout.lengths(), single_dev_output_layout.batch());
+        TempBufferLease packing_temp_buffer(tempBuffers,
+                                            local_comm_rank,
+                                            execution_plan.location,
+                                            packed_layout.logical_count() * output_elem_size);
+        scatter_node              = std::make_unique<CommScatter>(precision,
+                                                     desc.outArrayType,
+                                                     execution_plan.location,
+                                                     BufferPtr::temp(packing_temp_buffer.data()));
+        scatter_node->description = "Scatter contiguously-packed output data chunks for "
+                                    + std::to_string(output_bricks.size()) + " bricks";
+        // save the raw pointer as scatter_node will be moved below
+        auto scatter_node_raw_ptr = scatter_node.get();
+        // Add scatter_node to the plan, operations are added to it below
+        const auto scatter_idx = AddMultiPlanItem(std::move(scatter_node), antecedents);
+        // Devices may need to unpack their data (locally) after having received it from
+        // packing_temp_buffer
+        std::vector<TempBufferLease> local_packed_chunk;
+        size_t                       packed_offset = 0;
+        for(size_t b_idx = 0; b_idx < output_bricks.size(); b_idx++)
+        {
+            const auto& obrick = output_bricks[b_idx];
+            std::string description
+                = "pack brick " + std::to_string(b_idx) + "'s output data on device "
+                  + std::to_string(obrick.location.device) + " (rank "
+                  + std::to_string(obrick.location.comm_rank) + ") before scatter";
+
+            const auto packIdx = AddMultiPlanItem(
+                transpose_brick(local_comm_rank,
+                                execution_plan.location,
+                                obrick.layout.lengths_and_batches(),
+                                precision,
+                                desc.outArrayType,
+                                execution_plan.outputPtr,
+                                obrick.layout.offset_in(single_dev_output_layout),
+                                single_dev_output_layout.strides_and_distances(),
+                                BufferPtr::temp(packing_temp_buffer.data()),
+                                packed_offset,
+                                obrick.layout.contiguous_strides_and_distances(),
+                                std::move(description)),
+                antecedents);
+            AddAntecedent(scatter_idx, packIdx);
+            if(obrick.layout.is_contiguous())
+            {
+                // Bricks are packed to be contiguous - if output is the
+                // same shape, then there's no need for unpacking
+                scatter_node_raw_ptr->AddOperation(local_comm_rank,
+                                                   {obrick.location,
+                                                    output_buffers[b_idx],
+                                                    packed_offset,
+                                                    0 /* : destOffset */,
+                                                    obrick.layout.logical_count()});
+            }
+            else
+            {
+                // allocate memory for packed data chunk local to destination device
+                local_packed_chunk.emplace_back(tempBuffers,
+                                                local_comm_rank,
+                                                obrick.location,
+                                                obrick.layout.logical_count() * output_elem_size);
+
+                // send the data
+                scatter_node_raw_ptr->AddOperation(
+                    local_comm_rank,
+                    {obrick.location,
+                     BufferPtr::temp(local_packed_chunk.back().data()),
+                     packed_offset,
+                     0 /* : destOffset */,
+                     obrick.layout.logical_count()});
+
+                // unpack data after sending
+                description = "unpack brick " + std::to_string(b_idx)
+                              + "'s contiguous data chunk into user's output buffer";
+
+                scatter_plan_items.push_back(AddMultiPlanItem(
+                    transpose_brick(local_comm_rank,
+                                    obrick.location,
+                                    obrick.layout.lengths_and_batches(),
+                                    precision,
+                                    desc.outArrayType,
+                                    BufferPtr::temp(local_packed_chunk.back().data()),
+                                    0 /* : offsetIn */,
+                                    obrick.layout.contiguous_strides_and_distances(),
+                                    output_buffers[b_idx],
+                                    0 /* : offsetOut */,
+                                    obrick.layout.strides_and_distances(),
+                                    std::move(description)),
+                    {scatter_idx}));
+            }
+            packed_offset += obrick.layout.logical_count();
+        }
+    }
+    return scatter_plan_items;
+}
+
+void rocfft_plan_t::MakeSingleDevPlanWithGatherScatterIfNeeded()
+{
+    // The single-device execution plan item always operates on the current device.
+    // NOTE: until we have public API allowing users to set work buffers for
+    // more than one device (the current one, implicitly), the execution plan
+    // should not be instructed to operate on another device, as it may be
+    // incapable of accessing any user-provided work buffer if peer-to-peer
+    // device access is not enabled.
+    const auto exec_plan_location = rocfft_location_t::rank0_current_device();
+    const bool plan_is_single_dev = desc.has_undistributed_io_on_current_location();
+    auto       exec_plan_metadata = get_single_dev_exec_plan_metadata();
+    auto       exec_item          = BuildSingleDevicePlan(exec_plan_metadata,
+                                           desc.get_local_comm_rank(),
+                                           exec_plan_location,
+                                           transformType,
+                                           desc.loadOps,
+                                           desc.storeOps,
+                                           !plan_is_single_dev);
+    exec_item->description        = "Single-device FFT execution plan";
+    if(plan_is_single_dev)
+    {
+        AddMultiPlanItem(std::move(exec_item), {} /* no antecedent */);
+        return;
+    }
+    // Determine the input (resp. output) buffer of the single-device execution
+    // plan, infer the output (resp. input) buffer from its placement.
+    // Note: the execution plan's input buffer is the final destination of the
+    // gather items (if any); the execution plan's output buffer if the source
+    // of the scatter items (if any).
+    std::vector<TempBufferLease> exec_plan_leased_buffers;
+    exec_item->inputPtr = exec_item->outputPtr = BufferPtr(); // reset
+    for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
+    {
+        const auto io_loc = desc.expected_undistributed_location_for(io);
+        if(io_loc && *io_loc == exec_plan_location
+           && desc.undistributed_layout_for(io) == exec_item->rootPlan->layout_for(io))
+        {
+            if(io == io_data_label::INPUT)
+                exec_item->inputPtr = BufferPtr::user_input(0, desc.get_local_comm_rank());
+            else
+                exec_item->outputPtr = BufferPtr::user_output(0, desc.get_local_comm_rank());
+        }
+    }
+    // Set whatever is not set yet as a temporary buffer and/or as allowed by the
+    // root plan's placement
+    for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
+    {
+        auto& exec_io = io == io_data_label::INPUT ? exec_item->inputPtr : exec_item->outputPtr;
+        auto& other_exec_io
+            = other(io) == io_data_label::INPUT ? exec_item->inputPtr : exec_item->outputPtr;
+        if(exec_io)
+            continue; // already set
+        if(other_exec_io && exec_item->rootPlan->placement == rocfft_placement_inplace)
+            exec_io = other_exec_io;
+        else
+        {
+            exec_plan_leased_buffers.emplace_back(
+                tempBuffers,
+                desc.get_local_comm_rank(),
+                exec_plan_location,
+                exec_item->rootPlan->expected_buffer_size_for(io));
+            exec_io = BufferPtr::temp(exec_plan_leased_buffers.back().data());
+        }
+    }
+
+    // Save raw pointer before moving into multi-plan
+    auto exec_item_raw = exec_item.get();
+    // Gather user's input data buffers into execution plan's inputPtr buffer
+    auto gather_item_indices = CreateInputGatheringItems(*exec_item);
+    auto exec_item_index     = AddMultiPlanItem(std::move(exec_item), gather_item_indices);
+    // Scatter execution plan's outputPtr buffer into user's output data buffers
+    CreateOutputScatteringItems(*exec_item_raw, {exec_item_index});
 }
 
 // Transform (complex-complex FFT) one dimension of a brick, by
@@ -2161,13 +2364,11 @@ void rocfft_plan_t::GlobalTransposeP2P(size_t                     elem_size,
             TempBufferLease& pack     = packBufs.emplace_back(tempBuffers,
                                                           local_comm_rank,
                                                           inBrick.location,
-                                                          intersection.logical_count(),
-                                                          elem_size);
+                                                          intersection.logical_count() * elem_size);
             TempBufferLease& recv     = packBufs.emplace_back(tempBuffers,
                                                           local_comm_rank,
                                                           outBrick.location,
-                                                          intersection.logical_count(),
-                                                          elem_size);
+                                                          intersection.logical_count() * elem_size);
             auto             packIdx  = AddMultiPlanItem(transpose_brick(local_comm_rank,
                                                             inBrick.location,
                                                             intersection.lengths_and_batches(),
@@ -2373,13 +2574,11 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
     TempBufferLease send_buf(tempBuffers,
                              local_comm_rank,
                              {local_comm_rank, *local_send_device},
-                             cumulative_send_elems,
-                             elem_size);
+                             cumulative_send_elems * elem_size);
     TempBufferLease recv_buf(tempBuffers,
                              local_comm_rank,
                              {local_comm_rank, *local_recv_device},
-                             cumulative_recv_elems,
-                             elem_size);
+                             cumulative_recv_elems * elem_size);
 
     // go over all the intersections of in/out bricks again, this
     // time packing/unpacking the data to/from the newly-allocated
@@ -2774,8 +2973,7 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
         inputTemp.emplace_back(tempBuffers,
                                local_comm_rank,
                                inBrick.location,
-                               inBrick.layout.logical_count(),
-                               elem_size);
+                               inBrick.layout.logical_count() * elem_size);
         inputFFTBufs.emplace_back(BufferPtr::temp(inputTemp.back().data()));
     }
 
@@ -2895,8 +3093,8 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
                         tempLeases.emplace_back(tempBuffers,
                                                 local_comm_rank,
                                                 nextField.bricks[b].location,
-                                                nextField.bricks[b].layout.logical_count(),
-                                                elem_size);
+                                                nextField.bricks[b].layout.logical_count()
+                                                    * elem_size);
                         tempBufs[b] = BufferPtr::temp(tempLeases.back().data());
                     }
                     else
@@ -2964,7 +3162,7 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
             for(auto& b : transposedField.bricks)
             {
                 transposeOutputTemp.emplace_back(
-                    tempBuffers, local_comm_rank, b.location, b.layout.logical_count(), elem_size);
+                    tempBuffers, local_comm_rank, b.location, b.layout.logical_count() * elem_size);
                 transposeOutputBufs.emplace_back(
                     BufferPtr::temp(transposeOutputTemp.back().data()));
             }
@@ -3462,50 +3660,13 @@ rocfft_status rocfft_plan_create_internal(rocfft_plan                   plan,
         log_bench(rocfft_bench_command(plan));
 
         // Construct the plan
-
-        // If we have no input/output fields, then the single ExecPlan is
-        // exactly what we need to do.
-        // FIXME: this check should actually be single-brick/no bricks.
-        if(plan->desc.inFields.empty() && plan->desc.outFields.empty())
+        if(plan->desc.has_undistributed_io_on_current_location()
+           || !plan->BuildOptMultiDevicePlan())
         {
-            NodeMetaData rootPlanData(nullptr);
-            set_rootplan_params(plan, rootPlanData);
-            rootPlanData.deviceProp = get_curr_device_prop();
-            set_bluestein_strides(plan, rootPlanData);
-
-            auto singleDevicePlan = BuildSingleDevicePlan(rootPlanData,
-                                                          0,
-                                                          rocfft_location_t::rank0_current_device(),
-                                                          plan->transformType,
-                                                          plan->desc.loadOps,
-                                                          plan->desc.storeOps,
-                                                          false);
-            plan->AddMultiPlanItem(std::move(singleDevicePlan), {});
-        }
-        else
-        {
-            if(!plan->BuildOptMultiDevicePlan())
-            {
-                // If optimized multi-device was not possible (either because
-                // multi-device was not requested, or we can't optimize for
-                // that case), fall back to single-device plan
-
-                NodeMetaData rootPlanData(nullptr);
-                set_rootplan_params(plan, rootPlanData);
-                rootPlanData.deviceProp = get_curr_device_prop();
-                set_bluestein_strides(plan, rootPlanData);
-
-                auto singleDevicePlan
-                    = BuildSingleDevicePlan(rootPlanData,
-                                            0,
-                                            rocfft_location_t::rank0_current_device(),
-                                            plan->transformType,
-                                            plan->desc.loadOps,
-                                            plan->desc.storeOps,
-                                            true);
-
-                plan->GatherScatterSingleDevicePlan(std::move(singleDevicePlan));
-            }
+            // Plan is configured for single-device operations or the multi-device plan
+            // creation failed. Either way, a single-device execution is used, possibly
+            // with gather/scatter steps.
+            plan->MakeSingleDevPlanWithGatherScatterIfNeeded();
         }
 
         plan->AllocateInternalTempBuffers();


### PR DESCRIPTION
## Motivation & technical details

Implementation details for `rocfft_plan_t` objects and their possible fields' entries are impractical, particularly when it comes to how data layouts are handled and manipulated. Storing such parameters (_e.g._, range bounds and strides) without encapsulation
- increases the risk of producing inconsistent states across different objects that would expect consistency between one another;
- exposes risks for producing invalid or inconsistent intrinsical object states (_e.g._, different sizes for lengths and strides and/or `rank` being different than `length.size()`);
- results in exploding complexity for function signatures and validation of their arguments;
- etc.

The main motivation of this PR is to alleviate the above concerns by introducing a `data_layout_t` structure which would be suited for full and partial ranges of logical indices, _i.e._, usable for bricks as well as for plan's full data-range layouts: see `projects/rocfft/library/src/include/data_layout.h` and `projects/rocfft/library/src/data_layout.cpp`.

This work would enable the usage of this new structure mostly in `rocfft_plan_t` objects and their description's possible bricks, for now. Generalization to the rest of the code base is left for future work in order to minimize the scope of the suggested changes.

Some bugs were discovered (and addressed) in this effort:
- User-provided lengths and strides are not kept unchanged in the plans, they may be modified at plans creation: unit lengths removed, `rank` member decremented, and qualifying lengths sorted by increasing strides if consistent for both input and output. Similar operations are omitted for the possible bricks though, which would then have inconsistent states compared to the plan's expectations, resulting in crashes/errors.
   - This motivates a change towards executing `finalization` and `validation` operations only _once_, accounting for the _full_ object state in the corresponding scopes (some follow-up work required for multi-process-specific bits);
   - Configuration validation checks were reviewed and expand;
   - Some dedicated tests were added to `multi_device_test.cpp` to cover this bug example.
- The current gather-scatter path for multi-device usage does not handle the case of some (but not all) bricks being continuous in the execution plan's expected temporary buffer(s) correctly. 
   - This motivates the revisions to the gather-scatter code path with the intention of making its logic less stiff, minimizing interdependence of logic pieces found in different (functions') scopes, enabling in-place operations by default, etc.
   - Other dedicated tests were added to `multi_device_test.cpp` (see the `multi_gpu_some_continuous_brick` suite);

The current "TODO" of better handling single input/output fields with lone bricks (prioritizing them if used) was addressed as part of this work.

## Test Plan

- The test suite expanded herein was executed manually (extensively) on a `gfx90a` node with 8 devices;
- Multi-process tests were also executed on the same node (using 8 tasks, each assigned to a different device).
   - Note: multi-process real test cases with unit innermost lengths and callbacks were found to fail. That issue is not related to these changes (not tested/testable prior) and the corresponding tests are disabled for now.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
