### PR TITLE
[hipblaslt][CMS] Add BF16 224x128x64 NN tile solution

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx950/Equality/gfx950_Cijk_Ailk_Bljk_BBS_BH_BiasSB_HAS_SAV_UserArgs.yaml
@@ -132258,6 +132258,251 @@
     reorderGRInstForDTVB: false
     tailLoopOptA: false
     tailLoopOptB: false
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: true
+    ActivationFused: true
+    AssertAIGreaterThanEqual: -1
+    AssertAILessThanEqual: -1
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BaseName: Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT2gcWiuKTLj3TdqeW2pCoiS-9cwMnPbXAkYluleAb8Yb0=
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    CUOccupancy: -1
+    ClusterLocalRead: 1
+    CodeObjectVersion: '4'
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DebugStreamK: 0
+    DepthU: 64
+    DirectToLds: true
+    DirectToLdsA: true
+    DirectToLdsB: true
+    DirectToVgprA: false
+    DirectToVgprB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: true
+    ExpandPointerSwap: 0
+    ExpertSchedulingMode: 0
+    ForceDisableShadowInit: false
+    ForceUnrollSubIter: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 8
+    GlobalReadVectorWidthB: 8
+    GlobalSplitU: 0
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalSplitUWorkGroupMappingRoundRobin: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: false
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [9, 5, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 2, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: false, UseSFC: false, UseUniversalArgs: true}
+    Kernel: true
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT224x128x64_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA8_GRVWB8_GSU0_GSUAMB_GLS0_ISA950_IU1_K1_LDSTI1_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA0_LPB16_LPM0_LRVW8_LWPMn1_MIAV0_MIWT7_4_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SPO0_SRVW0_SSO0_SVW1_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA1_VWB4_WSGRA0_WSGRB0_WS64_WG32_8_1
+    LDSTrInst: 1
+    LSCA: 224
+    LSCB: 64
+    LSPA: 10
+    LSPB: 32
+    LVCA: 28
+    LVCB: 8
+    LVPA: 2
+    LVPB: 4
+    LdsBlockSizePerPadA: 1024
+    LdsBlockSizePerPadB: 1024
+    LdsBlockSizePerPadMetadata: 0
+    LdsBytesNoAmax: 111104
+    LdsInitCVgprs: false
+    LdsNumBytes: 111104
+    LdsNumElementsAlignedA: 28672
+    LdsNumElementsAlignedB: 16896
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 65536
+    LdsOffsetB: 28672
+    LdsOffsetB_Blk: 94208
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 28672
+    LdsOffsetMetadata_Blk: 94208
+    LdsPadA: 0
+    LdsPadB: 16
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 8
+    LocalSplitU: 1
+    LocalSplitUReuseLDS: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: true
+    LocalWriteUseSgprB: true
+    LoopIters: 2
+    LoopUnroll: 64
+    MFMA_BF16_1K: false
+    MIArchVgpr: false
+    MIBlock: [16, 16, 32, 1, 1, 1]
+    MIInputPerThread: 8
+    MIInputPerThreadA: 8
+    MIInputPerThreadB: 8
+    MIInputPerThreadMetadata: 8
+    MIOutputVectorWidth: 4
+    MIRegPerOut: 1
+    MIWaveGroup: [2, 2]
+    MIWaveTile: [7, 4]
+    MIWaveTileA: 7
+    MIWaveTileB: 4
+    MIWaveTileMetadata: 0
+    MacroTile0: 224
+    MacroTile1: 128
+    MacroTileA: 224
+    MacroTileB: 128
+    MagicDivAlg: 2
+    MathClocksUnrolledLoop: 0
+    MatrixInstB: 1
+    MatrixInstBM: 1
+    MatrixInstBN: 1
+    MatrixInstK: 32
+    MatrixInstM: 16
+    MatrixInstN: 16
+    MatrixInstruction: [16, 16, 32, 1]
+    MaxLDS: 163840
+    MaxOccupancy: 40
+    MbskPrefetchMethod: 0
+    MfmaInitCVgprs: true
+    NoLdsWriteCode: true
+    NoReject: false
+    NoTailLoop: false
+    NonDTLTailLoopA: true
+    NonDTLTailLoopB: true
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 4
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NonTemporalWS: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 112
+    NumGlobalWriteVectorsPerThread: 112
+    NumLoadsA: 7
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 7
+    NumLoadsPerpendicularB: 4
+    NumThreads: 256
+    NumTotalPackedLoadsA: 7
+    NumTotalPackedLoadsB: 4
+    NumWaveSplitK: 1
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 2
+    PrefetchLocalRead: 1
+    PreloadKernArgs: true
+    SFCWGM:
+    - [1, 1]
+    - [1, 1]
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 3
+    ScheduleLocalWrite: 1
+    SolutionIndex: 559
+    SolutionNameMin: Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT224x128x64_MI16x16x1_CMS_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTLA1_DTLB1_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA8_GRVWB8_GSU0_GSUAMB_GSUC0_GSUWGMRR0_GLS0_ISA950_IU1_K1_LDSTI1_LBSPPA1024_LBSPPB1024_LBSPPM0_LPA0_LPB16_LPM0_LRVW8_LWPMn1_MIAV0_MIWT7_4_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA1_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SU0_SUM0_SUS128_SPO0_SRVW0_SSO0_SVW1_SK3_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA1_VWB4_WSGRA0_WSGRB0_WS64_WG32_8_1_WGM8_WGMXCC1_WGMXCCGn1
+    SourceSwap: 1
+    SpaceFillingAlgo: []
+    StaggerU: 0
+    StaggerUMapping: 0
+    StaggerUStride: 128
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSwapAddr: false
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    StreamK: 3
+    StreamKAtomic: 0
+    StreamKFixupTreeReduction: 0
+    StreamKXCCMapping: 0
+    SubGroup0: 8
+    SubGroup1: 32
+    SubGroupA: 8
+    SubGroupB: 32
+    SuppressNoLoadLoop: false
+    SwapGlobalReadOrder: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 28
+    ThreadTile1: 4
+    ThreadTileA: 28
+    ThreadTileB: 4
+    TransposeLDS: 1
+    TransposeLDSMetadata: true
+    ULSGRODoubleG2L: 0
+    UnrollLoopSwapGlobalReadOrder: 0
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: true
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseCustomMainLoopSchedule: true
+    UseDirect32XEmulation: false
+    UseDot2F32XEmulation: false
+    UseDotInstruction: false
+    UseF32XEmulation: false
+    UseGeneralizedNLCOneA: true
+    UseGeneralizedNLCOneB: true
+    UseGeneralizedNLCOneMetadata: false
+    UseInstOffsetForGRO: 0
+    UseMFMAF32XEmulation: false
+    UsePLRPack: false
+    UseSgprForGRO: 0
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 4
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WaveSplitK: false
+    WavefrontSize: 64
+    WorkGroup: [32, 8, 1]
+    WorkGroupMapping: 8
+    WorkGroupMappingXCC: 1
+    WorkGroupMappingXCCGroup: -1
+    WorkGroupReduction: false
+    WorkspaceCheck: [4, 0, 0]
+    _DepthU: 64
+    _DepthUA: 64
+    _DepthUB: 64
+    _DepthUMetadata: 64
+    _GlobalAccumulation: PartialsBuffer
+    _UseSgprForGRO: 0
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 4
+    _staggerStrideShift: 0
+    enableGLTrA: false
+    enableGLTrB: false
+    enableLDSTrA: true
+    enableLDSTrB: false
+    numSubTiles: 1
+    reorderGRInstForDTVA: false
+    reorderGRInstForDTVB: false
+    tailLoopOptA: false
+    tailLoopOptB: false
 - [2, 3, 0, 1]
 - - - [112, 491520, 1, 128]
     - [0, 0.0]
