### PR TITLE
[hipDNN] Add some unhappy path testing for the engine config & knobs API

### DIFF
--- a/projects/hipdnn/tests/backend/CMakeLists.txt
+++ b/projects/hipdnn/tests/backend/CMakeLists.txt
@@ -50,6 +50,7 @@ target_compile_definitions(
             TEST_INCOMPLETE_API_PLUGIN_NAME="${TEST_INCOMPLETE_API_PLUGIN_NAME}"
             TEST_GOOD_DEFAULT_PLUGIN_NAME="${TEST_GOOD_DEFAULT_PLUGIN_NAME}"
             TEST_KNOBS_PLUGIN_NAME="${TEST_KNOBS_PLUGIN_NAME}"
+            TEST_KNOB_CONSTRAINT_VALIDATION_PLUGIN_NAME="${TEST_KNOB_CONSTRAINT_VALIDATION_PLUGIN_NAME}"
 )
 
 # Ensure test plugins are built before tests
@@ -64,6 +65,7 @@ add_dependencies(
     test_duplicate_id_b_plugin
     test_incomplete_api_plugin
     test_knobs_plugin
+    test_knob_constraint_validation_plugin
 )
 
 clang_tidy_check(public_hipdnn_backend_tests)

--- a/projects/hipdnn/tests/backend/IntegrationEngineConfigApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationEngineConfigApi.cpp
@@ -93,3 +93,97 @@ TEST_F(IntegrationEngineConfigApi, GetMaxWorkspaceSize)
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(maxWorkspaceSize, 1024);
 }
+
+TEST_F(IntegrationEngineConfigApi, GetAttributeBeforeFinalization)
+{
+    int64_t gidx = hipdnn_tests::plugin_constants::engineId<GoodPlugin>();
+    int64_t maxWorkspaceSize = 0;
+
+    test_util::populateTestEngineConfig(&_engineConfig, &_engine, &_graph, _handle, gidx, false);
+
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_ENGINECFG_WORKSPACE_SIZE,
+                                        HIPDNN_TYPE_INT64,
+                                        1,
+                                        nullptr,
+                                        &maxWorkspaceSize),
+              HIPDNN_STATUS_NOT_INITIALIZED);
+}
+
+TEST_F(IntegrationEngineConfigApi, GetMaxWorkspaceSizeInvalidType)
+{
+    int64_t gidx = hipdnn_tests::plugin_constants::engineId<GoodPlugin>();
+    int32_t maxWorkspaceSize = 0;
+
+    test_util::populateTestEngineConfig(&_engineConfig, &_engine, &_graph, _handle, gidx, true);
+
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_ENGINECFG_WORKSPACE_SIZE,
+                                        HIPDNN_TYPE_INT32,
+                                        1,
+                                        nullptr,
+                                        &maxWorkspaceSize),
+              HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(IntegrationEngineConfigApi, GetMaxWorkspaceSizeInvalidCount)
+{
+    int64_t gidx = hipdnn_tests::plugin_constants::engineId<GoodPlugin>();
+    int64_t maxWorkspaceSize = 0;
+
+    test_util::populateTestEngineConfig(&_engineConfig, &_engine, &_graph, _handle, gidx, true);
+
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_ENGINECFG_WORKSPACE_SIZE,
+                                        HIPDNN_TYPE_INT64,
+                                        2,
+                                        nullptr,
+                                        &maxWorkspaceSize),
+              HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(IntegrationEngineConfigApi, GetMaxWorkspaceSizeNullPointer)
+{
+    int64_t gidx = hipdnn_tests::plugin_constants::engineId<GoodPlugin>();
+
+    test_util::populateTestEngineConfig(&_engineConfig, &_engine, &_graph, _handle, gidx, true);
+
+    EXPECT_EQ(hipdnnBackendGetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_ENGINECFG_WORKSPACE_SIZE,
+                                        HIPDNN_TYPE_INT64,
+                                        1,
+                                        nullptr,
+                                        nullptr),
+              HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+}
+
+TEST_F(IntegrationEngineConfigApi, DoubleFinalization)
+{
+    int64_t gidx = hipdnn_tests::plugin_constants::engineId<GoodPlugin>();
+
+    test_util::populateTestEngineConfig(&_engineConfig, &_engine, &_graph, _handle, gidx, true);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(IntegrationEngineConfigApi, SetAttributeAfterFinalization)
+{
+    int64_t gidx = hipdnn_tests::plugin_constants::engineId<GoodPlugin>();
+
+    test_util::populateTestEngineConfig(&_engineConfig, &_engine, &_graph, _handle, gidx, true);
+
+    hipdnnBackendDescriptor_t newEngine = nullptr;
+    test_util::createTestEngine(&newEngine, &_graph, _handle, gidx, true);
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_ENGINECFG_ENGINE,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &newEngine),
+              HIPDNN_STATUS_NOT_INITIALIZED);
+
+    if(newEngine != nullptr)
+    {
+        EXPECT_EQ(hipdnnBackendDestroyDescriptor(newEngine), HIPDNN_STATUS_SUCCESS);
+    }
+}

