### PR TITLE
[Tensilelite] Added MIArchVgpr support for Complex Datatypes.

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/GlobalWriteBatch.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/GlobalWriteBatch.py
@@ -1626,13 +1626,13 @@ class GlobalWriteBatchWriter:
           newSumIdx = sumIdxV * 4 - self.parentWriter.states.c.startVgprValu
           vtmp1 = self.parentWriter.vgprPool.checkOutAligned(2, 2)
           vtmp2 = self.parentWriter.vgprPool.checkOutAligned(2, 2)
-          # tmp1 = a.real * b.real
+          # tmp1 = a.real * b.real (t1 = Ar*Cr)
           module.add(VMulF64(dst=vgpr(vtmp1,2), src0=sgpr("Alpha+0",2), src1=vgpr("ValuC+%u"%(newSumIdx+0),2)))
-          # tmp2 = a.imag * b.real
+          # tmp2 = a.imag * b.real (t2 = Ai*Cr)
           module.add(VMulF64(dst=vgpr(vtmp2,2), src0=sgpr("Alpha+2",2), src1=vgpr("ValuC+%u"%(newSumIdx+0),2)))
-          # c.real = a.real * b.real - a.imag * b.imag = tmp1 - a.imag * b.imag
+          # c.real = a.real * b.real - a.imag * b.imag = tmp1 - a.imag * b.imag (Cr = -Ai*Ci + t1).
           module.add(VFmaF64(dst=vgpr("ValuC+%u"%(newSumIdx+0),2), src0=sgpr("Alpha+2",2), src1=vgpr("ValuC+%u"%(newSumIdx+2),2).getMinus(), src2=vgpr(vtmp1,2)))
-          # c.imag = a.real * b.imag + a.imag * b.real = a.real * b.imag + tmp2
+          # c.imag = a.real * b.imag + a.imag * b.real = a.real * b.imag + tmp2 (Ci = Ar*Ci + t2).
           module.add(VFmaF64(dst=vgpr("ValuC+%u"%(newSumIdx+2),2), src0=sgpr("Alpha+0",2), src1=vgpr("ValuC+%u"%(newSumIdx+2),2), src2=vgpr(vtmp2,2)))
           if usePK:
             newSumIdx2 = newSumIdx + 4

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -4975,8 +4975,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     # for cgemm or zgemm + MIAV case, allocate 2 or 4 vgpr for alpha calculation (cannot use tmp vgpr in write batch)
     if kernel["ProblemType"]["DataType"].isComplex() \
-      and kernel["MIArchVgpr"] \
-      and (kernel["_GlobalAccumulation"] == 'SingleBuffer' or kernel["_GlobalAccumulation"] == None):
+      and kernel["MIArchVgpr"]: 
 
       # need proper alignment
       vgprIdx = ((vgprIdx+2 - 1)//2)*2

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterModules.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterModules.py
@@ -279,13 +279,13 @@ def mulMIoutAlphaToArch(kernel, startVgprAlphaTmp):
         vtmp1 = startVgprAlphaTmp
         vtmp2 = vtmp1 + 1
         # tmp1 = a.real * b.real
-        cimod.add(VMulF32(dst=vgpr(vtmp1), src0=sgpr("Alpha+0"), src1=vgpr("ValuC+%u"%srcIdx), comment=""))
+        cimod.add(VMulF32(dst=vgpr(vtmp1), src0=sgpr("Alpha+0"), src1=vgpr("ValuC+%u"%srcIdx), comment="tmp1 = a.real * b.real"))
         # tmp2 = a.imag * b.real
-        cimod.add(VMulF32(dst=vgpr(vtmp2), src0=sgpr("Alpha+1"), src1=vgpr("ValuC+%u"%srcIdx), comment=""))
+        cimod.add(VMulF32(dst=vgpr(vtmp2), src0=sgpr("Alpha+1"), src1=vgpr("ValuC+%u"%srcIdx), comment="tmp2 = a.imag * b.real"))
         # c.real = a.real * b.real - a.imag * b.imag = tmp1 - a.imag * b.imag
-        cimod.add(VFmaF32(dst=vgpr(Holder(name="ValuC")), src0=sgpr("Alpha+1"), src1=vgpr("ValuC+%u"%(srcIdx+accImOffset)).getMinus(), src2=vgpr(vtmp1)))
+        cimod.add(VFmaF32(dst=vgpr(Holder(name="ValuC")), src0=sgpr("Alpha+1"), src1=vgpr("ValuC+%u"%(srcIdx+accImOffset)).getMinus(), src2=vgpr(vtmp1), comment="c.real = a.real * b.real - a.imag * b.imag = tmp1 - a.imag * b.imag"))
         # c.imag = a.real * b.imag + a.imag * b.real = a.real * b.imag + tmp2
-        cimod.add(VFmaF32(dst=vgpr(Holder(name="ValuC+1")), src0=sgpr("Alpha+0"), src1=vgpr("ValuC+%u"%(srcIdx+accImOffset)), src2=vgpr(vtmp2)))
+        cimod.add(VFmaF32(dst=vgpr(Holder(name="ValuC+1")), src0=sgpr("Alpha+0"), src1=vgpr("ValuC+%u"%(srcIdx+accImOffset)), src2=vgpr(vtmp2), comment="c.imag = a.real * b.imag + a.imag * b.real = a.real * b.imag + tmp2"))
         itemList[destIdx] = cimod
     elif kernel["ProblemType"]["ComputeDataType"].isDoubleComplex():
       accImOffset = accVgprImagNumOffset(kernel)

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1530,11 +1530,8 @@ class Solution(collections.abc.Mapping):
 
     # Complex datatype restrictions.
     if state["ProblemType"]["DataType"].isComplex():
-      if (state["GlobalSplitU"] > 1 or state["GlobalSplitU"] == -1) and (state["GlobalSplitUAlgorithm"] != "MultipleBuffer"):
-        reject(state, printRejectionReason, "Complex datatype kernel currently only supports MultiBuffer GSU.")
-        return
-      if state["MIArchVgpr"]:
-        reject(state, printRejectionReason, "Complex datatype kernel does not support MIArchVgpr yet.")
+      if state["MIArchVgpr"] and state["StreamK"] != 0:
+        reject(state, printRejectionReason, "Complex datatype kernel does not support StreamK with MIArchVgpr yet.")
         return
 
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/cgemm.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/cgemm.yaml
@@ -60,7 +60,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
           # - [16, 16, 4, 1, 1, 2, 2, 2, 2]
         - ScheduleIterAlg: [1, 3] #,3]
-        - MIArchVgpr: [0] #, 1]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         # - StreamK: [3]
@@ -116,6 +116,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -157,6 +158,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -198,6 +200,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -239,6 +242,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -280,6 +284,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -321,6 +326,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -362,6 +368,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -403,6 +410,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/zgemm.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/zgemm.yaml
@@ -62,6 +62,7 @@ BenchmarkProblems:
           # - [16, 16, 4, 4, 4, 4, 4, 1, 4] #256x256 not-working
           # - [16, 16, 4, 1, 1, 2, 2, 2, 2]
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         # - StreamK: [3]
@@ -123,6 +124,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -164,6 +166,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -205,6 +208,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -246,6 +250,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -287,6 +292,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -328,6 +334,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -369,6 +376,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -410,6 +418,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 2, 2, 2, 2] #64x64
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
+        - MIArchVgpr: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/include/container.hpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/include/container.hpp
@@ -1003,12 +1003,14 @@ namespace rocisa
         std::string holderName;
         int         holderIdx;
         int         holderType;
