### PR TITLE
[hiptensor] Cleanup rtest script and XML

### DIFF
--- a/projects/hiptensor/rtest.py
+++ b/projects/hiptensor/rtest.py
@@ -1,23 +1,23 @@
 #!/usr/bin/python3
 """
-   Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
-   ies of the Software, and to permit persons to whom the Software is furnished
-   to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
 
-   The above copyright notice and this permission notice shall be included in all
-   copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
-   PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-   FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-   COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
-   CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 import re
@@ -28,13 +28,14 @@ import shlex
 import argparse
 import pathlib
 import platform
+import signal
 from genericpath import exists
 from fnmatch import fnmatchcase
 from xml.dom import minidom
 import multiprocessing
 import time
 
-SCRIPT_VERSION = 0.1
+SCRIPT_VERSION = 0.2
 
 args = {}
 OS_info = {}
@@ -42,9 +43,10 @@ OS_info = {}
 timeout = False
 test_proc = None
 stop = 0
-fail_regex = r'error|fail'
+fail_regex = r"error|fail"
 
-test_script = [ 'cd %IDIR%', '%XML%' ]
+test_script = ["cd %IDIR%", "%XML%"]
+
 
 class ArgAction(argparse.Action):
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
@@ -60,31 +62,70 @@ class ArgAction(argparse.Action):
             new = {**old, values[0]: values[1]}
         setattr(namespace, self.dest, new)
 
+
 def parse_args():
     """Parse command-line arguments"""
     parser = argparse.ArgumentParser(description="""
     Checks build arguments
     """)
-    parser.add_argument('-t', '--test', required=False, type=str, default=[], action='append',
-                        help='Test set to run from rtest.xml (required, e.g. osdb)')
-    parser.add_argument(      '--emulation', required=False, type=str, default=[], action='append', choices=['smoke', 'regression', 'extended', 'codecoverage'],
-                        help='Emulation set to run from rtest.xml (required, e.g. smoke)')
-    parser.add_argument(      '--name', required=False, type=str, default=[], action='append',
-                        help='Specifies tests to run from the set (optional, run all tests in the set by default)')
-    parser.add_argument('-o', '--output', type=str, required=False, default="xml",
-                        help='Test output file (optional, default: test_detail.xml)')
-    parser.add_argument('-a', '--argument', action=ArgAction, nargs=2, metavar=('NAME', 'VALUE'), default={},
-                        help='Arguments to substitute into the xml file (optional, multiple)')
-    parser.add_argument(      '--install_dir', type=str, required=False, default="build",
-                        help='Installation directory where build or release folders are (optional, default: build)')
-
+    parser.add_argument(
+        "-t",
+        "--test",
+        required=False,
+        type=str,
+        default=[],
+        action="append",
+        help="Test set to run from rtest.xml (required, e.g. smoke)",
+    )
+    parser.add_argument(
+        "--emulation",
+        required=False,
+        type=str,
+        default=[],
+        action="append",
+        choices=["smoke", "regression", "extended", "codecoverage"],
+        help="Emulation set to run from rtest.xml (required, e.g. smoke)",
+    )
+    parser.add_argument(
+        "--name",
+        required=False,
+        type=str,
+        default=[],
+        action="append",
+        help="Specifies tests to run from the set (optional, run all tests in the set by default)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        required=False,
+        default="xml",
+        help="Test output file (optional, default: test_detail.xml)",
+    )
+    parser.add_argument(
+        "-a",
+        "--argument",
+        action=ArgAction,
+        nargs=2,
+        metavar=("NAME", "VALUE"),
+        default={},
+        help="Arguments to substitute into the xml file (optional, multiple)",
+    )
+    parser.add_argument(
+        "--install_dir",
+        type=str,
+        required=False,
+        default="build",
+        help="Installation directory where build or release folders are (optional, default: build)",
+    )
 
     args = parser.parse_args()
 
     if not (args.test or args.emulation):
-        parser.error('either -t/--test or --emulation is required.')
+        parser.error("either -t/--test or --emulation is required.")
 
     return args
+
 
 def vram_detect():
     global OS_info
@@ -93,17 +134,18 @@ def vram_detect():
         cmd = "hipinfo.exe"
         process = subprocess.run([cmd], stdout=subprocess.PIPE)
         for line_in in process.stdout.decode().splitlines():
-            if 'totalGlobalMem' in line_in:
+            if "totalGlobalMem" in line_in:
                 OS_info["VRAM"] = float(line_in.split()[1])
                 break
     else:
         cmd = "rocminfo"
         process = subprocess.run([cmd], stdout=subprocess.PIPE)
         for line_in in process.stdout.decode().splitlines():
-            match = re.search(r'.*Size:.*([0-9]+)\(.*\).*KB', line_in, re.IGNORECASE)
+            match = re.search(r".*Size:.*([0-9]+)\(.*\).*KB", line_in, re.IGNORECASE)
             if match:
-                OS_info["VRAM"] = float(match.group(1))/(1024*1024)
+                OS_info["VRAM"] = float(match.group(1)) / (1024 * 1024)
                 break
+
 
 def os_detect():
     global OS_info
@@ -115,8 +157,8 @@ def os_detect():
             with open(inf_file) as f:
                 for line in f:
                     if "=" in line:
-                        k,v = line.strip().split("=")
-                        OS_info[k] = v.replace('"','')
+                        k, v = line.strip().split("=")
+                        OS_info[k] = v.replace('"', "")
     OS_info["NUM_PROC"] = os.cpu_count()
     vram_detect()
     print(OS_info)
@@ -126,17 +168,19 @@ def create_dir(dir_path):
     if os.path.isabs(dir_path):
         full_path = dir_path
     else:
-        full_path = os.path.join( os.getcwd(), dir_path )
+        full_path = os.path.join(os.getcwd(), dir_path)
     return pathlib.Path(full_path).mkdir(parents=True, exist_ok=True)
 
-def delete_dir(dir_path) :
-    if (not os.path.exists(dir_path)):
+
+def delete_dir(dir_path):
+    if not os.path.exists(dir_path):
         return
     if os.name == "nt":
-        return run_cmd( "RMDIR" , f"/S /Q {dir_path}")
+        return run_cmd("RMDIR", f"/S /Q {dir_path}")
     else:
         linux_path = pathlib.Path(dir_path).absolute()
-        return run_cmd( "rm" , f"-rf {linux_path}")
+        return run_cmd("rm", f"-rf {linux_path}")
+
 
 class TimerProcess(multiprocessing.Process):
 
@@ -150,14 +194,13 @@ class TimerProcess(multiprocessing.Process):
 
     def run(self):
         while not self.quit.is_set():
-            #print( f'time_stop {self.start_time} limit {self.max_time}')
-            if (self.max_time == 0):
+            if self.max_time == 0:
                 return
             t = time.monotonic()
-            if ( t - self.start_time > self.max_time ):
-                print( f'killing {self.kill_pid} t {t}')
+            if t - self.start_time > self.max_time:
+                print(f"killing {self.kill_pid} t {t}")
                 if os.name == "nt":
-                    cmd = ['TASKKILL', '/F', '/T', '/PID', str(self.kill_pid)]
+                    cmd = ["TASKKILL", "/F", "/T", "/PID", str(self.kill_pid)]
                     proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
                 else:
                     os.kill(self.kill_pid, signal.SIGKILL)
@@ -174,15 +217,15 @@ class TimerProcess(multiprocessing.Process):
 
 def time_stop(start, pid):
     global timeout, stop
-    while (True):
-        print( f'time_stop {start} limit {stop}')
+    while True:
+        print(f"time_stop {start} limit {stop}")
         t = time.monotonic()
-        if (stop == 0):
+        if stop == 0:
             return
-        if ( (stop > 0) and (t - start > stop) ):
-            print( f'killing {pid} t {t}')
+        if (stop > 0) and (t - start > stop):
+            print(f"killing {pid} t {t}")
             if os.name == "nt":
-                cmd = ['TASKKILL', '/F', '/T', '/PID', str(pid)]
+                cmd = ["TASKKILL", "/F", "/T", "/PID", str(pid)]
                 proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
             else:
                 test_proc.kill()
@@ -201,23 +244,21 @@ def find_cmd(cmd):
         status, _ = subprocess.getstatusoutput(f"which {cmd}")
         if status == 0:
             return cmd
-        search_paths = [
-            "."
-        ]
+        search_paths = ["."]
         for path_option in search_paths:
             cmd_opt = f"{path_option}/{cmd}"
             if os.path.isfile(cmd_opt) and os.access(cmd_opt, os.X_OK):
-               return cmd_opt
+                return cmd_opt
         raise RuntimeError(f"Cannot find the command or executable {cmd}")
 
 
-def run_cmd(cmd, test = False, time_limit = 0):
+def run_cmd(cmd, test=False, time_limit=0):
     global args
-    global test_proc, timer_thread
+    global test_proc
     global stop
-    if (cmd.startswith('cd ')):
+    if cmd.startswith("cd "):
         return os.chdir(cmd[3:])
-    if (cmd.startswith('mkdir ')):
+    if cmd.startswith("mkdir "):
         return create_dir(cmd[6:])
     cmdline = f"{cmd}"
     print(cmdline)
@@ -229,20 +270,22 @@ def run_cmd(cmd, test = False, time_limit = 0):
             error = False
             timeout = False
             cmd_parts = shlex.split(cmdline)
-            cmdline = find_cmd(cmd_parts[0]) + " " + cmd[len(cmd_parts[0]):]
-            test_proc = subprocess.Popen(cmdline, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+            cmdline = find_cmd(cmd_parts[0]) + " " + cmd[len(cmd_parts[0]) :]
+            test_proc = subprocess.Popen(
+                cmdline, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True
+            )
             if time_limit > 0:
                 start = time.monotonic()
-                #p = multiprocessing.Process(target=time_stop, args=(start, test_proc.pid))
+                # p = multiprocessing.Process(target=time_stop, args=(start, test_proc.pid))
                 p = TimerProcess(start, time_limit, test_proc.pid)
                 p.start()
             while True:
                 output = test_proc.stdout.readline()
-                if output == '' and test_proc.poll() is not None:
+                if output == "" and test_proc.poll() is not None:
                     break
                 elif output:
                     outstring = output.strip()
-                    print (outstring)
+                    print(outstring)
                     error = error or re.search(fail_regex, outstring, re.IGNORECASE)
             status = test_proc.poll()
             if time_limit > 0:
@@ -258,25 +301,25 @@ def run_cmd(cmd, test = False, time_limit = 0):
                 status = test_proc.returncode
     except:
         import traceback
+
         exc = traceback.format_exc()
-        print( "Python Exception: {0}".format(exc) )
+        print("Python Exception: {0}".format(exc))
         status = 3
     return status
+
 
 def batch(script, xml):
     global OS_info
     global args
     global fail_regex
-    #
+
     cwd = pathlib.os.curdir
-    rtest_cwd_path = os.path.abspath( os.path.join( cwd, 'rtest.xml') )
-    if os.path.isfile(rtest_cwd_path) and os.path.dirname(rtest_cwd_path).endswith( "staging" ):
+    rtest_cwd_path = os.path.abspath(os.path.join(cwd, "rtest.xml"))
+    if os.path.isfile(rtest_cwd_path) and os.path.dirname(rtest_cwd_path).endswith("staging"):
         # if in a staging directory then test locally
         test_dir = cwd
     else:
-        search_paths = [
-            f"{args.install_dir}"
-        ]
+        search_paths = [f"{args.install_dir}"]
         test_dir = ""
         for path_option in search_paths:
             if os.path.exists(path_option):
@@ -288,16 +331,16 @@ def batch(script, xml):
     fail = False
     for i in range(len(script)):
         cmdline = script[i]
-        xcmd = cmdline.replace('%IDIR%', test_dir)
-        cmd = xcmd.replace('%ODIR%', args.output)
-        if cmd.startswith('tdir '):
+        xcmd = cmdline.replace("%IDIR%", test_dir)
+        cmd = xcmd.replace("%ODIR%", args.output)
+        if cmd.startswith("tdir "):
             if pathlib.Path(cmd[5:]).exists():
-                return 0 # all further cmds skipped
+                return 0  # all further cmds skipped
             else:
                 continue
         error = False
-        if cmd.startswith('%XML%'):
-            fileversion = xml.getElementsByTagName('fileversion')
+        if cmd.startswith("%XML%"):
+            fileversion = xml.getElementsByTagName("fileversion")
             if len(fileversion) == 0:
                 print("INFO: Could not find the version of this xml configuration file. Version 0.1 assumed.")
             elif len(fileversion) > 1:
@@ -307,14 +350,14 @@ def batch(script, xml):
                 if version > SCRIPT_VERSION:
                     print(f"ERROR: This file requires script version >= {version}, have version {SCRIPT_VERSION}")
                     exit(1)
-            if xml.documentElement.hasAttribute('failure-regex'):
-                fail_regex = xml.documentElement.getAttribute('failure-regex')
+            if xml.documentElement.hasAttribute("failure-regex"):
+                fail_regex = xml.documentElement.getAttribute("failure-regex")
             # run the matching tests listed in the xml test file
             var_subs = {}
-            for var in xml.getElementsByTagName('var'):
-                name = var.getAttribute('name')
-                if var.hasAttribute('value'):
-                    val = var.getAttribute('value')
+            for var in xml.getElementsByTagName("var"):
+                name = var.getAttribute("name")
+                if var.hasAttribute("value"):
+                    val = var.getAttribute("value")
                 elif var.firstChild is not None:
                     val = var.firstChild.data
                 else:
@@ -322,23 +365,23 @@ def batch(script, xml):
                 var_subs[name] = val
             for name, val in args.argument.items():
                 var_subs[name] = val
-            available_cases = xml.getElementsByTagName('test') + xml.getElementsByTagName('emulation')
+            available_cases = xml.getElementsByTagName("test") + xml.getElementsByTagName("emulation")
             requested_cases = args.test + args.emulation
             for case in available_cases:
-                sets = case.getAttribute('sets')
-                runset = sets.split(',')
+                sets = case.getAttribute("sets")
+                runset = sets.split(",")
                 if len([x for x in requested_cases if x in runset]):
-                    for run in case.getElementsByTagName('run'):
-                        name = run.getAttribute('name')
+                    for run in case.getElementsByTagName("run"):
+                        name = run.getAttribute("name")
                         if (not args.name) or (name in args.name):
-                            vram_limit = run.getAttribute('vram_min')
+                            vram_limit = run.getAttribute("vram_min")
                             if vram_limit:
                                 if OS_info["VRAM"] < float(vram_limit):
-                                    print( f'***\n*** Skipped: {name} due to VRAM req.\n***')
+                                    print(f"***\n*** Skipped: {name} due to VRAM req.\n***")
                                     continue
                             if name:
-                                print( f'***\n*** Running: {name}\n***')
-                            time_limit = run.getAttribute('time_max')
+                                print(f"***\n*** Running: {name}\n***")
+                            time_limit = run.getAttribute("time_max")
                             if time_limit:
                                 timeout = float(time_limit)
                             else:
@@ -347,24 +390,27 @@ def batch(script, xml):
                             raw_cmd = run.firstChild.data
                             var_cmd = raw_cmd.format_map(var_subs)
                             error = run_cmd(var_cmd, True, timeout)
-                            if (error == 2):
-                                print( f'***\n*** Timed out when running: {name}\n***')
-                    continue
+                            if error == 2:
+                                print(f"***\n*** Timed out when running: {name}\n***")
+                            if error:
+                                print(f"***\n*** Error ({error}) while running: {name}\n***")
+                            fail = fail or error
         else:
             error = run_cmd(cmd)
-        fail = fail or error
+            fail = fail or error
 
-    if (fail):
-        if (cmd == "%XML%"):
+    if fail:
+        if cmd == "%XML%":
             print("FAILED xml test suite!")
         else:
             print(f"ERROR running: {cmd}")
-        if (os.curdir != cwd):
-            os.chdir( cwd )
+        if os.curdir != cwd:
+            os.chdir(cwd)
         return 1
-    if (os.curdir != cwd):
-        os.chdir( cwd )
+    if os.curdir != cwd:
+        os.chdir(cwd)
     return 0
+
 
 def run_tests():
     global test_script
@@ -373,32 +419,32 @@ def run_tests():
     # install
     cwd = os.curdir
 
-    xmlPath = os.path.join( cwd, 'rtest.xml')
-    xmlDoc = minidom.parse( xmlPath )
+    xmlPath = os.path.join(cwd, "rtest.xml")
+    xmlDoc = minidom.parse(xmlPath)
 
     scripts = []
-    scripts.append( test_script )
+    scripts.append(test_script)
     for i in scripts:
-        if (batch(i, xmlDoc)):
-            #print("Failure in script. ABORTING")
-            if (os.curdir != cwd):
-                os.chdir( cwd )
+        if batch(i, xmlDoc):
+            if os.curdir != cwd:
+                os.chdir(cwd)
             return 1
-    if (os.curdir != cwd):
-        os.chdir( cwd )
+    if os.curdir != cwd:
+        os.chdir(cwd)
     return 0
+
 
 def main():
     global args
-    global timer_thread
 
     os_detect()
     args = parse_args()
 
     status = run_tests()
 
-    if (status):
+    if status:
         sys.exit(status)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/projects/hiptensor/rtest.xml
+++ b/projects/hiptensor/rtest.xml
@@ -13,750 +13,255 @@
     <!-- smoke test -->
     <emulation sets="smoke">
         <run name="smoke001">./bin/contraction_mode_test  </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke002">./bin/elementwise_cpu_test  </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke003">./bin/elementwise_op_test </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke004">./bin/hiptensor_options_test  </run>
-    </emulation>
-    <emulation sets="smoke">
-        <run name="smoke005">./bin/interface_test  </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke006">./bin/logger_test  </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke007">./bin/reduction_cpu_impl_test </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke008">./bin/util_test </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke009">./bin/yaml_test </run>
-    </emulation>
-    <emulation sets="smoke">
-        <run name="smoke010">./bin/simple_elementwise_permute </run>
-    </emulation>
-    <emulation sets="smoke">
-        <run name="smoke011">./bin/simple_elementwise_binary </run>
-    </emulation>
-    <emulation sets="smoke">
-        <run name="smoke012">./bin/simple_elementwise_trinary </run>
-    </emulation>
-    <emulation sets="smoke">
-        <run name="smoke013">./bin/simple_reduction </run>
-    </emulation>
-    <emulation sets="smoke">
-        <run name="smoke014">./bin/simple_scale_contraction_f16_f16_f16_compute_f16 </run>
-    </emulation>
-    <emulation sets="smoke">
-        <run name="smoke015">./bin/simple_bilinear_contraction_f16_f16_f16_f16_compute_f16 </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke101">./bin/bilinear_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/bilinear_test_params_rank1.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke102">./bin/bilinear_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/bilinear_test_params_rank2.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke103">./bin/bilinear_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/bilinear_test_params_rank3.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke104">./bin/bilinear_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/bilinear_test_params_rank4.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke105">./bin/bilinear_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/bilinear_test_params_rank5.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke106">./bin/bilinear_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/bilinear_test_params_rank6.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke111">./bin/complex_bilinear_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_bilinear_test_params_rank1.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke112">./bin/complex_bilinear_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_bilinear_test_params_rank2.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke113">./bin/complex_bilinear_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_bilinear_test_params_rank3.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke114">./bin/complex_bilinear_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_bilinear_test_params_rank4.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke115">./bin/complex_bilinear_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_bilinear_test_params_rank5.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke116">./bin/complex_bilinear_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_bilinear_test_params_rank6.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke121">./bin/scale_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/scale_test_params_rank1.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke122">./bin/scale_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/scale_test_params_rank2.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke123">./bin/scale_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/scale_test_params_rank3.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke124">./bin/scale_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/scale_test_params_rank4.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke125">./bin/scale_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/scale_test_params_rank5.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke126">./bin/scale_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/scale_test_params_rank6.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke131">./bin/complex_scale_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_scale_test_params_rank1.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke132">./bin/complex_scale_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_scale_test_params_rank2.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke133">./bin/complex_scale_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_scale_test_params_rank3.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke134">./bin/complex_scale_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_scale_test_params_rank4.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke135">./bin/complex_scale_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_scale_test_params_rank5.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke136">./bin/complex_scale_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/smoke/complex_scale_test_params_rank6.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke201">./bin/rank2_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/permutation/rank2_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke202">./bin/rank3_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/permutation/rank3_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke203">./bin/rank4_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/permutation/rank4_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke204">./bin/rank5_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/permutation/rank5_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke205">./bin/rank6_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/permutation/rank6_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke211">./bin/rank2_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/binary_op/rank2_binary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke212">./bin/rank3_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/binary_op/rank3_binary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke213">./bin/rank4_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/binary_op/rank4_binary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke214">./bin/rank5_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/binary_op/rank5_binary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke215">./bin/rank6_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/binary_op/rank6_binary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke221">./bin/rank2_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/trinary_op/rank2_trinary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke222">./bin/rank3_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/trinary_op/rank3_trinary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke223">./bin/rank4_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/trinary_op/rank4_trinary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke224">./bin/rank5_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/trinary_op/rank5_trinary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke225">./bin/rank6_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/smoke/trinary_op/rank6_trinary_op_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke301">./bin/rank1_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/smoke/rank1_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke302">./bin/rank2_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/smoke/rank2_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke303">./bin/rank3_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/smoke/rank3_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke304">./bin/rank4_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/smoke/rank4_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke305">./bin/rank5_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/smoke/rank5_test_params.yaml {SMOKE_PARAMS} </run>
-    </emulation>
-    <emulation sets="smoke">
         <run name="smoke306">./bin/rank6_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/smoke/rank6_test_params.yaml {SMOKE_PARAMS} </run>
     </emulation>
 
     <emulation sets="regression">
         <run name="regression001">./bin/contraction_mode_test  </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression002">./bin/elementwise_cpu_test  </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression003">./bin/elementwise_op_test </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression004">./bin/hiptensor_options_test  </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression005">./bin/interface_test  </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression006">./bin/logger_test  </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression007">./bin/reduction_cpu_impl_test </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression008">./bin/util_test </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression009">./bin/yaml_test </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression010">./bin/simple_elementwise_permute </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression011">./bin/simple_elementwise_binary </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression012">./bin/simple_elementwise_trinary </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression013">./bin/simple_reduction </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression014">./bin/simple_scale_contraction_f16_f16_f16_compute_f16 </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression015">./bin/simple_bilinear_contraction_f16_f16_f16_f16_compute_f16 </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression016">./bin/simple_contraction_plan_cache </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression017">./bin/simple_contraction_c </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression018">./bin/simple_elementwise_binary_c </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression019">./bin/simple_reduction_c </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression101">./bin/bilinear_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/bilinear_test_params_rank1.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression102">./bin/bilinear_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/bilinear_test_params_rank2.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression103">./bin/bilinear_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/bilinear_test_params_rank3.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression104">./bin/bilinear_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/bilinear_test_params_rank4.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression105">./bin/bilinear_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/bilinear_test_params_rank5.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression106">./bin/bilinear_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/bilinear_test_params_rank6.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression111">./bin/complex_bilinear_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_bilinear_test_params_rank1.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression112">./bin/complex_bilinear_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_bilinear_test_params_rank2.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression113">./bin/complex_bilinear_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_bilinear_test_params_rank3.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression114">./bin/complex_bilinear_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_bilinear_test_params_rank4.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression115">./bin/complex_bilinear_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_bilinear_test_params_rank5.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression116">./bin/complex_bilinear_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_bilinear_test_params_rank6.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression121">./bin/scale_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/scale_test_params_rank1.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression122">./bin/scale_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/scale_test_params_rank2.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression123">./bin/scale_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/scale_test_params_rank3.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression124">./bin/scale_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/scale_test_params_rank4.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression125">./bin/scale_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/scale_test_params_rank5.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression126">./bin/scale_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/scale_test_params_rank6.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression131">./bin/complex_scale_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_scale_test_params_rank1.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression132">./bin/complex_scale_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_scale_test_params_rank2.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression133">./bin/complex_scale_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_scale_test_params_rank3.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression134">./bin/complex_scale_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_scale_test_params_rank4.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression135">./bin/complex_scale_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_scale_test_params_rank5.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression136">./bin/complex_scale_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/regression/complex_scale_test_params_rank6.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression201">./bin/rank2_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/permutation/rank2_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression202">./bin/rank3_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/permutation/rank3_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression203">./bin/rank4_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/permutation/rank4_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression204">./bin/rank5_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/permutation/rank5_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression205">./bin/rank6_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/permutation/rank6_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression211">./bin/rank2_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/binary_op/rank2_binary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression212">./bin/rank3_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/binary_op/rank3_binary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression213">./bin/rank4_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/binary_op/rank4_binary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression214">./bin/rank5_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/binary_op/rank5_binary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression215">./bin/rank6_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/binary_op/rank6_binary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression221">./bin/rank2_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/trinary_op/rank2_trinary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression222">./bin/rank3_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/trinary_op/rank3_trinary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression223">./bin/rank4_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/trinary_op/rank4_trinary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression224">./bin/rank5_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/trinary_op/rank5_trinary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression225">./bin/rank6_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/regression/trinary_op/rank6_trinary_op_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression301">./bin/rank1_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/regression/rank1_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression302">./bin/rank2_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/regression/rank2_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression303">./bin/rank3_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/regression/rank3_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression304">./bin/rank4_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/regression/rank4_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression305">./bin/rank5_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/regression/rank5_test_params.yaml {REGRESSION_PARAMS} </run>
-    </emulation>
-    <emulation sets="regression">
         <run name="regression306">./bin/rank6_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/regression/rank6_test_params.yaml {REGRESSION_PARAMS} </run>
     </emulation>
 
     <emulation sets="extend">
         <run name="extend001">./bin/contraction_mode_test  </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend002">./bin/elementwise_cpu_test  </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend003">./bin/elementwise_op_test </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend004">./bin/hiptensor_options_test  </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend005">./bin/interface_test  </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend006">./bin/logger_test  </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend007">./bin/reduction_cpu_impl_test </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend008">./bin/util_test </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend009">./bin/yaml_test </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend010">./bin/simple_elementwise_permute </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend011">./bin/simple_elementwise_binary </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend012">./bin/simple_elementwise_trinary </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend013">./bin/simple_reduction </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend014">./bin/simple_scale_contraction_f16_f16_f16_compute_f16 </run>
-    </emulation>
-    <emulation sets="extend">
         <run name="extend015">./bin/simple_bilinear_contraction_f16_f16_f16_f16_compute_f16 </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended101">./bin/bilinear_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/bilinear_test_params_rank1.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended102">./bin/bilinear_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/bilinear_test_params_rank2.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended103">./bin/bilinear_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/bilinear_test_params_rank3.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended104">./bin/bilinear_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/bilinear_test_params_rank4.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended105">./bin/bilinear_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/bilinear_test_params_rank5.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended106">./bin/bilinear_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/bilinear_test_params_rank6.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended111">./bin/complex_bilinear_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_bilinear_test_params_rank1.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended112">./bin/complex_bilinear_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_bilinear_test_params_rank2.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended113">./bin/complex_bilinear_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_bilinear_test_params_rank3.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended114">./bin/complex_bilinear_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_bilinear_test_params_rank4.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended115">./bin/complex_bilinear_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_bilinear_test_params_rank5.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended116">./bin/complex_bilinear_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_bilinear_test_params_rank6.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended121">./bin/scale_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/scale_test_params_rank1.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended122">./bin/scale_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/scale_test_params_rank2.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended123">./bin/scale_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/scale_test_params_rank3.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended124">./bin/scale_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/scale_test_params_rank4.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended125">./bin/scale_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/scale_test_params_rank5.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended126">./bin/scale_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/scale_test_params_rank6.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended131">./bin/complex_scale_contraction_test_m1n1k1 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_scale_test_params_rank1.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended132">./bin/complex_scale_contraction_test_m2n2k2 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_scale_test_params_rank2.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended133">./bin/complex_scale_contraction_test_m3n3k3 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_scale_test_params_rank3.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended134">./bin/complex_scale_contraction_test_m4n4k4 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_scale_test_params_rank4.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended135">./bin/complex_scale_contraction_test_m5n5k5 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_scale_test_params_rank5.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended136">./bin/complex_scale_contraction_test_m6n6k6 -y {EMULATION_ROOT}/{CONTRACTION_CONFIGS}/extended/complex_scale_test_params_rank6.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended201">./bin/rank2_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/permutation/rank2_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended202">./bin/rank3_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/permutation/rank3_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended203">./bin/rank4_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/permutation/rank4_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended204">./bin/rank5_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/permutation/rank5_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended205">./bin/rank6_elementwise_permute_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/permutation/rank6_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended211">./bin/rank2_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/binary_op/rank2_binary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended212">./bin/rank3_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/binary_op/rank3_binary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended213">./bin/rank4_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/binary_op/rank4_binary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended214">./bin/rank5_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/binary_op/rank5_binary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended215">./bin/rank6_elementwise_binary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/binary_op/rank6_binary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended221">./bin/rank2_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/trinary_op/rank2_trinary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended222">./bin/rank3_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/trinary_op/rank3_trinary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended223">./bin/rank4_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/trinary_op/rank4_trinary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended224">./bin/rank5_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/trinary_op/rank5_trinary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended225">./bin/rank6_elementwise_trinary_op_test -y {EMULATION_ROOT}/{PERMUTE_CONFIGS}/extended/trinary_op/rank6_trinary_op_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended301">./bin/rank1_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/extended/rank1_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended302">./bin/rank2_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/extended/rank2_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended303">./bin/rank3_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/extended/rank3_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended304">./bin/rank4_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/extended/rank4_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended305">./bin/rank5_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/extended/rank5_test_params.yaml {EXTENDED_PARAMS} </run>
-    </emulation>
-    <emulation sets="extended">
         <run name="extended306">./bin/rank6_reduction_test -y {EMULATION_ROOT}/{REDUCTION_CONFIGS}/extended/rank6_test_params.yaml {EXTENDED_PARAMS} </run>
     </emulation>
 
     <!-- code coverage -->
     <emulation sets="codecoverage">
         <run name="codecoverage001">./bin/contraction_mode_test  </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage002">./bin/elementwise_cpu_test  </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage003">./bin/elementwise_op_test </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage004">./bin/hiptensor_options_test  </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage005">./bin/interface_test  </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage006">./bin/logger_test  </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage007">./bin/reduction_cpu_impl_test </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage008">./bin/util_test </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage009">./bin/yaml_test </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage010">./bin/simple_elementwise_permute </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage011">./bin/simple_elementwise_binary </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage012">./bin/simple_elementwise_trinary </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage013">./bin/simple_reduction </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage014">./bin/simple_scale_contraction_f16_f16_f16_compute_f16 </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage015">./bin/simple_bilinear_contraction_f16_f16_f16_f16_compute_f16 </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage016">./bin/simple_contraction_plan_cache </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage017">./bin/simple_contraction_c </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage018">./bin/simple_elementwise_binary_c </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage019">./bin/simple_reduction_c </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage101">./bin/bilinear_contraction_test_m1n1k1 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/bilinear_test_params_rank1.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage102">./bin/bilinear_contraction_test_m2n2k2 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/bilinear_test_params_rank2.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage103">./bin/bilinear_contraction_test_m3n3k3 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/bilinear_test_params_rank3.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage104">./bin/bilinear_contraction_test_m4n4k4 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/bilinear_test_params_rank4.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage105">./bin/bilinear_contraction_test_m5n5k5 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/bilinear_test_params_rank5.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage106">./bin/bilinear_contraction_test_m6n6k6 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/bilinear_test_params_rank6.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage111">./bin/complex_bilinear_contraction_test_m1n1k1 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_bilinear_test_params_rank1.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage112">./bin/complex_bilinear_contraction_test_m2n2k2 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_bilinear_test_params_rank2.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage113">./bin/complex_bilinear_contraction_test_m3n3k3 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_bilinear_test_params_rank3.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage114">./bin/complex_bilinear_contraction_test_m4n4k4 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_bilinear_test_params_rank4.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage115">./bin/complex_bilinear_contraction_test_m5n5k5 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_bilinear_test_params_rank5.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage116">./bin/complex_bilinear_contraction_test_m6n6k6 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_bilinear_test_params_rank6.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage121">./bin/scale_contraction_test_m1n1k1 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/scale_test_params_rank1.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage122">./bin/scale_contraction_test_m2n2k2 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/scale_test_params_rank2.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage123">./bin/scale_contraction_test_m3n3k3 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/scale_test_params_rank3.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage124">./bin/scale_contraction_test_m4n4k4 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/scale_test_params_rank4.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage125">./bin/scale_contraction_test_m5n5k5 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/scale_test_params_rank5.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage126">./bin/scale_contraction_test_m6n6k6 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/scale_test_params_rank6.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage131">./bin/complex_scale_contraction_test_m1n1k1 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_scale_test_params_rank1.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage132">./bin/complex_scale_contraction_test_m2n2k2 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_scale_test_params_rank2.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage133">./bin/complex_scale_contraction_test_m3n3k3 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_scale_test_params_rank3.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage134">./bin/complex_scale_contraction_test_m4n4k4 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_scale_test_params_rank4.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage135">./bin/complex_scale_contraction_test_m5n5k5 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_scale_test_params_rank5.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage136">./bin/complex_scale_contraction_test_m6n6k6 -y {CODE_COVERAGE_ROOT}/{CONTRACTION_CONFIGS}/complex_scale_test_params_rank6.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage201">./bin/rank2_elementwise_permute_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank2_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage202">./bin/rank3_elementwise_permute_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank3_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage203">./bin/rank4_elementwise_permute_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank4_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage204">./bin/rank5_elementwise_permute_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank5_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage205">./bin/rank6_elementwise_permute_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank6_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage211">./bin/rank2_elementwise_binary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank2_binary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage212">./bin/rank3_elementwise_binary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank3_binary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage213">./bin/rank4_elementwise_binary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank4_binary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage214">./bin/rank5_elementwise_binary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank5_binary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage215">./bin/rank6_elementwise_binary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank6_binary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage221">./bin/rank2_elementwise_trinary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank2_trinary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage222">./bin/rank3_elementwise_trinary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank3_trinary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage223">./bin/rank4_elementwise_trinary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank4_trinary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage224">./bin/rank5_elementwise_trinary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank5_trinary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage225">./bin/rank6_elementwise_trinary_op_test -y {CODE_COVERAGE_ROOT}/{PERMUTE_CONFIGS}/rank6_trinary_op_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage301">./bin/rank1_reduction_test -y {CODE_COVERAGE_ROOT}/{REDUCTION_CONFIGS}/rank1_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage302">./bin/rank2_reduction_test -y {CODE_COVERAGE_ROOT}/{REDUCTION_CONFIGS}/rank2_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage303">./bin/rank3_reduction_test -y {CODE_COVERAGE_ROOT}/{REDUCTION_CONFIGS}/rank3_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage304">./bin/rank4_reduction_test -y {CODE_COVERAGE_ROOT}/{REDUCTION_CONFIGS}/rank4_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage305">./bin/rank5_reduction_test -y {CODE_COVERAGE_ROOT}/{REDUCTION_CONFIGS}/rank5_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
-    </emulation>
-    <emulation sets="codecoverage">
         <run name="codecoverage306">./bin/rank6_reduction_test -y {CODE_COVERAGE_ROOT}/{REDUCTION_CONFIGS}/rank6_test_params.yaml {CODE_COVERAGE_PARAMS} </run>
     </emulation>
 </testset>

--- a/projects/hiptensor/test/00_unit/CMakeLists.txt
+++ b/projects/hiptensor/test/00_unit/CMakeLists.txt
@@ -32,13 +32,13 @@
      )
  add_hiptensor_unit_test(util_test
      ${HIPTENSOR_COMMON_TEST_SOURCES}
-	 ${CMAKE_CURRENT_SOURCE_DIR}/util_test.cpp
-	 )
+     ${CMAKE_CURRENT_SOURCE_DIR}/util_test.cpp
+     )
  add_hiptensor_unit_test(hiptensor_options_test
      ${HIPTENSOR_COMMON_TEST_SOURCES}
-	 ${CMAKE_CURRENT_SOURCE_DIR}/hiptensor_options_test.cpp
-	 )
+     ${CMAKE_CURRENT_SOURCE_DIR}/hiptensor_options_test.cpp
+     )
  # add_hiptensor_unit_test(interface_test
      # ${HIPTENSOR_COMMON_TEST_SOURCES}
-	 # ${CMAKE_CURRENT_SOURCE_DIR}/interface_test.cpp
-	 # )
+     # ${CMAKE_CURRENT_SOURCE_DIR}/interface_test.cpp
+     # )


### PR DESCRIPTION
## Motivation

Clean up to make it easier to run the emulation set of tests.

## Technical Details

- Apply black to format the python script
- Remove invalid and long set of run commands from rtest.xml
- Fix display of final result for rtest.py execution

## Test Plan

Manually run rtest.py

## Test Result

The script is properly working

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
