### PR TITLE
[rocRoller] Change testing parallelism (use shards manually) and code-coverage tests

### DIFF
--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -72,15 +72,14 @@ def runTestCommand (platform, project)
 {
     String testExclude = platform.jenkinsLabel.contains('compile') ? '--gtest_filter=-*GPU*' : ''
 
-    def numShards = 4
+    def numShards = 16
 
     def command = """#!/usr/bin/env bash
                 set -ex
                 cd ${project.paths.project_build_prefix}
-                pushd build
-                export ROCROLLER_BUILD_DIR="\$(pwd)"
-                python3 ../.jenkins/run-tests-sharded.py \$ROCROLLER_BUILD_DIR ${numShards} "${testExclude}"
-                popd
+                python3 .jenkins/run-tests-sharded.py build ${numShards} "${testExclude}"
+
+                export ROCROLLER_BUILD_DIR="\$(pwd)/build"
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950
             """
 

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -79,8 +79,9 @@ def runTestCommand (platform, project)
                 cd ${project.paths.project_build_prefix}
                 python3 .jenkins/run-tests-sharded.py build ${numShards} "${testExclude}"
 
-                export ROCROLLER_BUILD_DIR="\$(pwd)/build"
-                scripts/rrperf generate --suite generate_gfx950 --arch gfx950
+                pushd build
+                ctest --parallel ${numShards} -R "GEMMClientTests.*"
+                popd
             """
 
     try

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -70,18 +70,16 @@ def runCompileCommand(platform, project, jobName, boolean codeCoverage=false, bo
 
 def runTestCommand (platform, project)
 {
-    String testExclude = platform.jenkinsLabel.contains('compile') ? '-LE GPU' : ''
+    String testExclude = platform.jenkinsLabel.contains('compile') ? '--gtest_filter=-*GPU*' : ''
 
-    def numThreads = 8
+    def numShards = 4
 
     def command = """#!/usr/bin/env bash
                 set -ex
                 cd ${project.paths.project_build_prefix}
-
                 pushd build
-                echo Using ${numThreads} out of `nproc` threads for testing.
-                OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=2 ctest -j ${numThreads} --output-on-failure ${testExclude}
                 export ROCROLLER_BUILD_DIR="\$(pwd)"
+                python3 ../.jenkins/run-tests-sharded.py \$ROCROLLER_BUILD_DIR ${numShards} "${testExclude}"
                 popd
                 scripts/rrperf generate --suite generate_gfx950 --arch gfx950
             """
@@ -244,7 +242,7 @@ def runPerformanceCommand (platform, project)
                     ./scripts/rrperf compare \\
                         \$(ls -trd ./performance_build_${platform.gpu}/performance_${platform.gpu}/*) \\
                             > performance_comparison_${platform.gpu}.md
-                    
+
                     ./scripts/rrperf compare --format resource_md \\
                         \$(ls -trd ./performance_build_${platform.gpu}/performance_${platform.gpu}/*) \\
                             > resource_comparison_${platform.gpu}.md
@@ -289,7 +287,7 @@ def runPerformanceCommand (platform, project)
                             ./performance_${platform.gpu}_master/performance_${platform.gpu}/* \\
                             ./performance_build_${platform.gpu}/performance_${platform.gpu}/* \\
                             > performance_comparison_${platform.gpu}.md
-                        
+
                         ./scripts/rrperf compare --format resource_md \\
                             ./performance_${platform.gpu}_master/performance_${platform.gpu}/* \\
                             ./performance_build_${platform.gpu}/performance_${platform.gpu}/* \\
@@ -357,19 +355,19 @@ def runPerformanceCommand (platform, project)
             if (!perfCommentExists) {
                 def comment = pullRequest.comment(perfCommentString)
             }
-            
+
             def resCommentTitle = "# Resource Report for ${platform.gpu}"
             def resCommentString = "${resCommentTitle}\n\n"
             def resResults = readFile("${project.paths.project_build_prefix}/resource_comparison_${platform.gpu}.md").trim()
-            
+
             def maxResultsLength = 60000
             def truncatedMessage = "\n```\n\n**Results truncated, see full report in workspace**"
-            
+
             if (resResults.length() > maxResultsLength) {
                 def truncateIndex = resResults.lastIndexOf('\n', maxResultsLength)
                 resResults = resResults.substring(0, truncateIndex) + truncatedMessage
             }
-            
+
             resCommentString += "## Results${estimateString}\n\n"
             resCommentString += "<details open>\n\n${resResults}\n</details>\n"
             resCommentString += "<details><summary>Links</summary>\n\n"

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -80,7 +80,7 @@ def runTestCommand (platform, project)
                 python3 .jenkins/run-tests-sharded.py build ${numShards} "${testExclude}"
 
                 pushd build
-                ctest --parallel ${numShards} -R "GEMMClientTests.*"
+                ctest --parallel ${numShards} -LE "GTEST|CATCH"
                 popd
             """
 

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -72,15 +72,19 @@ def runTestCommand (platform, project)
 {
     String testExclude = platform.jenkinsLabel.contains('compile') ? '--gtest_filter=-*GPU*' : ''
 
-    def numShards = 16
-
     def command = """#!/usr/bin/env bash
                 set -ex
                 cd ${project.paths.project_build_prefix}
-                python3 .jenkins/run-tests-sharded.py build ${numShards} "${testExclude}"
+
+                # Run sharded tests (auto-detects ncores/2, respecting cgroups)
+                python3 .jenkins/run-tests-sharded.py build "${testExclude}"
+
+                # Auto-detect shard count for remaining ctest tests (nproc respects cgroups)
+                NUM_SHARDS=\$(( \$(nproc) / 2 ))
+                NUM_SHARDS=\$(( NUM_SHARDS > 0 ? NUM_SHARDS : 1 ))
 
                 pushd build
-                ctest --parallel ${numShards} -LE "GTEST|CATCH"
+                ctest --parallel \${NUM_SHARDS} -LE "GTEST|CATCH"
                 popd
             """
 

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -72,6 +72,8 @@ def runTestCommand (platform, project)
 {
     String testExclude = platform.jenkinsLabel.contains('compile') ? '--gtest_filter=-*GPU*' : ''
 
+    def numThreads = 8
+
     def command = """#!/usr/bin/env bash
                 set -ex
                 cd ${project.paths.project_build_prefix}
@@ -79,12 +81,8 @@ def runTestCommand (platform, project)
                 # Run sharded tests (auto-detects ncores/2, respecting cgroups)
                 python3 .jenkins/run-tests-sharded.py build "${testExclude}"
 
-                # Auto-detect shard count for remaining ctest tests (nproc respects cgroups)
-                NUM_SHARDS=\$(( \$(nproc) / 2 ))
-                NUM_SHARDS=\$(( NUM_SHARDS > 0 ? NUM_SHARDS : 1 ))
-
                 pushd build
-                ctest --parallel \${NUM_SHARDS} -LE "GTEST|CATCH"
+                OPENBLAS_NUM_THREADS=2 OMP_NUM_THREADS=2 ctest --parallel ${numThreads} --output-on-failure -LE "GTEST|CATCH"
                 popd
             """
 

--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -79,7 +79,7 @@ def runTestCommand (platform, project)
                 cd ${project.paths.project_build_prefix}
 
                 # Run sharded tests (auto-detects ncores/2, respecting cgroups)
-                python3 .jenkins/run-tests-sharded.py build "${testExclude}"
+                scripts/run-tests-sharded build "${testExclude}"
 
                 pushd build
                 OPENBLAS_NUM_THREADS=2 OMP_NUM_THREADS=2 ctest --parallel ${numThreads} --output-on-failure -LE "GTEST|CATCH"

--- a/shared/rocroller/.jenkins/run-tests-sharded.py
+++ b/shared/rocroller/.jenkins/run-tests-sharded.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Run rocroller tests in parallel shards.
+
+Usage: run-tests-sharded.py [BUILD_DIR] [NUM_SHARDS] [GPU_FILTER]
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+
+def run_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_dir):
+    """Run a single shard of tests."""
+    print(f"Starting shard {shard_index} for {test_type}")
+
+    # Set environment variables
+    env = os.environ.copy()
+    env["OPENBLAS_NUM_THREADS"] = "1"
+    env["OMP_NUM_THREADS"] = "2"
+
+    # Build command based on test type
+    if test_type == "gtest":
+        # Google Test sharding
+        env["GTEST_TOTAL_SHARDS"] = str(num_shards)
+        env["GTEST_SHARD_INDEX"] = str(shard_index)
+
+        cmd = [test_exe]
+        if gpu_filter:
+            cmd.append(gpu_filter)
+        cmd.extend(
+            ["--gtest_output=xml:test_report/gtest_shard_{}.xml".format(shard_index)]
+        )
+    else:
+        # Catch2 sharding
+        cmd = [
+            test_exe,
+            "--shard-count",
+            str(num_shards),
+            "--shard-index",
+            str(shard_index),
+            "-r",
+            "junit",
+            "-o",
+            "test_report/catch2_shard_{}.xml".format(shard_index),
+        ]
+
+    try:
+        result = subprocess.run(
+            cmd, env=env, cwd=build_dir, check=True, capture_output=False
+        )
+        print(f"Shard {shard_index} for {test_type} completed successfully")
+        return (shard_index, test_type, 0)
+    except subprocess.CalledProcessError as e:
+        print(
+            f"Shard {shard_index} for {test_type} failed with exit code {e.returncode}"
+        )
+        return (shard_index, test_type, e.returncode)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run rocroller tests in parallel shards"
+    )
+    parser.add_argument(
+        "build_dir",
+        nargs="?",
+        default="build",
+        help="Path to build directory (default: build)",
+    )
+    parser.add_argument(
+        "num_shards",
+        nargs="?",
+        type=int,
+        default=4,
+        help="Number of parallel shards (default: 4)",
+    )
+    parser.add_argument(
+        "gpu_filter",
+        nargs="?",
+        default="",
+        help="GPU filter for Google Test (e.g., --gtest_filter=-*GPU*)",
+    )
+
+    args = parser.parse_args()
+
+    # Resolve build directory
+    build_dir = Path(args.build_dir).resolve()
+    if not build_dir.exists():
+        print(f"ERROR: Build directory does not exist: {build_dir}")
+        sys.exit(1)
+
+    # Check test executables exist
+    gtest_exe = build_dir / "test" / "rocroller-tests"
+    catch2_exe = build_dir / "test" / "rocroller-tests-catch"
+
+    if not gtest_exe.exists():
+        print(f"ERROR: Google Test executable not found: {gtest_exe}")
+        sys.exit(1)
+
+    if not catch2_exe.exists():
+        print(f"ERROR: Catch2 executable not found: {catch2_exe}")
+        sys.exit(1)
+
+    print("=" * 50)
+    print("Running sharded tests")
+    print(f"Build directory: {build_dir}")
+    print(f"Number of shards: {args.num_shards}")
+    print(f"GPU filter: {args.gpu_filter if args.gpu_filter else 'none'}")
+    print("=" * 50)
+
+    # Create test report directory
+    test_report_dir = build_dir / "test_report"
+    test_report_dir.mkdir(exist_ok=True)
+
+    # Prepare tasks
+    tasks = []
+
+    # Add Google Test shards
+    for i in range(args.num_shards):
+        tasks.append(
+            (i, str(gtest_exe), "gtest", args.num_shards, args.gpu_filter, build_dir)
+        )
+
+    # Add Catch2 shards
+    for i in range(args.num_shards):
+        tasks.append(
+            (i, str(catch2_exe), "catch2", args.num_shards, args.gpu_filter, build_dir)
+        )
+
+    # Run all shards in parallel
+    failed_shards = []
+
+    with ProcessPoolExecutor(max_workers=args.num_shards * 2) as executor:
+        futures = [executor.submit(run_shard, *task) for task in tasks]
+
+        for future in as_completed(futures):
+            try:
+                shard_index, test_type, exit_code = future.result()
+                if exit_code != 0:
+                    failed_shards.append((shard_index, test_type, exit_code))
+            except Exception as e:
+                print(f"ERROR: Unexpected exception: {e}")
+                failed_shards.append((-1, "unknown", 1))
+
+    print()
+
+    # Report results
+    if failed_shards:
+        print("FAILED: One or more test shards failed:")
+        for shard_index, test_type, exit_code in failed_shards:
+            print(f"  - {test_type} shard {shard_index}: exit code {exit_code}")
+        sys.exit(1)
+    else:
+        print("SUCCESS: All test shards completed successfully.")
+        print()
+        print(f"Test results written to: {test_report_dir}/")
+
+        # List generated XML files
+        xml_files = sorted(test_report_dir.glob("*.xml"))
+        if xml_files:
+            for xml_file in xml_files:
+                size = xml_file.stat().st_size
+                print(f"  - {xml_file.name} ({size:,} bytes)")
+
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/shared/rocroller/.jenkins/run-tests-sharded.py
+++ b/shared/rocroller/.jenkins/run-tests-sharded.py
@@ -14,11 +14,13 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 
 def run_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_dir):
     """Run a single shard of tests."""
