### PR TITLE
Add tensilelite directory to hipSPARSELt labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,6 +49,10 @@
   - any-glob-to-any-file: 'projects/hipsparselt/**/*'
   - any-glob-to-any-file: 'projects/hipblaslt/tensilelite/**/*'
 
+"ci:hipsparselt-fast":
+- changed-files:
+  - any-glob-to-any-file: 'projects/hipblaslt/tensilelite/**/*'
+
 "project: miopen":
 - changed-files:
   - any-glob-to-any-file: 'projects/miopen/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,6 +47,7 @@
 "project: hipsparselt":
 - changed-files:
   - any-glob-to-any-file: 'projects/hipsparselt/**/*'
+  - any-glob-to-any-file: 'projects/hipblaslt/tensilelite/**/*'
 
 "project: miopen":
 - changed-files:


### PR DESCRIPTION
## Motivation

- Add hipsparselt label to PRs touching tensilelite directory
- - math-ci will run hipsparselt jobs when this label is found

## Technical Details

- update to labeler config yaml

## Test Plan

- Testing must be done after PR is merged