### PR TITLE
[gfx115x] Update list of archs with reduced vgpr memory (#4023)

### DIFF
--- a/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
+++ b/projects/miopen/src/solver/conv/conv_wino_fury_RxS.cpp
@@ -76,7 +76,7 @@ uint32_t GetNGroups(uint64_t cu_count)
 bool GpuHasReducedVGPRMem(const std::string& dev_name)
 {
     static constexpr std::array<std::string_view, 8> kFullVgprMemDevices{
-        "gfx1100", "gfx1101", "gfx1150", "gfx1151", "gfx1152", "gfx1153", "gfx1200", "gfx1201"};
+        "gfx1100", "gfx1101", "gfx1151", "gfx1200", "gfx1201"};
     const std::string_view name{dev_name};
     return std::find(kFullVgprMemDevices.begin(), kFullVgprMemDevices.end(), name) ==
            kFullVgprMemDevices.end();


### PR DESCRIPTION
gfx1150, gfx1152 and gfx1153 has reduced vgpr memory.

Fixes [#2978](https://github.com/ROCm/TheRock/issues/2978)

## Motivation

By mistake gfx1150, gfx1152 and gfx1153 arches were marked as full vgpr memory (in https://github.com/ROCm/rocm-libraries/pull/3296), but they are not (confirmed via hip device api), e.g.
gfx1100, gfx1151: `regsPerBlock:                     196608`
gfx1150, gfx1152: `regsPerBlock:                     131072`

**Important**: Fury wino conv kernel continues to work on mentioned arches via
`rocm-libraries/projects/miopen/src/kernels/winograd/Conv_Winograd_Fury_v2_4_1_fp16_fp16acc_f2x3_c16_stride1.s` ## Technical Details

Update util function that return type of arch.

## Test Plan

Run unit tests:
`miopen_gtest --gtest_filter=*WinoFury*`

## Test Result

Unit tests are passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


(cherry picked from commit 1ff136dc311c80a601164aaa3818c1d7447be795)