### PR TITLE
[Origami] Improve selection time

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/CachingLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/CachingLibrary.hpp
@@ -135,12 +135,7 @@ namespace TensileLite
         template <typename SubMap, typename K>
         void add_impl(SubMap& map, Value const& value, K const& key)
         {
-            auto iter = map.find(key);
-
-            if(iter == map.end())
-                map.emplace(key, value);
-            else
-                iter->second = value;
+            map.insert_or_assign(key, value);
         }
 
         template <typename SubMap, typename K, typename... Ks>

--- a/projects/hipblaslt/tensilelite/include/Tensile/CachingLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/CachingLibrary.hpp
@@ -135,12 +135,12 @@ namespace TensileLite
         template <typename SubMap, typename K>
         void add_impl(SubMap& map, Value const& value, K const& key)
         {
-            // use faster emplace entry when key is new, otherwise update value with []
-            if(!map.count(key))
+            auto iter = map.find(key);
+
+            if(iter == map.end())
                 map.emplace(key, value);
             else
-                map[key] = value;
-
+                iter->second = value;
         }
 
         template <typename SubMap, typename K, typename... Ks>

--- a/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
@@ -232,12 +232,7 @@ namespace TensileLite
                     solutions
                         = row.second->findTopSolutions(problem, hardware, numSolutions - rv.size());
 
-                    if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(row.first.value.get()))
-                    {
-                        for(auto& sol : solutions)
-                            sol->tag = MySolution::MatchingTag::Prediction;
-                    }
-                    else if(dynamic_cast<Predicates::Contraction::EqualityMatching*>(row.first.value.get()))
+                    if(dynamic_cast<Predicates::Contraction::EqualityMatching*>(row.first.value.get()))
                     {
                         for(auto& sol : solutions)
                             sol->tag = MySolution::MatchingTag::Equal;
@@ -256,6 +251,11 @@ namespace TensileLite
                     {
                         for(auto& sol : solutions)
                             sol->tag = MySolution::MatchingTag::FreeSize;
+                    }
+                    else if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(row.first.value.get()))
+                    {
+                        for(auto& sol : solutions)
+                            sol->tag = MySolution::MatchingTag::Prediction;
                     }
                     // TODO- Experimental
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
@@ -232,7 +232,12 @@ namespace TensileLite
                     solutions
                         = row.second->findTopSolutions(problem, hardware, numSolutions - rv.size());
 