@@ -133381,6 +133626,8 @@
     - [557, 0.0]
   - - [4096, 1536, 1, 8192]
     - [558, 0.0]
+  - - [3584, 2048, 1, 8192]
+    - [559, 0.0]
 - null
 - null
 - DeviceEfficiency

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -1637,7 +1637,7 @@ def _get_schedule_224x128x64_16bit(kernel, useLDSTr, TLDS):
     elif isNN(kernel) and useLDSTr and TLDS==1:
         optSchedule = {
 
-            'SYNC'   : [[-1,3, 16,16, 27,27, 48,48]],
+            'SYNC'   : [[-1,3, 16,16, 27, 35,35, 48,48]],
             'GRIncA' : [[1,2,3,4,4,5,5,6,6]],
             'GRIncB' : [[7,7,8,8,9,9,10,11,11]],
 
@@ -1650,7 +1650,7 @@ def _get_schedule_224x128x64_16bit(kernel, useLDSTr, TLDS):
             'GRB'    : [[42,42, 45,45, 48,48, 51,51]],
 
             #After previous GRA is done.
-            'LRA1'   : [[29,30, 32,33, 35,36,37,38, 40,41, 43,44, 46,47]],
+            'LRA1'   : [[35,36,37,38,39,40,41,42,43,44,45,46,47,48]],
             #After previous GRB is done.
             'LRB1'   : [[49,50, 52,53]],
 
@@ -1666,9 +1666,10 @@ def _get_schedule_224x128x64_16bit(kernel, useLDSTr, TLDS):
                     SWaitCnt(dscnt=5, vlcnt=-1, vscnt=-1, comment="Wait for prior LRA1/LRB1 for the remaining main loop"),
                     SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0 to complete to start GRA"),
                     SBarrier(comment=""),
-                    SWaitCnt(dscnt=0, vlcnt=8, vscnt=-1, comment="Wait for LRB0/GRA to complete to start GRB/LRA1"),
+                    SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRB0 to complete"),
+                    SWaitCnt(dscnt=-1, vlcnt=11, vscnt=-1, comment="Wait for previous GRA to complete to start LRA1"),
                     SBarrier(comment=""),
-                    SWaitCnt(dscnt=-1, vlcnt=9, vscnt=-1, comment="Wait for GRB to complete to start LRB1"),
+                    SWaitCnt(dscnt=-1, vlcnt=9, vscnt=-1, comment="Wait for previous GRB to complete to start LRB1"),
                     SBarrier(comment=""),
                    ]
         nglshift = nllshift = 11 # vmcnt shift for ngl and nll

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -1599,37 +1599,82 @@ def _get_schedule_256x208x64_16bit(kernel, useLDSTr, TLDS):
     mfma_wave_group=[2, 2]
 )
 def _get_schedule_224x128x64_16bit(kernel, useLDSTr, TLDS):
