### PR TITLE
[rocblas] Optimize tpsv APa address calculation

### DIFF
--- a/projects/rocblas/library/src/blas2/rocblas_tpsv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tpsv_kernels.cpp
@@ -175,7 +175,7 @@ ROCBLAS_KERNEL_ILF void rocblas_tpsv_backward_substitution_calc(bool is_unit_dia
                 else
                     val += (CONJ ? conj(A[indexA]) : A[indexA]) * xshared[p];
 
-                indexA -= is_transpose ? 1 : colA;
+                indexA += is_transpose ? 1 : colA;
             }
 
             x[(tx + j) * incx] -= val;

--- a/projects/rocblas/library/src/blas2/rocblas_tpsv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tpsv_kernels.cpp
@@ -175,7 +175,7 @@ ROCBLAS_KERNEL_ILF void rocblas_tpsv_backward_substitution_calc(bool is_unit_dia
                 else
                     val += (CONJ ? conj(A[indexA]) : A[indexA]) * xshared[p];
 
-                indexA += is_transpose ? 1 : colA;
+                indexA += is_transpose ? 1 : colA + 1;
             }
 
             x[(tx + j) * incx] -= val;

--- a/projects/rocblas/library/src/blas2/rocblas_tpsv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tpsv_kernels.cpp
@@ -55,33 +55,25 @@ ROCBLAS_KERNEL_ILF void rocblas_tpsv_forward_substitution_calc(bool is_unit_diag
 
         __syncthreads();
 
+        rocblas_int rowA   = tx + i;
+        rocblas_int colA   = i;
+        size_t      indexA = rocblas_packed_matrix_index(is_transpose, is_transpose, n, rowA, colA);
         // iterate through the current block and solve elements
-        for(rocblas_int j = 0; j < BLK_SIZE; j++)
+        for(rocblas_int j = 0; j < BLK_SIZE; j++, colA++)
         {
             // solve element that can be solved
             if(tx == j && !is_unit_diag && j + i < n)
-            {
-                rocblas_int colA = j + i;
-                rocblas_int rowA = j + i;
-                size_t      indexA
-                    = rocblas_packed_matrix_index(is_transpose, is_transpose, n, rowA, colA);
                 xshared[tx] = xshared[tx] / (CONJ ? conj(A[indexA]) : A[indexA]);
-            }
 
             __syncthreads();
 
             // for rest of block, subtract previous solved part
             if(tx > j && j + i < n)
-            {
-                rocblas_int colA = j + i;
-                rocblas_int rowA = tx + i;
-                size_t      indexA
-                    = rocblas_packed_matrix_index(is_transpose, is_transpose, n, rowA, colA);
-
                 // Ensure row is in range, and subtract
                 if(rowA < n)
                     xshared[tx] -= (CONJ ? conj(A[indexA]) : A[indexA]) * xshared[j];
-            }
+
+            indexA += is_transpose ? 1 : n - colA - 1;
         }
 
         __syncthreads();
@@ -95,17 +87,17 @@ ROCBLAS_KERNEL_ILF void rocblas_tpsv_forward_substitution_calc(bool is_unit_diag
 
             // 2. Sum result (across columns) to be subtracted from original value
             T val = 0;
-            for(rocblas_int p = 0; p < BLK_SIZE; p++)
+            rocblas_int rowA = tx + j;
+            rocblas_int colA = i;
+            size_t indexA = rocblas_packed_matrix_index(is_transpose, is_transpose, n, rowA, colA);
+            for(rocblas_int p = 0; p < BLK_SIZE; p++, colA++)
             {
-                rocblas_int colA = i + p;
-                rocblas_int rowA = tx + j;
-                size_t      indexA
-                    = rocblas_packed_matrix_index(is_transpose, is_transpose, n, rowA, colA);
-
                 if(is_unit_diag && colA == rowA)
                     val += xshared[p];
                 else if(colA < n)
                     val += (CONJ ? conj(A[indexA]) : A[indexA]) * xshared[p];
+
+                indexA += is_transpose ? 1 : n - colA - 1;
             }
 
             x[(tx + j) * incx] -= val;
@@ -141,33 +133,25 @@ ROCBLAS_KERNEL_ILF void rocblas_tpsv_backward_substitution_calc(bool is_unit_dia
 
         __syncthreads();
 
+        rocblas_int rowA = tx + i;
+        rocblas_int colA = i + BLK_SIZE - 1;
+        size_t indexA    = rocblas_packed_matrix_index(!is_transpose, is_transpose, n, rowA, colA);
         // Iterate backwards through the current block to solve elements.
-        for(rocblas_int j = BLK_SIZE - 1; j >= 0; j--)
+        for(rocblas_int j = BLK_SIZE - 1; j >= 0; j--, colA--)
         {
             // Solve the new element that can be solved
             if(tx == j && !is_unit_diag && j + i >= 0)
-            {
-                rocblas_int colA = j + i;
-                rocblas_int rowA = j + i;
-                size_t      indexA
-                    = rocblas_packed_matrix_index(!is_transpose, is_transpose, n, rowA, colA);
                 xshared[tx] = xshared[tx] / (CONJ ? conj(A[indexA]) : A[indexA]);
-            }
 
             __syncthreads();
 
             // for rest of block, subtract previous solved part
             if(tx < j && j + i >= 0)
-            {
-                rocblas_int colA = j + i;
-                rocblas_int rowA = tx + i;
-                size_t      indexA
-                    = rocblas_packed_matrix_index(!is_transpose, is_transpose, n, rowA, colA);
-
                 // Ensure row is in range, and subtract
                 if(rowA >= 0)
                     xshared[tx] -= (CONJ ? conj(A[indexA]) : A[indexA]) * xshared[j];
-            }
+
+            indexA -= is_transpose ? 1 : colA;
         }
 
         __syncthreads();
@@ -181,17 +165,17 @@ ROCBLAS_KERNEL_ILF void rocblas_tpsv_backward_substitution_calc(bool is_unit_dia
 
             // 2. Sum result (across columns) to be subtracted from the original value
             T val = 0;
-            for(rocblas_int p = 0; p < BLK_SIZE; p++)
+            rocblas_int rowA = tx + j;
+            rocblas_int colA = i;
+            size_t indexA = rocblas_packed_matrix_index(!is_transpose, is_transpose, n, rowA, colA);
+            for(rocblas_int p = 0; p < BLK_SIZE; p++, colA++)
             {
-                rocblas_int colA = i + p;
-                rocblas_int rowA = tx + j;
-                size_t      indexA
-                    = rocblas_packed_matrix_index(!is_transpose, is_transpose, n, rowA, colA);
-
                 if(is_unit_diag && colA == rowA)
                     val += xshared[p];
                 else
                     val += (CONJ ? conj(A[indexA]) : A[indexA]) * xshared[p];
+
+                indexA -= is_transpose ? 1 : colA;
             }
 
             x[(tx + j) * incx] -= val;

--- a/projects/rocblas/library/src/blas2/rocblas_tpsv_kernels.cpp
+++ b/projects/rocblas/library/src/blas2/rocblas_tpsv_kernels.cpp
@@ -86,7 +86,7 @@ ROCBLAS_KERNEL_ILF void rocblas_tpsv_forward_substitution_calc(bool is_unit_diag
                 break;
 
             // 2. Sum result (across columns) to be subtracted from original value
-            T val = 0;
+            T           val  = 0;
             rocblas_int rowA = tx + j;
             rocblas_int colA = i;
             size_t indexA = rocblas_packed_matrix_index(is_transpose, is_transpose, n, rowA, colA);
@@ -164,7 +164,7 @@ ROCBLAS_KERNEL_ILF void rocblas_tpsv_backward_substitution_calc(bool is_unit_dia
                 break;
 
             // 2. Sum result (across columns) to be subtracted from the original value
-            T val = 0;
+            T           val  = 0;
             rocblas_int rowA = tx + j;
             rocblas_int colA = i;
             size_t indexA = rocblas_packed_matrix_index(!is_transpose, is_transpose, n, rowA, colA);


### PR DESCRIPTION
This pull request refactors and optimizes the forward and backward substitution routines in `rocblas_tpsv_kernels.cpp` by improving index calculations and loop structure. The changes enhance code clarity, reduce redundant calculations, and ensure more efficient traversal of packed matrix elements.

**Forward substitution improvements:**

* Refactored the calculation of matrix indices in the main substitution loop to initialize `rowA`, `colA`, and `indexA` before the loop and incrementally update them, reducing repeated computation and improving clarity.
* Optimized the summation loop by initializing `colA` and `indexA` outside the loop and updating them incrementally, streamlining access to packed matrix elements.

**Backward substitution improvements:**

* Refactored the backward substitution loop to initialize `rowA`, `colA`, and `indexA` before the loop and decrementally update them, improving efficiency and readability.
* Optimized the summation loop in backward substitution by initializing and updating `colA` and `indexA` incrementally, mirroring the improvements in forward substitution.