-                    if(dynamic_cast<Predicates::Contraction::EqualityMatching*>(row.first.value.get()))
+                    if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(row.first.value.get()))
+                    {
+                        for(auto& sol : solutions)
+                            sol->tag = MySolution::MatchingTag::Prediction;
+                    }
+                    else if(dynamic_cast<Predicates::Contraction::EqualityMatching*>(row.first.value.get()))
                     {
                         for(auto& sol : solutions)
                             sol->tag = MySolution::MatchingTag::Equal;
@@ -251,11 +256,6 @@ namespace TensileLite
                     {
                         for(auto& sol : solutions)
                             sol->tag = MySolution::MatchingTag::FreeSize;
-                    }
-                    else if(dynamic_cast<Predicates::Contraction::PredictionMatching*>(row.first.value.get()))
-                    {
-                        for(auto& sol : solutions)
-                            sol->tag = MySolution::MatchingTag::Prediction;
                     }
                     // TODO- Experimental
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
@@ -46,8 +46,9 @@ namespace TensileLite
     template <typename MyProblem, typename MySolution = typename MyProblem::Solution>
     struct ProblemPredictionLibrary : public SolutionLibrary<MyProblem, MySolution>
     {
-        std::vector<std::pair<int, std::shared_ptr<MySolution>>> solution_list;
-        std::vector<origami::config_t>                           origami_config_list;
+        std::unordered_map<int, std::shared_ptr<MySolution>> solutionmap;
+        std::vector<origami::config_t>                       origami_config_list;
+        std::unordered_map<origami::config_t, int>           origami_config_map;
 
         mutable std::atomic<bool> lastFindTopRetAll = false;
 
@@ -61,19 +62,17 @@ namespace TensileLite
         }
         virtual std::string description() const override
         {
-            if(solution_list.empty())
-                return concatenate(type(), ", solution_list: empty");
-            return concatenate(type(), solution_list.size());
+            if(solutionmap.empty())
+                return concatenate(type(), ", solutionmap: empty");
+            return concatenate(type(), solutionmap.size());
         }
 
         virtual std::shared_ptr<MySolution> getSolutionByIndex(MyProblem const& problem,
                                                                Hardware const&  hardware,
                                                                const int index) const override
         {
-            auto indexMatch =
-                std::find_if(solution_list.begin(), solution_list.end(),
-                             [&index](auto& s){ return s.first == index; });
-            if(indexMatch != solution_list.end())
+            auto indexMatch = solutionmap.find(index);
+            if(indexMatch != solutionmap.end())
                 return indexMatch->second;
             return nullptr;
         }
@@ -103,7 +102,7 @@ namespace TensileLite
             if(searchType == SolutionLibrarySearchType::DEFAULT)
                 return rv;
 
-            for(auto const& row : this->solution_list)
+            for(auto const& row : this->solutionmap)
             {
                 if(debug)
                     std::cout << row.second->description() << std::endl;
@@ -124,7 +123,7 @@ namespace TensileLite
             if(searchType == SolutionLibrarySearchType::DEFAULT)
                 return rv;
 
-            for(auto const& row : this->solution_list)
+            for(auto const& row : this->solutionmap)
             {
                 if(debug)
                     std::cout << row.second->description() << std::endl;
@@ -186,14 +185,19 @@ namespace TensileLite
 
             for(const auto& r : prediction_result)
             {
-                auto& solution = solution_list[r.config.index].second;
-                if((*(solution->hardwarePredicate))(hardware)
-                   && (*(solution->problemPredicate))(problem))
+                auto mapiter  = origami_config_map.find(r.config);
+                auto smapiter = solutionmap.find(mapiter->second);
+                if(mapiter != origami_config_map.end() && smapiter != solutionmap.end())
                 {
-                    rv.emplace_back(solution);
-                    if(rv.size() == numSolutions)
+                    auto solution = smapiter->second;
+                    if((*solution->hardwarePredicate)(hardware)
+                       && (*solution->problemPredicate)(problem))
                     {
-                        break;
+                        rv.emplace_back(solution);
+                        if(rv.size() == numSolutions)
+                        {
+                            break;
+                        }
                     }
                 }
             }

--- a/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/PredictionLibrary.hpp
@@ -46,9 +46,8 @@ namespace TensileLite
     template <typename MyProblem, typename MySolution = typename MyProblem::Solution>
     struct ProblemPredictionLibrary : public SolutionLibrary<MyProblem, MySolution>
     {
-        std::unordered_map<int, std::shared_ptr<MySolution>> solutionmap;
-        std::vector<origami::config_t>                       origami_config_list;
-        std::unordered_map<origami::config_t, int>           origami_config_map;
+        std::vector<std::pair<int, std::shared_ptr<MySolution>>> solution_list;
+        std::vector<origami::config_t>                           origami_config_list;
 
         mutable std::atomic<bool> lastFindTopRetAll = false;
 
@@ -62,17 +61,19 @@ namespace TensileLite
         }
         virtual std::string description() const override
         {
-            if(solutionmap.empty())
-                return concatenate(type(), ", solutionmap: empty");
-            return concatenate(type(), solutionmap.size());
+            if(solution_list.empty())
+                return concatenate(type(), ", solution_list: empty");
+            return concatenate(type(), solution_list.size());
         }
 
         virtual std::shared_ptr<MySolution> getSolutionByIndex(MyProblem const& problem,
                                                                Hardware const&  hardware,
                                                                const int index) const override
         {
-            auto indexMatch = solutionmap.find(index);
-            if(indexMatch != solutionmap.end())
+            auto indexMatch =
+                std::find_if(solution_list.begin(), solution_list.end(),
+                             [&index](auto& s){ return s.first == index; });
+            if(indexMatch != solution_list.end())
                 return indexMatch->second;
             return nullptr;
         }
@@ -102,7 +103,7 @@ namespace TensileLite
             if(searchType == SolutionLibrarySearchType::DEFAULT)
                 return rv;
 
-            for(auto const& row : this->solutionmap)
+            for(auto const& row : this->solution_list)
             {
                 if(debug)
                     std::cout << row.second->description() << std::endl;
@@ -123,7 +124,7 @@ namespace TensileLite
             if(searchType == SolutionLibrarySearchType::DEFAULT)
                 return rv;
 
-            for(auto const& row : this->solutionmap)
+            for(auto const& row : this->solution_list)
             {
                 if(debug)
                     std::cout << row.second->description() << std::endl;
@@ -185,19 +186,14 @@ namespace TensileLite
 
             for(const auto& r : prediction_result)
             {
-                auto mapiter  = origami_config_map.find(r.config);
-                auto smapiter = solutionmap.find(mapiter->second);
-                if(mapiter != origami_config_map.end() && smapiter != solutionmap.end())
+                auto& solution = solution_list[r.config.index].second;
+                if((*(solution->hardwarePredicate))(hardware)
+                   && (*(solution->problemPredicate))(problem))
                 {
-                    auto solution = smapiter->second;
-                    if((*solution->hardwarePredicate)(hardware)
-                       && (*solution->problemPredicate)(problem))
+                    rv.emplace_back(solution);
+                    if(rv.size() == numSolutions)
                     {
-                        rv.emplace_back(solution);
-                        if(rv.size() == numSolutions)
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
             }

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
@@ -68,6 +68,8 @@ namespace TensileLite
                                       "ProblemPredictionLibrary requires non empty "
                                       "mapping index set.");
 
+                    origami::get_runtime_options().cache_kernel_info = true;
+
                     for(std::size_t local_index = 0; local_index < mappingIndices.size(); local_index++)
                     {
                         int index = mappingIndices[local_index];

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
@@ -53,9 +53,9 @@ namespace TensileLite
                 std::vector<int> mappingIndices;
                 if(iot::outputting(io))
                 {
-                    mappingIndices.reserve(lib.solution_list.size());
+                    mappingIndices.reserve(lib.solutionmap.size());
 
-                    for(auto const& pair : lib.solution_list)
+                    for(auto const& pair : lib.solutionmap)
                         mappingIndices.push_back(pair.first);
 
                     iot::mapRequired(io, "table", mappingIndices);
@@ -68,11 +68,8 @@ namespace TensileLite
                                       "ProblemPredictionLibrary requires non empty "
                                       "mapping index set.");
 
-                    origami::get_runtime_options().cache_kernel_info = true;
-
-                    for(std::size_t local_index = 0; local_index < mappingIndices.size(); local_index++)
+                    for(int index : mappingIndices)
                     {
-                        int index = mappingIndices[local_index];
                         auto slnIter = ctx->solutions->find(index);
                         if(slnIter == ctx->solutions->end())
                         {
@@ -84,7 +81,7 @@ namespace TensileLite
                         else
                         {
                             auto solution = slnIter->second;
-                            lib.solution_list.push_back(std::make_pair(index, solution));
+                            lib.solutionmap.insert(std::make_pair(index, solution));
 
                             origami::dim3_t origami_mi;
                             if(solution->sizeMapping.matrixInstruction[0] == 0
@@ -116,10 +113,10 @@ namespace TensileLite
                                 .cache_hints_b              = solution->sizeMapping.nonTemporalB,
                                 .workspace_size             = std::numeric_limits<size_t>::max(),
                                 .workspace_size_per_elem_c  = std::numeric_limits<size_t>::max(),
-                                .index                      = static_cast<int>(local_index),
                             };
 
                             lib.origami_config_list.emplace_back(origami_config);
+                            lib.origami_config_map.insert(std::make_pair(origami_config, index));
                         }
                     }
                 }

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/PredictionLibrary.hpp
@@ -53,9 +53,9 @@ namespace TensileLite
                 std::vector<int> mappingIndices;
                 if(iot::outputting(io))
                 {
-                    mappingIndices.reserve(lib.solutionmap.size());
+                    mappingIndices.reserve(lib.solution_list.size());
 
-                    for(auto const& pair : lib.solutionmap)
+                    for(auto const& pair : lib.solution_list)
                         mappingIndices.push_back(pair.first);
 
                     iot::mapRequired(io, "table", mappingIndices);
@@ -68,8 +68,9 @@ namespace TensileLite
                                       "ProblemPredictionLibrary requires non empty "
                                       "mapping index set.");
 
-                    for(int index : mappingIndices)
+                    for(std::size_t local_index = 0; local_index < mappingIndices.size(); local_index++)
                     {
+                        int index = mappingIndices[local_index];
                         auto slnIter = ctx->solutions->find(index);
                         if(slnIter == ctx->solutions->end())
                         {
@@ -81,7 +82,7 @@ namespace TensileLite
                         else
                         {
                             auto solution = slnIter->second;
-                            lib.solutionmap.insert(std::make_pair(index, solution));
+                            lib.solution_list.push_back(std::make_pair(index, solution));
 
                             origami::dim3_t origami_mi;
                             if(solution->sizeMapping.matrixInstruction[0] == 0
@@ -113,10 +114,10 @@ namespace TensileLite
                                 .cache_hints_b              = solution->sizeMapping.nonTemporalB,
                                 .workspace_size             = std::numeric_limits<size_t>::max(),
                                 .workspace_size_per_elem_c  = std::numeric_limits<size_t>::max(),
+                                .index                      = static_cast<int>(local_index),
                             };
 
                             lib.origami_config_list.emplace_back(origami_config);
-                            lib.origami_config_map.insert(std::make_pair(origami_config, index));
                         }
                     }
                 }

--- a/shared/origami/include/origami/gemm.hpp
+++ b/shared/origami/include/origami/gemm.hpp
@@ -153,13 +153,13 @@ bool check_lds_capacity(const hardware_t& hardware,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
- * @param splitting_factor
+ * @param cache Precomputed quantities, grid_m, etc.
  * @return double Predicted L2-hitrate.
  */
 double estimate_l2_hit(const problem_t& problem,
                        const hardware_t& hardware,
                        const config_t& config,
-                       std::size_t splitting_factor);
+                       const origami_cache_t& cache);
 
 /**
  * @brief Estimate the MALL-hitrate (last-level cache.)
@@ -167,15 +167,13 @@ double estimate_l2_hit(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
- * @param num_active_cus
- * @param splitting_factor
- * @return double Predicted MALL-hitrate.
+ * @param cache Precomputed quantities, grid_m, etc.
+ * @return tuple<double: Predicted MALL-hitrate, size_t: MALL tile rows, size_t: MALL tile columns>
  */
-double estimate_mall_hit(const problem_t& problem,
-                         const hardware_t& hardware,
-                         const config_t& config,
-                         std::size_t num_active_cus,
-                         std::size_t splitting_factor);
+std::tuple<double,size_t,size_t> estimate_mall_hit(const problem_t& problem,
+                                                   const hardware_t& hardware,
+                                                   const config_t& config,
+                                                   const origami_cache_t& cache);
 
 /**
  * @brief Determine the memory latency per MT_M x MT_N x MT_K Macro Tile (L_MT).
@@ -183,15 +181,13 @@ double estimate_mall_hit(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
- * @param num_active_cus
- * @param splitting_factor
+ * @param cache Precomputed quantities, grid_m, etc.
  * @return double Latency in cycles.
  */
 double compute_memory_latency(const problem_t& problem,
                               const hardware_t& hardware,
                               const config_t& config,
-                              std::size_t num_active_cus,
-                              std::size_t splitting_factor);
+                              const origami_cache_t& cache);
 
 /**
  * @brief Computes the latency to compute a K-COMPLETE tile.
@@ -199,15 +195,13 @@ double compute_memory_latency(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
- * @param num_active_cus
- * @param splitting_factor
+ * @param cache Precomputed quantities, grid_m, etc.
  * @return double Latency in cycles.
  */
 double compute_tile_latency(const problem_t& problem,
                             const hardware_t& hardware,
                             const config_t& config,
-                            std::size_t num_active_cus,
-                            std::size_t splitting_factor);
+                            const origami_cache_t& cache);
 
 /**
  * @brief Computes the latency per K-complete macro-tile timestep.
@@ -219,15 +213,13 @@ double compute_tile_latency(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
- * @param num_active_cus
- * @param splitting_factor
+ * @param cache Precomputed quantities, grid_m, etc.
  * @return double Latency in cycles.
  */
 double compute_timestep_latency(const problem_t& problem,
                                 const hardware_t& hardware,
                                 const config_t& config,
-                                std::size_t num_active_cus,
-                                std::size_t splitting_factor);
+                                const origami_cache_t& cache);
 
 /**
  * @brief Compute the total latency of a gemm based on the latency of one timestep multiplied by the
@@ -236,12 +228,63 @@ double compute_timestep_latency(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
+ * @param kernel_cache Kernel precomputed quantities.
  * @param max_cus
  * @return double Latency in cycles.
  */
 double compute_total_latency(const problem_t& problem,
                              const hardware_t& hardware,
                              const config_t& config,
+                             const kernel_cache_t& kernel_cache,
                              size_t max_cus);
+
+/**
+ * @brief Creates a cache struct with origami info such as grid dimensions etc.
+ *
+ * @param problem Problem description (M, N, K, etc.)
+ * @param hardware Hardware characteristics (@see origami::hardware_t)
+ * @param config Kernel configuration.
+ * @param max_cus
+ * @return origami_cache_t struct
+ */
+origami_cache_t create_origami_cache(const problem_t& problem,
+                                     const hardware_t& hardware,
+                                     const config_t& config,
+                                     size_t max_cus);
+
+/**
+ * @brief Creates a cache struct with precomputed values depending only on the problem type,
+ * i.e., the info in problem_t but not size or batch.
+ *
+ * @param problem Problem description (a_dtype, etc.)
+ * @param hardware Hardware characteristics (@see origami::hardware_t)
+ * @param config Kernel configuration.
+ * @return origami_cache_t struct
+ */
+kernel_cache_t create_kernel_cache(const problem_t& problem,
+                                   const hardware_t& hardware,
+                                   const config_t& config);
+
+/**
+ * @brief Compute the total latency of a gemm based on the latency of one wave multiplied by the
+ * number of waves A wave is defined as the time it takes for one CU to complete one K-complete
+ * output tile.
+ *
+ * @param problem Problem description (M, N, K, etc.)
+ * @param hardware Hardware characteristics (@see origami::hardware_t)
+ * @param config Kernel configuration.
+ * @param max_cus
+ * @return double Latency in cycles.
+ */
+inline double compute_total_latency(const problem_t& problem,
+                                    const hardware_t& hardware,
+                                    const config_t& config,
+                                    size_t max_cus) {
+  return compute_total_latency(problem,
+                               hardware,
+                               config,
+                               create_kernel_cache(problem, hardware, config),
+                               max_cus);
+}
 
 }  // namespace origami

--- a/shared/origami/include/origami/gemm.hpp
+++ b/shared/origami/include/origami/gemm.hpp
@@ -14,9 +14,12 @@ namespace origami {
  *
  * @param problem Problem description (M, N, K, etc.)
  * @param config Kernel configuration.
+ * @param cache Precomputed quantities, grid_m, etc.
  * @return double ratio of the useful problem volume to the total scheduled volume.
  */
-double calculate_work_utilization(const problem_t& problem, const config_t& config);
+double calculate_work_utilization(const problem_t& problem,
+                                  const config_t& config,
+                                  const origami_cache_t& cache);
 
 /**
  * @brief calculate the output utilization which is the ratio of the useful problem volume to the total scheduled volume.
@@ -70,12 +73,14 @@ size_t round_elements_to_128B(size_t elements, size_t element_size_bits);
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
+ * @param cache Precomputed quantities, grid_m, etc.
  * @param l2_capacity_bytes l2 capacity in bytes
  * @return double
  */
 double compute_l2_hit_rate_global(const problem_t& problem,
                                   const hardware_t& hardware,
                                   const config_t& config,
+                                  const origami_cache_t& cache,
                                   size_t l2_capacity_bytes);
 
 /**

--- a/shared/origami/include/origami/gemm.hpp
+++ b/shared/origami/include/origami/gemm.hpp
@@ -16,8 +16,7 @@ namespace origami {
  * @param config Kernel configuration.
  * @return double ratio of the useful problem volume to the total scheduled volume.
  */
-double calculate_work_utilization(const problem_t& problem,
-                                  const config_t& config);
+double calculate_work_utilization(const problem_t& problem, const config_t& config);
 
 /**
  * @brief calculate the output utilization which is the ratio of the useful problem volume to the total scheduled volume.
@@ -183,19 +182,19 @@ double estimate_l2_hit(const problem_t& problem,
  * @param num_active_cus
  * @param splitting_factor
  * @param cache Precomputed quantities, grid_m, etc.
- * @return tuple<double: Predicted MALL-hitrate, size_t: MALL tile rows, size_t: MALL tile columns>
+ * @return double Predicted MALL-hitrate
  */
-std::tuple<double,size_t,size_t> estimate_mall_hit(const problem_t& problem,
-                                                   const hardware_t& hardware,
-                                                   const config_t& config,
-                                                   std::size_t num_active_cus,
-                                                   std::size_t splitting_factor,
-                                                   const origami_cache_t& cache);
-std::tuple<double,size_t,size_t> estimate_mall_hit(const problem_t& problem,
-                                                   const hardware_t& hardware,
-                                                   const config_t& config,
-                                                   std::size_t num_active_cus,
-                                                   std::size_t splitting_factor);
+double estimate_mall_hit(const problem_t& problem,
+                         const hardware_t& hardware,
+                         const config_t& config,
+                         std::size_t num_active_cus,
+                         std::size_t splitting_factor,
+                         const origami_cache_t& cache);
+double estimate_mall_hit(const problem_t& problem,
+                         const hardware_t& hardware,
+                         const config_t& config,
+                         std::size_t num_active_cus,
+                         std::size_t splitting_factor);
 
 /**
  * @brief Determine the memory latency per MT_M x MT_N x MT_K Macro Tile (L_MT).

--- a/shared/origami/include/origami/gemm.hpp
+++ b/shared/origami/include/origami/gemm.hpp
@@ -14,12 +14,10 @@ namespace origami {
  *
  * @param problem Problem description (M, N, K, etc.)
  * @param config Kernel configuration.
- * @param cache Precomputed quantities, grid_m, etc.
  * @return double ratio of the useful problem volume to the total scheduled volume.
  */
 double calculate_work_utilization(const problem_t& problem,
-                                  const config_t& config,
-                                  const origami_cache_t& cache);
+                                  const config_t& config);
 
 /**
  * @brief calculate the output utilization which is the ratio of the useful problem volume to the total scheduled volume.
@@ -80,7 +78,11 @@ size_t round_elements_to_128B(size_t elements, size_t element_size_bits);
 double compute_l2_hit_rate_global(const problem_t& problem,
                                   const hardware_t& hardware,
                                   const config_t& config,
-                                  const origami_cache_t& cache,
+                                  size_t l2_capacity_bytes,
+                                  const origami_cache_t& cache);
+double compute_l2_hit_rate_global(const problem_t& problem,
+                                  const hardware_t& hardware,
+                                  const config_t& config,
                                   size_t l2_capacity_bytes);
 
 /**
@@ -158,13 +160,19 @@ bool check_lds_capacity(const hardware_t& hardware,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
+ * @param splitting_factor
  * @param cache Precomputed quantities, grid_m, etc.
  * @return double Predicted L2-hitrate.
  */
 double estimate_l2_hit(const problem_t& problem,
                        const hardware_t& hardware,
                        const config_t& config,
+                       std::size_t splitting_factor,
                        const origami_cache_t& cache);
+double estimate_l2_hit(const problem_t& problem,
+                       const hardware_t& hardware,
+                       const config_t& config,
+                       std::size_t splitting_factor);
 
 /**
  * @brief Estimate the MALL-hitrate (last-level cache.)
@@ -172,13 +180,22 @@ double estimate_l2_hit(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
+ * @param num_active_cus
+ * @param splitting_factor
  * @param cache Precomputed quantities, grid_m, etc.
  * @return tuple<double: Predicted MALL-hitrate, size_t: MALL tile rows, size_t: MALL tile columns>
  */
 std::tuple<double,size_t,size_t> estimate_mall_hit(const problem_t& problem,
                                                    const hardware_t& hardware,
                                                    const config_t& config,
+                                                   std::size_t num_active_cus,
+                                                   std::size_t splitting_factor,
                                                    const origami_cache_t& cache);
+std::tuple<double,size_t,size_t> estimate_mall_hit(const problem_t& problem,
+                                                   const hardware_t& hardware,
+                                                   const config_t& config,
+                                                   std::size_t num_active_cus,
+                                                   std::size_t splitting_factor);
 
 /**
  * @brief Determine the memory latency per MT_M x MT_N x MT_K Macro Tile (L_MT).
@@ -186,13 +203,22 @@ std::tuple<double,size_t,size_t> estimate_mall_hit(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
+ * @param num_active_cus
+ * @param splitting_factor
  * @param cache Precomputed quantities, grid_m, etc.
  * @return double Latency in cycles.
  */
 double compute_memory_latency(const problem_t& problem,
                               const hardware_t& hardware,
                               const config_t& config,
+                              std::size_t num_active_cus,
+                              std::size_t splitting_factor,
                               const origami_cache_t& cache);
+double compute_memory_latency(const problem_t& problem,
+                              const hardware_t& hardware,
+                              const config_t& config,
+                              std::size_t num_active_cus,
+                              std::size_t splitting_factor);
 
 /**
  * @brief Computes the latency to compute a K-COMPLETE tile.
@@ -200,13 +226,22 @@ double compute_memory_latency(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
+ * @param num_active_cus
+ * @param splitting_factor
  * @param cache Precomputed quantities, grid_m, etc.
  * @return double Latency in cycles.
  */
 double compute_tile_latency(const problem_t& problem,
                             const hardware_t& hardware,
                             const config_t& config,
+                            std::size_t num_active_cus,
+                            std::size_t splitting_factor,
                             const origami_cache_t& cache);
+double compute_tile_latency(const problem_t& problem,
+                            const hardware_t& hardware,
+                            const config_t& config,
+                            std::size_t num_active_cus,
+                            std::size_t splitting_factor);
 
 /**
  * @brief Computes the latency per K-complete macro-tile timestep.
@@ -218,13 +253,22 @@ double compute_tile_latency(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
+ * @param num_active_cus
+ * @param splitting_factor
  * @param cache Precomputed quantities, grid_m, etc.
  * @return double Latency in cycles.
  */
 double compute_timestep_latency(const problem_t& problem,
                                 const hardware_t& hardware,
                                 const config_t& config,
+                                std::size_t num_active_cus,
+                                std::size_t splitting_factor,
                                 const origami_cache_t& cache);
+double compute_timestep_latency(const problem_t& problem,
+                                const hardware_t& hardware,
+                                const config_t& config,
+                                std::size_t num_active_cus,
+                                std::size_t splitting_factor);
 
 /**
  * @brief Compute the total latency of a gemm based on the latency of one timestep multiplied by the
@@ -233,14 +277,12 @@ double compute_timestep_latency(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
- * @param kernel_cache Kernel precomputed quantities.
  * @param max_cus
  * @return double Latency in cycles.
  */
 double compute_total_latency(const problem_t& problem,
                              const hardware_t& hardware,
                              const config_t& config,
-                             const kernel_cache_t& kernel_cache,
                              size_t max_cus);
 
 /**
@@ -249,13 +291,13 @@ double compute_total_latency(const problem_t& problem,
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
- * @param max_cus
+ * @param num_active_cus
  * @return origami_cache_t struct
  */
 origami_cache_t create_origami_cache(const problem_t& problem,
                                      const hardware_t& hardware,
                                      const config_t& config,
-                                     size_t max_cus);
+                                     std::size_t num_active_cus);
 
 /**
  * @brief Creates a cache struct with precomputed values depending only on the problem type,
@@ -269,27 +311,5 @@ origami_cache_t create_origami_cache(const problem_t& problem,
 kernel_cache_t create_kernel_cache(const problem_t& problem,
                                    const hardware_t& hardware,
                                    const config_t& config);
-
-/**
- * @brief Compute the total latency of a gemm based on the latency of one wave multiplied by the
- * number of waves A wave is defined as the time it takes for one CU to complete one K-complete
- * output tile.
- *
- * @param problem Problem description (M, N, K, etc.)
- * @param hardware Hardware characteristics (@see origami::hardware_t)
- * @param config Kernel configuration.
- * @param max_cus
- * @return double Latency in cycles.
- */
-inline double compute_total_latency(const problem_t& problem,
-                                    const hardware_t& hardware,
-                                    const config_t& config,
-                                    size_t max_cus) {
-  return compute_total_latency(problem,
-                               hardware,
-                               config,
-                               create_kernel_cache(problem, hardware, config),
-                               max_cus);
-}
 
 }  // namespace origami

--- a/shared/origami/include/origami/gemm.hpp
+++ b/shared/origami/include/origami/gemm.hpp
@@ -70,15 +70,9 @@ size_t round_elements_to_128B(size_t elements, size_t element_size_bits);
  * @param problem Problem description (M, N, K, etc.)
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
- * @param cache Precomputed quantities, grid_m, etc.
  * @param l2_capacity_bytes l2 capacity in bytes
  * @return double
  */
-double compute_l2_hit_rate_global(const problem_t& problem,
-                                  const hardware_t& hardware,
-                                  const config_t& config,
-                                  size_t l2_capacity_bytes,
-                                  const origami_cache_t& cache);
 double compute_l2_hit_rate_global(const problem_t& problem,
                                   const hardware_t& hardware,
                                   const config_t& config,
@@ -125,8 +119,8 @@ size_t compute_number_matrix_instructions(dim3_t mt, dim3_t mi);
  * @return double Latency in cycles.
  */
 double compute_cvt_overhead(const problem_t& problem,
-                                          const hardware_t& hardware,
-                                          const config_t& config);
+                            const hardware_t& hardware,
+                            const config_t& config);
 /**
  * @brief Compute the latency to process a single macro-tile for the given problem and hardware.
  *
@@ -160,14 +154,8 @@ bool check_lds_capacity(const hardware_t& hardware,
  * @param hardware Hardware characteristics (@see origami::hardware_t)
  * @param config Kernel configuration.
  * @param splitting_factor
- * @param cache Precomputed quantities, grid_m, etc.
  * @return double Predicted L2-hitrate.
  */
-double estimate_l2_hit(const problem_t& problem,
-                       const hardware_t& hardware,
-                       const config_t& config,
-                       std::size_t splitting_factor,
-                       const origami_cache_t& cache);
 double estimate_l2_hit(const problem_t& problem,
                        const hardware_t& hardware,
                        const config_t& config,
@@ -181,15 +169,8 @@ double estimate_l2_hit(const problem_t& problem,
  * @param config Kernel configuration.
  * @param num_active_cus
  * @param splitting_factor
- * @param cache Precomputed quantities, grid_m, etc.
- * @return double Predicted MALL-hitrate
+ * @return double Predicted MALL-hitrate.
  */
-double estimate_mall_hit(const problem_t& problem,
-                         const hardware_t& hardware,
-                         const config_t& config,
-                         std::size_t num_active_cus,
-                         std::size_t splitting_factor,
-                         const origami_cache_t& cache);
 double estimate_mall_hit(const problem_t& problem,
                          const hardware_t& hardware,
                          const config_t& config,
@@ -204,15 +185,8 @@ double estimate_mall_hit(const problem_t& problem,
  * @param config Kernel configuration.
  * @param num_active_cus
  * @param splitting_factor
- * @param cache Precomputed quantities, grid_m, etc.
  * @return double Latency in cycles.
  */
-double compute_memory_latency(const problem_t& problem,
-                              const hardware_t& hardware,
-                              const config_t& config,
-                              std::size_t num_active_cus,
-                              std::size_t splitting_factor,
-                              const origami_cache_t& cache);
 double compute_memory_latency(const problem_t& problem,
                               const hardware_t& hardware,
                               const config_t& config,
@@ -227,15 +201,8 @@ double compute_memory_latency(const problem_t& problem,
  * @param config Kernel configuration.
  * @param num_active_cus
  * @param splitting_factor
- * @param cache Precomputed quantities, grid_m, etc.
  * @return double Latency in cycles.
  */
-double compute_tile_latency(const problem_t& problem,
-                            const hardware_t& hardware,
-                            const config_t& config,
-                            std::size_t num_active_cus,
-                            std::size_t splitting_factor,
-                            const origami_cache_t& cache);
 double compute_tile_latency(const problem_t& problem,
                             const hardware_t& hardware,
                             const config_t& config,
@@ -254,15 +221,8 @@ double compute_tile_latency(const problem_t& problem,
  * @param config Kernel configuration.
  * @param num_active_cus
  * @param splitting_factor
- * @param cache Precomputed quantities, grid_m, etc.
  * @return double Latency in cycles.
  */
-double compute_timestep_latency(const problem_t& problem,
-                                const hardware_t& hardware,
-                                const config_t& config,
-                                std::size_t num_active_cus,
-                                std::size_t splitting_factor,
-                                const origami_cache_t& cache);
 double compute_timestep_latency(const problem_t& problem,
                                 const hardware_t& hardware,
                                 const config_t& config,
@@ -283,32 +243,5 @@ double compute_total_latency(const problem_t& problem,
                              const hardware_t& hardware,
                              const config_t& config,
                              size_t max_cus);
-
-/**
- * @brief Creates a cache struct with origami info such as grid dimensions etc.
- *
- * @param problem Problem description (M, N, K, etc.)
- * @param hardware Hardware characteristics (@see origami::hardware_t)
- * @param config Kernel configuration.
- * @param num_active_cus
- * @return origami_cache_t struct
- */
-origami_cache_t create_origami_cache(const problem_t& problem,
-                                     const hardware_t& hardware,
-                                     const config_t& config,
-                                     std::size_t num_active_cus);
-
-/**
- * @brief Creates a cache struct with precomputed values depending only on the problem type,
- * i.e., the info in problem_t but not size or batch.
- *
- * @param problem Problem description (a_dtype, etc.)
- * @param hardware Hardware characteristics (@see origami::hardware_t)
- * @param config Kernel configuration.
- * @return origami_cache_t struct
- */
-kernel_cache_t create_kernel_cache(const problem_t& problem,
-                                   const hardware_t& hardware,
-                                   const config_t& config);
 
 }  // namespace origami

--- a/shared/origami/include/origami/math.hpp
+++ b/shared/origami/include/origami/math.hpp
@@ -58,7 +58,9 @@ inline double ceiling_math(double value, double significance = 1.0)
  */
 template <class T>
 inline void hash_combine_helper(std::size_t& seed, const T& v) {
-  seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  // seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  // cheaper and good enough?
+  seed = (seed ^ (std::hash<T>{}(v) << 1)); // >> 1;
 }
 
 /**

--- a/shared/origami/include/origami/math.hpp
+++ b/shared/origami/include/origami/math.hpp
@@ -50,7 +50,26 @@ inline constexpr N safe_ceil_div(N n, D d) {
  */
 inline double ceiling_math(double value, double significance = 1.0)
 {
-    return std::ceil(value / significance) * significance;
+  return std::ceil(value / significance) * significance;
+}
+
+/**
+ * @brief Helper for hash_combine
+ */
+template <class T>
+inline void hash_combine_helper(std::size_t& seed, const T& v) {
+  seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+/**
+ * @brief Combine multiple hashes into one.
+ */
+template <typename... Types>
+inline std::size_t hash_combine(const Types&... args) {
+    std::size_t seed = 0;
+    // c++17 unary fold
+    (hash_combine_helper(seed, args), ...);
+    return seed;
 }
 
 }  // namespace math

--- a/shared/origami/include/origami/math.hpp
+++ b/shared/origami/include/origami/math.hpp
@@ -50,7 +50,7 @@ inline constexpr N safe_ceil_div(N n, D d) {
  */
 inline double ceiling_math(double value, double significance = 1.0)
 {
-  return std::ceil(value / significance) * significance;
+    return std::ceil(value / significance) * significance;
 }
 
 /**
@@ -68,10 +68,10 @@ inline void hash_combine_helper(std::size_t& seed, const T& v) {
  */
 template <typename... Types>
 inline std::size_t hash_combine(const Types&... args) {
-    std::size_t seed = 0;
-    // c++17 unary fold
-    (hash_combine_helper(seed, args), ...);
-    return seed;
+  std::size_t seed = 0;
+  // c++17 unary fold
+  (hash_combine_helper(seed, args), ...);
+  return seed;
 }
 
 }  // namespace math

--- a/shared/origami/include/origami/math.hpp
+++ b/shared/origami/include/origami/math.hpp
@@ -60,7 +60,7 @@ template <class T>
 inline void hash_combine_helper(std::size_t& seed, const T& v) {
   // seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
   // cheaper and good enough?
-  seed = (seed ^ (std::hash<T>{}(v) << 1)); // >> 1;
+  seed = (seed ^ (std::hash<T>{}(v) << 1));
 }
 
 /**

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -276,6 +276,10 @@ struct runtime_options {
   /// Heuristics variance threshold (reads from ANALYTICAL_GEMM_HEURISTICS_VARIANCE env var)
   double heuristics_variance;
 
+  /// Cache some quantities that depend on config and problem type.
+  /// This can be enabled if configs do not change between calls to origami.
+  bool cache_kernel_info;
+
   /**
    * @brief Default constructor that reads from environment variables.
    */
@@ -363,6 +367,8 @@ struct origami_cache_t {
   std::size_t num_active_cus;
   std::size_t splitting_factor;
 
+  double achievable_mem_bandwidth;
+
   kernel_cache_t kernel_cache;
 };
 
@@ -407,7 +413,7 @@ struct config_t {
   /// Grid selection algorithm.
   grid_selection_t grid_selection = grid_selection_t::k_split_aware;
 
-  /// Index of corresponding kernel
+  /// Index of corresponding kernel (not used by Origami)
   int index = 0;
 
   constexpr bool operator==(const config_t& o) const noexcept {
@@ -518,6 +524,15 @@ struct workgroup_mapping_t {
  */
 inline const runtime_options& get_runtime_options(const config_t& config) {
   (void)config;  // Unused parameter - kept for API compatibility
+  return runtime_options::get();
+}
+
+/**
+ * @brief Get runtime options (always uses global singleton).
+ *
+ * @return runtime_options& Reference to runtime options singleton
+ */
+inline runtime_options& get_runtime_options() {
   return runtime_options::get();
 }
 

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -322,6 +322,51 @@ struct runtime_options {
 };
 
 /**
+ * @brief Struct to cache variables for a config_t for a specific problem_type_t.
+ *
+ */
+struct kernel_cache_t {
+  /// TF32 conversion overhead
+  double L_cvt;
+
+  /// latency for single macro-tile
+  size_t mt_compute_latency;
+
+  /// whether the config macrotile fits in LDS
+  bool fits_lds_capacity;
+
+  double a_bytes;
+  double b_bytes;
+  double d_bytes;
+  int a_bits;
+  int b_bits;
+
+  /// data loaded from a single tile of A (MT_M x MT_K elements), in bytes
+  double a_loads_bytes;
+  /// data loaded from a single tile of B (MT_K x MT_N elements), in bytes
+  double b_loads_bytes;
+
+  std::size_t Ld_CU_bytes;
+};
+
+/**
+ * @brief Struct storing intermediate variables.
+ *
+ */
+struct origami_cache_t {
+  std::size_t grid_m;
+  std::size_t grid_n;
+  std::size_t grid_k;
+
+  std::size_t num_C_tiles;
+  std::size_t num_waves;
+  std::size_t num_active_cus;
+  std::size_t splitting_factor;
+
+  kernel_cache_t kernel_cache;
+};
+
+/**
  * @brief Full kernel configuration (tile shape + execution parameters).
  *
  * Holds the geometric tile sizes along with occupancy,
@@ -376,13 +421,11 @@ struct config_t {
   }
 
   std::size_t hash() const {
-    return std::hash<size_t>()(mt.m) ^ std::hash<size_t>()(mt.n) ^ std::hash<size_t>()(mt.k) ^
-           std::hash<size_t>()(mi.m) ^ std::hash<size_t>()(mi.n) ^ std::hash<size_t>()(mi.k) ^
-           std::hash<int>()(custom_mainloop_scheduling) ^
-           std::hash<int>()(cache_hints_a) ^ std::hash<int>()(cache_hints_b) ^
-           std::hash<int>()(workgroup_mapping) ^
-           std::hash<std::uint32_t>()(static_cast<std::uint32_t>(prediction_mode)) ^
-           std::hash<std::uint32_t>()(static_cast<std::uint32_t>(target));
+    return math::hash_combine(mt.m, mt.n, mt.k, mi.m, mi.n, mi.k,
+                              custom_mainloop_scheduling,
+                              cache_hints_a, cache_hints_b,
+                              workgroup_mapping, static_cast<std::uint32_t>(prediction_mode),
+                              static_cast<std::uint32_t>(target));
   }
 
   void validate() const {
@@ -433,6 +476,21 @@ struct problem_t {
   /// MX block size.
   std::size_t a_mx_block_size = 0;
   std::size_t b_mx_block_size = 0;
+
+  constexpr bool operator==(const problem_t& o) const noexcept { // = default;
+    return size == o.size && batch == o.batch &&
+           a_transpose == o.a_transpose && b_transpose == o.b_transpose &&
+           a_dtype == o.a_dtype && b_dtype == o.b_dtype &&
+           c_dtype == o.c_dtype && d_dtype == o.d_dtype && mi_dtype == o.mi_dtype &&
+           a_mx_block_size == o.a_mx_block_size && b_mx_block_size == o.b_mx_block_size;
+  }
+
+  std::size_t hash() const {
+    // problem type (ie everything here except size and batch) is used as a key
+    return math::hash_combine(static_cast<int>(a_transpose), static_cast<int>(b_transpose),
+                              static_cast<int>(a_dtype), static_cast<int>(b_dtype),
+                              static_cast<int>(c_dtype), static_cast<int>(d_dtype));
+  }
 };
 
 /**
@@ -531,5 +589,11 @@ struct hash<origami::config_t> {
     return config.hash();
   }
 };
+
+template <>
+struct hash<origami::problem_t> {
+  inline std::size_t operator()(const origami::problem_t& problem) const noexcept { return problem.hash(); }
+};
+
 }  // namespace std
 

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -366,9 +366,9 @@ struct origami_cache_t {
   std::size_t grid_k;
 
   std::size_t num_C_tiles;
-  std::size_t num_waves;
-  std::size_t num_active_cus;
-  std::size_t splitting_factor;
+  // std::size_t num_waves;
+  // std::size_t num_active_cus;
+  // std::size_t splitting_factor;
 
   double achievable_mem_bandwidth;
 

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -407,8 +407,8 @@ struct config_t {
   /// Grid selection algorithm.
   grid_selection_t grid_selection = grid_selection_t::k_split_aware;
 
-  /// CMS kernel flag
-  bool cms_kernel = false;
+  /// Index of corresponding kernel
+  int index = 0;
 
   constexpr bool operator==(const config_t& o) const noexcept {
     return mt == o.mt && 
@@ -424,7 +424,8 @@ struct config_t {
     return math::hash_combine(mt.m, mt.n, mt.k, mi.m, mi.n, mi.k,
                               custom_mainloop_scheduling,
                               cache_hints_a, cache_hints_b,
-                              workgroup_mapping, static_cast<std::uint32_t>(prediction_mode),
+                              workgroup_mapping, 
+                              static_cast<std::uint32_t>(prediction_mode),
                               static_cast<std::uint32_t>(target));
   }
 

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -409,7 +409,7 @@ struct config_t {
   grid_selection_t grid_selection = grid_selection_t::k_split_aware;
 
   /// Not used by Origami, but can be set by the user
-  int index = 0;
+  int index = -1;
 
   constexpr bool operator==(const config_t& o) const noexcept {
     return mt == o.mt && 

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -408,7 +408,7 @@ struct config_t {
   /// Grid selection algorithm.
   grid_selection_t grid_selection = grid_selection_t::k_split_aware;
 
-  /// Not used by Origami, but can be set by the user
+  /// Not used by Origami (except for computing a hash)
   int index = -1;
 
   constexpr bool operator==(const config_t& o) const noexcept {

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -144,8 +144,7 @@ struct matrix_instruction {
   }
 
   std::size_t hash() const {
-    return std::hash<size_t>()(MI_M) ^ std::hash<size_t>()(MI_N) ^ std::hash<size_t>()(MI_K) ^
-           std::hash<data_type_t>()(mi_input_type);
+    return math::hash_combine(MI_M, MI_N, MI_K, mi_input_type);
   }
 };
 
@@ -275,10 +274,6 @@ struct runtime_options {
 
   /// Heuristics variance threshold (reads from ANALYTICAL_GEMM_HEURISTICS_VARIANCE env var)
   double heuristics_variance;
-
-  /// Cache some quantities that depend on config and problem type.
-  /// This can be enabled if configs do not change between calls to origami.
-  bool cache_kernel_info;
 
   /**
    * @brief Default constructor that reads from environment variables.
@@ -416,9 +411,6 @@ struct config_t {
   /// Grid selection algorithm.
   grid_selection_t grid_selection = grid_selection_t::k_split_aware;
 
-  /// Index of corresponding kernel (not used by Origami)
-  int index = 0;
-
   constexpr bool operator==(const config_t& o) const noexcept {
     return mt == o.mt && 
            mi == o.mi && 
@@ -433,7 +425,7 @@ struct config_t {
     return math::hash_combine(mt.m, mt.n, mt.k, mi.m, mi.n, mi.k,
                               custom_mainloop_scheduling,
                               cache_hints_a, cache_hints_b,
-                              workgroup_mapping, 
+                              workgroup_mapping,
                               static_cast<std::uint32_t>(prediction_mode),
                               static_cast<std::uint32_t>(target));
   }
@@ -495,12 +487,6 @@ struct problem_t {
            a_mx_block_size == o.a_mx_block_size && b_mx_block_size == o.b_mx_block_size;
   }
 
-  std::size_t hash() const {
-    // problem type (ie everything here except size and batch) is used as a key
-    return math::hash_combine(static_cast<int>(a_transpose), static_cast<int>(b_transpose),
-                              static_cast<int>(a_dtype), static_cast<int>(b_dtype),
-                              static_cast<int>(c_dtype), static_cast<int>(d_dtype));
-  }
 };
 
 /**
@@ -527,15 +513,6 @@ struct workgroup_mapping_t {
  */
 inline const runtime_options& get_runtime_options(const config_t& config) {
   (void)config;  // Unused parameter - kept for API compatibility
-  return runtime_options::get();
-}
-
-/**
- * @brief Get runtime options (always uses global singleton).
- *
- * @return runtime_options& Reference to runtime options singleton
- */
-inline runtime_options& get_runtime_options() {
   return runtime_options::get();
 }
 
@@ -579,9 +556,7 @@ inline runtime_options& get_runtime_options() {
   }
 
   std::size_t hash() const {
-    return std::hash<data_type_t>()(mi_input_type) ^ 
-            std::hash<size_t>()(static_cast<size_t>(transA)) ^ std::hash<size_t>()(static_cast<size_t>(transB)) ^ 
-            std::hash<size_t>()(mt.m) ^ std::hash<size_t>()(mt.n) ^ std::hash<size_t>()(mt.k);
+    return math::hash_combine(mi_input_type, transA, transB, mt.m, mt.n, mt.k);
   }
 };
 
@@ -607,11 +582,6 @@ struct hash<origami::config_t> {
   inline std::size_t operator()(const origami::config_t& config) const noexcept {
     return config.hash();
   }
-};
-
-template <>
-struct hash<origami::problem_t> {
-  inline std::size_t operator()(const origami::problem_t& problem) const noexcept { return problem.hash(); }
 };
 
 }  // namespace std

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -336,6 +336,9 @@ struct kernel_cache_t {
   /// latency for single macro-tile
   size_t mt_compute_latency;
 
+  /// for CMS kernels
+  double main_loop_efficiency;
+
   /// whether the config macrotile fits in LDS
   bool fits_lds_capacity;
 

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -353,7 +353,7 @@ struct kernel_cache_t {
   /// data loaded from a single tile of B (MT_K x MT_N elements), in bytes
   double b_loads_bytes;
 
-  std::size_t Ld_CU_bytes;
+  double Ld_CU_bytes;
 };
 
 /**

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -361,9 +361,6 @@ struct origami_cache_t {
   std::size_t grid_k;
 
   std::size_t num_C_tiles;
-  // std::size_t num_waves;
-  // std::size_t num_active_cus;
-  // std::size_t splitting_factor;
 
   double achievable_mem_bandwidth;
 
@@ -410,6 +407,9 @@ struct config_t {
   target_t target = target_t::tensilelite;
   /// Grid selection algorithm.
   grid_selection_t grid_selection = grid_selection_t::k_split_aware;
+
+  /// Not used by Origami, but can be set by the user
+  int index = 0;
 
   constexpr bool operator==(const config_t& o) const noexcept {
     return mt == o.mt && 

--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -583,6 +583,5 @@ struct hash<origami::config_t> {
     return config.hash();
   }
 };
-
 }  // namespace std
 

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -939,7 +939,7 @@ origami_cache_t create_origami_cache(const problem_t& problem,
 
   struct key_compare_t {
       bool operator()(const key_t& a, const key_t& b) const {
-        return a.second.index == b.second.index && a.first == b.first && a.second == b.second;
+        return a.second.index == b.second.index && a == b;
       }
   };
 

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -612,7 +612,7 @@ double compute_memory_latency(const problem_t& problem,
   double L_mem_mem1 = (limited_mem1_bw > 0) ? (total_Ld / (limited_mem1_bw)) : 0.0;
 
   // 7) mem2‐limited from occupancy (Can't Issue enough load/stores)
-  double bw_limited = compute_mem_bw_from_occupancy(hardware, num_active_cus);
+  double bw_limited = cache.achievable_mem_bandwidth;
 
   // 8) loads that reach each level
   double Ld_mem2 =
@@ -707,7 +707,7 @@ double compute_tile_latency(const problem_t& problem,
   // L_compute *= std::max(L_compute, L_LDS);
 
   // 4) Epilogue: writes from all active CUs with limited bandwidth
-  double mem_bw_occ            = compute_mem_bw_from_occupancy(hardware, num_active_cus);
+  double mem_bw_occ            = cache.achievable_mem_bandwidth;
   double mem_bw_occ_limited    = hardware.mem3_perf_ratio * mem_bw_occ;
   size_t MT_M_rounded_128bytes = round_elements_to_128B(MT_M, datatype_to_bits(problem.a_dtype));
 
@@ -885,6 +885,7 @@ origami_cache_t create_origami_cache(const problem_t& problem,
     .num_waves = numWaves,
     .num_active_cus = num_active_cus,
     .splitting_factor = splitting_factor,
+    .achievable_mem_bandwidth = compute_mem_bw_from_occupancy(hardware, num_active_cus),
   };
 }
 

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -832,14 +832,14 @@ kernel_cache_t create_kernel_cache(const problem_t& problem_type,
   // Logic for block scaled datatypes (Assuming BS=32 and 8-bit scales)
   // TODO This is technically wrong, need separate flag to enable MX so we can differentiate FP8
   // and MX8
-  if (a_bits < 8 && problem.a_mx_block_size != 0) {
+  if (a_bits < 8 && problem_type.a_mx_block_size != 0) {
     // Number of scales per tile
-    size_t num_scales_A = math::safe_ceil_div(config.mt.mk(), problem.a_mx_block_size);
+    size_t num_scales_A = math::safe_ceil_div(config.mt.mk(), problem_type.a_mx_block_size);
     Ld_CU_bytes += num_scales_A;  // One Byte per scale
   }
-  if (b_bits < 8 && problem.b_mx_block_size != 0) {
+  if (b_bits < 8 && problem_type.b_mx_block_size != 0) {
     // Number of scales per tile
-    size_t num_scales_B = math::safe_ceil_div(config.mt.nk(), problem.b_mx_block_size);
+    size_t num_scales_B = math::safe_ceil_div(config.mt.nk(), problem_type.b_mx_block_size);
     Ld_CU_bytes += num_scales_B;  // One Byte per scale
   }
 
@@ -865,6 +865,7 @@ kernel_cache_t create_kernel_cache(const problem_t& problem_type,
 origami_cache_t create_origami_cache(const problem_t& problem,
                                      const hardware_t& hardware,
                                      const config_t& config,
+                                     const kernel_cache_t& kernel_cache,
                                      size_t max_cus) {
   // Find CU occupancy
   auto [num_wgs, num_active_cus, numWaves, splitting_factor] = compute_cu_occupancy(
@@ -883,7 +884,16 @@ origami_cache_t create_origami_cache(const problem_t& problem,
     .num_active_cus = num_active_cus,
     .splitting_factor = splitting_factor,
     .achievable_mem_bandwidth = compute_mem_bw_from_occupancy(hardware, num_active_cus),
+    .kernel_cache = kernel_cache
   };
+}
+
+origami_cache_t create_origami_cache(const problem_t& problem,
+                                     const hardware_t& hardware,
+                                     const config_t& config,
+                                     size_t max_cus) {
+  auto kernel_cache = create_kernel_cache(problem, hardware, config);
+  return create_origami_cache(problem, hardware, config, kernel_cache, max_cus);
 }
 
 // Compute the total latency of a gemm based on the latency of one wave multiplied by the number of
@@ -957,8 +967,7 @@ double compute_total_latency(const problem_t& problem,
   config_with_default_wgm.workgroup_mapping = std::max(defaultWGM, 1);
 
   // 1-2) Find CU occupancy, etc, store in cache
-  auto cache = create_origami_cache(problem, hardware, config_with_default_wgm, max_cus);
-  cache.kernel_cache = kernel_cache;
+  auto cache = create_origami_cache(problem, hardware, config_with_default_wgm, kernel_cache, max_cus);
 
   // 2) Compute latency of a wave
   // Compute latency of a wave

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -21,9 +21,7 @@
 #include "origami/streamk.hpp"
 
 namespace origami {
-double calculate_work_utilization(const problem_t& problem,
-                                  const config_t& config,
-                                  const origami_cache_t& cache) {
+double calculate_work_utilization(const problem_t& problem, const config_t& config) {
   const size_t M = problem.size.m;
   const size_t N = problem.size.n;
   const size_t K = problem.size.k;
@@ -35,11 +33,14 @@ double calculate_work_utilization(const problem_t& problem,
   if (MT_M <= 0 || MT_N <= 0) return 1.0;
 
   // Calculate the full dimensions covered by the launched grid of tiles (spatial).
-  const double launched_M = static_cast<double>(cache.grid_m) * static_cast<double>(MT_M);
-  const double launched_N = static_cast<double>(cache.grid_n) * static_cast<double>(MT_N);
+  const double launched_M =
+      static_cast<double>(math::safe_ceil_div(M, MT_M)) * static_cast<double>(MT_M);
+  const double launched_N =
+      static_cast<double>(math::safe_ceil_div(N, MT_N)) * static_cast<double>(MT_N);
 
   // Calculate the full depth covered by the k-loop iterations (temporal).
-  const double launched_K = static_cast<double>(cache.grid_k) * static_cast<double>(MT_K);
+  const double launched_K =
+      static_cast<double>(math::safe_ceil_div(K, MT_K)) * static_cast<double>(MT_K);
 
   // The utilization is the ratio of the useful problem volume to the total scheduled volume.
   const double useful_volume   = static_cast<double>(M * N * K);
@@ -361,13 +362,20 @@ double compute_mem_bw_from_occupancy(const hardware_t& hardware, size_t num_acti
 double estimate_l2_hit(const problem_t& problem,
                        const hardware_t& hardware,
                        const config_t& config,
+                       size_t splitting_factor) {                       
+  auto cache = create_origami_cache(problem, hardware, config, hardware.N_CU);
+  return estimate_l2_hit(problem, hardware, config, splitting_factor, cache);
+}
+
+double estimate_l2_hit(const problem_t& problem,
+                       const hardware_t& hardware,
+                       const config_t& config,
+                       size_t splitting_factor,
                        const origami_cache_t& cache) {
   // Use size_t for dimensions and counts to ensure type safety.
   const size_t workgroups_m     = cache.grid_m;
   const size_t workgroups_n     = cache.grid_n;
   const size_t total_workgroups = workgroups_m * workgroups_n;
-
-  const auto splitting_factor = cache.splitting_factor;
 
   // Concurrently executing workgroups are limited by the number of CUs.a
   const size_t concurrent_workgroups = std::min(total_workgroups, hardware.N_CU);
@@ -443,10 +451,18 @@ double estimate_l2_hit(const problem_t& problem,
 std::tuple<double, size_t, size_t> estimate_mall_hit(const problem_t& problem,
                                                      const hardware_t& hardware,
                                                      const config_t& config,
-                                                     const origami_cache_t& cache) {
-  const auto num_active_cus   = cache.num_active_cus;
-  const auto splitting_factor = cache.splitting_factor;
+                                                     size_t num_active_cus,
+                                                     size_t splitting_factor) {
+  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
+  return estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor);
+}
 
+std::tuple<double, size_t, size_t> estimate_mall_hit(const problem_t& problem,
+                                                     const hardware_t& hardware,
+                                                     const config_t& config,
+                                                     size_t num_active_cus,
+                                                     size_t splitting_factor,
+                                                     const origami_cache_t& cache) {
   const size_t workgroups_m = cache.grid_m;
   const size_t workgroups_n = cache.grid_n;
 
@@ -500,8 +516,16 @@ std::tuple<double, size_t, size_t> estimate_mall_hit(const problem_t& problem,
 double compute_l2_hit_rate_global(const problem_t& problem,
                                   const hardware_t& hardware,
                                   const config_t& config,
-                                  const origami_cache_t& cache,
                                   size_t l2_capacity_bytes) {
+  auto cache = create_origami_cache(problem, hardware, config, hardware.N_CU);
+  return compute_l2_hit_rate_global(problem, hardware, config, l2_capacity_bytes);
+}
+
+double compute_l2_hit_rate_global(const problem_t& problem,
+                                  const hardware_t& hardware,
+                                  const config_t& config,
+                                  size_t l2_capacity_bytes,
+                                  const origami_cache_t& cache) {
   // --- Hardware Parameters (as requested, defined locally) ---
   // You would normally get l2_capacity_bytes from your hardware_t struct.
   if (l2_capacity_bytes == 0) throw std::runtime_error("L2 Capacity is zero");
@@ -556,10 +580,21 @@ size_t round_elements_to_128B(size_t elements, size_t element_size_bits) {
   return round_up_mul(elements, E_block);
 }
 
+double compute_memory_latency(const problem_t& problem,
+                              const hardware_t& hardware,
+                              const config_t& config,
+                              std::size_t num_active_cus,
+                              std::size_t splitting_factor) {
+  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
+  return compute_memory_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
+}
+
 // Determine the memory latency
 double compute_memory_latency(const problem_t& problem,
                               const hardware_t& hardware,
                               const config_t& config,
+                              std::size_t num_active_cus,
+                              std::size_t splitting_factor,
                               const origami_cache_t& cache) {
   // Extract parameters from structured types
   const auto a_bytes = cache.kernel_cache.a_bytes;
@@ -575,15 +610,13 @@ double compute_memory_latency(const problem_t& problem,
   const size_t MT_N = config.mt.n;
   const size_t MT_K = config.mt.k;
 
-  const auto num_active_cus = cache.num_active_cus;
-
   // 1) Estimate L2 hit-rate
-  double H_mem1 = estimate_l2_hit(problem, hardware, config, cache);
+  double H_mem1 = estimate_l2_hit(problem, hardware, config, splitting_factor, cache);
 
   // Global cap on L2 hit-rate (prevents impossible cache residency claims)
   // (Assumes capacity is given in KiB, convert to bytes)
   double H_mem1_global =
-      compute_l2_hit_rate_global(problem, hardware, config, cache, hardware.L2_capacity * 1024);
+      compute_l2_hit_rate_global(problem, hardware, config, hardware.L2_capacity * 1024, cache);
 
   H_mem1 = std::min(H_mem1, H_mem1_global);
 
@@ -663,9 +696,21 @@ double compute_memory_latency(const problem_t& problem,
 /* ---------------------------------------------------------------------------------------- */
 /* Tile-related functions                                                                   */
 /* ---------------------------------------------------------------------------------------- */
+
 double compute_tile_latency(const problem_t& problem,
                             const hardware_t& hardware,
                             const config_t& config,
+                            std::size_t num_active_cus,
+                            std::size_t splitting_factor) {
+  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
+  return compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
+}
+
+double compute_tile_latency(const problem_t& problem,
+                            const hardware_t& hardware,
+                            const config_t& config,
+                            std::size_t num_active_cus,
+                            std::size_t splitting_factor,
                             const origami_cache_t& cache) {
   // Extract parameters from structured types
   const size_t K = problem.size.k;
@@ -679,16 +724,13 @@ double compute_tile_latency(const problem_t& problem,
   const auto b_bits  = cache.kernel_cache.b_bits;
   const auto d_bytes = cache.kernel_cache.d_bytes;
 
-  auto num_active_cus   = cache.num_active_cus;
-  auto splitting_factor = cache.splitting_factor;
-
   // 1) Compute per-tile latencies
   double L_compute = cache.kernel_cache.mt_compute_latency;
 
-  double L_mem = compute_memory_latency(problem, hardware, config, cache);
+  double L_mem = compute_memory_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
 
   // TODO Does work utilization need to be 128-byte rounded for a cache line?
-  double utilization        = calculate_work_utilization(problem, config, cache);
+  double utilization        = calculate_work_utilization(problem, config);
   // double output_utilization = calculate_output_utilization(problem, config, 1UL);
   // The effective latency per useful operation increases as utilization drops.
   // This penalty affects BOTH compute and memory bounds for the tile's core work.
@@ -781,9 +823,20 @@ double compute_tile_latency(const problem_t& problem,
 double compute_timestep_latency(const problem_t& problem,
                                 const hardware_t& hardware,
                                 const config_t& config,
+                                std::size_t num_active_cus,
+                                std::size_t splitting_factor) {
+  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
+  return compute_timestep_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
+}
+
+double compute_timestep_latency(const problem_t& problem,
+                                const hardware_t& hardware,
+                                const config_t& config,
+                                std::size_t num_active_cus,
+                                std::size_t splitting_factor,
                                 const origami_cache_t& cache) {
   // Assume latency of a timestep is latency of a single K-complete output tile computed on one CU.
-  double L_timestep = compute_tile_latency(problem, hardware, config, cache);
+  double L_timestep = compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
 
   return L_timestep;
 }
@@ -862,35 +915,43 @@ kernel_cache_t create_kernel_cache(const problem_t& problem_type,
 origami_cache_t create_origami_cache(const problem_t& problem,
                                      const hardware_t& hardware,
                                      const config_t& config,
-                                     const kernel_cache_t& kernel_cache,
-                                     size_t max_cus) {
-  // Find CU occupancy
-  auto [num_wgs, num_active_cus, numWaves, splitting_factor] = compute_cu_occupancy(
-      problem, hardware, config, config.grid_selection, max_cus);
-
+                                     std::size_t num_active_cus) {
   auto grid_m = math::safe_ceil_div(problem.size.m, config.mt.m);
   auto grid_n = math::safe_ceil_div(problem.size.n, config.mt.n);
   auto grid_k = math::safe_ceil_div(problem.size.k, config.mt.k);
+
+  auto problem_type = problem;
+  problem_type.batch = 0;
+  problem_type.size = {0, 0, 0};
+  using key_t = std::pair<problem_t, config_t>;
+  auto key = std::make_pair(problem_type, config);
+
+  struct key_hasher_t {
+      std::size_t operator()(const key_t& k) const {
+        auto& p = k.first;
+        auto& c = k.second;
+        return math::hash_combine(
+          c.mt.m, c.mt.n, c.mt.k, c.cache_hints_a, c.cache_hints_b,
+          static_cast<int>(p.a_transpose), static_cast<int>(p.b_transpose),
+          static_cast<int>(p.a_dtype));
+      }
+  };
+
+  static std::unordered_map<key_t, kernel_cache_t, key_hasher_t> kernel_cache_map;
+  // static std::mutex mut;
+  // std::unique_lock<std::mutex> lock(mut);
+  auto p_cache_entry = kernel_cache_map.find(key);
+  if (p_cache_entry == kernel_cache_map.end())
+    p_cache_entry = kernel_cache_map.insert({key, create_kernel_cache(problem_type, hardware, config)}).first;
 
   return origami_cache_t{
     .grid_m = grid_m,
     .grid_n = grid_n,
     .grid_k = grid_k,
     .num_C_tiles = grid_m * grid_n,
-    .num_waves = numWaves,
-    .num_active_cus = num_active_cus,
-    .splitting_factor = splitting_factor,
     .achievable_mem_bandwidth = compute_mem_bw_from_occupancy(hardware, num_active_cus),
-    .kernel_cache = kernel_cache
+    .kernel_cache = p_cache_entry->second
   };
-}
-
-origami_cache_t create_origami_cache(const problem_t& problem,
-                                     const hardware_t& hardware,
-                                     const config_t& config,
-                                     size_t max_cus) {
-  auto kernel_cache = create_kernel_cache(problem, hardware, config);
-  return create_origami_cache(problem, hardware, config, kernel_cache, max_cus);
 }
 
 // Compute the total latency of a gemm based on the latency of one wave multiplied by the number of
@@ -898,7 +959,6 @@ origami_cache_t create_origami_cache(const problem_t& problem,
 double compute_total_latency(const problem_t& problem,
                              const hardware_t& hardware,
                              const config_t& config,
-                             const kernel_cache_t& kernel_cache,
                              size_t max_cus) {
   assert(config.is_valid());
 
@@ -963,15 +1023,19 @@ double compute_total_latency(const problem_t& problem,
   auto config_with_default_wgm              = config;
   config_with_default_wgm.workgroup_mapping = std::max(defaultWGM, 1);
 
-  // 1-2) Find CU occupancy, etc, store in cache
-  auto cache = create_origami_cache(problem, hardware, config_with_default_wgm, kernel_cache, max_cus);
+  // 1-2) Find CU occupancy
+  auto [num_wgs, num_active_cus, num_timesteps, splitting_factor] = compute_cu_occupancy(
+      problem, hardware, config_with_default_wgm, config_with_default_wgm.grid_selection, max_cus);
+
+  auto cache = create_origami_cache(problem, hardware, config_with_default_wgm, num_active_cus);
 
   // 2) Compute latency of a wave
   // Compute latency of a wave
-  double L_wave = compute_timestep_latency(problem, hardware, config_with_default_wgm, cache);
+  double L_timestep = compute_timestep_latency(
+      problem, hardware, config_with_default_wgm, num_active_cus, splitting_factor, cache);
 
   // Compute latency for all waves and return it as the latency for the MT/problem
-  double total_latency = L_wave * cache.num_waves;
+  double total_latency = L_timestep * num_timesteps;
 
   // 3) Customized heuristics
   // TODO These are quantifying effects that don't work in the current math.

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -752,15 +752,8 @@ double compute_tile_latency(const problem_t& problem,
 
   // 5)
   // 5-0) Look up main_loop_efficiency from hardware map
-  double main_loop_efficiency = 1.0;
-  if (config.custom_mainloop_scheduling) {
-    main_loop_efficiency = hardware.get_adjusted_main_loop_efficiency(problem.a_transpose, 
-                                                                      problem.b_transpose, 
-                                                                      config.mt.m, 
-                                                                      config.mt.n, 
-                                                                      config.mt.k, 
-                                                                      problem.mi_dtype);
-  }
+  double main_loop_efficiency = cache.kernel_cache.main_loop_efficiency;
+
   // 5-1) Single-tile latency (apply penalty after finding the bottleneck)
   double L_tile_single = (std::max(L_compute, L_mem) * main_loop_efficiency * effective_tile_penalty) + L_cvt;
   L_prologue *= effective_tile_penalty;
@@ -853,6 +846,10 @@ kernel_cache_t create_kernel_cache(const problem_t& problem_type,
   return kernel_cache_t{
     .L_cvt = L_cvt,
     .mt_compute_latency = compute_mt_compute_latency(problem_type, hardware, config),
+    .main_loop_efficiency = config.custom_mainloop_scheduling ?
+      hardware.get_adjusted_main_loop_efficiency(
+        problem_type.a_transpose, problem_type.b_transpose,
+        config.mt.m, config.mt.n, config.mt.k, problem_type.mi_dtype) : 1.0,
     .fits_lds_capacity = check_lds_capacity(hardware, config.mt, problem_type.a_dtype, problem_type.b_dtype),
     .a_bytes = a_bytes,
     .b_bytes = b_bytes,

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -21,7 +21,9 @@
 #include "origami/streamk.hpp"
 
 namespace origami {
-double calculate_work_utilization(const problem_t& problem, const config_t& config) {
+double calculate_work_utilization(const problem_t& problem,
+                                  const config_t& config,
+                                  const origami_cache_t& cache) {
   const size_t M = problem.size.m;
   const size_t N = problem.size.n;
   const size_t K = problem.size.k;
@@ -33,14 +35,11 @@ double calculate_work_utilization(const problem_t& problem, const config_t& conf
   if (MT_M <= 0 || MT_N <= 0) return 1.0;
 
   // Calculate the full dimensions covered by the launched grid of tiles (spatial).
-  const double launched_M =
-      static_cast<double>(math::safe_ceil_div(M, MT_M)) * static_cast<double>(MT_M);
-  const double launched_N =
-      static_cast<double>(math::safe_ceil_div(N, MT_N)) * static_cast<double>(MT_N);
+  const double launched_M = static_cast<double>(cache.grid_m) * static_cast<double>(MT_M);
+  const double launched_N = static_cast<double>(cache.grid_n) * static_cast<double>(MT_N);
 
   // Calculate the full depth covered by the k-loop iterations (temporal).
-  const double launched_K =
-      static_cast<double>(math::safe_ceil_div(K, MT_K)) * static_cast<double>(MT_K);
+  const double launched_K = static_cast<double>(cache.grid_k) * static_cast<double>(MT_K);
 
   // The utilization is the ratio of the useful problem volume to the total scheduled volume.
   const double useful_volume   = static_cast<double>(M * N * K);
@@ -169,6 +168,7 @@ double emulated_tf32_arithmetic_intensity(double m, double n, double k, double b
 
 // Compute cvt overhead in x1 tf32 emulation
 // TODO: We can generalize the same routine to cover more GEMMs that perform conversion
+// This routine should not rely on problem.size or problem.batch
 static inline double compute_cvt_overhead_x1(const problem_t& problem,
                                              const hardware_t& hardware,
                                              const config_t& config) {
@@ -241,6 +241,7 @@ static inline double compute_cvt_overhead_x1(const problem_t& problem,
 }
 
 // Compute cvt overhead in tf32 emulation
+// This routine should not rely on problem.size or problem.batch
 double compute_cvt_overhead(const problem_t& problem,
                             const hardware_t& hardware,
                             const config_t& config) {
@@ -360,11 +361,13 @@ double compute_mem_bw_from_occupancy(const hardware_t& hardware, size_t num_acti
 double estimate_l2_hit(const problem_t& problem,
                        const hardware_t& hardware,
                        const config_t& config,
-                       size_t splitting_factor) {
+                       const origami_cache_t& cache) {
   // Use size_t for dimensions and counts to ensure type safety.
-  const size_t workgroups_m     = math::safe_ceil_div(problem.size.m, config.mt.m);
-  const size_t workgroups_n     = math::safe_ceil_div(problem.size.n, config.mt.n);
+  const size_t workgroups_m     = cache.grid_m;
+  const size_t workgroups_n     = cache.grid_n;
   const size_t total_workgroups = workgroups_m * workgroups_n;
+
+  const auto splitting_factor = cache.splitting_factor;
 
   // Concurrently executing workgroups are limited by the number of CUs.a
   const size_t concurrent_workgroups = std::min(total_workgroups, hardware.N_CU);
@@ -397,8 +400,8 @@ double estimate_l2_hit(const problem_t& problem,
   const auto a_bytes       = data_type_to_bytes(problem.a_dtype);
   const auto b_bytes       = data_type_to_bytes(problem.b_dtype);
   auto calculate_footprint = [&](auto tile_m, auto tile_n) {
-    auto a_footprint = tile_m * config.mt.mk() * a_bytes;
-    auto b_footprint = tile_n * config.mt.nk() * b_bytes;
+    auto a_footprint = tile_m * cache.kernel_cache.a_loads_bytes;
+    auto b_footprint = tile_n * cache.kernel_cache.b_loads_bytes;
     return a_footprint + b_footprint;
   };
 
@@ -416,8 +419,8 @@ double estimate_l2_hit(const problem_t& problem,
   }
 
   // Uncached reads are the first read of each unique element within the L2 tile.
-  const long long uncached_A_reads     = static_cast<long long>(l2_tile_m) * config.mt.mk();
-  const long long uncached_B_reads     = static_cast<long long>(l2_tile_n) * config.mt.nk();
+  const long long uncached_A_reads     = static_cast<long long>(l2_tile_m) * cache.kernel_cache.a_loads_bytes;
+  const long long uncached_B_reads     = static_cast<long long>(l2_tile_n) * cache.kernel_cache.b_loads_bytes;
   const long long total_uncached_reads = uncached_A_reads + uncached_B_reads;
 
   // Total reads are the sum of all reads performed by all workgroups in the L2 tile.
@@ -436,14 +439,16 @@ double estimate_l2_hit(const problem_t& problem,
   return std::max(0.0, std::min(l2_hit_rate, 1.0));
 }
 
-// Estimate MALL hit-rate
-double estimate_mall_hit(const problem_t& problem,
-                         const hardware_t& hardware,
-                         const config_t& config,
-                         size_t num_active_cus,
-                         size_t splitting_factor) {
-  const size_t workgroups_m = math::safe_ceil_div(problem.size.m, config.mt.m);
-  const size_t workgroups_n = math::safe_ceil_div(problem.size.n, config.mt.n);
+// Estimate MALL hit-rate, also return mall tile
+std::tuple<double, size_t, size_t> estimate_mall_hit(const problem_t& problem,
+                                                     const hardware_t& hardware,
+                                                     const config_t& config,
+                                                     const origami_cache_t& cache) {
+  const auto num_active_cus   = cache.num_active_cus;
+  const auto splitting_factor = cache.splitting_factor;
+
+  const size_t workgroups_m = cache.grid_m;
+  const size_t workgroups_n = cache.grid_n;
 
   if (num_active_cus == 0) throw std::runtime_error("Number of Active CUs was 0");
 
@@ -465,18 +470,18 @@ double estimate_mall_hit(const problem_t& problem,
   mall_tile_n = std::max(std::min(workgroups_n, mall_tile_n), static_cast<size_t>(1));
 
   // --- CRITICAL: Shrink tile to fit into MALL Capacity ---
-  const auto a_bytes = data_type_to_bytes(problem.a_dtype);
-  const auto b_bytes = data_type_to_bytes(problem.b_dtype);
+  const auto a_bytes = cache.kernel_cache.a_bytes;
+  const auto b_bytes = cache.kernel_cache.b_bytes;
 
   auto calculate_footprint = [&](auto tile_m, auto tile_n) {
-    auto a_footprint = tile_m * config.mt.mk() * a_bytes;
-    auto b_footprint = tile_n * config.mt.nk() * b_bytes;
+    auto a_footprint = tile_m * cache.kernel_cache.a_loads_bytes;
+    auto b_footprint = tile_n * cache.kernel_cache.b_loads_bytes;
     return a_footprint + b_footprint;
   };
 
   // --- Calculate Hit Rate based on the final, capacity-aware tile size ---
-  const long long uncached_A_reads     = static_cast<long long>(mall_tile_m) * config.mt.mk();
-  const long long uncached_B_reads     = static_cast<long long>(mall_tile_n) * config.mt.nk();
+  const long long uncached_A_reads     = static_cast<long long>(mall_tile_m) * cache.kernel_cache.a_loads_bytes;
+  const long long uncached_B_reads     = static_cast<long long>(mall_tile_n) * cache.kernel_cache.b_loads_bytes;
   const long long total_uncached_reads = uncached_A_reads + uncached_B_reads;
 
   const long long total_A_reads = uncached_A_reads * mall_tile_n;
@@ -488,7 +493,7 @@ double estimate_mall_hit(const problem_t& problem,
   double mall_hit_rate = static_cast<double>(cached_reads) / static_cast<double>(total_reads);
 
   // Clamp the final result to the valid [0, 1] range.
-  return std::max(0.0, std::min(mall_hit_rate, 1.0));
+  return {std::max(0.0, std::min(mall_hit_rate, 1.0)), mall_tile_m, mall_tile_n};
 }
 
 /**
@@ -498,25 +503,24 @@ double estimate_mall_hit(const problem_t& problem,
 double compute_l2_hit_rate_global(const problem_t& problem,
                                   const hardware_t& hardware,
                                   const config_t& config,
+                                  const origami_cache_t& cache,
                                   size_t l2_capacity_bytes) {
   // --- Hardware Parameters (as requested, defined locally) ---
   // You would normally get l2_capacity_bytes from your hardware_t struct.
   if (l2_capacity_bytes == 0) throw std::runtime_error("L2 Capacity is zero");
 
   // 1. Calculate the grid dimensions in terms of macro-tiles
-  const size_t grid_m = math::safe_ceil_div(problem.size.m, config.mt.m);
-  const size_t grid_n = math::safe_ceil_div(problem.size.n, config.mt.n);
+  const size_t grid_m = cache.grid_m;
+  const size_t grid_n = cache.grid_n;
 
   if (grid_m == 0 || grid_n == 0)
     throw std::runtime_error("estimate_l2_hit grid dimensions can not be zero");
 
   // 2. Calculate the working set size for one full pass of global reuse
   // This is the data needed by one full column of CUs (for A) and one full row (for B).
-  const double a_bytes = data_type_to_bytes(problem.a_dtype);
-  const double b_bytes = data_type_to_bytes(problem.b_dtype);
 
-  const double a_working_set           = static_cast<double>(grid_m * config.mt.mk()) * a_bytes;
-  const double b_working_set           = static_cast<double>(grid_n * config.mt.nk()) * b_bytes;
+  const double a_working_set           = grid_m * cache.kernel_cache.a_loads_bytes;
+  const double b_working_set           = grid_n * cache.kernel_cache.b_loads_bytes;
   const double total_working_set_bytes = a_working_set + b_working_set;
 
   // 3. CRUCIAL: Check if the working set fits in the L2 cache.
@@ -530,14 +534,12 @@ double compute_l2_hit_rate_global(const problem_t& problem,
 
   // 4. If it fits, calculate the idealized global hit rate
   // Total reads if nothing was cached
-  const double total_A_reads = static_cast<double>(grid_m * grid_n * config.mt.mk());
-  const double total_B_reads = static_cast<double>(grid_m * grid_n * config.mt.nk());
+  const double total_A_reads = grid_n * a_working_set;
+  const double total_B_reads = grid_m * b_working_set;
 
   // Uncached reads are the first-time fetches for each row/column
-  const double uncached_A_reads =
-      static_cast<double>(grid_m * config.mt.mk());  // One full column fetches A
-  const double uncached_B_reads =
-      static_cast<double>(grid_n * config.mt.nk());  // One full row fetches B
+  const double uncached_A_reads = a_working_set;  // One full column fetches A
+  const double uncached_B_reads = b_working_set;  // One full row fetches B
 
   const double total_reads = total_A_reads + total_B_reads;
   if (total_reads == 0) return 1.0;  // No reads, perfect hit rate.
@@ -561,13 +563,12 @@ size_t round_elements_to_128B(size_t elements, size_t element_size_bits) {
 double compute_memory_latency(const problem_t& problem,
                               const hardware_t& hardware,
                               const config_t& config,
-                              size_t num_active_cus,
-                              size_t splitting_factor) {
+                              const origami_cache_t& cache) {
   // Extract parameters from structured types
-  const auto a_bytes = data_type_to_bytes(problem.a_dtype);
-  const auto b_bytes = data_type_to_bytes(problem.b_dtype);
-  const auto a_bits  = datatype_to_bits(problem.a_dtype);
-  const auto b_bits  = datatype_to_bits(problem.b_dtype);
+  const auto a_bytes = cache.kernel_cache.a_bytes;
+  const auto b_bytes = cache.kernel_cache.b_bytes;
+  const auto a_bits  = cache.kernel_cache.a_bits;
+  const auto b_bits  = cache.kernel_cache.b_bits;
   size_t batch       = problem.batch;
 
   const bool a_trans = (problem.a_transpose == transpose_t::T);
@@ -577,13 +578,15 @@ double compute_memory_latency(const problem_t& problem,
   const size_t MT_N = config.mt.n;
   const size_t MT_K = config.mt.k;
 
+  const auto num_active_cus = cache.num_active_cus;
+
   // 1) Estimate L2 hit-rate
-  double H_mem1 = estimate_l2_hit(problem, hardware, config, splitting_factor);
+  double H_mem1 = estimate_l2_hit(problem, hardware, config, cache);
 
   // Global cap on L2 hit-rate (prevents impossible cache residency claims)
   // (Assumes capacity is given in KiB, convert to bytes)
   double H_mem1_global =
-      compute_l2_hit_rate_global(problem, hardware, config, hardware.L2_capacity * 1024);
+      compute_l2_hit_rate_global(problem, hardware, config, cache, hardware.L2_capacity * 1024);
 
   H_mem1 = std::min(H_mem1, H_mem1_global);
 
@@ -596,26 +599,7 @@ double compute_memory_latency(const problem_t& problem,
           : 0.0;  // MALL is not supported, so we emulate every read as a miss
 
   // 3) Total loads are loads from A and loads from B
-  size_t Ld_A_value = a_trans ?
-      MT_M * round_elements_to_128B(MT_K, a_bits) : round_elements_to_128B(MT_M, a_bits) * MT_K;
-  size_t Ld_B_value = b_trans ?
-      round_elements_to_128B(MT_N, b_bits) * MT_K : MT_N * round_elements_to_128B(MT_K, b_bits);
-  auto Ld_CU_bytes  = (Ld_A_value * a_bytes)    // A Bytes
-                     + (Ld_B_value * b_bytes);  // B Bytes
-
-  // Logic for block scaled datatypes (Assuming BS=32 and 8-bit scales)
-  // TODO This is technically wrong, need separate flag to enable MX so we can differentiate FP8
-  // and MX8
-  if (a_bits < 8 && problem.a_mx_block_size != 0) {
-    // Number of scales per tile
-    size_t num_scales_A = math::safe_ceil_div(config.mt.mk(), problem.a_mx_block_size);
-    Ld_CU_bytes += num_scales_A;  // One Byte per scale
-  }
-  if (b_bits < 8 && problem.b_mx_block_size != 0) {
-    // Number of scales per tile
-    size_t num_scales_B = math::safe_ceil_div(config.mt.nk(), problem.b_mx_block_size);
-    Ld_CU_bytes += num_scales_B;  // One Byte per scale
-  }
+  auto Ld_CU_bytes = cache.kernel_cache.Ld_CU_bytes;
 
   // 4) total loads by all CUs
   double total_Ld = Ld_CU_bytes * static_cast<double>(num_active_cus);
@@ -639,8 +623,8 @@ double compute_memory_latency(const problem_t& problem,
 
   // 9) enforce whole‐problem minimum loads when we can fit M/N in the CUs.
   // Calculate the tile of workgroups that can run concurrently (logic from estimate_mall_hit).
-  size_t grid_m = math::safe_ceil_div(problem.size.m, MT_M);
-  size_t grid_n = math::safe_ceil_div(problem.size.n, MT_N);
+  size_t grid_m = cache.grid_m;
+  size_t grid_n = cache.grid_n;
   size_t mall_m =
       math::safe_ceil_div(num_active_cus, static_cast<size_t>(config.workgroup_mapping));
   size_t mall_n = std::min(static_cast<size_t>(config.workgroup_mapping), grid_n);
@@ -656,9 +640,9 @@ double compute_memory_latency(const problem_t& problem,
   // This is the minimum unique bytes needed from HBM to feed the concurrent workgroups.
   double concurrent_batches =
       std::min(static_cast<double>(problem.batch),
-               std::max(static_cast<double>(num_active_cus) / (grid_m * grid_n), 1.));
-  double min_load = static_cast<double>((mall_m * config.mt.mk() * a_bytes) +
-                                        (mall_n * config.mt.nk() * b_bytes)) *
+               std::max(static_cast<double>(num_active_cus) / cache.num_C_tiles, 1.));
+  double min_load = static_cast<double>((mall_m * cache.kernel_cache.a_loads_bytes) +
+                                        (mall_n * cache.kernel_cache.b_loads_bytes)) *
                     concurrent_batches;  // Apply batching to the minimum load itself.
   // The actual loads cannot be less than this physical minimum.
   Ld_MEM  = std::max(Ld_MEM, min_load);
@@ -685,8 +669,7 @@ double compute_memory_latency(const problem_t& problem,
 double compute_tile_latency(const problem_t& problem,
                             const hardware_t& hardware,
                             const config_t& config,
-                            size_t num_active_cus,
-                            size_t splitting_factor) {
+                            const origami_cache_t& cache) {
   // Extract parameters from structured types
   const size_t K = problem.size.k;
   size_t batch   = problem.batch;
@@ -695,29 +678,31 @@ double compute_tile_latency(const problem_t& problem,
   const size_t MT_N = config.mt.n;
   const size_t MT_K = config.mt.k;
 
-  const auto a_bits  = datatype_to_bits(problem.a_dtype);
-  const auto b_bits  = datatype_to_bits(problem.b_dtype);
-  const auto d_bytes = data_type_to_bytes(problem.d_dtype);
+  const auto a_bits  = cache.kernel_cache.a_bits;
+  const auto b_bits  = cache.kernel_cache.b_bits;
+  const auto d_bytes = cache.kernel_cache.d_bytes;
+
+  auto num_active_cus   = cache.num_active_cus;
+  auto splitting_factor = cache.splitting_factor;
 
   // 1) Compute per-tile latencies
-  double L_compute = compute_mt_compute_latency(problem, hardware, config);
+  double L_compute = cache.kernel_cache.mt_compute_latency;
 
-  double L_mem =
-      compute_memory_latency(problem, hardware, config, num_active_cus, splitting_factor);
+  double L_mem = compute_memory_latency(problem, hardware, config, cache);
 
   // TODO Does work utilization need to be 128-byte rounded for a cache line?
-  double utilization        = calculate_work_utilization(problem, config);
-  double output_utilization = calculate_output_utilization(problem, config, 1UL);
+  double utilization        = calculate_work_utilization(problem, config, cache);
+  // double output_utilization = calculate_output_utilization(problem, config, 1UL);
   // The effective latency per useful operation increases as utilization drops.
   // This penalty affects BOTH compute and memory bounds for the tile's core work.
   double effective_tile_penalty = (utilization > 1e-9) ? (1.0 / (utilization)) : 1.0;
-  double output_utilization_penalty =
-      (output_utilization > 1e-9) ? (1.0 / (output_utilization)) : 1.0;
+  // double output_utilization_penalty =
+  //     (output_utilization > 1e-9) ? (1.0 / (output_utilization)) : 1.0;
   // 2) Work-group setup & iteration latencies
   double L_WG_setup = 1;  // WG_setup_Latency
 
   // 3) Prologue: 2.2× memory latency
-  double L_prologue = 1.5 * L_mem;  // 1.5 chosen emprically
+  double L_prologue = 1.5 * L_mem;  // 1.5 chosen empirically
 
   // L_compute *= std::max(L_compute, L_LDS);
 
@@ -732,12 +717,9 @@ double compute_tile_latency(const problem_t& problem,
   // One compute iteration happens in the prologue
   L_epilogue += L_compute * effective_tile_penalty;
   // Epilogue and Prologue overhead are reduced with higher occupancy kernels.
-  int grid_m = static_cast<int>(math::safe_ceil_div(problem.size.m, MT_M));
-  int grid_n = static_cast<int>(math::safe_ceil_div(problem.size.n, MT_N));
-
   size_t real_occupancy =
       std::min(std::max(config.occupancy, static_cast<int>(1)),
-               static_cast<int>(math::safe_ceil_div(grid_m * grid_n * batch * splitting_factor,
+               static_cast<int>(math::safe_ceil_div(cache.num_C_tiles * batch * splitting_factor,
                                                     hardware.N_CU)));  // Number of WGs per CU.
 
   L_prologue = L_prologue * pow(0.95, real_occupancy);  // Factor chosen empirically
@@ -749,11 +731,11 @@ double compute_tile_latency(const problem_t& problem,
 
     // Only the reduction CU reads from all splits.
     double partial_read_bytes =
-        grid_m * grid_n * n_partials * MT_M_rounded_128bytes * MT_N * static_cast<double>(d_bytes);
+        cache.num_C_tiles * n_partials * MT_M_rounded_128bytes * MT_N * static_cast<double>(d_bytes);
 
     // All CUs write (once for each partial, and once by the reduction CU for the output.)
     double partial_write_bytes =
-        grid_m * grid_n * MT_M_rounded_128bytes * MT_N * static_cast<double>(d_bytes);
+        cache.num_C_tiles * MT_M_rounded_128bytes * MT_N * static_cast<double>(d_bytes);
 
     double partial_readwrite_bytes = partial_read_bytes + partial_write_bytes;
 
@@ -766,15 +748,7 @@ double compute_tile_latency(const problem_t& problem,
     L_epilogue += L_reduce + partial_adds + 10000;
   }
   // 4'') tf32 emu has some more overhead
-  double L_cvt = 0;
-  if ((problem.mi_dtype == data_type_t::XFloat32) &&
-      (hardware.arch == hardware_t::architecture_t::gfx950)) {
-    L_cvt = compute_cvt_overhead(problem, hardware, config);
-  } else if ((a_bits == 32) && (b_bits == 32) && (problem.mi_dtype == data_type_t::BFloat16) &&
-             (hardware.arch == hardware_t::architecture_t::gfx950))  // SS_BSS on GFX950
-  {
-    L_cvt = compute_cvt_overhead_x1(problem, hardware, config);
-  }
+  double L_cvt = cache.kernel_cache.L_cvt;
 
   // 5)
   // 5-0) Look up main_loop_efficiency from hardware map
@@ -817,18 +791,109 @@ double compute_tile_latency(const problem_t& problem,
 double compute_timestep_latency(const problem_t& problem,
                                 const hardware_t& hardware,
                                 const config_t& config,
-                                size_t num_active_cus,
-                                size_t splitting_factor) {
+                                const origami_cache_t& cache) {
   // Assume latency of a timestep is latency of a single K-complete output tile computed on one CU.
-  double L_timestep =
-      compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor);
+  double L_timestep = compute_tile_latency(problem, hardware, config, cache);
 
   return L_timestep;
 }
 
+kernel_cache_t create_kernel_cache(const problem_t& problem_type,
+                                   const hardware_t& hardware,
+                                   const config_t& config) {
+  double L_cvt        = 0.0;
+  const bool tf32_emu = (problem_type.mi_dtype == data_type_t::XFloat32) &&
+                        (hardware.arch == hardware_t::architecture_t::gfx950);
+  if (tf32_emu) {
+    L_cvt = compute_cvt_overhead(problem_type, hardware, config);
+  } else {
+    const bool ss_bss_bf16 = (problem_type.a_dtype == data_type_t::Float) &&
+                             (problem_type.b_dtype == data_type_t::Float) &&
+                             (problem_type.mi_dtype == data_type_t::BFloat16) &&
+                             (hardware.arch == hardware_t::architecture_t::gfx950);
+    if (ss_bss_bf16) { L_cvt = compute_cvt_overhead_x1(problem_type, hardware, config); }
+  }
+  const std::size_t MT_M = config.mt.m;
+  const std::size_t MT_N = config.mt.n;
+  const std::size_t MT_K = config.mt.k;
+
+  const auto a_bytes = data_type_to_bytes(problem_type.a_dtype);
+  const auto b_bytes = data_type_to_bytes(problem_type.b_dtype);
+  const auto d_bytes = data_type_to_bytes(problem_type.d_dtype);
+  const auto a_bits  = datatype_to_bits(problem_type.a_dtype);
+  const auto b_bits  = datatype_to_bits(problem_type.b_dtype);
+
+  const bool a_trans = problem_type.a_transpose == transpose_t::T;
+  const bool b_trans = problem_type.b_transpose == transpose_t::T;
+
+  auto a_loads = config.mt.mk();
+  auto b_loads = config.mt.nk();
+
+  size_t Ld_A_value = a_trans ?
+      MT_M * round_elements_to_128B(MT_K, a_bits) : round_elements_to_128B(MT_M, a_bits) * MT_K;
+  size_t Ld_B_value = b_trans ?
+      round_elements_to_128B(MT_N, b_bits) * MT_K : MT_N * round_elements_to_128B(MT_K, b_bits);
+  auto Ld_CU_bytes  = (Ld_A_value * a_bytes)    // A Bytes
+                     + (Ld_B_value * b_bytes);  // B Bytes
+
+  // Logic for block scaled datatypes (Assuming BS=32 and 8-bit scales)
+  // TODO This is technically wrong, need separate flag to enable MX so we can differentiate FP8
+  // and MX8
+  if (a_bits < 8 && problem.a_mx_block_size != 0) {
+    // Number of scales per tile
+    size_t num_scales_A = math::safe_ceil_div(config.mt.mk(), problem.a_mx_block_size);
+    Ld_CU_bytes += num_scales_A;  // One Byte per scale
+  }
+  if (b_bits < 8 && problem.b_mx_block_size != 0) {
+    // Number of scales per tile
+    size_t num_scales_B = math::safe_ceil_div(config.mt.nk(), problem.b_mx_block_size);
+    Ld_CU_bytes += num_scales_B;  // One Byte per scale
+  }
+
+  return kernel_cache_t{
+    .L_cvt = L_cvt,
+    .mt_compute_latency = compute_mt_compute_latency(problem_type, hardware, config),
+    .fits_lds_capacity = check_lds_capacity(hardware, config.mt, problem_type.a_dtype, problem_type.b_dtype),
+    .a_bytes = a_bytes,
+    .b_bytes = b_bytes,
+    .d_bytes = d_bytes,
+    .a_bits = a_bits,
+    .b_bits = b_bits,
+    .a_loads_bytes = a_loads * a_bytes,
+    .b_loads_bytes = b_loads * b_bytes,
+    .Ld_CU_bytes = Ld_CU_bytes,
+  };
+}
+
+origami_cache_t create_origami_cache(const problem_t& problem,
+                                     const hardware_t& hardware,
+                                     const config_t& config,
+                                     size_t max_cus) {
+  // Find CU occupancy
+  auto [num_wgs, num_active_cus, numWaves, splitting_factor] = compute_cu_occupancy(
+      problem, hardware, config, grid_selection_t::k_split_aware, max_cus);
+
+  auto grid_m = math::safe_ceil_div(problem.size.m, config.mt.m);
+  auto grid_n = math::safe_ceil_div(problem.size.n, config.mt.n);
+  auto grid_k = math::safe_ceil_div(problem.size.k, config.mt.k);
+
+  return origami_cache_t{
+    .grid_m = grid_m,
+    .grid_n = grid_n,
+    .grid_k = grid_k,
+    .num_C_tiles = grid_m * grid_n,
+    .num_waves = numWaves,
+    .num_active_cus = num_active_cus,
+    .splitting_factor = splitting_factor,
+  };
+}
+
+// Compute the total latency of a gemm based on the latency of one wave multiplied by the number of
+// waves A wave is defined as : The time it takes for one CU to complete one K-complete output tile
 double compute_total_latency(const problem_t& problem,
                              const hardware_t& hardware,
                              const config_t& config,
+                             const kernel_cache_t& kernel_cache,
                              size_t max_cus) {
   assert(config.is_valid());
 
@@ -848,24 +913,13 @@ double compute_total_latency(const problem_t& problem,
   size_t MI_N = config.mi.n;
   size_t MI_K = config.mi.k;
 
-  const int a_bits  = datatype_to_bits(problem.a_dtype);
-  const int b_bits  = datatype_to_bits(problem.b_dtype);
-  const int a_bytes = data_type_to_bytes(problem.a_dtype);
+  const auto a_bits  = datatype_to_bits(problem.a_dtype);
+  const auto b_bits  = datatype_to_bits(problem.b_dtype);
 
   // 0) Short-circuit
   // We don't need to compute latency for all MTs. With this, we can shortcut.
   bool shortCircuit = true;
   if (shortCircuit) {
-    // When problem dimensions are small enough that we can fit them in one tile, we should do
-    // so. This short circuit condition also decreases selection latency when problems are very
-    // small :)
-    // TODO 256 and 256 here should be largest M and N tile dimensions in library
-    if (M <= 256 && N <= 256 && K < 1024 && batch != 1 && (MT_M < M || MT_N < N))
-      return std::numeric_limits<double>::max();
-
-    // Use Dot2 only for M < 3
-    if (MI_M == 1 && MI_N == 1 && MI_K == 64 && M > 2) return std::numeric_limits<double>::max();
-
     size_t K_mod_128bytes    = K * a_bits % 1024;
     size_t MT_K_mod_128bytes = MT_K * a_bits % 1024;
     if (K_mod_128bytes == 0 && MT_K_mod_128bytes == 0) {
@@ -885,6 +939,17 @@ double compute_total_latency(const problem_t& problem,
     } else if (config.cache_hints_a || config.cache_hints_b) {
       return std::numeric_limits<double>::max();
     }
+
+    // When problem dimensions are small enough that we can fit them in one tile, we should do
+    // so. This short circuit condition also decreases selection latency when problems are very
+    // small :)
+    // TODO 256 and 256 here should be largest M and N tile dimensions in library
+    if (batch != 1 && M <= 256 && N <= 256 && K < 1024 && (MT_M < M || MT_N < N))
+      return std::numeric_limits<double>::max();
+
+    // Use Dot2 only for M < 3
+    if (MI_M == 1 && MI_N == 1 && MI_K == 64 && M > 2)
+      return std::numeric_limits<double>::max();
   }
 
   // 1-1) To compute the latency, use default WGM. And WGM can't be greater than one
@@ -893,16 +958,16 @@ double compute_total_latency(const problem_t& problem,
   auto config_with_default_wgm              = config;
   config_with_default_wgm.workgroup_mapping = std::max(defaultWGM, 1);
 
-  // 1-2) Find CU occupancy
-  auto [num_wgs, num_active_cus, num_timesteps, splitting_factor] = compute_cu_occupancy(
-      problem, hardware, config_with_default_wgm, config_with_default_wgm.grid_selection, max_cus);
+  // 1-2) Find CU occupancy, etc, store in cache
+  auto cache = create_origami_cache(problem, hardware, config_with_default_wgm, max_cus);
+  cache.kernel_cache = kernel_cache;
 
-  // 2) Compute latency of a timestep
-  double L_timestep = compute_timestep_latency(
-      problem, hardware, config_with_default_wgm, num_active_cus, splitting_factor);
+  // 2) Compute latency of a wave
+  // Compute latency of a wave
+  double L_wave = compute_timestep_latency(problem, hardware, config_with_default_wgm, cache);
 
-  // Compute latency for all timesteps and return it as the latency for the MT/problem
-  double total_latency = L_timestep * num_timesteps;
+  // Compute latency for all waves and return it as the latency for the MT/problem
+  double total_latency = L_wave * cache.num_waves;
 
   // 3) Customized heuristics
   // TODO These are quantifying effects that don't work in the current math.
@@ -919,7 +984,7 @@ double compute_total_latency(const problem_t& problem,
 
     //  Heuristics for TF32
     if (tf32_emu) {
-      double bytes_per_element = a_bytes;
+      double bytes_per_element = cache.kernel_cache.a_bytes;
       double arith             = emulated_tf32_arithmetic_intensity(M, N, K, bytes_per_element);
       double compute_threshold = 1000;  // threshold empirically determined.
 

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -931,13 +931,19 @@ origami_cache_t create_origami_cache(const problem_t& problem,
         auto& p = k.first;
         auto& c = k.second;
         return math::hash_combine(
-          c.mt.m, c.mt.n, c.mt.k, c.cache_hints_a, c.cache_hints_b,
+          c.index,
           static_cast<int>(p.a_transpose), static_cast<int>(p.b_transpose),
           static_cast<int>(p.a_dtype));
       }
   };
 
-  static std::unordered_map<key_t, kernel_cache_t, key_hasher_t> kernel_cache_map;
+  struct key_compare_t {
+      bool operator()(const key_t& a, const key_t& b) const {
+        return a.second.index == b.second.index && a.first == b.first && a.second == b.second;
+      }
+  };
+
+  static std::unordered_map<key_t, kernel_cache_t, key_hasher_t, key_compare_t> kernel_cache_map;
   // static std::mutex mut;
   // std::unique_lock<std::mutex> lock(mut);
   auto p_cache_entry = kernel_cache_map.find(key);

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -470,9 +470,6 @@ std::tuple<double, size_t, size_t> estimate_mall_hit(const problem_t& problem,
   mall_tile_n = std::max(std::min(workgroups_n, mall_tile_n), static_cast<size_t>(1));
 
   // --- CRITICAL: Shrink tile to fit into MALL Capacity ---
-  const auto a_bytes = cache.kernel_cache.a_bytes;
-  const auto b_bytes = cache.kernel_cache.b_bytes;
-
   auto calculate_footprint = [&](auto tile_m, auto tile_n) {
     auto a_footprint = tile_m * cache.kernel_cache.a_loads_bytes;
     auto b_footprint = tile_n * cache.kernel_cache.b_loads_bytes;

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -869,7 +869,7 @@ origami_cache_t create_origami_cache(const problem_t& problem,
                                      size_t max_cus) {
   // Find CU occupancy
   auto [num_wgs, num_active_cus, numWaves, splitting_factor] = compute_cu_occupancy(
-      problem, hardware, config, grid_selection_t::k_split_aware, max_cus);
+      problem, hardware, config, config.grid_selection, max_cus);
 
   auto grid_m = math::safe_ceil_div(problem.size.m, config.mt.m);
   auto grid_n = math::safe_ceil_div(problem.size.n, config.mt.n);

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -362,7 +362,7 @@ double compute_mem_bw_from_occupancy(const hardware_t& hardware, size_t num_acti
 double estimate_l2_hit(const problem_t& problem,
                        const hardware_t& hardware,
                        const config_t& config,
-                       size_t splitting_factor) {                       
+                       size_t splitting_factor) {
   auto cache = create_origami_cache(problem, hardware, config, hardware.N_CU);
   return estimate_l2_hit(problem, hardware, config, splitting_factor, cache);
 }
@@ -447,22 +447,22 @@ double estimate_l2_hit(const problem_t& problem,
   return std::max(0.0, std::min(l2_hit_rate, 1.0));
 }
 
-// Estimate MALL hit-rate, also return mall tile
-std::tuple<double, size_t, size_t> estimate_mall_hit(const problem_t& problem,
-                                                     const hardware_t& hardware,
-                                                     const config_t& config,
-                                                     size_t num_active_cus,
-                                                     size_t splitting_factor) {
+// Estimate MALL hit-rate
+double estimate_mall_hit(const problem_t& problem,
+                         const hardware_t& hardware,
+                         const config_t& config,
+                         size_t num_active_cus,
+                         size_t splitting_factor) {
   auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
   return estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor);
 }
 
-std::tuple<double, size_t, size_t> estimate_mall_hit(const problem_t& problem,
-                                                     const hardware_t& hardware,
-                                                     const config_t& config,
-                                                     size_t num_active_cus,
-                                                     size_t splitting_factor,
-                                                     const origami_cache_t& cache) {
+double estimate_mall_hit(const problem_t& problem,
+                         const hardware_t& hardware,
+                         const config_t& config,
+                         size_t num_active_cus,
+                         size_t splitting_factor,
+                         const origami_cache_t& cache) {
   const size_t workgroups_m = cache.grid_m;
   const size_t workgroups_n = cache.grid_n;
 
@@ -506,7 +506,7 @@ std::tuple<double, size_t, size_t> estimate_mall_hit(const problem_t& problem,
   double mall_hit_rate = static_cast<double>(cached_reads) / static_cast<double>(total_reads);
 
   // Clamp the final result to the valid [0, 1] range.
-  return {std::max(0.0, std::min(mall_hit_rate, 1.0)), mall_tile_m, mall_tile_n};
+  return std::max(0.0, std::min(mall_hit_rate, 1.0));
 }
 
 /**

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -454,7 +454,7 @@ double estimate_mall_hit(const problem_t& problem,
                          size_t num_active_cus,
                          size_t splitting_factor) {
   auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
-  return estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor);
+  return estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor, cache);
 }
 
 double estimate_mall_hit(const problem_t& problem,
@@ -625,7 +625,7 @@ double compute_memory_latency(const problem_t& problem,
   // 2) Estimate mall hit-rate
   double H_mem2 =
       hardware.has_MALL()
-          ? estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor)
+          ? estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor, cache)
           : 0.0;  // MALL is not supported, so we emulate every read as a miss
 
   // 3) Total loads are loads from A and loads from B

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -22,6 +22,109 @@
 #include "origami/streamk.hpp"
 
 namespace origami {
+
+origami_cache_t create_origami_cache(const problem_t& problem,
+                                     const hardware_t& hardware,
+                                     const config_t& config,
+                                     std::size_t num_active_cus);
+
+kernel_cache_t create_kernel_cache(const problem_t& problem,
+                                   const hardware_t& hardware,
+                                   const config_t& config);
+
+double compute_l2_hit_rate_global_cache(const problem_t& problem,
+                                        const hardware_t& hardware,
+                                        const config_t& config,
+                                        size_t l2_capacity_bytes,
+                                        const origami_cache_t& cache);
+
+double estimate_l2_hit_cache(const problem_t& problem,
+                             const hardware_t& hardware,
+                             const config_t& config,
+                             std::size_t splitting_factor,
+                             const origami_cache_t& cache);
+
+double estimate_mall_hit_cache(const problem_t& problem,
+                               const hardware_t& hardware,
+                               const config_t& config,
+                               std::size_t num_active_cus,
+                               std::size_t splitting_factor,
+                               const origami_cache_t& cache);
+
+double compute_memory_latency_cache(const problem_t& problem,
+                                    const hardware_t& hardware,
+                                    const config_t& config,
+                                    std::size_t num_active_cus,
+                                    std::size_t splitting_factor,
+                                    const origami_cache_t& cache);
+
+double compute_tile_latency_cache(const problem_t& problem,
+                                  const hardware_t& hardware,
+                                  const config_t& config,
+                                  std::size_t num_active_cus,
+                                  std::size_t splitting_factor,
+                                  const origami_cache_t& cache);
+
+double compute_timestep_latency_cache(const problem_t& problem,
+                                      const hardware_t& hardware,
+                                      const config_t& config,
+                                      std::size_t num_active_cus,
+                                      std::size_t splitting_factor,
+                                      const origami_cache_t& cache);
+
+double compute_l2_hit_rate_global(const problem_t& problem,
+                                  const hardware_t& hardware,
+                                  const config_t& config,
+                                  size_t l2_capacity_bytes) {
+  auto cache = create_origami_cache(problem, hardware, config, hardware.N_CU);
+  return compute_l2_hit_rate_global_cache(problem, hardware, config, l2_capacity_bytes, cache);
+}
+
+double estimate_l2_hit(const problem_t& problem,
+                       const hardware_t& hardware,
+                       const config_t& config,
+                       size_t splitting_factor) {
+  auto cache = create_origami_cache(problem, hardware, config, hardware.N_CU);
+  return estimate_l2_hit_cache(problem, hardware, config, splitting_factor, cache);
+}
+
+double estimate_mall_hit(const problem_t& problem,
+                         const hardware_t& hardware,
+                         const config_t& config,
+                         size_t num_active_cus,
+                         size_t splitting_factor) {
+  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
+  return estimate_mall_hit_cache(problem, hardware, config, num_active_cus, splitting_factor, cache);
+}
+
+double compute_memory_latency(const problem_t& problem,
+                              const hardware_t& hardware,
+                              const config_t& config,
+                              std::size_t num_active_cus,
+                              std::size_t splitting_factor) {
+  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
+  return compute_memory_latency_cache(problem, hardware, config, num_active_cus, splitting_factor, cache);
+}
+
+double compute_tile_latency(const problem_t& problem,
+                            const hardware_t& hardware,
+                            const config_t& config,
+                            std::size_t num_active_cus,
+                            std::size_t splitting_factor) {
+  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
+  return compute_tile_latency_cache(problem, hardware, config, num_active_cus, splitting_factor, cache);
+}
+
+double compute_timestep_latency(const problem_t& problem,
+                                const hardware_t& hardware,
+                                const config_t& config,
+                                std::size_t num_active_cus,
+                                std::size_t splitting_factor) {
+  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
+  return compute_timestep_latency_cache(problem, hardware, config, num_active_cus, splitting_factor, cache);
+}
+
+
 double calculate_work_utilization(const problem_t& problem, const config_t& config) {
   const size_t M = problem.size.m;
   const size_t N = problem.size.n;
@@ -360,19 +463,11 @@ double compute_mem_bw_from_occupancy(const hardware_t& hardware, size_t num_acti
   return std::min(bw_limited, 1.0);
 }
 
-double estimate_l2_hit(const problem_t& problem,
-                       const hardware_t& hardware,
-                       const config_t& config,
-                       size_t splitting_factor) {
-  auto cache = create_origami_cache(problem, hardware, config, hardware.N_CU);
-  return estimate_l2_hit(problem, hardware, config, splitting_factor, cache);
-}
-
-double estimate_l2_hit(const problem_t& problem,
-                       const hardware_t& hardware,
-                       const config_t& config,
-                       size_t splitting_factor,
-                       const origami_cache_t& cache) {
+double estimate_l2_hit_cache(const problem_t& problem,
+                             const hardware_t& hardware,
+                             const config_t& config,
+                             size_t splitting_factor,
+                             const origami_cache_t& cache) {
   // Use size_t for dimensions and counts to ensure type safety.
   const size_t workgroups_m     = cache.grid_m;
   const size_t workgroups_n     = cache.grid_n;
@@ -449,21 +544,12 @@ double estimate_l2_hit(const problem_t& problem,
 }
 
 // Estimate MALL hit-rate
-double estimate_mall_hit(const problem_t& problem,
-                         const hardware_t& hardware,
-                         const config_t& config,
-                         size_t num_active_cus,
-                         size_t splitting_factor) {
-  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
-  return estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor, cache);
-}
-
-double estimate_mall_hit(const problem_t& problem,
-                         const hardware_t& hardware,
-                         const config_t& config,
-                         size_t num_active_cus,
-                         size_t splitting_factor,
-                         const origami_cache_t& cache) {
+double estimate_mall_hit_cache(const problem_t& problem,
+                               const hardware_t& hardware,
+                               const config_t& config,
+                               size_t num_active_cus,
+                               size_t splitting_factor,
+                               const origami_cache_t& cache) {
   const size_t workgroups_m = cache.grid_m;
   const size_t workgroups_n = cache.grid_n;
 
@@ -514,19 +600,11 @@ double estimate_mall_hit(const problem_t& problem,
  * @brief L2 hit rate from a global (problem-wide) perspective using the refactored API.
  * Computes in BYTES to correctly handle differing A/B dtypes.
  */
-double compute_l2_hit_rate_global(const problem_t& problem,
-                                  const hardware_t& hardware,
-                                  const config_t& config,
-                                  size_t l2_capacity_bytes) {
-  auto cache = create_origami_cache(problem, hardware, config, hardware.N_CU);
-  return compute_l2_hit_rate_global(problem, hardware, config, l2_capacity_bytes);
-}
-
-double compute_l2_hit_rate_global(const problem_t& problem,
-                                  const hardware_t& hardware,
-                                  const config_t& config,
-                                  size_t l2_capacity_bytes,
-                                  const origami_cache_t& cache) {
+double compute_l2_hit_rate_global_cache(const problem_t& problem,
+                                        const hardware_t& hardware,
+                                        const config_t& config,
+                                        size_t l2_capacity_bytes,
+                                        const origami_cache_t& cache) {
   // --- Hardware Parameters (as requested, defined locally) ---
   // You would normally get l2_capacity_bytes from your hardware_t struct.
   if (l2_capacity_bytes == 0) throw std::runtime_error("L2 Capacity is zero");
@@ -581,22 +659,13 @@ size_t round_elements_to_128B(size_t elements, size_t element_size_bits) {
   return round_up_mul(elements, E_block);
 }
 
-double compute_memory_latency(const problem_t& problem,
-                              const hardware_t& hardware,
-                              const config_t& config,
-                              std::size_t num_active_cus,
-                              std::size_t splitting_factor) {
-  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
-  return compute_memory_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
-}
-
 // Determine the memory latency
-double compute_memory_latency(const problem_t& problem,
-                              const hardware_t& hardware,
-                              const config_t& config,
-                              std::size_t num_active_cus,
-                              std::size_t splitting_factor,
-                              const origami_cache_t& cache) {
+double compute_memory_latency_cache(const problem_t& problem,
+                                    const hardware_t& hardware,
+                                    const config_t& config,
+                                    std::size_t num_active_cus,
+                                    std::size_t splitting_factor,
+                                    const origami_cache_t& cache) {
   // Extract parameters from structured types
   const auto a_bytes = cache.kernel_cache.a_bytes;
   const auto b_bytes = cache.kernel_cache.b_bytes;
@@ -612,12 +681,12 @@ double compute_memory_latency(const problem_t& problem,
   const size_t MT_K = config.mt.k;
 
   // 1) Estimate L2 hit-rate
-  double H_mem1 = estimate_l2_hit(problem, hardware, config, splitting_factor, cache);
+  double H_mem1 = estimate_l2_hit_cache(problem, hardware, config, splitting_factor, cache);
 
   // Global cap on L2 hit-rate (prevents impossible cache residency claims)
   // (Assumes capacity is given in KiB, convert to bytes)
   double H_mem1_global =
-      compute_l2_hit_rate_global(problem, hardware, config, hardware.L2_capacity * 1024, cache);
+      compute_l2_hit_rate_global_cache(problem, hardware, config, hardware.L2_capacity * 1024, cache);
 
   H_mem1 = std::min(H_mem1, H_mem1_global);
 
@@ -626,7 +695,7 @@ double compute_memory_latency(const problem_t& problem,
   // 2) Estimate mall hit-rate
   double H_mem2 =
       hardware.has_MALL()
-          ? estimate_mall_hit(problem, hardware, config, num_active_cus, splitting_factor, cache)
+          ? estimate_mall_hit_cache(problem, hardware, config, num_active_cus, splitting_factor, cache)
           : 0.0;  // MALL is not supported, so we emulate every read as a miss
 
   // 3) Total loads are loads from A and loads from B
@@ -697,22 +766,12 @@ double compute_memory_latency(const problem_t& problem,
 /* ---------------------------------------------------------------------------------------- */
 /* Tile-related functions                                                                   */
 /* ---------------------------------------------------------------------------------------- */
-
-double compute_tile_latency(const problem_t& problem,
-                            const hardware_t& hardware,
-                            const config_t& config,
-                            std::size_t num_active_cus,
-                            std::size_t splitting_factor) {
-  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
-  return compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
-}
-
-double compute_tile_latency(const problem_t& problem,
-                            const hardware_t& hardware,
-                            const config_t& config,
-                            std::size_t num_active_cus,
-                            std::size_t splitting_factor,
-                            const origami_cache_t& cache) {
+double compute_tile_latency_cache(const problem_t& problem,
+                                  const hardware_t& hardware,
+                                  const config_t& config,
+                                  std::size_t num_active_cus,
+                                  std::size_t splitting_factor,
+                                  const origami_cache_t& cache) {
   // Extract parameters from structured types
   const size_t K = problem.size.k;
   size_t batch   = problem.batch;
@@ -728,7 +787,7 @@ double compute_tile_latency(const problem_t& problem,
   // 1) Compute per-tile latencies
   double L_compute = cache.kernel_cache.mt_compute_latency;
 
-  double L_mem = compute_memory_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
+  double L_mem = compute_memory_latency_cache(problem, hardware, config, num_active_cus, splitting_factor, cache);
 
   // TODO Does work utilization need to be 128-byte rounded for a cache line?
   double utilization        = calculate_work_utilization(problem, config);
@@ -821,23 +880,14 @@ double compute_tile_latency(const problem_t& problem,
   return L_tile_total;
 }
 
-double compute_timestep_latency(const problem_t& problem,
-                                const hardware_t& hardware,
-                                const config_t& config,
-                                std::size_t num_active_cus,
-                                std::size_t splitting_factor) {
-  auto cache = create_origami_cache(problem, hardware, config, num_active_cus);
-  return compute_timestep_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
-}
-
-double compute_timestep_latency(const problem_t& problem,
-                                const hardware_t& hardware,
-                                const config_t& config,
-                                std::size_t num_active_cus,
-                                std::size_t splitting_factor,
-                                const origami_cache_t& cache) {
+double compute_timestep_latency_cache(const problem_t& problem,
+                                      const hardware_t& hardware,
+                                      const config_t& config,
+                                      std::size_t num_active_cus,
+                                      std::size_t splitting_factor,
+                                      const origami_cache_t& cache) {
   // Assume latency of a timestep is latency of a single K-complete output tile computed on one CU.
-  double L_timestep = compute_tile_latency(problem, hardware, config, num_active_cus, splitting_factor, cache);
+  double L_timestep = compute_tile_latency_cache(problem, hardware, config, num_active_cus, splitting_factor, cache);
 
   return L_timestep;
 }
@@ -1036,7 +1086,7 @@ double compute_total_latency(const problem_t& problem,
   auto cache = create_origami_cache(problem, hardware, config_with_default_wgm, num_active_cus);
 
   // 2) Compute latency of a timestep
-  double L_timestep = compute_timestep_latency(
+  double L_timestep = compute_timestep_latency_cache(
       problem, hardware, config_with_default_wgm, num_active_cus, splitting_factor, cache);
 
   // Compute latency for all timesteps and return it as the latency for the MT/problem

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -12,6 +12,7 @@
 #include <set>
 #include <stdexcept>
 #include <tuple>
+#include <mutex>
 
 #include "origami/hardware.hpp"
 #include "origami/math.hpp"
@@ -944,8 +945,8 @@ origami_cache_t create_origami_cache(const problem_t& problem,
   };
 
   static std::unordered_map<key_t, kernel_cache_t, key_hasher_t, key_compare_t> kernel_cache_map;
-  // static std::mutex mut;
-  // std::unique_lock<std::mutex> lock(mut);
+  static std::mutex mut;
+  std::unique_lock<std::mutex> lock(mut);
   auto p_cache_entry = kernel_cache_map.find(key);
   if (p_cache_entry == kernel_cache_map.end())
     p_cache_entry = kernel_cache_map.insert({key, create_kernel_cache(problem_type, hardware, config)}).first;
@@ -991,6 +992,16 @@ double compute_total_latency(const problem_t& problem,
   // We don't need to compute latency for all MTs. With this, we can shortcut.
   bool shortCircuit = true;
   if (shortCircuit) {
+    // When problem dimensions are small enough that we can fit them in one tile, we should do
+    // so. This short circuit condition also decreases selection latency when problems are very
+    // small :)
+    // TODO 256 and 256 here should be largest M and N tile dimensions in library
+    if (M <= 256 && N <= 256 && K < 1024 && batch != 1 && (MT_M < M || MT_N < N))
+      return std::numeric_limits<double>::max();
+
+    // Use Dot2 only for M < 3
+    if (MI_M == 1 && MI_N == 1 && MI_K == 64 && M > 2) return std::numeric_limits<double>::max();
+
     size_t K_mod_128bytes    = K * a_bits % 1024;
     size_t MT_K_mod_128bytes = MT_K * a_bits % 1024;
     if (K_mod_128bytes == 0 && MT_K_mod_128bytes == 0) {
@@ -1010,17 +1021,6 @@ double compute_total_latency(const problem_t& problem,
     } else if (config.cache_hints_a || config.cache_hints_b) {
       return std::numeric_limits<double>::max();
     }
-
-    // When problem dimensions are small enough that we can fit them in one tile, we should do
-    // so. This short circuit condition also decreases selection latency when problems are very
-    // small :)
-    // TODO 256 and 256 here should be largest M and N tile dimensions in library
-    if (batch != 1 && M <= 256 && N <= 256 && K < 1024 && (MT_M < M || MT_N < N))
-      return std::numeric_limits<double>::max();
-
-    // Use Dot2 only for M < 3
-    if (MI_M == 1 && MI_N == 1 && MI_K == 64 && M > 2)
-      return std::numeric_limits<double>::max();
   }
 
   // 1-1) To compute the latency, use default WGM. And WGM can't be greater than one
@@ -1035,12 +1035,11 @@ double compute_total_latency(const problem_t& problem,
 
   auto cache = create_origami_cache(problem, hardware, config_with_default_wgm, num_active_cus);
 
-  // 2) Compute latency of a wave
-  // Compute latency of a wave
+  // 2) Compute latency of a timestep
   double L_timestep = compute_timestep_latency(
       problem, hardware, config_with_default_wgm, num_active_cus, splitting_factor, cache);
 
-  // Compute latency for all waves and return it as the latency for the MT/problem
+  // Compute latency for all timesteps and return it as the latency for the MT/problem
   double total_latency = L_timestep * num_timesteps;
 
   // 3) Customized heuristics

--- a/shared/origami/src/origami/hardware.cpp
+++ b/shared/origami/src/origami/hardware.cpp
@@ -121,19 +121,19 @@ size_t hardware_t::get_mi_latency(size_t MI_M,
                                   size_t MI_N,
                                   size_t MI_K,
                                   data_type_t mi_input_type) const {
-  const auto& instruction_map = INSTRUCTION_MAP.at(arch);
-  auto key                    = matrix_instruction(MI_M, MI_N, MI_K, mi_input_type);
-
-  auto it = instruction_map.find(key);
-  if (it != instruction_map.end()) {
-    return it->second / parallel_mi_cu;
-  } else {
-    if (origami::runtime_options().get().debug_enabled)
-      std::cerr << "Warning: Latency not found for MI_M=" << MI_M << ", MI_N=" << MI_N
-                << ", MI_K=" << MI_K << ", mi_input_type=" << datatype_to_string(mi_input_type)
-                << ". Returning latency value of 32 (really slow).\n";
-    return 32 / parallel_mi_cu;  // Default latency if instruction is not found
+  auto it_arch_map = INSTRUCTION_MAP.find(arch);
+  if (it_arch_map != INSTRUCTION_MAP.end()) {
+    const auto& instruction_map = it_arch_map->second;
+    auto key                    = matrix_instruction(MI_M, MI_N, MI_K, mi_input_type);
+    auto it = instruction_map.find(key);
+    if (it != instruction_map.end())
+      return it->second / parallel_mi_cu;
   }
+  if (origami::runtime_options().get().debug_enabled)
+    std::cerr << "Warning: Latency not found for MI_M=" << MI_M << ", MI_N=" << MI_N
+              << ", MI_K=" << MI_K << ", mi_input_type=" << datatype_to_string(mi_input_type)
+              << ". Returning latency value of 32 (really slow).\n";
+  return 32 / parallel_mi_cu;  // Default latency if instruction is not found
 }
 
 double hardware_t::get_adjusted_main_loop_efficiency(transpose_t transA,
@@ -142,17 +142,19 @@ double hardware_t::get_adjusted_main_loop_efficiency(transpose_t transA,
                                                      size_t MT_N,
                                                      size_t MT_K,
                                                      data_type_t mi_input_type) const {
-  const auto& cms_map = CMS_MAP.at(arch);
-  auto key            = CMS_kernel(mi_input_type, transA, transB, MT_M, MT_N, MT_K);
-  auto it = cms_map.find(key);
-  if (it != cms_map.end()) {
-    if (origami::runtime_options().get().debug_enabled) {
-      std::cout << "Found " << key.to_string() << " with efficiency " << it->second << "\n";
+  auto it_arch_map = CMS_MAP.find(arch);
+  if (it_arch_map != CMS_MAP.end()) {
+    const auto& cms_map = it_arch_map->second;
+    auto key            = CMS_kernel(mi_input_type, transA, transB, MT_M, MT_N, MT_K);
+    auto it = cms_map.find(key);
+    if (it != cms_map.end()) {
+      if (origami::runtime_options().get().debug_enabled) {
+        std::cout << "Found " << key.to_string() << " with efficiency " << it->second << "\n";
+      }
+      return it->second;
     }
-    return it->second;
-  } else {
-    return 1.0;  // Default main loop efficiency
   }
+  return 1.0;  // Default main loop efficiency
 }
 
 bool hardware_t::has_MALL() const {

--- a/shared/origami/src/origami/origami.cpp
+++ b/shared/origami/src/origami/origami.cpp
@@ -6,7 +6,6 @@
 #include <cmath>
 #include <iomanip>
 #include <iostream>
-#include <mutex>
 
 #include "origami/gemm.hpp"
 #include "origami/math.hpp"

--- a/shared/origami/src/origami/origami.cpp
+++ b/shared/origami/src/origami/origami.cpp
@@ -272,7 +272,8 @@ std::vector<prediction_result_t> rank_configs(const problem_t& problem,
   static std::unordered_map<problem_t, std::vector<kernel_cache_t>> kernel_cache_map;
   static std::mutex mut;
   std::unique_lock<std::mutex> lock(mut);
-  auto p_cache_entry = kernel_cache_map.find(problem_type);
+  bool use_cache = get_runtime_options().cache_kernel_info;
+  auto p_cache_entry = use_cache ? kernel_cache_map.find(problem_type) : kernel_cache_map.end();
   if (p_cache_entry == kernel_cache_map.end()) {
     std::vector<kernel_cache_t> caches;
     caches.reserve(configs.size());
@@ -297,6 +298,7 @@ std::vector<prediction_result_t> rank_configs(const problem_t& problem,
     if (latency != std::numeric_limits<double>::max())
       latencies_configs.push_back({latency, std::cref(configs[i])});
   }
+  if(!use_cache) kernel_cache_map.clear();
   lock.unlock();
 
   if (latencies_configs.empty()) { throw std::runtime_error("No valid configs found."); }

--- a/shared/origami/src/origami/origami.cpp
+++ b/shared/origami/src/origami/origami.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <iomanip>
 #include <iostream>
+#include <mutex>
 
 #include "origami/gemm.hpp"
 #include "origami/math.hpp"
@@ -264,33 +265,56 @@ std::vector<prediction_result_t> rank_configs(const problem_t& problem,
                                               const std::vector<config_t>& configs) {
   if (configs.empty()) { throw std::runtime_error("No configurations provided."); }
 
-  std::vector<prediction_result_t> results(configs.size());
+  auto problem_type = problem;
+  problem_type.batch = 0;
+  problem_type.size = {0, 0, 0};
 
-  std::transform(configs.begin(),
-                 configs.end(),
-                 results.begin(),
-                 [&](const config_t& config) -> prediction_result_t {
-                   if (!check_lds_capacity(hardware, config.mt, problem.a_dtype, problem.b_dtype)) {
-                     return {std::numeric_limits<double>::max(), config};
-                   }
-                   double latency = compute_total_latency(problem, hardware, config, hardware.N_CU);
-                   return {latency, config};
-                 });
+  static std::unordered_map<problem_t, std::vector<kernel_cache_t>> kernel_cache_map;
+  static std::mutex mut;
+  std::unique_lock<std::mutex> lock(mut);
+  auto p_cache_entry = kernel_cache_map.find(problem_type);
+  if (p_cache_entry == kernel_cache_map.end()) {
+    std::vector<kernel_cache_t> caches;
+    caches.reserve(configs.size());
+    for (auto& config : configs)
+      caches.push_back(create_kernel_cache(problem_type, hardware, config));
+    p_cache_entry = kernel_cache_map.insert({problem_type, caches}).first;
+  }
+  auto& cache_entry = p_cache_entry->second;
 
-  results.erase(std::remove_if(results.begin(),
-                               results.end(),
-                               [](const prediction_result_t& p) {
-                                 return p.latency == std::numeric_limits<double>::max();
-                               }),
-                results.end());
+  struct prediction_result_wrapper_t {
+    double latency;
+    std::reference_wrapper<const config_t> config;
+  };
 
-  std::stable_sort(results.begin(),
-                   results.end(),
-                   [](const prediction_result_t& a, const prediction_result_t& b) {
+  std::vector<prediction_result_wrapper_t> latencies_configs;
+  latencies_configs.reserve(configs.size());
+
+  for (std::size_t i = 0; i < configs.size(); i++) {
+    if (!cache_entry[i].fits_lds_capacity)
+      continue;
+    double latency = compute_total_latency(problem, hardware, configs[i], cache_entry[i], hardware.N_CU);
+    if (latency != std::numeric_limits<double>::max())
+      latencies_configs.push_back({latency, std::cref(configs[i])});
+  }
+  lock.unlock();
+
+  if (latencies_configs.empty()) { throw std::runtime_error("No valid configs found."); }
+
+  std::stable_sort(latencies_configs.begin(),
+                   latencies_configs.end(),
+                   [](const auto& a, const auto& b) {
                      return a.latency < b.latency;
                    });
 
-  if (results.empty()) { throw std::runtime_error("No valid configs found."); }
+  std::vector<prediction_result_t> results;
+  results.reserve(latencies_configs.size());
+  std::transform(latencies_configs.begin(),
+                 latencies_configs.end(),
+                 std::back_inserter(results),
+                 [&](const auto& r) -> prediction_result_t {
+                   return {r.latency, r.config.get()};
+                 });
 
   // Compute arithmetic intensity for tie-breaking
   // Flops = 2 * MT_M * MT_N * MT_K, Memory traffic = MT_M*MT_K + MT_K*MT_N + MT_M*MT_N

--- a/shared/origami/src/origami/origami.cpp
+++ b/shared/origami/src/origami/origami.cpp
@@ -265,24 +265,6 @@ std::vector<prediction_result_t> rank_configs(const problem_t& problem,
                                               const std::vector<config_t>& configs) {
   if (configs.empty()) { throw std::runtime_error("No configurations provided."); }
 
-  auto problem_type = problem;
-  problem_type.batch = 0;
-  problem_type.size = {0, 0, 0};
-
-  static std::unordered_map<problem_t, std::vector<kernel_cache_t>> kernel_cache_map;
-  static std::mutex mut;
-  std::unique_lock<std::mutex> lock(mut);
-  bool use_cache = get_runtime_options().cache_kernel_info;
-  auto p_cache_entry = use_cache ? kernel_cache_map.find(problem_type) : kernel_cache_map.end();
-  if (p_cache_entry == kernel_cache_map.end()) {
-    std::vector<kernel_cache_t> caches;
-    caches.reserve(configs.size());
-    for (auto& config : configs)
-      caches.push_back(create_kernel_cache(problem_type, hardware, config));
-    p_cache_entry = kernel_cache_map.insert({problem_type, caches}).first;
-  }
-  auto& cache_entry = p_cache_entry->second;
-
   struct prediction_result_wrapper_t {
     double latency;
     std::reference_wrapper<const config_t> config;
@@ -291,15 +273,13 @@ std::vector<prediction_result_t> rank_configs(const problem_t& problem,
   std::vector<prediction_result_wrapper_t> latencies_configs;
   latencies_configs.reserve(configs.size());
 
-  for (std::size_t i = 0; i < configs.size(); i++) {
-    if (!cache_entry[i].fits_lds_capacity)
+  for (auto& config : configs) {
+    if (!check_lds_capacity(hardware, config.mt, problem.a_dtype, problem.b_dtype))
       continue;
-    double latency = compute_total_latency(problem, hardware, configs[i], cache_entry[i], hardware.N_CU);
+    double latency = compute_total_latency(problem, hardware, config, hardware.N_CU);
     if (latency != std::numeric_limits<double>::max())
-      latencies_configs.push_back({latency, std::cref(configs[i])});
+      latencies_configs.push_back({latency, std::cref(config)});
   }
-  if(!use_cache) kernel_cache_map.clear();
-  lock.unlock();
 
   if (latencies_configs.empty()) { throw std::runtime_error("No valid configs found."); }
 

--- a/shared/origami/src/origami/streamk.cpp
+++ b/shared/origami/src/origami/streamk.cpp
@@ -307,8 +307,9 @@ size_t grid_analytical(const problem_t& problem,
   size_t best_split   = 1;
   double best_latency = std::numeric_limits<double>::infinity();
 
+  auto cache = create_kernel_cache(problem, hardware, config);
   for (size_t split = 1; split <= MAX_SPLIT; ++split) {
-    double latency = compute_total_latency(problem, hardware, config, max_cus);
+    double latency = compute_total_latency(problem, hardware, config, cache, max_cus);
 
     if (latency < best_latency) {
       best_latency = latency;

--- a/shared/origami/src/origami/streamk.cpp
+++ b/shared/origami/src/origami/streamk.cpp
@@ -307,9 +307,9 @@ size_t grid_analytical(const problem_t& problem,
   size_t best_split   = 1;
   double best_latency = std::numeric_limits<double>::infinity();
 
-  auto cache = create_kernel_cache(problem, hardware, config);
+  // auto cache = create_kernel_cache(problem, hardware, config);
   for (size_t split = 1; split <= MAX_SPLIT; ++split) {
-    double latency = compute_total_latency(problem, hardware, config, cache, max_cus);
+    double latency = compute_total_latency(problem, hardware, config, max_cus);
 
     if (latency < best_latency) {
       best_latency = latency;

--- a/shared/origami/src/origami/streamk.cpp
+++ b/shared/origami/src/origami/streamk.cpp
@@ -332,6 +332,8 @@ size_t grid_k_split_aware(const problem_t& problem,
                           size_t max_cus) {
   size_t tiles = compute_number_of_output_tiles(
       config.mt.m, config.mt.n, problem.size.m, problem.size.n, problem.batch);
+  if (tiles == 0)
+    return 0;
 
   size_t sk_grid = tiles;  // Fallback if no good fractional tile is found
   if (max_cus > 0) sk_grid = std::min(sk_grid, max_cus);

--- a/shared/origami/src/origami/streamk.cpp
+++ b/shared/origami/src/origami/streamk.cpp
@@ -307,7 +307,6 @@ size_t grid_analytical(const problem_t& problem,
   size_t best_split   = 1;
   double best_latency = std::numeric_limits<double>::infinity();
 
-  // auto cache = create_kernel_cache(problem, hardware, config);
   for (size_t split = 1; split <= MAX_SPLIT; ++split) {
     double latency = compute_total_latency(problem, hardware, config, max_cus);
 

--- a/shared/origami/tests/test_gemm.cpp
+++ b/shared/origami/tests/test_gemm.cpp
@@ -1035,7 +1035,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
 
       // Test 3: Test with different problem sizes and different config
       problem = make_problem(8193, 2047, 4096);
-      config  = make_config(128, 128, 128, 32, 32, 8, 1);
+      config  = make_config(128, 128, 128, 32, 32, 8, false, 1);
       cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
       cache.splitting_factor = 1;
       auto result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, cache);
@@ -1045,7 +1045,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
         REQUIRE(result_different_problem_sizes == Approx(0.484).epsilon(1e-3));
 
       problem = make_problem(8193, 4093, 1024);
-      config  = make_config(64, 128, 128, 32, 32, 8, 1);
+      config  = make_config(64, 128, 128, 32, 32, 8, false, 1);
       cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
       cache.splitting_factor = 1;
       result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, cache);
@@ -1055,7 +1055,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
         REQUIRE(result_different_problem_sizes == Approx(0.6458).epsilon(1e-3));
 
       problem = make_problem(8193, 2047, 4096);
-      config  = make_config(256, 128, 64, 32, 32, 8, 1);
+      config  = make_config(256, 128, 64, 32, 32, 8, false, 1);
       cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
       cache.splitting_factor = 1;
       std::tie(result_different_problem_sizes, mall_m, mall_n) =
@@ -1066,7 +1066,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
         REQUIRE(result_different_problem_sizes == Approx(0.9065).epsilon(1e-3));
 
       problem = make_problem(8193, 4093, 1024);
-      config  = make_config(128, 256, 128, 32, 32, 8, 1);
+      config  = make_config(128, 256, 128, 32, 32, 8, false, 1);
       cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
       cache.splitting_factor = 1;
       std::tie(result_different_problem_sizes, mall_m, mall_n) =
@@ -1078,7 +1078,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
 
       // Test 4: Test edge cases (very small/large problems)
       problem                = make_problem(10, 11, 253);
-      config                 = make_config(256, 256, 64, 32, 32, 8, 1);
+      config                 = make_config(256, 256, 64, 32, 32, 8, false, 1);
       cache                  = create_origami_cache(problem, hardware, config, hardware.N_CU);
       cache.splitting_factor = 1;
       auto result_edge_cases = origami::estimate_l2_hit(problem, hardware, config, cache);

--- a/shared/origami/tests/test_gemm.cpp
+++ b/shared/origami/tests/test_gemm.cpp
@@ -24,7 +24,7 @@
  *
  *******************************************************************************/
 
-#include <catch2/catch_approx.hpp>
+ #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include "common.hpp"
@@ -251,41 +251,49 @@ TEST_CASE("GEMM: estimate_mall_hit", "[gemm]") {
 TEST_CASE("GEMM: calculate_work_utilization unit test", "[gemm]") {
   for (int gpu_arch : test_architectures) {
     DYNAMIC_SECTION("gfx" << gpu_arch << " - calculate_work_utilization unit test") {
-      auto problem = make_problem(4096, 4096, 1024);
-      auto config  = make_config(256, 256, 64, 32, 32, 8, false, 1);
+      auto problem  = make_problem(4096, 4096, 1024);
+      auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
+      auto hardware = make_hardware(gpu_arch);
+      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
       // Test 1: Test with perfect tile alignment (should return 1.0)
-      auto result = origami::calculate_work_utilization(problem, config);
+      auto result = origami::calculate_work_utilization(problem, config, cache);
       REQUIRE(result == 1.0);
 
       // Test 2: Test with non-aligned dimensions
       auto problem_non_aligned = make_problem(4351, 3839, 959);
-      auto result_non_aligned  = origami::calculate_work_utilization(problem_non_aligned, config);
+      cache = create_origami_cache(problem_non_aligned, hardware, config, hardware.N_CU);
+      auto result_non_aligned  = origami::calculate_work_utilization(problem_non_aligned, config, cache);
       REQUIRE(result_non_aligned == Approx(0.998).epsilon(1e-3));
 
       // Test 3: Test with zero dimensions (should return 1.0)
       auto problem_zero_dimensions = make_problem(0, 3839, 959);
+      cache = create_origami_cache(problem_zero_dimensions, hardware, config, hardware.N_CU);
       auto result_zero_dimensions =
-          origami::calculate_work_utilization(problem_zero_dimensions, config);
+          origami::calculate_work_utilization(problem_zero_dimensions, config, cache);
       REQUIRE(result_zero_dimensions == 1.0);
 
       // Test 4: Test with very small problems
       auto problem_very_small = make_problem(10, 20, 15);
-      auto result_very_small  = origami::calculate_work_utilization(problem_very_small, config);
+      cache = create_origami_cache(problem_very_small, hardware, config, hardware.N_CU);
+      auto result_very_small  = origami::calculate_work_utilization(problem_very_small, config, cache);
       REQUIRE(result_very_small == Approx(0.0007152).epsilon(1e-4));
 
       // Test 5: Test with very large problems
       auto problem_very_large = make_problem(409601, 409601, 4095);
-      auto result_very_large  = origami::calculate_work_utilization(problem_very_large, config);
+      cache = create_origami_cache(problem_very_large, hardware, config, hardware.N_CU);
+      auto result_very_large  = origami::calculate_work_utilization(problem_very_large, config, cache);
       REQUIRE(result_very_large == Approx(0.998).epsilon(1e-3));
 
       // Test 6: Test with skinny matrices
       auto problem_skinny = make_problem(128, 81920, 1024);  // Small M, Big N
-      auto result_skinny  = origami::calculate_work_utilization(problem_skinny, config);
+      cache = create_origami_cache(problem_skinny, hardware, config, hardware.N_CU);
+      auto result_skinny  = origami::calculate_work_utilization(problem_skinny, config, cache);
       REQUIRE(result_skinny == 0.5);
 
       problem_skinny = make_problem(81920, 128, 1024);  // Small N, Big M
-      result_skinny  = origami::calculate_work_utilization(problem_skinny, config);
+      cache = create_origami_cache(problem_skinny, hardware, config, hardware.N_CU);
+      result_skinny  = origami::calculate_work_utilization(problem_skinny, config, cache);
       REQUIRE(result_skinny == 0.5);
     }
   }
@@ -704,30 +712,34 @@ TEST_CASE("GEMM: compute_l2_hit_rate_global unit test", "[gemm]") {
       auto hardware = make_hardware(gpu_arch);
       auto problem  = make_problem(2047, 2047, 4096);
       auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
+      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
       // Test 1: Test with various problem sizes
       auto result_various_problem_sizes = origami::compute_l2_hit_rate_global(
-          problem, hardware, config, hardware.L2_capacity * 1024);
+          problem, hardware, config, cache, hardware.L2_capacity * 1024);
       REQUIRE(result_various_problem_sizes == 0.875);
 
       auto problem_small           = make_problem(331, 4077, 547);
+      cache                        = create_origami_cache(problem_small, hardware, config, hardware.N_CU);
       result_various_problem_sizes = origami::compute_l2_hit_rate_global(
-          problem_small, hardware, config, hardware.L2_capacity * 1024);
+          problem_small, hardware, config, cache, hardware.L2_capacity * 1024);
       REQUIRE(result_various_problem_sizes == 0.71875);
 
       auto problem_large           = make_problem(8193, 4077, 7453);
+      cache                        = create_origami_cache(problem_large, hardware, config, hardware.N_CU);
       result_various_problem_sizes = origami::compute_l2_hit_rate_global(
-          problem_large, hardware, config, hardware.L2_capacity * 1024);
+          problem_large, hardware, config, cache, hardware.L2_capacity * 1024);
       REQUIRE(result_various_problem_sizes == Approx(0.953).epsilon(1e-3));
 
       // Test 2: Test with different splitting factors (TODO)(is this a valid test case as this
       // function does not use splitting factors) Test 3: Test edge cases
-      REQUIRE_THROWS_WITH(origami::compute_l2_hit_rate_global(problem, hardware, config, 0UL),
+      REQUIRE_THROWS_WITH(origami::compute_l2_hit_rate_global(problem, hardware, config, cache, 0UL),
                           "L2 Capacity is zero");
 
       auto problem_zero = make_problem(0, 0, 7453);
+      cache             = create_origami_cache(problem_zero, hardware, config, hardware.N_CU);
       REQUIRE_THROWS_WITH(origami::compute_l2_hit_rate_global(
-                              problem_zero, hardware, config, hardware.L2_capacity * 1024),
+                              problem_zero, hardware, config, cache, hardware.L2_capacity * 1024),
                           "estimate_l2_hit grid dimensions can not be zero");
     }
   }
@@ -985,44 +997,58 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       auto hardware = make_hardware(gpu_arch);
       auto problem  = make_problem(2047, 2047, 4096);
       auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
+      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
       // Test 1: Test with different workgroup_mapping values (TODO)
 
       // Test 2: Test with various splitting factors
+      cache.splitting_factor = 0;
       auto result_different_splitting_factors =
-          origami::estimate_l2_hit(problem, hardware, config, 0);
+          origami::estimate_l2_hit(problem, hardware, config, cache);
       REQUIRE(result_different_splitting_factors == 0.0);
 
-      result_different_splitting_factors = origami::estimate_l2_hit(problem, hardware, config, 1);
+      cache.splitting_factor = 1;
+      result_different_splitting_factors = origami::estimate_l2_hit(problem, hardware, config, cache);
       REQUIRE(result_different_splitting_factors == 0.4375);
 
-      result_different_splitting_factors = origami::estimate_l2_hit(problem, hardware, config, -1);
+      cache.splitting_factor = -1;
+      result_different_splitting_factors = origami::estimate_l2_hit(problem, hardware, config, cache);
       REQUIRE(result_different_splitting_factors == 0.0);
 
-      result_different_splitting_factors =
-          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 0);
+      cache.splitting_factor = 0;
+      size_t mall_m, mall_n;
+      std::tie(result_different_splitting_factors, mall_m, mall_n) =
+          origami::estimate_mall_hit(problem, hardware, config, cache);
       REQUIRE(result_different_splitting_factors == 0.875);
 
-      result_different_splitting_factors =
-          origami::estimate_mall_hit(problem, hardware, config, 256, 1);
+      cache = create_origami_cache(problem, hardware, config, 256);
+      cache.splitting_factor = 1;
+      std::tie(result_different_splitting_factors, mall_m, mall_n) =
+          origami::estimate_mall_hit(problem, hardware, config, cache);
       REQUIRE(result_different_splitting_factors == 0.875);
 
-      result_different_splitting_factors =
-          origami::estimate_mall_hit(problem, hardware, config, 200, -1);
+      cache = create_origami_cache(problem, hardware, config, 200);
+      cache.splitting_factor = -1;
+      std::tie(result_different_splitting_factors, mall_m, mall_n) =
+          origami::estimate_mall_hit(problem, hardware, config, cache);
       REQUIRE(result_different_splitting_factors == 0.875);
 
       // Test 3: Test with different problem sizes and different config
-      problem                             = make_problem(8193, 2047, 4096);
-      config                              = make_config(128, 128, 128, 32, 32, 8, 1);
-      auto result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, 1);
+      problem = make_problem(8193, 2047, 4096);
+      config  = make_config(128, 128, 128, 32, 32, 8, 1);
+      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
+      cache.splitting_factor = 1;
+      auto result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, cache);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.4868).epsilon(1e-3));
       else if (gpu_arch == 950)
         REQUIRE(result_different_problem_sizes == Approx(0.484).epsilon(1e-3));
 
-      problem                        = make_problem(8193, 4093, 1024);
-      config                         = make_config(64, 128, 128, 32, 32, 8, 1);
-      result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, 1);
+      problem = make_problem(8193, 4093, 1024);
+      config  = make_config(64, 128, 128, 32, 32, 8, 1);
+      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
+      cache.splitting_factor = 1;
+      result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, cache);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.649).epsilon(1e-3));
       else if (gpu_arch == 950)
@@ -1030,8 +1056,10 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
 
       problem = make_problem(8193, 2047, 4096);
       config  = make_config(256, 128, 64, 32, 32, 8, 1);
-      result_different_problem_sizes =
-          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
+      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
+      cache.splitting_factor = 1;
+      std::tie(result_different_problem_sizes, mall_m, mall_n) =
+          origami::estimate_mall_hit(problem, hardware, config, cache);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.923).epsilon(1e-3));
       else if (gpu_arch == 950)
@@ -1039,8 +1067,10 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
 
       problem = make_problem(8193, 4093, 1024);
       config  = make_config(128, 256, 128, 32, 32, 8, 1);
-      result_different_problem_sizes =
-          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
+      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
+      cache.splitting_factor = 1;
+      std::tie(result_different_problem_sizes, mall_m, mall_n) =
+          origami::estimate_mall_hit(problem, hardware, config, cache);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.923).epsilon(1e-3));
       else if (gpu_arch == 950)
@@ -1049,22 +1079,32 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       // Test 4: Test edge cases (very small/large problems)
       problem                = make_problem(10, 11, 253);
       config                 = make_config(256, 256, 64, 32, 32, 8, 1);
-      auto result_edge_cases = origami::estimate_l2_hit(problem, hardware, config, 1);
+      cache                  = create_origami_cache(problem, hardware, config, hardware.N_CU);
+      cache.splitting_factor = 1;
+      auto result_edge_cases = origami::estimate_l2_hit(problem, hardware, config, cache);
       REQUIRE(result_edge_cases == 0.0);
 
-      problem           = make_problem(81930, 40930, 10240);
-      result_edge_cases = origami::estimate_l2_hit(problem, hardware, config, 1);
+      problem                = make_problem(81930, 40930, 10240);
+      cache                  = create_origami_cache(problem, hardware, config, hardware.N_CU);
+      cache.splitting_factor = 1;
+      result_edge_cases = origami::estimate_l2_hit(problem, hardware, config, cache);
       if (gpu_arch == 942)
         REQUIRE(result_edge_cases == Approx(0.4868).epsilon(1e-3));
       else if (gpu_arch == 950)
         REQUIRE(result_edge_cases == Approx(0.484).epsilon(1e-3));
 
-      problem           = make_problem(10, 11, 253);
-      result_edge_cases = origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
+      problem = make_problem(10, 11, 253);
+      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
+      cache.splitting_factor = 1;
+      std::tie(result_edge_cases, mall_m, mall_n) =
+          origami::estimate_mall_hit(problem, hardware, config, cache);
       REQUIRE(result_edge_cases == 0.0);
 
-      problem           = make_problem(81930, 40930, 10240);
-      result_edge_cases = origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
+      problem = make_problem(81930, 40930, 10240);
+      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
+      cache.splitting_factor = 1;
+      std::tie(result_edge_cases, mall_m, mall_n) =
+          origami::estimate_mall_hit(problem, hardware, config, cache);
       REQUIRE(result_edge_cases == Approx(0.498).epsilon(1e-3));
     }
   }

--- a/shared/origami/tests/test_gemm.cpp
+++ b/shared/origami/tests/test_gemm.cpp
@@ -124,13 +124,10 @@ TEST_CASE("GEMM: compute_memory_latency", "[gemm]") {
       auto config_small = make_config(128, 128, 64, 32, 32, 8, false, 8);
       auto config_large = make_config(256, 256, 128, 32, 32, 8, false, 8);
 
-      auto cache_small  = create_origami_cache(problem, hardware, config_small, hardware.N_CU);
-      auto cache_large  = create_origami_cache(problem, hardware, config_large, hardware.N_CU);
-
       auto mem_latency_small =
-          origami::compute_memory_latency(problem, hardware, config_small, cache_small);
+          origami::compute_memory_latency(problem, hardware, config_small, 304, 2);
       auto mem_latency_large =
-          origami::compute_memory_latency(problem, hardware, config_large, cache_large);
+          origami::compute_memory_latency(problem, hardware, config_large, 304, 2);
 
       REQUIRE(mem_latency_small < mem_latency_large);
     }
@@ -146,13 +143,10 @@ TEST_CASE("GEMM: compute_tile_latency", "[gemm]") {
       auto config_small = make_config(128, 128, 64, 32, 32, 8, false, 6);
       auto config_large = make_config(256, 256, 128, 32, 32, 8, false, 6);
 
-      auto cache_small  = create_origami_cache(problem, hardware, config_small, hardware.N_CU);
-      auto cache_large  = create_origami_cache(problem, hardware, config_large, hardware.N_CU);
-
       auto tile_latency_small =
-          origami::compute_tile_latency(problem, hardware, config_small, cache_small);
+          origami::compute_tile_latency(problem, hardware, config_small, 304, 3);
       auto tile_latency_large =
-          origami::compute_tile_latency(problem, hardware, config_large, cache_large);
+          origami::compute_tile_latency(problem, hardware, config_large, 304, 3);
 
       REQUIRE(tile_latency_large > tile_latency_small);
     }
@@ -166,10 +160,9 @@ TEST_CASE("GEMM: compute_timestep_latency", "[gemm]") {
       auto problem =
           make_problem(4096, 4096, 1024, origami::transpose_t::T, origami::transpose_t::N, 2);
       auto config = make_config(128, 128, 64, 32, 32, 8, false, 8);
-      auto cache  = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
-      auto tile_latency = origami::compute_tile_latency(problem, hardware, config, cache);
-      auto timestep_latency = origami::compute_timestep_latency(problem, hardware, config, cache);
+      auto tile_latency = origami::compute_tile_latency(problem, hardware, config, 304, 4);
+      auto timestep_latency = origami::compute_timestep_latency(problem, hardware, config, 304, 4);
 
       REQUIRE(timestep_latency == Approx(tile_latency));
     }
@@ -216,11 +209,10 @@ TEST_CASE("GEMM: estimate_l2_hit", "[gemm]") {
       auto hardware = make_hardware(gpu_arch);
       auto problem  = make_problem(4096, 4096, 1024);
       auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
-      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
       for (int wgm = 1; wgm < 1025; wgm++) {
         config.workgroup_mapping = wgm;
-        auto l2_hit              = origami::estimate_l2_hit(problem, hardware, config, cache);
+        auto l2_hit              = origami::estimate_l2_hit(problem, hardware, config, 3);
         REQUIRE(l2_hit > 0.0);
         REQUIRE(l2_hit < 1.0);
       }
@@ -234,11 +226,10 @@ TEST_CASE("GEMM: estimate_mall_hit", "[gemm]") {
       auto hardware = make_hardware(gpu_arch);
       auto problem  = make_problem(4096, 4096, 1024);
       auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
-      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
       for (int wgm = 1; wgm < 1025; wgm++) {
         config.workgroup_mapping        = wgm;
-        auto [mall_hit, mall_m, mall_n] = origami::estimate_mall_hit(problem, hardware, config, cache);
+        auto [mall_hit, mall_m, mall_n] = origami::estimate_mall_hit(problem, hardware, config, 304, 8);
         REQUIRE(mall_hit > 0.0);
         REQUIRE(mall_m <= hardware.N_CU);
         REQUIRE(mall_n <= hardware.N_CU);
@@ -251,49 +242,41 @@ TEST_CASE("GEMM: estimate_mall_hit", "[gemm]") {
 TEST_CASE("GEMM: calculate_work_utilization unit test", "[gemm]") {
   for (int gpu_arch : test_architectures) {
     DYNAMIC_SECTION("gfx" << gpu_arch << " - calculate_work_utilization unit test") {
-      auto problem  = make_problem(4096, 4096, 1024);
-      auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
-      auto hardware = make_hardware(gpu_arch);
-      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
+      auto problem = make_problem(4096, 4096, 1024);
+      auto config  = make_config(256, 256, 64, 32, 32, 8, false, 1);
 
       // Test 1: Test with perfect tile alignment (should return 1.0)
-      auto result = origami::calculate_work_utilization(problem, config, cache);
+      auto result = origami::calculate_work_utilization(problem, config);
       REQUIRE(result == 1.0);
 
       // Test 2: Test with non-aligned dimensions
       auto problem_non_aligned = make_problem(4351, 3839, 959);
-      cache = create_origami_cache(problem_non_aligned, hardware, config, hardware.N_CU);
-      auto result_non_aligned  = origami::calculate_work_utilization(problem_non_aligned, config, cache);
+      auto result_non_aligned  = origami::calculate_work_utilization(problem_non_aligned, config);
       REQUIRE(result_non_aligned == Approx(0.998).epsilon(1e-3));
 
       // Test 3: Test with zero dimensions (should return 1.0)
       auto problem_zero_dimensions = make_problem(0, 3839, 959);
-      cache = create_origami_cache(problem_zero_dimensions, hardware, config, hardware.N_CU);
       auto result_zero_dimensions =
-          origami::calculate_work_utilization(problem_zero_dimensions, config, cache);
+          origami::calculate_work_utilization(problem_zero_dimensions, config);
       REQUIRE(result_zero_dimensions == 1.0);
 
       // Test 4: Test with very small problems
       auto problem_very_small = make_problem(10, 20, 15);
-      cache = create_origami_cache(problem_very_small, hardware, config, hardware.N_CU);
-      auto result_very_small  = origami::calculate_work_utilization(problem_very_small, config, cache);
+      auto result_very_small  = origami::calculate_work_utilization(problem_very_small, config);
       REQUIRE(result_very_small == Approx(0.0007152).epsilon(1e-4));
 
       // Test 5: Test with very large problems
       auto problem_very_large = make_problem(409601, 409601, 4095);
-      cache = create_origami_cache(problem_very_large, hardware, config, hardware.N_CU);
-      auto result_very_large  = origami::calculate_work_utilization(problem_very_large, config, cache);
+      auto result_very_large  = origami::calculate_work_utilization(problem_very_large, config);
       REQUIRE(result_very_large == Approx(0.998).epsilon(1e-3));
 
       // Test 6: Test with skinny matrices
       auto problem_skinny = make_problem(128, 81920, 1024);  // Small M, Big N
-      cache = create_origami_cache(problem_skinny, hardware, config, hardware.N_CU);
-      auto result_skinny  = origami::calculate_work_utilization(problem_skinny, config, cache);
+      auto result_skinny  = origami::calculate_work_utilization(problem_skinny, config);
       REQUIRE(result_skinny == 0.5);
 
       problem_skinny = make_problem(81920, 128, 1024);  // Small N, Big M
-      cache = create_origami_cache(problem_skinny, hardware, config, hardware.N_CU);
-      result_skinny  = origami::calculate_work_utilization(problem_skinny, config, cache);
+      result_skinny  = origami::calculate_work_utilization(problem_skinny, config);
       REQUIRE(result_skinny == 0.5);
     }
   }
@@ -712,34 +695,30 @@ TEST_CASE("GEMM: compute_l2_hit_rate_global unit test", "[gemm]") {
       auto hardware = make_hardware(gpu_arch);
       auto problem  = make_problem(2047, 2047, 4096);
       auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
-      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
       // Test 1: Test with various problem sizes
       auto result_various_problem_sizes = origami::compute_l2_hit_rate_global(
-          problem, hardware, config, cache, hardware.L2_capacity * 1024);
+          problem, hardware, config, hardware.L2_capacity * 1024);
       REQUIRE(result_various_problem_sizes == 0.875);
 
       auto problem_small           = make_problem(331, 4077, 547);
-      cache                        = create_origami_cache(problem_small, hardware, config, hardware.N_CU);
       result_various_problem_sizes = origami::compute_l2_hit_rate_global(
-          problem_small, hardware, config, cache, hardware.L2_capacity * 1024);
+          problem_small, hardware, config, hardware.L2_capacity * 1024);
       REQUIRE(result_various_problem_sizes == 0.71875);
 
       auto problem_large           = make_problem(8193, 4077, 7453);
-      cache                        = create_origami_cache(problem_large, hardware, config, hardware.N_CU);
       result_various_problem_sizes = origami::compute_l2_hit_rate_global(
-          problem_large, hardware, config, cache, hardware.L2_capacity * 1024);
+          problem_large, hardware, config, hardware.L2_capacity * 1024);
       REQUIRE(result_various_problem_sizes == Approx(0.953).epsilon(1e-3));
 
       // Test 2: Test with different splitting factors (TODO)(is this a valid test case as this
       // function does not use splitting factors) Test 3: Test edge cases
-      REQUIRE_THROWS_WITH(origami::compute_l2_hit_rate_global(problem, hardware, config, cache, 0UL),
+      REQUIRE_THROWS_WITH(origami::compute_l2_hit_rate_global(problem, hardware, config, 0UL),
                           "L2 Capacity is zero");
 
       auto problem_zero = make_problem(0, 0, 7453);
-      cache             = create_origami_cache(problem_zero, hardware, config, hardware.N_CU);
       REQUIRE_THROWS_WITH(origami::compute_l2_hit_rate_global(
-                              problem_zero, hardware, config, cache, hardware.L2_capacity * 1024),
+                              problem_zero, hardware, config, hardware.L2_capacity * 1024),
                           "estimate_l2_hit grid dimensions can not be zero");
     }
   }
@@ -997,61 +976,45 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       auto hardware = make_hardware(gpu_arch);
       auto problem  = make_problem(2047, 2047, 4096);
       auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
-      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
       // Test 1: Test with different workgroup_mapping values (TODO)
 
       // Test 2: Test with various splitting factors
-      cache.splitting_factor = 0;
       auto result_different_splitting_factors =
-          origami::estimate_l2_hit(problem, hardware, config, cache);
+          origami::estimate_l2_hit(problem, hardware, config, 0);
       REQUIRE(result_different_splitting_factors == 0.0);
 
-      cache.splitting_factor = 1;
-      result_different_splitting_factors = origami::estimate_l2_hit(problem, hardware, config, cache);
+      result_different_splitting_factors = origami::estimate_l2_hit(problem, hardware, config, 1);
       REQUIRE(result_different_splitting_factors == 0.4375);
 
-      cache.splitting_factor = -1;
-      result_different_splitting_factors = origami::estimate_l2_hit(problem, hardware, config, cache);
+      result_different_splitting_factors = origami::estimate_l2_hit(problem, hardware, config, -1);
       REQUIRE(result_different_splitting_factors == 0.0);
 
-      cache.splitting_factor = 0;
-      cache.num_active_cus   = hardware.N_CU;
-      size_t mall_m, mall_n;
+      std::size_t mall_m, mall_n;
       std::tie(result_different_splitting_factors, mall_m, mall_n) =
-          origami::estimate_mall_hit(problem, hardware, config, cache);
+          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 0);
       REQUIRE(result_different_splitting_factors == 0.875);
 
-      cache = create_origami_cache(problem, hardware, config, 256);
-      cache.splitting_factor = 1;
-      cache.num_active_cus   = 256;
       std::tie(result_different_splitting_factors, mall_m, mall_n) =
-          origami::estimate_mall_hit(problem, hardware, config, cache);
+          origami::estimate_mall_hit(problem, hardware, config, 256, 1);
       REQUIRE(result_different_splitting_factors == 0.875);
 
-      cache = create_origami_cache(problem, hardware, config, 200);
-      cache.splitting_factor = -1;
-      cache.num_active_cus   = 200;
       std::tie(result_different_splitting_factors, mall_m, mall_n) =
-          origami::estimate_mall_hit(problem, hardware, config, cache);
+          origami::estimate_mall_hit(problem, hardware, config, 200, -1);
       REQUIRE(result_different_splitting_factors == 0.875);
 
       // Test 3: Test with different problem sizes and different config
-      problem = make_problem(8193, 2047, 4096);
-      config  = make_config(128, 128, 128, 32, 32, 8, false, 1);
-      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
-      cache.splitting_factor = 1;
-      auto result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, cache);
+      problem                             = make_problem(8193, 2047, 4096);
+      config                              = make_config(128, 128, 128, 32, 32, 8, false, 1);
+      auto result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, 1);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.4868).epsilon(1e-3));
       else if (gpu_arch == 950)
         REQUIRE(result_different_problem_sizes == Approx(0.484).epsilon(1e-3));
 
-      problem = make_problem(8193, 4093, 1024);
-      config  = make_config(64, 128, 128, 32, 32, 8, false, 1);
-      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
-      cache.splitting_factor = 1;
-      result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, cache);
+      problem                        = make_problem(8193, 4093, 1024);
+      config                         = make_config(64, 128, 128, 32, 32, 8, false, 1);
+      result_different_problem_sizes = origami::estimate_l2_hit(problem, hardware, config, 1);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.649).epsilon(1e-3));
       else if (gpu_arch == 950)
@@ -1059,11 +1022,8 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
 
       problem = make_problem(8193, 2047, 4096);
       config  = make_config(256, 128, 64, 32, 32, 8, false, 1);
-      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
-      cache.splitting_factor = 1;
-      cache.num_active_cus   = hardware.N_CU;
       std::tie(result_different_problem_sizes, mall_m, mall_n) =
-          origami::estimate_mall_hit(problem, hardware, config, cache);
+          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.923).epsilon(1e-3));
       else if (gpu_arch == 950)
@@ -1071,11 +1031,8 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
 
       problem = make_problem(8193, 4093, 1024);
       config  = make_config(128, 256, 128, 32, 32, 8, false, 1);
-      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
-      cache.splitting_factor = 1;
-      cache.num_active_cus   = hardware.N_CU;
       std::tie(result_different_problem_sizes, mall_m, mall_n) =
-          origami::estimate_mall_hit(problem, hardware, config, cache);
+          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.923).epsilon(1e-3));
       else if (gpu_arch == 950)
@@ -1084,34 +1041,24 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       // Test 4: Test edge cases (very small/large problems)
       problem                = make_problem(10, 11, 253);
       config                 = make_config(256, 256, 64, 32, 32, 8, false, 1);
-      cache                  = create_origami_cache(problem, hardware, config, hardware.N_CU);
-      cache.splitting_factor = 1;
-      auto result_edge_cases = origami::estimate_l2_hit(problem, hardware, config, cache);
+      auto result_edge_cases = origami::estimate_l2_hit(problem, hardware, config, 1);
       REQUIRE(result_edge_cases == 0.0);
 
-      problem                = make_problem(81930, 40930, 10240);
-      cache                  = create_origami_cache(problem, hardware, config, hardware.N_CU);
-      cache.splitting_factor = 1;
-      result_edge_cases = origami::estimate_l2_hit(problem, hardware, config, cache);
+      problem           = make_problem(81930, 40930, 10240);
+      result_edge_cases = origami::estimate_l2_hit(problem, hardware, config, 1);
       if (gpu_arch == 942)
         REQUIRE(result_edge_cases == Approx(0.4868).epsilon(1e-3));
       else if (gpu_arch == 950)
         REQUIRE(result_edge_cases == Approx(0.484).epsilon(1e-3));
 
-      problem = make_problem(10, 11, 253);
-      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
-      cache.splitting_factor = 1;
-      cache.num_active_cus   = hardware.N_CU;
-      std::tie(result_edge_cases, mall_m, mall_n) =
-          origami::estimate_mall_hit(problem, hardware, config, cache);
+      problem           = make_problem(10, 11, 253);
+      std::tie(result_edge_cases, mall_m, mall_n) = 
+          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       REQUIRE(result_edge_cases == 0.0);
 
-      problem = make_problem(81930, 40930, 10240);
-      cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
-      cache.splitting_factor = 1;
-      cache.num_active_cus   = hardware.N_CU;
+      problem           = make_problem(81930, 40930, 10240);
       std::tie(result_edge_cases, mall_m, mall_n) =
-          origami::estimate_mall_hit(problem, hardware, config, cache);
+          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       REQUIRE(result_edge_cases == Approx(0.498).epsilon(1e-3));
     }
   }

--- a/shared/origami/tests/test_gemm.cpp
+++ b/shared/origami/tests/test_gemm.cpp
@@ -124,10 +124,13 @@ TEST_CASE("GEMM: compute_memory_latency", "[gemm]") {
       auto config_small = make_config(128, 128, 64, 32, 32, 8, false, 8);
       auto config_large = make_config(256, 256, 128, 32, 32, 8, false, 8);
 
+      auto cache_small  = create_origami_cache(problem, hardware, config_small, hardware.N_CU);
+      auto cache_large  = create_origami_cache(problem, hardware, config_large, hardware.N_CU);
+
       auto mem_latency_small =
-          origami::compute_memory_latency(problem, hardware, config_small, 304, 2);
+          origami::compute_memory_latency(problem, hardware, config_small, cache_small);
       auto mem_latency_large =
-          origami::compute_memory_latency(problem, hardware, config_large, 304, 2);
+          origami::compute_memory_latency(problem, hardware, config_large, cache_large);
 
       REQUIRE(mem_latency_small < mem_latency_large);
     }
@@ -143,10 +146,13 @@ TEST_CASE("GEMM: compute_tile_latency", "[gemm]") {
       auto config_small = make_config(128, 128, 64, 32, 32, 8, false, 6);
       auto config_large = make_config(256, 256, 128, 32, 32, 8, false, 6);
 
+      auto cache_small  = create_origami_cache(problem, hardware, config_small, hardware.N_CU);
+      auto cache_large  = create_origami_cache(problem, hardware, config_large, hardware.N_CU);
+
       auto tile_latency_small =
-          origami::compute_tile_latency(problem, hardware, config_small, 304, 3);
+          origami::compute_tile_latency(problem, hardware, config_small, cache_small);
       auto tile_latency_large =
-          origami::compute_tile_latency(problem, hardware, config_large, 304, 3);
+          origami::compute_tile_latency(problem, hardware, config_large, cache_large);
 
       REQUIRE(tile_latency_large > tile_latency_small);
     }
@@ -160,9 +166,10 @@ TEST_CASE("GEMM: compute_timestep_latency", "[gemm]") {
       auto problem =
           make_problem(4096, 4096, 1024, origami::transpose_t::T, origami::transpose_t::N, 2);
       auto config = make_config(128, 128, 64, 32, 32, 8, false, 8);
+      auto cache  = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
-      auto tile_latency = origami::compute_tile_latency(problem, hardware, config, 304, 4);
-      auto timestep_latency = origami::compute_timestep_latency(problem, hardware, config, 304, 4);
+      auto tile_latency = origami::compute_tile_latency(problem, hardware, config, cache);
+      auto timestep_latency = origami::compute_timestep_latency(problem, hardware, config, cache);
 
       REQUIRE(timestep_latency == Approx(tile_latency));
     }
@@ -209,10 +216,11 @@ TEST_CASE("GEMM: estimate_l2_hit", "[gemm]") {
       auto hardware = make_hardware(gpu_arch);
       auto problem  = make_problem(4096, 4096, 1024);
       auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
+      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
       for (int wgm = 1; wgm < 1025; wgm++) {
         config.workgroup_mapping = wgm;
-        auto l2_hit              = origami::estimate_l2_hit(problem, hardware, config, 3);
+        auto l2_hit              = origami::estimate_l2_hit(problem, hardware, config, cache);
         REQUIRE(l2_hit > 0.0);
         REQUIRE(l2_hit < 1.0);
       }
@@ -226,11 +234,14 @@ TEST_CASE("GEMM: estimate_mall_hit", "[gemm]") {
       auto hardware = make_hardware(gpu_arch);
       auto problem  = make_problem(4096, 4096, 1024);
       auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
+      auto cache    = create_origami_cache(problem, hardware, config, hardware.N_CU);
 
       for (int wgm = 1; wgm < 1025; wgm++) {
-        config.workgroup_mapping = wgm;
-        auto mall_hit            = origami::estimate_mall_hit(problem, hardware, config, 304, 8);
+        config.workgroup_mapping        = wgm;
+        auto [mall_hit, mall_m, mall_n] = origami::estimate_mall_hit(problem, hardware, config, cache);
         REQUIRE(mall_hit > 0.0);
+        REQUIRE(mall_m <= hardware.N_CU);
+        REQUIRE(mall_n <= hardware.N_CU);
       }
     }
   }

--- a/shared/origami/tests/test_gemm.cpp
+++ b/shared/origami/tests/test_gemm.cpp
@@ -1064,8 +1064,6 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       cache.num_active_cus   = hardware.N_CU;
       std::tie(result_different_problem_sizes, mall_m, mall_n) =
           origami::estimate_mall_hit(problem, hardware, config, cache);
-      result_different_problem_sizes =
-          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.923).epsilon(1e-3));
       else if (gpu_arch == 950)

--- a/shared/origami/tests/test_gemm.cpp
+++ b/shared/origami/tests/test_gemm.cpp
@@ -1016,6 +1016,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       REQUIRE(result_different_splitting_factors == 0.0);
 
       cache.splitting_factor = 0;
+      cache.num_active_cus   = hardware.N_CU;
       size_t mall_m, mall_n;
       std::tie(result_different_splitting_factors, mall_m, mall_n) =
           origami::estimate_mall_hit(problem, hardware, config, cache);
@@ -1023,12 +1024,14 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
 
       cache = create_origami_cache(problem, hardware, config, 256);
       cache.splitting_factor = 1;
+      cache.num_active_cus   = 256;
       std::tie(result_different_splitting_factors, mall_m, mall_n) =
           origami::estimate_mall_hit(problem, hardware, config, cache);
       REQUIRE(result_different_splitting_factors == 0.875);
 
       cache = create_origami_cache(problem, hardware, config, 200);
       cache.splitting_factor = -1;
+      cache.num_active_cus   = 200;
       std::tie(result_different_splitting_factors, mall_m, mall_n) =
           origami::estimate_mall_hit(problem, hardware, config, cache);
       REQUIRE(result_different_splitting_factors == 0.875);
@@ -1058,8 +1061,11 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       config  = make_config(256, 128, 64, 32, 32, 8, false, 1);
       cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
       cache.splitting_factor = 1;
+      cache.num_active_cus   = hardware.N_CU;
       std::tie(result_different_problem_sizes, mall_m, mall_n) =
           origami::estimate_mall_hit(problem, hardware, config, cache);
+      result_different_problem_sizes =
+          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.923).epsilon(1e-3));
       else if (gpu_arch == 950)
@@ -1069,6 +1075,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       config  = make_config(128, 256, 128, 32, 32, 8, false, 1);
       cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
       cache.splitting_factor = 1;
+      cache.num_active_cus   = hardware.N_CU;
       std::tie(result_different_problem_sizes, mall_m, mall_n) =
           origami::estimate_mall_hit(problem, hardware, config, cache);
       if (gpu_arch == 942)
@@ -1096,6 +1103,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       problem = make_problem(10, 11, 253);
       cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
       cache.splitting_factor = 1;
+      cache.num_active_cus   = hardware.N_CU;
       std::tie(result_edge_cases, mall_m, mall_n) =
           origami::estimate_mall_hit(problem, hardware, config, cache);
       REQUIRE(result_edge_cases == 0.0);
@@ -1103,6 +1111,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       problem = make_problem(81930, 40930, 10240);
       cache   = create_origami_cache(problem, hardware, config, hardware.N_CU);
       cache.splitting_factor = 1;
+      cache.num_active_cus   = hardware.N_CU;
       std::tie(result_edge_cases, mall_m, mall_n) =
           origami::estimate_mall_hit(problem, hardware, config, cache);
       REQUIRE(result_edge_cases == Approx(0.498).epsilon(1e-3));

--- a/shared/origami/tests/test_gemm.cpp
+++ b/shared/origami/tests/test_gemm.cpp
@@ -24,7 +24,7 @@
  *
  *******************************************************************************/
 
- #include <catch2/catch_approx.hpp>
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include "common.hpp"
@@ -228,11 +228,9 @@ TEST_CASE("GEMM: estimate_mall_hit", "[gemm]") {
       auto config   = make_config(256, 256, 64, 32, 32, 8, false, 1);
 
       for (int wgm = 1; wgm < 1025; wgm++) {
-        config.workgroup_mapping        = wgm;
-        auto [mall_hit, mall_m, mall_n] = origami::estimate_mall_hit(problem, hardware, config, 304, 8);
+        config.workgroup_mapping = wgm;
+        auto mall_hit            = origami::estimate_mall_hit(problem, hardware, config, 304, 8);
         REQUIRE(mall_hit > 0.0);
-        REQUIRE(mall_m <= hardware.N_CU);
-        REQUIRE(mall_n <= hardware.N_CU);
       }
     }
   }
@@ -990,16 +988,15 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
       result_different_splitting_factors = origami::estimate_l2_hit(problem, hardware, config, -1);
       REQUIRE(result_different_splitting_factors == 0.0);
 
-      std::size_t mall_m, mall_n;
-      std::tie(result_different_splitting_factors, mall_m, mall_n) =
+      result_different_splitting_factors =
           origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 0);
       REQUIRE(result_different_splitting_factors == 0.875);
 
-      std::tie(result_different_splitting_factors, mall_m, mall_n) =
+      result_different_splitting_factors =
           origami::estimate_mall_hit(problem, hardware, config, 256, 1);
       REQUIRE(result_different_splitting_factors == 0.875);
 
-      std::tie(result_different_splitting_factors, mall_m, mall_n) =
+      result_different_splitting_factors =
           origami::estimate_mall_hit(problem, hardware, config, 200, -1);
       REQUIRE(result_different_splitting_factors == 0.875);
 
@@ -1022,7 +1019,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
 
       problem = make_problem(8193, 2047, 4096);
       config  = make_config(256, 128, 64, 32, 32, 8, false, 1);
-      std::tie(result_different_problem_sizes, mall_m, mall_n) =
+      result_different_problem_sizes =
           origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.923).epsilon(1e-3));
@@ -1031,7 +1028,7 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
 
       problem = make_problem(8193, 4093, 1024);
       config  = make_config(128, 256, 128, 32, 32, 8, false, 1);
-      std::tie(result_different_problem_sizes, mall_m, mall_n) =
+      result_different_problem_sizes =
           origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       if (gpu_arch == 942)
         REQUIRE(result_different_problem_sizes == Approx(0.923).epsilon(1e-3));
@@ -1052,13 +1049,11 @@ TEST_CASE("GEMM: estimate_l2_hit and  estimate_mall_hit unit test", "[gemm]") {
         REQUIRE(result_edge_cases == Approx(0.484).epsilon(1e-3));
 
       problem           = make_problem(10, 11, 253);
-      std::tie(result_edge_cases, mall_m, mall_n) = 
-          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
+      result_edge_cases = origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       REQUIRE(result_edge_cases == 0.0);
 
       problem           = make_problem(81930, 40930, 10240);
-      std::tie(result_edge_cases, mall_m, mall_n) =
-          origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
+      result_edge_cases = origami::estimate_mall_hit(problem, hardware, config, hardware.N_CU, 1);
       REQUIRE(result_edge_cases == Approx(0.498).epsilon(1e-3));
     }
   }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Improve Origami solution selection time by storing and reusing some quantities.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Add a struct `origami::origami_cache_t` to store variables used throughout the different origami routines, such as grid_m, to prevent recomputing these multiple times. These things can depend on the problem and the config. The origami_cache_t is passed around to all origami internal routines as the now new last argument. The original routines, not accepting the cache, now create the cache and then call the new routine with the cache as last argument.
- Add an `origami::kernel_cache_t` struct with variables that depend on the config and the problem type, where problem type is everything stored in the origami::problem_t except for the actual problem size and batch_count. This is for instance the TF32 conversion overhead, the macrotile compute latency, the mainloop efficiency. This kernel_cache_t is stored in a static map so it can be reused for the next call to origami::compute_total_latency with the same combination of problem_type and config. A kernel_cache_t object is stored in the origami_cache_t object passed around origami.
- In origami::rank_configs, do the sort with `reference_wrapper<const config_t>` instead of the original config_t's to reduce memory movement. Don't add configs to the vector for which the latency is Inf, to speedup the sort and avoid the erase.
- Store an `int index` member in `origami::config_t`, which can be set by the user to quickly retrieve the best solution corresponding to the first config in the sorted vector returned by `origami:rank_configs`. This index is used internally in Origami to quickly get a good hash of the config to lookup the config's cached variables.
- In origami::config_t removed the `cms_kernel` member, as it is not used since there is also the `custom_mainloop_scheduling` member.
- In test_gemm, fix some calls to `make_config` to set CMS to false instead of setting it to 1 (1 was meant for WGM?) (did not affect test outcome)
- In `streamk::grid_k_split_aware` avoid potential division by zero
- In `hardware_t::get_adjusted_main_loop_efficiency` check whether the hardware is in the map, if not return 1
- In `hardware_t::get_mi_latency` check whether the hardware is in the map, otherwise print warning, return large value
- Introduce `origami::math::hash_combine`. Combination with ^ (xor) leads to conflicts, for instance `N ^ T == T ^ N`.
- In CachingLibrary use `map.insert_or_assign` instead of `map.count` followed by emplace or assign to avoid double map lookup.



## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Should be covered by existing tests.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
