### PR TITLE
[Origami] Expose additional selection result parameters via Python interface

### DIFF
--- a/shared/origami/python/src/origami/selector.py
+++ b/shared/origami/python/src/origami/selector.py
@@ -374,47 +374,6 @@ class OrigamiMatmulSelector:
     #####
 
     @property
-    def reduction_strategy_algorithm(self):
-        """
-        Reduction strategy used for StreamK scheduling.
-        
-        Indicates the algorithm used for partial tile reductions in StreamK.
-        
-        Returns:
-            origami.reduction_t: The reduction strategy enum value.
-        """
-        return self._result.config.reduction_strategy
-
-
-    @property
-    def prediction_mode(self):
-        """
-        Prediction mode used for latency estimation during config selection.
-        
-        Controls whether fast analytical estimation or slower simulation-based
-        prediction was used to rank configurations.
-        
-        Returns:
-            origami.prediction_modes_t: The prediction mode enum value.
-        """
-        return self._result.config.prediction_mode
-
-
-    @property
-    def targeted_backend(self):
-        """
-        Target backend for kernel execution.
-        
-        Indicates which backend (e.g., Triton, TensileLite) the configuration
-        was selected for.
-        
-        Returns:
-            origami.target_t: The target backend enum value.
-        """
-        return self._result.config.target
-
-
-    @property
     def grid_selection_algorithm(self):
         """
         Grid selection algorithm used for determining grid size.

--- a/shared/origami/python/src/origami/selector.py
+++ b/shared/origami/python/src/origami/selector.py
@@ -177,6 +177,10 @@ class OrigamiMatmulSelector:
         )
 
 
+    #####
+    # Selection result properties
+    #####
+
     @property
     def macrotile_m(self):
         """
@@ -221,7 +225,8 @@ class OrigamiMatmulSelector:
             int: Workgroup mapping size.
         """
         return self._workgroup_mapping.wgm
-    
+
+
     @property
     def wgmxcc(self):
         """
@@ -234,7 +239,8 @@ class OrigamiMatmulSelector:
             int: Number of workgroups mapped per XCC.
         """
         return self._workgroup_mapping.wgmxcc
-    
+
+
     @property
     def wgmxccchunk(self):
         """
@@ -246,6 +252,7 @@ class OrigamiMatmulSelector:
             int: Chunk size for XCC workgroup mapping.
         """
         return self._workgroup_mapping.wgmxccchunk
+
 
     @property
     def number_of_cus(self):
@@ -280,6 +287,61 @@ class OrigamiMatmulSelector:
 
 
     @property
+    def cache_hints(self):
+        """
+        Cache hint bitmasks for operands A and B.
+        
+        Bitmask values corresponding to Triton's cache hint flags, controlling cache
+        behavior when loading matrix operands.
+        
+        Returns:
+            tuple[int, int]: A tuple of (cache_hints_a, cache_hints_b) bitmask values.
+        """
+        return (self._result.config.cache_hints_a, self._result.config.cache_hints_b)
+
+
+    @property
+    def matrix_instruction_dimensions(self):
+        """
+        Matrix instruction dimensions (M, N, K) for the selected configuration.
+        
+        These are the hardware matrix instruction dimensions used by the GEMM kernel,
+        determined by the GPU architecture and data types.
+        
+        Returns:
+            tuple[int, int, int]: A tuple of (mi_m, mi_n, mi_k) dimensions.
+        """
+        return (self._result.config.mi.m, self._result.config.mi.n, self._result.config.mi.k)
+
+
+    @property
+    def workspace_size(self):
+        """
+        Workspace buffer size in bytes required for the kernel.
+        
+        For StreamK and other algorithms that require temporary storage,
+        this indicates the total workspace memory needed.
+        
+        Returns:
+            int: Workspace size in bytes.
+        """
+        return self._result.config.workspace_size
+
+
+    @property
+    def workspace_size_per_elem_c(self):
+        """
+        Workspace size per output element in bytes.
+        
+        Used to calculate partial tile workspace requirements for StreamK scheduling.
+        
+        Returns:
+            int: Bytes of workspace required per output matrix element.
+        """
+        return self._result.config.workspace_size_per_elem_c
+
+
+    @property
     def even_k(self):
         """
         Whether the K dimension is evenly divisible by the macrotile K size.
