### PR TITLE
[hipBLASLt] Fix MatchTablePath in find_exact.py

### DIFF
--- a/projects/hipblaslt/utilities/find_exact.py
+++ b/projects/hipblaslt/utilities/find_exact.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -56,7 +56,7 @@ globalParameters["WorkingDir"] = {}
 globalParameters["WorkingDir"]["Bench"] = "0_Bench"
 globalParameters["WorkingDir"]["LogicYaml"] = "1_LogicYaml"
 globalParameters["WorkingDir"]["GridYaml"] = "2_GridYaml"
-globalParameters["MatchTablePath"] = "/library/src/amd_detail/rocblaslt/src/MatchTable.yaml"
+globalParameters["MatchTablePath"] = "/device-library/MatchTable.yaml"
 
 defaultBenchOptions = {"ProblemType": {
     "TransposeA": 0,


### PR DESCRIPTION
## Motivation

This PR updates default value of `globalParameters["MatchTablePath"]` in `find_exact.py`, which will be combined with `globalParameters["BuildDir"]` to formulate the absolute path to `MatchTable.yaml` as follow:

https://github.com/ROCm/rocm-libraries/blob/5b1b37b452f0ccdcc9ba70fdf9ff2b4ec6a6b6b5/projects/hipblaslt/utilities/find_exact.py#L328

## Test Plan
```bash
cd ~/rocm-libraries/projects/hipblaslt/utilities
python3 find_exact.py template.yaml ~/rocm-libraries/projects/hipblaslt/build/release/ output
```
## Test Result
Test passed without error
```
Running benchmarks
--Running size: result_NN_SSS_128x128x1x128.txt
Creating exact logic
--Reading matching table: /root/rocm-libraries/projects/hipblaslt/build/release/device-library/MatchTable.yaml
--Reading bench files
 --Found file /root/rocm-libraries/projects/hipblaslt/utilities/output/0_Bench/result_NN_SSS_128x128x1x128.txt
Writing logic yaml files: 100%|████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 14.73it/s]
```
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
