### PR TITLE
[hip-kernel-provider] Boilerplate code for developing the new HIP kernel provider hipDNN plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 # Project-specific ownership
 /dnn-providers/miopen-provider/                     @ROCm/hipdnn-reviewers
 /dnn-providers/hipblaslt-provider/                  @ROCm/hipdnn-reviewers
+/dnn-providers/hip-kernel-provider/                 @ROCm/hipdnn-reviewers
 /projects/composablekernel/                         @ROCm/ck-reviewers
 /projects/hipblas/                                  @ROCm/hipblas-reviewers
 /projects/hipblas-common/                           @ROCm/hipblas-common-reviewers

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -56,6 +56,10 @@
 - changed-files:
   - any-glob-to-any-file: 'dnn-providers/miopen-provider/**/*'
 
+"project: hip-kernel-provider":
+- changed-files:
+  - any-glob-to-any-file: 'dnn-providers/hip-kernel-provider/**/*'
+
 "project: none":
 - changed-files:
   - all-globs-to-all-files: ['!dnn-providers/**/*', '!projects/**/*', '!shared/**/*']

--- a/.github/repos-config.json
+++ b/.github/repos-config.json
@@ -242,6 +242,15 @@
       "auto_subtree_pull": false,
       "auto_subtree_push": false,
       "monorepo_source_of_truth": true
+    },
+    {
+      "name": "hip-kernel-provider",
+      "url": "ROCm/hipKernel-Provider",
+      "branch": "develop",
+      "category": "dnn-providers",
+      "auto_subtree_pull": false,
+      "auto_subtree_push": false,
+      "monorepo_source_of_truth": true
     }
   ]
 }

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -63,10 +63,6 @@ project_map = {
         "cmake_options": ["-DTHEROCK_ENABLE_ROCWMMA=ON"],
         "projects_to_test": ["rocwmma"],
     },
-    "hip-kernel-provider": {
-        "cmake_options": ["-DTHEROCK_ENABLE_HIP_KERNEL_PLUGIN=ON"],
-        "projects_to_test": ["hip_kernel_plugin"],
-    },
 }
 
 # For certain math components, they are optional during building and testing.
@@ -92,7 +88,7 @@ additional_options = {
             "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
             "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
         ],
-        "projects_to_test": ["hipdnn", "miopen_plugin", "hip_kernel_plugin"],
+        "projects_to_test": ["hipdnn", "miopen_plugin"],
         "project_to_add": "miopen",
     },
     "miopen-provider": {
@@ -104,6 +100,11 @@ additional_options = {
         ],
         "projects_to_test": ["miopen_plugin"],
         "project_to_add": "miopen",
+    },
+    "hip-kernel-provider": {
+        "cmake_options": ["-DTHEROCK_ENABLE_HIP_KERNEL_PLUGIN=ON"],
+        "projects_to_test": ["hip_kernel_plugin"],
+        "project_to_add": "miopen",  # TODO: We need to change this based on the deps of hip kernel provider!
     },
 }
 

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -6,6 +6,7 @@ import os
 
 subtree_to_project_map = {
     "dnn-providers/miopen-provider": "miopen-provider",
+    "dnn-providers/hip-kernel-provider": "hip-kernel-provider",
     "projects/hipblas": "blas",
     "projects/hipblas-common": "blas",
     "projects/hipblaslt": "blas",

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -101,6 +101,11 @@ additional_options = {
         "projects_to_test": ["miopen_plugin"],
         "project_to_add": "miopen",
     },
+    "hip-kernel-provider": {
+        "cmake_options": [],
+        "projects_to_test": ["hipdnn", "hip_kernel_plugin"],
+        "project_to_add": "hipdnn",
+    },
 }
 
 # If a project has dependencies that are also being built, we combine build options and test options

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -63,6 +63,10 @@ project_map = {
         "cmake_options": ["-DTHEROCK_ENABLE_ROCWMMA=ON"],
         "projects_to_test": ["rocwmma"],
     },
+    "hip-kernel-provider": {
+        "cmake_options": ["-DTHEROCK_ENABLE_HIP_KERNEL_PLUGIN=ON"],
+        "projects_to_test": ["hip_kernel_plugin"],
+    },
 }
 
 # For certain math components, they are optional during building and testing.
@@ -88,7 +92,7 @@ additional_options = {
             "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
             "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
         ],
-        "projects_to_test": ["hipdnn", "miopen_plugin"],
+        "projects_to_test": ["hipdnn", "miopen_plugin", "hip_kernel_plugin"],
         "project_to_add": "miopen",
     },
     "miopen-provider": {
@@ -100,10 +104,6 @@ additional_options = {
         ],
         "projects_to_test": ["miopen_plugin"],
         "project_to_add": "miopen",
-    },
-    "hip-kernel-provider": {
-        "cmake_options": ["-DTHEROCK_ENABLE_HIP_KERNEL_PLUGIN=ON"],
-        "projects_to_test": ["hip_kernel_plugin"],
     },
 }
 

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -102,9 +102,8 @@ additional_options = {
         "project_to_add": "miopen",
     },
     "hip-kernel-provider": {
-        "cmake_options": [],
-        "projects_to_test": ["hipdnn", "hip_kernel_plugin"],
-        "project_to_add": "hipdnn",
+        "cmake_options": ["-DTHEROCK_ENABLE_HIP_KERNEL_PLUGIN=ON"],
+        "projects_to_test": ["hip_kernel_plugin"],
     },
 }
 

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -63,6 +63,10 @@ project_map = {
         "cmake_options": ["-DTHEROCK_ENABLE_ROCWMMA=ON"],
         "projects_to_test": ["rocwmma"],
     },
+    "hip-kernel-provider": {
+        "cmake_options": ["-DTHEROCK_ENABLE_HIP_KERNEL_PLUGIN=ON"],
+        "projects_to_test": ["hip_kernel_plugin"],
+    },
 }
 
 # For certain math components, they are optional during building and testing.
@@ -100,11 +104,6 @@ additional_options = {
         ],
         "projects_to_test": ["miopen_plugin"],
         "project_to_add": "miopen",
-    },
-    "hip-kernel-provider": {
-        "cmake_options": ["-DTHEROCK_ENABLE_HIP_KERNEL_PLUGIN=ON"],
-        "projects_to_test": ["hip_kernel_plugin"],
-        "project_to_add": "miopen",  # TODO: We need to change this based on the deps of hip kernel provider!
     },
 }
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,8 @@ repos:
           (?x)
           ^projects/hipdnn/\.clang-format$|
           ^dnn-providers/miopen-provider/\.clang-format$|
-          ^dnn-providers/hipblaslt-provider/\.clang-format$
+          ^dnn-providers/hipblaslt-provider/\.clang-format$|
+          ^dnn-providers/hip-kernel-provider/\.clang-format$
       - id: check-added-large-files
 
   - repo: https://github.com/psf/black

--- a/dnn-providers/hip-kernel-provider/.clang-format
+++ b/dnn-providers/hip-kernel-provider/.clang-format
@@ -1,0 +1,125 @@
+# Style file for MLSE Libraries based on the modified rocBLAS style
+
+# Common settings
+BasedOnStyle:  WebKit
+TabWidth:        4
+IndentWidth:     4
+UseTab:          Never
+ColumnLimit: 100
+
+# Other languages JavaScript, Proto
+
+---
+Language: Cpp
+
+# http://releases.llvm.org/6.0.1/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
+# int formatted_code;
+# // clang-format off
+#     void    unformatted_code  ;
+# // clang-format on
+# void formatted_code_again;
+
+DisableFormat:   false
+Standard: Cpp11
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterCaseLabel: 'true'
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+#    AfterExternBlock : 'true'
+}
+
+#BreakAfterJavaFieldAnnotations: true
+#BreakBeforeInheritanceComma: false
+#BreakBeforeBinaryOperators: None
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializersBeforeComma: true
+#BreakStringLiterals: true
+
+CommentPragmas:  '^ IWYU pragma:'
+#CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+SpaceBeforeCpp11BracedList: false
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IndentCaseLabels: false
+IndentPPDirectives: None
+#FixNamespaceComments: true
+IndentWrappedFunctionNames: true
+InsertNewlineAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+#JavaScriptQuotes: Double
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+#ObjCSpaceAfterProperty: true
+#ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+#SpaceAfterTemplateKeyword: true
+#SpaceBeforeInheritanceColon: true
+
+#SortUsingDeclarations: true
+SortIncludes: true
+
+# Comments are for developers, they should arrange them
+ReflowComments: false
+
+#IncludeBlocks: Preserve
+---

--- a/dnn-providers/hip-kernel-provider/.clang-tidy
+++ b/dnn-providers/hip-kernel-provider/.clang-tidy
@@ -1,0 +1,54 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+Checks: >
+  -*,
+  bugprone-*
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  google-global-names-in-headers,
+  -fuchsia-trailing-return,
+  -modernize-use-trailing-return-type,
+  -modernize-concat-nested-namespaces,
+  -modernize-use-nodiscard,
+  -modernize-use-using,
+  -performance-enum-size,
+  -readability-magic-numbers,
+  -readability-identifier-length,
+  -readability-qualified-auto,
+  -readability-uppercase-literal-suffix,
+  -readability-avoid-unconditional-preprocessor-if,
+  -readability-use-anyofallof,
+  -readability-function-cognitive-complexity
+
+WarningsAsErrors: "*"
+HeaderFileExtensions: ['h','hpp']
+
+# This regex is a inclusion filter for the files to be checked. Its a Posix regex and
+# does not seem to support negative lookahead.
+HeaderFilterRegex: '.'
+ExcludeHeaderFilterRegex: '^(.*data_objects.*)$'
+
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase,           value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,               value: CamelCase }
+  - { key: readability-identifier-naming.StructCase,              value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase,            value: camelBack }
+  - { key: readability-identifier-naming.VariableCase,            value: camelBack }
+  - { key: readability-identifier-naming.ParameterCase,           value: camelBack }
+  - { key: readability-identifier-naming.MemberCase,              value: camelBack }
+  - { key: readability-identifier-naming.PrivateMemberCase,       value: camelBack }
+  - { key: readability-identifier-naming.ProtectedMemberPrefix,   value: _ }
+  - { key: readability-identifier-naming.PrivateMemberPrefix,     value: _ }
+  - { key: readability-identifier-naming.EnumCase,                value: CamelCase  }
+  - { key: readability-identifier-naming.EnumConstantCase,        value: UPPER_CASE }
+  - { key: readability-identifier-naming.GlobalConstantCase,      value: UPPER_CASE }
+  - { key: readability-identifier-naming.ConstexprVariableCase,   value: UPPER_CASE }
+  - { key: readability-identifier-naming.StaticVariablePrefix,    value: s_ }
+  # Ignore hipdnnHandle name everywhere (required for public API compatibility)
+  - { key: readability-identifier-naming.StructIgnoredRegexp,     value: "hipdnnHandle" }
+  - { key: readability-identifier-naming.ClassIgnoredRegexp,      value: "hipdnnHandle" }
+  - { key: readability-identifier-naming.TypedefIgnoredRegexp,    value: "hipdnnHandle" }

--- a/dnn-providers/hip-kernel-provider/.gitignore
+++ b/dnn-providers/hip-kernel-provider/.gitignore
@@ -1,0 +1,85 @@
+# build artifacts
+build*/
+
+# Compiled object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled headers
+*.gch
+*.pch
+*.ipch
+
+# Compiled dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Hipdnn local install
+install/
+
+# Fortran module files
+*.mod
+
+# Compiled static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# vim tags
+tags
+.tags
+.*.swp
+
+# Editors
+.vscode
+.cline_storage
+
+#code ql
+scripts*/codeql-*/
+scripts*/*_codeql_*/
+
+# build-in-source directory
+
+# emacs temporary/backup files
+.\#*
+\#*\#
+*~
+
+# GDB temporary files
+.gdb_history
+install.dir*
+
+# documentation artifacts
+_build/
+_images/
+_static/
+_templates/
+_toc.yml
+_doxygen/
+
+# JetBrains IDE
+.idea/
+cmake-build*/
+CMakeUserPresets.json
+
+# Python virtualenv
+.venv/
+hipdnn_env/
+
+# Python cache
+__pycache__/
+
+# Python egg
+*.egg-info/
+
+# Profiling data files
+*.profraw