@@ -306,6 +368,68 @@ class OrigamiMatmulSelector:
         """
         return self._grid
 
+
+    #####
+    # Selection decision properties - for examining how selections were made after-the-fact
+    #####
+
+    @property
+    def reduction_strategy_algorithm(self):
+        """
+        Reduction strategy used for StreamK scheduling.
+        
+        Indicates the algorithm used for partial tile reductions in StreamK.
+        
+        Returns:
+            origami.reduction_t: The reduction strategy enum value.
+        """
+        return self._result.config.reduction_strategy
+
+
+    @property
+    def prediction_mode(self):
+        """
+        Prediction mode used for latency estimation during config selection.
+        
+        Controls whether fast analytical estimation or slower simulation-based
+        prediction was used to rank configurations.
+        
+        Returns:
+            origami.prediction_modes_t: The prediction mode enum value.
+        """
+        return self._result.config.prediction_mode
+
+
+    @property
+    def targeted_backend(self):
+        """
+        Target backend for kernel execution.
+        
+        Indicates which backend (e.g., Triton, TensileLite) the configuration
+        was selected for.
+        
+        Returns:
+            origami.target_t: The target backend enum value.
+        """
+        return self._result.config.target
+
+
+    @property
+    def grid_selection_algorithm(self):
+        """
+        Grid selection algorithm used for determining grid size.
+        
+        Indicates which algorithm was used to select the number of workgroups.
+        
+        Returns:
+            origami.grid_selection_t: The grid selection algorithm enum value.
+        """
+        return self._result.config.grid_selection
+
+
+    #####
+    # Internal helper functions
+    #####
 
     def _generate_configs(self, config_gen) -> [origami.config_t]:
         """

--- a/shared/origami/python/src/origami/selector.py
+++ b/shared/origami/python/src/origami/selector.py
@@ -177,10 +177,6 @@ class OrigamiMatmulSelector:
         )
 
 
-    #####
-    # Selection result properties
-    #####
-
     @property
     def macrotile_m(self):
         """
@@ -369,10 +365,6 @@ class OrigamiMatmulSelector:
         return self._grid
 
 
-    #####
-    # Selection decision properties - for examining how selections were made after-the-fact
-    #####
-
     @property
     def grid_selection_algorithm(self):
         """
@@ -385,10 +377,6 @@ class OrigamiMatmulSelector:
         """
         return self._result.config.grid_selection
 
-
-    #####
-    # Internal helper functions
-    #####
 
     def _generate_configs(self, config_gen) -> [origami.config_t]:
         """

--- a/shared/origami/python/tests/test_selector.py
+++ b/shared/origami/python/tests/test_selector.py
@@ -480,6 +480,154 @@ def test_selector_problem_creation(rocm_device):
     assert selector._problem.batch == 1
 
 
