### PR TITLE
[codecov] Use carryforward to compare reports between projects or flags, not just the latest commit

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,20 @@
+flag_management:
+  default_rules:
+    carryforward: true # compare reports between projects or flags, not just the latest commit
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false  # post comment even if coverage does not change
+  require_base: no # post without previous or base report
+  require_head: yes # must have PR or head report to post
+  show_carryforward_flags: true # use carryforward for PRs
+
 coverage:
   status:
     project:
       default:
-        enabled: false
+        enabled: false # only check flags instead of whole monorepo
       composable_kernel:
         flags: [composable_kernel]
         target: 80%


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Use carryforward flags so that reports compare between projects or flags, not just the latest commit

eg: for https://github.com/ROCm/rocm-libraries/pull/3972#issuecomment-3793091037 the large diff is due to codecov comparing the PR coverage to hipBLASLt (the last commit to develop) instead of the rocSPARSE flag

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Uses carryforward as default for flag management and carryfoward flags for PR comments

https://docs.codecov.com/docs/flags
https://docs.codecov.com/docs/carryforward-flags

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