--- a/dnn-providers/hip-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/CMakeLists.txt
@@ -1,0 +1,160 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+message(STATUS "Building HIP kernel provider plugin standalone")
+cmake_minimum_required(VERSION 3.25.2)
+add_compile_definitions(__HIP_PLATFORM_AMD__)
+
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/ClangToolChain.cmake"
+    CACHE STRING "Toolchain file"
+)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(HIP_KERNEL_PLUGIN_VERSION "0.0.1")
+project(hipDNN VERSION ${HIP_KERNEL_PLUGIN_VERSION} LANGUAGES CXX)
+
+if(NOT WIN32)
+    # Only set if not already specified by user
+    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+        set(CMAKE_INSTALL_PREFIX "${ROCM_PATH}" CACHE PATH "Install path prefix" FORCE)
+    endif()
+    message(STATUS "Setting CMAKE_INSTALL_PREFIX to ${CMAKE_INSTALL_PREFIX}")
+endif()
+
+include(GNUInstallDirs)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE
+    CACHE BOOL "Add paths to linker search and installed rpath"
+)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib/cmake/hip
+        ${HIP_DIR}/cmake
+)
+
+# Enable testing for standalone build
+# Migrate HIP_DNN_SKIP_TESTS -> HIPDNN_SKIP_TESTS
+if(DEFINED HIP_DNN_SKIP_TESTS)
+    set(HIPDNN_SKIP_TESTS ${HIP_DNN_SKIP_TESTS} CACHE BOOL "Skip building tests" FORCE)
+    unset(HIP_DNN_SKIP_TESTS CACHE)
+    message(DEPRECATION "HIP_DNN_SKIP_TESTS has been renamed to HIPDNN_SKIP_TESTS. Please update your build scripts to use -DHIPDNN_SKIP_TESTS instead.")
+endif()
+option(HIPDNN_SKIP_TESTS "Skip building tests" OFF)
+
+list(
+    PREPEND
+    HIPDNN_WARNING_COMPILE_OPTIONS
+    -Werror # Treat all warnings as errors
+    -Wall # Enable most common warnings
+    -Wextra # Enable additional warnings not covered by -Wall
+    -Wpedantic # Enforce strict ISO C++ compliance
+    -Wshadow # Warn about variable shadowing
+    -Wnon-virtual-dtor # Warn if a class with virtual functions has a non-virtual destructor
+    -Wold-style-cast # Warn about C-style casts
+    -Wcast-align # Warn about potential performance issues with misaligned casts
+    -Woverloaded-virtual # Warn if a base class function is hidden by a derived class function
+                            # with the same name
+    -Wconversion # Warn about implicit type conversions that may alter a value
+    -Wsign-conversion # Warn about implicit conversions between signed and unsigned types
+    -Wnull-dereference # Warn about dereferencing null pointers
+    -Wdouble-promotion # Warn when a float is implicitly promoted to a double
+    -Wformat=2 # Enable stricter format string checks
+    -Winit-self # Warn about variables initialized with itself
+    -Wunreachable-code # Warn about unreachable code
+    -Wno-error=unused-command-line-argument # Disable error for unused command line arguments
+    -Wswitch-default # Warn if a switch statement does not have a default case
+)
+
+# NOTE: Workaround until llvm & hip cmake modules fixes symlink logic in their config files;
+# remove when fixed. Added to prevent issues with not finding hip cmake.
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH} ${ROCM_PATH}/hip)
+
+find_package(hip REQUIRED)
+find_package(hipdnn_data_sdk CONFIG REQUIRED)
+find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+
+# Setup testing dependencies & tests for standalone build
+include(Dependencies)
+include(Tests)
+
+if(WIN32)
+    set(HIPDNN_PLUGIN_ENGINE_ROOTDIR "bin")
+else()
+    set(HIPDNN_PLUGIN_ENGINE_ROOTDIR "lib")
+endif()
+
+set(HIPDNN_BUILD_PLUGIN_ENGINE_DIR
+    "${CMAKE_BINARY_DIR}/${HIPDNN_PLUGIN_ENGINE_ROOTDIR}/${HIPDNN_PLUGIN_ENGINE_SUBDIR}"
+)
+
+message(STATUS "Plugin build directory: ${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}")
+message(STATUS "Plugin install directory: ${HIPDNN_INSTALL_PLUGIN_ENGINE_DIR}")
+file(MAKE_DIRECTORY ${HIPDNN_BUILD_PLUGIN_ENGINE_DIR})
+
+# OBJECT library for hip kernel plugin implementation
+add_library(
+    hip_kernel_plugin_impl OBJECT
+    EngineManager.cpp
+)
+target_compile_definitions(
+    hip_kernel_plugin_impl PRIVATE COMPONENT_NAME="hip_kernel_plugin"
+)
+target_include_directories(hip_kernel_plugin_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(hip_kernel_plugin_impl PUBLIC hipdnn_data_sdk hipdnn_plugin_sdk)
+target_compile_options(hip_kernel_plugin_impl PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+set_target_properties(hip_kernel_plugin_impl PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    POSITION_INDEPENDENT_CODE ON
+)
+
+# Static library for unit tests to link against (provides access to internal implementation)
+add_library(hip_kernel_plugin_private STATIC $<TARGET_OBJECTS:hip_kernel_plugin_impl>)
+target_compile_definitions(hip_kernel_plugin_private PRIVATE COMPONENT_NAME="hip_kernel_plugin")
+target_include_directories(hip_kernel_plugin_private PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(hip_kernel_plugin_private PUBLIC hipdnn_data_sdk hipdnn_plugin_sdk)
+
+# Shared library for hip kernel plugin
+add_library(hip_kernel_plugin SHARED $<TARGET_OBJECTS:hip_kernel_plugin_impl>)
+target_compile_definitions(hip_kernel_plugin PRIVATE COMPONENT_NAME="hip_kernel_plugin")
+target_link_libraries(hip_kernel_plugin PRIVATE hipdnn_data_sdk hipdnn_plugin_sdk)
+target_link_libraries(hip_kernel_plugin PRIVATE "-Xlinker --exclude-libs=ALL")
+target_compile_options(hip_kernel_plugin PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+set_target_properties(
+    hip_kernel_plugin
+    PROPERTIES CXX_VISIBILITY_PRESET hidden
+               LIBRARY_OUTPUT_DIRECTORY "${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}"
+               RUNTIME_OUTPUT_DIRECTORY "${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}"
+               ARCHIVE_OUTPUT_DIRECTORY "${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}"
+               INSTALL_RPATH "${ROCM_PATH}/lib"
+               INSTALL_RPATH_USE_LINK_PATH TRUE
+               BUILD_WITH_INSTALL_RPATH TRUE
+)
+
+# Set RPATH origin for TheRock integration. The plugins are installed to
+# lib/hipdnn_plugins/engines/ which is 2 levels below lib/, so TheRock needs
+# this hint to calculate correct relative RPATHs.
+set_target_properties(hip_kernel_plugin PROPERTIES
+    THEROCK_INSTALL_RPATH_ORIGIN "lib/hipdnn_plugins/engines")
+
+if(NOT HIPDNN_SKIP_TESTS)
+    add_subdirectory(tests)
+    add_subdirectory(integration_tests)
+
+    # Keep this after all build folders have been added so they have a chance to register their tests
+    # using add_*_test_target()
+    finalize_test_targets()
+
+    # For standalone builds we need to install the ctest files
+    install_hip_kernel_plugin_ctest_files()
+endif()
+
+# Install plugin library target
+install(TARGETS hip_kernel_plugin EXPORT hip-kernel-plugin
+        LIBRARY DESTINATION ${HIPDNN_RELATIVE_INSTALL_PLUGIN_ENGINE_DIR}
+        RUNTIME DESTINATION ${HIPDNN_RELATIVE_INSTALL_PLUGIN_ENGINE_DIR}
+)

--- a/dnn-providers/hip-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/CMakeLists.txt
@@ -107,6 +107,8 @@ add_library(
     EngineManager.cpp
     HipKernelPlugin.cpp
     HipKernelPluginPublic.cpp
+    HipKernelContainer.cpp
+    engines/HipKernelEngine.cpp
 )
 target_compile_definitions(
     hip_kernel_plugin_impl PRIVATE COMPONENT_NAME="hip_kernel_plugin"

--- a/dnn-providers/hip-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Copyright © Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
+if(BUILD_PLUGIN_AS_DEPENDENCY)
+    message(STATUS "Only standalone build supported for now")
+    return()
+endif()
+
 message(STATUS "Building HIP kernel provider plugin standalone")
 cmake_minimum_required(VERSION 3.25.2)
 add_compile_definitions(__HIP_PLATFORM_AMD__)
@@ -100,6 +105,8 @@ file(MAKE_DIRECTORY ${HIPDNN_BUILD_PLUGIN_ENGINE_DIR})
 add_library(
     hip_kernel_plugin_impl OBJECT
     EngineManager.cpp
+    HipKernelPlugin.cpp
+    HipKernelPluginPublic.cpp
 )
 target_compile_definitions(
     hip_kernel_plugin_impl PRIVATE COMPONENT_NAME="hip_kernel_plugin"

--- a/dnn-providers/hip-kernel-provider/EngineManager.cpp
+++ b/dnn-providers/hip-kernel-provider/EngineManager.cpp
@@ -1,8 +1,6 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include <algorithm>
-
 #include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
 

--- a/dnn-providers/hip-kernel-provider/EngineManager.cpp
+++ b/dnn-providers/hip-kernel-provider/EngineManager.cpp
@@ -1,0 +1,75 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <algorithm>
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "EngineManager.hpp"
+
+using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using hipdnn_plugin_sdk::HipdnnPluginException;
+
+namespace hip_kernel_plugin
+{
+
+void EngineManager::addEngine(std::unique_ptr<IEngine> engine)
+{
+    _engines.emplace(engine->id(), std::move(engine));
+}
+
+std::vector<int64_t> EngineManager::getApplicableEngineIds(
+    HipdnnEnginePluginHandle& handle, const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph)
+{
+    std::vector<int64_t> applicable;
+    for(const auto& engine : _engines)
+    {
+        if(engine.second->isApplicable(handle, opGraph))
+        {
+            applicable.push_back(engine.second->id());
+        }
+    }
+    return applicable;
+}
+
+void EngineManager::getEngineDetails(HipdnnEnginePluginHandle& handle,
+                                     const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                                     int64_t engineId,
+                                     hipdnnPluginConstData_t& engineDetailsOut)
+{
+    auto& engine = getEngine(engineId);
+    engine.getDetails(handle, opGraph, engineDetailsOut);
+}
+
+size_t EngineManager::getWorkspaceSize(
+    const HipdnnEnginePluginHandle& handle,
+    int64_t engineId,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+{
+    auto& engine = getEngine(engineId);
+    return engine.getWorkspaceSize(handle, opGraph);
+}
+
+void EngineManager::initializeExecutionContext(
+    const HipdnnEnginePluginHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    HipdnnEnginePluginExecutionContext& executionContext) const
+{
+    auto& engine = getEngine(engineConfig.engineId());
+    engine.initializeExecutionContext(handle, opGraph, engineConfig, executionContext);
+}
+
+IEngine& EngineManager::getEngine(int64_t engineId) const
+{
+    auto it = _engines.find(engineId);
+    if(it == _engines.end())
+    {
+        throw HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INVALID_VALUE,
+                                    "Engine with ID " + std::to_string(engineId) + " not found.");
+    }
+    return *it->second;
+}
+
+}

--- a/dnn-providers/hip-kernel-provider/EngineManager.hpp
+++ b/dnn-providers/hip-kernel-provider/EngineManager.hpp
@@ -1,0 +1,55 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+#include "engines/EngineInterface.hpp"
+
+namespace hip_kernel_plugin
+{
+
+class EngineManager
+{
+public:
+    EngineManager() = default;
+    ~EngineManager() = default;
+
+    //disallow copy and assignment
+    EngineManager(const EngineManager&) = delete;
+    EngineManager& operator=(const EngineManager&) = delete;
+
+    void addEngine(std::unique_ptr<IEngine> engine);
+
+    std::vector<int64_t>
+        getApplicableEngineIds(HipdnnEnginePluginHandle& handle,
+                               const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph);
+
+    void getEngineDetails(HipdnnEnginePluginHandle& handle,
+                          const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                          int64_t engineId,
+                          hipdnnPluginConstData_t& engineDetailsOut);
+
+    size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                            int64_t engineId,
+                            const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const;
+
+    void initializeExecutionContext(
+        const HipdnnEnginePluginHandle& handle,
+        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        HipdnnEnginePluginExecutionContext& executionContext) const;
+
+private:
+    IEngine& getEngine(int64_t engineId) const;
+
+    std::unordered_map<int64_t, std::unique_ptr<IEngine>> _engines;
+};
+
+}

--- a/dnn-providers/hip-kernel-provider/HipKernelContainer.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelContainer.cpp
@@ -1,0 +1,112 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipKernelContainer.hpp"
+#include "EngineManager.hpp"
+#include "engines/HipKernelEngine.hpp"
+
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_data_sdk/utilities/EngineNames.hpp>
+
+namespace hip_kernel_plugin
+{
+
+// ============================================================================
+// Engine Registration
+// ============================================================================
+// For plugins that are not yet globally registered (by adding a call to
+// HIPDNN_REGISTER_ENGINE() in "hipdnn_data_sdk/utilities/EngineNames.hpp"),
+// use HIPDNN_REGISTER_ENGINE to register the engine names here. This will:
+// 1. Create _NAME and _ID constants for the engine
+// 2. Detect hash collisions with other formally-registered engines
+//
+// Example for new engines:
+// HIPDNN_REGISTER_ENGINE(MY_CUSTOM_ENGINE, "MY_CUSTOM_ENGINE")
+// HIPDNN_REGISTER_ENGINE(MY_OTHER_ENGINE, "MY_OTHER_ENGINE")
+// ============================================================================
+using namespace hipdnn_data_sdk::utilities;
+HIPDNN_REGISTER_ENGINE(HIP_KERNEL_ENGINE, "HIP_KERNEL_ENGINE");
+
+const std::vector<HipKernelContainer::EngineDefinition>& HipKernelContainer::getEngineDefinitions()
+{
+    static const std::vector<EngineDefinition> s_engineDefinitions = {
+        // HIP_KERNEL_ENGINE
+        {HIP_KERNEL_ENGINE_ID,
+         []() -> std::unique_ptr<IEngine> {
+             auto engine = std::make_unique<HipKernelEngine>(HIP_KERNEL_ENGINE_ID);
+             // add more plan builders here as they are created, for example:
+             // engine->addPlanBuilder(std::make_unique<HipKernelBatchnormPlanBuilder>());
+             return engine;
+         }}
+
+        // ====================================================================
+        // Additional engines would be added here
+        // ====================================================================
+        // Example:
+        // ,{MY_CUSTOM_ENGINE_ID, []() -> std::unique_ptr<IEngine> {
+        //     auto engine = std::make_unique<MyCustomEngine>(MY_CUSTOM_ENGINE_ID);
+        //     engine->addPlanBuilder(std::make_unique<CustomPlanBuilder>());
+        //     // ... configure plan builders for this engine
+        //     return engine;
+        // }}
+        // ,{MY_OTHER_ENGINE_ID, []() -> std::unique_ptr<IEngine> {
+        //     auto engine = std::make_unique<MyOtherEngine>(MY_OTHER_ENGINE_ID);
+        //     engine->addPlanBuilder(std::make_unique<OtherPlanBuilder>());
+        //     // ... configure plan builders for this engine
+        //     return engine;
+        // }}
+        // ====================================================================
+    };
+
+    return s_engineDefinitions;
+}
+
+uint32_t
+    HipKernelContainer::copyEngineIds(int64_t* engineIds, uint32_t maxEngines, uint32_t& numEngines)
+{
+    const auto& engineDefinitions = getEngineDefinitions();
+    auto totalEngines = static_cast<uint32_t>(engineDefinitions.size());
+
+    if(maxEngines == 0)
+    {
+        // When maxEngines is 0, set numEngines to total count
+        numEngines = totalEngines;
+        return totalEngines;
+    }
+
+    // Copy up to maxEngines IDs using index-based loop
+    auto enginesToCopy = std::min(maxEngines, totalEngines);
+    for(uint32_t i = 0; i < enginesToCopy; ++i)
+    {
+        engineIds[i] = engineDefinitions[i].id;
+    }
+
+    // When maxEngines > 0, set numEngines to number copied
+    numEngines = enginesToCopy;
+
+    return totalEngines;
+}
+
+HipKernelContainer::HipKernelContainer()
+{
+    HIPDNN_LOG_INFO("Creating HipKernelContainer");
+
+    _engineManager = std::make_unique<EngineManager>();
+
+    for(const auto& engineDefinition : getEngineDefinitions())
+    {
+        _engineManager->addEngine(engineDefinition.createEngine());
+    }
+}
+
+HipKernelContainer::~HipKernelContainer()
+{
+    HIPDNN_LOG_INFO("Destroying HipKernelContainer");
+}
+
+EngineManager& HipKernelContainer::getEngineManager()
+{
+    return *_engineManager;
+}
+
+} // namespace hip_kernel_plugin

--- a/dnn-providers/hip-kernel-provider/HipKernelContainer.hpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelContainer.hpp
@@ -1,0 +1,51 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace hip_kernel_plugin
+{
+
+class EngineManager;
+class IEngine;
+
+/*
+ * Container class to manage the intantiation and ownership of all HIP kernel plan builders and engines.
+ * The class designs use dependency injection to get the components they need in order to function.
+ * This makes it easier to test and maintain the code as you can swap out implementations.
+ *
+ * The construction sequence should contain no logic other than the creation of various classes.
+ * If logic is needed, it should be placed in a separate function that can be called after the
+ * container has finished constructing all its components.
+ */
+class HipKernelContainer
+{
+public:
+    HipKernelContainer();
+    ~HipKernelContainer();
+
+    // Copy engine IDs into a buffer.
+    // If maxEngines == 0: Does not copy, only queries total count.
+    // If maxEngines > 0: Copies up to maxEngines IDs into *engineIds, sets numEngines to number copied.
+    // Returns: Total number of available engines (regardless of maxEngines value).
+    static uint32_t copyEngineIds(int64_t* engineIds, uint32_t maxEngines, uint32_t& numEngines);
+
+    EngineManager& getEngineManager();
+
+private:
+    struct EngineDefinition
+    {
+        int64_t id; // Set id using EngineNames.hpp.
+        std::function<std::unique_ptr<IEngine>()> createEngine;
+    };
+
+    static const std::vector<EngineDefinition>& getEngineDefinitions();
+
+    std::unique_ptr<EngineManager> _engineManager;
+};
+
+}

--- a/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
@@ -13,6 +13,7 @@
 #include <hipdnn_plugin_sdk/PluginLastErrorManager.hpp>
 
 #include "EngineManager.hpp"
+#include "HipKernelContainer.hpp"
 #include "HipdnnEnginePluginExecutionContext.hpp"
 #include "HipdnnEnginePluginHandle.hpp"
 
@@ -25,6 +26,13 @@ using namespace hip_kernel_plugin;
 
 // NOLINTNEXTLINE
 thread_local char PluginLastErrorManager::s_lastError[HIPDNN_PLUGIN_ERROR_STRING_MAX_LENGTH] = "";
+
+// Keep a weak pointer to the HipKernelContainer thats made when we create a plugin handle.
+// The original shared_ptr is then stored on the handle so that it can be used for the lifecycle
+// of the handle.  If we create another handle, then we can use the weak pointer to get access
+// to the existing HipKernelContainer.  If all handles are destroyed, then this allows us to properly
+// clean up the container without having to fully unload the plugin.
+std::weak_ptr<HipKernelContainer> hipKernelContainerLifecyclePtr;
 
 extern "C" {
 
@@ -86,6 +94,80 @@ hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callbac
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(callback);
         hipdnn::logging::initializeCallbackLogging(pluginName, callback);
+        LOG_API_SUCCESS(apiName, "", "");
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
+                                                           uint32_t maxEngines,
+                                                           uint32_t* numEngines)
+{
+    LOG_API_ENTRY("engineIds={:p}, maxEngines={}, numEngines={:p}",
+                  static_cast<void*>(engineIds),
+                  maxEngines,
+                  static_cast<void*>(numEngines));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        if(maxEngines != 0)
+        {
+            throwIfNull(engineIds);
+        }
+        throwIfNull(numEngines);
+
+        auto totalEngines = HipKernelContainer::copyEngineIds(engineIds, maxEngines, *numEngines);
+
+        LOG_API_SUCCESS(apiName, "numEngines={} totalEngines={}", *numEngines, totalEngines);
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* handle)
+{
+    LOG_API_ENTRY("handle_ptr={:p}", static_cast<void*>(handle));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+
+        *handle = new HipdnnEnginePluginHandle();
+
+        auto hipKernelContainerPtr = hipKernelContainerLifecyclePtr.lock();
+        if(hipKernelContainerPtr != nullptr)
+        {
+            (*handle)->hipKernelContainer = hipKernelContainerPtr;
+        }
+        else
+        {
+            static std::mutex s_hipKernelContainerMutex;
+            std::lock_guard<std::mutex> lock(s_hipKernelContainerMutex);
+
+            // if we do have a race condition that results in threads getting locked, we want to
+            // ensure that we only create one instance.  Therefore, the second thread to get
+            // through will just read from the weak pointer rather than create a new instance.
+            hipKernelContainerPtr = hipKernelContainerLifecyclePtr.lock();
+            if(hipKernelContainerPtr != nullptr)
+            {
+                (*handle)->hipKernelContainer = hipKernelContainerPtr;
+            }
+            else
+            {
+                (*handle)->hipKernelContainer = std::make_shared<HipKernelContainer>();
+                hipKernelContainerLifecyclePtr = (*handle)->hipKernelContainer;
+            }
+        }
+
+        LOG_API_SUCCESS(apiName, "createdHandle={:p}", static_cast<void*>(*handle));
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t handle)
+{
+    LOG_API_ENTRY("handle={:p}", static_cast<void*>(handle));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+
+        delete handle;
+        handle = nullptr;
+
         LOG_API_SUCCESS(apiName, "", "");
     });
 }

--- a/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
@@ -13,6 +13,8 @@
 #include <hipdnn_plugin_sdk/PluginLastErrorManager.hpp>
 
 #include "EngineManager.hpp"
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
 
 static const char* pluginName = "hip_kernel_plugin";
 static const char* pluginVersion = "1.0.0";
@@ -85,6 +87,250 @@ hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callbac
         throwIfNull(callback);
         hipdnn::logging::initializeCallbackLogging(pluginName, callback);
         LOG_API_SUCCESS(apiName, "", "");
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginSetStreamImpl(hipdnnEnginePluginHandle_t handle,
+                                                     hipStream_t stream)
+{
+    LOG_API_ENTRY(
+        "handle={:p}, stream_id={:p}", static_cast<void*>(handle), static_cast<void*>(stream));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+
+        handle->setStream(stream);
+
+        LOG_API_SUCCESS(apiName, "", "");
+    });
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetApplicableEngineIdsImpl(hipdnnEnginePluginHandle_t handle,
+                                                 const hipdnnPluginConstData_t* opGraph,
+                                                 int64_t* engineIds,
+                                                 uint32_t maxEngines,
+                                                 uint32_t* numEngines)
+{
+    LOG_API_ENTRY("handle={:p}, opGraph={:p}, engineIds={:p}, maxEngines={}, numEngines={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<const void*>(opGraph),
+                  static_cast<void*>(engineIds),
+                  maxEngines,
+                  static_cast<void*>(numEngines));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(opGraph);
+        if(maxEngines != 0)
+        {
+            throwIfNull(engineIds);
+        }
+        throwIfNull(numEngines);
+
+        auto& engineManager = handle->getEngineManager();
+        GraphWrapper opGraphWrapper(opGraph->ptr, opGraph->size);
+
+        auto applicableEngines = engineManager.getApplicableEngineIds(*handle, opGraphWrapper);
+
+        *numEngines = 0;
+        for(auto& engineId : applicableEngines)
+        {
+            if(*numEngines == maxEngines)
+            {
+                *numEngines = static_cast<uint32_t>(applicableEngines.size());
+                HIPDNN_LOG_INFO("Maximum number of engines reached ({}), ignoring additional "
+                                "engines, numEngines count: {}",
+                                maxEngines,
+                                *numEngines);
+                break;
+            }
+
+            engineIds[*numEngines] = engineId;
+            (*numEngines)++;
+        }
+
+        LOG_API_SUCCESS(apiName, "numEngines={}", *numEngines);
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
+                                                            int64_t engineId,
+                                                            const hipdnnPluginConstData_t* opGraph,
+                                                            hipdnnPluginConstData_t* engineDetails)
+{
+    LOG_API_ENTRY("handle={:p}, engineId={}, opGraph={:p}, engineDetails={:p}",
+                  static_cast<void*>(handle),
+                  engineId,
+                  static_cast<const void*>(opGraph),
+                  static_cast<void*>(engineDetails));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(opGraph);
+        throwIfNull(engineDetails);
+
+        auto& engineManager = handle->getEngineManager();
+        GraphWrapper opGraphWrapper(opGraph->ptr, opGraph->size);
+
+        engineManager.getEngineDetails(*handle, opGraphWrapper, engineId, *engineDetails);
+
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+    });
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginDestroyEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
+                                               hipdnnPluginConstData_t* engineDetails)
+{
+    LOG_API_ENTRY("handle={:p}, engineDetails={}",
+                  static_cast<void*>(handle),
+                  static_cast<void*>(engineDetails));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(engineDetails);
+        throwIfNull(engineDetails->ptr);
+
+        handle->removeEngineDetailsDetachedBuffer(engineDetails->ptr);
+
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+    });
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetWorkspaceSizeImpl(hipdnnEnginePluginHandle_t handle,
+                                           const hipdnnPluginConstData_t* engineConfig,
+                                           const hipdnnPluginConstData_t* opGraph,
+                                           size_t* workspaceSize)
+{
+    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, workspaceSize={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<const void*>(engineConfig),
+                  static_cast<const void*>(opGraph),
+                  static_cast<void*>(workspaceSize));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(engineConfig);
+        throwIfNull(opGraph);
+        throwIfNull(workspaceSize);
+
+        auto& engineManager = handle->getEngineManager();
+
+        EngineConfigWrapper engineConfigWrapper(engineConfig->ptr, engineConfig->size);
+        GraphWrapper opGraphWrapper(opGraph->ptr, opGraph->size);
+        *workspaceSize = engineManager.getWorkspaceSize(
+            *handle, engineConfigWrapper.engineId(), opGraphWrapper);
+
+        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle,
+    const hipdnnPluginConstData_t* engineConfig,
+    const hipdnnPluginConstData_t* opGraph,
+    hipdnnEnginePluginExecutionContext_t* executionContext)
+{
+    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, executionContext={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<const void*>(engineConfig),
+                  static_cast<const void*>(opGraph),
+                  static_cast<void*>(executionContext));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(engineConfig);
+        throwIfNull(opGraph);
+        throwIfNull(executionContext);
+
+        GraphWrapper opGraphWrapper(opGraph->ptr, opGraph->size);
+        EngineConfigWrapper engineConfigWrapper(engineConfig->ptr, engineConfig->size);
+
+        auto& engineManager = handle->getEngineManager();
+
+        auto context = new HipdnnEnginePluginExecutionContext;
+
+        try
+        {
+            engineManager.initializeExecutionContext(
+                *handle, opGraphWrapper, engineConfigWrapper, *context);
+        }
+        catch(...)
+        {
+            delete context;
+            throw;
+        }
+
+        *executionContext = context;
+
+        LOG_API_SUCCESS(
+            apiName, "created_execution_context={:p}", static_cast<void*>(*executionContext));
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle, hipdnnEnginePluginExecutionContext_t executionContext)
+{
+    LOG_API_ENTRY("handle={:p}, executionContext={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<void*>(executionContext));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(executionContext);
+
+        delete executionContext;
+
+        LOG_API_SUCCESS(apiName, "destroyed executionContext", "");
+    });
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle,
+    hipdnnEnginePluginExecutionContext_t executionContext,
+    size_t* workspaceSize)
+{
+    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspaceSize={:p}",
+                  static_cast<void*>(handle),
+                  static_cast<const void*>(executionContext),
+                  static_cast<void*>(workspaceSize));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(executionContext);
+        throwIfNull(workspaceSize);
+
+        *workspaceSize = executionContext->plan().getWorkspaceSize(*handle);
+
+        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+    });
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginExecuteOpGraphImpl(hipdnnEnginePluginHandle_t handle,
+                                         hipdnnEnginePluginExecutionContext_t executionContext,
+                                         void* workspace,
+                                         const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                         uint32_t numDeviceBuffers)
+{
+    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspace={:p}, deviceBuffers={:p}, "
+                  "numDeviceBuffers={}",
+                  static_cast<void*>(handle),
+                  static_cast<void*>(executionContext),
+                  workspace,
+                  static_cast<const void*>(deviceBuffers),
+                  numDeviceBuffers);
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(handle);
+        throwIfNull(executionContext);
+        throwIfNull(deviceBuffers);
+
+        executionContext->plan().execute(*handle, deviceBuffers, numDeviceBuffers, workspace);
+
+        LOG_API_SUCCESS(apiName, "executed graph", "");
     });
 }
 

