### PR TITLE
Add primbench to labeler yaml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -97,6 +97,10 @@
 - changed-files:
   - any-glob-to-any-file: 'shared/origami/**/*'
 
+"shared: primbench":
+- changed-files:
+  - any-glob-to-any-file: 'shared/primbench/**/*'
+
 "shared: rocroller":
 - changed-files:
   - any-glob-to-any-file: 'shared/rocroller/**/*'


### PR DESCRIPTION
## Motivation

- Have autolabeler add `shared: primbench` label to PRs modifying shared/primbench files

## Technical Details

- yaml edited similar to other projects

## Test Plan

- Must be tested after merge