### PR TITLE
Allow dynamic values of AMDGPU_FAMILIES

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -16,6 +16,14 @@ on:
       projects:
         type: string
         description: "Insert space-separated list of projects to test or 'all' to test all projects. ex: 'projects/rocprim projects/hipcub'"
+      linux_amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx1151"
+        default: ""
+      windows_amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx1151"
+        default: ""
   workflow_call:
 
 permissions:
@@ -83,8 +91,7 @@ jobs:
       - name: Fetch Linux targets for build and test
         env:
           THEROCK_PACKAGE_PLATFORM: "linux"
-          # TODO(geomin12): Allow dynamic values of AMDGPU_FAMILIES, with opt-in options
-          AMDGPU_FAMILIES: "gfx94X, gfx950"
+          AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families || 'gfx94X, gfx950' }}
           # Variable comes from ROCm organization variable 'ROCM_THEROCK_TEST_RUNNERS'
           ROCM_THEROCK_TEST_RUNNERS: ${{ vars.ROCM_THEROCK_TEST_RUNNERS }}
           # TODO(#2656): Migrate the organization variable to S3 file. Below code is a temporary resolution
@@ -97,8 +104,7 @@ jobs:
       - name: Fetch Windows targets for build and test
         env:
           THEROCK_PACKAGE_PLATFORM: "windows"
-          # TODO(geomin12): Allow dynamic values of AMDGPU_FAMILIES, with opt-in options
-          AMDGPU_FAMILIES: "gfx1151"
+          AMDGPU_FAMILIES: ${{ inputs.windows_amdgpu_families || 'gfx1151' }}
           # Variable comes from ROCm organization variable 'ROCM_THEROCK_TEST_RUNNERS'
           ROCM_THEROCK_TEST_RUNNERS: ${{ vars.ROCM_THEROCK_TEST_RUNNERS }}
           # TODO(#2656): Migrate the organization variable to S3 file. Below code is a temporary resolution


### PR DESCRIPTION
## Motivation

Allow choosing gpu family when triggering the workflow manually

## Technical Details

Add workflow dispatch input to have linux_amdgpu_families and windows_amdgpu_families 

## Test Plan

From the actions/All workflows, choose "TheRock CI", pick a branch, then type in a gfx arch in linux and a gfx arch in windows

## Test Result

Refer to:
For test Type in test/miopen, now we see
https://github.com/ROCm/rocm-libraries/actions/runs/21373209630

**It captures the MIOPEN test error**


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
