### PR TITLE
[hipDNN] Update Dockerfile to use `install_rocm_from_artifacts.py` and `--latest-release` option

### DIFF
--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -44,7 +44,8 @@ RUN apt-get update && apt-get install -y \
 # ============================================================================
 # Prebuilt stage - downloads and extracts dev env prebuilt binaries tarball
 #
-# Uses install_rocm_from_artifacts.py for downloading ROCm artifacts.
+# New path: uses install_rocm_from_artifacts.py for downloading ROCm artifacts.
+# Legacy path: uses wget/tar when deprecated args are set (backward compat).
 #
 # Example: Default build (latest nightly for gfx94X-dcgpu):
 #   docker build -f Dockerfile.ubuntu24 -t hipdnn:prebuilt .
@@ -74,33 +75,54 @@ ARG THEROCK_RELEASE=latest
 # Full artifact group (combines ASIC and variant)
 ARG THEROCK_ARTIFACT_GROUP=$THEROCK_ASIC-$THEROCK_ASIC_VARIANT
 
+# Deprecated build args (kept for backward compatibility)
+ARG THEROCK_GIT_TAG=
+ARG THEROCK_PREBUILT_ID=
+ARG THEROCK_TARBALL=
+
 # Clone TheRock for build tools (shallow clone, only need scripts)
 RUN git clone --depth 1 https://github.com/ROCm/TheRock.git /TheRock
 
 WORKDIR /TheRock
 
-RUN python3 -m venv /venv
-ENV PATH="/venv/bin:$PATH"
-RUN pip install -r requirements.txt
+RUN python3 -m venv /venv && /venv/bin/pip install -r requirements.txt
 
-# Install ROCm from artifacts directly to /opt/rocm
-# - If THEROCK_RELEASE=latest, uses --latest-release to fetch newest nightly
-# - Otherwise, uses --release to fetch specific version
-RUN if [ "$THEROCK_RELEASE" = "latest" ]; then \
-        echo "Installing latest nightly release for $THEROCK_ARTIFACT_GROUP"; \
-        python build_tools/install_rocm_from_artifacts.py \
+# Install ROCm - two paths:
+# 1. Legacy: any deprecated arg set → wget/tar (old method, no translation needed)
+# 2. New: install_rocm_from_artifacts.py
+# Priority: THEROCK_TARBALL > THEROCK_PREBUILT_ID > THEROCK_GIT_TAG
+RUN if [ -n "$THEROCK_TARBALL" ] || [ -n "$THEROCK_PREBUILT_ID" ] || [ -n "$THEROCK_GIT_TAG" ]; then \
+        echo "WARNING: Using deprecated build args. Migrate to THEROCK_RELEASE + THEROCK_ARTIFACT_GROUP." >&2; \
+        tarball="${THEROCK_TARBALL:-therock-dist-linux-${THEROCK_PREBUILT_ID:-$THEROCK_ARTIFACT_GROUP-$THEROCK_GIT_TAG}.tar.gz}"; \
+        echo "Downloading: $tarball"; \
+        mkdir -p /opt/rocm && \
+        wget --progress=dot:giga \
+            "https://therock-nightly-tarball.s3.us-east-2.amazonaws.com/$tarball" \
+            -O "/tmp/$tarball" && \
+        tar -xf "/tmp/$tarball" -C /opt/rocm --strip-components=1 && \
+        rm "/tmp/$tarball"; \
+        version=$(echo "$tarball" | sed 's/^therock-dist-linux-//; s/\.tar\.gz$//' | rev | cut -d- -f1 | rev); \
+        echo "$version" > /opt/rocm/THEROCK_VERSION; \
+    elif [ "$THEROCK_RELEASE" = "latest" ]; then \
+        echo "Installing latest nightly for $THEROCK_ARTIFACT_GROUP"; \
+        /venv/bin/python build_tools/install_rocm_from_artifacts.py \
             --latest-release \
             --artifact-group "$THEROCK_ARTIFACT_GROUP" \
-            --output-dir /opt/rocm; \
+            --output-dir /opt/rocm \
+            2>&1 | tee /tmp/install.log; \
+        grep -i 'version\|release' /tmp/install.log > /opt/rocm/THEROCK_VERSION || \
+            echo "latest (version details unavailable)" > /opt/rocm/THEROCK_VERSION; \
     else \
         echo "Installing release $THEROCK_RELEASE for $THEROCK_ARTIFACT_GROUP"; \
