### PR TITLE
[tensilelite] Fix assertion failure with SFCWGM

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Contractions.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Contractions.py
@@ -702,12 +702,15 @@ class InternalArgsSupport:
 
     @classmethod
     def FromOriginalState(cls, d):
+        # Set useSFC to True if SpaceFillingAlgo is non-empty, regardless of
+        # the explicit InternalSupportParams setting
+        useSFC = d['InternalSupportParams']['UseSFC'] or len(d.get('SpaceFillingAlgo', [])) > 0
         return cls(version = d['InternalSupportParams']['KernArgsVersion'],
                    gsu = d['InternalSupportParams']['SupportUserGSU'],
                    wgm = d['InternalSupportParams']['SupportCustomWGM'],
                    staggerU = d['InternalSupportParams']['SupportCustomStaggerU'],
                    useUniversalArgs = d['InternalSupportParams']['UseUniversalArgs'],
-                   useSFC = d['InternalSupportParams']['UseSFC'])
+                   useSFC = useSFC)
 
     def __init__(self, **kwargs):
         for (key, value) in list(kwargs.items()):

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -1064,12 +1064,18 @@ namespace TensileLite
             defaultWGMXCCCHUNK = pAMDGPU->fixedWGMXCCCHUNK;
         }
 
-        // WGM should be in this range: [-1023, -1022, ..., -1, 0, 1, ..., 1023]
-        assert(std::fabs(defaultWGM) < 1024);
-        // WGMXCC should be in this range: [0, 1, 2, 3, ..., 63]
-        assert(defaultWGMXCC >= 0 && defaultWGMXCC < 64);
-        // WGMXCCCHUNK should be in this range: [0, 1, 2, 3, ..., 1023]
-        assert(defaultWGMXCCCHUNK >= 0 && defaultWGMXCCCHUNK < 1024);
+        // These range assertions only apply when SpaceFillingCurve (SFC) is not used.
+        // When SFC is enabled, workGroupMapping contains a packed 32-bit encoding of
+        // grid dimensions (SFCWGM) which can exceed the normal WGM range.
+        if(!internalArgsSupport.useSFC)
+        {
+            // WGM should be in this range: [-1023, -1022, ..., -1, 0, 1, ..., 1023]
+            assert(std::fabs(defaultWGM) < 1024);
+            // WGMXCC should be in this range: [0, 1, 2, 3, ..., 63]
+            assert(defaultWGMXCC >= 0 && defaultWGMXCC < 64);
+            // WGMXCCCHUNK should be in this range: [0, 1, 2, 3, ..., 1023]
+            assert(defaultWGMXCCCHUNK >= 0 && defaultWGMXCCCHUNK < 1024);
+        }
         
         return std::make_tuple(defaultWGM, defaultWGMXCC, defaultWGMXCCCHUNK);
     }


### PR DESCRIPTION
 [tensilelite] Fix assertion failure when using SpaceFillingAlgo with SFCWGM

Bug Description:
The test `Tensile/Tests/common/gemm/gfx950/general_wgm.yaml` was failing with exit code 134 (SIGABRT) when run with Debug builds. The failure occurred at an assertion in `calculateAutoWGM()` at line 1068 of `src/ContractionSolution.cpp`:

    assert(std::fabs(defaultWGM) < 1024);

This assertion enforces that the WorkGroupMapping (WGM) value must be in the range [-1023, 1023], which is valid for standard WGM values.

Root Cause:
When the SpaceFillingAlgo feature is used with SFCWGM parameters, the `workGroupMapping` field is repurposed to store a packed 32-bit encoding of grid dimensions for the space-filling curve algorithm. The encoding format is:

    (msb) [GridDimN_L2, GridDimM_L2, GridDimN_L1, GridDimM_L1] (lsb)

Each dimension uses 8 bits, so values like `[[8,1],[4,3]]` encode to approximately 50 million (0x03040108), which far exceeds the 1024 limit intended for standard WGM values.

The test YAML file specifies:
    SpaceFillingAlgo: [[], [0,1,2], [2,2,2], [0], [1,0], [2,3]]
    SFCWGM: [[[5,5],[2,2]], [[8,1],[4,3]]]

When a non-empty SpaceFillingAlgo is used, the packed SFCWGM value is passed as workGroupMapping, triggering the assertion failure.

Why CI passed but local Debug builds failed:
The C/C++ `assert()` macro is disabled when `NDEBUG` is defined, which typically occurs in Release builds. We default to Release builds when building tensilelite_client here:

https://github.com/ROCm/rocm-libraries/blob/develop/projects/hipblaslt/tensilelite/tasks.py#L17

The Fix:
    Two changes were made:

    1. In `Tensile/Contractions.py`, modified `InternalArgsSupport.FromOriginalState()`
       to automatically set `useSFC = True` when `SpaceFillingAlgo` is non-empty.
       Previously, `useSFC` was only read from `InternalSupportParams` and defaulted
       to `False`, meaning the flag wasn't being set correctly for SFC kernels.

    2. In `src/ContractionSolution.cpp`, wrapped the range assertions in a check
       for `!internalArgsSupport.useSFC`. When SFC is enabled, the assertions are
       skipped since the workGroupMapping value has different semantics (packed
       grid dimensions rather than a simple WGM value).

    This approach uses the explicit `useSFC` flag rather than inferring SFC usage
    from the workGroupMapping value, making the code more readable and maintainable.

## Test Plan

TENSILELITE_CLIENT_ARGS="--build-type Debug --gpu-targets gfx950 --clean" tox -e py3 -- Tensile/Tests/ -k "general_wgm.yaml"

## Test Result

test PASSES when `--build-type Debug` is used. Without this commit, the test FAILs.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

AIGECORE-113