### PR TITLE
[hipDNN]: fix namespace compilation error after namespace renames

### DIFF
--- a/dnn-providers/miopen-provider/tests/common/MiopenHandleFixture.hpp
+++ b/dnn-providers/miopen-provider/tests/common/MiopenHandleFixture.hpp
@@ -7,7 +7,7 @@
 #include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <miopen/miopen.h>
 
-namespace miopen_legacy_plugin::test_common
+namespace test_common
 {
 
 /// @brief Base test fixture that creates and destroys a raw MIOpen handle.


### PR DESCRIPTION
## Motivation

We merged a namespace rename PR to move miopen_legacy_plugin to just be miopen_plugin.  At the same time another PR introduced this file with the old namespace name.  

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