-        python build_tools/install_rocm_from_artifacts.py \
+        /venv/bin/python build_tools/install_rocm_from_artifacts.py \
             --release "$THEROCK_RELEASE" \
             --artifact-group "$THEROCK_ARTIFACT_GROUP" \
-            --output-dir /opt/rocm; \
+            --output-dir /opt/rocm \
+            2>&1 | tee /tmp/install.log; \
+        echo "$THEROCK_RELEASE" > /opt/rocm/THEROCK_VERSION; \
     fi
 
-RUN rm -rf /TheRock /venv
+RUN rm -rf /TheRock /venv /tmp/install.log
 
 # ============================================================================
 # Build from source stage - clones and builds TheRock

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -44,34 +44,69 @@ RUN apt-get update && apt-get install -y \
 # ============================================================================
 # Prebuilt stage - downloads and extracts dev env prebuilt binaries tarball
 #
-# Example build command for default tarball build (gfx94X, 7.0.0rc20250909):
-# docker build -f Dockerfile.ubuntu24 -t hipdnn:prebuilt .
-# This will download and install prebuilt binaries using therock-dist-linux-gfx94X-dcgpu-7.0.0rc20250909.tar.gz
+# Uses install_rocm_from_artifacts.py for downloading ROCm artifacts.
 #
-# Example build command to select tarball for asic family gfx950-dcgpu, build tag 7.0.0rc20250908:
-# docker build -f Dockerfile.ubuntu24 --build-arg THEROCK_ASIC=gfx950 --build-arg THEROCK_GIT_TAG=7.0.0rc20250908 -t hipdnn:fullbuild .
-# This will download and install prebuilt binaries using therock-dist-linux-gfx950-dcgpu-7.0.0rc20250908.tar.gz
+# Example: Default build (latest nightly for gfx94X-dcgpu):
+#   docker build -f Dockerfile.ubuntu24 -t hipdnn:prebuilt .
 #
-# Example build command to select tarball for asic family gfx950-all, build tag 7.9.0rc20251005:
-# docker build -f Dockerfile.ubuntu24 --build-arg THEROCK_PREBUILT_ID=gfx120X-all-7.9.0rc20251005 .
-# This will download and install prebuilt binaries using therock-dist-linux-gfx120X-all-7.9.0rc20251005.tar.gz
+# Example: Specific release version:
+#   docker build -f Dockerfile.ubuntu24 \
+#       --build-arg THEROCK_RELEASE=7.11.0a20260115 \
+#       -t hipdnn:prebuilt .
 #
-# Example build command to select tarball for asic family gfx950-all, build tag 7.9.0rc20251005:
-# docker build -f Dockerfile.ubuntu24 --build-arg THEROCK_TARBALL=therock-dist-linux-gfx120X-all-7.9.0rc20251005.tar.gz .
-# This will download and install prebuilt binaries using therock-dist-linux-gfx120X-all-7.9.0rc20251005.tar.gz
+# Example: Different ASIC family:
+#   docker build -f Dockerfile.ubuntu24 \
+#       --build-arg THEROCK_ASIC=gfx110X \
+#       --build-arg THEROCK_ASIC_VARIANT=all \
+#       -t hipdnn:prebuilt .
+#
+# Example: Full artifact group override:
+#   docker build -f Dockerfile.ubuntu24 \
+#       --build-arg THEROCK_ARTIFACT_GROUP=gfx120X-all \
+#       -t hipdnn:prebuilt .
 # ============================================================================
 FROM base AS install_therock_prebuilt
 
+# Build args for release selection
 ARG THEROCK_ASIC=gfx94X
-ARG THEROCK_GIT_TAG=7.0.0rc20250909
-ARG THEROCK_PREBUILT_ID=$THEROCK_ASIC-dcgpu-$THEROCK_GIT_TAG
-ARG THEROCK_TARBALL=therock-dist-linux-$THEROCK_PREBUILT_ID.tar.gz
+ARG THEROCK_ASIC_VARIANT=dcgpu
+ARG THEROCK_RELEASE=latest
+# Full artifact group (combines ASIC and variant)
+ARG THEROCK_ARTIFACT_GROUP=$THEROCK_ASIC-$THEROCK_ASIC_VARIANT
 
-RUN mkdir -p /opt/rocm
-WORKDIR /tmp
+# Clone TheRock for build tools (shallow clone, only need scripts)
+RUN git clone --depth 1 https://github.com/ROCm/TheRock.git /TheRock
 
