### PR TITLE
[hipSPARSELt] Using a version script to limit symbol visibility

### DIFF
--- a/projects/hipsparselt/library/CMakeLists.txt
+++ b/projects/hipsparselt/library/CMakeLists.txt
@@ -50,6 +50,8 @@ set_target_properties(
                                                                            "hidden"
 )
 
+set_target_propertieS(hipsparselt PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libhipsparselt.map")
+
 target_include_directories(
     hipsparselt
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/projects/hipsparselt/library/libhipsparselt.map
+++ b/projects/hipsparselt/library/libhipsparselt.map
@@ -1,0 +1,10 @@
+{
+    global:
+        hipsparseLt*;
+        *hipsparselt*;
+        *string_to_hip_datatype*;
+
+    local:
+        *;
+};
+


### PR DESCRIPTION
## Motivation

Both hipsparselt and hipblaslt statically include TensileLite objects. When different versions of these libraries are installed in the same environment, this can lead to symbol collisions at runtime.
Current hipblaslt and hipsparselt have used -fvisibility=hidden, but it didn’t fully prevent the collisions.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