-    if not (isTN(kernel) and TLDS):
-        return False, None
     kernel["MfmaInitCVgprs"] = True
-    nglshift = nllshift = 11 # vmcnt shift for ngl and nll
-    optSchedule = {
-    'SYNC': [[-1, 6, 14, 14, 27,27, 47, 47]], 
-    'LRA0': [[0,1, 2,3,4,5,5]],
-    'GRIncA': [[0, 0, 1, 1, 2,2 , 3,3, 4]],
-    'LRB0': [[9, 11,13, 19]],
-    'GRIncB': [[ 6,6,7,7,8,8,9,9,10]],
-    'GRA': [[14, 14, 16,16,18,18,20,20,23,23, 26,26, 27, 27]], 
-    'LRSA': [[26]],
-    'LRSB': [[26]],
-    'GRB': [[33,34,36,38,38,42,42,46]],
-    'LWSA': [[54]],
-    'LWSB': [[54]],
-    'LRA1': [[30,35,44, 45, 46, 48,51]],
-    'LRB1': [[47,52,54,55]],
-    'LCC': [[55, 55]],
-    }
 
-    syncCode = [
-        SWaitCnt(dscnt=3, vlcnt=-1, vscnt=-1, comment="wait for all of LRA1 and the first instance of LRB1"),
-        SWaitCnt(dscnt=8, vlcnt=-1, vscnt=-1, comment="wait for the second instance of LRB1"),
-        SWaitCnt(dscnt=3, vlcnt=-1, vscnt=-1, comment="wait for all LRA0 to complete so GRA could begin. Makes sure LRB1 is completed so no need for a barrier at 21"),
-        SBarrier(comment=""),
-        SWaitCnt(dscnt=0, vlcnt=10, vscnt=-1, comment="wait for all LR. All of previous GRB (4) and current GRA (6), total of 10 can be outstanding"),
-        SBarrier(comment=""),
-        SWaitCnt(dscnt=-1, vlcnt=11, vscnt=-1, comment="Outstanding LR are all LRA so no need to wait. All of GR from previous iteration must be done."),
-        SBarrier(comment="")
-    ]
+    optSchedule = dict()
+    syncCode = []
+
+    nglshift = nllshift = 0 # vmcnt shift for ngl and nll
+    if isTN(kernel) and not useLDSTr and TLDS==1:
+        nglshift = nllshift = 11 # vmcnt shift for ngl and nll
+        optSchedule = {
+            'SYNC': [[-1, 6, 14, 14, 27,27, 47, 47]],
+            'LRA0': [[0,1, 2,3,4,5,5]],
+            'GRIncA': [[0, 0, 1, 1, 2,2 , 3,3, 4]],
+            'LRB0': [[9, 11,13, 19]],
+            'GRIncB': [[ 6,6,7,7,8,8,9,9,10]],
+            'GRA': [[14, 14, 16,16,18,18,20,20,23,23, 26,26, 27, 27]],
+            'LRSA': [[26]],
+            'LRSB': [[26]],
+            'GRB': [[33,34,36,38,38,42,42,46]],
+            'LWSA': [[54]],
+            'LWSB': [[54]],
+            'LRA1': [[30,35,44, 45, 46, 48,51]],
+            'LRB1': [[47,52,54,55]],
+            'LCC': [[55, 55]],
+        }
+
+        syncCode = [
+            SWaitCnt(dscnt=3, vlcnt=-1, vscnt=-1, comment="wait for all of LRA1 and the first instance of LRB1"),
+            SWaitCnt(dscnt=8, vlcnt=-1, vscnt=-1, comment="wait for the second instance of LRB1"),
+            SWaitCnt(dscnt=3, vlcnt=-1, vscnt=-1, comment="wait for all LRA0 to complete so GRA could begin. Makes sure LRB1 is completed so no need for a barrier at 21"),
+            SBarrier(comment=""),
+            SWaitCnt(dscnt=0, vlcnt=10, vscnt=-1, comment="wait for all LR. All of previous GRB (4) and current GRA (6), total of 10 can be outstanding"),
+            SBarrier(comment=""),
+            SWaitCnt(dscnt=-1, vlcnt=11, vscnt=-1, comment="Outstanding LR are all LRA so no need to wait. All of GR from previous iteration must be done."),
+            SBarrier(comment="")
+        ]
+    elif isNN(kernel) and useLDSTr and TLDS==1:
+        optSchedule = {
+
+            'SYNC'   : [[-1,3, 16,16, 27,27, 48,48]],
+            'GRIncA' : [[1,2,3,4,4,5,5,6,6]],
+            'GRIncB' : [[7,7,8,8,9,9,10,11,11]],
+
+            'LRA0'   : [[0,1,1,2,2,3,4,5,6,7,8,9,10,11]],
+            'LRB0'   : [[17,18,19,20]],   ## After LRA0, we can mix LRB0 and GRA
+
+            ## GRA should start after LRA0 is done.
+            'GRA'    : [[15,16, 19,19, 22,22, 25,25, 28,28, 31,31, 34,34]],
+            ## GRB should start after LRB0 is done.
+            'GRB'    : [[42,42, 45,45, 48,48, 51,51]],
+
+            #After previous GRA is done.
+            'LRA1'   : [[29,30, 32,33, 35,36,37,38, 40,41, 43,44, 46,47]],
+            #After previous GRB is done.
+            'LRB1'   : [[49,50, 52,53]],
+
+            'LRSA'   : [[24]], # after LRA0 and before LRA1
+            'LRSB'   : [[24]], # after LRB0 and before LRB2
+            'LWSA'   : [[53]], # For A
+            'LWSB'   : [[54]],
+
+            'LCC'    : [[54, 55]],
+        }
+        # note: syncCode needs to be
+        syncCode = [SWaitCnt(dscnt=3, vlcnt=-1, vscnt=-1, comment="Wait for necessary prior LRA1/LRB1 before starting main loop"),
+                    SWaitCnt(dscnt=5, vlcnt=-1, vscnt=-1, comment="Wait for prior LRA1/LRB1 for the remaining main loop"),
+                    SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="Wait for LRA0 to complete to start GRA"),
+                    SBarrier(comment=""),
+                    SWaitCnt(dscnt=0, vlcnt=8, vscnt=-1, comment="Wait for LRB0/GRA to complete to start GRB/LRA1"),
+                    SBarrier(comment=""),
+                    SWaitCnt(dscnt=-1, vlcnt=9, vscnt=-1, comment="Wait for GRB to complete to start LRB1"),
+                    SBarrier(comment=""),
+                   ]
+        nglshift = nllshift = 11 # vmcnt shift for ngl and nll
+    else:
+        return False, None
+
     numMfma = 56
     opt1 = ScheduleInfo(1, numMfma, optSchedule, syncCode, nglshift, nllshift)
     return True, opt1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