-RUN wget --progress=dot:giga https://therock-nightly-tarball.s3.us-east-2.amazonaws.com/$THEROCK_TARBALL
-RUN tar -xf $THEROCK_TARBALL -C /opt/rocm --strip-components=1
+WORKDIR /TheRock
+
+# Setup Python environment
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install -r requirements.txt
+
+# Install ROCm from artifacts
+# The script extracts tarball to {output-dir}/rocm/, then we move to /opt/rocm
+# Note: Script deletes output-dir if exists, so we use a temp location
+# - If THEROCK_RELEASE=latest, uses --latest-release to fetch newest nightly
+# - Otherwise, uses --release to fetch specific version
+RUN if [ "$THEROCK_RELEASE" = "latest" ]; then \
+        echo "Installing latest nightly release for $THEROCK_ARTIFACT_GROUP"; \
+        python build_tools/install_rocm_from_artifacts.py \
+            --latest-release \
+            --artifact-group "$THEROCK_ARTIFACT_GROUP" \
+            --output-dir /tmp/therock-install; \
+    else \
+        echo "Installing release $THEROCK_RELEASE for $THEROCK_ARTIFACT_GROUP"; \
+        python build_tools/install_rocm_from_artifacts.py \
+            --release "$THEROCK_RELEASE" \
+            --artifact-group "$THEROCK_ARTIFACT_GROUP" \
+            --output-dir /tmp/therock-install; \
+    fi && \
+    mv /tmp/therock-install/rocm /opt/rocm && \
+    rm -rf /tmp/therock-install
+
+# Cleanup to reduce image size
+RUN rm -rf /TheRock /opt/venv
 
 # ============================================================================
 # Build from source stage - clones and builds TheRock

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -51,18 +51,18 @@ RUN apt-get update && apt-get install -y \
 #
 # Example: Specific release version:
 #   docker build -f Dockerfile.ubuntu24 \
-#       --build-arg THEROCK_RELEASE=7.11.0a20260115 \
+#       --build-arg THEROCK_RELEASE=7.12.0a20260202 \
 #       -t hipdnn:prebuilt .
 #
 # Example: Different ASIC family:
 #   docker build -f Dockerfile.ubuntu24 \
-#       --build-arg THEROCK_ASIC=gfx110X \
-#       --build-arg THEROCK_ASIC_VARIANT=all \
+#       --build-arg THEROCK_ASIC=gfx90X \
+#       --build-arg THEROCK_ASIC_VARIANT=dcgpu \
 #       -t hipdnn:prebuilt .
 #
 # Example: Full artifact group override:
 #   docker build -f Dockerfile.ubuntu24 \
-#       --build-arg THEROCK_ARTIFACT_GROUP=gfx120X-all \
+#       --build-arg THEROCK_ARTIFACT_GROUP=gfx110X-all \
 #       -t hipdnn:prebuilt .
 # ============================================================================
 FROM base AS install_therock_prebuilt
@@ -105,7 +105,7 @@ RUN rm -rf /TheRock /venv
 # ============================================================================
 # Build from source stage - clones and builds TheRock
 #
-# Example build command for default source build (default branch, gfx90a):
+# Example build command for default source build (default branch, gfx94X):
 # docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild -t hipdnn:fullbuild .
 #
 # Example build command for overriding ASIC and git hash:
@@ -131,7 +131,7 @@ RUN rm -rf /TheRock /venv
 # ============================================================================
 FROM base AS install_therock_fullbuild
 
-ARG THEROCK_ASIC=gfx90a
+ARG THEROCK_ASIC=gfx94X
 ARG THEROCK_GIT_HASH=default
 ARG THEROCK_BUILD_MODE=Release
 ARG THEROCK_BUILD_PRESET=linux-release-package

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -83,9 +83,7 @@ RUN python3 -m venv /venv
 ENV PATH="/venv/bin:$PATH"
 RUN pip install -r requirements.txt
 
-# Install ROCm from artifacts
-# The script extracts tarball (which contains rocm/ directory) to output-dir
-# Result: {output-dir}/rocm/ -> /opt/rocm/
+# Install ROCm from artifacts directly to /opt/rocm
 # - If THEROCK_RELEASE=latest, uses --latest-release to fetch newest nightly
 # - Otherwise, uses --release to fetch specific version
 RUN if [ "$THEROCK_RELEASE" = "latest" ]; then \
