### PR TITLE
[hipDNN][miopen-provider] Enable clang tidy and format for miopen plugin.

### DIFF
--- a/dnn-providers/miopen-provider/CMakeLists.txt
+++ b/dnn-providers/miopen-provider/CMakeLists.txt
@@ -46,6 +46,15 @@ if(NOT BUILD_PLUGIN_AS_DEPENDENCY)
         message(DEPRECATION "HIP_DNN_SKIP_TESTS has been renamed to HIPDNN_SKIP_TESTS. Please update your build scripts to use -DHIPDNN_SKIP_TESTS instead.")
     endif()
     option(HIPDNN_SKIP_TESTS "Skip building tests" OFF)
+    option(ENABLE_CLANG_FORMAT "Enable Clang-Format checks" ON)
+    if(WIN32)
+        option(ENABLE_CLANG_TIDY "Enable Clang-Tidy checks" OFF)
+        if(ENABLE_CLANG_TIDY)
+            message(WARNING "Clang-Tidy enabled on Windows - this significantly increases build time.")
+        endif()
+    else()
+        option(ENABLE_CLANG_TIDY "Enable Clang-Tidy checks" ON)
+    endif()
 
     list(
         PREPEND
@@ -83,6 +92,8 @@ if(NOT BUILD_PLUGIN_AS_DEPENDENCY)
     include(Dependencies)
     include(Tests)
 
+    include(cmake/ClangTidy.cmake)
+    include(cmake/ClangCheck.cmake)
 else()
     message(STATUS "Building miopen provider plugin as a dependency")
 endif()
@@ -135,9 +146,7 @@ target_include_directories(miopen_legacy_plugin_private PUBLIC ${CMAKE_CURRENT_S
 target_link_libraries(miopen_legacy_plugin_private PUBLIC MIOpen hipdnn_data_sdk hipdnn_plugin_sdk)
 target_compile_options(miopen_legacy_plugin_private PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 
-if(BUILD_PLUGIN_AS_DEPENDENCY)
-    clang_tidy_check(miopen_legacy_plugin_private)
-endif()
+clang_tidy_check(miopen_legacy_plugin_private)
 
 add_library(miopen_legacy_plugin SHARED MiopenLegacyPluginPublic.cpp)
 target_compile_definitions(miopen_legacy_plugin PRIVATE COMPONENT_NAME="miopen_legacy_plugin")
@@ -157,9 +166,7 @@ set_target_properties(
                BUILD_WITH_INSTALL_RPATH TRUE
 )
 
-if(BUILD_PLUGIN_AS_DEPENDENCY)
-    clang_tidy_check(miopen_legacy_plugin)
-endif()
+clang_tidy_check(miopen_legacy_plugin)
 
 if(NOT HIPDNN_SKIP_TESTS)
     add_subdirectory(tests)

--- a/dnn-providers/miopen-provider/cmake/CheckToolVersion.cmake
+++ b/dnn-providers/miopen-provider/cmake/CheckToolVersion.cmake
@@ -1,0 +1,207 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+# Expected tool versions
+set(EXPECTED_CLANG_FORMAT_VERSION "18")
+set(EXPECTED_CLANG_TIDY_VERSION "20")
+set(EXPECTED_LLVM_VERSION "20")
+
+# Helper function to generate version-specific search paths hints by concatenating the base path
+# with a list of versioned path names.
+function(get_versioned_search_paths OUTPUT_VAR BASE_PATH VERSION)
+    set(PATHS_LIST
+        "${BASE_PATH}${VERSION}/bin" "${BASE_PATH}${VERSION}/lib/llvm/bin"
+        "${BASE_PATH}/${VERSION}/bin" "${BASE_PATH}/${VERSION}/lib/llvm/bin" "${BASE_PATH}/bin"
+        "${BASE_PATH}/lib/llvm/bin"
+    )
+    set(${OUTPUT_VAR} ${PATHS_LIST} PARENT_SCOPE)
+endfunction()
+
+# CMake find_program() search order: CMAKE_PREFIX_PATH, CMAKE_PROGRAM_PATH, find_program(HINTS)
+# which is set to LLVM_TOOL_HINTS below when LLVM_TOOLS_SEARCH_PREFIX is provided by the user,
+# CMAKE_*_COMPILER_PATH, system PATH, CMake built-in common locations, and finally
+# find_program(PATHS) which is set to LLVM_TOOL_PATHS in this file. All folders are searched first
+# for the first program name, and this then repeats for each name provided in find_program(NAMES).
+if(NOT WIN32)
+    # Common search paths
+    set(LLVM_TOOL_PATHS /usr/bin /usr/local/bin /opt/rocm/llvm/bin)
+    if(DEFINED ROCM_PATH)
+        list(APPEND LLVM_TOOL_PATHS ${ROCM_PATH}/llvm/bin)
+    endif()
+endif()
+
+# Set up LLVM_TOOL_HINTS if LLVM_TOOLS_SEARCH_PREFIX is defined
+# First check if it was set via cmake -D, otherwise fall back to environment variable
+if(DEFINED LLVM_TOOLS_SEARCH_PREFIX)
+    set(LLVM_TOOL_HINTS "${LLVM_TOOLS_SEARCH_PREFIX}")
+    message(VERBOSE "Using LLVM_TOOLS_SEARCH_PREFIX hint: ${LLVM_TOOLS_SEARCH_PREFIX}")
+elseif(DEFINED ENV{LLVM_TOOLS_SEARCH_PREFIX})
+    set(LLVM_TOOL_HINTS "$ENV{LLVM_TOOLS_SEARCH_PREFIX}")
+    message(VERBOSE "Using LLVM_TOOLS_SEARCH_PREFIX hint from environment: $ENV{LLVM_TOOLS_SEARCH_PREFIX}")
+endif()
+
+# Checks the version of a tool
+function(checkToolVersion TOOL_BINARY TOOL_NAME EXPECTED_VERSION VERSION_REGEX
+         SUCCESS_MESSAGE_FORMAT
+)
+    execute_process(
+        COMMAND ${TOOL_BINARY} --version OUTPUT_VARIABLE VERSION_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(VERSION_OUTPUT MATCHES "${VERSION_REGEX}")
+        set(TOOL_MAJOR_VERSION "${CMAKE_MATCH_1}")
+        if(NOT TOOL_MAJOR_VERSION STREQUAL EXPECTED_VERSION)
+            message(
+                WARNING
+                    "${TOOL_NAME} version mismatch! Expected: ${EXPECTED_VERSION}, Found: ${TOOL_MAJOR_VERSION}, Full version: ${VERSION_OUTPUT}"
+            )
+        else()
+            string(REPLACE "{VERSION}" "${TOOL_MAJOR_VERSION}" SUCCESS_MSG
+                           "${SUCCESS_MESSAGE_FORMAT}"
+            )
+            string(REPLACE "{PATH}" "${TOOL_BINARY}" SUCCESS_MSG "${SUCCESS_MSG}")
+            message(STATUS "${SUCCESS_MSG}")
+        endif()
+        # Set the major version in parent scope for potential use
+        set(${TOOL_NAME}_MAJOR_VERSION ${TOOL_MAJOR_VERSION} PARENT_SCOPE)
+    else()
+        message(WARNING "Could not determine ${TOOL_NAME} version from: ${VERSION_OUTPUT}")
+        set(${TOOL_NAME}_MAJOR_VERSION "unknown" PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Common helper function to find and check a tool. This function will search first for a file named
+# ${TOOL_NAME}-${EXPECTED_VERSION} and then for the bare ${TOOL_NAME}. Folders based on a provided
+# LLVM_TOOLS_SEARCH_PREFIX will be searched as well as the standard CMake paths used by
+# find_program().
+# ~~~
+# Parameters:
+#   OUTPUT_VAR - Variable name to store the found tool path
+#   TOOL_NAME - The single name of the single tool to search for (e.g., "clang-format")
+#   EXPECTED_VERSION - Expected version to search for (typically assumed to be the tool's major version number)
+#   VERSION_REGEX - Regex to extract the relevant portion to match EXPECTED_VERSION frmo the tool's --version output
+#   ERROR_LEVEL - FATAL_ERROR, WARNING, STATUS, or VERBOSE for the not found message
+# ~~~
+function(findAndCheckTool OUTPUT_VAR TOOL_NAME EXPECTED_VERSION VERSION_REGEX ERROR_LEVEL)
+    # Build version-specific paths if LLVM_TOOL_HINTS is set
+    set(SEARCH_HINTS)
+    if(DEFINED LLVM_TOOL_HINTS)
+        foreach(HINT ${LLVM_TOOL_HINTS})
+            get_versioned_search_paths(VERSIONED_HINTS "${HINT}" "${EXPECTED_VERSION}")
+            list(APPEND SEARCH_HINTS ${VERSIONED_HINTS})
+        endforeach()
+    endif()
+
+    find_program(
+        ${OUTPUT_VAR} NAMES ${TOOL_NAME}-${EXPECTED_VERSION} ${TOOL_NAME} HINTS ${SEARCH_HINTS}
+        PATHS ${LLVM_TOOL_PATHS}
+    )
+
+    if(NOT ${OUTPUT_VAR})
+        # Format SEARCH_HINTS with one path per line for output.
+        string(REPLACE ";" "\n  " FORMATTED_HINTS "${SEARCH_HINTS}")
+        if(ERROR_LEVEL STREQUAL "FATAL_ERROR")
+            message(
+                FATAL_ERROR
+                    "\n${TOOL_NAME} not found in searching PATH, CMake PROGRAM and PREFIX paths, and these LLVM_TOOLS_SEARCH_PREFIX derived paths:\n  ${FORMATTED_HINTS}\n"
+            )
+        else()
+            message(
+                ${ERROR_LEVEL}
+                "${TOOL_NAME} not found in searching PATH, CMake PROGRAM and PREFIX paths, and LLVM_TOOLS_SEARCH_PREFIX derived paths"
+            )
+            if(SEARCH_HINTS)
+                message(
+                    VERBOSE
+                    "Search included the following LLVM_TOOLS_SEARCH_PREFIX derived paths:\n  ${FORMATTED_HINTS}"
+                )
+            endif()
+        endif()
+        return()
+    endif()
+
+    if(VERSION_REGEX STREQUAL "SKIP_VERSION_CHECK")
+        message(STATUS "Found ${TOOL_NAME} at ${${OUTPUT_VAR}}")
+    else()
+        checktoolversion(
+            ${${OUTPUT_VAR}} "${TOOL_NAME}" ${EXPECTED_VERSION} "${VERSION_REGEX}"
+            "Found ${TOOL_NAME} version {VERSION} at {PATH}"
+        )
+    endif()
+
+    # Export to parent scope
+    set(${OUTPUT_VAR} ${${OUTPUT_VAR}} PARENT_SCOPE)
+endfunction()
+
+# Finds and checks clang-format
+function(findAndCheckClangFormat)
+    findandchecktool(
+        CLANG_FORMAT_BINARY "clang-format" ${EXPECTED_CLANG_FORMAT_VERSION}
+        "clang-format version ([0-9]+)\\." FATAL_ERROR
+    )
+
+    # Export to parent scope
+    set(CLANG_FORMAT_BINARY ${CLANG_FORMAT_BINARY} PARENT_SCOPE)
+endfunction()
+
+# Finds and checks clang-tidy
+function(findAndCheckClangTidy)
+    if(ENABLE_CLANG_TIDY)
+        set(_not_found_log_level FATAL_ERROR)
+    else()
+        set(_not_found_log_level STATUS)
+    endif()
+
+    findandchecktool(
+        CLANG_TIDY_EXE "clang-tidy" ${EXPECTED_CLANG_TIDY_VERSION} "version ([0-9]+)\\."
+        ${_not_found_log_level}
+    )
+
+    # Export to parent scope
+    set(CLANG_TIDY_EXE ${CLANG_TIDY_EXE} PARENT_SCOPE)
+
+    findandchecktool(
+        RUN_CLANG_TIDY_EXE "run-clang-tidy" ${EXPECTED_CLANG_TIDY_VERSION} "SKIP_VERSION_CHECK"
+        VERBOSE
+    )
+
+    if(RUN_CLANG_TIDY_EXE)
+        set(RUN_CLANG_TIDY_EXE ${RUN_CLANG_TIDY_EXE} PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Finds and checks LLVM tools
+function(findAndCheckLlvmTools)
+    # Define the tools we need
+    set(LLVM_TOOLS llvm-profdata llvm-cov llvm-cxxfilt)
+
+    foreach(TOOL ${LLVM_TOOLS})
+        string(TOUPPER ${TOOL} TOOL_UPPER)
+        string(REPLACE "-" "_" TOOL_VAR ${TOOL_UPPER})
+
+        findandchecktool(
+            ${TOOL_VAR}_BINARY "${TOOL}" ${EXPECTED_LLVM_VERSION} "LLVM version ([0-9]+)\\."
+            FATAL_ERROR
+        )
+
+        # Export to parent scope
+        set(${TOOL_VAR}_BINARY ${${TOOL_VAR}_BINARY} PARENT_SCOPE)
+    endforeach()
+endfunction()
+
+# Finds and checks llvm-symbolizer
+function(findAndCheckLlvmSymbolizer)
+    findandchecktool(
+        LLVM_SYMBOLIZER_EXE "llvm-symbolizer" ${EXPECTED_LLVM_VERSION} "LLVM version ([0-9]+)\\."
+        WARNING
+    )
+
+    if(LLVM_SYMBOLIZER_EXE)
+        set(CMAKE_SYMBOLIZER ${LLVM_SYMBOLIZER_EXE} PARENT_SCOPE)
+        # Export to parent scope
+        set(LLVM_SYMBOLIZER_EXE ${LLVM_SYMBOLIZER_EXE} PARENT_SCOPE)
+    else()
+        message(WARNING "ASAN tests will be missing symbolized stack traces.")
+    endif()
+endfunction()

--- a/dnn-providers/miopen-provider/cmake/ClangCheck.cmake
+++ b/dnn-providers/miopen-provider/cmake/ClangCheck.cmake
@@ -1,0 +1,64 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+# Helper function to verify a compiler is AMD/ROCm clang
+function(verifyAmdRocmCompiler COMPILER_PATH COMPILER_NAME)
+    execute_process(
+        COMMAND ${COMPILER_PATH} --version OUTPUT_VARIABLE VERSION_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+    )
+
+    if(VERSION_OUTPUT MATCHES "clang version"
+       AND (VERSION_OUTPUT MATCHES "ROCm" OR VERSION_OUTPUT MATCHES "AMD" OR COMPILER_PATH MATCHES
+                                                                             "rocm")
+    )
+        message(STATUS "✓ Confirmed AMD/ROCm type ${COMPILER_NAME} compiler")
+    else()
+        string(REGEX REPLACE "[\r\n]+" "\n  " VERSION_OUTPUT "${VERSION_OUTPUT}")
+        message(
+            WARNING "\n"
+                    "Unable to confirm AMD/ROCm type ${COMPILER_NAME} compiler: ${COMPILER_PATH}\n"
+                    "Expected to find \"AMD\" or \"ROCm\" in the compiler version.\n"
+                    "Actual compiler version reported:\n  ${VERSION_OUTPUT}\n"
+        )
+    endif()
+endfunction()
+
+# Verify that we're using AMD/ROCm compiler.
+verifyamdrocmcompiler(${CMAKE_CXX_COMPILER} "C++")
+
+if(ENABLE_CLANG_FORMAT)
+    include(${CMAKE_CURRENT_LIST_DIR}/CheckToolVersion.cmake)
+
+    set(CLANG_FORMAT_PRUNE
+        -path
+        "./build"
+        -prune
+        -o
+        -path
+        "./data_sdk/include/hipdnn_data_sdk/data_objects"
+        -prune
+        -o
+    )
+
+    # Find and check clang-format version using unified function
+    findandcheckclangformat()
+
+    add_custom_target(
+        check_format
+        COMMAND find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|c\\|h\\)" -exec
+                ${CLANG_FORMAT_BINARY} --dry-run --Werror {} +
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        VERBATIM
+        COMMENT "Checking code format"
+    )
+
+    add_custom_target(
+        format
+        COMMAND find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|c\\|h\\)" -exec
+                ${CLANG_FORMAT_BINARY} --verbose -i {} +
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        VERBATIM
+        COMMENT "Formatting code"
+    )
+endif() # ENABLE_CLANG_FORMAT

--- a/dnn-providers/miopen-provider/cmake/ClangTidy.cmake
+++ b/dnn-providers/miopen-provider/cmake/ClangTidy.cmake
@@ -1,0 +1,100 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+include(${CMAKE_CURRENT_LIST_DIR}/CheckToolVersion.cmake)
+include(ProcessorCount)
+
+findandcheckclangtidy()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Sets up clang-tidy command variables with appropriate compiler flags for C++ and HIP files
+function(setClangTidyVars)
+    set(CLANG_TIDY_COMMAND ${CLANG_TIDY_EXE} -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy -p
+                           ${CMAKE_BINARY_DIR} PARENT_SCOPE
+    )
+    if(NOT CLANG_TIDY_HIP_ARGS)
+        message(VERBOSE "Detecting HIP include directory for clang-tidy...")
+        if(HIP_INCLUDE_DIR)
+            set(CLANG_TIDY_HIP_ARGS -extra-arg=-D__HIP_PLATFORM_AMD__ -extra-arg=-D__HIPCC__
+                                    -extra-arg=-isystem -extra-arg=${HIP_INCLUDE_DIR}
+                CACHE INTERNAL "Clang-tidy extra arguments for HIP files"
+            )
+            message(
+                STATUS
+                    "Configured clang-tidy HIP arguments with include directory: ${HIP_INCLUDE_DIR}"
+            )
+        else()
+            message(
+                WARNING
+                    "Could not determine HIP include directory. Tidy checks for HIP files may fail."
+            )
+        endif()
+    endif()
+    set(CLANG_TIDY_HIP_ARGS ${CLANG_TIDY_HIP_ARGS} PARENT_SCOPE)
+endfunction()
+
+# Add the 'tidy' target to the project to run tidy on all files in the hipDNN folder.
+function(add_clang_tidy_custom_target)
+    if(WIN32)
+        message(STATUS "Skipped creating 'tidy' targets; not available on Windows")
+        return()
+    endif()
+    if(ENABLE_CLANG_TIDY)
+        set(_not_found_log_level WARNING)
+    else()
+        set(_not_found_log_level STATUS)
+    endif()
+    if(RUN_CLANG_TIDY_EXE)
+        processorcount(N)
+        if(NOT N EQUAL 0)
+            set(CLANG_TIDY_JOBS ${N})
+        else()
+            set(CLANG_TIDY_JOBS 1)
+        endif()
+
+        # Target for running tidy on all files using HIP args for all files.
+        add_custom_target(
+            tidy
+            COMMAND
+                ${RUN_CLANG_TIDY_EXE} -p ${CMAKE_BINARY_DIR}
+                -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy -source-filter "^(?!.*_deps/).*" -quiet
+                -j ${CLANG_TIDY_JOBS} ${CLANG_TIDY_HIP_ARGS}
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMENT
+                "Running clang-tidy on all source files and headers (${CLANG_TIDY_JOBS} parallel jobs)..."
+            VERBATIM
+        )
+
+        # Target for running tidy on all C++ language files (no HIP args)
+        add_custom_target(
+            tidy-cxx
+            COMMAND
+                ${RUN_CLANG_TIDY_EXE} -p ${CMAKE_BINARY_DIR}
+                -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy -source-filter
+                "^(?!.*(_deps/)).*" -quiet -j ${CLANG_TIDY_JOBS}
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            COMMENT "Running clang-tidy on C++ files (${CLANG_TIDY_JOBS} parallel jobs)..."
+            VERBATIM
+        )
+    else()
+        message(${_not_found_log_level}
+                "run-clang-tidy-20 not found. The 'tidy' targets will not be available."
+        )
+    endif()
+endfunction()
+
+# Enable clang-tidy checks for a specific target during compilation.
+#
+# @param TARGET target to enable clang-tidy checks for
+function(clang_tidy_check TARGET)
+    setclangtidyvars()
+    if(ENABLE_CLANG_TIDY)
+        set_target_properties(${TARGET} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+        if(CLANG_TIDY_HIP_ARGS)
+            set(CLANG_TIDY_HIP_COMMAND ${CLANG_TIDY_COMMAND} ${CLANG_TIDY_HIP_ARGS})
+            set_target_properties(${TARGET} PROPERTIES HIP_CLANG_TIDY "${CLANG_TIDY_HIP_COMMAND}")
+        endif()
+        set_target_properties(${TARGET} PROPERTIES C_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+    endif()
+endfunction()

--- a/dnn-providers/miopen-provider/integration_tests/CMakeLists.txt
+++ b/dnn-providers/miopen-provider/integration_tests/CMakeLists.txt
@@ -43,7 +43,6 @@ target_link_libraries(
 # integration tests depend on the MIOpen Provider Plugin
 add_dependencies(miopen_plugin_integration_test miopen_legacy_plugin)
 
-if(BUILD_PLUGIN_AS_DEPENDENCY)
-    clang_tidy_check(miopen_plugin_integration_test)
-endif()
+clang_tidy_check(miopen_plugin_integration_test)
+
 add_integration_test_target(miopen_plugin_integration_test ${CMAKE_CURRENT_BINARY_DIR})

--- a/dnn-providers/miopen-provider/tests/CMakeLists.txt
+++ b/dnn-providers/miopen-provider/tests/CMakeLists.txt
@@ -51,8 +51,6 @@ target_link_libraries(
 # make it so tests inside folders can find the mocks folder without having to use a relative path.
 target_include_directories(miopen_legacy_plugin_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-if(BUILD_PLUGIN_AS_DEPENDENCY)
-    clang_tidy_check(miopen_legacy_plugin_tests)
-endif()
+clang_tidy_check(miopen_legacy_plugin_tests)
 
 add_unit_test_target(miopen_legacy_plugin_tests ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
## Motivation

With the miopen-provider plugin project being moved to a standalone build, the toolchain support for clang-tidy and clang-format was missing from the cmake project. This PR adds that support to the miopen-provider project for standalone builds and maintains this support for the miopen-provider build as a dependency of the hipDNN project.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
