### PR TITLE
[CK] fix path for build filter

### DIFF
--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -272,10 +272,10 @@ def shouldRunCICheck() {
             script: '''
                 if [ "$CHANGE_ID" != "" ]; then
                     # For PR builds, compare against target branch
-                    git diff --name-only origin/$CHANGE_TARGET...HEAD
+                    git diff --name-only origin/$CHANGE_TARGET...HEAD --projects/composablekernel/
                 else
                     # For regular builds, compare against previous commit
-                    git diff --name-only HEAD~1..HEAD
+                    git diff --name-only HEAD~1..HEAD --projects/composablekernel/
                 fi
             '''
         ).trim().split('\n')


### PR DESCRIPTION
## Motivation

Fix the filter that determines whether CI builds are necessary.

## Technical Details

A script checks the files list returned by git diff and checks whether any code source was modified. If not, if only documentation was changed, it will allow skipping the builds. We make sure we only look at the changes in projects/composablekernel/ folder.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