+@pytest.mark.integration
+def test_selector_cache_hints_property(rocm_device):
+    """Test cache_hints property returns a tuple of two integers."""
+    config_gen = create_mock_config_gen()
+
+    selector = OrigamiMatmulSelector(
+        config_gen=config_gen,
+        m=2048,
+        n=2048,
+        k=2048,
+        a_dtype=torch.float16,
+        b_dtype=torch.float16,
+        out_dtype=torch.float16,
+        device=rocm_device
+    )
+
+    cache_hints = selector.cache_hints
+    assert isinstance(cache_hints, tuple)
+    assert len(cache_hints) == 2
+    assert isinstance(cache_hints[0], int)
+    assert isinstance(cache_hints[1], int)
+    assert cache_hints[0] >= 0
+    assert cache_hints[1] >= 0
+
+
+@pytest.mark.integration
+def test_selector_matrix_instruction_dimensions_property(rocm_device):
+    """Test matrix_instruction_dimensions property returns a tuple of three positive integers."""
+    config_gen = create_mock_config_gen()
+
+    selector = OrigamiMatmulSelector(
+        config_gen=config_gen,
+        m=2048,
+        n=2048,
+        k=2048,
+        a_dtype=torch.float16,
+        b_dtype=torch.float16,
+        out_dtype=torch.float16,
+        device=rocm_device
+    )
+
+    mi_dims = selector.matrix_instruction_dimensions
+    assert isinstance(mi_dims, tuple)
+    assert len(mi_dims) == 3
+    assert all(isinstance(dim, int) for dim in mi_dims)
+    assert all(dim > 0 for dim in mi_dims)
+
+
+@pytest.mark.integration
+def test_selector_workspace_size_property(rocm_device):
+    """Test workspace_size property returns a non-negative integer."""
+    config_gen = create_mock_config_gen()
+
+    selector = OrigamiMatmulSelector(
+        config_gen=config_gen,
+        m=2048,
+        n=2048,
+        k=2048,
+        a_dtype=torch.float16,
+        b_dtype=torch.float16,
+        out_dtype=torch.float16,
+        device=rocm_device
+    )
+
+    assert isinstance(selector.workspace_size, int)
+    assert selector.workspace_size >= 0
+
+
+@pytest.mark.integration
+def test_selector_workspace_size_per_elem_c_property(rocm_device):
+    """Test workspace_size_per_elem_c property returns a non-negative integer."""
+    config_gen = create_mock_config_gen()
+
+    selector = OrigamiMatmulSelector(
+        config_gen=config_gen,
+        m=2048,
+        n=2048,
+        k=2048,
+        a_dtype=torch.float16,
+        b_dtype=torch.float16,
+        out_dtype=torch.float16,
+        device=rocm_device
+    )
+
+    assert isinstance(selector.workspace_size_per_elem_c, int)
+    assert selector.workspace_size_per_elem_c >= 0
+
+
+@pytest.mark.integration
+def test_selector_wgmxcc_property(rocm_device):
+    """Test wgmxcc (workgroup mapping across XCCs) property."""
+    config_gen = create_mock_config_gen()
+
+    selector = OrigamiMatmulSelector(
+        config_gen=config_gen,
+        m=2048,
+        n=2048,
+        k=2048,
+        a_dtype=torch.float16,
+        b_dtype=torch.float16,
+        out_dtype=torch.float16,
+        device=rocm_device
+    )
+
+    assert isinstance(selector.wgmxcc, int)
+    assert selector.wgmxcc > 0
+
+
+@pytest.mark.integration
+def test_selector_wgmxccchunk_property(rocm_device):
+    """Test wgmxccchunk (workgroup mapping chunk size) property."""
+    config_gen = create_mock_config_gen()
+
+    selector = OrigamiMatmulSelector(
+        config_gen=config_gen,
+        m=2048,
+        n=2048,
+        k=2048,
+        a_dtype=torch.float16,
+        b_dtype=torch.float16,
+        out_dtype=torch.float16,
+        device=rocm_device
+    )
+
+    assert isinstance(selector.wgmxccchunk, int)
+    assert selector.wgmxccchunk >= 0
+
+
+@pytest.mark.integration
+def test_selector_grid_selection_algorithm_property(rocm_device):
+    """Test grid_selection_algorithm property returns a valid grid_selection_t enum."""
+    config_gen = create_mock_config_gen()
+
+    selector = OrigamiMatmulSelector(
+        config_gen=config_gen,
+        m=2048,
+        n=2048,
+        k=2048,
+        a_dtype=torch.float16,
+        b_dtype=torch.float16,
+        out_dtype=torch.float16,
+        device=rocm_device
+    )
+
+    grid_selection = selector.grid_selection_algorithm
+    assert isinstance(grid_selection, origami.grid_selection_t)
+
+
 #####
 # Tests for _check_transpose_type functionality
 #####

--- a/shared/origami/python/tests/test_selector.py
+++ b/shared/origami/python/tests/test_selector.py
@@ -503,6 +503,9 @@ def test_selector_cache_hints_property(rocm_device):
     assert isinstance(cache_hints[1], int)
     assert cache_hints[0] >= 0
     assert cache_hints[1] >= 0