@@ -93,13 +91,13 @@ RUN if [ "$THEROCK_RELEASE" = "latest" ]; then \
         python build_tools/install_rocm_from_artifacts.py \
             --latest-release \
             --artifact-group "$THEROCK_ARTIFACT_GROUP" \
-            --output-dir /opt; \
+            --output-dir /opt/rocm; \
     else \
         echo "Installing release $THEROCK_RELEASE for $THEROCK_ARTIFACT_GROUP"; \
         python build_tools/install_rocm_from_artifacts.py \
             --release "$THEROCK_RELEASE" \
             --artifact-group "$THEROCK_ARTIFACT_GROUP" \
-            --output-dir /opt; \
+            --output-dir /opt/rocm; \
     fi
 
 RUN rm -rf /TheRock /venv

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -79,14 +79,13 @@ RUN git clone --depth 1 https://github.com/ROCm/TheRock.git /TheRock
 
 WORKDIR /TheRock
 
-# Setup Python environment
-RUN python3 -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
 RUN pip install -r requirements.txt
 
 # Install ROCm from artifacts
-# The script extracts tarball to {output-dir}/rocm/, then we move to /opt/rocm
-# Note: Script deletes output-dir if exists, so we use a temp location
+# The script extracts tarball (which contains rocm/ directory) to output-dir
+# Result: {output-dir}/rocm/ -> /opt/rocm/
 # - If THEROCK_RELEASE=latest, uses --latest-release to fetch newest nightly
 # - Otherwise, uses --release to fetch specific version
 RUN if [ "$THEROCK_RELEASE" = "latest" ]; then \
@@ -94,19 +93,16 @@ RUN if [ "$THEROCK_RELEASE" = "latest" ]; then \
         python build_tools/install_rocm_from_artifacts.py \
             --latest-release \
             --artifact-group "$THEROCK_ARTIFACT_GROUP" \
-            --output-dir /tmp/therock-install; \
+            --output-dir /opt; \
     else \
         echo "Installing release $THEROCK_RELEASE for $THEROCK_ARTIFACT_GROUP"; \
         python build_tools/install_rocm_from_artifacts.py \
             --release "$THEROCK_RELEASE" \
             --artifact-group "$THEROCK_ARTIFACT_GROUP" \
-            --output-dir /tmp/therock-install; \
-    fi && \
-    mv /tmp/therock-install/rocm /opt/rocm && \
-    rm -rf /tmp/therock-install
+            --output-dir /opt; \
+    fi
 
-# Cleanup to reduce image size
-RUN rm -rf /TheRock /opt/venv
+RUN rm -rf /TheRock /venv
 
 # ============================================================================
 # Build from source stage - clones and builds TheRock

