### PR TITLE
hipblaslt: Guard immintrin.h include with x86 architecture check

### DIFF
--- a/projects/hipblaslt/clients/common/include/hipblaslt_math.hpp
+++ b/projects/hipblaslt/clients/common/include/hipblaslt_math.hpp
@@ -30,7 +30,9 @@
 #include <hip/hip_runtime.h>
 #include <hipblaslt/hipblaslt.h>
 #include <hipblaslt/hipblaslt_xfloat32.h>
+#if defined(__x86_64__) || defined(__i386__)
 #include <immintrin.h>
+#endif
 #include <type_traits>
 
 /* ============================================================================================ */


### PR DESCRIPTION
## Motivation

The <immintrin.h> header is x86-specific and causes build failures on arm64. Add preprocessor guards since the include appears unused in hipblaslt_math.hpp.
I have created the patch for Ubuntu archive, but I'd like to forward the patch upstream.

## Test Result

Please see the successful build logs here with this patch applied:
https://launchpadlibrarian.net/845340605/buildlog_ubuntu-resolute-arm64.hipblaslt_7.1.0+dfsg-2ubuntu1~exp2_BUILDING.txt.gz

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Update Jun 4
Moved to https://github.com/ROCm/rocm-libraries/pull/8064