--- a/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
@@ -637,3 +637,454 @@ TEST_F(IntegrationKnobsApi, GetMaxWorkspaceSizeWithKnobs)
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(workspaceSize, 1024); // Test plugin returns 1024
 }
+
+// =============================================================================
+// Constraint Type Validation Tests
+// =============================================================================
+
+class IntegrationConstraintValidationApi : public ::testing::Test
+{
+protected:
+    hipdnnBackendDescriptor_t _engine = nullptr;
+    hipdnnBackendDescriptor_t _engineConfig = nullptr;
+    hipdnnBackendDescriptor_t _graph = nullptr;
+    hipdnnHandle_t _handle = nullptr;
+
+    void SetUp() override
+    {
+        const std::array<const char*, 1> paths
+            = {hipdnn_tests::plugin_constants::testKnobConstraintValidationPluginPath().c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+
+        ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        if(_engineConfig != nullptr)
+        {
+            EXPECT_EQ(hipdnnBackendDestroyDescriptor(_engineConfig), HIPDNN_STATUS_SUCCESS);
+        }
+        if(_engine != nullptr)
+        {
+            EXPECT_EQ(hipdnnBackendDestroyDescriptor(_engine), HIPDNN_STATUS_SUCCESS);
+        }
+        if(_graph != nullptr)
+        {
+            EXPECT_EQ(hipdnnBackendDestroyDescriptor(_graph), HIPDNN_STATUS_SUCCESS);
+        }
+        if(_handle != nullptr)
+        {
+            EXPECT_EQ(hipdnnDestroy(_handle), HIPDNN_STATUS_SUCCESS);
+            _handle = nullptr;
+        }
+    }
+
+    void setupEngineConfig()
+    {
+        int64_t gidx = hipdnn_tests::plugin_constants::engineId<KnobConstraintValidationPlugin>();
+        ASSERT_EQ(
+            hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR, &_engineConfig),
+            HIPDNN_STATUS_SUCCESS);
+        test_util::createTestEngine(&_engine, &_graph, _handle, gidx, true);
+        ASSERT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                            HIPDNN_ATTR_ENGINECFG_ENGINE,
+                                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                            1,
+                                            &_engine),
+                  HIPDNN_STATUS_SUCCESS);
+    }
+};
+
+TEST_F(IntegrationConstraintValidationApi, IntValueToFloatConstraint)
+{
+    setupEngineConfig();
+
+    auto knobBuffer
+        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.float_knob", 5);
+    hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                        HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                        1,
+                                        &knobData),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    ASSERT_EQ(
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
+
+    if(executionPlan != nullptr)
+    {
+        hipdnnBackendDestroyDescriptor(executionPlan);
+    }
+}
+
+TEST_F(IntegrationConstraintValidationApi, FloatValueToIntConstraint)
+{
+    setupEngineConfig();
+
+    auto knobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createFloatKnobSetting(
+        "constraint.int_knob", 50.0);
+    hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                        HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                        1,
+                                        &knobData),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    ASSERT_EQ(
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
+
+    if(executionPlan != nullptr)
+    {
+        hipdnnBackendDestroyDescriptor(executionPlan);
+    }
+}
+
+TEST_F(IntegrationConstraintValidationApi, StringValueToIntConstraint)
+{
+    setupEngineConfig();
+
+    auto knobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createStringKnobSetting(
+        "constraint.int_knob", "50");
+    hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                        HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                        1,
+                                        &knobData),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    ASSERT_EQ(
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
+
+    if(executionPlan != nullptr)
+    {
+        hipdnnBackendDestroyDescriptor(executionPlan);
+    }
+}
+
+TEST_F(IntegrationConstraintValidationApi, IntValueToStringConstraint)
+{
+    setupEngineConfig();
+
+    auto knobBuffer
+        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.string_knob", 0);
+    hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                        HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                        1,
+                                        &knobData),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    ASSERT_EQ(
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
+
+    if(executionPlan != nullptr)
+    {
+        hipdnnBackendDestroyDescriptor(executionPlan);
+    }
+}
+
+TEST_F(IntegrationConstraintValidationApi, FloatValueToStringConstraint)
+{
+    setupEngineConfig();
+
+    auto knobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createFloatKnobSetting(
+        "constraint.string_knob", 1.5);
+    hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                        HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                        1,
+                                        &knobData),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    ASSERT_EQ(
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
+
+    if(executionPlan != nullptr)
+    {
+        hipdnnBackendDestroyDescriptor(executionPlan);
+    }
+}
+
+TEST_F(IntegrationConstraintValidationApi, StringValueToFloatConstraint)
+{
+    setupEngineConfig();
+
+    auto knobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createStringKnobSetting(
+        "constraint.float_knob", "5.0");
+    hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                        HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                        1,
+                                        &knobData),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    ASSERT_EQ(
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
+
+    if(executionPlan != nullptr)
+    {
+        hipdnnBackendDestroyDescriptor(executionPlan);
+    }
+}
+
+TEST_F(IntegrationConstraintValidationApi, CorrectTypesSucceed)
+{
+    setupEngineConfig();
+
+    auto intKnobBuffer
+        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.int_knob", 50);
+    auto floatKnobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createFloatKnobSetting(
+        "constraint.float_knob", 5.0);
+    auto stringKnobBuffer = hipdnn_plugin_sdk::KnobSettingFactory::createStringKnobSetting(
+        "constraint.string_knob", "beta");
+
+    std::vector<hipdnnBackendFlatbufferData_t> knobDataArray
+        = {{intKnobBuffer.data(), intKnobBuffer.size()},
+           {floatKnobBuffer.data(), floatKnobBuffer.size()},
+           {stringKnobBuffer.data(), stringKnobBuffer.size()}};
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                        HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                        3,
+                                        knobDataArray.data()),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    ASSERT_EQ(
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_SUCCESS);
+
+    if(executionPlan != nullptr)
+    {
+        hipdnnBackendDestroyDescriptor(executionPlan);
+    }
+}
+
+TEST_F(IntegrationConstraintValidationApi, UnknownKnobIsIgnored)
+{
+    setupEngineConfig();
+
+    auto knobBuffer
+        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("unknown.knob", 123);
+    hipdnnBackendFlatbufferData_t knobData = {knobBuffer.data(), knobBuffer.size()};
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                        HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                        1,
+                                        &knobData),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    ASSERT_EQ(
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_SUCCESS);
+
+    if(executionPlan != nullptr)
+    {
+        hipdnnBackendDestroyDescriptor(executionPlan);
+    }
+}
+
+TEST_F(IntegrationConstraintValidationApi, MixedValidAndInvalidKnobs)
+{
+    setupEngineConfig();
+
+    auto validKnobBuffer
+        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.int_knob", 50);
+    auto invalidKnobBuffer
+        = hipdnn_plugin_sdk::KnobSettingFactory::createIntKnobSetting("constraint.float_knob", 5);
+
+    std::vector<hipdnnBackendFlatbufferData_t> knobDataArray
+        = {{validKnobBuffer.data(), validKnobBuffer.size()},
+           {invalidKnobBuffer.data(), invalidKnobBuffer.size()}};
+
+    EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
+                                        HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                        HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                        2,
+                                        knobDataArray.data()),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDescriptor_t executionPlan = nullptr;
+    ASSERT_EQ(
+        hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(
+        hipdnnBackendSetAttribute(
+            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+        HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &_engineConfig),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
+
+    if(executionPlan != nullptr)
+    {
+        hipdnnBackendDestroyDescriptor(executionPlan);
+    }
+}

--- a/projects/hipdnn/tests/frontend/CMakeLists.txt
+++ b/projects/hipdnn/tests/frontend/CMakeLists.txt
@@ -40,6 +40,7 @@ target_compile_definitions(
             TEST_INCOMPLETE_API_PLUGIN_NAME="${TEST_INCOMPLETE_API_PLUGIN_NAME}"
             TEST_GOOD_DEFAULT_PLUGIN_NAME="${TEST_GOOD_DEFAULT_PLUGIN_NAME}"
             TEST_KNOBS_PLUGIN_NAME="${TEST_KNOBS_PLUGIN_NAME}"
+            TEST_KNOB_CONSTRAINT_VALIDATION_PLUGIN_NAME="${TEST_KNOB_CONSTRAINT_VALIDATION_PLUGIN_NAME}"
 )
 
 # Ensure test plugins are built before tests
@@ -53,6 +54,7 @@ add_dependencies(
     test_duplicate_id_b_plugin
     test_incomplete_api_plugin
     test_knobs_plugin
+    test_knob_constraint_validation_plugin
 )
 
 clang_tidy_check(public_hipdnn_frontend_tests)

--- a/projects/hipdnn/tests/test_plugins/CMakeLists.txt
+++ b/projects/hipdnn/tests/test_plugins/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_DUPLICATE_ID_B_PLUGIN_NAME "test_duplicate_id_b_plugin")
 set(TEST_INCOMPLETE_API_PLUGIN_NAME "test_incomplete_api_plugin")
 set(TEST_GOOD_DEFAULT_PLUGIN_NAME "test_good_default_plugin")
 set(TEST_KNOBS_PLUGIN_NAME "test_knobs_plugin")