--- a/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
+++ b/projects/hipdnn/dockerfiles/Dockerfile.ubuntu24
@@ -110,7 +110,10 @@ RUN if [ -n "$THEROCK_TARBALL" ] || [ -n "$THEROCK_PREBUILT_ID" ] || [ -n "$THER
             --artifact-group "$THEROCK_ARTIFACT_GROUP" \
             --output-dir /opt/rocm \
             2>&1 | tee /tmp/install.log; \
-        grep -i 'version\|release' /tmp/install.log > /opt/rocm/THEROCK_VERSION || \
+        # Fragile: depends on install_rocm_from_artifacts.py printing
+        # "Found latest release: <version>". Falls back if format changes. \
+        version=$(grep -oP 'Found latest release: \K\S+' /tmp/install.log) && \
+            echo "$version" > /opt/rocm/THEROCK_VERSION || \
             echo "latest (version details unavailable)" > /opt/rocm/THEROCK_VERSION; \
     else \
         echo "Installing release $THEROCK_RELEASE for $THEROCK_ARTIFACT_GROUP"; \

--- a/projects/hipdnn/dockerfiles/README.md
+++ b/projects/hipdnn/dockerfiles/README.md
@@ -50,6 +50,38 @@ https://github.com/ROCm/TheRock/issues/2179
 | `THEROCK_ASIC_VARIANT` | `dcgpu` | GPU variant suffix (e.g., `dcgpu`, `all`, `dgpu`). Combined with `THEROCK_ASIC` to form the artifact group. |
 | `THEROCK_ARTIFACT_GROUP` | `$THEROCK_ASIC-$THEROCK_ASIC_VARIANT` | Full artifact group override. Available groups: `gfx90X-dcgpu`, `gfx94X-dcgpu`, `gfx950-dcgpu`, `gfx110X-all`, `gfx110X-dgpu`, `gfx120X-all`, etc. See [TheRock releases](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#index-page-listing) for the full list. |
 
+#### Version Logging
+
+The prebuilt stage writes the installed TheRock version to `/opt/rocm/THEROCK_VERSION` inside the image. For pinned releases, this contains the exact version string. For `latest` builds, it captures version information from the install output.
+
+#### ⚠️ Deprecated Prebuilt Arguments
+
+> [!CAUTION]
+> The following build args are **deprecated** and will be removed in a future release. When any of these args are set, the build uses the original wget/tar download method instead of `install_rocm_from_artifacts.py`. A deprecation warning is printed during the build.
+
+| Deprecated Argument | Replacement | Behavior |
+|---------------------|-------------|----------|
+| `THEROCK_TARBALL` | `THEROCK_ARTIFACT_GROUP` + `THEROCK_RELEASE` | Used as-is as the tarball filename for wget download |
+| `THEROCK_PREBUILT_ID` | `THEROCK_ARTIFACT_GROUP` + `THEROCK_RELEASE` | Prefixed with `therock-dist-linux-` and suffixed with `.tar.gz` for wget download |
+| `THEROCK_GIT_TAG` | `THEROCK_RELEASE` | Combined with `THEROCK_ARTIFACT_GROUP` to construct the tarball filename |
+
+Priority when multiple legacy args are set: `THEROCK_TARBALL` > `THEROCK_PREBUILT_ID` > `THEROCK_GIT_TAG`.
+
+**Migration examples:**
+```bash
+# Old: --build-arg THEROCK_GIT_TAG=7.0.0rc20250909
+# New:
+--build-arg THEROCK_RELEASE=7.0.0rc20250909
+
+# Old: --build-arg THEROCK_PREBUILT_ID=gfx94X-dcgpu-7.0.0rc20250909
+# New:
+--build-arg THEROCK_ARTIFACT_GROUP=gfx94X-dcgpu --build-arg THEROCK_RELEASE=7.0.0rc20250909
+
+# Old: --build-arg THEROCK_TARBALL=therock-dist-linux-gfx94X-dcgpu-7.0.0rc20250909.tar.gz
+# New:
+--build-arg THEROCK_ARTIFACT_GROUP=gfx94X-dcgpu --build-arg THEROCK_RELEASE=7.0.0rc20250909
+```
+
 #### 🏗️ Fullbuild-Only Arguments
 
 > [!NOTE]

--- a/projects/hipdnn/dockerfiles/README.md
+++ b/projects/hipdnn/dockerfiles/README.md
@@ -39,6 +39,10 @@ The Dockerfile supports two build types: **prebuilt** (using nightly tarballs) a
 > [!NOTE]
 > Prebuilt mode downloads pre-compiled binaries from TheRock nightly builds using `install_rocm_from_artifacts.py` (much faster than building from source)
 
+> [!NOTE]
+> There is currently an issue with using the prebuilt binaries with the gfx90X ASIC family. Refer to this GitHub issue for more details:
+https://github.com/ROCm/TheRock/issues/2179
+
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `THEROCK_RELEASE` | `latest` | Release version to install. Use `latest` to automatically fetch the newest nightly build, or specify a version like `7.12.0a20260202`. Available versions can be found at [TheRock nightly tarballs](https://therock-nightly-tarball.s3.amazonaws.com/). |

--- a/projects/hipdnn/dockerfiles/README.md
+++ b/projects/hipdnn/dockerfiles/README.md
@@ -37,19 +37,14 @@ The Dockerfile supports two build types: **prebuilt** (using nightly tarballs) a
 #### 📦 Prebuilt-Only Arguments
 
 > [!NOTE]
-> Prebuilt mode downloads pre-compiled binaries from TheRock nightly builds (much faster)
-
-> [!NOTE]
-> There is currently an issue with using the prebuilt binaries with the gfx90X ASIC family. Refer to this GitHub issue for more details:
-https://github.com/ROCm/TheRock/issues/2179
-
+> Prebuilt mode downloads pre-compiled binaries from TheRock nightly builds using `install_rocm_from_artifacts.py` (much faster than building from source)
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `THEROCK_GIT_TAG`<br>_(deprecated)_ | `7.0.0rc20250909` | Build tag for [nightly tarballs](https://therock-nightly-tarball.s3.amazonaws.com/). Used to create the precompiled binaries download filename key: `therock-dist-linux-$THEROCK_ASIC-dcgpu-$THEROCK_GIT_TAG.tar.gz`.<br>Alternatively, specify the full prebuilt ID using `THEROCK_PREBUILT_ID`, or the full tarball name using `THEROCK_TARBALL`, below. |
-| `THEROCK_ASIC`<br>_(deprecated)_ | `gfx94X` for prebuilt | GPU (dcgpu) architecture target. The values for THEROCK_ASIC for prebuilt mode can be found [here](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#index-page-listing) or parsed directly from the tarball filename keys listed [here](https://therock-nightly-tarball.s3.amazonaws.com/).<br>Future support [here](https://github.com/ROCm/TheRock/blob/main/ROADMAP.md#rocm-on-linux).<br>Note: For prebuilt mode, ensure that the specified dcgpu asic is supported by the prebuilt artifacts as set in `THEROCK_GIT_TAG` described above. |
-| `THEROCK_PREBUILT_ID`<br>_(recommended)_ | `$THEROCK_ASIC-dcgpu-$THEROCK_GIT_TAG` | GPU architecture family and build tag. The values for `$THEROCK_ASIC-dcgpu` for prebuilt mode can be found in the _GFX family_ column from the table [here](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#index-page-listing) or parsed directly from the tarball filename keys listed [here](https://therock-nightly-tarball.s3.amazonaws.com/).<br>Future support [here](https://github.com/ROCm/TheRock/blob/main/ROADMAP.md#rocm-on-linux)<br>The resulting tarball filename key will be  `therock-dist-linux-$THEROCK_PREBUILT_ID.tar.gz` |
-| `THEROCK_TARBALL` | `therock-dist-linux-gfx94X-dcgpu-7.0.0rc20250909.tar.gz` | Overrides the full tarball path for [nightly tarballs](https://therock-nightly-tarball.s3.amazonaws.com/) (setting this will ignore THEROCK_ASIC, THEROCK_GIT_TAG, and THEROCK_PREBUILT_ID). |
+| `THEROCK_RELEASE` | `latest` | Release version to install. Use `latest` to automatically fetch the newest nightly build, or specify a version like `7.12.0a20260202`. Available versions can be found at [TheRock nightly tarballs](https://therock-nightly-tarball.s3.amazonaws.com/). |
+| `THEROCK_ASIC` | `gfx94X` | GPU architecture family prefix. Combined with `THEROCK_ASIC_VARIANT` to form the artifact group. |
+| `THEROCK_ASIC_VARIANT` | `dcgpu` | GPU variant suffix (e.g., `dcgpu`, `all`, `dgpu`). Combined with `THEROCK_ASIC` to form the artifact group. |
+| `THEROCK_ARTIFACT_GROUP` | `$THEROCK_ASIC-$THEROCK_ASIC_VARIANT` | Full artifact group override. Available groups: `gfx90X-dcgpu`, `gfx94X-dcgpu`, `gfx950-dcgpu`, `gfx110X-all`, `gfx110X-dgpu`, `gfx120X-all`, etc. See [TheRock releases](https://github.com/ROCm/TheRock/blob/main/RELEASES.md#index-page-listing) for the full list. |
 
 #### 🏗️ Fullbuild-Only Arguments
 
@@ -60,7 +55,7 @@ https://github.com/ROCm/TheRock/issues/2179
 |----------|---------|-------------|
 | `THEROCK_GIT_HASH` | `default` | Specific git commit hash to checkout (uses default branch if not specified). |
 | `ROCM_LIBRARIES_REF` | `default` | Specific git commit hash for rocm-libraries submodule to checkout (uses default branch if not specified). |
-| `THEROCK_ASIC` | `gfx90a` for fullbuild | GPU architecture target. The values for THEROCK_ASIC for fullbuild mode can be found in the LLVM Target column of the Supported GPU table [here](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html). |
+| `THEROCK_ASIC` | `gfx94X` | GPU architecture target. The values for THEROCK_ASIC for fullbuild mode can be found in the LLVM Target column of the Supported GPU table [here](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html). |
 | `THEROCK_BUILD_MODE` | `Release` | Build mode: `Preset` (uses TheRock presets), `Debug`, or `Release` (uses CMake build types). |
 | `THEROCK_BUILD_PRESET` | `linux-release-package` | Specify which build preset to use when THEROCK_BUILD_MODE=Preset. |
 | `BUILD_JOBS` | `0` | Number of parallel build jobs. 0 uses all available CPU cores. |
@@ -68,43 +63,56 @@ https://github.com/ROCm/TheRock/issues/2179
 ### Build Examples
 
 #### 📦 Prebuilt Mode (Recommended)
-The list of latest precompiled tarballs is available [here](https://therock-nightly-tarball.s3.amazonaws.com/)..
 
-**Default prebuilt** (gfx94X, tag 7.0.0rc20250909):
+**Default prebuilt** (latest nightly for gfx94X-dcgpu):
 ```bash
 docker build -f Dockerfile.ubuntu24 -t hipdnn:prebuilt .
 ```
 
-This will download and install prebuilt binaries using the filename `therock-dist-linux-gfx94X-dcgpu-7.0.0rc20250909.tar.gz` and tags the image as `hipdnn:prebuilt`.
+This will automatically download and install the latest nightly build for gfx94X-dcgpu.
 
-**Override ASIC and Git Tag** (gfx950, tag 7.0.0rc20250908):
-
+**Specific release version**:
 ```bash
-docker build -f Dockerfile.ubuntu24 --build-arg THEROCK_ASIC=gfx950 --build-arg THEROCK_GIT_TAG=7.0.0rc20250908 -t hipdnn:prebuilt_gfx950 .
+docker build -f Dockerfile.ubuntu24 \
+    --build-arg THEROCK_RELEASE=7.12.0a20260202 \
+    -t hipdnn:prebuilt .
 ```
 
-This will download and install prebuilt artifacts using the filename `therock-dist-linux-gfx950-dcgpu-7.0.0rc20250908.tar.gz` and tags the image as `hipdnn:prebuilt_gfx950`.
+**Different ASIC family** (MI100/MI200 series):
+```bash
+docker build -f Dockerfile.ubuntu24 \
+    --build-arg THEROCK_ASIC=gfx90X \
+    --build-arg THEROCK_ASIC_VARIANT=dcgpu \
+    -t hipdnn:prebuilt_gfx90X .
+```
+
+**Full artifact group override** (RDNA3):
+```bash
+docker build -f Dockerfile.ubuntu24 \
+    --build-arg THEROCK_ARTIFACT_GROUP=gfx110X-all \
+    -t hipdnn:prebuilt_rdna3 .
+```
 
 #### 🏗️ Fullbuild Mode
 
 Note that the full build can take several hours to complete.
 
-**Default fullbuild** (gfx90a, default branch):
+**Default fullbuild** (gfx94X, default branch):
 ```bash
 docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild -t hipdnn:fullbuild .
 ```
 
-**Debug build** (gfx90a, debug mode):
+**Debug build** (gfx94X, debug mode):
 ```bash
 docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_BUILD_MODE=Debug -t hipdnn:debug .
 ```
 
-**Release build with limited cores** (gfx90a, release mode, 4 cores):
+**Release build with limited cores** (gfx94X, release mode, 4 cores):
 ```bash
 docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_BUILD_MODE=Release --build-arg BUILD_JOBS=4 -t hipdnn:release .
 ```
 
-**Custom preset with all cores** (gfx90a, custom preset):
+**Custom preset with all cores** (gfx94X, custom preset):
 ```bash
 docker build -f Dockerfile.ubuntu24 --build-arg BUILD_TYPE=fullbuild --build-arg THEROCK_BUILD_MODE=Preset --build-arg THEROCK_BUILD_PRESET=linux-debug-package -t hipdnn:custom-preset .
 ```


### PR DESCRIPTION
## Motivation

To ensure the Dockerfile always builds with the latest release by default.

Disclaimer: the Dockerfile **always** uses gfx94X as the default target now.

## Test Plan

Verify docker images with prebuilt ROCm are correct. In particular, the latest release variant and by specifying a specific release.

```bash
docker build -f Dockerfile.ubuntu24 --build-arg THEROCK_RELEASE=7.12.0a20260202 --build-arg THEROCK_ASIC=gfx90X -t hipdnn:prebuilt2 .
```

```bash
docker build -f Dockerfile.ubuntu24 -t hipdnn:prebuilt --build-arg THEROCK_ASIC=gfx90X .
```

## Test Result

Images build successfully, and hipDNN can be built inside each container.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.