--- a/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
@@ -1,0 +1,91 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_plugin_sdk/EnginePluginApi.h>
+#include <hipdnn_plugin_sdk/PluginApi.h>
+#include <hipdnn_plugin_sdk/PluginDataTypeHelpers.hpp>
+#include <hipdnn_plugin_sdk/PluginHelpers.hpp>
+#include <hipdnn_plugin_sdk/PluginLastErrorManager.hpp>
+
+#include "EngineManager.hpp"
+
+static const char* pluginName = "hip_kernel_plugin";
+static const char* pluginVersion = "1.0.0";
+
+using namespace hipdnn_data_sdk::flatbuffer_utilities;
+using namespace hipdnn_plugin_sdk;
+using namespace hip_kernel_plugin;
+
+// NOLINTNEXTLINE
+thread_local char PluginLastErrorManager::s_lastError[HIPDNN_PLUGIN_ERROR_STRING_MAX_LENGTH] = "";
+
+extern "C" {
+
+hipdnnPluginStatus_t hipdnnPluginGetNameImpl(const char** name)
+{
+    LOG_API_ENTRY("name_ptr={:p}", static_cast<void*>(name));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(name);
+
+        *name = pluginName;
+
+        LOG_API_SUCCESS(apiName, "pluginName={:p}", static_cast<void*>(name));
+    });
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetVersionImpl(const char** version)
+{
+    LOG_API_ENTRY("versionPtr={:p}", static_cast<void*>(version));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(version);
+
+        *version = pluginVersion;
+
+        LOG_API_SUCCESS(apiName, "version={:p}", static_cast<void*>(version));
+    });
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetTypeImpl(hipdnnPluginType_t* type)
+{
+    LOG_API_ENTRY("typePtr={:p}", static_cast<void*>(type));
+
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(type);
+
+        *type = HIPDNN_PLUGIN_TYPE_ENGINE;
+
+        LOG_API_SUCCESS(apiName, "type={}", *type);
+    });
+}
+
+void hipdnnPluginGetLastErrorStringImpl(const char** errorStr)
+{
+    LOG_API_ENTRY("errorStrPtr={:p}", static_cast<void*>(errorStr));
+
+    hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(errorStr);
+
+        *errorStr = PluginLastErrorManager::getLastError();
+
+        LOG_API_SUCCESS(apiName, "errorStr={:p}", static_cast<void*>(errorStr));
+    });
+}
+
+// Once plugins are loaded via plugin manager then logging will work for them
+hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callback)
+{
+    return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
+        throwIfNull(callback);
+        hipdnn::logging::initializeCallbackLogging(pluginName, callback);
+        LOG_API_SUCCESS(apiName, "", "");
+    });
+}
+
+} // extern "C"

--- a/dnn-providers/hip-kernel-provider/HipKernelPlugin.hpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPlugin.hpp
@@ -18,4 +18,50 @@ void hipdnnPluginGetLastErrorStringImpl(const char** errorStr);
 
 hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callback);
 
+hipdnnPluginStatus_t hipdnnEnginePluginSetStreamImpl(hipdnnEnginePluginHandle_t handle,
+                                                     hipStream_t stream);
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetApplicableEngineIdsImpl(hipdnnEnginePluginHandle_t handle,
+                                                 const hipdnnPluginConstData_t* opGraph,
+                                                 int64_t* engineIds,
+                                                 uint32_t maxEngines,
+                                                 uint32_t* numEngines);
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
+                                                            int64_t engineId,
+                                                            const hipdnnPluginConstData_t* opGraph,
+                                                            hipdnnPluginConstData_t* engineDetails);
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginDestroyEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
+                                               hipdnnPluginConstData_t* engineDetails);
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetWorkspaceSizeImpl(hipdnnEnginePluginHandle_t handle,
+                                           const hipdnnPluginConstData_t* engineConfig,
+                                           const hipdnnPluginConstData_t* opGraph,
+                                           size_t* workspaceSize);
+
+hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle,
+    const hipdnnPluginConstData_t* engineConfig,
+    const hipdnnPluginConstData_t* opGraph,
+    hipdnnEnginePluginExecutionContext_t* executionContext);
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle, hipdnnEnginePluginExecutionContext_t executionContext);
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+    hipdnnEnginePluginHandle_t handle,
+    hipdnnEnginePluginExecutionContext_t executionContext,
+    size_t* workspaceSize);
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginExecuteOpGraphImpl(hipdnnEnginePluginHandle_t handle,
+                                         hipdnnEnginePluginExecutionContext_t executionContext,
+                                         void* workspace,
+                                         const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                         uint32_t numDeviceBuffers);
+
 } // extern "C"

--- a/dnn-providers/hip-kernel-provider/HipKernelPlugin.hpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPlugin.hpp
@@ -18,6 +18,14 @@ void hipdnnPluginGetLastErrorStringImpl(const char** errorStr);
 
 hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callback);
 
+hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
+                                                           uint32_t maxEngines,
+                                                           uint32_t* numEngines);
+
+hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* handle);
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t handle);
+
 hipdnnPluginStatus_t hipdnnEnginePluginSetStreamImpl(hipdnnEnginePluginHandle_t handle,
                                                      hipStream_t stream);
 

--- a/dnn-providers/hip-kernel-provider/HipKernelPlugin.hpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPlugin.hpp
@@ -1,0 +1,21 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_plugin_sdk/PluginApi.h>
+
+extern "C" {
+
+hipdnnPluginStatus_t hipdnnPluginGetNameImpl(const char** name);
+
+hipdnnPluginStatus_t hipdnnPluginGetVersionImpl(const char** version);
+
+hipdnnPluginStatus_t hipdnnPluginGetTypeImpl(hipdnnPluginType_t* type);
+
+void hipdnnPluginGetLastErrorStringImpl(const char** errorStr);
+
+hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callback);
+
+} // extern "C"

--- a/dnn-providers/hip-kernel-provider/HipKernelPluginPublic.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPluginPublic.cpp
@@ -34,4 +34,80 @@ hipdnnPluginStatus_t hipdnnPluginSetLoggingCallback(hipdnnCallback_t callback)
     return hipdnnPluginSetLoggingCallbackImpl(callback);
 }
 
