### PR TITLE
Add optional enhanced metadata fields to test categories

### DIFF
--- a/shared/ctest/README.md
+++ b/shared/ctest/README.md
@@ -152,7 +152,7 @@ test_categories:
       - "performance-critical"
       - "numerical-stability"
     dependencies:
-      - "other_category"  # Run this category after dependencies complete
+      - "other_category"  # Metadata for related categories (not enforced by parser; for documentation/tooling)
 
     # Standard fields (from base)
     exclude: ["*always_exclude*"]
@@ -179,12 +179,13 @@ execution_settings:
 | `source_coverage` | Source files/functions tested by this category | `["library/src/gemm.cpp:matmul_kernel"]` |
 | `api_coverage` | API functions tested by this category | `["hipblasLtMatmul", "hipblasLtMatmulAlgo"]` |
 | `feature_tags` | Semantic tags for classification and filtering | `["performance-critical", "mixed-precision"]` |
-| `dependencies` | Test categories that should run first | `["auxiliary"]` - run auxiliary tests before this category |
+| `dependencies` | Related test categories (documentation only) | `["auxiliary"]` - advisory metadata for downstream tooling |
 | `llm_context` | Top-level guidance for AI-assisted workflows | Instructions for AI tools on test selection logic |
 
 **Key Points:**
 - All enhancement fields are **optional** - teams can ignore them entirely ✅
 - Projects can adopt incrementally: start with just `notes`, add more later ✅
+- **Parser does NOT process these fields** - they are for documentation and downstream tooling only ✅
 - Parser gracefully ignores unknown fields - no code changes needed ✅
 - Enables richer test documentation and future AI-assisted workflows ✅
 

--- a/shared/ctest/README.md
+++ b/shared/ctest/README.md
@@ -126,6 +126,68 @@ execution_settings:
 - `category_timeouts`: Timeouts for specific categories (before multiplier is applied)
 ```
 
+### **Enhanced Structure (Optional Fields)**
+
+All fields below are **optional** and can be added incrementally. Teams can use them for richer test documentation and enable future capabilities like AI-assisted test selection:
+
+```yaml
+test_categories:
+  category_name:
+    # Required fields (same as base)
+    description: "Human-readable description"
+    test_patterns: ["*pattern1*", "*pattern2*"]
+    labels: ["label1", "label2"]
+
+    # Optional enhancement fields - add only if useful for your project
+    notes: |
+      Human-readable context about when to run these tests.
+      Can include historical context, gotchas, or guidance for developers and AI tools.
+    source_coverage:
+      - "library/src/file.cpp"
+      - "library/src/module.cpp:function_name"
+    api_coverage:
+      - "apiFunction1"
+      - "apiFunction2"
+    feature_tags:
+      - "performance-critical"
+      - "numerical-stability"
+    dependencies:
+      - "other_category"  # Run this category after dependencies complete
+
+    # Standard fields (from base)
+    exclude: ["*always_exclude*"]
+    exclude_windows: ["*linux_only*"]
+    exclude_linux: ["*windows_only*"]
+
+# Optional: Top-level context for AI/LLM tools
+llm_context:
+  code_to_test_mapping_guidelines: |
+    Guidance for AI tools on how to map code changes to test categories.
+    Projects can use this for AI-assisted test selection.
+
+execution_settings:
+  default_timeout: 300
+  category_timeouts:
+    category_name: 600
+```
+
+**Optional Field Descriptions:**
+
+| Field | Purpose | Example Use |
+|-------|---------|-------------|
+| `notes` | Free-form text for context and documentation | "Run when epilogue changes. See bug #8765 for history" |
+| `source_coverage` | Source files/functions tested by this category | `["library/src/gemm.cpp:matmul_kernel"]` |
+| `api_coverage` | API functions tested by this category | `["hipblasLtMatmul", "hipblasLtMatmulAlgo"]` |
+| `feature_tags` | Semantic tags for classification and filtering | `["performance-critical", "mixed-precision"]` |
+| `dependencies` | Test categories that should run first | `["auxiliary"]` - run auxiliary tests before this category |
+| `llm_context` | Top-level guidance for AI-assisted workflows | Instructions for AI tools on test selection logic |
+
+**Key Points:**
+- All enhancement fields are **optional** - teams can ignore them entirely ✅
+- Projects can adopt incrementally: start with just `notes`, add more later ✅
+- Parser gracefully ignores unknown fields - no code changes needed ✅
+- Enables richer test documentation and future AI-assisted workflows ✅
+
 ### **GPU Exclusion with Hierarchical Matching**
 
 GPU-specific exclusions use hierarchical pattern matching with wildcard 'X':


### PR DESCRIPTION
## Add Optional Enhanced Metadata Fields to Test Categories

This PR adds optional fields to the `test_categories.yaml` schema to enable richer test documentation and future AI-assisted test selection.

### Key Points ✅

- **All new fields are optional** - Zero burden on teams that don't want them
- **100% backward compatible** - Existing YAML files work unchanged
- **Minimal code changes** - Parser naturally ignores unknown fields (no code changes needed!)
- **Incremental adoption** - Teams add fields only when they see value
- **Clear documentation** - Enhanced README with examples and use cases

### Changes

1. **README.md**: Document optional enhancement fields with examples and use cases

### Examples

**Minimal usage (works exactly as base PR):**
```yaml
test_categories:
  smoke:
    description: "Quick sanity tests"
    test_patterns: ["*smoke*"]
    labels: ["smoke"]
```

**Enhanced usage (when team wants better documentation):**
```yaml
test_categories:
  smoke:
    description: "Quick sanity tests"
    notes: "Run for any API changes. Critical path tests."
    source_coverage: ["library/src/api.cpp"]
    api_coverage: ["initialize", "cleanup"]
    feature_tags: ["fast", "critical-path"]
    test_patterns: ["*smoke*"]
    labels: ["smoke"]
```

### Why Include Optional Fields in the Standard?

1. **Consistency** - Teams wanting richer metadata have a standardized structure
2. **Flexibility** - No mandatory adoption, teams use what they need
3. **Prevents divergence** - Projects like hipBLASlt that need extra metadata can adopt the standard as-is rather than creating project-specific extensions
4. **Future-proof** - Enables innovation (AI-assisted test selection, better documentation) without breaking changes

### Testing

- ✅ Parser gracefully ignores optional fields (no code changes needed)
- ✅ CTest execution behavior unchanged
- ✅ Backward compatible with existing deployments

### Context

This enables projects like hipBLASlt (with ~200+ test configurations) to adopt the standardized approach with rich test metadata, rather than implementing project-specific extensions that would defeat the standardization effort.

This PR is a rebase of #3897 to target the new MIOpen branch (`users/dravindr/ctest_miopen` from PR #3513) instead of the abandoned PR #2411.