### PR TITLE
[hipDNN] Rename remaining knob_id_str to knob_id

### DIFF
--- a/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
+++ b/projects/hipdnn/plugin_sdk/tests/TestKnobFactory.cpp
@@ -46,7 +46,7 @@ TEST(TestKnobFactory, CreateIntKnobDeprecated)
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_STREQ(root->knob_id_str()->c_str(), "deprecated_int_knob");
+    EXPECT_STREQ(root->knob_id()->c_str(), "deprecated_int_knob");
     EXPECT_TRUE(root->deprecated());
 }
 
@@ -81,7 +81,7 @@ TEST(TestKnobFactory, CreateFloatKnobDeprecated)
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_STREQ(root->knob_id_str()->c_str(), "deprecated_float_knob");
+    EXPECT_STREQ(root->knob_id()->c_str(), "deprecated_float_knob");
     EXPECT_TRUE(root->deprecated());
 }
 
@@ -121,6 +121,6 @@ TEST(TestKnobFactory, CreateStringKnobDeprecated)
     auto root
         = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(builder.GetBufferPointer());
 
-    EXPECT_STREQ(root->knob_id_str()->c_str(), "deprecated_string_knob");
+    EXPECT_STREQ(root->knob_id()->c_str(), "deprecated_string_knob");
     EXPECT_TRUE(root->deprecated());
 }

--- a/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
@@ -156,7 +156,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateIntKnob)
 
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
 
-        if(knob->knob_id_str()->str() == "test.int_knob")
+        if(knob->knob_id()->str() == "test.int_knob")
         {
             foundIntKnob = true;
 
@@ -217,7 +217,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateFloatKnob)
     {
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
 
-        if(knob->knob_id_str()->str() == "test.float_knob")
+        if(knob->knob_id()->str() == "test.float_knob")
         {
             foundFloatKnob = true;
 
@@ -277,7 +277,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateStringKnob)
     {
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
 
-        if(knob->knob_id_str()->str() == "test.string_knob")
+        if(knob->knob_id()->str() == "test.string_knob")
         {
             foundStringKnob = true;
 
@@ -347,7 +347,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoValidateDeprecatedKnob)
     {
         auto knob = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::Knob>(knobData[i].ptr);
 
-        if(knob->knob_id_str()->str() == "test.deprecated_knob")
+        if(knob->knob_id()->str() == "test.deprecated_knob")
         {
             foundDeprecatedKnob = true;
 


### PR DESCRIPTION
## Motivation

Fixed build issues after merge conflicts: https://github.com/ROCm/rocm-libraries/pull/4105 and https://github.com/ROCm/rocm-libraries/pull/3982:
```
/opt/rocm-libraries-full/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp:159:18: error: no member named 'knob_id_str' in 'hipdnn_data_sdk::data_objects::Knob'
  159 |         if(knob->knob_id_str()->str() == "test.int_knob")
      |            ~~~~  ^
/opt/rocm-libraries-full/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp:220:18: error: no member named 'knob_id_str' in 'hipdnn_data_sdk::data_objects::Knob'
  220 |         if(knob->knob_id_str()->str() == "test.float_knob")
      |            ~~~~  ^
/opt/rocm-libraries-full/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp:280:18: error: no member named 'knob_id_str' in 'hipdnn_data_sdk::data_objects::Knob'
  280 |         if(knob->knob_id_str()->str() == "test.string_knob")
      |            ~~~~  ^
/opt/rocm-libraries-full/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp:350:18: error: no member named 'knob_id_str' in 'hipdnn_data_sdk::data_objects::Knob'
  350 |         if(knob->knob_id_str()->str() == "test.deprecated_knob")
      |            ~~~~  ^
4 errors generated.
```

## Technical Details

Rename remaining `knob_id_str` to `knob_id`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