@@ -618,6 +618,40 @@ BenchmarkProblems:
           - Range: [[256], [96], [1], [1, 1, 64]]
           - Range: [[256], [96], [1], [32, 64, 256]]
         - BiasTypeArgs: ['b']
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+           - [16, 16,32, 1,  1, 7, 4,  2,2 ]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1]
+        - LDSTrInst: [1]
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - StreamK: [3]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[224], [128], [1], [64, 64, 256]]    # - Range: [[MT0], [MT1], [1], [DU, DU, 4*DU]]
+          - Range: [[224], [128], [1], [1,1,64]]         # - Range: [[MT0], [MT1], [1], [1,1,DU]]
+          - Range: [[224], [128], [1], [32, 64, 256]]    # - Range: [[MT0], [MT1], [1], [DU/2, DU, 4*DU]]
+        - BiasTypeArgs: ['b']
   ########################################
   # HHS NN - standard
   ########################################

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
@@ -648,9 +648,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [128], [1], [64, 64, 256]]    # - Range: [[MT0], [MT1], [1], [DU, DU, 4*DU]]
-          - Range: [[224], [128], [1], [1,1,64]]         # - Range: [[MT0], [MT1], [1], [1,1,DU]]
-          - Range: [[224], [128], [1], [32, 64, 256]]    # - Range: [[MT0], [MT1], [1], [DU/2, DU, 4*DU]]
+          - Range: [[224], [128], [1], [64, 64, 256]]
+          - Range: [[224], [128], [1], [1,1,64]]
+          - Range: [[224], [128], [1], [32, 64, 256]]
         - BiasTypeArgs: ['b']
   ########################################
   # HHS NN - standard

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -407,6 +407,7 @@ class TestCustomScheduleBF16:
         # fmt: off
         "transA, transB, lds_tr_inst,  tr_lds", [
         (  True,  False,       False,       1),
+        ( False,  False,        True,       1),
         # fmt: on
         ])
     def test_schedule_224x128x64_16bit(self, transA, transB, lds_tr_inst, tr_lds):