+        std::vector<int> holderOffsets;
 
         HolderContainer(const std::string& regType, const std::string& holderName, float regNum)
             : RegisterContainer(regType, RegName(holderName), 0, regNum)
             , holderName(holderName)
             , holderIdx(0)
             , holderType(1)
+            , holderOffsets({})
         {
         }
 
@@ -1017,6 +1019,7 @@ namespace rocisa
             , holderName(regName.name)
             , holderIdx(0)
             , holderType(1)
+            , holderOffsets(regName.offsets)
         {
         }
 
@@ -1025,6 +1028,7 @@ namespace rocisa
             , holderName("")
             , holderIdx(holderIdx)
             , holderType(0)
+            , holderOffsets({})
         {
         }
 
@@ -1033,6 +1037,7 @@ namespace rocisa
             , holderName(other.holderName)
             , holderIdx(other.holderIdx)
             , holderType(other.holderType)
+            , holderOffsets(other.holderOffsets)
         {
         }
 
@@ -1041,6 +1046,7 @@ namespace rocisa
             , holderName(std::move(other.holderName))
             , holderIdx(other.holderIdx)
             , holderType(other.holderType)
+            , holderOffsets(std::move(other.holderOffsets))
         {
         }
 
@@ -1052,6 +1058,7 @@ namespace rocisa
                 holderName = other.holderName;
                 holderIdx  = other.holderIdx;
                 holderType = other.holderType;
+                holderOffsets = other.holderOffsets;
             }
             return *this;
         }
@@ -1064,6 +1071,7 @@ namespace rocisa
                 holderName = std::move(other.holderName);
                 holderIdx  = other.holderIdx;
                 holderType = other.holderType;
+                holderOffsets = std::move(other.holderOffsets);
             }
             return *this;
         }
@@ -1083,6 +1091,9 @@ namespace rocisa
             {
                 regName = std::move(RegName(holderName));
                 regName->offsets.insert(regName->offsets.begin(), num);
+                for(int offset : holderOffsets) {
+                    regName->offsets.push_back(offset);
+                }
             }
         }
 


### PR DESCRIPTION
## Motivation

Added MIArchVgpr support for Complex Datatypes.

## Technical Details

Fixed AlphaTmpVgpr initialization, and rocisa register offset bug:

- Updated condition to initialize AlphaTmpVgpr if MIArchVgpr parameter is enabled. Required to generate `MulMIOutAlphaToArch' code (https://github.com/ROCm/rocm-libraries/blob/c20a85b6c458ef44c1f0e30c35b286a0395fb8fa/projects/hipblaslt/tensilelite/Tensile/KernelWriterModules.py#L251) regardless of postGSU Accumulation scheme.
- Fixed underlying `Holder` struct bug: correctly passes string passed offsets to `RegisterContainer`. Required to update imaginary register for C/ZGEMM. (https://github.com/ROCm/rocm-libraries/blob/c20a85b6c458ef44c1f0e30c35b286a0395fb8fa/projects/hipblaslt/tensilelite/Tensile/KernelWriterModules.py#L288)

## Test Plan

Tested for C & Z with MIArchVgpr: [0, 1] on gfx942 and gfx950

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