+hipdnnPluginStatus_t hipdnnEnginePluginSetStream(hipdnnEnginePluginHandle_t handle,
+                                                 hipStream_t stream)
+{
+    return hipdnnEnginePluginSetStreamImpl(handle, stream);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetApplicableEngineIds(hipdnnEnginePluginHandle_t handle,
+                                             const hipdnnPluginConstData_t* opGraph,
+                                             int64_t* engineIds,
+                                             uint32_t maxEngines,
+                                             uint32_t* numEngines)
+{
+    return hipdnnEnginePluginGetApplicableEngineIdsImpl(
+        handle, opGraph, engineIds, maxEngines, numEngines);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetails(hipdnnEnginePluginHandle_t handle,
+                                                        int64_t engineId,
+                                                        const hipdnnPluginConstData_t* opGraph,
+                                                        hipdnnPluginConstData_t* engineDetails)
+{
+    return hipdnnEnginePluginGetEngineDetailsImpl(handle, engineId, opGraph, engineDetails);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroyEngineDetails(hipdnnEnginePluginHandle_t handle,
+                                                            hipdnnPluginConstData_t* engineDetails)
+{
+    return hipdnnEnginePluginDestroyEngineDetailsImpl(handle, engineDetails);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSize(hipdnnEnginePluginHandle_t handle,
+                                                        const hipdnnPluginConstData_t* engineConfig,
+                                                        const hipdnnPluginConstData_t* opGraph,
+                                                        size_t* workspaceSize)
+{
+    return hipdnnEnginePluginGetWorkspaceSizeImpl(handle, engineConfig, opGraph, workspaceSize);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginCreateExecutionContext(hipdnnEnginePluginHandle_t handle,
+                                             const hipdnnPluginConstData_t* engineConfig,
+                                             const hipdnnPluginConstData_t* opGraph,
+                                             hipdnnEnginePluginExecutionContext_t* executionContext)
+{
+    return hipdnnEnginePluginCreateExecutionContextImpl(
+        handle, engineConfig, opGraph, executionContext);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginDestroyExecutionContext(hipdnnEnginePluginHandle_t handle,
+                                              hipdnnEnginePluginExecutionContext_t executionContext)
+{
+    return hipdnnEnginePluginDestroyExecutionContextImpl(handle, executionContext);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContext(
+    hipdnnEnginePluginHandle_t handle,
+    hipdnnEnginePluginExecutionContext_t executionContext,
+    size_t* workspaceSize)
+{
+    return hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+        handle, executionContext, workspaceSize);
+}
+
+hipdnnPluginStatus_t
+    hipdnnEnginePluginExecuteOpGraph(hipdnnEnginePluginHandle_t handle,
+                                     hipdnnEnginePluginExecutionContext_t executionContext,
+                                     void* workspace,
+                                     const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                     uint32_t numDeviceBuffers)
+{
+    return hipdnnEnginePluginExecuteOpGraphImpl(
+        handle, executionContext, workspace, deviceBuffers, numDeviceBuffers);
+}
+
 } // extern "C"

--- a/dnn-providers/hip-kernel-provider/HipKernelPluginPublic.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPluginPublic.cpp
@@ -1,0 +1,37 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <hipdnn_plugin_sdk/EnginePluginApi.h>
+#include <hipdnn_plugin_sdk/PluginApi.h>
+
+#include "HipKernelPlugin.hpp"
+
+extern "C" {
+
+hipdnnPluginStatus_t hipdnnPluginGetName(const char** name)
+{
+    return hipdnnPluginGetNameImpl(name);
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetVersion(const char** version)
+{
+    return hipdnnPluginGetVersionImpl(version);
+}
+
+hipdnnPluginStatus_t hipdnnPluginGetType(hipdnnPluginType_t* type)
+{
+    return hipdnnPluginGetTypeImpl(type);
+}
+
+void hipdnnPluginGetLastErrorString(const char** errorStr)
+{
+    hipdnnPluginGetLastErrorStringImpl(errorStr);
+}
+
+// Once plugins are loaded via plugin manager then logging will work for them
+hipdnnPluginStatus_t hipdnnPluginSetLoggingCallback(hipdnnCallback_t callback)
+{
+    return hipdnnPluginSetLoggingCallbackImpl(callback);
+}
+
+} // extern "C"

--- a/dnn-providers/hip-kernel-provider/HipdnnEnginePluginExecutionContext.hpp
+++ b/dnn-providers/hip-kernel-provider/HipdnnEnginePluginExecutionContext.hpp
@@ -1,0 +1,57 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+
+#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "engines/plans/PlanInterface.hpp"
+
+struct HipdnnEnginePluginExecutionContext
+{
+public:
+    virtual ~HipdnnEnginePluginExecutionContext() = default;
+
+    bool hasValidPlan() const
+    {
+        return _plan != nullptr;
+    }
+
+    void setPlan(std::unique_ptr<hip_kernel_plugin::IPlan> plan)
+    {
+        _plan = std::move(plan);
+    }
+
+    virtual hip_kernel_plugin::IPlan& plan() const
+    {
+        if(!hasValidPlan())
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                "Cannot get plan in execution context, its not set");
+        }
+        return *_plan;
+    }
+
+    void setBenchmarkingEnabled(bool enabled)
+    {
+        _benchmarkingEnabled = enabled;
+    }
+
+    bool benchmarkingEnabled() const
+    {
+        return _benchmarkingEnabled;
+    }
+
+private:
+    std::unique_ptr<hip_kernel_plugin::IPlan> _plan;
+    bool _benchmarkingEnabled = false;
+};

--- a/dnn-providers/hip-kernel-provider/HipdnnEnginePluginHandle.hpp
+++ b/dnn-providers/hip-kernel-provider/HipdnnEnginePluginHandle.hpp
@@ -1,0 +1,69 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <flatbuffers/flatbuffers.h>
+#include <memory>
+#include <unordered_map>
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "HipKernelContainer.hpp"
+
+// NOLINTBEGIN
+struct HipdnnEnginePluginHandle
+{
+public:
+    virtual ~HipdnnEnginePluginHandle() = default;
+
+    void setStream(hipStream_t stream)
+    {
+        _stream = stream;
+    }
+
+    hipStream_t getStream() const
+    {
+        return _stream;
+    }
+
+    std::shared_ptr<hip_kernel_plugin::HipKernelContainer> hipKernelContainer;
+    hip_kernel_plugin::EngineManager& getEngineManager()
+    {
+        return hipKernelContainer->getEngineManager();
+    }
+
+    void storeEngineDetailsDetachedBuffer(const void* ptr,
+                                          std::unique_ptr<flatbuffers::DetachedBuffer> buffer)
+    {
+        HIPDNN_LOG_INFO("Storing detached buffer at address: {:p}", ptr);
+        _engineDetailsBuffers[ptr] = std::move(buffer);
+    }
+
+    void removeEngineDetailsDetachedBuffer(const void* ptr)
+    {
+        HIPDNN_LOG_INFO("Removing detached buffer at address: {:p}", ptr);
+
+        auto it = _engineDetailsBuffers.find(ptr);
+        if(it != _engineDetailsBuffers.end())
+        {
+            _engineDetailsBuffers.erase(it);
+        }
+        else
+        {
+            HIPDNN_LOG_WARN("No detached buffer found at address: {:p}. Could not remove engine "
+                            "details. Ensure you "
+                            "are using the same hipdnn handle you used for engine details creation",
+                            ptr);
+        }
+    }
+
+private:
+    hipStream_t _stream = nullptr;
+    std::unordered_map<const void*, std::unique_ptr<flatbuffers::DetachedBuffer>>
+        _engineDetailsBuffers;
+};
+
+// NOLINTEND

--- a/dnn-providers/hip-kernel-provider/HipdnnEnginePluginHandle.hpp
+++ b/dnn-providers/hip-kernel-provider/HipdnnEnginePluginHandle.hpp
@@ -29,7 +29,6 @@ public:
         return _stream;
     }
 
-    std::shared_ptr<hip_kernel_plugin::HipKernelContainer> hipKernelContainer;
     hip_kernel_plugin::EngineManager& getEngineManager()
     {
         return hipKernelContainer->getEngineManager();
@@ -59,6 +58,8 @@ public:
                             ptr);
         }
     }
+
+    std::shared_ptr<hip_kernel_plugin::HipKernelContainer> hipKernelContainer;
 
 private:
     hipStream_t _stream = nullptr;

--- a/dnn-providers/hip-kernel-provider/README.md
+++ b/dnn-providers/hip-kernel-provider/README.md
@@ -1,0 +1,12 @@
+# HIP kernel provider plugin
+A plugin that provides engines for HIP kernels to solve certain hipDNN graphs.
+
+:construction: **This project is under active development** :construction:
+
+## Building
+This plugin should be built as a standalone plugin. To build the plugin, first install hipDNN on the system and then follow these steps:
+
+1. Navigate to the `dnn-providers/hip-kernel-provider` directory.
+2. Make a build directory using `mkdir build && cd build`.
+3. Configure the build using `cmake -DCMAKE_CXX_COMPILER=<path to amdclang>/clang++ ..`.
+4. Finally, run `ninja` to build the plugin.

--- a/dnn-providers/hip-kernel-provider/cmake/ClangToolChain.cmake
+++ b/dnn-providers/hip-kernel-provider/cmake/ClangToolChain.cmake
@@ -1,0 +1,38 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+# Platform-specific compiler configuration
+
+if(UNIX)
+    set(DEFAULT_ROCM_PATH "/opt/rocm")
+    set(DEFAULT_ROCM_LLVM_ROOT "/llvm")
+    set(DEFAULT_ROCM_COMPILER_EXTENSION "")
+elseif(WIN32)
+    set(DEFAULT_ROCM_PATH "C:/dist/therock")
+    set(DEFAULT_ROCM_LLVM_ROOT "/lib/llvm")
+    set(DEFAULT_ROCM_COMPILER_EXTENSION ".exe")
+endif()
+
+if(NOT DEFINED ROCM_PATH)
+    set(ROCM_PATH ${DEFAULT_ROCM_PATH} CACHE PATH "Path to ROCm installation")
+endif()
+
+list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES "ROCM_PATH")
+
+# Unix/Linux: Use ROCm LLVM Clang
+set(ROCM_LLVM_BIN_DIR ${ROCM_PATH}${DEFAULT_ROCM_LLVM_ROOT}/bin)
+set(ROCM_LLVM_LIB_DIR ${ROCM_PATH}${DEFAULT_ROCM_LLVM_ROOT}/lib)
+set(CMAKE_RC_COMPILER rc.exe)
+
+if(EXISTS ${ROCM_LLVM_BIN_DIR})
+    # Set the C and C++ compilers to clang and clang++ with a specific directory hint
+    set(CMAKE_C_COMPILER ${ROCM_LLVM_BIN_DIR}/clang${DEFAULT_ROCM_COMPILER_EXTENSION})
+    set(CMAKE_CXX_COMPILER ${ROCM_LLVM_BIN_DIR}/clang++${DEFAULT_ROCM_COMPILER_EXTENSION})
+
+    message(STATUS "Using ROCm Clang compilers from ${ROCM_LLVM_BIN_DIR}")
+else()
+    message(
+        FATAL_ERROR
+            "The directory ${ROCM_LLVM_BIN_DIR} does not exist. Cannot auto select clang compilers."
+    )
+endif()

--- a/dnn-providers/hip-kernel-provider/cmake/Dependencies.cmake
+++ b/dnn-providers/hip-kernel-provider/cmake/Dependencies.cmake
@@ -1,0 +1,29 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+cmake_minimum_required(VERSION 3.25.2)
+
+# Only setup dependencies for standalone builds
+if(NOT HIPDNN_SKIP_TESTS)
+    include(FetchContent)
+
+    # Try to find GTest first
+    find_package(GTest CONFIG QUIET)
+
+    if(NOT GTest_FOUND)
+        message(STATUS "Fetching GTest for standalone plugin build")
+
+        fetchcontent_declare(
+            googletest URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
+                           DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        )
+
+        set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
+        set(INSTALL_GTEST OFF CACHE INTERNAL "")
+        set(BUILD_GMOCK ON CACHE INTERNAL "")
+
+        fetchcontent_makeavailable(googletest)
+    else()
+        message(STATUS "Found system GTest")
+    endif()
+endif()

