### PR TITLE
Enable larger MXFP8 tiles

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/rocroller_host.cpp
@@ -446,9 +446,11 @@ rocblaslt_status
     }
     catch(const std::exception& e)
     {
-        std::cerr << "Error building the following kernel:" << std::endl;
-        std::cerr << params->toString() << std::endl;
-        std::cerr << e.what() << std::endl;
+        std::stringstream msg;
+        msg << "Error building the following kernel:" << std::endl;
+        msg << params->toString() << std::endl;
+        msg << e.what() << std::endl;
+        log_info(__func__, msg.str());
         return rocblaslt_status_not_implemented;
     }
 

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/rocroller/solution_selection.cpp
@@ -204,7 +204,7 @@ std::vector<SolutionIndexParameters> chooseSolutionIndexParameters(
                 || kernelType.typeA == rocRoller::DataType::BF8
                 || kernelType.typeB == rocRoller::DataType::FP8
                 || kernelType.typeB == rocRoller::DataType::BF8)
-               && wgt.m + wgt.n > 256)
+               && (wgt.m == 192 || wgt.n == 192))
                 continue;
 
             // 6bit datatypes only work with power of 2 tile sizes
@@ -255,7 +255,12 @@ std::vector<SolutionIndexParameters> chooseSolutionIndexParameters(
                          || kernelType.typeA == rocRoller::DataType::BF6
                          || kernelType.typeB == rocRoller::DataType::FP6
                          || kernelType.typeB == rocRoller::DataType::BF6);
-            if(numTiles < analytical_hardware.N_CU && !isF6)
+            auto isLargeF8 = ((kernelType.typeA == rocRoller::DataType::FP8
+                || kernelType.typeA == rocRoller::DataType::BF8
+                || kernelType.typeB == rocRoller::DataType::FP8
+                || kernelType.typeB == rocRoller::DataType::BF8)
+               && wgt.m + wgt.n > 256);
+            if(numTiles < analytical_hardware.N_CU && !isF6 && !isLargeF8)
             {
                 params.back().streamK = true;
             }


### PR DESCRIPTION
## Motivation

rocRoller can now generate larger tile sizes for MXFP8 GEMMs. This PR enables more of them to be used in hipBLASLt, which will give better performance for some GEMM sizes (up to 30% performance increase).

## Technical Details

Enabled the tile sizes that did not run out of registers. Was not able to use StreamK with larger tile sizes still.

Also changed error message when kernels can't be created to go to logging instead of cerr.

## Test Plan

Run existing tests and verify all kernels are being generated.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
