### PR TITLE
[hipDNN] Rename knob_id_str to knob_id

### DIFF
--- a/projects/hipdnn/backend/tests/descriptors/TestEngineDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestEngineDescriptor.cpp
@@ -514,7 +514,7 @@ TEST_F(TestEngineDescriptorWithKnobs, GetKnobInfoReturnsSerializedKnobs)
         ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_data_sdk::data_objects::Knob>());
 
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
-        ASSERT_EQ(knob->knob_id_str()->str(), "test_knob_" + std::to_string(i));
+        ASSERT_EQ(knob->knob_id()->str(), "test_knob_" + std::to_string(i));
     }
 }
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/knob_value_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/knob_value_generated.h
@@ -812,7 +812,7 @@ inline ::flatbuffers::Offset<StringConstraint> CreateStringConstraintDirect(
 
 struct KnobT : public ::flatbuffers::NativeTable {
   typedef Knob TableType;
-  std::string knob_id_str{};
+  std::string knob_id{};
   std::string description{};
   hipdnn_data_sdk::data_objects::KnobValueUnion default_value{};
   hipdnn_data_sdk::data_objects::KnobConstraintUnion constraint{};
@@ -823,7 +823,7 @@ struct Knob FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef KnobT NativeTableType;
   typedef KnobBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
-    VT_KNOB_ID_STR = 4,
+    VT_KNOB_ID = 4,
     VT_DESCRIPTION = 6,
     VT_DEFAULT_VALUE_TYPE = 8,
     VT_DEFAULT_VALUE = 10,
@@ -831,11 +831,11 @@ struct Knob FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_CONSTRAINT = 14,
     VT_DEPRECATED = 16
   };
-  const ::flatbuffers::String *knob_id_str() const {
-    return GetPointer<const ::flatbuffers::String *>(VT_KNOB_ID_STR);
+  const ::flatbuffers::String *knob_id() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_KNOB_ID);
   }
