### PR TITLE
[rocPRIM] Disable flaky test cases on gfx1151 Windows systems

### DIFF
--- a/projects/rocprim/test/rocprim/test_device_merge_sort.cpp
+++ b/projects/rocprim/test/rocprim/test_device_merge_sort.cpp
@@ -112,8 +112,12 @@ using RocprimDeviceSortTestsParams = ::testing::Types<
     // Test the algorithm with graphs
     DeviceSortParams<int, int, ::rocprim::less<int>, true>,
     // Test the virtual shared memory
+    // Note: these two cases can fail on gfx1151 on Windows without raising out of memory errors.
+    // Disable these tests there until this problem is resolved.
+#if !(defined(__gfx1151__) && defined(_WIN32))
     DeviceSortParams<int, common::custom_huge_type<2048, float>>,
     DeviceSortParams<common::custom_huge_type<2048, float>>,
+#endif
     // Test with iterators
     DeviceSortParams<int, int, ::rocprim::less<int>, false, true>,
     // Test with custom config


### PR DESCRIPTION
## Motivation
CI tests fail on two test cases in the test_device_merge_sort suite on gfx1151 systems with Windows. The failures are not currently reproducible locally.

## Technical Details

This change disable these two tests cases on gfx1151 Windows machines until the root cause can be determined.

## Test Plan

Build and run the test_device_merge_sort target on a gfx1151 Windows system. Verify that no tests fail.

## Test Result

All tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
