### PR TITLE
Fix intermittent kernel compilation failures in BnFwdTrainingSpatial

### DIFF
--- a/projects/miopen/src/include/miopen/batchnorm/common_spatial.hpp
+++ b/projects/miopen/src/include/miopen/batchnorm/common_spatial.hpp
@@ -79,6 +79,10 @@ inline void GetSpatialMultipleConfig(const miopen::batchnorm::ProblemDescription
                                      size_t& xlocalsize,
                                      size_t& ylocalsize)
 {
+    // Initialize to safe defaults at the start of the function
+    xlocalsize = 1;
+    ylocalsize = 1;
+
     int n, c, h, w;
     std::tie(n, c, h, w)    = tien<4>(problem.GetXDesc().GetLengths());
     unsigned int in_cstride = h * w;
@@ -226,10 +230,10 @@ inline void GetVariantFromKernelId(const std::string& kernel_id,
     vectorsize = std::stoi(seglist[1]);
     if(variant != 2)
     {
-        xlocalsize = 1;
-        ylocalsize = 1;
-        zlocalsize = 1;
-        nelements  = 1;
+        // For variant 0, 1, 3 (spatial single), kernel_id only contains
+        // variant and vectorsize. The workgroup sizes (xlocalsize, ylocalsize,
+        // zlocalsize, nelements) are not stored in kernel_id and must be
+        // computed by the caller based on problem-size heuristics.
         return;
     }
     xlocalsize = std::stoi(seglist[2]);

--- a/projects/miopen/src/include/miopen/batchnorm/common_spatial.hpp
+++ b/projects/miopen/src/include/miopen/batchnorm/common_spatial.hpp
@@ -91,8 +91,7 @@ inline void GetSpatialMultipleConfig(const miopen::batchnorm::ProblemDescription
     {
         if(c % vectorsize != 0)
         {
-            xlocalsize = 1;
-            ylocalsize = 1;
+            // xlocalsize and ylocalsize already initialized to 1
             return;
         }
         GetLocalConfigNHWC(problem, vectorsize, xlocalsize, ylocalsize);
@@ -101,11 +100,10 @@ inline void GetSpatialMultipleConfig(const miopen::batchnorm::ProblemDescription
     {
         if(in_cstride % vectorsize != 0)
         {
-            xlocalsize = 1;
-            ylocalsize = 1;
+            // xlocalsize and ylocalsize already initialized to 1
             return;
         }
-        xlocalsize = 1;
+        // xlocalsize stays at 1
         ylocalsize = 1024;
         if(ylocalsize > in_cstride / vectorsize)
         {

--- a/projects/miopen/src/include/miopen/batchnorm/common_spatial.hpp
+++ b/projects/miopen/src/include/miopen/batchnorm/common_spatial.hpp
@@ -87,6 +87,8 @@ inline void GetSpatialMultipleConfig(const miopen::batchnorm::ProblemDescription
     {
         if(c % vectorsize != 0)
         {
+            xlocalsize = 1;
+            ylocalsize = 1;
             return;
         }
         GetLocalConfigNHWC(problem, vectorsize, xlocalsize, ylocalsize);
@@ -95,6 +97,8 @@ inline void GetSpatialMultipleConfig(const miopen::batchnorm::ProblemDescription
     {
         if(in_cstride % vectorsize != 0)
         {
+            xlocalsize = 1;
+            ylocalsize = 1;
             return;
         }
         xlocalsize = 1;
@@ -222,6 +226,10 @@ inline void GetVariantFromKernelId(const std::string& kernel_id,
     vectorsize = std::stoi(seglist[1]);
     if(variant != 2)
     {
+        xlocalsize = 1;
+        ylocalsize = 1;
+        zlocalsize = 1;
+        nelements  = 1;
         return;
     }
     xlocalsize = std::stoi(seglist[2]);

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
@@ -779,7 +779,8 @@ struct MIOpenBatchNormFwdTrainSpatialImplVar2
         }
 
         if constexpr(!mio_bn_config::use_amdgcn || mio_bn_config::launch_dim.grp0 > 1 ||
-                     (mio_bn_config::lds_gcn_size == 1) || mio_bn_config::vec_size_x > 1)
+                     (mio_bn_config::lds_gcn_size == 1) || mio_bn_config::vec_size_x > 1 ||
+                     (MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL < 64))
         {
             __shared__ FpAccumCType
                 lcl_data[2 * MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL];

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
@@ -796,11 +796,14 @@ struct MIOpenBatchNormFwdTrainSpatialImplVar2
         }
         else
         {
+            // C++17 idiomatic: ensure array size is never zero using constexpr ternary
+            constexpr auto grp_final_total =
+                MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL;
+            constexpr auto lds_gcn_array_size = grp_final_total >= 64 ? grp_final_total / 64 : 1;
+
             commitID = 64;
-            __shared__ FpAccumCType
-                lcl_data_x[MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL / 64];
-            __shared__ FpAccumCType
-                lcl_data_y[MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL / 64];
+            __shared__ FpAccumCType lcl_data_x[lds_gcn_array_size];
+            __shared__ FpAccumCType lcl_data_y[lds_gcn_array_size];
             miopen::reduction::gcn_reduce2(
                 mean, variance, INHW, lcl_data_x, lcl_data_y, ylid + zlid * ygrp_sz);
         }

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
@@ -778,12 +778,15 @@ struct MIOpenBatchNormFwdTrainSpatialImplVar2
             }
         }
 
+        // Total workgroup size for final kernel - reused in condition and array declarations
+        constexpr auto grp_final_total =
+            MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL;
+
         if constexpr(!mio_bn_config::use_amdgcn || mio_bn_config::launch_dim.grp0 > 1 ||
                      (mio_bn_config::lds_gcn_size == 1) || mio_bn_config::vec_size_x > 1 ||
-                     (MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL < 64))
+                     (grp_final_total < 64))
         {
-            __shared__ FpAccumCType
-                lcl_data[2 * MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL];
+            __shared__ FpAccumCType lcl_data[2 * grp_final_total];
 
             miopen::reduction::lds_reduce2_2d(mean,
                                               variance,
@@ -797,8 +800,6 @@ struct MIOpenBatchNormFwdTrainSpatialImplVar2
         else
         {
             // C++17 idiomatic: ensure array size is never zero using constexpr ternary
-            constexpr auto grp_final_total =
-                MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL;
             constexpr auto lds_gcn_array_size = grp_final_total >= 64 ? grp_final_total / 64 : 1;
 
             commitID = 64;

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
@@ -779,8 +779,7 @@ struct MIOpenBatchNormFwdTrainSpatialImplVar2
         }
 
         // Total workgroup size for final kernel - reused in condition and array declarations
-        constexpr auto grp_final_total =
-            MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL;
+        constexpr auto grp_final_total = MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL;
 
         if constexpr(!mio_bn_config::use_amdgcn || mio_bn_config::launch_dim.grp0 > 1 ||
                      (mio_bn_config::lds_gcn_size == 1) || mio_bn_config::vec_size_x > 1 ||

--- a/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
@@ -220,12 +220,12 @@ ConvSolution BnFwdTrainingSpatial::GetSolution(const ExecutionContext& context,
 
     int variant       = -1;
     size_t vectorsize = 1;
-    size_t xlocalsize, xgridsize;
+    size_t xlocalsize = 1, xgridsize = 0;
     size_t ylocalsize = 1, ygridsize = 1;
     size_t zlocalsize = 1, zgridsize = 1;
-    unsigned int ldsgcn, ldsnogcn;
+    unsigned int ldsgcn = 0, ldsnogcn = 0;
     int stash_method = 0;
-    size_t nelements;
+    size_t nelements = 1;
 
     GetVariantFromKernelId(
         config.kernel_id, variant, vectorsize, xlocalsize, ylocalsize, zlocalsize, nelements);

--- a/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
@@ -55,8 +55,8 @@ bool PerformanceConfigBnFwdTraining::IsValid(
 
     // if default config is variant 2, check if it can be applied
     // (based on variant 2 restrictions)
-    size_t vectorsize, xlocalsize, ylocalsize, zlocalsize, nelements;
-    int variant;
+    size_t vectorsize = 1, xlocalsize = 1, ylocalsize = 1, zlocalsize = 1, nelements = 1;
+    int variant = -1;
     GetVariantFromKernelId(
         this->kernel_id, variant, vectorsize, xlocalsize, ylocalsize, zlocalsize, nelements);
     if(variant == 2)

--- a/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
+++ b/projects/miopen/src/solver/batchnorm/forward_spatial.cpp
@@ -220,7 +220,7 @@ ConvSolution BnFwdTrainingSpatial::GetSolution(const ExecutionContext& context,
 
     int variant       = -1;
     size_t vectorsize = 1;
-    size_t xlocalsize = 1, xgridsize = 0;
+    size_t xlocalsize = 1, xgridsize = 1;
     size_t ylocalsize = 1, ygridsize = 1;
     size_t zlocalsize = 1, zgridsize = 1;
     unsigned int ldsgcn = 0, ldsnogcn = 0;


### PR DESCRIPTION
## Motivation
Fix kernel compilation failures in BnFwdTrainingSpatial caused by two related issues:

1. Uninitialized local size variables producing random garbage values
2. Missing compile-time guard for warp-reduction LDS arrays when workgroup < 64 threads

## To Reproduce

```bash
rm -rf ~/.config/miopen/*.udb.txt ~/.cache/miopen/
rm -rf /tmp/.config/miopen/ /tmp/.cache/miopen/
MIOPEN_FIND_ENFORCE=SEARCH MIOPEN_LOG_LEVEL=5 ./bin/MIOpenDriver bnorm -n 1024 -c 64 -H 13 -W 13 -m 1 --forw 1 -s 1 -V 1
```

## Technical Details

### Bug 1: Uninitialized Variables (Host)

Variables declared without initialization:

```cpp
size_t xlocalsize, xgridsize;  // uninitialized
```

For Variants 0/1/3, early returns skip initialization, leaving garbage values that propagate to kernel template parameters. Depending on stack memory state, errors include:

- `error: array is too large (18446744073709545792 elements)`
- `error: variable length array declaration cannot have 'static' storage duration`
- `error: zero-length arrays are not permitted in HIP device code`

### Bug 2: Missing Compile-Time Guard (Kernel)

The warp-reduction path divides LDS size by 64:

```cpp
__shared__ FpAccumCType lcl_data_x[MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL / 64];
```

When Variants 0/1/3 set workgroup size to 1×1×1, this computes `1/64 = 0`, producing illegal zero-length arrays. Note that `if constexpr` only suppresses template instantiation, not parsing of ill-formed code like zero-length arrays.

## Fix

### Host side (`common_spatial.hpp`, `forward_spatial.cpp`)

Initialize variables to safe defaults:

```cpp
size_t xlocalsize = 1, xgridsize = 1;
size_t ylocalsize = 1, ygridsize = 1;
size_t zlocalsize = 1, zgridsize = 1;
size_t nelements = 1;
unsigned int ldsgcn = 0, ldsnogcn = 0;
```

### Kernel side (`MIOpenBatchNormFwdTrainSpatial.cpp`)

Use C++17 constexpr ternary to ensure array size is always ≥ 1:

```cpp
else
{
    // C++17 idiomatic: ensure array size is never zero using constexpr ternary
    constexpr auto grp_final_total =
        MIO_BN_GRP0_FINAL * MIO_BN_GRP1_FINAL * MIO_BN_GRP2_FINAL;
    constexpr auto lds_gcn_array_size = grp_final_total >= 64 ? grp_final_total / 64 : 1;

    commitID = 64;
    __shared__ FpAccumCType lcl_data_x[lds_gcn_array_size];
    __shared__ FpAccumCType lcl_data_y[lds_gcn_array_size];
    miopen::reduction::gcn_reduce2(...);
}
```

__Why this works:__

- `constexpr` ensures compile-time evaluation (zero runtime overhead)
- When workgroup ≥ 64: array size = `grp_final_total / 64` (correct, same as before)
- When workgroup < 64: array size = 1 (valid), but this `else` branch is never taken due to `if constexpr` guard
- Dead code elimination removes the unused size-1 arrays from the binary

## Test Plan

- Existing batchnorm training tests pass
- Verified no zero-length array errors with deterministic workgroup sizes
- Confirmed warp-reduction path only executes when workgroup ≥ 64 threads