+    # Verify property matches underlying data
+    assert cache_hints[0] == selector._result.config.cache_hints_a
+    assert cache_hints[1] == selector._result.config.cache_hints_b
 
 
 @pytest.mark.integration
@@ -526,6 +529,10 @@ def test_selector_matrix_instruction_dimensions_property(rocm_device):
     assert len(mi_dims) == 3
     assert all(isinstance(dim, int) for dim in mi_dims)
     assert all(dim > 0 for dim in mi_dims)
+    # Verify property matches underlying data
+    assert mi_dims[0] == selector._result.config.mi.m
+    assert mi_dims[1] == selector._result.config.mi.n
+    assert mi_dims[2] == selector._result.config.mi.k
 
 
 @pytest.mark.integration
@@ -546,6 +553,8 @@ def test_selector_workspace_size_property(rocm_device):
 
     assert isinstance(selector.workspace_size, int)
     assert selector.workspace_size >= 0
+    # Verify property matches underlying data
+    assert selector.workspace_size == selector._result.config.workspace_size
 
 
 @pytest.mark.integration
@@ -566,6 +575,8 @@ def test_selector_workspace_size_per_elem_c_property(rocm_device):
 
     assert isinstance(selector.workspace_size_per_elem_c, int)
     assert selector.workspace_size_per_elem_c >= 0
+    # Verify property matches underlying data
+    assert selector.workspace_size_per_elem_c == selector._result.config.workspace_size_per_elem_c
 
 
 @pytest.mark.integration
@@ -586,6 +597,8 @@ def test_selector_wgmxcc_property(rocm_device):
 
     assert isinstance(selector.wgmxcc, int)
     assert selector.wgmxcc > 0
+    # Verify property matches underlying data
+    assert selector.wgmxcc == selector._workgroup_mapping.wgmxcc
 
 
 @pytest.mark.integration
@@ -606,6 +619,8 @@ def test_selector_wgmxccchunk_property(rocm_device):
 
     assert isinstance(selector.wgmxccchunk, int)
     assert selector.wgmxccchunk >= 0
+    # Verify property matches underlying data
+    assert selector.wgmxccchunk == selector._workgroup_mapping.wgmxccchunk
 
 
 @pytest.mark.integration
@@ -626,6 +641,8 @@ def test_selector_grid_selection_algorithm_property(rocm_device):
 
     grid_selection = selector.grid_selection_algorithm
     assert isinstance(grid_selection, origami.grid_selection_t)
+    # Verify property matches underlying data
+    assert grid_selection == selector._result.config.grid_selection
 
 
 #####


### PR DESCRIPTION
## Motivation

The `OrigamiMatmulSelector` Python wrapper currently provides easy access to only a subset of the configuration results from the Origami analytical model while the rest are hidden away quite deeply in the call hierarchy.  Downstream consumers may want  access to these parameters to tune their GEMM kernels more precisely.

This PR exposes the remaining selected `config_t` fields that are available through the nanobindings, making the Python interface more complete and useful for callers who desire all selection information.

## Technical Details

New properties added to `OrigamiMatmulSelector`:
- `cache_hints`
- `matrix_instruction_dimensions`
- `workspace_size`
- `workspace_size_per_elem_c`
- `grid_selection_algorithm`

These all obtain their value from the `config_t` which Origami selected as the best config for the given problem.

## Test Plan

- Adds tests to the existing `test_selector.py` file to ensure each property is accessible, the values are the types/shapes expected, and that the values match the underlying `config_t`.  Correctness checks regarding accuracy of selection should come from the underlying Origami C++ tests.

## Test Result

```
============================== test session starts ==============================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/AMD/aunderwo/repos/rocm-libraries/shared/origami/python
configfile: pyproject.toml
collected 65 items

tests/test_hardware.py ........                                           [ 12%]
tests/test_origami.py ...................                                 [ 41%]
tests/test_selector.py ......................................             [100%]

============================== 65 passed in 0.20s ==============================
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
