### PR TITLE
[Origami] Skip test-selector if torch not found.

### DIFF
--- a/shared/origami/python/tests/test_selector.py
+++ b/shared/origami/python/tests/test_selector.py
@@ -6,7 +6,9 @@
 import pytest
 import math
 import origami
-import torch
+
+# Skip entire module if torch is not available (selector requires torch)
+torch = pytest.importorskip("torch", reason="torch is required for OrigamiMatmulSelector tests.")
 
 from origami.selector import OrigamiMatmulSelector
 from .conftest import create_config_list


### PR DESCRIPTION
## Motivation

Makes `torch` completely optional by skipping dependent tests if it is not found.

## Technical Details

```
# Skip entire module if torch is not available (selector requires torch)
torch = pytest.importorskip("torch", reason="torch is required for OrigamiMatmulSelector tests.")
```

## Test Plan

Run tests using CI + TheRock build.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
