### PR TITLE
[rocPRIM] Fixing doxygen errors in the rocprim docs

### DIFF
--- a/projects/rocprim/docs/reference/rocPRIM-type-traits.rst
+++ b/projects/rocprim/docs/reference/rocPRIM-type-traits.rst
@@ -46,9 +46,6 @@ Available traits
 .. doxygenstruct:: rocprim::traits::float_bit_mask
   :members:
 
-.. doxygenstruct:: rocprim::traits::is_fundamental 
-  :members:
-
 .. doxygenstruct:: rocprim::traits::radix_key_codec 
   :members:
 


### PR DESCRIPTION
## Motivation

There are doxygen errors in the type trait docs that need to be addressed.