### PR DESCRIPTION
## Motivation

Add CMS solution for BF16 224x128x64 NN tile.

## Technical Details

Problem size: [M, N, K] = [3584, 2048, 8192]

- **Tensile**: CMS achieves **~9.2% speedup** vs. non-CMS
- **main-loop efficiency**: improves from 67.0% to **89.3%**
- **hipblaslt-bench** with K=8192: no gains (~**3.3% regression**) w.r.t. baseline with 256x256x64 Origami kernel
- **hipblaslt-bench** with K=4096: **6.6% speedup** w.r.t. baseline with 192x160x128 Origami kernel

After optimizing by [617fe4c](https://github.com/ROCm/rocm-libraries/pull/4304/commits/617fe4ca168447ee7ead826d204f85440b77f716)

- **Tensile**: CMS achieves **~9.3% speedup** vs. non-CMS
- **main-loop efficiency**: improves from 67.0% to **90.4%**
- **hipblaslt-bench** with K=8192: no gains (~**3.2% regression**) w.r.t. baseline with 256x256x64 Origami kernel
- **hipblaslt-bench** with K=4096: **7.2% speedup** w.r.t. baseline with 192x160x128 Origami kernel
- ALL tests PASSED.

## Test Result

All tests PASSED via Tensile as well as **hipblaslt-test**
```
        - ProblemSizes:
          - Exact: [3584, 2048, 1, 8192]  # [224x16, 128x16, 1, 64x128]
          - Range: [[224], [128], [1], [64, 64, 256]]
          - Range: [[224], [128], [1], [1,1,64]]
          - Range: [[224], [128], [1], [32, 64, 256]]
```
```
[----------] Global test environment tear-down
[==========] 21891 tests from 12 test suites ran. (1483495 ms total)
[  PASSED  ] 21891 tests.
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

AIGECORE-107