### PR TITLE
Use unordered_map for SolutionMap to improve lookup performance

### DIFF
--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -56,6 +56,7 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/program_options.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <memory>
@@ -672,12 +673,22 @@ int main(int argc, const char* argv[])
     }
 
     if(firstSolutionIdx < 0)
-        firstSolutionIdx = library->solutions.begin()->first;
+    {
+        // Find minimum key in unordered_map
+        firstSolutionIdx = std::min_element(
+            library->solutions.begin(),
+            library->solutions.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; })->first;
+    }
 
     if(numSolutions < 0)
     {
-        auto iter = library->solutions.end();
-        iter--;
+        // Find maximum key in unordered_map (result unused but kept for consistency)
+        auto maxIt = std::max_element(
+            library->solutions.begin(),
+            library->solutions.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
+        (void)maxIt; // Suppress unused variable warning
     }
 
     auto dataInit = std::make_shared<DataInitialization>(args, problemFactory);

--- a/projects/hipblaslt/tensilelite/client/src/SolutionIterator.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/SolutionIterator.cpp
@@ -28,6 +28,7 @@
 
 #include "ResultReporter.hpp"
 #include <Tensile/Debug.hpp>
+#include <algorithm>
 
 namespace TensileLite
 {
@@ -187,12 +188,21 @@ namespace TensileLite
             m_firstSolutionIdx = firstSolutionIdx;
 
             if(m_firstSolutionIdx < 0)
-                m_firstSolutionIdx = library->solutions.begin()->first;
+            {
+                // Find minimum key in unordered_map
+                m_firstSolutionIdx = std::min_element(
+                    library->solutions.begin(),
+                    library->solutions.end(),
+                    [](const auto& a, const auto& b) { return a.first < b.first; })->first;
+            }
 
             if(numSolutions < 0)
             {
-                auto iter         = library->solutions.rbegin();
-                m_lastSolutionIdx = iter->first;
+                // Find maximum key in unordered_map
+                m_lastSolutionIdx = std::max_element(
+                    library->solutions.begin(),
+                    library->solutions.end(),
+                    [](const auto& a, const auto& b) { return a.first < b.first; })->first;
             }
             else
             {

--- a/projects/hipblaslt/tensilelite/include/Tensile/MasterSolutionLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/MasterSolutionLibrary.hpp
@@ -31,6 +31,7 @@
 #include <filesystem>
 #include <map>
 #include <memory>
+#include <unordered_map>
 
 #include <Tensile/Debug.hpp>
 #include <Tensile/SolutionLibrary.hpp>
@@ -45,8 +46,9 @@ namespace TensileLite
     /**
  * \ingroup SolutionLibrary
  */
+    // Using unordered_map for O(1) lookups instead of std::map's O(log n)
     template <typename MySolution>
-    using SolutionMap = std::map<int, std::shared_ptr<MySolution>>;
+    using SolutionMap = std::unordered_map<int, std::shared_ptr<MySolution>>;
 
     template <typename MySolution>
     struct LibraryIOContext


### PR DESCRIPTION
Change SolutionMap from std::map to std::unordered_map for O(1) average lookup time instead of O(log n). This improves performance in the solution iteration hot path where getSolution() is called frequently.

- MasterSolutionLibrary.hpp: Change SolutionMap typedef from std::map to std::unordered_map with int keys
- SolutionIterator.cpp: Replace begin()->first and rbegin()->first with std::min_element/std::max_element since unordered_map has no ordering
- main.cpp: Same min/max element changes for finding solution index bounds

The min/max operations are O(n) but only run once during initialization, while the hot path lookups are now O(1) instead of O(log n).

## Motivation

Some timing info seems to indicate that solution selection in the tests might be a bottleneck. 

## Technical Details

We are doing O(log n) lookup in the hot path where a hash table look up is probably better.

## Test Plan

Run CI 

