### PR TITLE
[CK] MICI: Correct path for build trace script

### DIFF
--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -126,7 +126,7 @@ def generateAndArchiveBuildTraceVisualization(String buildTraceFileName) {
         sh """#!/bin/bash
             ls -la
             mkdir -p workspace
-            cp ./script/infra_helper/capture_build_trace.js ./workspace
+            cp ./projects/composablekernel/script/infra_helper/capture_build_trace.js ./workspace
             cp ${buildTraceFileName} ./workspace/${buildTraceFileName}
             chmod 777 ./workspace
             ls -la ./workspace

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -1268,8 +1268,8 @@ pipeline {
             description: "Run CK_BUILDER tests (default: ON)")
         booleanParam(
             name: "RUN_ALL_UNIT_TESTS",
-            defaultValue: false,
-            description: "Run all unit tests (default: OFF)")
+            defaultValue: true,
+            description: "Run all unit tests (default: ON)")
         booleanParam(
             name: "RUN_PYTORCH_TESTS",
             defaultValue: false,


### PR DESCRIPTION
## Motivation

- Corrects path to script due to superrepo migration
- Forces all tests to run by default

## Technical Details

- now in /projects/composablekernel

