### PR TITLE
[rocsparse] Fix missing trailing slash in matrices directory path when environment variable is set

### DIFF
--- a/projects/rocsparse/clients/common/rocsparse_clients_matrices_dir.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_clients_matrices_dir.cpp
@@ -46,9 +46,16 @@ private:
         {
             this->m_path
                 = rocsparse_clients_envariables::get(rocsparse_clients_envariables::MATRICES_DIR);
+            // Ensure trailing slash for proper path concatenation
+            const size_t size = this->m_path.size();
+            if((size > 0) && (this->m_path[size - 1] != '/'))
+            {
+                this->m_path += "/";
+            }
         }
 
-        fs::path default_path = rocsparse_exepath();
+        // Compute default path by checking possible relative locations
+        fs::path exe_path = rocsparse_exepath();
 
         static constexpr const char* possible_relative_paths[] = {
             // Development build: executable in build_dir/clients/staging, matrices in build_dir/clients/matrices
@@ -59,7 +66,7 @@ private:
 
         for(const auto& rel_path : possible_relative_paths)
         {
-            fs::path test_path = default_path / rel_path;
+            fs::path test_path = exe_path / rel_path;
             if(fs::exists(test_path))
             {
                 this->m_default_path = test_path.string() + "/";
@@ -67,14 +74,22 @@ private:
             }
         }
 
-        if(this->m_default_path.empty())
+        // If no default path found and no environment variable set, print warning but don't throw.
+        // The error will be handled later when the path is actually used.
+        if(this->m_default_path.empty() && !this->m_is_defined)
         {
-            std::cerr << "rocsparse: could not find matrices directory. Please set "
+            std::cerr << "rocsparse: warning: could not find matrices directory. Please set "
                          "ROCSPARSE_CLIENTS_MATRICES_DIR "
                          "environment variable, or use the option --matrices-dir"
                       << std::endl;
-
-            throw rocsparse_status_internal_error;
+            // Fall back to the old default path behavior to avoid breaking existing setups
+            this->m_default_path = exe_path.string();
+            const size_t size    = this->m_default_path.size();
+            if((size > 0) && (this->m_default_path[size - 1] != '/'))
+            {
+                this->m_default_path += "/";
+            }
+            this->m_default_path += "../matrices/";
         }
     }
 

--- a/projects/rocsparse/clients/common/rocsparse_clients_matrices_dir.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_clients_matrices_dir.cpp
@@ -28,6 +28,22 @@
 #include <cstdio>
 #include <filesystem>
 
+// Helper to ensure trailing separator using std::filesystem (portable for Windows/Linux)
+static std::string ensure_trailing_separator(const std::string& path_str)
+{
+    namespace fs = std::filesystem;
+    if(path_str.empty())
+        return path_str;
+    fs::path p(path_str);
+    // Use make_preferred() to get platform-appropriate separators
+    std::string result = p.make_preferred().string();
+    if(!result.empty() && result.back() != fs::path::preferred_separator)
+    {
+        result += fs::path::preferred_separator;
+    }
+    return result;
+}
+
 //
 //
 //
@@ -44,14 +60,8 @@ private:
             rocsparse_clients_envariables::MATRICES_DIR);
         if(this->m_is_defined)
         {
-            this->m_path
-                = rocsparse_clients_envariables::get(rocsparse_clients_envariables::MATRICES_DIR);
-            // Ensure trailing slash for proper path concatenation
-            const size_t size = this->m_path.size();
-            if((size > 0) && (this->m_path[size - 1] != '/'))
-            {
-                this->m_path += "/";
-            }
+            this->m_path = ensure_trailing_separator(
+                rocsparse_clients_envariables::get(rocsparse_clients_envariables::MATRICES_DIR));
         }
 
         // Compute default path by checking possible relative locations
@@ -83,13 +93,7 @@ private:
                          "environment variable, or use the option --matrices-dir"
                       << std::endl;
             // Fall back to the old default path behavior to avoid breaking existing setups
-            this->m_default_path = exe_path.string();
-            const size_t size    = this->m_default_path.size();
-            if((size > 0) && (this->m_default_path[size - 1] != '/'))
-            {
-                this->m_default_path += "/";
-            }
-            this->m_default_path += "../matrices/";
+            this->m_default_path = (exe_path / ".." / "matrices" / "").make_preferred().string();
         }
     }
 
@@ -129,10 +133,7 @@ public:
     {
         clients_matrices_dir& self = instance();
         self.m_is_defined          = true;
-        self.m_path                = p;
-        const size_t size          = p.size();
-        if((size > 0) && (p[size - 1] != '/'))
-            self.m_path += "/";
+        self.m_path                = ensure_trailing_separator(p);
     }
 };
 


### PR DESCRIPTION
## Description

Fixes a regression introduced in commit `7639abe` where tests using external CSR matrix files (e.g., `bmwcra_1`, `amazon0312`) hang indefinitely in automated test environments.

## Root Cause

When `ROCSPARSE_CLIENTS_MATRICES_DIR` environment variable is set, the trailing slash was not added to the path. This caused incorrect path concatenation:

- **Bug**: `/path/to/matricesbmwcra_1.csr`
- **Expected**: `/path/to/matrices/bmwcra_1.csr`

## Changes

- Add trailing slash handling for `m_path` when environment variable is set
- Replace `throw` with warning and fallback to prevent crashes during static initialization
- Only trigger fallback when both default path not found AND no env var set
