### PR TITLE
[hipblaslt][CMS] Fix Validator bugs related to mfma reordering

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1713,7 +1713,7 @@ def schedule_get(name: str, code_path: int, schedule_info: 'ScheduleInfo') -> li
 
 
 def _transform_index_with_force_unroll_sub_iter(
-    needed_by: int,
+    linear_index: int,
     is_lr0: bool,
     is_lra: bool,
     n_tiles_a: int,
@@ -1724,23 +1724,53 @@ def _transform_index_with_force_unroll_sub_iter(
 ) -> int:
     """
     Convert column-major linear index into needed_by mfma index when ForceUnrollSubIter is enabled.
+    
+    LR data is consumed by multiple MFMAs (one for each tile in the opposite dimension).
+    With MFMA reordering, we find the earliest consumer.
     """
-    # For LR0s, add offset for second half of tiles
-    if is_lr0:
-        if is_lra:
-            needed_by += n_tiles_a // 2
-        else:  # LRB0
-            needed_by += n_tiles_a * (n_tiles_b // 2)
+    mfmas_per_tile = 3 if use_f32x_emulation else 1
     
-    # Apply ForceUnrollSubIter reordering on TILE indices first,
-    # then convert to MFMA indices for F32X emulation
-    needed_by = index_for_force_unroll_sub_iter(needed_by, n_tiles_a, n_tiles_b)
+    # Determine the tile coordinate for this LR
+    # For LRA: linear_index is the A tile index
+    # For LRB: linear_index is n_tiles_a * B tile index, so extract B tile
+    if is_lra:
+        a_tile = linear_index
+        if is_lr0:
+            a_tile += n_tiles_a // 2  # Second half of A tiles
+    else:
+        b_tile = linear_index // n_tiles_a
+        if is_lr0:
+            b_tile += n_tiles_b // 2  # Second half of B tiles
     
-    if use_f32x_emulation:  # Each tile requires 3 MFMAs
-        needed_by *= 3
+    def compute_consumer_mfma_index(a: int, b: int) -> int:
+        """Compute MFMA index for tile (a, b) after ForceUnrollSubIter permutation."""
+        # Column-major tile index
+        col_major_idx = a + b * n_tiles_a
+        # Apply ForceUnrollSubIter permutation
+        permuted = index_for_force_unroll_sub_iter(col_major_idx, n_tiles_a, n_tiles_b)
+        # Convert to MFMA index (multiply by 3 for TF32)
+        return permuted * mfmas_per_tile
     
     if mfma_reorder:
-        needed_by = mfma_reorder[needed_by]
+        # Find earliest consumer across all tiles in the opposite dimension
+        if is_lra:
+            # LRA's A tile is consumed by MFMAs at (a_tile, b) for all b tiles
+            needed_by = min(
+                mfma_reorder[compute_consumer_mfma_index(a_tile, b)]
+                for b in range(n_tiles_b)
+            )
+        else:
+            # LRB's B tile is consumed by MFMAs at (a, b_tile) for all a tiles
+            needed_by = min(
+                mfma_reorder[compute_consumer_mfma_index(a, b_tile)]
+                for a in range(n_tiles_a)
+            )
+    else:
+        # Without reorder, the first consumer (in permuted order) is always earliest
+        if is_lra:
+            needed_by = compute_consumer_mfma_index(a_tile, 0)
+        else:
+            needed_by = compute_consumer_mfma_index(0, b_tile)
     
     if not is_lr0:  # LR1/LR3 reads data for next iteration.
         needed_by += num_vmfma
@@ -1749,23 +1779,46 @@ def _transform_index_with_force_unroll_sub_iter(
 
 
 def _transform_index_standard(
-    needed_by: int,
+    linear_index: int,
     is_lr0: bool,
+    is_lra: bool,
+    n_tiles_a: int,
+    n_tiles_b: int,
     use_f32x_emulation: bool,
     mfma_reorder: list[int],
     num_vmfma: int
 ) -> int:
     """
     Convert column-major linear index into needed_by mfma index when ForceUnrollSubIter is disabled.
+    
+    LR data is consumed by multiple MFMAs (one for each tile in the opposite dimension).
+    With MFMA reordering, we find the earliest consumer.
     """
-    if use_f32x_emulation:  # Each tile requires 3 MFMAs
-        needed_by *= 3
+    mfmas_per_tile = 3 if use_f32x_emulation else 1
+    
+    # Convert linear index to MFMA base index
+    needed_by = linear_index * mfmas_per_tile
     
     if is_lr0:  # LR0 reads data for 2nd half of this iteration (when present)
         needed_by += num_vmfma // 2
     
     if mfma_reorder:
-        needed_by = mfma_reorder[needed_by]
+        # With reordering, we need to find the earliest consumer across all tiles in the opposite dimension.
+        # LR data is used by multiple MFMAs - one for each tile in the opposite dimension.
+        if is_lra:
+            # LRA's A tile is consumed by MFMAs at (a, b) for all b tiles
+            # In column-major layout: index = base + b * n_tiles_a * mfmas_per_tile
+            needed_by = min(
+                mfma_reorder[needed_by + b * n_tiles_a * mfmas_per_tile]
+                for b in range(n_tiles_b)
+            )
+        else:
+            # LRB's B tile is consumed by MFMAs at (a, b) for all a tiles
+            # In column-major layout: index = base + a * mfmas_per_tile
+            needed_by = min(
+                mfma_reorder[needed_by + a * mfmas_per_tile]
+                for a in range(n_tiles_a)
+            )
     
     if not is_lr0:  # LR1/LR3 reads data for first half of next iteration
         needed_by += num_vmfma
@@ -1833,15 +1886,14 @@ def lr_needed_by_mfma(
     
     # Apply transformations based on scheduling mode
     is_lr0 = local_read_name == "LRA0" or local_read_name == "LRB0"
+    
+    transform_function = _transform_index_standard
     if force_unroll_sub_iter:
-        needed_by = _transform_index_with_force_unroll_sub_iter(
-            linear_index, is_lr0, is_lra, n_tiles_a, n_tiles_b,
-            use_f32x_emulation, mfma_reorder, num_vmfma
-        )
-    else:
-        needed_by = _transform_index_standard(
-            linear_index, is_lr0, use_f32x_emulation, mfma_reorder, num_vmfma
-        )
+        transform_function = _transform_index_with_force_unroll_sub_iter        
+    needed_by = transform_function(
+        linear_index, is_lr0, is_lra, n_tiles_a, n_tiles_b,
+        use_f32x_emulation, mfma_reorder, num_vmfma
+    )
     
     return needed_by
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -963,8 +963,8 @@ def find_earliest_mfma_execution(
     tile_index: int,
     mfma_in_tile: int,
     base_offset: int,
-    num_a_tiles: int,
-    num_b_tiles: int,
+    n_a_tiles: int,
+    n_b_tiles: int,
     mfma_reorder: list[int],
     mfmas_per_tile: int = 3,
 ) -> int:
@@ -992,7 +992,7 @@ def find_earliest_mfma_execution(
     """
     # Column-major layout: A tiles are contiguous, B tiles are strided
     a_tile_stride = mfmas_per_tile
-    b_tile_stride = num_a_tiles * mfmas_per_tile
+    b_tile_stride = n_a_tiles * mfmas_per_tile
     
     def tile_to_logical_mfma(a_tile: int, b_tile: int) -> int:
         """Convert (a_tile, b_tile) to logical MFMA index."""
@@ -1011,13 +1011,13 @@ def find_earliest_mfma_execution(
         # PackB prepares B tile data, used by MFMAs: (A0, Bi), (A1, Bi), ... for all A tiles
         return min(
             mfma_reorder[tile_to_logical_mfma(a_tile, tile_index)]
-            for a_tile in range(num_a_tiles)
+            for a_tile in range(n_a_tiles)
         )
     else:
         # PackA prepares A tile data, used by MFMAs: (Ai, B0), (Ai, B1), ... for all B tiles
         return min(
             mfma_reorder[tile_to_logical_mfma(tile_index, b_tile)]
-            for b_tile in range(num_b_tiles)
+            for b_tile in range(n_b_tiles)
         )
 
 def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reorder: list[int], mfmas_by_index: dict[int, MFMA], num_vmfma: int, kernel: 'Solution') -> None:
@@ -1098,8 +1098,8 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
                 tile_index=tile_index,
                 mfma_in_tile=0,  # BF16 has only 1 MFMA per tile
                 base_offset=base_offset,
-                num_a_tiles=n_tiles_a,
-                num_b_tiles=n_tiles_b,
+                n_a_tiles=n_tiles_a,
+                n_b_tiles=n_tiles_b,
                 mfma_reorder=mfma_reorder,
                 mfmas_per_tile=1,  # BF16: 1 MFMA per tile pair
             )
@@ -1114,8 +1114,10 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
         # First 4 packs (CVT0) feed into indices 4-5 (4x4 MFMAs)
         # Middle 2 packs are 4x4 MFMAs.
         # Last 4 packs (CVT1) feed into the actual MFMAs starting at base_offset
-        n_tiles_a_quarter = n_tiles_a // 4
-        n_tiles_b_quarter = n_tiles_b // 4
+        
+        # Half tile count since each quarter uses half of the A tiles and half of the B tiles.
+        n_tiles_a //= 2
+        n_tiles_b //= 2
 
         packs = sorted(packs, key=lambda x: x.issue_index)
         for i_pack, pack in enumerate(packs):
@@ -1155,8 +1157,8 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
                 tile_index=group_index,
                 mfma_in_tile=pack_offset,
                 base_offset=base_offset,
-                num_a_tiles=n_tiles_a_quarter,
-                num_b_tiles=n_tiles_b_quarter,
+                n_a_tiles=n_tiles_a,
+                n_b_tiles=n_tiles_b,
                 mfma_reorder=mfma_reorder,
             )
             
@@ -1168,8 +1170,9 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
                 pack.needed_by = mfma_needed_by
     else:
         # Regular TF32: Packs come in groups of 24
-        n_tiles_a_quarter = n_tiles_a // 4
-        n_tiles_b_quarter = n_tiles_b // 4
+        # Half tile count since each quarter uses half of the A tiles and half of the B tiles.
+        n_tiles_a //= 2
+        n_tiles_b //= 2
         for pack in packs:
             idx_in_group = pack.issue_index % 24
             # Which group of 24 packs (which tile) does this pack belong to?
@@ -1193,8 +1196,8 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
                 tile_index=group_index,
                 mfma_in_tile=mfma_in_tile,
                 base_offset=base_offset,
-                num_a_tiles=n_tiles_a_quarter,
-                num_b_tiles=n_tiles_b_quarter,
+                n_a_tiles=n_tiles_a,
+                n_b_tiles=n_tiles_b,
                 mfma_reorder=mfma_reorder,
             )
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -958,6 +958,68 @@ def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) 
             for _, gr in grs:
                 gr.needed_by = LR_target.issued_at
 
+def find_earliest_mfma_execution(
+    is_pack_B: bool,
+    tile_index: int,
+    mfma_in_tile: int,
+    base_offset: int,
+    num_a_tiles: int,
+    num_b_tiles: int,
+    mfma_reorder: list[int],
+    mfmas_per_tile: int = 3,
+) -> int:
+    """
+    Find the earliest MFMA execution index that uses a Pack's output.
+    
+    MFMAs form a 2D grid of (a_tile, b_tile) pairs, stored column-major (A contiguous).
+    Each tile pair may have multiple MFMAs (3 for TF32, 1 for BF16).
+    With MFMA reordering, a Pack's data may be used by multiple MFMAs (one per opposite tile),
+    interleaved in complex ways.
+    This function finds the one that executes first.
+    
+    Args:
+        is_pack_B: True if this is a PackB, False for PackA.
+        tile_index: Which tile this Pack prepares data for (B tile if is_pack_B, else A tile).
+        mfma_in_tile: Which MFMA within the tile group (0 for BF16; 0, 1, or 2 for TF32).
+        base_offset: Base MFMA index offset (e.g., for iteration quarter or half).
+        num_a_tiles: Number of A tiles.
+        num_b_tiles: Number of B tiles.
+        mfma_reorder: MFMA reordering list (logical -> execution index), or empty if no reordering.
+        mfmas_per_tile: Number of MFMAs per tile pair (1 for BF16, 3 for TF32). Defaults to 3.
+    
+    Returns:
+        The earliest execution index among all MFMAs that use this Pack's output.
+    """
+    # Column-major layout: A tiles are contiguous, B tiles are strided
+    a_tile_stride = mfmas_per_tile
+    b_tile_stride = num_a_tiles * mfmas_per_tile
+    
+    def tile_to_logical_mfma(a_tile: int, b_tile: int) -> int:
+        """Convert (a_tile, b_tile) to logical MFMA index."""
+        return base_offset + a_tile * a_tile_stride + b_tile * b_tile_stride + mfma_in_tile
+    
+    # Without MFMA reordering, logical index == execution index.
+    # The first MFMA in the tile is always the earliest consumer.
+    if not mfma_reorder:
+        if is_pack_B:
+            return tile_to_logical_mfma(a_tile=0, b_tile=tile_index)
+        else:
+            return tile_to_logical_mfma(a_tile=tile_index, b_tile=0)
+    
+    # With reordering, search all MFMAs that use this Pack's output to find the earliest
+    if is_pack_B:
+        # PackB prepares B tile data, used by MFMAs: (A0, Bi), (A1, Bi), ... for all A tiles
+        return min(
+            mfma_reorder[tile_to_logical_mfma(a_tile, tile_index)]
+            for a_tile in range(num_a_tiles)
+        )
+    else:
+        # PackA prepares A tile data, used by MFMAs: (Ai, B0), (Ai, B1), ... for all B tiles
+        return min(
+            mfma_reorder[tile_to_logical_mfma(tile_index, b_tile)]
+            for b_tile in range(num_b_tiles)
+        )
+
 def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reorder: list[int], mfmas_by_index: dict[int, MFMA], num_vmfma: int, kernel: 'Solution') -> None:
     """
     Set the needed_by field for Pack instructions.
@@ -1022,7 +1084,7 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
     base_offset = needed_by_offset % num_vmfma
     
     if not is_tf32_emulation:
-        # BF16 case
+        # BF16 case: 1 MFMA per tile pair
         # Calculate packs_per_tile dynamically based on actual pack count
         n_tiles = n_tiles_b if is_pack_B else n_tiles_a
         packs_per_tile = len(packs) // n_tiles
@@ -1030,17 +1092,17 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
         for pack in packs:
             # Determine which tile this pack belongs to
             tile_index = pack.issue_index // packs_per_tile
-            # Calculate the base needed_by index (in column-major order, relative to offset)
-            pack_offset = (tile_index * n_tiles_a if is_pack_B else tile_index)
             
-            # Combine with half-iteration offset to get logical MFMA index within iteration
-            logical_index = base_offset + pack_offset
-            
-            # Apply mfma_reorder to get execution position within iteration
-            if mfma_reorder:
-                execution_index = mfma_reorder[logical_index]
-            else:
-                execution_index = logical_index
+            execution_index = find_earliest_mfma_execution(
+                is_pack_B=is_pack_B,
+                tile_index=tile_index,
+                mfma_in_tile=0,  # BF16 has only 1 MFMA per tile
+                base_offset=base_offset,
+                num_a_tiles=n_tiles_a,
+                num_b_tiles=n_tiles_b,
+                mfma_reorder=mfma_reorder,
+                mfmas_per_tile=1,  # BF16: 1 MFMA per tile pair
+            )
             
             # Add iteration offset to get final position
             needed_by = iteration_offset + execution_index
@@ -1053,6 +1115,7 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
         # Middle 2 packs are 4x4 MFMAs.
         # Last 4 packs (CVT1) feed into the actual MFMAs starting at base_offset
         n_tiles_a_quarter = n_tiles_a // 4
+        n_tiles_b_quarter = n_tiles_b // 4
 
         packs = sorted(packs, key=lambda x: x.issue_index)
         for i_pack, pack in enumerate(packs):
@@ -1077,39 +1140,28 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
                 pack.needed_by = packs[i_pack + 1]
                 continue
             
-            # Calculate tile-based offset: each tile requires 3 MFMAs
-            # For PackA: tiles are indexed sequentially (0, 1, 2, ...)
-            # For PackB: tiles span n_tiles_a_quarter MFMAs in column-major order
-            if is_pack_B:
-                tile_offset = group_index * n_tiles_a_quarter * 3
-            else:
-                tile_offset = group_index * 3
-            
-            # Calculate pack_offset within the tile
+            # Calculate pack_offset within the tile (which MFMA within the 3-MFMA group uses this pack)
             if idx_in_group < 4:
-                # First 4 CVT0 packs: These feed into 4x4 MFMAs
-                # For validation, we set needed_by to the first MFMA in the tile
+                # First 4 CVT0 packs: feed into the 1st MFMA of each tile (bf16*bf16)
                 pack_offset = 0
             else:
-                # Last 4 CVT1 packs (indices 6-9)
-                # These produce error terms used by actual MFMAs
-                # Following the same pattern as regular TF32 (groups of 24):
-                # A_error is used in mfma 2/3
-                # B_error is used in mfma 3/3
+                # Last 4 CVT1 packs (indices 6-9): produce error terms used by 2nd/3rd MFMAs
+                # A_error is used in mfma 2/3 (offset 1)
+                # B_error is used in mfma 3/3 (offset 2)
                 pack_offset = 2 if is_pack_B else 1
             
-            # Combine with quarter offset and tile offset to get logical MFMA index within iteration
-            logical_index = base_offset + tile_offset + pack_offset
-            
-            # Apply mfma_reorder to get execution position within iteration
-            if mfma_reorder:
-                execution_index = mfma_reorder[logical_index]
-            else:
-                execution_index = logical_index
+            earliest_execution = find_earliest_mfma_execution(
+                is_pack_B=is_pack_B,
+                tile_index=group_index,
+                mfma_in_tile=pack_offset,
+                base_offset=base_offset,
+                num_a_tiles=n_tiles_a_quarter,
+                num_b_tiles=n_tiles_b_quarter,
+                mfma_reorder=mfma_reorder,
+            )
             
             # Add iteration offset to get final position
-            needed_by = iteration_offset + execution_index
-            mfma_needed_by = mfmas_by_index[needed_by]
+            mfma_needed_by = mfmas_by_index[iteration_offset + earliest_execution]
             # Packs 0-3 have multiple needed_by. But since both have the same min quad-cycle wait,
             # We can pick the one that occurs sooner as it's the active constraint.
             if pack.needed_by.issued_at > mfma_needed_by.issued_at:
@@ -1117,44 +1169,37 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
     else:
         # Regular TF32: Packs come in groups of 24
         n_tiles_a_quarter = n_tiles_a // 4
+        n_tiles_b_quarter = n_tiles_b // 4
         for pack in packs:
             idx_in_group = pack.issue_index % 24
+            # Which group of 24 packs (which tile) does this pack belong to?
+            group_index = pack.issue_index // 24
+
             # Middle 16 packs (4-19) don't need needed_by set
             # They are depended on by the last 4 packs and are handled implicitly.
             if 4 <= idx_in_group < 20:
                 continue
 
-            # Calculate base index relative to quarter start
-            pack_offset = 0
-            # 1. Find fp32 mfma (column-major indexing within each quarter)
-            fp32_delta = (idx_in_group % 20) // 4
-            if is_pack_B:
-                fp32_delta *= n_tiles_a_quarter
-            pack_offset += 3 * fp32_delta  # 3 bf16 mfmas per fp32 mfma
-
-            # 2. Adjust into bf16 approximation
-            bf16_delta = 0
-            if idx_in_group < 4:  # bf16 approximations terms
-                # A_bf16 & B_bf16 are used in mfma 1/3
-                pass
-            elif idx_in_group >= 20:  # error terms
-                # A_error is used in mfma 2/3
-                # B_error is used in mfma 3/3
-                bf16_delta = 2 if is_pack_B else 1
-            pack_offset += bf16_delta
-            
-            # Combine with quarter offset to get logical MFMA index within iteration
-            logical_index = base_offset + pack_offset
-            
-            # Apply mfma_reorder to get execution position within iteration
-            if mfma_reorder:
-                execution_index = mfma_reorder[logical_index]
+            # Determine which MFMA within the 3-MFMA tile group uses this pack
+            if idx_in_group < 4:
+                # CVT0 packs (bf16 approximations) are used by MFMA 0 (bf16*bf16)
+                mfma_in_tile = 0
             else:
-                execution_index = logical_index
-            
+                # CVT1 packs (error terms): A_error -> 2nd MFMA, B_error -> 3rd MFMA
+                mfma_in_tile = 2 if is_pack_B else 1
+
+            earliest_execution = find_earliest_mfma_execution(
+                is_pack_B=is_pack_B,
+                tile_index=group_index,
+                mfma_in_tile=mfma_in_tile,
+                base_offset=base_offset,
+                num_a_tiles=n_tiles_a_quarter,
+                num_b_tiles=n_tiles_b_quarter,
+                mfma_reorder=mfma_reorder,
+            )
+
             # Add iteration offset to get final position
-            needed_by = iteration_offset + execution_index
-            pack.needed_by = mfmas_by_index[needed_by]
+            pack.needed_by = mfmas_by_index[iteration_offset + earliest_execution]
        
 
 def _handle_min_pack_quad_cycles(packs: list[Pack], is_4x4mfma: bool) -> None:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -869,3 +869,136 @@ class TestLRNeededByMFMA:
                              force_unroll_sub_iter, use_f32x_emulation=True)
                              for lr_idx in range(len(expected_indices))]
             assert actual_indices == expected_indices, f"{lr_name}: expected {expected_indices}, got {actual_indices}"
+
+    def test_mfma_reorder_requires_min_across_consumers_bf16(self):
+        """
+        Test that exposes the bug where MFMA reorder causes a later logical consumer
+        to execute before the first logical consumer.
+        
+        LR data is consumed by multiple MFMAs (one per tile in the opposite dimension).
+        Before the fix, the code assumed that the first mfma before the reorder would still be the first mfma after the reorder. 
+        With complex reordering, a different consumer can execute first.
+        
+        This test uses a reorder that swaps columns in the second half:
+        - Column 0 ↔ Column 3
+        - Column 1 ↔ Column 2
+        
+        Second half layout (column-major) before reorder:
+        | 16 20 24 28 |
+        | 17 21 25 29 |
+        | 18 22 26 30 |
+        | 19 23 27 31 |
+        
+        After column swap reorder:
+        | 28 24 20 16 |
+        | 29 25 21 17 |
+        | 30 26 22 18 |
+        | 31 27 23 19 |
+        
+        For LRA0 (A tile 0 in second half):
+        - Logical consumers: 16, 20, 24, 28 (entire row 0)
+        - After reorder: 28, 24, 20, 16
+        - Correct answer: min(28, 24, 20, 16) = 16
+        - Bug (checking only first consumer): mfma_reorder[16] = 28
+        """
+        n_tiles_a, n_tiles_b = 4, 4
+        n_local_reads_a, n_local_reads_b = 4, 4
+        num_vmfma = 2 * n_tiles_a * n_tiles_b
+
+        force_unroll_sub_iter = False
+        
+        # Column swap reorder for second half: col 0↔3, col 1↔2
+        # First half unchanged, second half has columns swapped
+        mfma_reorder = list(range(16)) + [28, 29, 30, 31, 24, 25, 26, 27, 20, 21, 22, 23, 16, 17, 18, 19]
+
+        expected_results = {
+            # LRA0: A tiles in second half, consumed by MFMAs in each row
+            # For A tile i, consumers are at columns 0,1,2,3 -> after reorder, column 3 executes first
+            "LRA0": [16, 17, 18, 19],  # min across all B tiles after reorder
+            # LRB0: B tiles in second half, consumed by MFMAs in each column
+            # For B tile j, consumers are at rows 0,1,2,3 (same column) -> reorder within column
+            "LRB0": [28, 24, 20, 16],  # min across all A tiles after reorder
+            # LRA1/LRB1: first half of next iteration (unchanged by this reorder)
+            "LRA1": [32, 33, 34, 35],
+            "LRB1": [32, 36, 40, 44],
+        }
+
+        for lr_name, expected_indices in expected_results.items():
+            actual_indices = [
+                lr_needed_by_mfma(lr_name, lr_idx, num_vmfma, mfma_reorder, n_tiles_a, n_tiles_b,
+                                  n_local_reads_a, n_local_reads_b, force_unroll_sub_iter, use_f32x_emulation=False)
+                for lr_idx in range(len(expected_indices))
+            ]
+            assert actual_indices == expected_indices, f"{lr_name}: expected {expected_indices}, got {actual_indices}"
+
+    def test_mfma_reorder_requires_min_across_consumers_force_unroll_bf16(self):
+        """
+        Test that exposes the bug with ForceUnrollSubIter enabled.
+        
+        ForceUnrollSubIter layout before reorder:
+        |  0  2 |  8 10 |
+        |  1  3 |  9 11 |
+        |-------|-------|
+        |  4  6 | 12 14 |
+        |  5  7 | 13 15 |
+
+        After reorder:
+        |  3  1 |  11 9 |
+        |  2  0 |  10 8 |
+        |-------|-------|
+        |  7  5 |  15 13 |
+        |  6  4 |  14 12 |
+        
+        This test uses a reorder that reverses execution within each quadrant,
+        so the "first" consumer in each quadrant executes last.
+        
+        For LRA0 (A tile 2 = second half of rows, lr_idx=0):
+        - Consumers: (2,0), (2,1), (2,2), (2,3) in original coords
+        - After ForceUnrollSubIter: 4, 6, 12, 14
+        - After reorder (reverse in quadrant): 5, 7, 15, 13
+        - Correct answer: min(5, 7, 15, 13) = 5
+        - Bug (checking only first consumer): mfma_reorder[4] = 5
+        
+        Note: In this particular test, the bug doesn't manifest for LRA0 idx=0
+        because the first consumer happens to still be the minimum after reorder.
+        But it does manifest for other cases where the reorder moves a non-first
+        consumer to an earlier execution slot.
+        """
+        n_tiles_a, n_tiles_b = 4, 4
+        n_local_reads_a, n_local_reads_b = 4, 4
+        num_vmfma = n_tiles_a * n_tiles_b
+
+        force_unroll_sub_iter = True
+        
+        # Reorder that reverses within each quadrant
+        # Quadrant 0: [0,1,2,3] -> [3,2,1,0]
+        # Quadrant 1: [4,5,6,7] -> [7,6,5,4]
+        # Quadrant 2: [8,9,10,11] -> [11,10,9,8]
+        # Quadrant 3: [12,13,14,15] -> [15,14,13,12]
+        mfma_reorder = [3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12]
+
+        expected_results = {
+            # LRA0: A tiles 2-3 (second half)
+            # A tile 2: col-major (2,0),(2,1),(2,2),(2,3) = 2,6,10,14 -> ForceUnroll 4,6,12,14 -> reorder 7,5,15,13 -> min=5
+            # A tile 3: col-major (3,0),(3,1),(3,2),(3,3) = 3,7,11,15 -> ForceUnroll 5,7,13,15 -> reorder 6,4,14,12 -> min=4
+            "LRA0": [5, 5, 4, 4],
+            # LRB0: B tiles 2-3 (second half)
+            # B tile 2: col-major (0,2),(1,2),(2,2),(3,2) = 8,9,10,11 -> ForceUnroll 8,9,12,13 -> reorder 11,10,15,14 -> min=10
+            # B tile 3: col-major (0,3),(1,3),(2,3),(3,3) = 12,13,14,15 -> ForceUnroll 10,11,14,15 -> reorder 9,8,13,12 -> min=8
+            "LRB0": [10, 10, 8, 8],
+            # LRA3/LRB3: first half for next iteration (computed, then + num_vmfma)
+            # A tile 0: col-major (0,0),(0,1),(0,2),(0,3) = 0,4,8,12 -> ForceUnroll 0,2,8,10 -> reorder 3,1,11,9 -> min=1 -> +16=17
+            # A tile 1: col-major (1,0),(1,1),(1,2),(1,3) = 1,5,9,13 -> ForceUnroll 1,3,9,11 -> reorder 2,0,10,8 -> min=0 -> +16=16
+            "LRA3": [17, 17, 16, 16],
+            # B tile 0: col-major (0,0),(1,0),(2,0),(3,0) = 0,1,2,3 -> ForceUnroll 0,1,4,5 -> reorder 3,2,7,6 -> min=2 -> +16=18
+            # B tile 1: col-major (0,1),(1,1),(2,1),(3,1) = 4,5,6,7 -> ForceUnroll 2,3,6,7 -> reorder 1,0,5,4 -> min=0 -> +16=16
+            "LRB3": [18, 18, 16, 16],
+        }
+
+        for lr_name, expected_indices in expected_results.items():
+            actual_indices = [
+                lr_needed_by_mfma(lr_name, lr_idx, num_vmfma, mfma_reorder, n_tiles_a, n_tiles_b,
+                                  n_local_reads_a, n_local_reads_b, force_unroll_sub_iter, use_f32x_emulation=False)
+                for lr_idx in range(len(expected_indices))
+            ]
+            assert actual_indices == expected_indices, f"{lr_name}: expected {expected_indices}, got {actual_indices}"

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
@@ -26,7 +26,8 @@
 from typing import Any, Optional
 from rocisa.instruction import SWaitCnt, SNop
 
-from Tensile.Components.CMSValidator import verify_packs_start_and_end_at_correct_indices
+from Tensile.Components.CMSValidator import verify_packs_start_and_end_at_correct_indices, isValid
+from Tensile.Components.CustomSchedule import ScheduleInfo
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidatePackBF16(CMSValidationTestBase):
@@ -536,14 +537,14 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
     """
     Only tests with UsePLRPack since performance is better.
     Use MFMA reorder to swap Q2 and Q3.
-
-    | 0 |  6 |     | 0 |  3 |
-    | 1 |  7 |     | 1 |  4 |
-    | 2 |  8 |     | 2 |  5 |
-    ----------     ----------
-    | 3 |  9 |  -> | 6 |  9 |
-    | 4 | 10 |     | 7 | 10 |
-    | 5 | 11 |     | 8 | 11 |
+    
+    With MIWaveTileA=4, MIWaveTileB=4, TF32 (3 MFMAs per tile), we have 48 MFMAs:
+    - Q1 (indices 0-11): first quarter
+    - Q2 (indices 12-23): second quarter
+    - Q3 (indices 24-35): third quarter
+    - Q4 (indices 36-47): fourth quarter
+    
+    MFMA reorder swaps Q2 and Q3 (indices 12-23 execute at 24-35 positions and vice versa).
     """
     def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
@@ -552,6 +553,8 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
         kernel_updates["UseDirect32XEmulation"] = True
         kernel_updates["ForceUnrollSubIter"] = True
         kernel_updates["DepthU"] = 32
+        kernel_updates["MIWaveTileA"] = 4  # Need >= 4 for n_tiles_quarter >= 1
+        kernel_updates["MIWaveTileB"] = 4  # Need >= 4 for n_tiles_quarter >= 1
         super().setUp(kernel_updates)
 
         self.q1s = 0
@@ -566,7 +569,8 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
         self.q4s = self.q3e + 1
         self.q4e = self.num_vmfma - 1
 
-        self.mfma_reorder = [0, 1, 2, 6, 7, 8, 3, 4, 5, 9, 10, 11]
+        # MFMA reorder: swap Q2 (indices 12-23) and Q3 (indices 24-35)
+        self.mfma_reorder = list(range(12)) + list(range(24, 36)) + list(range(12, 24)) + list(range(36, 48))
     
     def validation_function(self, sched, kernel_dict, codePathIdx):
         return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
@@ -575,22 +579,22 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
         """
         Simple passing case.
         """
-        assert self.num_vmfma == 12
+        assert self.num_vmfma == 48
 
         optSchedule = {
             "SYNC": [[self.q1s+1, self.q2s+1, self.q3s+1, self.q4s+1]],
 
-            "LRA0": [[self.q2s] * 2],
-            "PackA0": [[self.q2e] * 24],
+            "LRA0": [[self.q2s] * 4],
+            "PackA0": [[self.q2e] * 48],
 
-            "LRB0": [[self.q1s] * 2],
-            "PackB0": [[self.q1e] * 24],
+            "LRB0": [[self.q1s] * 4],
+            "PackB0": [[self.q1e] * 48],
             
-            "LRB3": [[self.q3s] * 2],
-            "PackB3": [[self.q3e] * 24],
+            "LRB3": [[self.q3s] * 4],
+            "PackB3": [[self.q3e] * 48],
 
-            "LRA3": [[self.q4s] * 2],
-            "PackA3": [[self.q4e] * 24],
+            "LRA3": [[self.q4s] * 4],
+            "PackA3": [[self.q4e] * 48],
         }
 
         syncCode = [
@@ -606,19 +610,19 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
         """
         Failing case where PackB0 are issued too early (before LRB0s are complete).
         """
-        assert self.num_vmfma == 12
+        assert self.num_vmfma == 48
 
         optSchedule = {
             "SYNC": [[self.q1e]],
-            "LRA0": [[self.q1s] * 2],
-            "LRB0": [[self.q1s] * 2],
-            "PackB0": [[self.q1s+1] * 24],
+            "LRA0": [[self.q1s] * 4],
+            "LRB0": [[self.q1s] * 4],
+            "PackB0": [[self.q1s+1] * 48],
         }
 
         syncCode = [
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0s")
         ]
-        self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackB0 @ idx=1 issued too early, must be issued after idx=2 (because of LRB0 issued @ idx=0).", mfmaReorder=self.mfma_reorder)
+        self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackB0 @ idx=1 issued too early, must be issued after idx=11 (because of LRB0 issued @ idx=0).", mfmaReorder=self.mfma_reorder)
 
 class TestValidatePackTF32CrossPackInterleaving(CMSValidationTestBase):
     """
@@ -1336,3 +1340,61 @@ class TestValidatePackTF32MFMA4x4x4MultipleTiles(CMSValidationTestBase):
 
         # Tile 1's CVT0 at index 9 is too late - needed by MFMA at index 9
         self.validate(optSchedule, syncCode, 1, 2, 2, 0, "PackA0 @ idx=9 issued too late, must be issued before MFMA @ idx=9.")
+
+    def test_broken_pack_schedule_with_mfma_reorder(self):
+        """
+        Test that the validator detects pack scheduling bugs (read-before-write hazards)
+        with complex MFMA reordering.
+        
+        Broken PackA0 schedule (packs at idx 27-30, MFMA needs them at idx 26) should fail.
+        This is a real-world 128x256x32 TF32 NT configuration with MFMA reordering.
+        """
+        # Minimal kernel config for 128x256x32 TF32 NT validation
+        kernel = {
+            "UseF32XEmulation": True, "UseDirect32XEmulation": True, "UseMFMAF32XEmulation": True,
+            "ForceUnrollSubIter": True, "DirectToLds": True, "SwapGlobalReadOrder": False,
+            "UsePLRPack": True, "MIWaveTileA": 4, "MIWaveTileB": 8, "Use64bShadowLimit": 1,
+        }
+
+        # Hardcoded schedule from _get_schedule_128x256x32_TF32 NT case
+        # with broken PackA0: packs at indices 27-30, but MFMA at index 26 needs their results
+        schedule_info = ScheduleInfo(
+            numCodePaths=2,
+            numMfma=96,
+            optSchedule={
+                "SYNC": [[1, 78]],
+                "LRA0": [[0]*16],
+                "LRB0": [[0]*32],
+                "LRA3": [[77]*16],
+                "LRB3": [[48]*32],
+                # BROKEN PackA0: indices 27-30 instead of 24-26, causing read-before-write
+                "PackA0": [[
+                    20, 20, 21, 21, 
+                    23, 23, 
+                    28, 28, 28, 28,
+
+                    27, 27, 27, 27,
+                    28, 28, 
+                    30, 30, 30, 30]],
+
+                "PackB0": [[42, 42, 42, 43, 48, 48, 49, 49, 49, 50, 43, 43, 44, 44, 48, 48, 50, 50, 50, 51, 45, 45, 46, 46, 48, 48, 51, 51, 52, 52, 46, 47, 47, 47, 48, 48, 52, 53, 53, 53]],
+                "PackB3": [[67, 67, 68, 68, 75, 75, 76, 76, 77, 77, 69, 69, 70, 70, 75, 75, 78, 78, 86, 86, 71, 71, 72, 72, 75, 75, 87, 87, 88, 88, 73, 73, 74, 74, 75, 75, 89, 89, 90, 90]],
+                "PackA3": [[89, 89, 90, 90, 92, 92, 93, 93, 93, 94, 90, 91, 91, 91, 92, 92, 94, 94, 95, 95]],
+            },
+            syncCode=[
+                SWaitCnt(dscnt=0),
+                SWaitCnt(dscnt=0)
+            ],
+            nglshift=12,
+            nllshift=12,
+            mfmaReorder=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                         20, 21, 22, 23, 24, 40, 25, 32, 44, 33, 26, 41, 27, 34, 45, 35, 28, 42,
+                         29, 36, 46, 37, 30, 43, 31, 38, 47, 39, 48, 56, 64, 49, 57, 65, 50, 58,
+                         66, 51, 59, 67, 52, 60, 68, 53, 61, 69, 54, 62, 70, 55, 63, 71, 72, 73,
+                         74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
+                         92, 93, 94, 95],
+        )
+
+        valid, message = isValid(schedule_info, {"kernel": kernel})
+        assert not valid
+        assert message == "Code path 0: PackA0 @ idx=27 issued too late, must be issued before MFMA @ idx=26."

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
@@ -24,7 +24,7 @@
 ################################################################################
 
 from typing import Any, Optional
-from rocisa.instruction import SWaitCnt, SNop
+from rocisa.instruction import SWaitCnt, SNop, SBarrier
 
 from Tensile.Components.CMSValidator import verify_packs_start_and_end_at_correct_indices, isValid
 from Tensile.Components.CustomSchedule import ScheduleInfo
@@ -1362,11 +1362,7 @@ class TestValidatePackTF32MFMA4x4x4MultipleTiles(CMSValidationTestBase):
             numCodePaths=2,
             numMfma=96,
             optSchedule={
-                "SYNC": [[1, 78]],
-                "LRA0": [[0]*16],
-                "LRB0": [[0]*32],
-                "LRA3": [[77]*16],
-                "LRB3": [[48]*32],
+
                 # BROKEN PackA0: indices 27-30 instead of 24-26, causing read-before-write
                 "PackA0": [[
                     20, 20, 21, 21, 
@@ -1377,24 +1373,52 @@ class TestValidatePackTF32MFMA4x4x4MultipleTiles(CMSValidationTestBase):
                     28, 28, 
                     30, 30, 30, 30]],
 
+                "SYNC": [[1, 1, 3, 49, 78]],
+                "GRIncA": [[0]*9],
+                "GRIncB": [[0]*9],
+                "LRA0": [[0]*16],
+                "LRB0": [[0]*32],
+                "LRA3": [[77]*16],
+                "LRB3": [[48]*32],
+                "LCC": [[0]*9],
+                "LWSA": [[0]],
+                "LWSB": [[0]],
+                "LWRA": [[0]],
+                "LWRA": [[0]],
+                "GRA": [[2]*8],
+                "GRB": [[2]*8],
                 "PackB0": [[42, 42, 42, 43, 48, 48, 49, 49, 49, 50, 43, 43, 44, 44, 48, 48, 50, 50, 50, 51, 45, 45, 46, 46, 48, 48, 51, 51, 52, 52, 46, 47, 47, 47, 48, 48, 52, 53, 53, 53]],
                 "PackB3": [[67, 67, 68, 68, 75, 75, 76, 76, 77, 77, 69, 69, 70, 70, 75, 75, 78, 78, 86, 86, 71, 71, 72, 72, 75, 75, 87, 87, 88, 88, 73, 73, 74, 74, 75, 75, 89, 89, 90, 90]],
                 "PackA3": [[89, 89, 90, 90, 92, 92, 93, 93, 93, 94, 90, 91, 91, 91, 92, 92, 94, 94, 95, 95]],
             },
             syncCode=[
                 SWaitCnt(dscnt=0),
-                SWaitCnt(dscnt=0)
+                SBarrier(comment=""),
+                SWaitCnt(vlcnt=0),
+                SWaitCnt(dscnt=0),
+                SWaitCnt(dscnt=0),
             ],
             nglshift=12,
             nllshift=12,
-            mfmaReorder=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                         20, 21, 22, 23, 24, 40, 25, 32, 44, 33, 26, 41, 27, 34, 45, 35, 28, 42,
-                         29, 36, 46, 37, 30, 43, 31, 38, 47, 39, 48, 56, 64, 49, 57, 65, 50, 58,
-                         66, 51, 59, 67, 52, 60, 68, 53, 61, 69, 54, 62, 70, 55, 63, 71, 72, 73,
-                         74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91,
-                         92, 93, 94, 95],
+            mfmaReorder=[
+                 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 
+                24, 32, 25, 36, 44, 37, 26, 33, 27, 38, 45, 39, 28, 34, 29, 40, 46, 41, 30, 35, 31, 42, 47, 43,
+                48, 56, 64, 49, 57, 65, 50, 58, 66, 51, 59, 67, 52, 60, 68, 53, 61, 69, 54, 62, 70, 55, 63, 71,
+                72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95],
         )
 
         valid, message = isValid(schedule_info, {"kernel": kernel})
+        assert valid  # Schedule previously failed, now passes.
+
+        # Check it fails where it's expected to.
+        schedule_info.optSchedule["PackA0"] = [[
+            20, 20, 21, 21, 
+            23, 23, 
+            28, 28, 28, 28,
+
+            37, 37, 37, 37,
+            40, 40, 
+            41, 41, 41, 41]]
+        valid, message = isValid(schedule_info, {"kernel": kernel})
         assert not valid
-        assert message == "Code path 0: PackA0 @ idx=27 issued too late, must be issued before MFMA @ idx=26."
+        assert message == "Code path 0: PackA0 @ idx=37 issued too late, must be issued before MFMA @ idx=36."


### PR DESCRIPTION
## Motivation

Found while developing CMS schedules. With MFMA reordering enabled, the validator would sometimes allows packs and local reads to be issued after the first MFMA that uses them.

## Technical Details

The current implementation finds the first MFMA that uses the data from a LR/Pack and finds it's new order after mfmaReorder is applied. This implicitly assumes (incorrectly) that the relative order of the MFMAs which use data from a given LR/Pack is maintained. This is obviously false. The new approach checks all MFMAs that use the data and returns the earliest one.

<!-- Explain the changes along with any relevant GitHub links. -->

Depends on #4076.

## Test Plan

1. Add new tests which exercise the bug.
2. Run existing tests.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
