### PR TITLE
Fix CPU reference computation for f32_bf16_r 

### DIFF
--- a/projects/hipblaslt/clients/common/include/norm.hpp
+++ b/projects/hipblaslt/clients/common/include/norm.hpp
@@ -592,10 +592,3 @@ bool norm_check(double norm_error, hipDataType type)
         return false;
     }
 }
-
-bool norm_check(double norm_error, hipDataType type, hipblasComputeType_t compute_type)
-{
-    if(compute_type == HIPBLAS_COMPUTE_32F_FAST_16BF && type == HIP_R_32F)
-        return norm_error < 0.5;
-    return norm_check(norm_error, type);
-}

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -990,7 +990,7 @@ void check(hipStream_t                   stream,
             hipblaslt_error += norm_error;
             if(arg.norm_check_assert)
             {
-                CHECK_SUCCESS(norm_check(norm_error, To, arg.compute_type));
+                CHECK_SUCCESS(norm_check(norm_error, To));
             }
 
             if(arg.amaxD)
@@ -1023,7 +1023,7 @@ void check(hipStream_t                   stream,
                 hipblaslt_error += norm_error;
                 if(arg.norm_check_assert)
                 {
-                    CHECK_SUCCESS(norm_check(norm_error, Taux, arg.compute_type));
+                    CHECK_SUCCESS(norm_check(norm_error, Taux));
                 }
             }
             if(arg.gradient && arg.bias_vector)
@@ -1184,12 +1184,20 @@ std::tuple<hipDataType, hipDataType> derive_unset_compute_input_type(const Argum
     // when compute_input_type type is unset
     if(real_compute_input_typeA == HIPBLASLT_DATATYPE_INVALID)
     {
-        real_compute_input_typeA = computeTypeToRealDataType(arg.compute_type);
+        // Special case: for f32_bf16 mode, the compute input type should be bf16
+        if(arg.compute_type == HIPBLAS_COMPUTE_32F_FAST_16BF)
+            real_compute_input_typeA = HIP_R_16BF;
+        else
+            real_compute_input_typeA = computeTypeToRealDataType(arg.compute_type);
     }
 
     if(real_compute_input_typeB == HIPBLASLT_DATATYPE_INVALID)
     {
-        real_compute_input_typeB = computeTypeToRealDataType(arg.compute_type);
+        // Special case: for f32_bf16 mode, the compute input type should be bf16
+        if(arg.compute_type == HIPBLAS_COMPUTE_32F_FAST_16BF)
+            real_compute_input_typeB = HIP_R_16BF;
+        else
+            real_compute_input_typeB = computeTypeToRealDataType(arg.compute_type);
     }
 
     return {real_compute_input_typeA, real_compute_input_typeB};


### PR DESCRIPTION
Fix CPU reference computation for f32_bf16_r (HIPBLAS_COMPUTE_32F_FAST_16BF) mode

Problem:
When running hipblaslt-bench with --verify for f32_bf16_r compute type (--compute_type f32_bf16_r), the norm_error was extremely high (~7e-05) compared to pure bf16 (~1.7e-05) or pure fp32 (~1.6e-07). This led to commit d5ed3c10 adding a workaround that relaxed the error tolerance to 0.5 for this compute type.

Root Cause:
The f32_bf16_r mode is defined as:
  acc_fp32 += bf16(a_fp32) * bf16(b_fp32)

The GPU correctly truncates fp32 inputs to bf16 before multiplication, then accumulates in fp32. However, the CPU reference was NOT performing this truncation.

The bug was in derive_unset_compute_input_type() which calls computeTypeToRealDataType() to determine the compute input type when not explicitly set. For HIPBLAS_COMPUTE_32F_FAST_16BF, this function returns HIP_R_32F (the accumulator type) instead of HIP_R_16BF (the compute input type).

This caused TciA and TciB to be set to HIP_R_32F. In cblas_gemm(), the condition:
  if(realDataTypeSize(TiA) > realDataTypeSize(TciACast))

evaluated to false (4 > 4), so the bf16 truncation path was skipped and the CPU reference performed full fp32 arithmetic.

The result was comparing:
  - GPU: acc += bf16(a) * bf16(b)  (correct)
  - CPU: acc += a * b              (incorrect - no bf16 truncation)

Fix:
Add special handling in derive_unset_compute_input_type() to return HIP_R_16BF for HIPBLAS_COMPUTE_32F_FAST_16BF mode. This ensures the CPU reference correctly truncates fp32 inputs to bf16 before multiplication, matching the GPU behavior.

With this fix, the CPU and GPU computations are equivalent, so the high error tolerance workaround in norm.hpp is no longer needed and has been removed.

## Test Plan

`hipblastlt-test` on gfx950

AIGECORE-122