### PR TITLE
[hipblas] Guard immintrin.h include with x86 architecture check

### DIFF
--- a/projects/hipblas/clients/include/type_utils.h
+++ b/projects/hipblas/clients/include/type_utils.h
@@ -30,7 +30,9 @@
 #include <cmath>
 #include <complex>
 #include <cstdio>
+#if defined(__x86_64__) || defined(__i386__)
 #include <immintrin.h>
+#endif
 #include <iostream>
 #include <random>
 #include <type_traits>


### PR DESCRIPTION
## Motivation

The <immintrin.h> header is x86-specific and causes build failures on arm64. Add preprocessor guards since the include appears unused in type_utils.h.
I have created the patch for Ubuntu archive, but I'd like to forward the patch upstream.

## Test Result

Please see the successful build logs here with this patch applied:
https://launchpadlibrarian.net/845378289/buildlog_ubuntu-resolute-arm64.hipblas_7.1.0-0ubuntu3~git202601300756.91b72fa~ubuntu26.04.1_BUILDING.txt.gz

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