+set(TEST_KNOB_CONSTRAINT_VALIDATION_PLUGIN_NAME "test_knob_constraint_validation_plugin")
 
 # Function to create a test plugin with common configuration
 function(add_test_plugin target_name)
@@ -79,6 +80,9 @@ add_test_plugin(${TEST_INCOMPLETE_API_PLUGIN_NAME} TestIncompleteApiPlugin.cpp)
 # test_knobs_plugin is a plugin that exposes engine configuration knobs
 add_test_plugin(${TEST_KNOBS_PLUGIN_NAME} TestKnobsPlugin.cpp)
 
+# test_knob_constraint_validation_plugin is a plugin that validates knob constraint types
+add_test_plugin(${TEST_KNOB_CONSTRAINT_VALIDATION_PLUGIN_NAME} TestKnobConstraintValidationPlugin.cpp)
+
 # Create the default plugin in test_plugins/default
 set(test_good_default_plugin_OUTPUT_DIR "${HIPDNN_TEST_PLUGIN_DIR}/default")
 set(test_good_default_plugin_INSTALL_DIR "${HIPDNN_TEST_PLUGIN_INSTALL_DIR}/default")
@@ -98,3 +102,4 @@ set(TEST_DUPLICATE_ID_B_PLUGIN_NAME "${TEST_DUPLICATE_ID_B_PLUGIN_NAME}" PARENT_
 set(TEST_INCOMPLETE_API_PLUGIN_NAME "${TEST_INCOMPLETE_API_PLUGIN_NAME}" PARENT_SCOPE)
 set(TEST_GOOD_DEFAULT_PLUGIN_NAME "${TEST_GOOD_DEFAULT_PLUGIN_NAME}" PARENT_SCOPE)
 set(TEST_KNOBS_PLUGIN_NAME "${TEST_KNOBS_PLUGIN_NAME}" PARENT_SCOPE)
+set(TEST_KNOB_CONSTRAINT_VALIDATION_PLUGIN_NAME "${TEST_KNOB_CONSTRAINT_VALIDATION_PLUGIN_NAME}" PARENT_SCOPE)

--- a/projects/hipdnn/tests/test_plugins/TestKnobConstraintValidationPlugin.cpp
+++ b/projects/hipdnn/tests/test_plugins/TestKnobConstraintValidationPlugin.cpp
@@ -1,0 +1,313 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "TestPluginCommon.hpp"
+#include "TestPluginEngineIdMap.hpp"
+
+#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_plugin_sdk/KnobFactory.hpp>
+
+// NOLINTNEXTLINE
+thread_local char
+    hipdnn_plugin_sdk::PluginLastErrorManager::s_lastError[HIPDNN_PLUGIN_ERROR_STRING_MAX_LENGTH]
+    = "";
+
+class KnobConstraintValidationPlugin : public TestPluginBase
+{
+public:
+    const char* getPluginName() const override
+    {
+        return "test_KnobConstraintValidationPlugin";
+    }
+
+    const char* getPluginVersion() const override
+    {
+        return "1.0.0";
+    }
+
+    int64_t getEngineId() const override
+    {
+        return hipdnn_tests::plugin_constants::engineId<KnobConstraintValidationPlugin>();
+    }
+
+    uint32_t getNumEngines() const override
+    {
+        return 1;
+    }
+
+    uint32_t getNumApplicableEngines() const override
+    {
+        return 1;
+    }
+
+    // Override enginePluginGetEngineDetails to return knobs
+    static hipdnnPluginStatus_t getEngineDetails(hipdnnEnginePluginHandle_t handle,
+                                                 int64_t engineId,
+                                                 const hipdnnPluginConstData_t* opGraph,
+                                                 hipdnnPluginConstData_t* engineDetails)
+    {
+        LOG_API_ENTRY("handle={:p}, engineId={}, opGraph={:p}, engineDetails={:p}",
+                      static_cast<void*>(handle),
+                      engineId,
+                      static_cast<const void*>(opGraph),
+                      static_cast<void*>(engineDetails));
+
+        return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+            hipdnn_plugin_sdk::throwIfNull(handle);
+            hipdnn_plugin_sdk::throwIfNull(opGraph);
+            hipdnn_plugin_sdk::throwIfNull(engineDetails);
+            hipdnn_plugin_sdk::throwIfNull(getInstance());
+
+            if(!getInstance()->supportsEngineOperations())
+            {
+                throw hipdnn_plugin_sdk::HipdnnPluginException(
+                    HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                    "No engines available - cannot get engine details");
+            }
+
+            flatbuffers::FlatBufferBuilder builder;
+
+            // Create knobs vector using KnobFactory
+            std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>> knobOffsets;
+
+            // Knob 1: Integer knob with min/max/step constraints
+            knobOffsets.push_back(hipdnn_plugin_sdk::KnobFactory::createIntKnob(
+                builder,
+                "constraint.int_knob",
+                "Integer knob for constraint validation testing",
+                50, // default value
+                0, // min
+                100, // max
+                5, // step
+                {})); // no explicit valid values
+
+            // Knob 2: Float knob with min/max constraints
+            knobOffsets.push_back(hipdnn_plugin_sdk::KnobFactory::createFloatKnob(
+                builder,
+                "constraint.float_knob",
+                "Float knob for constraint validation testing",
+                5.0f, // default value
+                0.0f, // min
+                10.0f)); // max
+
+            // Knob 3: String knob with valid_values constraint
+            knobOffsets.push_back(hipdnn_plugin_sdk::KnobFactory::createStringKnob(
+                builder,
+                "constraint.string_knob",
+                "String knob for constraint validation testing",
+                "beta", // default value
+                {"alpha", "beta", "gamma"})); // valid values
+
+            auto knobsVector = builder.CreateVector(knobOffsets);
+            auto newEngineDetails = hipdnn_data_sdk::data_objects::CreateEngineDetails(
+                builder, getInstance()->getEngineId(), knobsVector);
+            builder.Finish(newEngineDetails);
+            auto serializedDetails = builder.Release();
+
+            auto* tempBuffer = new uint8_t[serializedDetails.size()];
+            std::memcpy(tempBuffer, serializedDetails.data(), serializedDetails.size());
+
+            engineDetails->ptr = tempBuffer;
+            engineDetails->size = serializedDetails.size();
+
+            LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+        });
+    }
+
+    // Override createExecutionContext to validate knob types
+    static hipdnnPluginStatus_t
+        createExecutionContext(hipdnnEnginePluginHandle_t handle,
+                               const hipdnnPluginConstData_t* engineConfig,
+                               const hipdnnPluginConstData_t* opGraph,
+                               hipdnnEnginePluginExecutionContext_t* executionContext)
+    {
+        LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, executionContext={:p}",
+                      static_cast<void*>(handle),
+                      static_cast<const void*>(engineConfig),
+                      static_cast<const void*>(opGraph),
+                      static_cast<void*>(executionContext));
+
+        return hipdnn_plugin_sdk::tryCatch([&]() {
+            hipdnn_plugin_sdk::throwIfNull(handle);
+            hipdnn_plugin_sdk::throwIfNull(engineConfig);
+            hipdnn_plugin_sdk::throwIfNull(opGraph);
+            hipdnn_plugin_sdk::throwIfNull(executionContext);
+
+            // Deserialize engineConfig to access knob settings
+            hipdnn_plugin_sdk::EngineConfigWrapper configWrapper(engineConfig->ptr,
+                                                                 engineConfig->size);
+
+            // Validate knob types
+            for(const auto& knobSetting : configWrapper.knobSettingWrappers())
+            {
+                auto knobId = knobSetting->knobId();
+                auto valueType = knobSetting->valueType();
+
+                // Match against known knobs and validate type
+                if(knobId == "constraint.int_knob")
+                {
+                    if(valueType != hipdnn_data_sdk::data_objects::KnobValue::IntValue)
+                    {
+                        throw hipdnn_plugin_sdk::HipdnnPluginException(
+                            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                            "Type mismatch for constraint.int_knob: expected IntValue");
+                    }
+                }
+                else if(knobId == "constraint.float_knob")
+                {
+                    if(valueType != hipdnn_data_sdk::data_objects::KnobValue::FloatValue)
+                    {
+                        throw hipdnn_plugin_sdk::HipdnnPluginException(
+                            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                            "Type mismatch for constraint.float_knob: expected FloatValue");
+                    }
+                }
+                else if(knobId == "constraint.string_knob")
+                {
+                    if(valueType != hipdnn_data_sdk::data_objects::KnobValue::StringValue)
+                    {
+                        throw hipdnn_plugin_sdk::HipdnnPluginException(
+                            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                            "Type mismatch for constraint.string_knob: expected StringValue");
+                    }
+                }
+                // Unknown knobs are silently ignored, real plugins might log a warning but were not
+                // testing that
+            }
+
+            // Create execution context as normal using base class implementation
+            return TestPluginBase::enginePluginCreateExecutionContext(
+                handle, engineConfig, opGraph, executionContext);
+        });
+    }
+};
+
+// Initialize plugin instance on load
+__attribute__((constructor)) static void initializePlugin()
+{
+    TestPluginBase::setInstance(std::make_unique<KnobConstraintValidationPlugin>());
+}
+
+// Custom API registration that overrides enginePluginGetEngineDetails and createExecutionContext
+extern "C" {
+hipdnnPluginStatus_t hipdnnPluginGetName(const char** name)
+{
+    return TestPluginBase::pluginGetName(name);
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetVersion(const char** version)
+{
+    return TestPluginBase::pluginGetVersion(version);
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetType(hipdnnPluginType_t* type)
+{
+    return TestPluginBase::pluginGetType(type);
+}
+
+void hipdnnPluginGetLastErrorString(const char** errorStr)
+{
+    TestPluginBase::pluginGetLastErrorString(errorStr);
+}
+
+hipdnnPluginStatus_t hipdnnPluginSetLoggingCallback(hipdnnCallback_t callback)
+{
+    return TestPluginBase::pluginSetLoggingCallback(callback);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetAllEngineIds(int64_t* engineIds, uint32_t maxEngines, uint32_t* numEngines)
+{
+    return TestPluginBase::enginePluginGetAllEngineIds(engineIds, maxEngines, numEngines);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginCreate(hipdnnEnginePluginHandle_t* handle)
+{
+    return TestPluginBase::enginePluginCreate(handle);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroy(hipdnnEnginePluginHandle_t handle)
+{
+    return TestPluginBase::enginePluginDestroy(handle);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginSetStream(hipdnnEnginePluginHandle_t handle,
+                                                 hipStream_t stream)
+{
+    return TestPluginBase::enginePluginSetStream(handle, stream);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetApplicableEngineIds(hipdnnEnginePluginHandle_t handle,
+                                             const hipdnnPluginConstData_t* opGraph,
+                                             int64_t* engineIds,
+                                             uint32_t maxEngines,
+                                             uint32_t* numEngines)
+{
+    return TestPluginBase::enginePluginGetApplicableEngineIds(
+        handle, opGraph, engineIds, maxEngines, numEngines);
+}
+
+// Override to use KnobConstraintValidationPlugin::getEngineDetails
+hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetails(hipdnnEnginePluginHandle_t handle,
+                                                        int64_t engineId,
+                                                        const hipdnnPluginConstData_t* opGraph,
+                                                        hipdnnPluginConstData_t* engineDetails)
+{
+    return KnobConstraintValidationPlugin::getEngineDetails(
+        handle, engineId, opGraph, engineDetails);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyEngineDetails(hipdnnEnginePluginHandle_t handle,
+                                                            hipdnnPluginConstData_t* engineDetails)
+{
+    return TestPluginBase::enginePluginDestroyEngineDetails(handle, engineDetails);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSize(hipdnnEnginePluginHandle_t handle,
+                                                        const hipdnnPluginConstData_t* engineConfig,
+                                                        const hipdnnPluginConstData_t* opGraph,
+                                                        size_t* workspaceSize)
+{
+    return TestPluginBase::enginePluginGetWorkspaceSize(
+        handle, engineConfig, opGraph, workspaceSize);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContext(
+    hipdnnEnginePluginHandle_t handle,
+    hipdnnEnginePluginExecutionContext_t executionContext,
+    size_t* workspaceSize)
+{
+    return TestPluginBase::enginePluginGetWorkspaceSize(handle, executionContext, workspaceSize);
+}
+
+// Override to use KnobConstraintValidationPlugin::createExecutionContext
+hipdnnPluginStatus_t
+    hipdnnEnginePluginCreateExecutionContext(hipdnnEnginePluginHandle_t handle,
+                                             const hipdnnPluginConstData_t* engineConfig,
+                                             const hipdnnPluginConstData_t* opGraph,
+                                             hipdnnEnginePluginExecutionContext_t* executionContext)
+{
+    return KnobConstraintValidationPlugin::createExecutionContext(
+        handle, engineConfig, opGraph, executionContext);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginDestroyExecutionContext(hipdnnEnginePluginHandle_t handle,
+                                              hipdnnEnginePluginExecutionContext_t executionContext)
+{
+    return TestPluginBase::enginePluginDestroyExecutionContext(handle, executionContext);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginExecuteOpGraph(hipdnnEnginePluginHandle_t handle,
+                                     hipdnnEnginePluginExecutionContext_t executionContext,
+                                     void* workspace,
+                                     const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                     uint32_t numDeviceBuffers)
+{
+    return TestPluginBase::enginePluginExecuteOpGraph(
+        handle, executionContext, workspace, deviceBuffers, numDeviceBuffers);
+}
+} // extern "C"

--- a/projects/hipdnn/tests/test_plugins/TestPluginConstants.hpp
+++ b/projects/hipdnn/tests/test_plugins/TestPluginConstants.hpp
@@ -98,4 +98,11 @@ inline const std::string& testKnobsPluginPath()
     static const std::string s_testKnobsPluginPath = getPluginPath(TEST_KNOBS_PLUGIN_NAME);
     return s_testKnobsPluginPath;
 }
+
+inline const std::string& testKnobConstraintValidationPluginPath()
+{
+    static const std::string s_testKnobConstraintValidationPluginPath
+        = getPluginPath(TEST_KNOB_CONSTRAINT_VALIDATION_PLUGIN_NAME);
+    return s_testKnobConstraintValidationPluginPath;
+}
 } // namespace hipdnn_tests::plugin_constants

--- a/projects/hipdnn/tests/test_plugins/TestPluginEngineIdMap.hpp
+++ b/projects/hipdnn/tests/test_plugins/TestPluginEngineIdMap.hpp
@@ -30,3 +30,4 @@ HIPDNN_MAP_TO_ID(ExecuteFailsPlugin, -6);
 HIPDNN_MAP_TO_ID(DuplicateIdAPlugin, -7);
 HIPDNN_MAP_TO_ID(DuplicateIdBPlugin, -7);
 HIPDNN_MAP_TO_ID(KnobsPlugin, -8);
+HIPDNN_MAP_TO_ID(KnobConstraintValidationPlugin, -9);


### PR DESCRIPTION
## Motivation

There seemed to be some missing integration tests for the engine config and knobs settings.  This PR aims to add some additional coverage.

## Technical Details

Tests added for engine config descriptor and the knobs settings that get passed to a plugin.  The plugin decides if a bad knob setting returns an error or silently fails.  For the test, the plugin will fail if it gets a known KnobSetting with a unexpected constraint type.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