--- a/dnn-providers/hip-kernel-provider/cmake/Tests.cmake
+++ b/dnn-providers/hip-kernel-provider/cmake/Tests.cmake
@@ -1,0 +1,252 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+if(HIPDNN_SKIP_TESTS)
+    return()
+endif()
+
+include(GoogleTest)
+
+find_package(Python3 COMPONENTS Interpreter)
+
+set(CHECK_DEPENDS_GLOBAL "" CACHE INTERNAL "Accumulated global dependencies for test name validation" FORCE)
+set(CHECK_EXECUTABLE_PATHS_GLOBAL "" CACHE INTERNAL "Accumulated global check executable paths" FORCE)
+
+# Builds the test environment list with optional code coverage support
+# ~~~
+# Parameters:
+#   OUT_VAR - The name of the variable to store the result in (will be set in PARENT_SCOPE)
+# ~~~
+function(_build_test_environment_list_internal OUT_VAR)
+    set(ENVIRONMENT_LIST "")
+    if(DEFINED TEST_ENVIRONMENT)
+        set(ENVIRONMENT_LIST ${TEST_ENVIRONMENT})
+    endif()
+
+    if(HIPDNN_ENABLE_COVERAGE)
+        # Ensure coverage report directory exists
+        file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/coverage_report/profraw")
+
+        # For code coverage builds, we want each profraw file to have a unique name.  The %m in the
+        # LLVM_PROFILE_FILE environment variable will auto generate a unique id.
+        list(APPEND ENVIRONMENT_LIST
+             "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage_report/profraw/%m.profraw"
+        )
+    endif()
+
+    set(${OUT_VAR} ${ENVIRONMENT_LIST} PARENT_SCOPE)
+endfunction() # _build_test_environment_list_internal
+
+# Creates a custom target to validate test names using a Python script
+function(_create_test_name_validation_target_internal)
+    if(Python3_FOUND)
+        # Write list of test executables with their paths to a file
+        set(TEST_EXECUTABLES_FILE ${CMAKE_BINARY_DIR}/test_executables.txt)
+        list(REMOVE_DUPLICATES CHECK_EXECUTABLE_PATHS_GLOBAL)
+        file(WRITE ${TEST_EXECUTABLES_FILE} "")
+        foreach(test_executable ${CHECK_EXECUTABLE_PATHS_GLOBAL})
+            file(APPEND ${TEST_EXECUTABLES_FILE} "${test_executable}\n")
+        endforeach()
+
+        add_custom_command(
+            OUTPUT ${CMAKE_BINARY_DIR}/test_names_validated
+            COMMAND
+                ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/scripts/test_name_validator.py
+                --test-executables ${TEST_EXECUTABLES_FILE} --build-dir ${CMAKE_BINARY_DIR} --strict
+            COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/test_names_validated
+            DEPENDS ${CMAKE_SOURCE_DIR}/cmake/scripts/test_name_validator.py ${CHECK_DEPENDS_GLOBAL}
+            COMMENT "Validating test names with --gtest_list_tests test collection"
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            VERBATIM
+        )
+
+        add_custom_target(
+            validate_test_names DEPENDS ${CMAKE_BINARY_DIR}/test_names_validated
+            COMMENT "Validating test names"
+        )
+    else()
+        message(WARNING "Python3 not found. Test name validation will be skipped.")
+        add_custom_target(
+            validate_test_names COMMAND ${CMAKE_COMMAND} -E echo
+                                        "Test name validation skipped - Python3 not found"
+            COMMENT "Skipping test name validation"
+        )
+    endif() # Python3_FOUND
+endfunction() # _create_test_name_validation_target_internal
+
+enable_testing() # Cmake wont discover or run tests without this line
+
+# Internal helper function to create a ctest target
+# ~~~
+# Parameters:
+#   TARGET_NAME - Name of the ctest target to create
+#   LABEL - Optional label filter for ctest (empty string for no filter)
+#   VERBOSE - Set to TRUE to add --verbose flag, FALSE otherwise
+#   COMMENT - Comment describing the target
+# ~~~
+function(_add_ctest_target_internal TARGET_NAME LABEL VERBOSE COMMENT)
+    # Build the ctest command
+    set(CTEST_CMD ${CMAKE_COMMAND} -E env ${CTEST_ENV} ${CMAKE_CTEST_COMMAND})
+
+    # Add label filter if specified
+    if(NOT "${LABEL}" STREQUAL "")
+        list(APPEND CTEST_CMD -L "${LABEL}")
+    endif()
+
+    # Always add --output-on-failure
+    list(APPEND CTEST_CMD --output-on-failure)
+
+    # Add --verbose if requested
+    if(VERBOSE)
+        list(APPEND CTEST_CMD --verbose)
+    endif()
+
+    # Add configuration
+    list(APPEND CTEST_CMD -C ${CMAKE_CFG_INTDIR})
+
+    # Create the target
+    add_custom_target(${TARGET_NAME} COMMAND ${CTEST_CMD} COMMENT "${COMMENT}" USES_TERMINAL)
+    add_dependencies(${TARGET_NAME} validate_test_names)
+    message(VERBOSE "Created ${TARGET_NAME} target")
+endfunction() # _add_ctest_target_internal
+
+# Internal helper function to create the check targets for running tests via ctest
+function(_create_ctest_targets_internal)
+    # cmake-format: off
+    # Build test environment once for all ctest targets
+    _build_test_environment_list_internal(CTEST_ENV)
+
+    # Regular targets (without --verbose)
+    _add_ctest_target_internal(check_ctest "" FALSE "Running all tests via ctest")
+    _add_ctest_target_internal(unit-check_ctest "unit_test" FALSE "Running unit tests via ctest")
+    _add_ctest_target_internal(integration-check_ctest "integration_test" FALSE "Running integration tests via ctest")
+
+    # Verbose targets (with --verbose)
+    _add_ctest_target_internal(check_ctest-verbose "" TRUE "Running all tests via ctest (verbose)")
+    _add_ctest_target_internal(unit-check_ctest-verbose "unit_test" TRUE "Running unit tests via ctest (verbose)")
+    _add_ctest_target_internal(integration-check_ctest-verbose "integration_test" TRUE "Running integration tests via ctest (verbose)")
+    # cmake-format: on
+endfunction() # create_ctest_targets
+
+# Finalizes and creates all of the test targets
+function(finalize_test_targets)
+    _create_test_name_validation_target_internal()
+
+    _create_ctest_targets_internal()
+
+    # cmake-format: off
+    # Create alias test targets without '_ctest' in the name
+    # Regular targets (without --verbose)
+    add_custom_target(check DEPENDS check_ctest COMMENT "Running all tests via ctest")
+    add_custom_target(unit-check DEPENDS unit-check_ctest COMMENT "Running unit tests via ctest")
+    add_custom_target(integration-check DEPENDS integration-check_ctest COMMENT "Running integration tests via ctest")
+    message(STATUS "Created ctest targets: check, unit-check, integration-check")
+    # Verbose targets (with --verbose)
+    add_custom_target(check-verbose DEPENDS check_ctest-verbose COMMENT "Running all tests via ctest (verbose)")
+    add_custom_target(unit-check-verbose DEPENDS unit-check_ctest-verbose COMMENT "Running unit tests via ctest (verbose)")
+    add_custom_target(integration-check-verbose DEPENDS integration-check_ctest-verbose COMMENT "Running integration tests via ctest (verbose)")
+    message(STATUS "Created ctest verbose targets: check-verbose, unit-check-verbose, integration-check-verbose")
+    # cmake-format: on
+endfunction() # finalize_test_targets
+
+# ~~~
+# Internal helper function to record, configure, and register a ctest test target. Assumes that the
+# test target is a gtest executable, setting up:
+# - Test name validation tracking (adds to global dependency and executable path lists)
+# - RPATH settings for relocatable test executables
+# - Installation rules for test binaries
+# - CTest registration with appropriate labels (e.g. unit / integration test labels)
+# Parameters:
+#   APPEND_FUNCTION_SUFFIX - Label to apply to the test (e.g., "unit_test", "integration_test", "test")
+#   TARGET - Name of the test executable target (must already exist)
+#   WORKING_DIR - Working directory for test execution
+# ~~~
+function(_add_test_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
+    set(TARGET_EXE ${TARGET})
+
+    # Add executable suffix if needed (e.g., .exe on Windows)
+    if(CMAKE_EXECUTABLE_SUFFIX)
+        set(TARGET_EXE "${TARGET_EXE}${CMAKE_EXECUTABLE_SUFFIX}")
+    endif()
+
+    message(STATUS "Appending ${APPEND_FUNCTION_SUFFIX} check target: ${TARGET} -> ${TARGET_EXE} in working directory: ${WORKING_DIR}")
+
+    # Track the dependencies for test name validation
+    set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET}
+        CACHE INTERNAL "Accumulated global dependencies for test name validation" FORCE
+    )
+    # Track the binary paths for test name validation
+    set(CHECK_EXECUTABLE_PATHS_GLOBAL ${CHECK_EXECUTABLE_PATHS_GLOBAL} "${CMAKE_INSTALL_BINDIR}/${TARGET_EXE}"
+        CACHE INTERNAL "Accumulated global check executable paths" FORCE
+    )
+
+    # Track this test target for later use in generating installed CTestTestfile.cmake
+    set_property(GLOBAL APPEND PROPERTY HIPDNN_TEST_TARGETS ${TARGET})
+
+    set_target_properties(
+        ${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}"
+    )
+
+    # Track this test target for later use in generating installed CTestTestfile.cmake
+    set_property(GLOBAL APPEND PROPERTY HIP_KERNEL_PLUGIN_TEST_TARGETS ${TARGET})
+
+    # Make test executables relocatable so they can find libraries when build directory is moved
+    # Include both the main lib directory and the engine plugin directories
+    set_target_properties(
+        ${TARGET}
+        PROPERTIES
+            INSTALL_RPATH
+            "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR};\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}/hipdnn_plugins/engines"
+            INSTALL_RPATH_USE_LINK_PATH TRUE
+            BUILD_RPATH_USE_ORIGIN TRUE
+    )
+
+    # Install test executables to bin directory
+    install(TARGETS ${TARGET} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    add_test(NAME ${TARGET} COMMAND ${TARGET} WORKING_DIRECTORY ${WORKING_DIR})
+    set_tests_properties(${TARGET} PROPERTIES LABELS ${APPEND_FUNCTION_SUFFIX})
+endfunction() # _add_gtest_target_internal
+
+# Adds a generic test target
+function(add_unclassified_test_target TARGET WORKING_DIR)
+    _add_test_target_internal(test ${TARGET} ${WORKING_DIR})
+endfunction() # add_unclassified_test_target
+
+# Adds a unit test target
+function(add_unit_test_target TARGET WORKING_DIR)
+    _add_test_target_internal(unit_test ${TARGET} ${WORKING_DIR})
+endfunction() # add_unit_test_target
+
+# Adds an integration test target
+function(add_integration_test_target TARGET WORKING_DIR)
+    _add_test_target_internal(integration_test ${TARGET} ${WORKING_DIR})
+endfunction() # add_integration_test_target
+
+# Install CTest configuration files for direct test execution This should be called once at the end
+# of the main CMakeLists.txt after all tests are registered
+function(install_hip_kernel_plugin_ctest_files)
+    # Define the CTest installation directory
+    set(HIP_KERNEL_PLUGIN_CTEST_FILE_INSTALL_PATH "${CMAKE_INSTALL_BINDIR}/hip_kernel_plugin")
+
+    # Generate a new CTestTestfile.cmake that references installed test executables
+    set(INSTALLED_CTEST_FILE "${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake.install")
+
+    file(WRITE "${INSTALLED_CTEST_FILE}"
+         "# Autogenerated CTestTestfile for installed hip_kernel_plugin tests\n"
+    )
+    file(APPEND "${INSTALLED_CTEST_FILE}" "# Generated by hip_kernel_plugin build system\n\n")
+
+    # Get all test targets that were registered
+    get_property(all_tests GLOBAL PROPERTY HIP_KERNEL_PLUGIN_TEST_TARGETS)
+
+    foreach(test_target ${all_tests})
+        file(APPEND "${INSTALLED_CTEST_FILE}" "add_test(${test_target} \"../${test_target}\")\n")
+    endforeach()
+
+    # Install the generated CTestTestfile.cmake to HIP_KERNEL_PLUGIN_CTEST_FILE_INSTALL_PATH
+    install(FILES "${INSTALLED_CTEST_FILE}"
+            DESTINATION ${HIP_KERNEL_PLUGIN_CTEST_FILE_INSTALL_PATH} RENAME CTestTestfile.cmake
+    )
+
+endfunction() # install_hip_kernel_plugin_ctest_files

--- a/dnn-providers/hip-kernel-provider/engines/EngineInterface.hpp
+++ b/dnn-providers/hip-kernel-provider/engines/EngineInterface.hpp
@@ -1,0 +1,44 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <stdint.h>
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hip_kernel_plugin
+{
+
+class IEngine
+{
+public:
+    virtual ~IEngine() = default;
+
+    virtual int64_t id() const = 0;
+
+    virtual bool isApplicable(HipdnnEnginePluginHandle& handle,
+                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+        = 0;
+    virtual void getDetails(HipdnnEnginePluginHandle& handle,
+                            const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                            hipdnnPluginConstData_t& detailsOut) const
+        = 0;
+
+    virtual size_t
+        getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                         const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+        = 0;
+
+    virtual void initializeExecutionContext(
+        const HipdnnEnginePluginHandle& handle,
+        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        HipdnnEnginePluginExecutionContext& executionContext) const
+        = 0;
+};
+
+}

--- a/dnn-providers/hip-kernel-provider/engines/HipKernelEngine.cpp
+++ b/dnn-providers/hip-kernel-provider/engines/HipKernelEngine.cpp
@@ -1,0 +1,146 @@
+﻿// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipKernelEngine.hpp"
+
+#include <hipdnn_data_sdk/data_objects/engine_details_generated.h>
+#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+#include <hipdnn_plugin_sdk/GlobalKnobDefines.hpp>
+#include <hipdnn_plugin_sdk/KnobFactory.hpp>
+
+namespace hip_kernel_plugin
+{
+
+HipKernelEngine::HipKernelEngine(int64_t id)
+    : _id(id)
+{
+}
+
+int64_t HipKernelEngine::id() const
+{
+    return _id;
+}
+
+bool HipKernelEngine::isApplicable(
+    HipdnnEnginePluginHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+{
+    // This is wrong if we ever have more than 1 plan builder thats applicable.
+    // If this is the case, we should split plan builders accross multiple engines.
+    for(const auto& planBuilder : _planBuilders)
+    {
+        if(planBuilder->isApplicable(handle, opGraph))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void HipKernelEngine::getDetails(HipdnnEnginePluginHandle& handle,
+                                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                                 hipdnnPluginConstData_t& detailsOut) const
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    auto knob = hipdnn_plugin_sdk::KnobFactory::createIntKnob(
+        builder, hipdnn_plugin_sdk::BENCHMARKING_KNOB_NAME, "Enable benchmarking", 0, 0, 1, 1, {});
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Knob>> knobsVector;
+    knobsVector.push_back(knob);
+
+    // Collect custom knobs from plan builders
+    for(const auto& planBuilder : _planBuilders)
+    {
+        auto customKnobs = planBuilder->getCustomKnobs(handle, opGraph);
+
+        if(customKnobs.empty())
+        {
+            continue;
+        }
+
+        for(const auto& knobT : customKnobs)
+        {
+            auto knobOffset = hipdnn_data_sdk::data_objects::Knob::Pack(builder, &knobT);
+            knobsVector.push_back(knobOffset);
+        }
+
+        // Only one plan builder should be applicable for a given graph and return custom knobs.
+        // Stop after finding the first one to avoid duplicates.
+        break;
+    }
+
+    auto knobs = builder.CreateVector(knobsVector);
+
+    auto engineDetails = hipdnn_data_sdk::data_objects::CreateEngineDetails(builder, _id, knobs);
+    builder.Finish(engineDetails);
+    auto detachedBuffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
+    detailsOut.ptr = detachedBuffer->data();
+    detailsOut.size = detachedBuffer->size();
+
+    handle.storeEngineDetailsDetachedBuffer(detailsOut.ptr, std::move(detachedBuffer));
+}
+
+size_t HipKernelEngine::getWorkspaceSize(
+    const HipdnnEnginePluginHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+{
+    size_t workspaceSize = 0;
+    for(const auto& planBuilder : _planBuilders)
+    {
+        if(planBuilder->isApplicable(handle, opGraph))
+        {
+            workspaceSize = std::max(workspaceSize, planBuilder->getWorkspaceSize(handle, opGraph));
+        }
+    }
+    return workspaceSize;
+}
+
+void HipKernelEngine::initializeExecutionContext(
+    const HipdnnEnginePluginHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    HipdnnEnginePluginExecutionContext& executionContext) const
+{
+    if(engineConfig.isValid())
+    {
+        if(engineConfig.hasKnobSetting(hipdnn_plugin_sdk::BENCHMARKING_KNOB_NAME))
+        {
+            const auto& knobSetting
+                = engineConfig.getKnobSettingByName(hipdnn_plugin_sdk::BENCHMARKING_KNOB_NAME);
+            if(knobSetting.valueType() == hipdnn_data_sdk::data_objects::KnobValue::IntValue)
+            {
+                auto value = knobSetting.valueAs<hipdnn_data_sdk::data_objects::IntValue>().value();
+                executionContext.setBenchmarkingEnabled(value != 0);
+            }
+            else
+            {
+                HIPDNN_LOG_WARN(
+                    "Benchmarking knob setting value is not an integer. Type: {}",
+                    hipdnn_data_sdk::data_objects::EnumNameKnobValue(knobSetting.valueType()));
+            }
+        }
+    }
+    else
+    {
+        HIPDNN_LOG_WARN("Engine config is invalid");
+    }
+
+    for(const auto& planBuilder : _planBuilders)
+    {
+        if(planBuilder->isApplicable(handle, opGraph))
+        {
+            planBuilder->buildPlan(handle, opGraph, engineConfig, executionContext);
+            break;
+        }
+    }
+}
+
+void HipKernelEngine::addPlanBuilder(std::unique_ptr<IPlanBuilder> planBuilder)
+{
+    _planBuilders.push_back(std::move(planBuilder));
+}
+
+}

--- a/dnn-providers/hip-kernel-provider/engines/HipKernelEngine.hpp
+++ b/dnn-providers/hip-kernel-provider/engines/HipKernelEngine.hpp
@@ -1,0 +1,45 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+#include <set>
+
+#include "EngineInterface.hpp"
+#include "plans/PlanBuilderInterface.hpp"
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hip_kernel_plugin
+{
+
+class HipKernelEngine : public IEngine
+{
+public:
+    HipKernelEngine(int64_t id);
+
+    int64_t id() const override;
+
+    bool isApplicable(HipdnnEnginePluginHandle& handle,
+                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    void getDetails(HipdnnEnginePluginHandle& handle,
+                    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                    hipdnnPluginConstData_t& detailsOut) const override;
+    size_t getWorkspaceSize(
+        const HipdnnEnginePluginHandle& handle,
+        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+
+    void initializeExecutionContext(
+        const HipdnnEnginePluginHandle& handle,
+        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+        const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        HipdnnEnginePluginExecutionContext& executionContext) const override;
+
+    void addPlanBuilder(std::unique_ptr<IPlanBuilder> planBuilder);
+
+private:
+    int64_t _id;
+    std::vector<std::unique_ptr<IPlanBuilder>> _planBuilders;
+};
+
+}

--- a/dnn-providers/hip-kernel-provider/engines/plans/PlanBuilderInterface.hpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/PlanBuilderInterface.hpp
@@ -1,0 +1,47 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineConfigWrapper.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+
+namespace hip_kernel_plugin
+{
+
+class IPlanBuilder
+{
+public:
+    virtual ~IPlanBuilder() = default;
+
+    virtual bool isApplicable(const HipdnnEnginePluginHandle& handle,
+                              const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+        = 0;
+
+    virtual size_t
+        getWorkspaceSize(const HipdnnEnginePluginHandle& handle,
+                         const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+        = 0;
+
+    virtual void buildPlan(
+        const HipdnnEnginePluginHandle& handle,
+        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+        [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+        HipdnnEnginePluginExecutionContext& executionContext) const
+        = 0;
+
+    virtual std::vector<hipdnn_data_sdk::data_objects::KnobT>
+        getCustomKnobs(const HipdnnEnginePluginHandle& handle,
+                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+        = 0;
+};
+}

--- a/dnn-providers/hip-kernel-provider/engines/plans/PlanInterface.hpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/PlanInterface.hpp
@@ -1,0 +1,25 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hip_kernel_plugin
+{
+
+class IPlan
+{
+public:
+    virtual ~IPlan() = default;
+
+    virtual size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle) const = 0;
+
+    virtual void execute(const HipdnnEnginePluginHandle& handle,
+                         const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                         uint32_t numDeviceBuffers,
+                         void* workspace = nullptr) const
+        = 0;
+};
+
+}

--- a/dnn-providers/hip-kernel-provider/integration_tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/integration_tests/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+find_package(Threads REQUIRED)
+
+find_package(hipdnn_test_sdk CONFIG REQUIRED)
+find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+
+add_executable(
+    hip_kernel_plugin_integration_tests
+    main.cpp
+)
+
+target_compile_options(hip_kernel_plugin_integration_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+
+# To use the build tree plugin, we use the path relative to the test binary instead of the installed
+# libhipdnn_backend.so HIPDNN_PLUGIN_ENGINE_SUBDIR is provided by the sdk
+target_compile_definitions(
+    hip_kernel_plugin_integration_tests
+    PRIVATE
+        PLUGIN_PATH="../$<IF:$<PLATFORM_ID:Windows>,bin,lib>/${HIPDNN_PLUGIN_ENGINE_SUBDIR}/hip_kernel_plugin"
+)
+
+target_link_libraries(
+    hip_kernel_plugin_integration_tests PUBLIC GTest::gtest hip::host hipdnn_test_sdk hipdnn_plugin_sdk Threads::Threads
+)
+
+# Ensure that the hip_kernel_plugin is built before the integration tests
+add_dependencies(hip_kernel_plugin_integration_tests hip_kernel_plugin)
+
+add_integration_test_target(hip_kernel_plugin_integration_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/dnn-providers/hip-kernel-provider/integration_tests/main.cpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/main.cpp
@@ -1,0 +1,25 @@
+/*
+Copyright © Advanced Micro Devices, Inc., or its affiliates.
+SPDX-License-Identifier: MIT
+*/
+
+#include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
+#include <hipdnn_frontend.hpp>
+#include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    hipdnn_frontend::initializeFrontendLogging();
+
+    // Register HipErrorHandler to check and clear HIP errors after each test
+    testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+    listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
+
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
+}

--- a/dnn-providers/hip-kernel-provider/tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+add_compile_definitions(__HIP_PLATFORM_AMD__)
+find_package(hip REQUIRED)
+find_package(Threads REQUIRED)
+
+find_package(hipdnn_test_sdk CONFIG REQUIRED)
+find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+
+add_executable(
+    hip_kernel_plugin_tests
+    main.cpp
+)
+
+target_compile_options(hip_kernel_plugin_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
+
+target_link_libraries(
+    hip_kernel_plugin_tests PUBLIC GTest::gtest GTest::gmock hip::host
+                               hip_kernel_plugin_private hipdnn_test_sdk hipdnn_plugin_sdk Threads::Threads
+)
+
+# make it so tests inside folders can find the mocks folder without having to use a relative path.
+target_include_directories(hip_kernel_plugin_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_unit_test_target(hip_kernel_plugin_tests ${CMAKE_CURRENT_BINARY_DIR})

--- a/dnn-providers/hip-kernel-provider/tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/tests/CMakeLists.txt
@@ -10,7 +10,13 @@ find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
 
 add_executable(
     hip_kernel_plugin_tests
+    engines/TestHipKernelEngine.cpp
     main.cpp
+    TestHipKernelEngineManager.cpp
+    TestHipKernelEnginePluginApi.cpp
+    TestHipKernelHipdnnEnginePluginHandle.cpp
+    TestHipKernelHipdnnPluginExecutionContext.cpp
+    TestHipKernelPluginApi.cpp
 )
 
 target_compile_options(hip_kernel_plugin_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})

--- a/dnn-providers/hip-kernel-provider/tests/TestHipKernelEngineManager.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/TestHipKernelEngineManager.cpp
@@ -1,0 +1,202 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <memory>
+#include <set>
+
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
+#include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+
+#include "EngineManager.hpp"
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+#include "mocks/MockEngine.hpp"
+#include "mocks/MockHipdnnEnginePluginExecutionContext.hpp"
+
+using namespace hip_kernel_plugin;
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_plugin_sdk;
+using ::testing::Return;
+
+TEST(TestHipKernelEngineManager, ReturnsApplicableEngineIds)
+{
+    std::set<std::unique_ptr<IEngine>> engines;
+
+    auto mockEngine1 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine1, id()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mockEngine1, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(true));
+
+    auto mockEngine2 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine2, id()).WillRepeatedly(Return(2));
+    EXPECT_CALL(*mockEngine2, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(false));
+
+    EngineManager manager;
+    manager.addEngine(std::move(mockEngine1));
+    manager.addEngine(std::move(mockEngine2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    auto applicable = manager.getApplicableEngineIds(dummyHandle, mockGraph);
+
+    EXPECT_EQ(applicable.size(), 1);
+    EXPECT_EQ(applicable[0], 1);
+}
+
+TEST(TestHipKernelEngineManager, ReturnsMultipleApplicableEngineIds)
+{
+    std::set<std::unique_ptr<IEngine>> engines;
+
+    auto mockEngine1 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine1, id()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mockEngine1, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(true));
+
+    auto mockEngine2 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine2, id()).WillRepeatedly(Return(2));
+    EXPECT_CALL(*mockEngine2, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(true));
+
+    EngineManager manager;
+    manager.addEngine(std::move(mockEngine1));
+    manager.addEngine(std::move(mockEngine2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    auto applicable = manager.getApplicableEngineIds(dummyHandle, mockGraph);
+
+    EXPECT_EQ(applicable.size(), 2);
+    EXPECT_TRUE(std::find(applicable.begin(), applicable.end(), 1) != applicable.end());
+    EXPECT_TRUE(std::find(applicable.begin(), applicable.end(), 2) != applicable.end());
+}
+
+TEST(TestHipKernelEngineManager, ReturnsNoApplicableEngineIds)
+{
+    std::set<std::unique_ptr<IEngine>> engines;
+
+    auto mockEngine1 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine1, id()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mockEngine1, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(false));
+
+    auto mockEngine2 = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine2, id()).WillRepeatedly(Return(2));
+    EXPECT_CALL(*mockEngine2, isApplicable(::testing::_, ::testing::_))
+        .WillRepeatedly(Return(false));
+
+    EngineManager manager;
+    manager.addEngine(std::move(mockEngine1));
+    manager.addEngine(std::move(mockEngine2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    auto applicable = manager.getApplicableEngineIds(dummyHandle, mockGraph);
+
+    EXPECT_TRUE(applicable.empty());
+}
+
+TEST(TestHipKernelEngineManager, ReturnsEngineDetails)
+{
+    EngineManager manager;
+
+    hipdnnPluginConstData_t engineDetails;
+    engineDetails.ptr = reinterpret_cast<const void*>(0x12345678);
+    engineDetails.size = 200;
+    auto mockEngine = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine, id()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mockEngine, getDetails(::testing::_, ::testing::_, ::testing::_))
+        .WillOnce([&engineDetails](HipdnnEnginePluginHandle& handle,
+                                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& graph,
+                                   hipdnnPluginConstData_t& out) {
+            (void)handle;
+            (void)graph;
+            out.ptr = engineDetails.ptr;
+            out.size = engineDetails.size;
+        });
+
+    manager.addEngine(std::move(mockEngine));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle = {};
+    hipdnnPluginConstData_t details;
+    manager.getEngineDetails(dummyHandle, mockGraph, 1, details);
+
+    EXPECT_EQ(details.ptr, engineDetails.ptr);
+    EXPECT_EQ(details.size, engineDetails.size);
+}
+
+TEST(TestHipKernelEngineManager, ThrowsOnInvalidEngineId)
+{
+    EngineManager manager;
+
+    MockGraph mockGraph;
+    hipdnnPluginConstData_t engineDetails;
+
+    HipdnnEnginePluginHandle dummyHandle = {};
+    EXPECT_THROW(manager.getEngineDetails(dummyHandle, mockGraph, 999, engineDetails),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestHipKernelEngineManager, GetWorkspaceSizeReturnsCorrectValue)
+{
+    EngineManager manager;
+
+    auto mockEngine = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine, id()).WillRepeatedly(Return(42));
+    HipdnnEnginePluginHandle dummyHandle = {};
+    MockGraph mockGraph;
+    EXPECT_CALL(*mockEngine, getWorkspaceSize(::testing::_, ::testing::_)).WillOnce(Return(4096));
+
+    manager.addEngine(std::move(mockEngine));
+
+    size_t workspaceSize = manager.getWorkspaceSize(dummyHandle, 42, mockGraph);
+    EXPECT_EQ(workspaceSize, 4096);
+}
+
+TEST(TestHipKernelEngineManager, GetWorkspaceSizeThrowsOnInvalidEngineId)
+{
+    EngineManager manager;
+    HipdnnEnginePluginHandle dummyHandle = {};
+    MockGraph mockGraph;
+
+    EXPECT_THROW(manager.getWorkspaceSize(dummyHandle, 999, mockGraph),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestHipKernelEngineManager, InitializeExecutionContextCallsEngine)
+{
+    auto mockEngine = std::make_unique<MockEngine>();
+    EXPECT_CALL(*mockEngine, id()).WillRepeatedly(Return(7));
+    EXPECT_CALL(*mockEngine,
+                initializeExecutionContext(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(1);
+
+    EngineManager manager;
+    manager.addEngine(std::move(mockEngine));
+    HipdnnEnginePluginHandle dummyHandle = {};
+    MockGraph mockGraph;
+    MockEngineConfig mockEngineConfig;
+    ON_CALL(mockEngineConfig, engineId()).WillByDefault(Return(7));
+    EXPECT_CALL(mockEngineConfig, engineId()).Times(testing::AnyNumber()); // Uninteresting call
+    MockHipdnnEnginePluginExecutionContext execCtx;
+
+    manager.initializeExecutionContext(dummyHandle, mockGraph, mockEngineConfig, execCtx);
+}
+
+TEST(TestHipKernelEngineManager, InitializeExecutionContextThrowsOnInvalidEngineId)
+{
+    MockHipdnnEnginePluginExecutionContext execCtx;
+    EngineManager manager;
+    HipdnnEnginePluginHandle dummyHandle = {};
+    MockGraph mockGraph;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_CALL(mockEngineConfig, engineId()).Times(testing::AnyNumber()); // Uninteresting call
+    EXPECT_THROW(
+        manager.initializeExecutionContext(dummyHandle, mockGraph, mockEngineConfig, execCtx),
+        hipdnn_plugin_sdk::HipdnnPluginException);
+}

--- a/dnn-providers/hip-kernel-provider/tests/TestHipKernelEnginePluginApi.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/TestHipKernelEnginePluginApi.cpp
@@ -1,0 +1,443 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include <HipKernelPlugin.hpp>
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
+#include <hipdnn_data_sdk/utilities/EngineNames.hpp>
+#include <hipdnn_plugin_sdk/EnginePluginApi.h>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+#include <hipdnn_plugin_sdk/PluginGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+#include "mocks/MockHipdnnEnginePluginExecutionContext.hpp"
+
+TEST(TestHipKernelEnginePluginApi, GetAllEngineIdsNull)
+{
+    std::array<int64_t, 1> engineIds = {0};
+    uint32_t numEngines = 0;
+
+    EXPECT_EQ(hipdnnEnginePluginGetAllEngineIdsImpl(nullptr, 0, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetAllEngineIdsImpl(nullptr, 1, &numEngines),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetAllEngineIdsImpl(engineIds.data(), 1, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, GetAllEngineIdsValid)
+{
+    std::array<int64_t, 1> engineIds = {0};
+    uint32_t numEngines = 0;
+
+    //get max 1 engine
+    auto status = hipdnnEnginePluginGetAllEngineIdsImpl(engineIds.data(), 1, &numEngines);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(numEngines, 1u);
+    EXPECT_EQ(engineIds[0], hipdnn_data_sdk::utilities::engineNameToId("HIP_KERNEL_ENGINE"));
+
+    status = hipdnnEnginePluginGetAllEngineIdsImpl(nullptr, 0, &numEngines);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(numEngines, 1u);
+}
+
+TEST(TestHipKernelEnginePluginApi, CreateNullHandle)
+{
+    EXPECT_EQ(hipdnnEnginePluginCreateImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, DestroyNullHandle)
+{
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, SetStreamNullHandle)
+{
+    EXPECT_EQ(hipdnnEnginePluginSetStreamImpl(nullptr, nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, GetApplicableEngineIdsNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto opGraph = reinterpret_cast<hipdnnPluginConstData_t*>(0x5678);
+    std::array<int64_t, 1> engineIds = {0};
+    uint32_t numEngines = 0;
+
+    EXPECT_EQ(hipdnnEnginePluginGetApplicableEngineIdsImpl(nullptr, nullptr, nullptr, 0, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetApplicableEngineIdsImpl(
+                  nullptr, opGraph, engineIds.data(), 1, &numEngines),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetApplicableEngineIdsImpl(
+                  handle, nullptr, engineIds.data(), 1, &numEngines),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(
+        hipdnnEnginePluginGetApplicableEngineIdsImpl(handle, opGraph, nullptr, 1, &numEngines),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(
+        hipdnnEnginePluginGetApplicableEngineIdsImpl(handle, opGraph, engineIds.data(), 1, nullptr),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, GetEngineDetailsNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto opGraph = reinterpret_cast<hipdnnPluginConstData_t*>(0x5678);
+    hipdnnPluginConstData_t engineDetailsOut;
+
+    EXPECT_EQ(hipdnnEnginePluginGetEngineDetailsImpl(nullptr, 1, nullptr, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetEngineDetailsImpl(nullptr, 1, opGraph, &engineDetailsOut),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetEngineDetailsImpl(handle, 1, nullptr, &engineDetailsOut),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginGetEngineDetailsImpl(handle, 1, opGraph, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, DestroyEngineDetailsNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    hipdnnPluginConstData_t engineDetailsOut;
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyEngineDetailsImpl(nullptr, &engineDetailsOut),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyEngineDetailsImpl(handle, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    engineDetailsOut.ptr = nullptr;
+    EXPECT_EQ(hipdnnEnginePluginDestroyEngineDetailsImpl(handle, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, GetWorkspaceSizeNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto engineConfig = reinterpret_cast<hipdnnPluginConstData_t*>(0x5678);
+    auto opGraph = reinterpret_cast<hipdnnPluginConstData_t*>(0x9abc);
+    size_t workspaceSize = 123;
+
+    // Null handle
+    EXPECT_EQ(
+        hipdnnEnginePluginGetWorkspaceSizeImpl(nullptr, engineConfig, opGraph, &workspaceSize),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null engineConfig
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeImpl(handle, nullptr, opGraph, &workspaceSize),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null opGraph
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeImpl(handle, engineConfig, nullptr, &workspaceSize),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null workspaceSize
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeImpl(handle, engineConfig, opGraph, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, CreateExecutionContextNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto engineConfig = reinterpret_cast<hipdnnPluginConstData_t*>(0x5678);
+    auto opGraph = reinterpret_cast<hipdnnPluginConstData_t*>(0x9abc);
+    hipdnnEnginePluginExecutionContext_t executionContext;
+
+    // Null handle
+    EXPECT_EQ(hipdnnEnginePluginCreateExecutionContextImpl(
+                  nullptr, engineConfig, opGraph, &executionContext),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null engineConfig
+    EXPECT_EQ(
+        hipdnnEnginePluginCreateExecutionContextImpl(handle, nullptr, opGraph, &executionContext),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null opGraph
+    EXPECT_EQ(hipdnnEnginePluginCreateExecutionContextImpl(
+                  handle, engineConfig, nullptr, &executionContext),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null executionContext
+    EXPECT_EQ(hipdnnEnginePluginCreateExecutionContextImpl(handle, engineConfig, opGraph, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, DestroyExecutionContextNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    MockHipdnnEnginePluginExecutionContext executionContext;
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyExecutionContextImpl(nullptr, &executionContext),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyExecutionContextImpl(handle, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestHipKernelEnginePluginApi, GetWorkspaceSizeFromExecutionContextNull)
+{
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto executionContext = reinterpret_cast<hipdnnEnginePluginExecutionContext_t>(0x5678);
+    size_t workspaceSize = 123;
+
+    // Null handle
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+                  nullptr, executionContext, &workspaceSize),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null executionContext
+    EXPECT_EQ(
+        hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(handle, nullptr, &workspaceSize),
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+
+    // Null workspaceSize
+    EXPECT_EQ(hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+                  handle, executionContext, nullptr),
+              HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, CreateAlsoCreatesHipKernelHandleOnSuccess)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+
+    auto status = hipdnnEnginePluginCreateImpl(&handle);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, CreateTwiceGivesTheSameContainerHandle)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle1 = nullptr;
+    auto status1 = hipdnnEnginePluginCreateImpl(&handle1);
+
+    hipdnnEnginePluginHandle_t handle2 = nullptr;
+    auto status2 = hipdnnEnginePluginCreateImpl(&handle2);
+
+    EXPECT_EQ(status1, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(status2, HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    EXPECT_EQ(handle1->hipKernelContainer, handle2->hipKernelContainer);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle1), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle2), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, CreateNonNullHandlePointer)
+{
+    SKIP_IF_NO_DEVICES();
+    auto handle = reinterpret_cast<hipdnnEnginePluginHandle_t>(0x1234);
+    auto status = hipdnnEnginePluginCreateImpl(&handle);
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+    // Clean up
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, SetStreamNullStream)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    EXPECT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnEnginePluginSetStreamImpl(handle, nullptr), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    // Clean up
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, SetStreamValidStream)
+{
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    EXPECT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    hipStream_t stream = nullptr;
+    EXPECT_EQ(hipStreamCreate(&stream), hipSuccess);
+    EXPECT_EQ(hipdnnEnginePluginSetStreamImpl(handle, stream), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(handle->getStream(), stream);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipStreamDestroy(stream), hipSuccess);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, GetApplicableEngineIdsValid)
+{
+    GTEST_SKIP()
+        << "Skipping as there are no valid graphs that the HIP kernel plugin can support yet.";
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
+    auto serializedGraph = builder.Release();
+    hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
+    std::array<int64_t, 1> engineIds = {0};
+    uint32_t numEngines = 0;
+
+    // get max 1 engine
+    auto status = hipdnnEnginePluginGetApplicableEngineIdsImpl(
+        handle, &opGraph, engineIds.data(), 1, &numEngines);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(numEngines, 1u);
+    EXPECT_EQ(engineIds[0], hipdnn_data_sdk::utilities::engineNameToId("HIP_KERNEL_ENGINE"));
+
+    engineIds[0] = 1337;
+    status = hipdnnEnginePluginGetApplicableEngineIdsImpl(
+        handle, &opGraph, engineIds.data(), 0, &numEngines);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(numEngines, 1u);
+    EXPECT_EQ(engineIds[0], 1337);
+
+    // Clean up
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, GetEngineDetailsValid)
+{
+    GTEST_SKIP()
+        << "Skipping as there are no valid graphs that the HIP kernel plugin can support yet.";
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
+    auto serializedGraph = builder.Release();
+    hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
+    hipdnnPluginConstData_t engineDetailsOut;
+
+    auto status = hipdnnEnginePluginGetEngineDetailsImpl(
+        handle,
+        hipdnn_data_sdk::utilities::engineNameToId("HIP_KERNEL_ENGINE"),
+        &opGraph,
+        &engineDetailsOut);
+
+    hipdnn_data_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(
+        engineDetailsOut.ptr, engineDetailsOut.size);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(engineDetails.engineId(),
+              hipdnn_data_sdk::utilities::engineNameToId("HIP_KERNEL_ENGINE"));
+
+    // Clean up
+    EXPECT_EQ(hipdnnEnginePluginDestroyEngineDetailsImpl(handle, &engineDetailsOut),
+              HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, GetWorkspaceSizeValid)
+{
+    GTEST_SKIP()
+        << "Skipping as there are no valid graphs that the HIP kernel plugin can support yet.";
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    // Create a valid flatbuffer graph and engine config
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
+    auto serializedGraph = builder.Release();
+    hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
+
+    auto engineConfigBuilder = hipdnn_test_sdk::utilities::createValidEngineConfig(
+        hipdnn_data_sdk::utilities::engineNameToId("HIP_KERNEL_ENGINE"));
+    auto serializedEngineConfig = engineConfigBuilder.Release();
+    hipdnnPluginConstData_t engineConfig
+        = hipdnn_plugin_sdk::createValidConstDataEngineConfig(serializedEngineConfig);
+
+    size_t workspaceSize = 0;
+    auto status
+        = hipdnnEnginePluginGetWorkspaceSizeImpl(handle, &engineConfig, &opGraph, &workspaceSize);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(workspaceSize, 0u); // batchnorm workspace size is always 0
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, CreateExecutionContextValid)
+{
+    GTEST_SKIP()
+        << "Skipping as there are no valid graphs that the HIP kernel plugin can support yet.";
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
+    auto serializedGraph = builder.Release();
+    hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
+
+    auto engineConfigBuilder = hipdnn_test_sdk::utilities::createValidEngineConfig(
+        hipdnn_data_sdk::utilities::engineNameToId("HIP_KERNEL_ENGINE"));
+    auto serializedEngineConfig = engineConfigBuilder.Release();
+    hipdnnPluginConstData_t engineConfig
+        = hipdnn_plugin_sdk::createValidConstDataEngineConfig(serializedEngineConfig);
+
+    hipdnnEnginePluginExecutionContext_t executionContext = nullptr;
+    auto status = hipdnnEnginePluginCreateExecutionContextImpl(
+        handle, &engineConfig, &opGraph, &executionContext);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    ASSERT_NE(executionContext, nullptr);
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyExecutionContextImpl(handle, executionContext),
+              HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
+TEST(TestGpuHipKernelEnginePluginApi, GetWorkspaceSizeFromExecutionContextValid)
+{
+    GTEST_SKIP()
+        << "Skipping as there are no valid graphs that the HIP kernel plugin can support yet.";
+    SKIP_IF_NO_DEVICES();
+    hipdnnEnginePluginHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnEnginePluginCreateImpl(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdTrainingGraph();
+    auto serializedGraph = builder.Release();
+    hipdnnPluginConstData_t opGraph = hipdnn_plugin_sdk::createValidConstDataGraph(serializedGraph);
+
+    auto engineConfigBuilder = hipdnn_test_sdk::utilities::createValidEngineConfig(
+        hipdnn_data_sdk::utilities::engineNameToId("HIP_KERNEL_ENGINE"));
+    auto serializedEngineConfig = engineConfigBuilder.Release();
+    hipdnnPluginConstData_t engineConfig
+        = hipdnn_plugin_sdk::createValidConstDataEngineConfig(serializedEngineConfig);
+
+    hipdnnEnginePluginExecutionContext_t executionContext = nullptr;
+    auto status = hipdnnEnginePluginCreateExecutionContextImpl(
+        handle, &engineConfig, &opGraph, &executionContext);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    ASSERT_NE(executionContext, nullptr);
+
+    size_t workspaceSize = 0;
+    status = hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
+        handle, executionContext, &workspaceSize);
+
+    EXPECT_EQ(status, HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(workspaceSize, 0u); // batchnorm workspace size is always 0
+
+    EXPECT_EQ(hipdnnEnginePluginDestroyExecutionContextImpl(handle, executionContext),
+              HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnEnginePluginDestroyImpl(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}

--- a/dnn-providers/hip-kernel-provider/tests/TestHipKernelHipdnnEnginePluginHandle.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/TestHipKernelHipdnnEnginePluginHandle.cpp
@@ -1,0 +1,83 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <flatbuffers/flatbuffers.h>
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "HipdnnEnginePluginHandle.hpp"
+
+class TestHipKernelHipdnnEnginePluginHandle : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        _handle = std::make_unique<HipdnnEnginePluginHandle>();
+    }
+
+    std::unique_ptr<HipdnnEnginePluginHandle> _handle;
+};
+
+TEST_F(TestHipKernelHipdnnEnginePluginHandle, DefaultConstruction)
+{
+    EXPECT_EQ(_handle->hipKernelContainer, nullptr);
+    EXPECT_EQ(_handle->getStream(), nullptr);
+}
+
+TEST_F(TestHipKernelHipdnnEnginePluginHandle, StoreDetachedBuffer)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto createdString = builder.CreateString("test");
+    builder.Finish(createdString);
+    auto buffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
+    const void* ptr = reinterpret_cast<const void*>(0x12354);
+
+    _handle->storeEngineDetailsDetachedBuffer(ptr, std::move(buffer));
+
+    // Buffer should be stored, verify by trying to remove it
+    _handle->removeEngineDetailsDetachedBuffer(ptr);
+}
+
+TEST_F(TestHipKernelHipdnnEnginePluginHandle, RemoveDetachedBuffer)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    auto createdString = builder.CreateString("test");
+    builder.Finish(createdString);
+    auto buffer = std::make_unique<flatbuffers::DetachedBuffer>(builder.Release());
+    const void* ptr = reinterpret_cast<const void*>(0x12354);
+
+    _handle->storeEngineDetailsDetachedBuffer(ptr, std::move(buffer));
+    _handle->removeEngineDetailsDetachedBuffer(ptr);
+
+    // Should not crash when removing non-existent buffer
+    _handle->removeEngineDetailsDetachedBuffer(ptr);
+}
+
+TEST_F(TestHipKernelHipdnnEnginePluginHandle, RemoveNonExistentBuffer)
+{
+    const void* fakePtr = reinterpret_cast<const void*>(0x12345678);
+
+    // Should not crash when removing non-existent buffer
+    EXPECT_NO_THROW(_handle->removeEngineDetailsDetachedBuffer(fakePtr));
+}
+
+TEST_F(TestHipKernelHipdnnEnginePluginHandle, MultipleBuffers)
+{
+    flatbuffers::FlatBufferBuilder builder1;
+    auto createdString1 = builder1.CreateString("test");
+    builder1.Finish(createdString1);
+    auto buffer1 = std::make_unique<flatbuffers::DetachedBuffer>(builder1.Release());
+    const void* ptr1 = reinterpret_cast<const void*>(0x12354);
+
+    flatbuffers::FlatBufferBuilder builder2;
+    auto createdString2 = builder2.CreateString("test2");
+    builder2.Finish(createdString2);
+    auto buffer2 = std::make_unique<flatbuffers::DetachedBuffer>(builder2.Release());
+    const void* ptr2 = reinterpret_cast<const void*>(0x54311);
+
+    _handle->storeEngineDetailsDetachedBuffer(ptr1, std::move(buffer1));
+    _handle->storeEngineDetailsDetachedBuffer(ptr2, std::move(buffer2));
+
+    _handle->removeEngineDetailsDetachedBuffer(ptr1);
+    _handle->removeEngineDetailsDetachedBuffer(ptr2);
+}

--- a/dnn-providers/hip-kernel-provider/tests/TestHipKernelHipdnnPluginExecutionContext.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/TestHipKernelHipdnnPluginExecutionContext.cpp
@@ -1,0 +1,56 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "mocks/MockPlan.hpp"
+
+#include "HipdnnEnginePluginExecutionContext.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+
+using namespace hip_kernel_plugin;
+
+TEST(TestHipKernelHipdnnEnginePluginExecutionContext, SetAndGetPlan)
+{
+    HipdnnEnginePluginExecutionContext ctx;
+
+    auto mockPlan = std::make_unique<hip_kernel_plugin::MockPlan>();
+    auto* planPtr = mockPlan.get();
+    ctx.setPlan(std::move(mockPlan));
+
+    hip_kernel_plugin::IPlan& planRef = ctx.plan();
+
+    EXPECT_EQ(&planRef, planPtr);
+}
+
+TEST(TestHipKernelHipdnnEnginePluginExecutionContext, HasValidPlan)
+{
+    HipdnnEnginePluginExecutionContext ctx;
+
+    EXPECT_FALSE(ctx.hasValidPlan());
+
+    auto mockPlan = std::make_unique<hip_kernel_plugin::MockPlan>();
+    ctx.setPlan(std::move(mockPlan));
+
+    EXPECT_TRUE(ctx.hasValidPlan());
+}
+
+TEST(TestHipKernelHipdnnEnginePluginExecutionContext, GetPlanThrowsIfNotSet)
+{
+    HipdnnEnginePluginExecutionContext ctx;
+
+    EXPECT_THROW(ctx.plan(), hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+TEST(TestHipKernelHipdnnEnginePluginExecutionContext, GetWorkspaceSize)
+{
+    HipdnnEnginePluginExecutionContext ctx;
+
+    auto mockPlan = std::make_unique<hip_kernel_plugin::MockPlan>();
+    EXPECT_CALL(*mockPlan, getWorkspaceSize(::testing::_)).WillOnce(testing::Return(42));
+    ctx.setPlan(std::move(mockPlan));
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(ctx.plan().getWorkspaceSize(dummyHandle), 42);
+}

--- a/dnn-providers/hip-kernel-provider/tests/TestHipKernelPluginApi.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/TestHipKernelPluginApi.cpp
@@ -1,0 +1,78 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "hipdnn_plugin_sdk/PluginApi.h"
+#include <HipKernelPlugin.hpp>
+#include <array>
+#include <gtest/gtest.h>
+#include <iostream>
+
+namespace
+{
+void testLoggingCallback(hipdnnSeverity_t severity, const char* msg)
+{
+    (void)severity;
+    // std::cout << msg << "\n"; // uncomment to see formatted log messages during tests.
+    // It does not use the true callback yet since the plugin is not yet loaded.
+    (void)msg;
+}
+
+class TestHipKernelPluginApi : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        ASSERT_EQ(hipdnnPluginSetLoggingCallbackImpl(testLoggingCallback),
+                  HIPDNN_PLUGIN_STATUS_SUCCESS);
+    }
+};
+} // namespace
+
+TEST_F(TestHipKernelPluginApi, GetNameSuccess)
+{
+    const char* name = nullptr;
+    EXPECT_EQ(hipdnnPluginGetNameImpl(&name), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_STREQ(name, "hip_kernel_plugin");
+}
+
+TEST_F(TestHipKernelPluginApi, GetNameNullptr)
+{
+    EXPECT_EQ(hipdnnPluginGetNameImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestHipKernelPluginApi, GetVersionSuccess)
+{
+    const char* version = nullptr;
+    EXPECT_EQ(hipdnnPluginGetVersionImpl(&version), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_STREQ(version, "1.0.0");
+}
+
+TEST_F(TestHipKernelPluginApi, GetVersionNullptr)
+{
+    EXPECT_EQ(hipdnnPluginGetVersionImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestHipKernelPluginApi, GetTypeSuccess)
+{
+    hipdnnPluginType_t type;
+    EXPECT_EQ(hipdnnPluginGetTypeImpl(&type), HIPDNN_PLUGIN_STATUS_SUCCESS);
+    EXPECT_EQ(type, HIPDNN_PLUGIN_TYPE_ENGINE);
+}
+
+TEST_F(TestHipKernelPluginApi, GetTypeNullptr)
+{
+    EXPECT_EQ(hipdnnPluginGetTypeImpl(nullptr), HIPDNN_PLUGIN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestHipKernelPluginApi, GetLastErrorStringSuccess)
+{
+    const char* errorStr = nullptr;
+    hipdnnPluginGetLastErrorStringImpl(&errorStr);
+    ASSERT_NE(errorStr, nullptr);
+    EXPECT_GE(strlen(errorStr), 0u);
+}
+
+TEST_F(TestHipKernelPluginApi, GetLastErrorStringNullptr)
+{
+    EXPECT_NO_THROW(hipdnnPluginGetLastErrorStringImpl(nullptr));
+}

--- a/dnn-providers/hip-kernel-provider/tests/engines/TestHipKernelEngine.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/engines/TestHipKernelEngine.cpp
@@ -1,0 +1,451 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <set>
+
+#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/EngineDetailsWrapper.hpp>
+#include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+
+#include "engines/HipKernelEngine.hpp"
+#include "mocks/MockHipdnnEnginePluginExecutionContext.hpp"
+#include "mocks/MockPlanBuilder.hpp"
+#include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
+
+using namespace hip_kernel_plugin;
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_data_sdk::flatbuffer_utilities;
+
+TEST(TestHipKernelEngine, ConstructorAndId)
+{
+    HipKernelEngine engine(42);
+    EXPECT_EQ(engine.id(), 42);
+}
+
+TEST(TestHipKernelEngine, WorkspaceSizeReturnsZeroIfNoPlanBuilders)
+{
+    HipKernelEngine engine(1);
+
+    MockGraph mockGraph;
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(engine.getWorkspaceSize(dummyHandle, mockGraph), 0u);
+}
+
+TEST(TestHipKernelEngine, WorkspaceSizeReturnsPlanBuilderWorkspace)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder, getWorkspaceSize(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(1337u));
+
+    HipKernelEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+
+    MockGraph mockGraph;
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(engine.getWorkspaceSize(dummyHandle, mockGraph), 1337u);
+}
+
+TEST(TestHipKernelEngine, WorkspaceSizeReturnsMaxPlanBuilderWorkspace)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder, getWorkspaceSize(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(1337u));
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder2, getWorkspaceSize(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(45000u));
+
+    HipKernelEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(engine.getWorkspaceSize(dummyHandle, mockGraph), 45000u);
+}
+
+TEST(TestHipKernelEngine, WorkspaceSizeReturnsZeroIfNoPlanBuilderApplicable)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+
+    HipKernelEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+
+    MockGraph mockGraph;
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_EQ(engine.getWorkspaceSize(dummyHandle, mockGraph), 0u);
+}
+
+TEST(TestHipKernelEngine, IsApplicableReturnsTrueIfAnyPlanBuilderApplicable)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+
+    HipKernelEngine engine(0);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+
+    MockGraph mockGraph;
+    auto graphBuilder = hipdnn_test_sdk::utilities::createEmptyValidGraph();
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_TRUE(engine.isApplicable(dummyHandle, mockGraph));
+}
+
+TEST(TestHipKernelEngine, IsApplicableReturnsAfterTheFirstApplicablePlanBuilder)
+{
+    auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    EXPECT_CALL(*mockPlanBuilder1, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_)).Times(0);
+
+    HipKernelEngine engine(0);
+    engine.addPlanBuilder(std::move(mockPlanBuilder1));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+    auto graphBuilder = hipdnn_test_sdk::utilities::createEmptyValidGraph();
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_TRUE(engine.isApplicable(dummyHandle, mockGraph));
+}
+
+TEST(TestHipKernelEngine, IsApplicableReturnsFalseIfNoPlanBuilders)
+{
+    HipKernelEngine engine(0);
+
+    MockGraph mockGraph;
+    auto graphBuilder = hipdnn_test_sdk::utilities::createEmptyValidGraph();
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_FALSE(engine.isApplicable(dummyHandle, mockGraph));
+}
+
+TEST(TestHipKernelEngine, IsApplicableReturnsFalseIfNoPlanBuilderApplicable)
+{
+    auto mockPlanBuilder = std::make_unique<MockPlanBuilder>();
+    EXPECT_CALL(*mockPlanBuilder, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+
+    HipKernelEngine engine(0);
+    engine.addPlanBuilder(std::move(mockPlanBuilder));
+
+    MockGraph mockGraph;
+    auto graphBuilder = hipdnn_test_sdk::utilities::createEmptyValidGraph();
+
+    HipdnnEnginePluginHandle dummyHandle;
+    EXPECT_FALSE(engine.isApplicable(dummyHandle, mockGraph));
+}
+
+TEST(TestHipKernelEngine, GetDetailsReturnsSerializedEngineDetails)
+{
+    HipKernelEngine engine(1);
+    HipdnnEnginePluginHandle dummyHandle;
+    MockGraph mockGraph;
+
+    hipdnnPluginConstData_t result;
+    engine.getDetails(dummyHandle, mockGraph, result);
+
+    hipdnn_data_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(result.ptr,
+                                                                              result.size);
+    EXPECT_EQ(engineDetails.engineId(), 1);
+}
+
+TEST(TestHipKernelEngine, GetDetailsContainsBenchmarkingKnob)
+{
+    HipKernelEngine engine(1);
+    HipdnnEnginePluginHandle dummyHandle;
+    MockGraph mockGraph;
+
+    hipdnnPluginConstData_t result;
+    engine.getDetails(dummyHandle, mockGraph, result);
+
+    hipdnn_data_sdk::flatbuffer_utilities::EngineDetailsWrapper engineDetails(result.ptr,
+                                                                              result.size);
+    ASSERT_EQ(engineDetails.knobCount(), 1u);
+
+    const auto& knob = engineDetails.getKnobByName("global.benchmarking");
+    EXPECT_EQ(knob.knobId(), "global.benchmarking");
+    EXPECT_EQ(knob.description(), "Enable benchmarking");
+
+    ASSERT_TRUE(knob.hasDefaultValue());
+    EXPECT_EQ(knob.defaultValueType(), hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    const auto& defaultValue = knob.defaultValueAs<hipdnn_data_sdk::data_objects::IntValue>();
+    EXPECT_EQ(defaultValue.value(), 0);
+
+    ASSERT_TRUE(knob.hasConstraint());
+    EXPECT_EQ(knob.constraintType(), hipdnn_data_sdk::data_objects::KnobConstraint::IntConstraint);
+    const auto& constraint = knob.constraintAs<hipdnn_data_sdk::data_objects::IntConstraint>();
+    EXPECT_EQ(constraint.min_value(), 0);
+    EXPECT_EQ(constraint.max_value(), 1);
+    EXPECT_EQ(constraint.step(), 1);
+}
+
+TEST(TestHipKernelEngine, GetDetailsOnlyUsesFirstPlanBuilderCustomKnobs)
+{
+    auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    // Set up first plan builder to return a custom knob
+    hipdnn_data_sdk::data_objects::KnobT knob1;
+    knob1.knob_id = "custom.knob1";
+    knob1.description = "First custom knob";
+    hipdnn_data_sdk::data_objects::IntValueT defaultValue1;
+    defaultValue1.value = 1;
+    knob1.default_value.Set(defaultValue1);
+
+    std::vector<hipdnn_data_sdk::data_objects::KnobT> customKnobs1;
+    customKnobs1.push_back(knob1);
+
+    EXPECT_CALL(*mockPlanBuilder1, getCustomKnobs(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(customKnobs1));
+
+    // Set up second plan builder to also return a custom knob (this should be ignored)
+    hipdnn_data_sdk::data_objects::KnobT knob2;
+    knob2.knob_id = "custom.knob2";
+    knob2.description = "Second custom knob";
+    hipdnn_data_sdk::data_objects::IntValueT defaultValue2;
+    defaultValue2.value = 2;
+    knob2.default_value.Set(defaultValue2);
+
+    std::vector<hipdnn_data_sdk::data_objects::KnobT> customKnobs2;
+    customKnobs2.push_back(knob2);
+
+    // This should NOT be called because we break after first non-empty custom knobs
+    EXPECT_CALL(*mockPlanBuilder2, getCustomKnobs(::testing::_, ::testing::_)).Times(0);
+
+    HipKernelEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder1));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    HipdnnEnginePluginHandle dummyHandle;
+    MockGraph mockGraph;
+
+    hipdnnPluginConstData_t result;
+    engine.getDetails(dummyHandle, mockGraph, result);
+
+    hipdnn_plugin_sdk::EngineDetailsWrapper engineDetails(result.ptr, result.size);
+
+    // Should have 2 knobs: benchmarking (always present) + custom.knob1 (from first builder)
+    ASSERT_EQ(engineDetails.knobCount(), 2u);
+
+    // Verify benchmarking knob is present
+    const auto& benchmarkingKnob = engineDetails.getKnobByName("global.benchmarking");
+    EXPECT_EQ(benchmarkingKnob.knobId(), "global.benchmarking");
+
+    // Verify first custom knob is present
+    const auto& customKnob1 = engineDetails.getKnobByName("custom.knob1");
+    EXPECT_EQ(customKnob1.knobId(), "custom.knob1");
+    EXPECT_EQ(customKnob1.description(), "First custom knob");
+
+    // Verify second custom knob is NOT present (would throw if we tried to access it)
+    EXPECT_THROW(engineDetails.getKnobByName("custom.knob2"), std::out_of_range);
+}
+
+TEST(TestHipKernelEngine, InitializeExecutionContextInvokesFirstApplicablePlanBuilder)
+{
+    auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    // Only the first plan builder is applicable
+    EXPECT_CALL(*mockPlanBuilder1, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder1,
+                buildPlan(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(1);
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_)).Times(0);
+    EXPECT_CALL(*mockPlanBuilder2,
+                buildPlan(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(0);
+
+    HipKernelEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder1));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockConfig;
+    EXPECT_CALL(mockConfig, isValid()).WillRepeatedly(::testing::Return(false));
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, mockConfig, ctx);
+}
+
+TEST(TestHipKernelEngine, InitializeExecutionContextSetsBenchmarkingEnabled)
+{
+    HipKernelEngine engine(1);
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto knobIdOffset = builder.CreateString("global.benchmarking");
+    auto knobValue = hipdnn_data_sdk::data_objects::CreateIntValue(builder, 1);
+    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
+    knobSettingBuilder.add_knob_id(knobIdOffset);
+    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value(knobValue.Union());
+    auto knobSetting = knobSettingBuilder.Finish();
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    knobsVector.push_back(knobSetting);
+    auto knobs = builder.CreateVector(knobsVector);
+
+    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(builder, 1, knobs);
+    builder.Finish(engineConfig);
+
+    auto buffer = builder.Release();
+    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                             buffer.size());
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, configWrapper, ctx);
+
+    EXPECT_TRUE(ctx.benchmarkingEnabled());
+}
+
+TEST(TestHipKernelEngine, InitializeExecutionContextSetsBenchmarkingDisabled)
+{
+    HipKernelEngine engine(1);
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto knobIdOffset = builder.CreateString("global.benchmarking");
+    auto knobValue
+        = hipdnn_data_sdk::data_objects::CreateIntValue(builder, static_cast<int64_t>(0));
+    hipdnn_data_sdk::data_objects::KnobSettingBuilder knobSettingBuilder(builder);
+    knobSettingBuilder.add_knob_id(knobIdOffset);
+    knobSettingBuilder.add_value_type(hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    knobSettingBuilder.add_value(knobValue.Union());
+    auto knobSetting = knobSettingBuilder.Finish();
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::KnobSetting>> knobsVector;
+    knobsVector.push_back(knobSetting);
+    auto knobs = builder.CreateVector(knobsVector);
+
+    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(builder, 1, knobs);
+    builder.Finish(engineConfig);
+
+    auto buffer = builder.Release();
+    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                             buffer.size());
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, configWrapper, ctx);
+
+    EXPECT_FALSE(ctx.benchmarkingEnabled());
+}
+
+TEST(TestHipKernelEngine, InitializeExecutionContextDefaultsBenchmarkingDisabledWhenConfigInvalid)
+{
+    HipKernelEngine engine(1);
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockConfig;
+
+    EXPECT_CALL(mockConfig, isValid()).WillRepeatedly(::testing::Return(false));
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, mockConfig, ctx);
+
+    EXPECT_FALSE(ctx.benchmarkingEnabled());
+}
+
+TEST(TestHipKernelEngine, InitializeExecutionContextDefaultsBenchmarkingDisabledWhenNoKnobs)
+{
+    HipKernelEngine engine(1);
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto engineConfig = hipdnn_data_sdk::data_objects::CreateEngineConfig(builder, 1, 0);
+    builder.Finish(engineConfig);
+
+    auto buffer = builder.Release();
+    hipdnn_data_sdk::flatbuffer_utilities::EngineConfigWrapper configWrapper(buffer.data(),
+                                                                             buffer.size());
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, configWrapper, ctx);
+
+    EXPECT_FALSE(ctx.benchmarkingEnabled());
+}
+
+TEST(TestHipKernelEngine, InitializeExecutionContextSkipsNonApplicableBuilders)
+{
+    auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    // First plan builder not applicable, second is
+    EXPECT_CALL(*mockPlanBuilder1, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+    EXPECT_CALL(*mockPlanBuilder1,
+                buildPlan(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(0);
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(true));
+    EXPECT_CALL(*mockPlanBuilder2,
+                buildPlan(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(1);
+
+    HipKernelEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder1));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockConfig;
+    EXPECT_CALL(mockConfig, isValid()).WillRepeatedly(::testing::Return(false));
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, mockConfig, ctx);
+}
+
+TEST(TestHipKernelEngine, InitializeExecutionContextDoesNotCallBuildPlanIfNoApplicableBuilders)
+{
+    auto mockPlanBuilder1 = std::make_unique<MockPlanBuilder>();
+    auto mockPlanBuilder2 = std::make_unique<MockPlanBuilder>();
+
+    EXPECT_CALL(*mockPlanBuilder1, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+    EXPECT_CALL(*mockPlanBuilder1,
+                buildPlan(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(0);
+    EXPECT_CALL(*mockPlanBuilder2, isApplicable(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(false));
+    EXPECT_CALL(*mockPlanBuilder2,
+                buildPlan(::testing::_, ::testing::_, ::testing::_, ::testing::_))
+        .Times(0);
+
+    HipKernelEngine engine(1);
+    engine.addPlanBuilder(std::move(mockPlanBuilder1));
+    engine.addPlanBuilder(std::move(mockPlanBuilder2));
+
+    MockGraph mockGraph;
+    HipdnnEnginePluginHandle dummyHandle;
+    MockHipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockConfig;
+    EXPECT_CALL(mockConfig, isValid()).WillRepeatedly(::testing::Return(false));
+
+    engine.initializeExecutionContext(dummyHandle, mockGraph, mockConfig, ctx);
+}

--- a/dnn-providers/hip-kernel-provider/tests/main.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/main.cpp
@@ -1,0 +1,26 @@
+/*
+Copyright © Advanced Micro Devices, Inc., or its affiliates.
+SPDX-License-Identifier: MIT
+*/
+
+#include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
+
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
+#include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    hipdnn::logging::initializeCallbackLogging(COMPONENT_NAME,
+                                               hipdnn_test_sdk::utilities::testLoggingCallback);
+
+    // Register HipErrorHandler to check and clear HIP errors after each test
+    testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
+    listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
+
+    auto result = RUN_ALL_TESTS();
+    spdlog::shutdown();
+    return result;
+}

--- a/dnn-providers/hip-kernel-provider/tests/mocks/MockEngine.hpp
+++ b/dnn-providers/hip-kernel-provider/tests/mocks/MockEngine.hpp
@@ -1,0 +1,47 @@
+/*
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+*/
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+#include "engines/EngineInterface.hpp"
+
+namespace hip_kernel_plugin
+{
+
+class MockEngine : public IEngine
+{
+public:
+    MOCK_METHOD(int64_t, id, (), (const, override));
+    MOCK_METHOD(bool,
+                isApplicable,
+                (HipdnnEnginePluginHandle & handle,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                (const, override));
+    MOCK_METHOD(void,
+                getDetails,
+                (HipdnnEnginePluginHandle & handle,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 hipdnnPluginConstData_t& detailsOut),
+                (const, override));
+    MOCK_METHOD(size_t,
+                getWorkspaceSize,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                (const, override));
+
+    MOCK_METHOD(void,
+                initializeExecutionContext,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                 HipdnnEnginePluginExecutionContext& executionContext),
+                (const, override));
+};
+
+} // namespace hip_kernel_plugin

--- a/dnn-providers/hip-kernel-provider/tests/mocks/MockHipdnnEnginePluginExecutionContext.hpp
+++ b/dnn-providers/hip-kernel-provider/tests/mocks/MockHipdnnEnginePluginExecutionContext.hpp
@@ -1,0 +1,25 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+
+#include "mocks/MockPlan.hpp"
+
+#include "HipdnnEnginePluginExecutionContext.hpp"
+
+struct MockHipdnnEnginePluginExecutionContext : public HipdnnEnginePluginExecutionContext
+{
+    MockHipdnnEnginePluginExecutionContext()
+        : mockPlan(std::make_unique<hip_kernel_plugin::MockPlan>())
+    {
+    }
+
+    hip_kernel_plugin::IPlan& plan() const override
+    {
+        return *mockPlan;
+    }
+
+    std::unique_ptr<hip_kernel_plugin::MockPlan> mockPlan;
+};

--- a/dnn-providers/hip-kernel-provider/tests/mocks/MockPlan.hpp
+++ b/dnn-providers/hip-kernel-provider/tests/mocks/MockPlan.hpp
@@ -1,0 +1,29 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include "engines/plans/PlanInterface.hpp"
+#include <gmock/gmock.h>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hip_kernel_plugin
+{
+
+class MockPlan : public IPlan
+{
+public:
+    MOCK_METHOD(size_t,
+                getWorkspaceSize,
+                (const HipdnnEnginePluginHandle& handle),
+                (const, override));
+    MOCK_METHOD(void,
+                execute,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                 uint32_t numDeviceBuffers,
+                 void* workspace),
+                (const, override));
+};
+
+}

--- a/dnn-providers/hip-kernel-provider/tests/mocks/MockPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/tests/mocks/MockPlanBuilder.hpp
@@ -1,0 +1,44 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+
+#include "engines/plans/PlanBuilderInterface.hpp"
+
+namespace hip_kernel_plugin
+{
+
+class MockPlanBuilder : public IPlanBuilder
+{
+public:
+    MOCK_METHOD(bool,
+                isApplicable,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                (const, override));
+    MOCK_METHOD(size_t,
+                getWorkspaceSize,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                (const, override));
+
+    MOCK_METHOD(void,
+                buildPlan,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                 HipdnnEnginePluginExecutionContext& executionContext),
+                (const, override));
+
+    MOCK_METHOD((std::vector<hipdnn_data_sdk::data_objects::KnobT>),
+                getCustomKnobs,
+                (const HipdnnEnginePluginHandle& handle,
+                 const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph),
+                (const, override));
+};
+
+}


### PR DESCRIPTION
## Motivation

This PR introduces the initial boilerplate required to start developing the MVP for the new hipDNN HIP kernel provider plugin. It targets a feature branch that will be merged once the MVP functionality is complete.

## Technical Details

- Adds a `.gitignore` to exclude files that should not be version-controlled.
- Adds a `CMakeLists.txt` defining core dependencies and build configuration.
- Adds initial boilerplate for `EngineManager`, along with `tests/` and `integration_tests/`, to serve as a foundation for further development.
- Adds `.clang-format` and `.clang-tidy` to ensure consistency of future development efforts.
- Adds unit tests for different preliminary functionalities of the plugin.

## Test Plan

Build the new plugin and the tests by following the instructions in `README.md` under `dnn-providers/hip-kernel-provider`. Unit tests for the new plugin can be run by navigating to the build directory and executing `./bin/hip_kernel_plugin_tests`.

## Test Result

The plugin builds successfully, including the main HIP kernel plugin and the static test libraries. Most of the unit tests pass except for a few skipped tests, as there are no valid graphs for the relevant ops in the plugin yet.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.