### PR TITLE
[rocprim] Fix memory access fault while testing rocsparse with a debug build

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_radix_sort.hpp
@@ -571,10 +571,12 @@ struct radix_sort_and_scatter_helper
             ::rocprim::syncthreads();
 
             // Update the digit offsets
+            // Note: exclusive_digit_prefix and digit_counts are arrays of size digits_per_thread (=1),
+            // so we must use index 0, not flat_id, to avoid out-of-bounds access.
             if(flat_id < radix_size)
             {
                 storage.digit_offsets[flat_id]
-                    += exclusive_digit_prefix[flat_id] + digit_counts[flat_id];
+                    += exclusive_digit_prefix[0] + digit_counts[0];
             }
         }
     }


### PR DESCRIPTION
There is a memory access fault in rocprim observed only when we build rocsparse in debug but not in release mode.

After creating a minimal reproducer that uses only rocprim and presents the same behavior (OK in release, KO in debug), I believe that I identify the issue.

This PR fixes the issue both for the minimal reproducer and the rocsparse test (built in debug).