### PR TITLE
[ci] Updating variable group-id for OSSCI

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -29,7 +29,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
-        --group-add 110
+        --group-add 992
         --env-file /etc/podinfo/gha-gpu-isolation-settings
     strategy:
       fail-fast: false

--- a/projects/composablekernel/.github/workflows/therock-test-component.yml
+++ b/projects/composablekernel/.github/workflows/therock-test-component.yml
@@ -29,7 +29,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
-        --group-add 110
+        --group-add 992
         --env-file /etc/podinfo/gha-gpu-isolation-settings
     strategy:
       fail-fast: false


### PR DESCRIPTION
OSSCI migrated mi325s, so need a new groupID

Sanity works here: https://github.com/ROCm/TheRock/actions/runs/21723540679/job/62659665907
normal run works here: https://github.com/ROCm/TheRock/actions/runs/21723540679/job/62659791422

I've dabbled with organization variables, however, this does not work for forks so for now, we will do the manual update