### PR TITLE
[hipTensor] Fix uninitialized output param in hiptensorEstimateWorkspaceSize

### DIFF
--- a/projects/hiptensor/library/src/hiptensor.cpp
+++ b/projects/hiptensor/library/src/hiptensor.cpp
@@ -637,7 +637,7 @@ hiptensorStatus_t hiptensorEstimateWorkspaceSize(const hiptensorHandle_t        
         return contractionGetWorkspaceSize(
             handle, desc, planPref, workspacePref, workspaceSizeEstimate);
     }
-    *workspaceSizeEstimate = 0;
+    *workspaceSizeEstimate = 0u;
     return HIPTENSOR_STATUS_SUCCESS;
 }
 

--- a/projects/hiptensor/library/src/hiptensor.cpp
+++ b/projects/hiptensor/library/src/hiptensor.cpp
@@ -637,6 +637,7 @@ hiptensorStatus_t hiptensorEstimateWorkspaceSize(const hiptensorHandle_t        
         return contractionGetWorkspaceSize(
             handle, desc, planPref, workspacePref, workspaceSizeEstimate);
     }
+    *workspaceSizeEstimate = 0;
     return HIPTENSOR_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/rocm-libraries/issues/3934

## Technical Details

When the operation type is not `HIPTENSOR_CONTRACTION`, the function returns `HIPTENSOR_STATUS_SUCCESS` without writing to the `workspaceSizeEstimate` output parameter, which is an API contract violation.

Initialize `*workspaceSizeEstimate = 0;` before returning `HIPTENSOR_STATUS_SUCCESS` for non-contraction operations to offload caller's responsibility. Reduction operations don't require workspace: 

https://github.com/ROCm/rocm-libraries/blob/4d61dd60de7da030528468e81c987f2fcd691934/projects/hiptensor/library/src/reduction/hiptensor_reduction.cpp#L89

Other non-contraction operations don't require workspace as per their respective API signatures.

## Test Plan

Created a test program that:
1. Creates a reduction operation descriptor
2. Calls `hiptensorEstimateWorkspaceSize()` with a non-zero sentinel value

## Test Result

Verified that the output parameter is written as 0 following the test

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
