### PR TITLE
[ci] Bump TheRock CI 2026-02-02

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 56d71ec3450f87a888ef56da0673ca09a6b56450 # 2026-01-27 commit
+          ref: c2d46f9f6ede1c6e58255cda08c193f0a3714e12 # 2026-02-02 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 56d71ec3450f87a888ef56da0673ca09a6b56450 # 2026-01-27 commit
+          ref: c2d46f9f6ede1c6e58255cda08c193f0a3714e12 # 2026-02-02 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 56d71ec3450f87a888ef56da0673ca09a6b56450 # 2026-01-27 commit
+          ref: c2d46f9f6ede1c6e58255cda08c193f0a3714e12 # 2026-02-02 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 56d71ec3450f87a888ef56da0673ca09a6b56450 # 2026-01-27 commit
+          ref: c2d46f9f6ede1c6e58255cda08c193f0a3714e12 # 2026-02-02 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 56d71ec3450f87a888ef56da0673ca09a6b56450 # 2026-01-27 commit
+          ref: c2d46f9f6ede1c6e58255cda08c193f0a3714e12 # 2026-02-02 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: 56d71ec3450f87a888ef56da0673ca09a6b56450 # 2026-01-27 commit
+          ref: c2d46f9f6ede1c6e58255cda08c193f0a3714e12 # 2026-02-02 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 56d71ec3450f87a888ef56da0673ca09a6b56450 # 2026-01-27 commit
+          ref: c2d46f9f6ede1c6e58255cda08c193f0a3714e12 # 2026-02-02 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
## Motivation

Update to 2026-02-02 TheRock SHA for latest Origami build support. Ref: https://github.com/ROCm/rocm-libraries/pull/4195.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.