-  ::flatbuffers::String *mutable_knob_id_str() {
-    return GetPointer<::flatbuffers::String *>(VT_KNOB_ID_STR);
+  ::flatbuffers::String *mutable_knob_id() {
+    return GetPointer<::flatbuffers::String *>(VT_KNOB_ID);
   }
   const ::flatbuffers::String *description() const {
     return GetPointer<const ::flatbuffers::String *>(VT_DESCRIPTION);
@@ -889,8 +889,8 @@ struct Knob FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_KNOB_ID_STR) &&
-           verifier.VerifyString(knob_id_str()) &&
+           VerifyOffset(verifier, VT_KNOB_ID) &&
+           verifier.VerifyString(knob_id()) &&
            VerifyOffset(verifier, VT_DESCRIPTION) &&
            verifier.VerifyString(description()) &&
            VerifyField<uint8_t>(verifier, VT_DEFAULT_VALUE_TYPE, 1) &&
@@ -935,8 +935,8 @@ struct KnobBuilder {
   typedef Knob Table;
   ::flatbuffers::FlatBufferBuilder &fbb_;
   ::flatbuffers::uoffset_t start_;
-  void add_knob_id_str(::flatbuffers::Offset<::flatbuffers::String> knob_id_str) {
-    fbb_.AddOffset(Knob::VT_KNOB_ID_STR, knob_id_str);
+  void add_knob_id(::flatbuffers::Offset<::flatbuffers::String> knob_id) {
+    fbb_.AddOffset(Knob::VT_KNOB_ID, knob_id);
   }
   void add_description(::flatbuffers::Offset<::flatbuffers::String> description) {
     fbb_.AddOffset(Knob::VT_DESCRIPTION, description);
@@ -969,7 +969,7 @@ struct KnobBuilder {
 
 inline ::flatbuffers::Offset<Knob> CreateKnob(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    ::flatbuffers::Offset<::flatbuffers::String> knob_id_str = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> knob_id = 0,
     ::flatbuffers::Offset<::flatbuffers::String> description = 0,
     hipdnn_data_sdk::data_objects::KnobValue default_value_type = hipdnn_data_sdk::data_objects::KnobValue::NONE,
     ::flatbuffers::Offset<void> default_value = 0,
@@ -980,7 +980,7 @@ inline ::flatbuffers::Offset<Knob> CreateKnob(
   builder_.add_constraint(constraint);
   builder_.add_default_value(default_value);
   builder_.add_description(description);
-  builder_.add_knob_id_str(knob_id_str);
+  builder_.add_knob_id(knob_id);
   builder_.add_deprecated(deprecated);
   builder_.add_constraint_type(constraint_type);
   builder_.add_default_value_type(default_value_type);
@@ -989,18 +989,18 @@ inline ::flatbuffers::Offset<Knob> CreateKnob(
 
 inline ::flatbuffers::Offset<Knob> CreateKnobDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    const char *knob_id_str = nullptr,
+    const char *knob_id = nullptr,
     const char *description = nullptr,
     hipdnn_data_sdk::data_objects::KnobValue default_value_type = hipdnn_data_sdk::data_objects::KnobValue::NONE,
     ::flatbuffers::Offset<void> default_value = 0,
     hipdnn_data_sdk::data_objects::KnobConstraint constraint_type = hipdnn_data_sdk::data_objects::KnobConstraint::NONE,
     ::flatbuffers::Offset<void> constraint = 0,
     bool deprecated = false) {
-  auto knob_id_str__ = knob_id_str ? _fbb.CreateString(knob_id_str) : 0;
+  auto knob_id__ = knob_id ? _fbb.CreateString(knob_id) : 0;
   auto description__ = description ? _fbb.CreateString(description) : 0;
   return hipdnn_data_sdk::data_objects::CreateKnob(
       _fbb,
-      knob_id_str__,
+      knob_id__,
       description__,
       default_value_type,
       default_value,
@@ -1256,7 +1256,7 @@ inline ::flatbuffers::Offset<StringConstraint> CreateStringConstraint(::flatbuff
 
 inline bool operator==(const KnobT &lhs, const KnobT &rhs) {
   return
-      (lhs.knob_id_str == rhs.knob_id_str) &&
+      (lhs.knob_id == rhs.knob_id) &&
       (lhs.description == rhs.description) &&
       (lhs.default_value == rhs.default_value) &&
       (lhs.constraint == rhs.constraint) &&
@@ -1277,7 +1277,7 @@ inline KnobT *Knob::UnPack(const ::flatbuffers::resolver_function_t *_resolver) 
 inline void Knob::UnPackTo(KnobT *_o, const ::flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = knob_id_str(); if (_e) _o->knob_id_str = _e->str(); }
+  { auto _e = knob_id(); if (_e) _o->knob_id = _e->str(); }
   { auto _e = description(); if (_e) _o->description = _e->str(); }
   { auto _e = default_value_type(); _o->default_value.type = _e; }
   { auto _e = default_value(); if (_e) _o->default_value.value = hipdnn_data_sdk::data_objects::KnobValueUnion::UnPack(_e, default_value_type(), _resolver); }
@@ -1294,7 +1294,7 @@ inline ::flatbuffers::Offset<Knob> CreateKnob(::flatbuffers::FlatBufferBuilder &
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { ::flatbuffers::FlatBufferBuilder *__fbb; const KnobT* __o; const ::flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _knob_id_str = _o->knob_id_str.empty() ? 0 : _fbb.CreateString(_o->knob_id_str);
+  auto _knob_id = _o->knob_id.empty() ? 0 : _fbb.CreateString(_o->knob_id);
   auto _description = _o->description.empty() ? 0 : _fbb.CreateString(_o->description);
   auto _default_value_type = _o->default_value.type;
   auto _default_value = _o->default_value.Pack(_fbb);
@@ -1303,7 +1303,7 @@ inline ::flatbuffers::Offset<Knob> CreateKnob(::flatbuffers::FlatBufferBuilder &
   auto _deprecated = _o->deprecated;
   return hipdnn_data_sdk::data_objects::CreateKnob(
       _fbb,
-      _knob_id_str,
+      _knob_id,
       _description,
       _default_value_type,
       _default_value,

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/KnobWrapper.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/flatbuffer_utilities/KnobWrapper.hpp
@@ -108,7 +108,7 @@ public:
     std::string knobIdStr() const override
     {
         throwIfNotValid();
-        auto str = _shallowKnob->knob_id_str();
+        auto str = _shallowKnob->knob_id();
         return str != nullptr ? str->str() : "";
     }
 

--- a/projects/hipdnn/data_sdk/schemas/knob_value.fbs
+++ b/projects/hipdnn/data_sdk/schemas/knob_value.fbs
@@ -48,7 +48,7 @@ union KnobConstraint {
 
 // Knob metadata
 table Knob {
-    knob_id: string;          // Unique identifier (namespaced by plugin)
+    knob_id: string;              // Unique identifier (namespaced by plugin)
     description: string;          // Help text
     default_value: KnobValue;     // Default setting
     constraint: KnobConstraint;   // Validation rules

--- a/projects/hipdnn/data_sdk/schemas/knob_value.fbs
+++ b/projects/hipdnn/data_sdk/schemas/knob_value.fbs
@@ -48,7 +48,7 @@ union KnobConstraint {
 
 // Knob metadata
 table Knob {
-    knob_id_str: string;          // Unique identifier (namespaced by plugin)
+    knob_id: string;          // Unique identifier (namespaced by plugin)
     description: string;          // Help text
     default_value: KnobValue;     // Default setting
     constraint: KnobConstraint;   // Validation rules

--- a/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestEngineDetailsWrapper.cpp
+++ b/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestEngineDetailsWrapper.cpp
@@ -32,7 +32,7 @@ flatbuffers::FlatBufferBuilder
         auto descOffset = builder.CreateString("Description for " + knobIdStr);
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id_str(knobIdStrOffset);
+        knobBuilder.add_knob_id(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobs.push_back(knobBuilder.Finish());
     }

--- a/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestKnobWrapper.cpp
+++ b/projects/hipdnn/data_sdk/tests/flatbuffer_utilities/TestKnobWrapper.cpp
@@ -49,7 +49,7 @@ protected:
         }
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id_str(knobIdStrOffset);
+        knobBuilder.add_knob_id(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobBuilder.add_deprecated(deprecated);
 
@@ -82,7 +82,7 @@ protected:
         auto floatVal = hipdnn_data_sdk::data_objects::CreateFloatValue(builder, defaultValue);
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id_str(knobIdStrOffset);
+        knobBuilder.add_knob_id(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobBuilder.add_default_value_type(hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
         knobBuilder.add_default_value(floatVal.Union());
@@ -107,7 +107,7 @@ protected:
             = hipdnn_data_sdk::data_objects::CreateFloatConstraint(builder, minValue, maxValue);
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id_str(knobIdStrOffset);
+        knobBuilder.add_knob_id(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobBuilder.add_default_value_type(hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
         knobBuilder.add_default_value(floatVal.Union());
@@ -145,7 +145,7 @@ protected:
             builder, maxLength, validValuesVector);
 
         hipdnn_data_sdk::data_objects::KnobBuilder knobBuilder(builder);
-        knobBuilder.add_knob_id_str(knobIdStrOffset);
+        knobBuilder.add_knob_id(knobIdStrOffset);
         knobBuilder.add_description(descOffset);
         knobBuilder.add_default_value_type(hipdnn_data_sdk::data_objects::KnobValue::StringValue);
         knobBuilder.add_default_value(stringValue.Union());

--- a/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
@@ -17,7 +17,7 @@ TEST(TestKnobFactory, CreateIntKnob)
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_STREQ(root->knob_id_str()->c_str(), "int_knob");
+    EXPECT_STREQ(root->knob_id()->c_str(), "int_knob");
     EXPECT_STREQ(root->description()->c_str(), "description");
     EXPECT_EQ(root->default_value_type(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
     EXPECT_EQ(root->default_value_as_IntValue()->value(), 10);
@@ -44,7 +44,7 @@ TEST(TestKnobFactory, CreateFloatKnob)
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_STREQ(root->knob_id_str()->c_str(), "float_knob");
+    EXPECT_STREQ(root->knob_id()->c_str(), "float_knob");
     EXPECT_STREQ(root->description()->c_str(), "description");
     EXPECT_EQ(root->default_value_type(), hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
     EXPECT_FLOAT_EQ(root->default_value_as_FloatValue()->value(), 1.5f);
@@ -65,7 +65,7 @@ TEST(TestKnobFactory, CreateStringKnob)
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_STREQ(root->knob_id_str()->c_str(), "string_knob");
+    EXPECT_STREQ(root->knob_id()->c_str(), "string_knob");
     EXPECT_STREQ(root->description()->c_str(), "description");
     EXPECT_EQ(root->default_value_type(), hipdnn_data_sdk::data_objects::KnobValue::StringValue);
     EXPECT_STREQ(root->default_value_as_StringValue()->value()->c_str(), "option1");


### PR DESCRIPTION
## Motivation

Rename `knob_id_str` to `knob_id` to make consistent across schemas