-    print(f"Starting shard {shard_index} for {test_type}")
+    test_prefix = "G" if test_type == "gtest" else "C"
+    shard_tag = f"[{test_prefix}{shard_index:02d}]"
+    print(f"{shard_tag} Starting shard")
 
     # Set environment variables
     env = os.environ.copy()
-    env["OPENBLAS_NUM_THREADS"] = "1"
+    env["OPENBLAS_NUM_THREADS"] = "2"
     env["OMP_NUM_THREADS"] = "2"
 
     # Build command based on test type
@@ -48,16 +50,36 @@ def run_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_di
         ]
 
     try:
-        result = subprocess.run(
-            cmd, env=env, cwd=build_dir, check=True, capture_output=False
+        # Run process and capture output
+        process = subprocess.Popen(
+            cmd,
+            env=env,
+            cwd=build_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
         )
-        print(f"Shard {shard_index} for {test_type} completed successfully")
-        return (shard_index, test_type, 0)
-    except subprocess.CalledProcessError as e:
-        print(
-            f"Shard {shard_index} for {test_type} failed with exit code {e.returncode}"
-        )
-        return (shard_index, test_type, e.returncode)
+
+        # Read and print output line by line with prefix
+        for line in process.stdout:
+            line = line.rstrip()
+            if line:
+                print(f"{shard_tag} {line}", flush=True)
+
+        # Wait for process to complete
+        return_code = process.wait()
+
+        if return_code == 0:
+            print(f"{shard_tag} Completed successfully")
+            return (shard_index, test_type, 0)
+        else:
+            print(f"{shard_tag} Failed with exit code {return_code}")
+            return (shard_index, test_type, return_code)
+
+    except Exception as e:
+        print(f"{shard_tag} Exception: {e}")
+        return (shard_index, test_type, 1)
 
 
 def main():
@@ -115,26 +137,39 @@ def main():
     test_report_dir = build_dir / "test_report"
     test_report_dir.mkdir(exist_ok=True)
 
-    # Prepare tasks
-    tasks = []
+    # Run all shards
+    failed_shards = []
 
-    # Add Google Test shards
+    # Run Google Test shards first
+    print("\n--- Running Google Test shards ---")
+    gtest_tasks = []
     for i in range(args.num_shards):
-        tasks.append(
+        gtest_tasks.append(
             (i, str(gtest_exe), "gtest", args.num_shards, args.gpu_filter, build_dir)
         )
 
-    # Add Catch2 shards
+    with ProcessPoolExecutor(max_workers=args.num_shards) as executor:
+        futures = [executor.submit(run_shard, *task) for task in gtest_tasks]
+
+        for future in as_completed(futures):
+            try:
+                shard_index, test_type, exit_code = future.result()
+                if exit_code != 0:
+                    failed_shards.append((shard_index, test_type, exit_code))
+            except Exception as e:
+                print(f"ERROR: Unexpected exception: {e}")
+                failed_shards.append((-1, "unknown", 1))
+
+    # Run Catch2 shards after Google Test completes
+    print("\n--- Running Catch2 shards ---")
+    catch2_tasks = []
     for i in range(args.num_shards):
-        tasks.append(
+        catch2_tasks.append(
             (i, str(catch2_exe), "catch2", args.num_shards, args.gpu_filter, build_dir)
         )
 
-    # Run all shards in parallel
-    failed_shards = []
-
-    with ProcessPoolExecutor(max_workers=args.num_shards * 2) as executor:
-        futures = [executor.submit(run_shard, *task) for task in tasks]
+    with ProcessPoolExecutor(max_workers=args.num_shards) as executor:
+        futures = [executor.submit(run_shard, *task) for task in catch2_tasks]
 
         for future in as_completed(futures):
             try:

--- a/shared/rocroller/.jenkins/run-tests-sharded.py
+++ b/shared/rocroller/.jenkins/run-tests-sharded.py
@@ -1,22 +1,74 @@
 #!/usr/bin/env python3
 """Run rocroller tests in parallel shards.
 
-Usage: run-tests-sharded.py [BUILD_DIR] [NUM_SHARDS] [GPU_FILTER]
+Usage: run-tests-sharded.py [BUILD_DIR] [GPU_FILTER]
+
+Number of shards is auto-detected as ncores/2.
 """
 
 import argparse
 import os
+import pty
+import select
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from concurrent.futures import ProcessPoolExecutor, as_completed
 
 
-def run_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_dir):
-    """Run a single shard of tests."""
+@dataclass
+class ShardInfo:
+    """Information about a running test shard."""
+
+    process: subprocess.Popen
+    master_fd: int
+    shard_tag: str
+    shard_index: int
+    test_type: str
+    output_buffer: str = ""
+
+
+def get_gpu_arch():
+    """Detect GPU architecture (e.g., gfx1201) if possible."""
+    try:
+        result = subprocess.run(
+            ["rocminfo"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+        # Look for gfx architecture in output
+        for line in result.stdout.splitlines():
+            if "Name:" in line and "gfx" in line.lower():
+                # Extract gfx architecture (e.g., gfx1201)
+                parts = line.lower().split()
+                for part in parts:
+                    if part.startswith("gfx"):
+                        return part.strip()
+    except:
+        pass
+    return None
+
+
+def get_available_cpus():
+    """Get the number of CPUs available, respecting cgroups and affinity."""
+    try:
+        result = subprocess.run(
+            ["nproc"], capture_output=True, text=True, check=True, timeout=1
+        )
+        return int(result.stdout.strip())
+    except:
+        pass
+
+    return os.cpu_count() or 4
+
+
+def start_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_dir):
+    """Start a shard of tests and return process info."""
     test_prefix = "G" if test_type == "gtest" else "C"
     shard_tag = f"[{test_prefix}{shard_index:02d}]"
-    print(f"{shard_tag} Starting shard")
+    print(f"{shard_tag} Starting shard", flush=True)
 
     # Set environment variables
     env = os.environ.copy()
@@ -25,20 +77,21 @@ def run_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_di
 
     # Build command based on test type
     if test_type == "gtest":
-        # Google Test sharding
         env["GTEST_TOTAL_SHARDS"] = str(num_shards)
         env["GTEST_SHARD_INDEX"] = str(shard_index)
 
         cmd = [test_exe]
+        cmd.append("--gtest_shuffle")
         if gpu_filter:
             cmd.append(gpu_filter)
         cmd.extend(
             ["--gtest_output=xml:test_report/gtest_shard_{}.xml".format(shard_index)]
         )
     else:
-        # Catch2 sharding
         cmd = [
             test_exe,
+            "--order",
+            "rand",
             "--shard-count",
             str(num_shards),
             "--shard-index",
@@ -49,37 +102,104 @@ def run_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_di
             "test_report/catch2_shard_{}.xml".format(shard_index),
         ]
 
-    try:
-        # Run process and capture output
-        process = subprocess.Popen(
-            cmd,
-            env=env,
-            cwd=build_dir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-        )
+    # Use pseudo-TTY to ensure line-buffered output from subprocess
+    master_fd, slave_fd = pty.openpty()
 
-        # Read and print output line by line with prefix
-        for line in process.stdout:
-            line = line.rstrip()
-            if line:
-                print(f"{shard_tag} {line}", flush=True)
+    process = subprocess.Popen(
+        cmd,
+        env=env,
+        cwd=build_dir,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        close_fds=True,
+    )
 
-        # Wait for process to complete
-        return_code = process.wait()
+    # Close slave fd in parent process
+    os.close(slave_fd)
 
-        if return_code == 0:
-            print(f"{shard_tag} Completed successfully")
-            return (shard_index, test_type, 0)
-        else:
-            print(f"{shard_tag} Failed with exit code {return_code}")
-            return (shard_index, test_type, return_code)
+    return ShardInfo(
+        process=process,
+        master_fd=master_fd,
+        shard_tag=shard_tag,
+        shard_index=shard_index,
+        test_type=test_type,
+        output_buffer="",
+    )
 
-    except Exception as e:
-        print(f"{shard_tag} Exception: {e}")
-        return (shard_index, test_type, 1)
+
+def run_shards(shard_infos):
+    """Run multiple shards and multiplex their I/O using select."""
+    active_shards = {info.master_fd: info for info in shard_infos}
+    failed_shards = []
+
+    while active_shards:
+        fds = list(active_shards.keys())
+
+        ready, _, _ = select.select(fds, [], [], 0.1)
+
+        for fd in ready:
+            info = active_shards[fd]
+
+            try:
+                chunk = os.read(fd, 4096).decode("utf-8", errors="replace")
+                if chunk:
+                    info.output_buffer += chunk
+
+                    # Process complete lines
+                    while "\n" in info.output_buffer:
+                        line, info.output_buffer = info.output_buffer.split("\n", 1)
+                        line = line.rstrip("\r")
+                        if line:
+                            print(f"{info.shard_tag} {line}", flush=True)
+            except OSError:
+                # File descriptor closed or error
+                pass
+
+        # Check which processes have finished
+        finished_fds = []
+        for fd, info in active_shards.items():
+            if info.process.poll() is not None:
+                finished_fds.append(fd)
+
+        # Handle finished processes
+        for fd in finished_fds:
+            info = active_shards[fd]
+
+            # Read any remaining output
+            try:
+                while True:
+                    chunk = os.read(fd, 4096).decode("utf-8", errors="replace")
+                    if not chunk:
+                        break
+                    info.output_buffer += chunk
+            except OSError:
+                pass
+
+            # Print any remaining buffered output
+            if info.output_buffer:
+                for line in info.output_buffer.split("\n"):
+                    line = line.rstrip("\r")
+                    if line:
+                        print(f"{info.shard_tag} {line}", flush=True)
+
+            # Close file descriptor
+            os.close(fd)
+
+            # Get return code
+            return_code = info.process.wait()
+
+            if return_code == 0:
+                print(f"{info.shard_tag} Completed successfully", flush=True)
+            else:
+                print(
+                    f"{info.shard_tag} Failed with exit code {return_code}", flush=True
+                )
+                failed_shards.append((info.shard_index, info.test_type, return_code))
+
+            # Remove from active shards
+            del active_shards[fd]
+
+    return failed_shards
 
 
 def main():
@@ -93,13 +213,6 @@ def main():
         help="Path to build directory (default: build)",
     )
     parser.add_argument(
-        "num_shards",
-        nargs="?",
-        type=int,
-        default=4,
-        help="Number of parallel shards (default: 4)",
-    )
-    parser.add_argument(
         "gpu_filter",
         nargs="?",
         default="",
@@ -107,6 +220,17 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Auto-detect number of available CPUs (respecting cgroups) and use half
+    num_cores = get_available_cpus()
+    num_shards = max(1, num_cores // 2)
+
+    # Cap shards to 8 on gfx1201 due to hanging issues
+    gpu_arch = get_gpu_arch()
+    if gpu_arch and "gfx1201" in gpu_arch:
+        if num_shards > 8:
+            print(f"Detected {gpu_arch}, capping shards to 8 (was {num_shards})")
+            num_shards = 8
 
     # Resolve build directory
     build_dir = Path(args.build_dir).resolve()
@@ -129,7 +253,10 @@ def main():
     print("=" * 50)
     print("Running sharded tests")
     print(f"Build directory: {build_dir}")
-    print(f"Number of shards: {args.num_shards}")
+    print(f"Available cores: {num_cores}")
+    if gpu_arch:
+        print(f"GPU architecture: {gpu_arch}")
+    print(f"Number of shards: {num_shards} (auto-detected)")
     print(f"GPU filter: {args.gpu_filter if args.gpu_filter else 'none'}")
     print("=" * 50)
 
@@ -142,43 +269,42 @@ def main():
 
     # Run Google Test shards first
     print("\n--- Running Google Test shards ---")
-    gtest_tasks = []
-    for i in range(args.num_shards):
-        gtest_tasks.append(
-            (i, str(gtest_exe), "gtest", args.num_shards, args.gpu_filter, build_dir)
-        )
+    gtest_infos = []
+    for i in range(num_shards):
+        try:
+            info = start_shard(
+                i, str(gtest_exe), "gtest", num_shards, args.gpu_filter, build_dir
+            )
+            gtest_infos.append(info)
+        except Exception as e:
+            print(f"ERROR: Failed to start gtest shard {i}: {e}", flush=True)
+            failed_shards.append((i, "gtest", 1))
 
-    with ProcessPoolExecutor(max_workers=args.num_shards) as executor:
-        futures = [executor.submit(run_shard, *task) for task in gtest_tasks]
-
-        for future in as_completed(futures):
-            try:
-                shard_index, test_type, exit_code = future.result()
-                if exit_code != 0:
-                    failed_shards.append((shard_index, test_type, exit_code))
-            except Exception as e:
-                print(f"ERROR: Unexpected exception: {e}")
-                failed_shards.append((-1, "unknown", 1))
+    # Run all gtest shards and wait for completion
+    gtest_failures = run_shards(gtest_infos)
+    failed_shards.extend(gtest_failures)
 
     # Run Catch2 shards after Google Test completes
     print("\n--- Running Catch2 shards ---")
-    catch2_tasks = []
-    for i in range(args.num_shards):
-        catch2_tasks.append(
-            (i, str(catch2_exe), "catch2", args.num_shards, args.gpu_filter, build_dir)
-        )
+    catch2_infos = []
+    for i in range(num_shards):
+        try:
+            info = start_shard(
+                i,
+                str(catch2_exe),
+                "catch2",
+                num_shards,
+                args.gpu_filter,
+                build_dir,
+            )
+            catch2_infos.append(info)
+        except Exception as e:
+            print(f"ERROR: Failed to start catch2 shard {i}: {e}", flush=True)
+            failed_shards.append((i, "catch2", 1))
 
-    with ProcessPoolExecutor(max_workers=args.num_shards) as executor:
-        futures = [executor.submit(run_shard, *task) for task in catch2_tasks]
-
-        for future in as_completed(futures):
-            try:
-                shard_index, test_type, exit_code = future.result()
-                if exit_code != 0:
-                    failed_shards.append((shard_index, test_type, exit_code))
-            except Exception as e:
-                print(f"ERROR: Unexpected exception: {e}")
-                failed_shards.append((-1, "unknown", 1))
+    # Run all catch2 shards and wait for completion
+    catch2_failures = run_shards(catch2_infos)
+    failed_shards.extend(catch2_failures)
 
     print()
 

--- a/shared/rocroller/.jenkins/run-tests-sharded.py
+++ b/shared/rocroller/.jenkins/run-tests-sharded.py
@@ -102,6 +102,11 @@ def start_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_
             "test_report/catch2_shard_{}.xml".format(shard_index),
         ]
 
+    # Log the command being executed
+    cmd_str = " ".join(cmd)
+    print(f"{shard_tag} Running command in {build_dir}:", flush=True)
+    print(f"{shard_tag}   {cmd_str}", flush=True)
+
     # Use pseudo-TTY to ensure line-buffered output from subprocess
     master_fd, slave_fd = pty.openpty()
 

--- a/shared/rocroller/README.md
+++ b/shared/rocroller/README.md
@@ -147,21 +147,6 @@ CXX=<g++ or clang++ path> CC=<gcc or clang path> cmake .. [cmake options]
   ctest -LE GPU
   ```
 
-**Exclude Exhaustive GEMM Tests (for faster test runs or code coverage):**
-  ```bash
-  ctest -LE GEMM_EXHAUSTIVE
-  ```
-  This excludes heavily parameterized GEMM tests that test all
-  combinations of parameters.  The excluded tests include
-  parameterized variants of StreamK, mixed precision
-  (FP8/BF8/FP6/BF6/FP4/FP16/BF16), swizzle/scale, unroll, WMMA, and
-  DirectLDS tests. Basic GEMM feature tests are still included.
-
-**Run Only Exhaustive GEMM Tests:**
-  ```bash
-  ctest -L GEMM_EXHAUSTIVE
-  ```
-
 ### With GTest
 **Run All GTest Tests:**
   ```bash

--- a/shared/rocroller/README.md
+++ b/shared/rocroller/README.md
@@ -147,6 +147,21 @@ CXX=<g++ or clang++ path> CC=<gcc or clang path> cmake .. [cmake options]
   ctest -LE GPU
   ```
 
+**Exclude Exhaustive GEMM Tests (for faster test runs or code coverage):**
+  ```bash
+  ctest -LE GEMM_EXHAUSTIVE
+  ```
+  This excludes heavily parameterized GEMM tests that test all
+  combinations of parameters.  The excluded tests include
+  parameterized variants of StreamK, mixed precision
+  (FP8/BF8/FP6/BF6/FP4/FP16/BF16), swizzle/scale, unroll, WMMA, and
+  DirectLDS tests. Basic GEMM feature tests are still included.
+
+**Run Only Exhaustive GEMM Tests:**
+  ```bash
+  ctest -L GEMM_EXHAUSTIVE
+  ```
+
 ### With GTest
 **Run All GTest Tests:**
   ```bash

--- a/shared/rocroller/scripts/codecov
+++ b/shared/rocroller/scripts/codecov
@@ -125,19 +125,17 @@ else
 
     # The `%m` creates a different prof file for each object file. So one for
     # rocroller.so and one for rocroller-tests.
-    # Also had to switch to using ctest so seg faults can be handled gracefully.
+    # Using sharded test runner with codecov profile for better parallelization
+    # and centralized test filtering configuration.
     #
-    # Exclude GEMM_EXHAUSTIVE tests to reduce code coverage execution time.
-    # These are heavily parameterized GEMM tests that test all parameter combinations
-    # but are not needed for coverage validation (basic GEMM tests still run).
+    # The codecov profile excludes slow/exhaustive tests to reduce execution time
+    # while maintaining good coverage validation (basic tests still run).
 
-    echo Using $(nproc) threads for code coverage tests.
-    OMP_NUM_THREADS=8 LLVM_PROFILE_FILE=${code_cov_path}/rocroller-tests_%m.profraw ctest \
-        -j $(nproc) \
-        --test-dir ${build_path} \
-        --output-on-failure \
-        -LE "GEMM_EXHAUSTIVE" \
-        ${ctest_re_flag} "${ctest_re}"
+    echo Using sharded test runner with codecov profile.
+    LLVM_PROFILE_FILE=${code_cov_path}/rocroller-tests_%m.profraw \
+        ${script_path}/run-tests-sharded \
+        ${build_path} \
+        --profile codecov
 
     # this combines them back together.
     /opt/rocm/lib/llvm/bin/llvm-profdata merge \

--- a/shared/rocroller/scripts/codecov
+++ b/shared/rocroller/scripts/codecov
@@ -126,12 +126,17 @@ else
     # The `%m` creates a different prof file for each object file. So one for
     # rocroller.so and one for rocroller-tests.
     # Also had to switch to using ctest so seg faults can be handled gracefully.
+    #
+    # Exclude GEMM_EXHAUSTIVE tests to reduce code coverage execution time.
+    # These are heavily parameterized GEMM tests that test all parameter combinations
+    # but are not needed for coverage validation (basic GEMM tests still run).
 
     echo Using $(nproc) threads for code coverage tests.
     OMP_NUM_THREADS=8 LLVM_PROFILE_FILE=${code_cov_path}/rocroller-tests_%m.profraw ctest \
         -j $(nproc) \
         --test-dir ${build_path} \
         --output-on-failure \
+        -LE "GEMM_EXHAUSTIVE" \
         ${ctest_re_flag} "${ctest_re}"
 
     # this combines them back together.

--- a/shared/rocroller/scripts/run-tests-sharded
+++ b/shared/rocroller/scripts/run-tests-sharded
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Run rocroller tests in parallel shards.
 
-Usage: run-tests-sharded.py [BUILD_DIR] [GPU_FILTER]
+Usage: run-tests-sharded [BUILD_DIR] [GPU_FILTER]
 
 Number of shards is auto-detected as ncores/2.
 """
@@ -12,6 +12,7 @@ import pty
 import select
 import subprocess
 import sys
+import yaml
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -64,7 +65,85 @@ def get_available_cpus():
     return os.cpu_count() or 4
 
 
-def start_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_dir):
+def load_test_profile(profile_name):
+    """Load test profile configuration from YAML file."""
+    # Look for test-profiles.yaml in rocroller root (parent of scripts)
+    script_dir = Path(__file__).parent
+    yaml_path = script_dir.parent / "test-profiles.yaml"
+
+    if not yaml_path.exists():
+        raise FileNotFoundError(f"Test profiles file not found: {yaml_path}")
+
+    with open(yaml_path, "r") as f:
+        config = yaml.safe_load(f)
+
+    if "profiles" not in config or profile_name not in config["profiles"]:
+        available = ", ".join(config.get("profiles", {}).keys())
+        raise ValueError(f"Profile '{profile_name}' not found. Available: {available}")
+
+    return config["profiles"][profile_name]
+
+
+def build_gtest_filter(profile_config):
+    """Build gtest filter string from profile config include/exclude lists.
+
+    Format: --gtest_filter=include1:include2-exclude1:exclude2:exclude3
+    The negative sign appears once before the first exclude pattern.
+    """
+    if not profile_config or "gtest" not in profile_config:
+        return None
+
+    gtest = profile_config["gtest"]
+    includes = gtest.get("include", [])
+    excludes = gtest.get("exclude", [])
+
+    if not includes and not excludes:
+        return None
+
+    # Build filter string with proper gtest format
+    parts = []
+    if includes:
+        parts.append(":".join(includes))
+    if excludes:
+        # Negative sign goes before the first exclude, then join rest with ':'
+        parts.append("-" + ":".join(excludes))
+
+    return "".join(parts)
+
+
+def build_catch2_filter(profile_config):
+    """Build catch2 filter string from profile config include/exclude lists.
+
+    Format: include patterns as-is, exclude patterns with ~ prefix
+    """
+    if not profile_config or "catch2" not in profile_config:
+        return None
+
+    catch2 = profile_config["catch2"]
+    includes = catch2.get("include", [])
+    excludes = catch2.get("exclude", [])
+
+    if not includes and not excludes:
+        return None
+
+    # Catch2 uses ~pattern for exclusion
+    filter_parts = []
+    filter_parts.extend(includes)
+    filter_parts.extend([f"~{pattern}" for pattern in excludes])
+
+    # Join with commas or as separate arguments depending on catch2 version
+    return ",".join(filter_parts) if filter_parts else None
+
+
+def start_shard(
+    shard_index,
+    test_exe,
+    test_type,
+    num_shards,
+    gpu_filter,
+    build_dir,
+    profile_config=None,
+):
     """Start a shard of tests and return process info."""
     test_prefix = "G" if test_type == "gtest" else "C"
     shard_tag = f"[{test_prefix}{shard_index:02d}]"
@@ -82,8 +161,15 @@ def start_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_
 
         cmd = [test_exe]
         cmd.append("--gtest_shuffle")
-        if gpu_filter:
+
+        # Apply profile filter if provided, otherwise use gpu_filter
+        profile_filter = build_gtest_filter(profile_config)
+        if profile_filter:
+            cmd.append(f"--gtest_filter={profile_filter}")
+            print(f"{shard_tag} Applying gtest filter from profile", flush=True)
+        elif gpu_filter:
             cmd.append(gpu_filter)
+
         cmd.extend(
             ["--gtest_output=xml:test_report/gtest_shard_{}.xml".format(shard_index)]
         )
@@ -101,6 +187,13 @@ def start_shard(shard_index, test_exe, test_type, num_shards, gpu_filter, build_
             "-o",
             "test_report/catch2_shard_{}.xml".format(shard_index),
         ]
+
+        # Apply catch2 filter from profile if provided
+        profile_filter = build_catch2_filter(profile_config)
+        if profile_filter:
+            # Catch2 filter goes as a positional argument at the end
+            cmd.append(profile_filter)
+            print(f"{shard_tag} Applying catch2 filter from profile", flush=True)
 
     # Log the command being executed
     cmd_str = " ".join(cmd)
@@ -223,6 +316,16 @@ def main():
         default="",
         help="GPU filter for Google Test (e.g., --gtest_filter=-*GPU*)",
     )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help="Test profile to use from test-profiles.yaml (e.g., precheckin, codecov)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List tests that would run with the given profile/filters, but don't execute them",
+    )
 
     args = parser.parse_args()
 
@@ -255,19 +358,68 @@ def main():
         print(f"ERROR: Catch2 executable not found: {catch2_exe}")
         sys.exit(1)
 
+    # Load profile configuration if specified
+    profile_config = None
+    if args.profile:
+        profile_config = load_test_profile(args.profile)
+        print(f"Using test profile: {args.profile}")
+        if profile_config.get("description"):
+            print(f"  {profile_config['description']}")
+
     print("=" * 50)
-    print("Running sharded tests")
+    print("Running sharded tests" + (" [DRY RUN]" if args.dry_run else ""))
     print(f"Build directory: {build_dir}")
     print(f"Available cores: {num_cores}")
     if gpu_arch:
         print(f"GPU architecture: {gpu_arch}")
-    print(f"Number of shards: {num_shards} (auto-detected)")
+    if not args.dry_run:
+        print(f"Number of shards: {num_shards} (auto-detected)")
     print(f"GPU filter: {args.gpu_filter if args.gpu_filter else 'none'}")
+    if args.profile:
+        print(f"Test profile: {args.profile}")
+    if args.dry_run:
+        print("Mode: DRY RUN - listing tests only")
     print("=" * 50)
 
     # Create test report directory
     test_report_dir = build_dir / "test_report"
     test_report_dir.mkdir(exist_ok=True)
+
+    # Handle dry-run mode: list tests instead of executing
+    if args.dry_run:
+        print("\n=== DRY RUN MODE: Listing tests that would be executed ===\n")
+        
+        # List Google Test tests
+        print("--- Google Test Suite ---")
+        gtest_cmd = [str(gtest_exe), "--gtest_list_tests"]
+        profile_filter = build_gtest_filter(profile_config)
+        if profile_filter:
+            gtest_cmd.append(f"--gtest_filter={profile_filter}")
+            print(f"Applied gtest filter: {profile_filter}\n")
+        elif args.gpu_filter:
+            gtest_cmd.append(args.gpu_filter)
+            print(f"Applied gtest filter: {args.gpu_filter}\n")
+        
+        result = subprocess.run(gtest_cmd, cwd=build_dir)
+        if result.returncode != 0:
+            print(f"ERROR: Failed to list gtest tests (exit code {result.returncode})")
+            sys.exit(1)
+        
+        # List Catch2 tests
+        print("\n--- Catch2 Test Suite ---")
+        catch2_cmd = [str(catch2_exe), "--list-tests"]
+        profile_filter = build_catch2_filter(profile_config)
+        if profile_filter:
+            catch2_cmd.append(profile_filter)
+            print(f"Applied catch2 filter: {profile_filter}\n")
+        
+        result = subprocess.run(catch2_cmd, cwd=build_dir)
+        if result.returncode != 0:
+            print(f"ERROR: Failed to list catch2 tests (exit code {result.returncode})")
+            sys.exit(1)
+        
+        print("\n=== DRY RUN COMPLETE ===")
+        sys.exit(0)
 
     # Run all shards
     failed_shards = []
@@ -278,7 +430,13 @@ def main():
     for i in range(num_shards):
         try:
             info = start_shard(
-                i, str(gtest_exe), "gtest", num_shards, args.gpu_filter, build_dir
+                i,
+                str(gtest_exe),
+                "gtest",
+                num_shards,
+                args.gpu_filter,
+                build_dir,
+                profile_config,
             )
             gtest_infos.append(info)
         except Exception as e:
@@ -301,6 +459,7 @@ def main():
                 num_shards,
                 args.gpu_filter,
                 build_dir,
+                profile_config,
             )
             catch2_infos.append(info)
         except Exception as e:

--- a/shared/rocroller/test-profiles.yaml
+++ b/shared/rocroller/test-profiles.yaml
@@ -1,0 +1,47 @@
+# rocRoller Test profiles
+profiles:
+  precheckin:
+    description: "Test suite for pre-commit validation"
+    gtest:
+      include: []
+      exclude: []
+    catch2:
+      include: []
+      exclude: []
+    ctest:
+      include: []
+      exclude: []
+  
+  # Codecov profile - excludes slow/exhaustive tests
+  codecov:
+    description: "Reduced test suite for code coverage analysis"
+    gtest:
+      include: []
+      exclude:
+        - "GEMMTest/StreamKWGMTestGPU.*"
+        - "GEMMTest/StreamKMultipleFixupsTestGPU.*"
+        - "GEMMTest/StreamKTestGPU.*"
+        - "GEMMF16Test/GEMMF16TestGPU.*"
+        - "GEMMF16Test/GEMMF16NTTestGPU.*"
+        - "GEMMF8F6F4Test/GEMMF8F6F4TestGPU.*"
+        - "MixedGEMMTest/MixedGEMMF8F6F4TestGPU.*"
+        - "ScaledMixedGEMMTest/ScaledMixedGEMMF8F6F4TestGPU.*"
+        - "GEMMTest/SwizzleScaledTestGPU.*"
+        - "GEMMTest/SwizzleScaledUnrollTestGPU.*"
+        - "GEMMTest/UnrollKTestGPU.*"
+        - "GEMMJammedTest/GEMMJammedTestGPU.*"
+        - "*WMMA*TestGPU*"
+        - "GEMMTest/GEMMLargeMacroTileTestGPU.*"
+        - "GEMMDirectLDSTestBasic/GEMMDirectLDSTestBasicGPU.*"
+        - "GEMMDirectLDSTest/GEMMDirectLDSTestGPU.*"
+        - "GEMMDirectLDSTest/GEMMDirectLDSF8F6F4TestGPU.*"
+        - "GEMMDirectLDSTestPrefetch/GEMMDirectLDSTestPrefetchGPU.*"
+        - "GEMMMXFP4TNSwizzleScaledUnrollTest/*"
+        - "ScaledMMCPU/*"
+        - "GEMMTest/SwizzleScaledF4TNTestGPU.*"
+    catch2:
+      include: []
+      exclude: []
+    ctest:
+      include: []
+      exclude: []

--- a/shared/rocroller/test/CMakeLists.txt
+++ b/shared/rocroller/test/CMakeLists.txt
@@ -120,23 +120,26 @@ if(ROCROLLER_ENABLE_TEST_DISCOVERY)
         TEST_FILTER "-*GPU_*"
         DISCOVERY_MODE PRE_TEST
         PROPERTIES
-            ENVIRONMENT "${asan_opts}"
+            "LABELS" "GTEST"
+            "ENVIRONMENT" "${asan_opts}"
     )
     gtest_discover_tests(
         rocroller-tests
         XML_OUTPUT_DIR ${TEST_REPORT_DIR}
         TEST_FILTER "*GPU_*"
-        PROPERTIES "LABELS" "GPU"
-        DISCOVERY_MODE PRE_TEST
         PROPERTIES
-            ENVIRONMENT "${asan_opts}"
+            "LABELS" "GPU"
+            "LABELS" "GTEST"
+            "ENVIRONMENT" "${asan_opts}"
+        DISCOVERY_MODE PRE_TEST
     )
     gtest_discover_tests(
         arch-gen-tests
         XML_OUTPUT_DIR ${TEST_REPORT_DIR}
         DISCOVERY_MODE PRE_TEST
         PROPERTIES
-            ENVIRONMENT "${asan_opts}"
+            "LABELS" "GTEST"
+            "ENVIRONMENT" "${asan_opts}"
     )
 
     if(ROCROLLER_ENABLE_CATCH)

--- a/shared/rocroller/test/CMakeLists.txt
+++ b/shared/rocroller/test/CMakeLists.txt
@@ -133,24 +133,6 @@ if(ROCROLLER_ENABLE_TEST_DISCOVERY)
             "ENVIRONMENT" "${asan_opts}"
         DISCOVERY_MODE PRE_TEST
     )
-    # Label exhaustive GEMM parameterized tests to exclude from code
-    # coverage.  These tests cover all parameter combinations for
-    # various GEMM features but take a long time to execute. Basic
-    # GEMM tests (GPU_BasicGEMM, etc.) are NOT labeled here and will
-    # still run during code coverage to ensure core functionality is
-    # tested. To exclude these tests: ctest -LE GEMM_EXHAUSTIVE To run
-    # only these tests: ctest -L GEMM_EXHAUSTIVE
-    gtest_discover_tests(
-        rocroller-tests
-        XML_OUTPUT_DIR ${TEST_REPORT_DIR}
-        TEST_FILTER "GEMMTest/StreamKWGMTestGPU.*:GEMMTest/StreamKMultipleFixupsTestGPU.*:GEMMTest/StreamKTestGPU.*:GEMMF16Test/GEMMF16TestGPU.*:GEMMF16Test/GEMMF16NTTestGPU.*:GEMMF8F6F4Test/GEMMF8F6F4TestGPU.*:MixedGEMMTest/MixedGEMMF8F6F4TestGPU.*:ScaledMixedGEMMTest/ScaledMixedGEMMF8F6F4TestGPU.*:GEMMTest/SwizzleScaledTestGPU.*:GEMMTest/SwizzleScaledUnrollTestGPU.*:GEMMTest/UnrollKTestGPU.*:GEMMJammedTest/GEMMJammedTestGPU.*:*WMMA*TestGPU*:GEMMTest/GEMMLargeMacroTileTestGPU.*:GEMMDirectLDSTestBasic/GEMMDirectLDSTestBasicGPU.*:GEMMDirectLDSTest/GEMMDirectLDSTestGPU.*:GEMMDirectLDSTestPrefetch/GEMMDirectLDSTestPrefetchGPU.*:GEMMMXFP4TNSwizzleScaledUnrollTest/*"
-        PROPERTIES
-            "LABELS" "GPU"
-            "LABELS" "GTEST"
-            "LABELS" "GEMM_EXHAUSTIVE"
-            "ENVIRONMENT" "${asan_opts}"
-        DISCOVERY_MODE PRE_TEST
-    )
     gtest_discover_tests(
         arch-gen-tests
         XML_OUTPUT_DIR ${TEST_REPORT_DIR}

--- a/shared/rocroller/test/CMakeLists.txt
+++ b/shared/rocroller/test/CMakeLists.txt
@@ -133,6 +133,24 @@ if(ROCROLLER_ENABLE_TEST_DISCOVERY)
             "ENVIRONMENT" "${asan_opts}"
         DISCOVERY_MODE PRE_TEST
     )
+    # Label exhaustive GEMM parameterized tests to exclude from code
+    # coverage.  These tests cover all parameter combinations for
+    # various GEMM features but take a long time to execute. Basic
+    # GEMM tests (GPU_BasicGEMM, etc.) are NOT labeled here and will
+    # still run during code coverage to ensure core functionality is
+    # tested. To exclude these tests: ctest -LE GEMM_EXHAUSTIVE To run
+    # only these tests: ctest -L GEMM_EXHAUSTIVE
+    gtest_discover_tests(
+        rocroller-tests
+        XML_OUTPUT_DIR ${TEST_REPORT_DIR}
+        TEST_FILTER "GEMMTest/StreamKWGMTestGPU.*:GEMMTest/StreamKMultipleFixupsTestGPU.*:GEMMTest/StreamKTestGPU.*:GEMMF16Test/GEMMF16TestGPU.*:GEMMF16Test/GEMMF16NTTestGPU.*:GEMMF8F6F4Test/GEMMF8F6F4TestGPU.*:MixedGEMMTest/MixedGEMMF8F6F4TestGPU.*:ScaledMixedGEMMTest/ScaledMixedGEMMF8F6F4TestGPU.*:GEMMTest/SwizzleScaledTestGPU.*:GEMMTest/SwizzleScaledUnrollTestGPU.*:GEMMTest/UnrollKTestGPU.*:GEMMJammedTest/GEMMJammedTestGPU.*:*WMMA*TestGPU*:GEMMTest/GEMMLargeMacroTileTestGPU.*:GEMMDirectLDSTestBasic/GEMMDirectLDSTestBasicGPU.*:GEMMDirectLDSTest/GEMMDirectLDSTestGPU.*:GEMMDirectLDSTestPrefetch/GEMMDirectLDSTestPrefetchGPU.*:GEMMMXFP4TNSwizzleScaledUnrollTest/*"
+        PROPERTIES
+            "LABELS" "GPU"
+            "LABELS" "GTEST"
+            "LABELS" "GEMM_EXHAUSTIVE"
+            "ENVIRONMENT" "${asan_opts}"
+        DISCOVERY_MODE PRE_TEST
+    )
     gtest_discover_tests(
         arch-gen-tests
         XML_OUTPUT_DIR ${TEST_REPORT_DIR}


### PR DESCRIPTION
This PR runs google-tests and catch2-tests manually (using shards) instead of using ctest.  It uses this technique for both "precheckin" and "codecov" CI pipelines.

This PR also adds a `shared/rocroller/test-profiles.yaml` file that defines test filters.  There are include/exclude filters for both "precheckin" and "codecov" profiles.

Codecov: a lot of GEMM tests (but not all) have been excluded.  This significantly reduces the number of tests that are run as part of "codecov".  It reduces the time taken for the codecov pipeline (from 5+ hours, which times-out; to < 45mins).  This also reduces our coverage by roughly 5%.

Precheckin: All tests are run; but they are run in shards.  This significantly reduces the number of HIP device related API calls (like hipGetDevice etc); and generally speeds up testing as new processes do not need to be spun up. We suspect that segfaults observed previously may have been related to excessive HSA runtime calls running concurrently.

The number of cores available is auto detected using `nproc` (which respects `cgroups` etc). Then, `nproc/2` shards are run by default. On gfx1201 we limit this to 8 regardless of the number of cores. Each shard may use up to 2 OMP/OPENBLAS threads. Google-test shards are run first, then catch2, then any remaining tests are run using `ctest` with a modest number of cores (this runs `pytest` etc).
