### PR TITLE
[MIOpen] replace boost algos

### DIFF
--- a/projects/miopen/driver/conv_driver.hpp
+++ b/projects/miopen/driver/conv_driver.hpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 #ifndef GUARD_MIOPEN_CONV_DRIVER_HPP
 #define GUARD_MIOPEN_CONV_DRIVER_HPP
 
@@ -54,14 +32,13 @@
 #include <../test/tensor_holder.hpp>
 #include <../test/verify.hpp>
 
-#include <boost/range/adaptors.hpp>
-
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <sstream>
 #include <type_traits>
 #include <vector>
@@ -1044,7 +1021,7 @@ std::vector<int> ConvDriver<Tgpu, Tref>::GetInputTensorLengthsFromCmdLine()
     in_lens[0] = inflags.GetValueInt("batchsize");
     in_lens[1] = inflags.GetValueInt("in_channels");
 
-    auto in_spatial_lens = boost::adaptors::slice(in_lens, 2, 2 + spatial_dim);
+    auto in_spatial_lens = in_lens | std::views::drop(2) | std::views::take(spatial_dim);
 
     if(spatial_dim == 2)
     {
@@ -1073,7 +1050,7 @@ std::vector<int> ConvDriver<Tgpu, Tref>::GetWeightTensorLengthsFromCmdLine()
     int spatial_dim = inflags.GetValueInt("spatial_dim");
     wei_lens.resize(2 + spatial_dim);
 
-    auto wei_spatial_lens = boost::adaptors::slice(wei_lens, 2, 2 + spatial_dim);
+    auto wei_spatial_lens = wei_lens | std::views::drop(2) | std::views::take(spatial_dim);
 
     int group_count = std::max(inflags.GetValueInt("group_count"), 1);
 

--- a/projects/miopen/src/convolution.cpp
+++ b/projects/miopen/src/convolution.cpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 #include <miopen/convolution.hpp>
 
 #include <miopen/any_solver.hpp>
@@ -42,14 +20,14 @@
 
 #include <nlohmann/json.hpp>
 
-#include <cassert>
-#include <cstddef>
 #include <algorithm>
+#include <cassert>
 #include <cmath>
+#include <cstddef>
 #include <ostream>
+#include <ranges>
 
 #include <boost/range/combine.hpp>
-#include <boost/range/adaptors.hpp>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_DIRECT)
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM)
@@ -250,17 +228,17 @@ ConvolutionDescriptor::GetForwardOutputTensorWithLayout(const TensorDescriptor& 
     std::size_t in_n, in_c;
     std::tie(in_n, in_c) = miopen::tie_pick<0, 1>{}(xDesc.GetLengths());
 
-    auto in_spatial = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
+    auto in_spatial = xDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     std::size_t wei_k, wei_c;
     std::tie(wei_k, wei_c) = miopen::tie_pick<0, 1>{}(wDesc.GetLengths());
 
-    auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+    auto wei_spatial = wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     if(wDesc.GetLayout_str() == "CHWNc")
     {
         std::tie(wei_k, wei_c) = miopen::tie_pick<3, 0>{}(wDesc.GetLengths());
-        wei_spatial            = boost::adaptors::slice(wDesc.GetLengths(), 1, 1 + spatial_dim);
+        wei_spatial = wDesc.GetLengths() | std::views::drop(1) | std::views::take(spatial_dim);
     }
 
     if(mode == miopenConvolution)
@@ -293,7 +271,7 @@ ConvolutionDescriptor::GetForwardOutputTensorWithLayout(const TensorDescriptor& 
     std::size_t out_c = 0;
     std::vector<std::size_t> out_lens(spatial_dim + 2);
 
-    auto out_spatial = boost::adaptors::slice(out_lens, 2, 2 + spatial_dim);
+    auto out_spatial = out_lens | std::views::drop(2) | std::views::take(spatial_dim);
 
     if(paddingMode == miopenPaddingSame && mode == miopenConvolution &&
        miopen::all_of(GetConvDilations(), [](auto v) { return v == 1; }))

--- a/projects/miopen/src/gemm_v2.cpp
+++ b/projects/miopen/src/gemm_v2.cpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 #include <miopen/config.h>
 #include <miopen/gemm_v2.hpp>
 #include <miopen/logger.hpp>
@@ -64,7 +42,7 @@
 #include <miopen/perf_field.hpp>
 #endif
 
-#include <boost/range/adaptors.hpp>
+#include <ranges>
 #include <tuple> // std::ignore
 
 #if MIOPEN_USE_ROCBLAS
@@ -1547,8 +1525,10 @@ GemmDescriptor CreateGemmDescriptorConvFwd(const TensorDescriptor& wDesc,
     int in_c  = xDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, wDesc.GetLengths().size());
-    auto out_spatial = boost::adaptors::slice(yDesc.GetLengths(), 2, yDesc.GetLengths().size());
+    auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(wDesc.GetLengths().size() - 2);
+    auto out_spatial =
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(yDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = false;
@@ -1598,8 +1578,10 @@ GemmDescriptor CreateGemmDescriptorConvBwdData(const TensorDescriptor& wDesc,
     int in_c  = dxDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, wDesc.GetLengths().size());
-    auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, dyDesc.GetLengths().size());
+    auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(wDesc.GetLengths().size() - 2);
+    auto out_spatial = dyDesc.GetLengths() | std::views::drop(2) |
+                       std::views::take(dyDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = true;
@@ -1649,8 +1631,10 @@ GemmDescriptor CreateGemmDescriptorConvBwdWeight(const TensorDescriptor& dyDesc,
     std::size_t in_c  = xDesc.GetLengths()[1];
     std::size_t wei_k = dwDesc.GetLengths()[0];
 
-    auto wei_spatial = boost::adaptors::slice(dwDesc.GetLengths(), 2, dwDesc.GetLengths().size());
-    auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, dyDesc.GetLengths().size());
+    auto wei_spatial = dwDesc.GetLengths() | std::views::drop(2) |
+                       std::views::take(dwDesc.GetLengths().size() - 2);
+    auto out_spatial = dyDesc.GetLengths() | std::views::drop(2) |
+                       std::views::take(dyDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = false;
@@ -1703,7 +1687,8 @@ GemmDescriptor CreateGemmDescriptorConvCNHWFwd(const TensorDescriptor& wDesc,
     int in_c  = xDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto out_spatial = boost::adaptors::slice(yDesc.GetLengths(), 2, yDesc.GetLengths().size());
+    auto out_spatial =
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(yDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = false;
@@ -1754,7 +1739,8 @@ GemmDescriptor CreateGemmDescriptorConvCNHWBwdData(const TensorDescriptor& wDesc
     int in_c  = dxDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, dyDesc.GetLengths().size());
+    auto out_spatial = dyDesc.GetLengths() | std::views::drop(2) |
+                       std::views::take(dyDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = true;
@@ -1809,7 +1795,8 @@ GemmDescriptor CreateGemmStridedBatchedDescriptorConv1x1Fwd(const TensorDescript
     int in_c  = xDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto in_spatial = boost::adaptors::slice(xDesc.GetLengths(), 2, xDesc.GetLengths().size());
+    auto in_spatial =
+        xDesc.GetLengths() | std::views::drop(2) | std::views::take(xDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = false;
@@ -1861,7 +1848,8 @@ GemmDescriptor CreateGemmStridedBatchedDescriptorConv1x1BwdData(const TensorDesc
     int in_c  = dxDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto in_spatial = boost::adaptors::slice(dxDesc.GetLengths(), 2, dxDesc.GetLengths().size());
+    auto in_spatial = dxDesc.GetLengths() | std::views::drop(2) |
+                      std::views::take(dxDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = true;
@@ -1913,7 +1901,8 @@ GemmDescriptor CreateGemmStridedBatchedDescriptorConv1x1BwdWeight(const TensorDe
     int in_c  = xDesc.GetLengths()[1];
     int wei_k = dwDesc.GetLengths()[0];
 
-    auto in_spatial = boost::adaptors::slice(xDesc.GetLengths(), 2, xDesc.GetLengths().size());
+    auto in_spatial =
+        xDesc.GetLengths() | std::views::drop(2) | std::views::take(xDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = false;
@@ -1963,8 +1952,10 @@ GemmDescriptor CreateGemmDescriptorGroupConvFwd(const TensorDescriptor& wDesc,
     int in_c  = xDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, wDesc.GetLengths().size());
-    auto out_spatial = boost::adaptors::slice(yDesc.GetLengths(), 2, yDesc.GetLengths().size());
+    auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(wDesc.GetLengths().size() - 2);
+    auto out_spatial =
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(yDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = false;
@@ -2015,8 +2006,10 @@ GemmDescriptor CreateGemmDescriptorGroupConvBwdData(const TensorDescriptor& wDes
     int in_c  = dxDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, wDesc.GetLengths().size());
-    auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, dyDesc.GetLengths().size());
+    auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(wDesc.GetLengths().size() - 2);
+    auto out_spatial = dyDesc.GetLengths() | std::views::drop(2) |
+                       std::views::take(dyDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = true;
@@ -2067,8 +2060,10 @@ GemmDescriptor CreateGemmDescriptorGroupConvBwdWeight(const TensorDescriptor& dy
     int in_c  = xDesc.GetLengths()[1];
     int wei_k = dwDesc.GetLengths()[0];
 
-    auto wei_spatial = boost::adaptors::slice(dwDesc.GetLengths(), 2, dwDesc.GetLengths().size());
-    auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, dyDesc.GetLengths().size());
+    auto wei_spatial = dwDesc.GetLengths() | std::views::drop(2) |
+                       std::views::take(dwDesc.GetLengths().size() - 2);
+    auto out_spatial = dyDesc.GetLengths() | std::views::drop(2) |
+                       std::views::take(dyDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = false;
@@ -2120,7 +2115,8 @@ GemmDescriptor CreateGemmDescriptorGroupConvCNHWFwd(const TensorDescriptor& wDes
     int in_c  = xDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto out_spatial = boost::adaptors::slice(yDesc.GetLengths(), 2, yDesc.GetLengths().size());
+    auto out_spatial =
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(yDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = false;
@@ -2172,7 +2168,8 @@ GemmDescriptor CreateGemmDescriptorGroupConvCNHWBwdData(const TensorDescriptor& 
     int in_c  = dxDesc.GetLengths()[1];
     int wei_k = wDesc.GetLengths()[0];
 
-    auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, dyDesc.GetLengths().size());
+    auto out_spatial = dyDesc.GetLengths() | std::views::drop(2) |
+                       std::views::take(dyDesc.GetLengths().size() - 2);
 
     bool isColMajor = false;
     bool transA     = true;

--- a/projects/miopen/src/include/miopen/util.hpp
+++ b/projects/miopen/src/include/miopen/util.hpp
@@ -7,7 +7,6 @@
 #include <miopen/common.hpp>
 #include <miopen/miopen.h>
 
-#include <span>
 #include <vector>
 
 namespace miopen {
@@ -19,9 +18,9 @@ MIOPEN_INTERNALS_EXPORT float Im2ColGPU(const Handle& handle,
                                         ConstData_t im,
                                         std::size_t im_offset,
                                         std::size_t in_c,
-                                        std::span<const size_t> in_spatial,
-                                        std::span<const size_t> wei_spatial,
-                                        std::span<const size_t> out_spatial,
+                                        const std::vector<size_t>& in_spatial,
+                                        const std::vector<size_t>& wei_spatial,
+                                        const std::vector<size_t>& out_spatial,
                                         const std::vector<int>& pad_spatial,
                                         const std::vector<int>& stride_spatial,
                                         const std::vector<int>& dilation_spatial,
@@ -31,13 +30,13 @@ MIOPEN_INTERNALS_EXPORT float Im2ColGPU(const Handle& handle,
 MIOPEN_INTERNALS_EXPORT float Col2ImGPU(const Handle& handle,
                                         std::size_t spatial_dim,
                                         ConstData_t col,
-                                        std::span<const size_t> out_spatial,
-                                        std::span<const size_t> wei_spatial,
+                                        const std::vector<size_t>& out_spatial,
+                                        const std::vector<size_t>& wei_spatial,
                                         const std::vector<int>& pad_spatial,
                                         const std::vector<int>& stride_spatial,
                                         const std::vector<int>& dilation_spatial,
                                         std::size_t in_c,
-                                        std::span<const size_t> in_spatial,
+                                        const std::vector<size_t>& in_spatial,
                                         Data_t im,
                                         std::size_t im_offset,
                                         miopenDataType_t type);

--- a/projects/miopen/src/include/miopen/util.hpp
+++ b/projects/miopen/src/include/miopen/util.hpp
@@ -1,69 +1,45 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 #ifndef MIOPEN_UTIL_HPP_
 #define MIOPEN_UTIL_HPP_
 
 #include <miopen/common.hpp>
 #include <miopen/miopen.h>
 
-#include <boost/range/adaptors.hpp>
+#include <span>
 
 namespace miopen {
 
 struct Handle;
 
-MIOPEN_INTERNALS_EXPORT float
-Im2ColGPU(const Handle& handle,
-          std::size_t spatial_dim,
-          ConstData_t im,
-          std::size_t im_offset,
-          std::size_t in_c,
-          const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& in_spatial,
-          const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& wei_spatial,
-          const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& out_spatial,
-          const std::vector<int>& pad_spatial,
-          const std::vector<int>& stride_spatial,
-          const std::vector<int>& dilation_spatial,
-          Data_t col,
-          miopenDataType_t type);
+MIOPEN_INTERNALS_EXPORT float Im2ColGPU(const Handle& handle,
+                                        std::size_t spatial_dim,
+                                        ConstData_t im,
+                                        std::size_t im_offset,
+                                        std::size_t in_c,
+                                        std::span<const size_t> in_spatial,
+                                        std::span<const size_t> wei_spatial,
+                                        std::span<const size_t> out_spatial,
+                                        const std::vector<int>& pad_spatial,
+                                        const std::vector<int>& stride_spatial,
+                                        const std::vector<int>& dilation_spatial,
+                                        Data_t col,
+                                        miopenDataType_t type);
 
-MIOPEN_INTERNALS_EXPORT float
-Col2ImGPU(const Handle& handle,
-          std::size_t spatial_dim,
-          ConstData_t col,
-          const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& out_spatial,
-          const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& wei_spatial,
-          const std::vector<int>& pad_spatial,
-          const std::vector<int>& stride_spatial,
-          const std::vector<int>& dilation_spatial,
-          std::size_t in_c,
-          const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& in_spatial,
-          Data_t im,
-          std::size_t im_offset,
-          miopenDataType_t type);
+MIOPEN_INTERNALS_EXPORT float Col2ImGPU(const Handle& handle,
+                                        std::size_t spatial_dim,
+                                        ConstData_t col,
+                                        std::span<const size_t> out_spatial,
+                                        std::span<const size_t> wei_spatial,
+                                        const std::vector<int>& pad_spatial,
+                                        const std::vector<int>& stride_spatial,
+                                        const std::vector<int>& dilation_spatial,
+                                        std::size_t in_c,
+                                        std::span<const size_t> in_spatial,
+                                        Data_t im,
+                                        std::size_t im_offset,
+                                        miopenDataType_t type);
 
 MIOPEN_INTERNALS_EXPORT float transpose_NCHW2CNHW(const Handle& handle,
                                                   int n,

--- a/projects/miopen/src/include/miopen/util.hpp
+++ b/projects/miopen/src/include/miopen/util.hpp
@@ -8,6 +8,7 @@
 #include <miopen/miopen.h>
 
 #include <span>
+#include <vector>
 
 namespace miopen {
 

--- a/projects/miopen/src/kernel_build_params.cpp
+++ b/projects/miopen/src/kernel_build_params.cpp
@@ -1,32 +1,8 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2019 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
+#include <ranges>
 #include <sstream>
-
-#include <boost/range/adaptor/transformed.hpp>
 
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/stringutils.hpp>
@@ -37,7 +13,7 @@ static std::string GenerateDefines(const std::vector<KernelBuildParameter>& opti
                                    const std::string& prefix)
 {
     const auto strs =
-        options | boost::adaptors::transformed([&prefix](const KernelBuildParameter& define) {
+        options | std::views::transform([&prefix](const KernelBuildParameter& define) {
             std::ostringstream ss;
 
             ss << '-';

--- a/projects/miopen/src/ocl/utilocl.cpp
+++ b/projects/miopen/src/ocl/utilocl.cpp
@@ -9,7 +9,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <span>
 
 #define WG_SIZE (static_cast<size_t>(256))
 #define MAX_ACTIVE_THREADS (64 * 4 * 64)
@@ -629,9 +628,9 @@ float Im2ColGPU(const Handle& handle,
                 ConstData_t im,
                 std::size_t im_offset,
                 std::size_t in_c,
-                std::span<const size_t> in_spatial,
-                std::span<const size_t> wei_spatial,
-                std::span<const size_t> out_spatial,
+                const std::vector<size_t>& in_spatial,
+                const std::vector<size_t>& wei_spatial,
+                const std::vector<size_t>& out_spatial,
                 const std::vector<int>& pad_spatial,
                 const std::vector<int>& stride_spatial,
                 const std::vector<int>& dilation_spatial,
@@ -695,13 +694,13 @@ float Im2ColGPU(const Handle& handle,
 float Col2ImGPU(const Handle& handle,
                 std::size_t spatial_dim,
                 ConstData_t col,
-                std::span<const size_t> out_spatial,
-                std::span<const size_t> wei_spatial,
+                const std::vector<size_t>& out_spatial,
+                const std::vector<size_t>& wei_spatial,
                 const std::vector<int>& pad_spatial,
                 const std::vector<int>& stride_spatial,
                 const std::vector<int>& dilation_spatial,
                 std::size_t in_c,
-                std::span<const size_t> in_spatial,
+                const std::vector<size_t>& in_spatial,
                 Data_t im,
                 std::size_t im_offset,
                 miopenDataType_t type)

--- a/projects/miopen/src/ocl/utilocl.cpp
+++ b/projects/miopen/src/ocl/utilocl.cpp
@@ -1,42 +1,19 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2025 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 #include <miopen/datatype.hpp>
 #include <miopen/float_equal.hpp>
 #include <miopen/kernel_cache.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/util.hpp>
 
-#include <boost/range/adaptors.hpp>
-
 #include <cmath>
 #include <cstdint>
+#include <span>
 
-#define WG_SIZE (static_cast<size_t>(256))
-#define MAX_ACTIVE_THREADS (64 * 4 * 64)
-#define MAX_LOCAL_MEM 65536
+constexpr size_t WG_SIZE            = 256;
+constexpr size_t MAX_ACTIVE_THREADS = static_cast<const size_t>(64 * 4 * 64);
+constexpr size_t MAX_LOCAL_MEM      = 65536;
 
 namespace miopen {
 
@@ -647,20 +624,19 @@ float Col2Im3dGPU(const Handle& handle,
     return handle.GetKernelTime();
 }
 
-float Im2ColGPU(
-    const Handle& handle,
-    std::size_t spatial_dim,
-    ConstData_t im,
-    std::size_t im_offset,
-    std::size_t in_c,
-    const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& in_spatial,
-    const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& wei_spatial,
-    const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& out_spatial,
-    const std::vector<int>& pad_spatial,
-    const std::vector<int>& stride_spatial,
-    const std::vector<int>& dilation_spatial,
-    Data_t col,
-    miopenDataType_t type)
+float Im2ColGPU(const Handle& handle,
+                std::size_t spatial_dim,
+                ConstData_t im,
+                std::size_t im_offset,
+                std::size_t in_c,
+                std::span<const size_t> in_spatial,
+                std::span<const size_t> wei_spatial,
+                std::span<const size_t> out_spatial,
+                const std::vector<int>& pad_spatial,
+                const std::vector<int>& stride_spatial,
+                const std::vector<int>& dilation_spatial,
+                Data_t col,
+                miopenDataType_t type)
 {
     switch(spatial_dim)
     {
@@ -716,20 +692,19 @@ float Im2ColGPU(
     }
 }
 
-float Col2ImGPU(
-    const Handle& handle,
-    std::size_t spatial_dim,
-    ConstData_t col,
-    const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& out_spatial,
-    const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& wei_spatial,
-    const std::vector<int>& pad_spatial,
-    const std::vector<int>& stride_spatial,
-    const std::vector<int>& dilation_spatial,
-    std::size_t in_c,
-    const decltype(boost::adaptors::slice(std::vector<std::size_t>(), 0, 1))& in_spatial,
-    Data_t im,
-    std::size_t im_offset,
-    miopenDataType_t type)
+float Col2ImGPU(const Handle& handle,
+                std::size_t spatial_dim,
+                ConstData_t col,
+                std::span<const size_t> out_spatial,
+                std::span<const size_t> wei_spatial,
+                const std::vector<int>& pad_spatial,
+                const std::vector<int>& stride_spatial,
+                const std::vector<int>& dilation_spatial,
+                std::size_t in_c,
+                std::span<const size_t> in_spatial,
+                Data_t im,
+                std::size_t im_offset,
+                miopenDataType_t type)
 {
     switch(spatial_dim)
     {

--- a/projects/miopen/src/ocl/utilocl.cpp
+++ b/projects/miopen/src/ocl/utilocl.cpp
@@ -11,9 +11,9 @@
 #include <cstdint>
 #include <span>
 
-constexpr size_t WG_SIZE            = 256;
-constexpr size_t MAX_ACTIVE_THREADS = static_cast<const size_t>(64 * 4 * 64);
-constexpr size_t MAX_LOCAL_MEM      = 65536;
+#define WG_SIZE (static_cast<size_t>(256))
+#define MAX_ACTIVE_THREADS (64 * 4 * 64)
+#define MAX_LOCAL_MEM 65536
 
 namespace miopen {
 

--- a/projects/miopen/src/solver.cpp
+++ b/projects/miopen/src/solver.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2026 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/activ/solvers.hpp>
 #include <miopen/adam/solvers.hpp>
@@ -53,8 +30,8 @@
 #include <miopen/any_solver.hpp>
 #include <miopen/timer.hpp>
 
-#include <boost/range/adaptor/transformed.hpp>
 #include <ostream>
+#include <ranges>
 
 namespace miopen {
 namespace solver {
@@ -120,7 +97,7 @@ void PrecompileSolutions(const Handle& h,
 std::ostream& operator<<(std::ostream& os, const ConvSolution& s)
 {
     auto strings =
-        s.construction_params | boost::adaptors::transformed([](auto k) { return k.kernel_name; });
+        s.construction_params | std::views::transform([](auto k) { return k.kernel_name; });
     os << s.solver_id << ": " << JoinStrings(strings, "/");
     return os;
 }

--- a/projects/miopen/src/solver.cpp
+++ b/projects/miopen/src/solver.cpp
@@ -30,8 +30,8 @@
 #include <miopen/any_solver.hpp>
 #include <miopen/timer.hpp>
 
+#include <algorithm>
 #include <ostream>
-#include <ranges>
 
 namespace miopen {
 namespace solver {
@@ -96,9 +96,10 @@ void PrecompileSolutions(const Handle& h,
 
 std::ostream& operator<<(std::ostream& os, const ConvSolution& s)
 {
-    auto strings =
-        s.construction_params | std::views::transform([](auto k) { return k.kernel_name; });
-    os << s.solver_id << ": " << JoinStrings(strings, "/");
+    std::transform(s.construction_params.begin(),
+                   s.construction_params.end(),
+                   std::ostream_iterator<std::string>(os, "/"),
+                   [](const auto& k) { return k.kernel_name; });
     return os;
 }
 

--- a/projects/miopen/src/solver/conv/gemm.cpp
+++ b/projects/miopen/src/solver/conv/gemm.cpp
@@ -260,6 +260,8 @@ ConvSolution GemmFwd1x1_0_2::GetSolution(const ExecutionContext& context,
         xDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
     const auto out_spatial_ =
         yDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
+    const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
 
     std::size_t in_n, in_c;
     std::tie(in_n, in_c) = tie_pick<0, 1>()(xDesc.GetLengths());
@@ -273,156 +275,150 @@ ConvSolution GemmFwd1x1_0_2::GetSolution(const ExecutionContext& context,
     const auto lowp_quant   = conv.lowp_quant;
     const auto conv_strides = conv.GetConvStrides();
 
-    solution.invoker_factory =
-        [            =,
-         in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end()),
-         out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end())](
-            const std::vector<Kernel>&) {
-            const std::size_t out_spatial_size = std::accumulate(out_spatial.begin(),
-                                                                 out_spatial.end(),
-                                                                 std::size_t(1),
-                                                                 std::multiplies<std::size_t>());
+    solution.invoker_factory = [=](const std::vector<Kernel>&) {
+        const std::size_t out_spatial_size = std::accumulate(
+            out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
 
-            return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
-                float time_gemm         = 0;
-                const auto& conv_params = primitive_params.CastTo<miopen::conv::DataInvokeParams>();
-                const auto& workSpace   = conv_params.workSpace;
-                const auto workSpaceSize = conv_params.workSpaceSize;
-                const auto x             = conv_params.tensors.in;
-                const auto w             = conv_params.tensors.w;
-                const auto y             = conv_params.tensors.out;
+        return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
+            float time_gemm          = 0;
+            const auto& conv_params  = primitive_params.CastTo<miopen::conv::DataInvokeParams>();
+            const auto& workSpace    = conv_params.workSpace;
+            const auto workSpaceSize = conv_params.workSpaceSize;
+            const auto x             = conv_params.tensors.in;
+            const auto w             = conv_params.tensors.w;
+            const auto y             = conv_params.tensors.out;
 
-                if((workSpace == nullptr && workspace_req > 0) || workSpaceSize < workspace_req)
-                {
-                    MIOPEN_THROW("Not enough workspace for GEMM (" + std::to_string(workSpaceSize) +
-                                 " provided, " + std::to_string(workspace_req) + " required)");
-                }
+            if((workSpace == nullptr && workspace_req > 0) || workSpaceSize < workspace_req)
+            {
+                MIOPEN_THROW("Not enough workspace for GEMM (" + std::to_string(workSpaceSize) +
+                             " provided, " + std::to_string(workspace_req) + " required)");
+            }
 
-                const std::string name = group_count > 1 ? "groupconv" : "convolution";
-                MIOPEN_LOG_FUNCTION(name + ", 1x1 u2xv2");
+            const std::string name = group_count > 1 ? "groupconv" : "convolution";
+            MIOPEN_LOG_FUNCTION(name + ", 1x1 u2xv2");
 
-                // y = CNHW2NCHW(w * NCHW2CNHW(x))
-                transpose_NCHW2CNHW(handle,
-                                    in_n,
-                                    in_c,
-                                    in_spatial[0],
-                                    in_spatial[1],
-                                    out_spatial[0],
-                                    out_spatial[1],
-                                    x,
-                                    workSpace,
-                                    0,
-                                    0,
-                                    conv_strides[0],
-                                    conv_strides[1],
-                                    xDesc.GetType());
-                if(handle.IsProfilingEnabled())
-                    time_gemm = handle.GetKernelTime();
+            // y = CNHW2NCHW(w * NCHW2CNHW(x))
+            transpose_NCHW2CNHW(handle,
+                                in_n,
+                                in_c,
+                                in_spatial[0],
+                                in_spatial[1],
+                                out_spatial[0],
+                                out_spatial[1],
+                                x,
+                                workSpace,
+                                0,
+                                0,
+                                conv_strides[0],
+                                conv_strides[1],
+                                xDesc.GetType());
+            if(handle.IsProfilingEnabled())
+                time_gemm = handle.GetKernelTime();
 
-                std::size_t x_t_size = in_n * in_c * out_spatial_size;
+            std::size_t x_t_size = in_n * in_c * out_spatial_size;
 
-                std::size_t wksp_offset = 0;
-                if(wDesc.GetType() == miopenInt8)
-                {
-                    wksp_offset = x_t_size;
-                    transpose_packed_MN2NM(handle,
-                                           in_c,
-                                           static_cast<int>(in_n * out_spatial_size),
-                                           0,
-                                           wksp_offset,
-                                           workSpace,
-                                           workSpace,
-                                           xDesc.GetType());
-
-                    if(handle.IsProfilingEnabled())
-                        time_gemm += handle.GetKernelTime();
-
-                    x_t_size *= 2;
-                }
-
-                if(wDesc.GetType() == miopenInt8)
-                {
-                    const auto xts = GetTypeSize(xDesc.GetType());
-                    if(xts > 0)
-                    {
-                        const auto yts_div_xts = GetTypeSize(yDesc.GetType()) / xts;
-                        if(yts_div_xts > 0)
-                            x_t_size /= yts_div_xts;
-                    }
-                }
-
-                miopenStatus_t gemm_status;
-                auto gemm_desc = [&]() {
-                    auto tmp            = tmp_gemm_desc;
-                    tmp.gfx90a_alt_impl = conv_params.gfx90aFp16alt;
-                    return tmp;
-                }();
-
-                if(group_count > 1)
-                {
-                    gemm_status = CallGemmStridedBatched(handle,
-                                                         gemm_desc,
-                                                         w,
-                                                         0,
-                                                         workSpace,
-                                                         0,
-                                                         workSpace,
-                                                         x_t_size,
-                                                         GemmBackend_t::rocblas);
-                }
-                else
-                {
-                    // tensors.y = CNHW2NCHW(tensors.w * NCHW2CNHW(tensors.x))
-                    gemm_status = CallGemm(handle,
-                                           gemm_desc,
-                                           w,
-                                           0,
-                                           workSpace,
-                                           wksp_offset,
-                                           workSpace,
-                                           x_t_size,
-                                           GemmBackend_t::rocblas);
-                }
-
-                if(gemm_status != miopenStatusSuccess)
-                    MIOPEN_THROW("GEMM execution failure");
+            std::size_t wksp_offset = 0;
+            if(wDesc.GetType() == miopenInt8)
+            {
+                wksp_offset = x_t_size;
+                transpose_packed_MN2NM(handle,
+                                       in_c,
+                                       static_cast<int>(in_n * out_spatial_size),
+                                       0,
+                                       wksp_offset,
+                                       workSpace,
+                                       workSpace,
+                                       xDesc.GetType());
 
                 if(handle.IsProfilingEnabled())
                     time_gemm += handle.GetKernelTime();
 
-                transpose_CNHW2NCHW(handle,
-                                    in_n,
-                                    wei_k,
-                                    out_spatial[0],
-                                    out_spatial[1],
-                                    out_spatial[0],
-                                    out_spatial[1],
-                                    workSpace,
-                                    y,
-                                    x_t_size,
-                                    0,
-                                    1,
-                                    1,
-                                    yDesc.GetType());
+                x_t_size *= 2;
+            }
+
+            if(wDesc.GetType() == miopenInt8)
+            {
+                const auto xts = GetTypeSize(xDesc.GetType());
+                if(xts > 0)
+                {
+                    const auto yts_div_xts = GetTypeSize(yDesc.GetType()) / xts;
+                    if(yts_div_xts > 0)
+                        x_t_size /= yts_div_xts;
+                }
+            }
+
+            miopenStatus_t gemm_status;
+            auto gemm_desc = [&]() {
+                auto tmp            = tmp_gemm_desc;
+                tmp.gfx90a_alt_impl = conv_params.gfx90aFp16alt;
+                return tmp;
+            }();
+
+            if(group_count > 1)
+            {
+                gemm_status = CallGemmStridedBatched(handle,
+                                                     gemm_desc,
+                                                     w,
+                                                     0,
+                                                     workSpace,
+                                                     0,
+                                                     workSpace,
+                                                     x_t_size,
+                                                     GemmBackend_t::rocblas);
+            }
+            else
+            {
+                // tensors.y = CNHW2NCHW(tensors.w * NCHW2CNHW(tensors.x))
+                gemm_status = CallGemm(handle,
+                                       gemm_desc,
+                                       w,
+                                       0,
+                                       workSpace,
+                                       wksp_offset,
+                                       workSpace,
+                                       x_t_size,
+                                       GemmBackend_t::rocblas);
+            }
+
+            if(gemm_status != miopenStatusSuccess)
+                MIOPEN_THROW("GEMM execution failure");
+
+            if(handle.IsProfilingEnabled())
+                time_gemm += handle.GetKernelTime();
+
+            transpose_CNHW2NCHW(handle,
+                                in_n,
+                                wei_k,
+                                out_spatial[0],
+                                out_spatial[1],
+                                out_spatial[0],
+                                out_spatial[1],
+                                workSpace,
+                                y,
+                                x_t_size,
+                                0,
+                                1,
+                                1,
+                                yDesc.GetType());
+            if(handle.IsProfilingEnabled())
+                time_gemm += handle.GetKernelTime();
+
+            if(wDesc.GetType() == miopenInt8 && yDesc.GetType() != miopenInt32)
+            {
+                TensorDescriptor ygemmDesc(miopenInt32, yDesc.GetLengths(), yDesc.GetStrides());
+
+                CastTensor(handle, &lowp_quant, true, ygemmDesc, y, yDesc, y, 0, 0);
                 if(handle.IsProfilingEnabled())
                     time_gemm += handle.GetKernelTime();
+            }
 
-                if(wDesc.GetType() == miopenInt8 && yDesc.GetType() != miopenInt32)
-                {
-                    TensorDescriptor ygemmDesc(miopenInt32, yDesc.GetLengths(), yDesc.GetStrides());
-
-                    CastTensor(handle, &lowp_quant, true, ygemmDesc, y, yDesc, y, 0, 0);
-                    if(handle.IsProfilingEnabled())
-                        time_gemm += handle.GetKernelTime();
-                }
-
-                if(handle.IsProfilingEnabled())
-                {
-                    handle.ResetKernelTime();
-                    handle.AccumKernelTime(time_gemm);
-                }
-            };
+            if(handle.IsProfilingEnabled())
+            {
+                handle.ResetKernelTime();
+                handle.AccumKernelTime(time_gemm);
+            }
         };
+    };
 
     return solution;
 #else
@@ -521,6 +517,9 @@ ConvSolution GemmFwd1x1_0_1_int8::GetSolution(const ExecutionContext& context,
     const auto out_spatial_ =
         yDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
+    const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
+    const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
+
     const auto workspace_req = GetWorkspaceSize(context, problem);
 
     auto solution         = ConvSolution{miopenStatusSuccess};
@@ -544,12 +543,7 @@ ConvSolution GemmFwd1x1_0_1_int8::GetSolution(const ExecutionContext& context,
     const auto x_type     = xDesc.GetType();
     const auto lowp_quant = conv.lowp_quant;
 
-    solution.invoker_factory = [            =,
-                                in_spatial  = std::vector<std::size_t>(in_spatial_.begin(),
-                                                                      in_spatial_.end()),
-                                out_spatial = std::vector<std::size_t>(out_spatial_.begin(),
-                                                                       out_spatial_.end())](
-                                   const std::vector<Kernel>&) {
+    solution.invoker_factory = [=](const std::vector<Kernel>&) {
         const std::size_t in_spatial_size = std::accumulate(
             in_spatial.begin(), in_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
 

--- a/projects/miopen/src/solver/conv/gemm.cpp
+++ b/projects/miopen/src/solver/conv/gemm.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2020 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/conv/solvers.hpp>
 
@@ -36,7 +13,7 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/gemm_common.hpp>
 
-#include <boost/range/adaptors.hpp>
+#include <ranges>
 
 namespace miopen {
 namespace solver {
@@ -129,7 +106,7 @@ float GemmFwdBase::GetWti(const ExecutionContext&, const ProblemDescription& pro
     std::size_t in_n, in_c;
     std::tie(in_n, in_c)    = tie_pick<0, 1>()(xDesc.GetLengths());
     std::size_t spatial_dim = conv.GetSpatialDimension();
-    auto wei_spatial        = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+    auto wei_spatial = wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     // Use transpose path 1x1, stride=2
     if(conv.GetSpatialDimension() == 2 &&
@@ -199,7 +176,7 @@ size_t GemmFwd1x1_0_2::GetWorkspaceSize(const ExecutionContext& context,
     std::tie(in_n, in_c) = miopen::tie_pick<0, 1>{}(xDesc.GetLengths());
 
     const auto out_spatial =
-        boost::adaptors::slice(yDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
 
     const auto x_t_size = in_n * in_c * (xDesc.GetType() == miopenInt8 ? 2 : 1) *
                           std::accumulate(out_spatial.begin(),
@@ -235,7 +212,8 @@ bool GemmFwd1x1_0_2::IsApplicable(const ExecutionContext& context,
     decltype(auto) wDesc = problem.GetWeights();
 
     const auto spatial_dim = conv.GetSpatialDimension();
-    const auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     return conv.GetSpatialDimension() == 2 &&
            miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
@@ -278,8 +256,10 @@ ConvSolution GemmFwd1x1_0_2::GetSolution(const ExecutionContext& context,
     const auto workspace_req = GetWorkspaceSize(context, problem);
 
     const std::size_t spatial_dim = conv.GetSpatialDimension();
-    const auto& in_spatial_       = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto& out_spatial_      = boost::adaptors::slice(yDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto in_spatial_ =
+        xDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto out_spatial_ =
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     std::size_t in_n, in_c;
     std::tie(in_n, in_c) = tie_pick<0, 1>()(xDesc.GetLengths());
@@ -293,153 +273,156 @@ ConvSolution GemmFwd1x1_0_2::GetSolution(const ExecutionContext& context,
     const auto lowp_quant   = conv.lowp_quant;
     const auto conv_strides = conv.GetConvStrides();
 
-    solution.invoker_factory = [=](const std::vector<Kernel>&) {
-        const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
-        const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
+    solution.invoker_factory =
+        [            =,
+         in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end()),
+         out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end())](
+            const std::vector<Kernel>&) {
+            const std::size_t out_spatial_size = std::accumulate(out_spatial.begin(),
+                                                                 out_spatial.end(),
+                                                                 std::size_t(1),
+                                                                 std::multiplies<std::size_t>());
 
-        const std::size_t out_spatial_size = std::accumulate(
-            out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
+            return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
+                float time_gemm         = 0;
+                const auto& conv_params = primitive_params.CastTo<miopen::conv::DataInvokeParams>();
+                const auto& workSpace   = conv_params.workSpace;
+                const auto workSpaceSize = conv_params.workSpaceSize;
+                const auto x             = conv_params.tensors.in;
+                const auto w             = conv_params.tensors.w;
+                const auto y             = conv_params.tensors.out;
 
-        return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
-            float time_gemm          = 0;
-            const auto& conv_params  = primitive_params.CastTo<miopen::conv::DataInvokeParams>();
-            const auto& workSpace    = conv_params.workSpace;
-            const auto workSpaceSize = conv_params.workSpaceSize;
-            const auto x             = conv_params.tensors.in;
-            const auto w             = conv_params.tensors.w;
-            const auto y             = conv_params.tensors.out;
-
-            if((workSpace == nullptr && workspace_req > 0) || workSpaceSize < workspace_req)
-            {
-                MIOPEN_THROW("Not enough workspace for GEMM (" + std::to_string(workSpaceSize) +
-                             " provided, " + std::to_string(workspace_req) + " required)");
-            }
-
-            const std::string name = group_count > 1 ? "groupconv" : "convolution";
-            MIOPEN_LOG_FUNCTION(name + ", 1x1 u2xv2");
-
-            // y = CNHW2NCHW(w * NCHW2CNHW(x))
-            transpose_NCHW2CNHW(handle,
-                                in_n,
-                                in_c,
-                                in_spatial[0],
-                                in_spatial[1],
-                                out_spatial[0],
-                                out_spatial[1],
-                                x,
-                                workSpace,
-                                0,
-                                0,
-                                conv_strides[0],
-                                conv_strides[1],
-                                xDesc.GetType());
-            if(handle.IsProfilingEnabled())
-                time_gemm = handle.GetKernelTime();
-
-            std::size_t x_t_size = in_n * in_c * out_spatial_size;
-
-            std::size_t wksp_offset = 0;
-            if(wDesc.GetType() == miopenInt8)
-            {
-                wksp_offset = x_t_size;
-                transpose_packed_MN2NM(handle,
-                                       in_c,
-                                       static_cast<int>(in_n * out_spatial_size),
-                                       0,
-                                       wksp_offset,
-                                       workSpace,
-                                       workSpace,
-                                       xDesc.GetType());
-
-                if(handle.IsProfilingEnabled())
-                    time_gemm += handle.GetKernelTime();
-
-                x_t_size *= 2;
-            }
-
-            if(wDesc.GetType() == miopenInt8)
-            {
-                const auto xts = GetTypeSize(xDesc.GetType());
-                if(xts > 0)
+                if((workSpace == nullptr && workspace_req > 0) || workSpaceSize < workspace_req)
                 {
-                    const auto yts_div_xts = GetTypeSize(yDesc.GetType()) / xts;
-                    if(yts_div_xts > 0)
-                        x_t_size /= yts_div_xts;
+                    MIOPEN_THROW("Not enough workspace for GEMM (" + std::to_string(workSpaceSize) +
+                                 " provided, " + std::to_string(workspace_req) + " required)");
                 }
-            }
 
-            miopenStatus_t gemm_status;
-            auto gemm_desc = [&]() {
-                auto tmp            = tmp_gemm_desc;
-                tmp.gfx90a_alt_impl = conv_params.gfx90aFp16alt;
-                return tmp;
-            }();
+                const std::string name = group_count > 1 ? "groupconv" : "convolution";
+                MIOPEN_LOG_FUNCTION(name + ", 1x1 u2xv2");
 
-            if(group_count > 1)
-            {
-                gemm_status = CallGemmStridedBatched(handle,
-                                                     gemm_desc,
-                                                     w,
-                                                     0,
-                                                     workSpace,
-                                                     0,
-                                                     workSpace,
-                                                     x_t_size,
-                                                     GemmBackend_t::rocblas);
-            }
-            else
-            {
-                // tensors.y = CNHW2NCHW(tensors.w * NCHW2CNHW(tensors.x))
-                gemm_status = CallGemm(handle,
-                                       gemm_desc,
-                                       w,
-                                       0,
-                                       workSpace,
-                                       wksp_offset,
-                                       workSpace,
-                                       x_t_size,
-                                       GemmBackend_t::rocblas);
-            }
+                // y = CNHW2NCHW(w * NCHW2CNHW(x))
+                transpose_NCHW2CNHW(handle,
+                                    in_n,
+                                    in_c,
+                                    in_spatial[0],
+                                    in_spatial[1],
+                                    out_spatial[0],
+                                    out_spatial[1],
+                                    x,
+                                    workSpace,
+                                    0,
+                                    0,
+                                    conv_strides[0],
+                                    conv_strides[1],
+                                    xDesc.GetType());
+                if(handle.IsProfilingEnabled())
+                    time_gemm = handle.GetKernelTime();
 
-            if(gemm_status != miopenStatusSuccess)
-                MIOPEN_THROW("GEMM execution failure");
+                std::size_t x_t_size = in_n * in_c * out_spatial_size;
 
-            if(handle.IsProfilingEnabled())
-                time_gemm += handle.GetKernelTime();
+                std::size_t wksp_offset = 0;
+                if(wDesc.GetType() == miopenInt8)
+                {
+                    wksp_offset = x_t_size;
+                    transpose_packed_MN2NM(handle,
+                                           in_c,
+                                           static_cast<int>(in_n * out_spatial_size),
+                                           0,
+                                           wksp_offset,
+                                           workSpace,
+                                           workSpace,
+                                           xDesc.GetType());
 
-            transpose_CNHW2NCHW(handle,
-                                in_n,
-                                wei_k,
-                                out_spatial[0],
-                                out_spatial[1],
-                                out_spatial[0],
-                                out_spatial[1],
-                                workSpace,
-                                y,
-                                x_t_size,
-                                0,
-                                1,
-                                1,
-                                yDesc.GetType());
-            if(handle.IsProfilingEnabled())
-                time_gemm += handle.GetKernelTime();
+                    if(handle.IsProfilingEnabled())
+                        time_gemm += handle.GetKernelTime();
 
-            if(wDesc.GetType() == miopenInt8 && yDesc.GetType() != miopenInt32)
-            {
-                TensorDescriptor ygemmDesc(miopenInt32, yDesc.GetLengths(), yDesc.GetStrides());
+                    x_t_size *= 2;
+                }
 
-                CastTensor(handle, &lowp_quant, true, ygemmDesc, y, yDesc, y, 0, 0);
+                if(wDesc.GetType() == miopenInt8)
+                {
+                    const auto xts = GetTypeSize(xDesc.GetType());
+                    if(xts > 0)
+                    {
+                        const auto yts_div_xts = GetTypeSize(yDesc.GetType()) / xts;
+                        if(yts_div_xts > 0)
+                            x_t_size /= yts_div_xts;
+                    }
+                }
+
+                miopenStatus_t gemm_status;
+                auto gemm_desc = [&]() {
+                    auto tmp            = tmp_gemm_desc;
+                    tmp.gfx90a_alt_impl = conv_params.gfx90aFp16alt;
+                    return tmp;
+                }();
+
+                if(group_count > 1)
+                {
+                    gemm_status = CallGemmStridedBatched(handle,
+                                                         gemm_desc,
+                                                         w,
+                                                         0,
+                                                         workSpace,
+                                                         0,
+                                                         workSpace,
+                                                         x_t_size,
+                                                         GemmBackend_t::rocblas);
+                }
+                else
+                {
+                    // tensors.y = CNHW2NCHW(tensors.w * NCHW2CNHW(tensors.x))
+                    gemm_status = CallGemm(handle,
+                                           gemm_desc,
+                                           w,
+                                           0,
+                                           workSpace,
+                                           wksp_offset,
+                                           workSpace,
+                                           x_t_size,
+                                           GemmBackend_t::rocblas);
+                }
+
+                if(gemm_status != miopenStatusSuccess)
+                    MIOPEN_THROW("GEMM execution failure");
+
                 if(handle.IsProfilingEnabled())
                     time_gemm += handle.GetKernelTime();
-            }
 
-            if(handle.IsProfilingEnabled())
-            {
-                handle.ResetKernelTime();
-                handle.AccumKernelTime(time_gemm);
-            }
+                transpose_CNHW2NCHW(handle,
+                                    in_n,
+                                    wei_k,
+                                    out_spatial[0],
+                                    out_spatial[1],
+                                    out_spatial[0],
+                                    out_spatial[1],
+                                    workSpace,
+                                    y,
+                                    x_t_size,
+                                    0,
+                                    1,
+                                    1,
+                                    yDesc.GetType());
+                if(handle.IsProfilingEnabled())
+                    time_gemm += handle.GetKernelTime();
+
+                if(wDesc.GetType() == miopenInt8 && yDesc.GetType() != miopenInt32)
+                {
+                    TensorDescriptor ygemmDesc(miopenInt32, yDesc.GetLengths(), yDesc.GetStrides());
+
+                    CastTensor(handle, &lowp_quant, true, ygemmDesc, y, yDesc, y, 0, 0);
+                    if(handle.IsProfilingEnabled())
+                        time_gemm += handle.GetKernelTime();
+                }
+
+                if(handle.IsProfilingEnabled())
+                {
+                    handle.ResetKernelTime();
+                    handle.AccumKernelTime(time_gemm);
+                }
+            };
         };
-    };
 
     return solution;
 #else
@@ -459,9 +442,11 @@ size_t GemmFwd1x1_0_1_int8::GetWorkspaceSize(const ExecutionContext& context,
     decltype(auto) yDesc  = problem.GetOut();
 
     const auto spatial_dim = conv.GetSpatialDimension();
-    const auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto out_spatial = boost::adaptors::slice(yDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto wei_c       = wDesc.GetLengths()[1];
+    const auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto out_spatial =
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto wei_c = wDesc.GetLengths()[1];
 
     const auto ws_size = wei_c *
                          std::accumulate(wei_spatial.begin(),
@@ -498,7 +483,8 @@ bool GemmFwd1x1_0_1_int8::IsApplicable(const ExecutionContext& context,
     decltype(auto) wDesc = problem.GetWeights();
 
     const auto spatial_dim = conv.GetSpatialDimension();
-    const auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
     if(problem.IsTensorsCasted() || problem.IsFp8() || problem.IsBfp8())
         return false;
 
@@ -530,8 +516,10 @@ ConvSolution GemmFwd1x1_0_1_int8::GetSolution(const ExecutionContext& context,
     const std::size_t spatial_dim = conv.GetSpatialDimension();
 
     // This ones do not store data directly, so they should be copied to vectors for invokers.
-    const auto& in_spatial_  = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto& out_spatial_ = boost::adaptors::slice(yDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto in_spatial_ =
+        xDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto out_spatial_ =
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     const auto workspace_req = GetWorkspaceSize(context, problem);
 
@@ -556,10 +544,12 @@ ConvSolution GemmFwd1x1_0_1_int8::GetSolution(const ExecutionContext& context,
     const auto x_type     = xDesc.GetType();
     const auto lowp_quant = conv.lowp_quant;
 
-    solution.invoker_factory = [=](const std::vector<Kernel>&) {
-        const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
-        const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
-
+    solution.invoker_factory = [            =,
+                                in_spatial  = std::vector<std::size_t>(in_spatial_.begin(),
+                                                                      in_spatial_.end()),
+                                out_spatial = std::vector<std::size_t>(out_spatial_.begin(),
+                                                                       out_spatial_.end())](
+                                   const std::vector<Kernel>&) {
         const std::size_t in_spatial_size = std::accumulate(
             in_spatial.begin(), in_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
 
@@ -647,7 +637,8 @@ bool GemmFwd1x1_0_1::IsApplicable(const ExecutionContext& context,
     decltype(auto) wDesc = problem.GetWeights();
 
     const auto spatial_dim = conv.GetSpatialDimension();
-    const auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     return miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
            miopen::all_of(conv.GetConvPads(), [](auto v) { return v == 0; }) &&
@@ -677,8 +668,10 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
     const std::size_t spatial_dim = conv.GetSpatialDimension();
 
     // This ones do not store data directly, so they should be copied to vectors for invokers.
-    const auto& in_spatial_  = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto& out_spatial_ = boost::adaptors::slice(yDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto& in_spatial =
+        xDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto& out_spatial =
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     auto solution = ConvSolution{miopenStatusSuccess};
 
@@ -700,9 +693,6 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
             tmp.conv_attributes = problem.GetConv().attribute;
             return tmp;
         }();
-
-        const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
-        const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
 
         const std::size_t in_spatial_size = std::accumulate(
             in_spatial.begin(), in_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
@@ -778,9 +768,6 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
             return tmp;
         }();
 
-        const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
-        const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
-
         solution.invoker_factory = [=](const std::vector<Kernel>&) {
             MIOPEN_LOG_FUNCTION("convolution, 1x1");
 
@@ -829,9 +816,11 @@ size_t GemmFwdRest::GetWorkspaceSize(const ExecutionContext& context,
     decltype(auto) yDesc  = problem.GetOut();
 
     const auto spatial_dim = conv.GetSpatialDimension();
-    const auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto out_spatial = boost::adaptors::slice(yDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto wei_c       = wDesc.GetLengths()[1];
+    const auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto out_spatial =
+        yDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto wei_c = wDesc.GetLengths()[1];
 
     const auto workspace_size = wei_c *
                                 std::accumulate(wei_spatial.begin(),
@@ -920,11 +909,12 @@ ConvSolution GemmFwdRest::GetSolution(const ExecutionContext& context,
             return tmp;
         }();
 
-        decltype(auto) in_spatial_ = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
+        decltype(auto) in_spatial_ =
+            xDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
         decltype(auto) out_spatial_ =
-            boost::adaptors::slice(yDesc.GetLengths(), 2, 2 + spatial_dim);
+            yDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
         decltype(auto) wei_spatial_ =
-            boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+            wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
         const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
         const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());

--- a/projects/miopen/src/solver/conv/gemm_bwd.cpp
+++ b/projects/miopen/src/solver/conv/gemm_bwd.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2021 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/conv/solvers.hpp>
 
@@ -36,7 +13,7 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/solver/gemm_common.hpp>
 
-#include <boost/range/adaptors.hpp>
+#include <ranges>
 
 namespace miopen {
 namespace solver {
@@ -118,7 +95,7 @@ float GemmBwdBase::GetWti(const ExecutionContext&, const ProblemDescription& pro
     std::size_t in_n, in_c;
     std::tie(in_n, in_c)    = tie_pick<0, 1>()(dxDesc.GetLengths());
     std::size_t spatial_dim = conv.GetSpatialDimension();
-    auto wei_spatial        = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+    auto wei_spatial = wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     // 1x1 does not require col2im
     if(conv.GetSpatialDimension() == 2 &&
@@ -169,7 +146,7 @@ size_t GemmBwd1x1_stride2::GetWorkspaceSize(const ExecutionContext& context,
     const auto in_c = dxDesc.GetLengths()[1];
 
     const auto out_spatial =
-        boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
+        dyDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
 
     const auto dx_t_size = in_n * in_c *
                            std::accumulate(out_spatial.begin(),
@@ -207,7 +184,8 @@ bool GemmBwd1x1_stride2::IsApplicable(const ExecutionContext& context,
     const auto& wDesc = problem.GetWeights();
 
     const auto spatial_dim = conv.GetSpatialDimension();
-    const auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     return conv.GetSpatialDimension() == 2 &&
            miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
@@ -252,13 +230,15 @@ ConvSolution GemmBwd1x1_stride2::GetSolution(const ExecutionContext& context,
     std::size_t in_n, in_c;
     std::tie(in_n, in_c) = tie_pick<0, 1>()(dxDesc.GetLengths());
 
-    const auto wei_k        = wDesc.GetLengths()[0];
-    const auto spatial_dim  = conv.GetSpatialDimension();
-    const auto in_spatial_  = boost::adaptors::slice(dxDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto out_spatial_ = boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto in_spatial   = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
-    const auto out_spatial  = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
-    const auto strides      = conv.GetConvStrides();
+    const auto wei_k       = wDesc.GetLengths()[0];
+    const auto spatial_dim = conv.GetSpatialDimension();
+    const auto in_spatial_ =
+        dxDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto out_spatial_ =
+        dyDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
+    const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
+    const auto strides     = conv.GetConvStrides();
 
     const auto workspace_req = GetWorkspaceSize(context, problem);
 
@@ -408,7 +388,8 @@ bool GemmBwd1x1_stride1::IsApplicable(const ExecutionContext& context,
     const auto& wDesc = problem.GetWeights();
 
     const auto spatial_dim = conv.GetSpatialDimension();
-    const auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     return miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
            miopen::all_of(conv.GetConvPads(), [](auto v) { return v == 0; }) &&
@@ -464,9 +445,10 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
             const auto in_c  = dxDesc.GetLengths()[1];
             const auto wei_k = wDesc.GetLengths()[0];
 
-            const auto in_spatial = boost::adaptors::slice(dxDesc.GetLengths(), 2, 2 + spatial_dim);
+            const auto in_spatial =
+                dxDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
             const auto out_spatial =
-                boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + spatial_dim);
+                dyDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
             std::size_t out_spatial_size = std::accumulate(out_spatial.begin(),
                                                            out_spatial.end(),
@@ -552,8 +534,10 @@ size_t GemmBwdRest::GetWorkspaceSize(const ExecutionContext& context,
 
     const auto spatial_dim = conv.GetSpatialDimension();
 
-    const auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto wei_spatial =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto out_spatial =
+        dyDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
 
     const auto wei_c = wDesc.GetLengths()[1];
 
@@ -610,13 +594,16 @@ ConvSolution GemmBwdRest::GetSolution(const ExecutionContext& context,
 
     const auto group_count = conv.group_count;
 
-    const auto spatial_dim  = conv.GetSpatialDimension();
-    const auto in_spatial_  = boost::adaptors::slice(dxDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto wei_spatial_ = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto out_spatial_ = boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto in_spatial   = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
-    const auto wei_spatial  = std::vector<std::size_t>(wei_spatial_.begin(), wei_spatial_.end());
-    const auto out_spatial  = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
+    const auto spatial_dim = conv.GetSpatialDimension();
+    const auto in_spatial_ =
+        dxDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto wei_spatial_ =
+        wDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto out_spatial_ =
+        dyDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
+    const auto wei_spatial = std::vector<std::size_t>(wei_spatial_.begin(), wei_spatial_.end());
+    const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
 
     // dx = transpose(w) * dy
     const auto tmp_gemm_desc = [&]() {

--- a/projects/miopen/src/solver/conv/gemm_wrw.cpp
+++ b/projects/miopen/src/solver/conv/gemm_wrw.cpp
@@ -373,12 +373,16 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
     const auto in_c           = xDesc.GetLengths()[1];
     const auto wei_k          = dwDesc.GetLengths()[0];
 
-    const auto in_spatial =
+    const auto in_spatial_ =
         xDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
-    const auto wei_spatial =
+    const auto wei_spatial_ =
         dwDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
-    const auto out_spatial =
+    const auto out_spatial_ =
         dyDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
+
+    const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
+    const auto wei_spatial = std::vector<std::size_t>(wei_spatial_.begin(), wei_spatial_.end());
+    const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
 
     const auto out_spatial_size = std::accumulate(
         out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());

--- a/projects/miopen/src/solver/conv/gemm_wrw.cpp
+++ b/projects/miopen/src/solver/conv/gemm_wrw.cpp
@@ -1,28 +1,5 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2024 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
 
 #include <miopen/conv/solvers.hpp>
 
@@ -33,7 +10,7 @@
 #include <miopen/tensor_ops.hpp>
 #include <miopen/util.hpp>
 
-#include <boost/range/adaptors.hpp>
+#include <ranges>
 
 namespace miopen {
 namespace solver {
@@ -115,7 +92,7 @@ float GemmWrwBase::GetWti(const ExecutionContext&, const ProblemDescription& pro
     std::size_t in_n, in_c;
     std::tie(in_n, in_c) = tie_pick<0, 1>()(xDesc.GetLengths());
     const auto wei_spatial =
-        boost::adaptors::slice(dwDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
+        dwDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
 
     // if not 1x1
     if((miopen::any_of(wei_spatial, [](auto v) { return v != 1; }) ||
@@ -158,7 +135,7 @@ bool GemmWrw1x1_stride1::IsApplicable(const ExecutionContext& context,
     const auto& conv   = problem.GetConv();
 
     const auto wei_spatial =
-        boost::adaptors::slice(dwDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
+        dwDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
 
     return miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
            miopen::all_of(conv.GetConvStrides(), [](auto v) { return v == 1; }) &&
@@ -208,9 +185,9 @@ ConvSolution GemmWrw1x1_stride1::GetSolution(const ExecutionContext&,
     }();
 
     const auto in_spatial =
-        boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
+        xDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
     const auto out_spatial =
-        boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
+        dyDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
 
     const auto out_spatial_size = std::accumulate(
         out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
@@ -313,9 +290,11 @@ size_t GemmWrwUniversal::GetWorkspaceSize(const ExecutionContext& context,
     const auto& conv   = problem.GetConv();
 
     const auto spatial_dim = conv.GetSpatialDimension();
-    const auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto wei_spatial = boost::adaptors::slice(dwDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto wei_c       = dwDesc.GetLengths()[1];
+    const auto out_spatial =
+        dyDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto wei_spatial =
+        dwDesc.GetLengths() | std::views::drop(2) | std::views::take(spatial_dim);
+    const auto wei_c = dwDesc.GetLengths()[1];
 
     const auto ws_size = GetTypeSize(dyDesc.GetType()) * wei_c *
                          std::accumulate(out_spatial.begin(),
@@ -394,16 +373,12 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
     const auto in_c           = xDesc.GetLengths()[1];
     const auto wei_k          = dwDesc.GetLengths()[0];
 
-    const auto in_spatial_ =
-        boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
-    const auto wei_spatial_ =
-        boost::adaptors::slice(dwDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
-    const auto out_spatial_ =
-        boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
-
-    const auto in_spatial  = std::vector<std::size_t>(in_spatial_.begin(), in_spatial_.end());
-    const auto wei_spatial = std::vector<std::size_t>(wei_spatial_.begin(), wei_spatial_.end());
-    const auto out_spatial = std::vector<std::size_t>(out_spatial_.begin(), out_spatial_.end());
+    const auto in_spatial =
+        xDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
+    const auto wei_spatial =
+        dwDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
+    const auto out_spatial =
+        dyDesc.GetLengths() | std::views::drop(2) | std::views::take(conv.GetSpatialDimension());
 
     const auto out_spatial_size = std::accumulate(
         out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());


### PR DESCRIPTION
## Motivation

This PR is a part of efforts to remove boost library as dependency.

## Technical Details

replace 
`boost::adaptors::slice(_container_, X, X+Y)` -> `_container_ | std::views::drop(X) | std::views::take(Y)`
`boost::adaptors::transformed()` -> `std::views::transform()`


## Test Plan & Test Results

CI shall be passed

## Submission Checklist

- [x] I have ran the tests, and they are all passing locally
- [x] I have ran `make format` to ensure the changes have been formatted


continuation PR is https://github.com/ROCm/rocm-libraries/pull/4370
