### PR TITLE
[hipSOLVER] Add API for getrfBatched

### DIFF
--- a/projects/hipsolver/CHANGELOG.md
+++ b/projects/hipsolver/CHANGELOG.md
@@ -6,6 +6,12 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ## (Unreleased) hipSOLVER
 
 ### Added
+
+* Added functions:
+  * getrfBatched
+    * hipsolverXgetrfBatched_bufferSize
+    * hipsolverXgetrfBatched
+
 ### Changed
 ### Removed
 ### Optimized

--- a/projects/hipsolver/clients/gtest/getrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/getrf_gtest.cpp
@@ -57,6 +57,17 @@ const vector<int> n_size_range = {
     100,
 };
 
+// cuBLAS getrfBatched only supports square matrices (m == n).
+// Each entry is {{m, lda}, n} with n == m to ensure square inputs.
+const vector<getrf_tuple> batched_square_range = {
+    // invalid (triggers bad-args test when m == -1 and n == -1)
+    {{-1, 1}, -1},
+    // normal (valid) square samples
+    {{32, 32}, 32},
+    {{50, 50}, 50},
+    {{70, 100}, 70},
+};
+
 // // for daily_lapack tests
 // const vector<vector<int>> large_matrix_size_range = {
 //     {192, 192},
@@ -134,6 +145,14 @@ class GETRF_COMPAT_64 : public GETRF_BASE<API_COMPAT, false, int64_t, size_t>
 };
 
 class GETRF_COMPAT_NPVT_64 : public GETRF_BASE<API_COMPAT, true, int64_t, size_t>
+{
+};
+
+class GETRF_BATCHED : public GETRF_BASE<API_NORMAL, false, int, int>
+{
+};
+
+class GETRF_NPVT_BATCHED : public GETRF_BASE<API_NORMAL, true, int, int>
 {
 };
 
@@ -261,42 +280,42 @@ TEST_P(GETRF_COMPAT_NPVT_64, __double_complex)
 
 // batched tests
 
-TEST_P(GETRF, batched__float)
+TEST_P(GETRF_BATCHED, batched__float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(GETRF, batched__double)
+TEST_P(GETRF_BATCHED, batched__double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(GETRF, batched__float_complex)
+TEST_P(GETRF_BATCHED, batched__float_complex)
 {
     run_tests<true, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF, batched__double_complex)
+TEST_P(GETRF_BATCHED, batched__double_complex)
 {
     run_tests<true, false, hipsolverDoubleComplex>();
 }
 
-TEST_P(GETRF_NPVT, batched__float)
+TEST_P(GETRF_NPVT_BATCHED, batched__float)
 {
     run_tests<true, false, float>();
 }
 
-TEST_P(GETRF_NPVT, batched__double)
+TEST_P(GETRF_NPVT_BATCHED, batched__double)
 {
     run_tests<true, false, double>();
 }
 
-TEST_P(GETRF_NPVT, batched__float_complex)
+TEST_P(GETRF_NPVT_BATCHED, batched__float_complex)
 {
     run_tests<true, false, hipsolverComplex>();
 }
 
-TEST_P(GETRF_NPVT, batched__double_complex)
+TEST_P(GETRF_NPVT_BATCHED, batched__double_complex)
 {
     run_tests<true, false, hipsolverDoubleComplex>();
 }
@@ -348,3 +367,7 @@ INSTANTIATE_TEST_SUITE_P(checkin_lapack,
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          GETRF_COMPAT_NPVT_64,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(n_size_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, GETRF_BATCHED, ValuesIn(batched_square_range));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, GETRF_NPVT_BATCHED, ValuesIn(batched_square_range));

--- a/projects/hipsolver/clients/gtest/getrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/getrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -108,7 +108,7 @@ protected:
         if(arg.peek<rocblas_int>("m") == -1 && arg.peek<rocblas_int>("n") == -1)
             testing_getrf_bad_arg<API, BATCHED, STRIDED, T, I, SIZE>();
 
-        arg.batch_count = 1;
+        arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
         testing_getrf<API, BATCHED, STRIDED, NPVT, T, I, SIZE>(arg);
     }
 };
@@ -257,6 +257,48 @@ TEST_P(GETRF_COMPAT_NPVT_64, __float_complex)
 TEST_P(GETRF_COMPAT_NPVT_64, __double_complex)
 {
     run_tests<false, false, hipsolverDoubleComplex>();
+}
+
+// batched tests
+
+TEST_P(GETRF, batched__float)
+{
+    run_tests<true, false, float>();
+}
+
+TEST_P(GETRF, batched__double)
+{
+    run_tests<true, false, double>();
+}
+
+TEST_P(GETRF, batched__float_complex)
+{
+    run_tests<true, false, hipsolverComplex>();
+}
+
+TEST_P(GETRF, batched__double_complex)
+{
+    run_tests<true, false, hipsolverDoubleComplex>();
+}
+
+TEST_P(GETRF_NPVT, batched__float)
+{
+    run_tests<true, false, float>();
+}
+
+TEST_P(GETRF_NPVT, batched__double)
+{
+    run_tests<true, false, double>();
+}
+
+TEST_P(GETRF_NPVT, batched__float_complex)
+{
+    run_tests<true, false, hipsolverComplex>();
+}
+
+TEST_P(GETRF_NPVT, batched__double_complex)
+{
+    run_tests<true, false, hipsolverDoubleComplex>();
 }
 
 // INSTANTIATE_TEST_SUITE_P(daily_lapack,

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -5350,6 +5350,125 @@ inline hipsolverStatus_t hipsolver_getrf(testAPI_t               API,
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
+}
+
+// batched
+inline hipsolverStatus_t hipsolver_getrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, float** A, int lda, int strideP, int* lwork, int bc)
+{
+    return hipsolverSgetrfBatched_bufferSize(handle, m, n, A, lda, strideP, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_getrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, double** A, int lda, int strideP, int* lwork, int bc)
+{
+    return hipsolverDgetrfBatched_bufferSize(handle, m, n, A, lda, strideP, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_getrfBatched_bufferSize(hipsolverHandle_t  handle,
+                                                           int                m,
+                                                           int                n,
+                                                           hipsolverComplex** A,
+                                                           int                lda,
+                                                           int                strideP,
+                                                           int*               lwork,
+                                                           int                bc)
+{
+    return hipsolverCgetrfBatched_bufferSize(
+        handle, m, n, (hipFloatComplex**)A, lda, strideP, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_getrfBatched_bufferSize(hipsolverHandle_t        handle,
+                                                           int                      m,
+                                                           int                      n,
+                                                           hipsolverDoubleComplex** A,
+                                                           int                      lda,
+                                                           int                      strideP,
+                                                           int*                     lwork,
+                                                           int                      bc)
+{
+    return hipsolverZgetrfBatched_bufferSize(
+        handle, m, n, (hipDoubleComplex**)A, lda, strideP, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_getrfBatched(hipsolverHandle_t handle,
+                                                int               m,
+                                                int               n,
+                                                float**           A,
+                                                int               lda,
+                                                float*            work,
+                                                int               lwork,
+                                                int*              devIpiv,
+                                                int               strideP,
+                                                int*              devInfo,
+                                                int               bc)
+{
+    return hipsolverSgetrfBatched(handle, m, n, A, lda, work, lwork, devIpiv, strideP, devInfo, bc);
+}
+
+inline hipsolverStatus_t hipsolver_getrfBatched(hipsolverHandle_t handle,
+                                                int               m,
+                                                int               n,
+                                                double**          A,
+                                                int               lda,
+                                                double*           work,
+                                                int               lwork,
+                                                int*              devIpiv,
+                                                int               strideP,
+                                                int*              devInfo,
+                                                int               bc)
+{
+    return hipsolverDgetrfBatched(handle, m, n, A, lda, work, lwork, devIpiv, strideP, devInfo, bc);
+}
+
+inline hipsolverStatus_t hipsolver_getrfBatched(hipsolverHandle_t  handle,
+                                                int                m,
+                                                int                n,
+                                                hipsolverComplex** A,
+                                                int                lda,
+                                                hipsolverComplex*  work,
+                                                int                lwork,
+                                                int*               devIpiv,
+                                                int                strideP,
+                                                int*               devInfo,
+                                                int                bc)
+{
+    return hipsolverCgetrfBatched(handle,
+                                  m,
+                                  n,
+                                  (hipFloatComplex**)A,
+                                  lda,
+                                  (hipFloatComplex*)work,
+                                  lwork,
+                                  devIpiv,
+                                  strideP,
+                                  devInfo,
+                                  bc);
+}
+
+inline hipsolverStatus_t hipsolver_getrfBatched(hipsolverHandle_t        handle,
+                                                int                      m,
+                                                int                      n,
+                                                hipsolverDoubleComplex** A,
+                                                int                      lda,
+                                                hipsolverDoubleComplex*  work,
+                                                int                      lwork,
+                                                int*                     devIpiv,
+                                                int                      strideP,
+                                                int*                     devInfo,
+                                                int                      bc)
+{
+    return hipsolverZgetrfBatched(handle,
+                                  m,
+                                  n,
+                                  (hipDoubleComplex**)A,
+                                  lda,
+                                  (hipDoubleComplex*)work,
+                                  lwork,
+                                  devIpiv,
+                                  strideP,
+                                  devInfo,
+                                  bc);
 }
 /********************************************************/
 

--- a/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
+++ b/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -87,6 +87,7 @@ class hipsolver_dispatcher
             {"gesvdj", testing_gesvdj<API_NORMAL, false, false, T>},
             {"gesvdj_batched", testing_gesvdj<API_NORMAL, false, true, T>},
             {"getrf", testing_getrf<API_NORMAL, false, false, false, T, int, int>},
+            {"getrf_batched", testing_getrf<API_NORMAL, true, false, false, T, int, int>},
             {"getrf_64", testing_getrf<API_COMPAT, false, false, false, T, int64_t, size_t>},
             {"getrs", testing_getrs<API_NORMAL, false, false, T, int, int>},
             {"getrs_64", testing_getrs<API_COMPAT, false, false, T, int64_t, size_t>},

--- a/projects/hipsolver/clients/include/testing_getrf.hpp
+++ b/projects/hipsolver/clients/include/testing_getrf.hpp
@@ -154,7 +154,8 @@ void testing_getrf_bad_arg()
 
         int size_W;
         hipsolver_getrfBatched_bufferSize(handle, m, n, dA.data(), lda, stP, &size_W, bc);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
+        int                            size_W_elems = (size_W + sizeof(T) - 1) / sizeof(T);
+        device_strided_batch_vector<T> dWork(size_W_elems, 1, size_W_elems, 1);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -862,6 +863,7 @@ void testing_getrf(Arguments& argus)
     {
         int size_W;
         hipsolver_getrfBatched_bufferSize(handle, m, n, (T**)nullptr, lda, stP, &size_W, bc);
+        int size_W_elems = (size_W + sizeof(T) - 1) / sizeof(T);
 
         // memory allocations
         host_batch_vector<T>             hA(size_A, 1, bc);
@@ -873,7 +875,7 @@ void testing_getrf(Arguments& argus)
         device_batch_vector<T>           dA(size_A, 1, bc);
         device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
-        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, 1);
+        device_strided_batch_vector<T>   dWork(size_W_elems, 1, size_W_elems, 1);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());

--- a/projects/hipsolver/clients/include/testing_getrf.hpp
+++ b/projects/hipsolver/clients/include/testing_getrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -142,26 +142,64 @@ void testing_getrf_bad_arg()
     I                      stP = 1;
     int                    bc  = 1;
 
-    if(BATCHED)
+    if constexpr(BATCHED)
     {
-        // // memory allocations
-        // device_batch_vector<T>           dA(1, 1, 1);
-        // device_strided_batch_vector<I>   dIpiv(1, 1, 1, 1);
-        // device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
-        // CHECK_HIP_ERROR(dA.memcheck());
-        // CHECK_HIP_ERROR(dIpiv.memcheck());
-        // CHECK_HIP_ERROR(dInfo.memcheck());
+        // memory allocations
+        device_batch_vector<T>           dA(1, 1, 1);
+        device_strided_batch_vector<int> dIpiv(stP, 1, stP, bc);
+        device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dIpiv.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
 
-        // SIZE size_dW, size_hW;
-        // hipsolver_getrf_bufferSize(API, handle, params, m, n, dA.data(), lda, &size_dW, &size_hW);
-        // host_strided_batch_vector<T>   hWork(size_hW, 1, size_hW, 1);
-        // device_strided_batch_vector<T> dWork(size_dW, 1, size_dW, 1);
-        // if(size_dW)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
+        int size_W;
+        hipsolver_getrfBatched_bufferSize(handle, m, n, dA.data(), lda, stP, &size_W, bc);
+        device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
+        if(size_W)
+            CHECK_HIP_ERROR(dWork.memcheck());
 
-        // // check bad arguments
-        // getrf_checkBadArgs<API>(
-        //     handle, params, m, n, dA.data(), lda, stA, dIpiv.data(), stP, dWork.data(), size_dW, hWork.data(), size_hW, dInfo.data(), bc);
+        // check bad arguments
+        // handle
+        EXPECT_ROCBLAS_STATUS(hipsolver_getrfBatched(nullptr,
+                                                     m,
+                                                     n,
+                                                     dA.data(),
+                                                     lda,
+                                                     dWork.data(),
+                                                     size_W,
+                                                     dIpiv.data(),
+                                                     stP,
+                                                     dInfo.data(),
+                                                     bc),
+                              HIPSOLVER_STATUS_NOT_INITIALIZED);
+
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
+        // pointers
+        EXPECT_ROCBLAS_STATUS(hipsolver_getrfBatched(handle,
+                                                     m,
+                                                     n,
+                                                     (T**)nullptr,
+                                                     lda,
+                                                     dWork.data(),
+                                                     size_W,
+                                                     dIpiv.data(),
+                                                     stP,
+                                                     dInfo.data(),
+                                                     bc),
+                              HIPSOLVER_STATUS_INVALID_VALUE);
+        EXPECT_ROCBLAS_STATUS(hipsolver_getrfBatched(handle,
+                                                     m,
+                                                     n,
+                                                     dA.data(),
+                                                     lda,
+                                                     dWork.data(),
+                                                     size_W,
+                                                     dIpiv.data(),
+                                                     stP,
+                                                     (int*)nullptr,
+                                                     bc),
+                              HIPSOLVER_STATUS_INVALID_VALUE);
+#endif
     }
     else
     {
@@ -476,6 +514,243 @@ void getrf_getPerfData(const hipsolverHandle_t   handle,
     *gpu_time_used /= hot_calls;
 }
 
+template <bool NPVT,
+          typename T,
+          typename TdA,
+          typename TdWork,
+          typename INTd,
+          typename Th,
+          typename INTh>
+void getrfBatched_getError(const hipsolverHandle_t handle,
+                           const int               m,
+                           const int               n,
+                           TdA&                    dA,
+                           const int               lda,
+                           TdWork&                 dWork,
+                           const int               lwork,
+                           INTd&                   dIpiv,
+                           const int               strideP,
+                           INTd&                   dInfo,
+                           const int               bc,
+                           Th&                     hA,
+                           Th&                     hARes,
+                           INTh&                   hIpiv,
+                           INTh&                   hIpivRes,
+                           INTh&                   hInfo,
+                           INTh&                   hInfoRes,
+                           double*                 max_err)
+{
+    // input data initialization
+    getrfBatched_initData<NPVT, true, true, T>(
+        handle, m, n, dA, lda, dIpiv, strideP, dInfo, bc, hA, hIpiv, hInfo);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(hipsolver_getrfBatched(handle,
+                                               m,
+                                               n,
+                                               dA.data(),
+                                               lda,
+                                               dWork.data(),
+                                               lwork,
+                                               NPVT ? nullptr : dIpiv.data(),
+                                               strideP,
+                                               dInfo.data(),
+                                               bc));
+    CHECK_HIP_ERROR(hARes.transfer_from(dA));
+    if(!NPVT)
+        CHECK_HIP_ERROR(hIpivRes.transfer_from(dIpiv));
+    CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
+
+    // CPU lapack
+    for(int b = 0; b < bc; ++b)
+        cpu_getrf(m, n, hA[b], lda, hIpiv[b], hInfo[b]);
+
+    // error is ||hA - hARes|| / ||hA||
+    // using frobenius norm
+    double err;
+    *max_err = 0;
+    for(int b = 0; b < bc; ++b)
+    {
+        err      = norm_error('F', m, n, lda, hA[b], hARes[b]);
+        *max_err = err > *max_err ? err : *max_err;
+
+        // also check pivoting (count the number of incorrect pivots)
+        if(!NPVT)
+        {
+            err = 0;
+            for(int i = 0; i < min(m, n); ++i)
+            {
+                EXPECT_EQ(hIpiv[b][i], hIpivRes[b][i]) << "where b = " << b << ", i = " << i;
+                if(hIpiv[b][i] != hIpivRes[b][i])
+                    err++;
+            }
+            *max_err = err > *max_err ? err : *max_err;
+        }
+    }
+
+    // also check info for singularities
+    err = 0;
+    for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
+        if(hInfo[b][0] != hInfoRes[b][0])
+            err++;
+    }
+    *max_err += err;
+}
+
+template <bool NPVT,
+          typename T,
+          typename TdA,
+          typename TdWork,
+          typename INTd,
+          typename Th,
+          typename INTh>
+void getrfBatched_getPerfData(const hipsolverHandle_t handle,
+                              const int               m,
+                              const int               n,
+                              TdA&                    dA,
+                              const int               lda,
+                              TdWork&                 dWork,
+                              const int               lwork,
+                              INTd&                   dIpiv,
+                              const int               strideP,
+                              INTd&                   dInfo,
+                              const int               bc,
+                              Th&                     hA,
+                              INTh&                   hIpiv,
+                              INTh&                   hInfo,
+                              double*                 gpu_time_used,
+                              double*                 cpu_time_used,
+                              const int               hot_calls,
+                              const bool              perf)
+{
+    if(!perf)
+    {
+        getrfBatched_initData<NPVT, true, false, T>(
+            handle, m, n, dA, lda, dIpiv, strideP, dInfo, bc, hA, hIpiv, hInfo);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us_no_sync();
+        for(int b = 0; b < bc; ++b)
+            cpu_getrf(m, n, hA[b], lda, hIpiv[b], hInfo[b]);
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
+    }
+
+    getrfBatched_initData<NPVT, true, false, T>(
+        handle, m, n, dA, lda, dIpiv, strideP, dInfo, bc, hA, hIpiv, hInfo);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        getrfBatched_initData<NPVT, false, true, T>(
+            handle, m, n, dA, lda, dIpiv, strideP, dInfo, bc, hA, hIpiv, hInfo);
+
+        CHECK_ROCBLAS_ERROR(hipsolver_getrfBatched(handle,
+                                                   m,
+                                                   n,
+                                                   dA.data(),
+                                                   lda,
+                                                   dWork.data(),
+                                                   lwork,
+                                                   NPVT ? nullptr : dIpiv.data(),
+                                                   strideP,
+                                                   dInfo.data(),
+                                                   bc));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(hipsolverGetStream(handle, &stream));
+    double start;
+
+    for(int iter = 0; iter < hot_calls; iter++)
+    {
+        getrfBatched_initData<NPVT, false, true, T>(
+            handle, m, n, dA, lda, dIpiv, strideP, dInfo, bc, hA, hIpiv, hInfo);
+
+        start = get_time_us_sync(stream);
+        hipsolver_getrfBatched(handle,
+                               m,
+                               n,
+                               dA.data(),
+                               lda,
+                               dWork.data(),
+                               lwork,
+                               NPVT ? nullptr : dIpiv.data(),
+                               strideP,
+                               dInfo.data(),
+                               bc);
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <bool NPVT,
+          bool CPU,
+          bool GPU,
+          typename T,
+          typename TdA,
+          typename INTd,
+          typename Th,
+          typename INTh>
+void getrfBatched_initData(const hipsolverHandle_t handle,
+                           const int               m,
+                           const int               n,
+                           TdA&                    dA,
+                           const int               lda,
+                           INTd&                   dIpiv,
+                           const int               strideP,
+                           INTd&                   dInfo,
+                           const int               bc,
+                           Th&                     hA,
+                           INTh&                   hIpiv,
+                           INTh&                   hInfo)
+{
+    if(CPU)
+    {
+        T tmp;
+        rocblas_init<T>(hA, true);
+
+        for(int b = 0; b < bc; ++b)
+        {
+            // scale A to avoid singularities
+            for(int i = 0; i < m; i++)
+            {
+                for(int j = 0; j < n; j++)
+                {
+                    if(i == j)
+                        hA[b][i + j * lda] += 400;
+                    else
+                        hA[b][i + j * lda] -= 4;
+                }
+            }
+
+            if(!NPVT)
+            {
+                // shuffle rows to test pivoting
+                // always the same permutation for debugging purposes
+                for(int i = 0; i < m / 2; i++)
+                {
+                    for(int j = 0; j < n; j++)
+                    {
+                        tmp                        = hA[b][i + j * lda];
+                        hA[b][i + j * lda]         = hA[b][m - 1 - i + j * lda];
+                        hA[b][m - 1 - i + j * lda] = tmp;
+                    }
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy data to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
 template <testAPI_t API,
           bool      BATCHED,
           bool      STRIDED,
@@ -516,26 +791,20 @@ void testing_getrf(Arguments& argus)
     if(invalid_size)
     {
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
-        if(BATCHED)
+        if constexpr(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_getrf(API,
-            //                                       NPVT,
-            //                                       handle,
-            //                                       params,
-            //                                       m,
-            //                                       n,
-            //                                       (T* const*)nullptr,
-            //                                       lda,
-            //                                       stA,
-            //                                       (I*)nullptr,
-            //                                       stP,
-            //                                       (T*)nullptr,
-            //                                       0,
-            //                                       (T*)nullptr,
-            //                                       0,
-            //                                       (int*)nullptr,
-            //                                       bc),
-            //                       HIPSOLVER_STATUS_INVALID_VALUE);
+            EXPECT_ROCBLAS_STATUS(hipsolver_getrfBatched(handle,
+                                                         m,
+                                                         n,
+                                                         (T**)nullptr,
+                                                         lda,
+                                                         (T*)nullptr,
+                                                         0,
+                                                         (int*)nullptr,
+                                                         stP,
+                                                         (int*)nullptr,
+                                                         bc),
+                                  HIPSOLVER_STATUS_INVALID_VALUE);
         }
         else
         {
@@ -567,90 +836,100 @@ void testing_getrf(Arguments& argus)
     }
 
     // memory size query is necessary
-    SIZE size_dW, size_hW;
-    hipsolver_getrf_bufferSize(API, handle, params, m, n, (T*)nullptr, lda, &size_dW, &size_hW);
-
-    if(argus.mem_query)
+    if constexpr(BATCHED)
     {
-        rocsolver_bench_inform(inform_mem_query, size_dW);
-        return;
+        int size_W;
+        hipsolver_getrfBatched_bufferSize(handle, m, n, (T**)nullptr, lda, stP, &size_W, bc);
+        if(argus.mem_query)
+        {
+            rocsolver_bench_inform(inform_mem_query, size_W);
+            return;
+        }
+    }
+    else
+    {
+        SIZE size_dW, size_hW;
+        hipsolver_getrf_bufferSize(API, handle, params, m, n, (T*)nullptr, lda, &size_dW, &size_hW);
+
+        if(argus.mem_query)
+        {
+            rocsolver_bench_inform(inform_mem_query, size_dW);
+            return;
+        }
     }
 
-    if(BATCHED)
+    if constexpr(BATCHED)
     {
-        // // memory allocations
-        // host_batch_vector<T>             hA(size_A, 1, bc);
-        // host_batch_vector<T>             hARes(size_ARes, 1, bc);
-        // host_strided_batch_vector<int>   hIpiv(size_P, 1, stP, bc);
-        // host_strided_batch_vector<I>     hIpivRes(size_PRes, 1, stPRes, bc);
-        // host_strided_batch_vector<int>   hInfo(1, 1, 1, bc);
-        // host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
-        // host_strided_batch_vector<T>     hWork(size_hW, 1, size_hW, 1); // size_hW accounts for bc
-        // device_batch_vector<T>           dA(size_A, 1, bc);
-        // device_strided_batch_vector<I>   dIpiv(size_P, 1, stP, bc);
-        // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
-        // device_strided_batch_vector<T>   dWork(size_dW, 1, size_dW, 1); // size_dW accounts for bc
-        // if(size_A)
-        //     CHECK_HIP_ERROR(dA.memcheck());
-        // CHECK_HIP_ERROR(dInfo.memcheck());
-        // if(size_P)
-        //     CHECK_HIP_ERROR(dIpiv.memcheck());
-        // if(size_dW)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
+        int size_W;
+        hipsolver_getrfBatched_bufferSize(handle, m, n, (T**)nullptr, lda, stP, &size_W, bc);
 
-        // // check computations
-        // if(argus.unit_check || argus.norm_check)
-        //     getrf_getError<API, NPVT, T>(handle,
-        //                                  params,
-        //                                  m,
-        //                                  n,
-        //                                  dA,
-        //                                  lda,
-        //                                  stA,
-        //                                  dIpiv,
-        //                                  stP,
-        //                                  dWork,
-        //                                  size_dW,
-        //                                  hWork,
-        //                                  size_hW,
-        //                                  dInfo,
-        //                                  bc,
-        //                                  hA,
-        //                                  hARes,
-        //                                  hIpiv,
-        //                                  hIpivRes,
-        //                                  hInfo,
-        //                                  hInfoRes,
-        //                                  &max_error);
+        // memory allocations
+        host_batch_vector<T>             hA(size_A, 1, bc);
+        host_batch_vector<T>             hARes(size_ARes, 1, bc);
+        host_strided_batch_vector<int>   hIpiv(size_P, 1, stP, bc);
+        host_strided_batch_vector<int>   hIpivRes(size_PRes, 1, stPRes, bc);
+        host_strided_batch_vector<int>   hInfo(1, 1, 1, bc);
+        host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
+        device_batch_vector<T>           dA(size_A, 1, bc);
+        device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
+        device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, 1);
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+        if(!NPVT && size_P)
+            CHECK_HIP_ERROR(dIpiv.memcheck());
+        if(size_W)
+            CHECK_HIP_ERROR(dWork.memcheck());
 
-        // // collect performance data
-        // if(argus.timing)
-        //     getrf_getPerfData<API, NPVT, T>(handle,
-        //                                     params,
-        //                                     m,
-        //                                     n,
-        //                                     dA,
-        //                                     lda,
-        //                                     stA,
-        //                                     dIpiv,
-        //                                     stP,
-        //                                     dWork,
-        //                                     size_dW,
-        //                                     hWork,
-        //                                     size_hW,
-        //                                     dInfo,
-        //                                     bc,
-        //                                     hA,
-        //                                     hIpiv,
-        //                                     hInfo,
-        //                                     &gpu_time_used,
-        //                                     &cpu_time_used,
-        //                                     hot_calls,
-        //                                     argus.perf);
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+            getrfBatched_getError<NPVT, T>(handle,
+                                           m,
+                                           n,
+                                           dA,
+                                           lda,
+                                           dWork,
+                                           size_W,
+                                           dIpiv,
+                                           stP,
+                                           dInfo,
+                                           bc,
+                                           hA,
+                                           hARes,
+                                           hIpiv,
+                                           hIpivRes,
+                                           hInfo,
+                                           hInfoRes,
+                                           &max_error);
+
+        // collect performance data
+        if(argus.timing)
+            getrfBatched_getPerfData<NPVT, T>(handle,
+                                              m,
+                                              n,
+                                              dA,
+                                              lda,
+                                              dWork,
+                                              size_W,
+                                              dIpiv,
+                                              stP,
+                                              dInfo,
+                                              bc,
+                                              hA,
+                                              hIpiv,
+                                              hInfo,
+                                              &gpu_time_used,
+                                              &cpu_time_used,
+                                              hot_calls,
+                                              argus.perf);
     }
 
     else
     {
+        SIZE size_dW, size_hW;
+        hipsolver_getrf_bufferSize(API, handle, params, m, n, (T*)nullptr, lda, &size_dW, &size_hW);
+
         // memory allocations
         host_strided_batch_vector<T>     hA(size_A, 1, stA, bc);
         host_strided_batch_vector<T>     hARes(size_ARes, 1, stARes, bc);
@@ -735,7 +1014,7 @@ void testing_getrf(Arguments& argus)
             std::cerr << "\n============================================\n";
             std::cerr << "Arguments:\n";
             std::cerr << "============================================\n";
-            if(BATCHED)
+            if constexpr(BATCHED)
             {
                 rocsolver_bench_output("m", "n", "lda", "strideP", "batch_c");
                 rocsolver_bench_output(m, n, lda, stP, bc);

--- a/projects/hipsolver/library/include/internal/hipsolver-functions.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-functions.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
@@ -1269,6 +1269,91 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t handle,
                                                    int               lwork,
                                                    int*              devIpiv,
                                                    int*              devInfo);
+
+// getrfBatched
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     float*            A[],
+                                                                     int               lda,
+                                                                     int               strideP,
+                                                                     int*              lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     double*           A[],
+                                                                     int               lda,
+                                                                     int               strideP,
+                                                                     int*              lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     hipFloatComplex*  A[],
+                                                                     int               lda,
+                                                                     int               strideP,
+                                                                     int*              lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     hipDoubleComplex* A[],
+                                                                     int               lda,
+                                                                     int               strideP,
+                                                                     int*              lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrfBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          float*            A[],
+                                                          int               lda,
+                                                          float*            work,
+                                                          int               lwork,
+                                                          int*              devIpiv,
+                                                          int               strideP,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrfBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          double*           A[],
+                                                          int               lda,
+                                                          double*           work,
+                                                          int               lwork,
+                                                          int*              devIpiv,
+                                                          int               strideP,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrfBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          hipFloatComplex*  A[],
+                                                          int               lda,
+                                                          hipFloatComplex*  work,
+                                                          int               lwork,
+                                                          int*              devIpiv,
+                                                          int               strideP,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrfBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          hipDoubleComplex* A[],
+                                                          int               lda,
+                                                          hipDoubleComplex* work,
+                                                          int               lwork,
+                                                          int*              devIpiv,
+                                                          int               strideP,
+                                                          int*              devInfo,
+                                                          int               batch_count);
 
 // getrs
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,

--- a/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
@@ -7252,7 +7252,7 @@ try
     else
     {
         CHECK_HIPSOLVER_ERROR(hipsolverCgetrfBatched_bufferSize(
-            (rocblas_handle)handle, m, n, A, strideP, lda, &lwork, batch_count));
+            (rocblas_handle)handle, m, n, A, lda, strideP, &lwork, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
     }
 

--- a/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -7011,6 +7011,287 @@ try
     else
         return hipsolver::rocblas2hip_status(rocsolver_zgetrf_npvt(
             (rocblas_handle)handle, m, n, (rocblas_double_complex*)A, lda, devInfo));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** GETRF_BATCHED ********************/
+hipsolverStatus_t hipsolverSgetrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, float* A[], int lda, int* lwork, int batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_sgetrf_batched(
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, std::min(m, n), nullptr, batch_count));
+    rocsolver_sgetrf_npvt_batched((rocblas_handle)handle, m, n, nullptr, lda, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, double* A[], int lda, int* lwork, int batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_dgetrf_batched(
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, std::min(m, n), nullptr, batch_count));
+    rocsolver_dgetrf_npvt_batched((rocblas_handle)handle, m, n, nullptr, lda, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    hipFloatComplex*  A[],
+                                                    int               lda,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_cgetrf_batched(
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, std::min(m, n), nullptr, batch_count));
+    rocsolver_cgetrf_npvt_batched((rocblas_handle)handle, m, n, nullptr, lda, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    hipDoubleComplex* A[],
+                                                    int               lda,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_zgetrf_batched(
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, std::min(m, n), nullptr, batch_count));
+    rocsolver_zgetrf_npvt_batched((rocblas_handle)handle, m, n, nullptr, lda, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSgetrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         float*            A[],
+                                         int               lda,
+                                         float*            work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverSgetrfBatched_bufferSize(
+            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    if(devIpiv != nullptr)
+        return hipsolver::rocblas2hip_status(rocsolver_sgetrf_batched(
+            (rocblas_handle)handle, m, n, A, lda, devIpiv, std::min(m, n), devInfo, batch_count));
+    else
+        return hipsolver::rocblas2hip_status(rocsolver_sgetrf_npvt_batched(
+            (rocblas_handle)handle, m, n, A, lda, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         double*           A[],
+                                         int               lda,
+                                         double*           work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverDgetrfBatched_bufferSize(
+            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    if(devIpiv != nullptr)
+        return hipsolver::rocblas2hip_status(rocsolver_dgetrf_batched(
+            (rocblas_handle)handle, m, n, A, lda, devIpiv, std::min(m, n), devInfo, batch_count));
+    else
+        return hipsolver::rocblas2hip_status(rocsolver_dgetrf_npvt_batched(
+            (rocblas_handle)handle, m, n, A, lda, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         hipFloatComplex*  A[],
+                                         int               lda,
+                                         hipFloatComplex*  work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverCgetrfBatched_bufferSize(
+            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    if(devIpiv != nullptr)
+        return hipsolver::rocblas2hip_status(rocsolver_cgetrf_batched((rocblas_handle)handle,
+                                                                      m,
+                                                                      n,
+                                                                      (rocblas_float_complex**)A,
+                                                                      lda,
+                                                                      devIpiv,
+                                                                      std::min(m, n),
+                                                                      devInfo,
+                                                                      batch_count));
+    else
+        return hipsolver::rocblas2hip_status(rocsolver_cgetrf_npvt_batched(
+            (rocblas_handle)handle, m, n, (rocblas_float_complex**)A, lda, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         hipDoubleComplex* A[],
+                                         int               lda,
+                                         hipDoubleComplex* work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverZgetrfBatched_bufferSize(
+            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    if(devIpiv != nullptr)
+        return hipsolver::rocblas2hip_status(rocsolver_zgetrf_batched((rocblas_handle)handle,
+                                                                      m,
+                                                                      n,
+                                                                      (rocblas_double_complex**)A,
+                                                                      lda,
+                                                                      devIpiv,
+                                                                      std::min(m, n),
+                                                                      devInfo,
+                                                                      batch_count));
+    else
+        return hipsolver::rocblas2hip_status(rocsolver_zgetrf_npvt_batched(
+            (rocblas_handle)handle, m, n, (rocblas_double_complex**)A, lda, devInfo, batch_count));
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
@@ -7188,6 +7188,8 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
     }
 
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
     if(devIpiv != nullptr)
         return hipsolver::rocblas2hip_status(rocsolver_sgetrf_batched(
             (rocblas_handle)handle, m, n, A, lda, devIpiv, strideP, devInfo, batch_count));
@@ -7222,6 +7224,8 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
     }
 
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
     if(devIpiv != nullptr)
         return hipsolver::rocblas2hip_status(rocsolver_dgetrf_batched(
             (rocblas_handle)handle, m, n, A, lda, devIpiv, strideP, devInfo, batch_count));
@@ -7255,6 +7259,8 @@ try
             (rocblas_handle)handle, m, n, A, lda, strideP, &lwork, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
     }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
 
     if(devIpiv != nullptr)
         return hipsolver::rocblas2hip_status(rocsolver_cgetrf_batched((rocblas_handle)handle,
@@ -7296,6 +7302,8 @@ try
             (rocblas_handle)handle, m, n, A, lda, strideP, &lwork, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
     }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
 
     if(devIpiv != nullptr)
         return hipsolver::rocblas2hip_status(rocsolver_zgetrf_batched((rocblas_handle)handle,

--- a/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
@@ -7018,8 +7018,14 @@ catch(...)
 }
 
 /******************** GETRF_BATCHED ********************/
-hipsolverStatus_t hipsolverSgetrfBatched_bufferSize(
-    hipsolverHandle_t handle, int m, int n, float* A[], int lda, int* lwork, int batch_count)
+hipsolverStatus_t hipsolverSgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    float*            A[],
+                                                    int               lda,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
 try
 {
     if(!handle)
@@ -7032,7 +7038,7 @@ try
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_sgetrf_batched(
-        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, std::min(m, n), nullptr, batch_count));
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, strideP, nullptr, batch_count));
     rocsolver_sgetrf_npvt_batched((rocblas_handle)handle, m, n, nullptr, lda, nullptr, batch_count);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
@@ -7049,8 +7055,14 @@ catch(...)
     return hipsolver::exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverDgetrfBatched_bufferSize(
-    hipsolverHandle_t handle, int m, int n, double* A[], int lda, int* lwork, int batch_count)
+hipsolverStatus_t hipsolverDgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    double*           A[],
+                                                    int               lda,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
 try
 {
     if(!handle)
@@ -7063,7 +7075,7 @@ try
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_dgetrf_batched(
-        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, std::min(m, n), nullptr, batch_count));
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, strideP, nullptr, batch_count));
     rocsolver_dgetrf_npvt_batched((rocblas_handle)handle, m, n, nullptr, lda, nullptr, batch_count);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
@@ -7085,6 +7097,7 @@ hipsolverStatus_t hipsolverCgetrfBatched_bufferSize(hipsolverHandle_t handle,
                                                     int               n,
                                                     hipFloatComplex*  A[],
                                                     int               lda,
+                                                    int               strideP,
                                                     int*              lwork,
                                                     int               batch_count)
 try
@@ -7099,7 +7112,7 @@ try
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_cgetrf_batched(
-        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, std::min(m, n), nullptr, batch_count));
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, strideP, nullptr, batch_count));
     rocsolver_cgetrf_npvt_batched((rocblas_handle)handle, m, n, nullptr, lda, nullptr, batch_count);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
@@ -7121,6 +7134,7 @@ hipsolverStatus_t hipsolverZgetrfBatched_bufferSize(hipsolverHandle_t handle,
                                                     int               n,
                                                     hipDoubleComplex* A[],
                                                     int               lda,
+                                                    int               strideP,
                                                     int*              lwork,
                                                     int               batch_count)
 try
@@ -7135,7 +7149,7 @@ try
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_zgetrf_batched(
-        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, std::min(m, n), nullptr, batch_count));
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, strideP, nullptr, batch_count));
     rocsolver_zgetrf_npvt_batched((rocblas_handle)handle, m, n, nullptr, lda, nullptr, batch_count);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
@@ -7160,6 +7174,7 @@ hipsolverStatus_t hipsolverSgetrfBatched(hipsolverHandle_t handle,
                                          float*            work,
                                          int               lwork,
                                          int*              devIpiv,
+                                         int               strideP,
                                          int*              devInfo,
                                          int               batch_count)
 try
@@ -7169,13 +7184,13 @@ try
     else
     {
         CHECK_HIPSOLVER_ERROR(hipsolverSgetrfBatched_bufferSize(
-            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+            (rocblas_handle)handle, m, n, A, lda, strideP, &lwork, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
     }
 
     if(devIpiv != nullptr)
         return hipsolver::rocblas2hip_status(rocsolver_sgetrf_batched(
-            (rocblas_handle)handle, m, n, A, lda, devIpiv, std::min(m, n), devInfo, batch_count));
+            (rocblas_handle)handle, m, n, A, lda, devIpiv, strideP, devInfo, batch_count));
     else
         return hipsolver::rocblas2hip_status(rocsolver_sgetrf_npvt_batched(
             (rocblas_handle)handle, m, n, A, lda, devInfo, batch_count));
@@ -7193,6 +7208,7 @@ hipsolverStatus_t hipsolverDgetrfBatched(hipsolverHandle_t handle,
                                          double*           work,
                                          int               lwork,
                                          int*              devIpiv,
+                                         int               strideP,
                                          int*              devInfo,
                                          int               batch_count)
 try
@@ -7202,13 +7218,13 @@ try
     else
     {
         CHECK_HIPSOLVER_ERROR(hipsolverDgetrfBatched_bufferSize(
-            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+            (rocblas_handle)handle, m, n, A, lda, strideP, &lwork, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
     }
 
     if(devIpiv != nullptr)
         return hipsolver::rocblas2hip_status(rocsolver_dgetrf_batched(
-            (rocblas_handle)handle, m, n, A, lda, devIpiv, std::min(m, n), devInfo, batch_count));
+            (rocblas_handle)handle, m, n, A, lda, devIpiv, strideP, devInfo, batch_count));
     else
         return hipsolver::rocblas2hip_status(rocsolver_dgetrf_npvt_batched(
             (rocblas_handle)handle, m, n, A, lda, devInfo, batch_count));
@@ -7226,6 +7242,7 @@ hipsolverStatus_t hipsolverCgetrfBatched(hipsolverHandle_t handle,
                                          hipFloatComplex*  work,
                                          int               lwork,
                                          int*              devIpiv,
+                                         int               strideP,
                                          int*              devInfo,
                                          int               batch_count)
 try
@@ -7235,7 +7252,7 @@ try
     else
     {
         CHECK_HIPSOLVER_ERROR(hipsolverCgetrfBatched_bufferSize(
-            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+            (rocblas_handle)handle, m, n, A, strideP, lda, &lwork, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
     }
 
@@ -7246,7 +7263,7 @@ try
                                                                       (rocblas_float_complex**)A,
                                                                       lda,
                                                                       devIpiv,
-                                                                      std::min(m, n),
+                                                                      strideP,
                                                                       devInfo,
                                                                       batch_count));
     else
@@ -7266,6 +7283,7 @@ hipsolverStatus_t hipsolverZgetrfBatched(hipsolverHandle_t handle,
                                          hipDoubleComplex* work,
                                          int               lwork,
                                          int*              devIpiv,
+                                         int               strideP,
                                          int*              devInfo,
                                          int               batch_count)
 try
@@ -7275,7 +7293,7 @@ try
     else
     {
         CHECK_HIPSOLVER_ERROR(hipsolverZgetrfBatched_bufferSize(
-            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+            (rocblas_handle)handle, m, n, A, lda, strideP, &lwork, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
     }
 
@@ -7286,7 +7304,7 @@ try
                                                                       (rocblas_double_complex**)A,
                                                                       lda,
                                                                       devIpiv,
-                                                                      std::min(m, n),
+                                                                      strideP,
                                                                       devInfo,
                                                                       batch_count));
     else

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -3938,8 +3938,14 @@ catch(...)
 }
 
 /******************** GETRF_BATCHED ********************/
-hipsolverStatus_t hipsolverSgetrfBatched_bufferSize(
-    hipsolverHandle_t handle, int m, int n, float* A[], int lda, int* lwork, int batch_count)
+hipsolverStatus_t hipsolverSgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    float*            A[],
+                                                    int               lda,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
 try
 {
     if(!handle)
@@ -3957,8 +3963,14 @@ catch(...)
     return hipsolver::exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverDgetrfBatched_bufferSize(
-    hipsolverHandle_t handle, int m, int n, double* A[], int lda, int* lwork, int batch_count)
+hipsolverStatus_t hipsolverDgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    double*           A[],
+                                                    int               lda,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
 try
 {
     if(!handle)
@@ -3981,6 +3993,7 @@ hipsolverStatus_t hipsolverCgetrfBatched_bufferSize(hipsolverHandle_t handle,
                                                     int               n,
                                                     hipFloatComplex*  A[],
                                                     int               lda,
+                                                    int               strideP,
                                                     int*              lwork,
                                                     int               batch_count)
 try
@@ -4005,6 +4018,7 @@ hipsolverStatus_t hipsolverZgetrfBatched_bufferSize(hipsolverHandle_t handle,
                                                     int               n,
                                                     hipDoubleComplex* A[],
                                                     int               lda,
+                                                    int               strideP,
                                                     int*              lwork,
                                                     int               batch_count)
 try
@@ -4032,6 +4046,7 @@ hipsolverStatus_t hipsolverSgetrfBatched(hipsolverHandle_t handle,
                                          float*            work,
                                          int               lwork,
                                          int*              devIpiv,
+                                         int               strideP,
                                          int*              devInfo,
                                          int               batch_count)
 try
@@ -4042,7 +4057,11 @@ try
     if(m != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(cublasSgetrfBatched((cublasHandle_t) handle, n, A, lda, devIpiv, devInfo, batch_count);
+    if(strideP != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(
+        cublasSgetrfBatched((cublasHandle_t)handle, n, A, lda, devIpiv, devInfo, batch_count));
 }
 catch(...)
 {
@@ -4057,6 +4076,7 @@ hipsolverStatus_t hipsolverDgetrfBatched(hipsolverHandle_t handle,
                                          double*           work,
                                          int               lwork,
                                          int*              devIpiv,
+                                         int               strideP,
                                          int*              devInfo,
                                          int               batch_count)
 try
@@ -4067,7 +4087,11 @@ try
     if(m != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(cublasSgetrfBatched((cublasHandle_t) handle, n, A, lda, devIpiv, devInfo, batch_count);
+    if(strideP != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(
+        cublasDgetrfBatched((cublasHandle_t)handle, n, A, lda, devIpiv, devInfo, batch_count));
 }
 catch(...)
 {
@@ -4082,31 +4106,9 @@ hipsolverStatus_t hipsolverCgetrfBatched(hipsolverHandle_t handle,
                                          hipFloatComplex*  work,
                                          int               lwork,
                                          int*              devIpiv,
+                                         int               strideP,
                                          int*              devInfo,
-                                         int               batch_count) try
-    if(!handle) return HIPSOLVER_STATUS_NOT_INITIALIZED;
-
-if(m != n)
-    return HIPSOLVER_STATUS_INVALID_VALUE;
-
-    return hipsolver::cuda2hip_status(cublasSgetrfBatched((cublasHandle_t) handle, n, (cuComplex**)A, lda, devIpiv, devInfo, batch_count);
-{
-}
-catch(...)
-{
-    return hipsolver::exception2hip_status();
-}
-
-hipsolverStatus_t hipsolverZgetrfBatched(hipsolverHandle_t handle,
-                                  int               m,
-                                  int               n,
-                                  hipDoubleComplex* A[],
-                                  int               lda,
-                                  hipDoubleComplex* work,
-                                  int               lwork,
-                                  int*              devIpiv,
-                                  int*              devInfo,
-                                  int               batch_count)
+                                         int               batch_count)
 try
 {
     if(!handle)
@@ -4115,13 +4117,46 @@ try
     if(m != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(cublasSgetrfBatched((cublasHandle_t) handle, n, (cuDoubleComplex**)A, lda, devIpiv, devInfo, batch_count);
+    if(strideP != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasCgetrfBatched(
+        (cublasHandle_t)handle, n, (cuComplex**)A, lda, devIpiv, devInfo, batch_count));
 }
 catch(...)
 {
     return hipsolver::exception2hip_status();
 }
 
+hipsolverStatus_t hipsolverZgetrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         hipDoubleComplex* A[],
+                                         int               lda,
+                                         hipDoubleComplex* work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int               strideP,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    if(m != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    if(strideP != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasZgetrfBatched(
+        (cublasHandle_t)handle, n, (cuDoubleComplex**)A, lda, devIpiv, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
 
 /******************** GETRS ********************/
 hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,
@@ -7872,4 +7907,4 @@ catch(...)
     return hipsolver::exception2hip_status();
 }
 
-    } // extern C
+} // extern C

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -3937,6 +3937,192 @@ catch(...)
     return hipsolver::exception2hip_status();
 }
 
+/******************** GETRF_BATCHED ********************/
+hipsolverStatus_t hipsolverSgetrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, float* A[], int lda, int* lwork, int batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(m != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, double* A[], int lda, int* lwork, int batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(m != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    hipFloatComplex*  A[],
+                                                    int               lda,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(m != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    hipDoubleComplex* A[],
+                                                    int               lda,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(m != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSgetrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         float*            A[],
+                                         int               lda,
+                                         float*            work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    if(m != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasSgetrfBatched((cublasHandle_t) handle, n, A, lda, devIpiv, devInfo, batch_count);
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         double*           A[],
+                                         int               lda,
+                                         double*           work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    if(m != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasSgetrfBatched((cublasHandle_t) handle, n, A, lda, devIpiv, devInfo, batch_count);
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         hipFloatComplex*  A[],
+                                         int               lda,
+                                         hipFloatComplex*  work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int*              devInfo,
+                                         int               batch_count) try
+    if(!handle) return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+if(m != n)
+    return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasSgetrfBatched((cublasHandle_t) handle, n, (cuComplex**)A, lda, devIpiv, devInfo, batch_count);
+{
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetrfBatched(hipsolverHandle_t handle,
+                                  int               m,
+                                  int               n,
+                                  hipDoubleComplex* A[],
+                                  int               lda,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  int*              devIpiv,
+                                  int*              devInfo,
+                                  int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    if(m != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasSgetrfBatched((cublasHandle_t) handle, n, (cuDoubleComplex**)A, lda, devIpiv, devInfo, batch_count);
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+
 /******************** GETRS ********************/
 hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,
                                              hipsolverOperation_t trans,
@@ -7686,4 +7872,4 @@ catch(...)
     return hipsolver::exception2hip_status();
 }
 
-} // extern C
+    } // extern C

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -4060,8 +4060,18 @@ try
     if(strideP != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(
-        cublasSgetrfBatched((cublasHandle_t)handle, n, A, lda, devIpiv, devInfo, batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status
+        = cublasSgetrfBatched(cublas_handle, n, A, lda, devIpiv, devInfo, batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {
@@ -4090,8 +4100,18 @@ try
     if(strideP != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(
-        cublasDgetrfBatched((cublasHandle_t)handle, n, A, lda, devIpiv, devInfo, batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status
+        = cublasDgetrfBatched(cublas_handle, n, A, lda, devIpiv, devInfo, batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {
@@ -4120,8 +4140,18 @@ try
     if(strideP != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(cublasCgetrfBatched(
-        (cublasHandle_t)handle, n, (cuComplex**)A, lda, devIpiv, devInfo, batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status
+        = cublasCgetrfBatched(cublas_handle, n, (cuComplex**)A, lda, devIpiv, devInfo, batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {
@@ -4150,8 +4180,18 @@ try
     if(strideP != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(cublasZgetrfBatched(
-        (cublasHandle_t)handle, n, (cuDoubleComplex**)A, lda, devIpiv, devInfo, batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status = cublasZgetrfBatched(
+        cublas_handle, n, (cuDoubleComplex**)A, lda, devIpiv, devInfo, batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -250,6 +250,33 @@ hipsolverDeterministicMode_t cuda2hip_deterministic(cusolverDeterministicMode_t 
     }
 }
 #endif
+
+hipsolverStatus_t cuda2hip_status(cublasStatus_t cuStatus)
+{
+    switch(cuStatus)
+    {
+    case CUBLAS_STATUS_SUCCESS:
+        return HIPSOLVER_STATUS_SUCCESS;
+    case CUBLAS_STATUS_NOT_INITIALIZED:
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    case CUBLAS_STATUS_ALLOC_FAILED:
+        return HIPSOLVER_STATUS_ALLOC_FAILED;
+    case CUBLAS_STATUS_INVALID_VALUE:
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    case CUBLAS_STATUS_MAPPING_ERROR:
+        return HIPSOLVER_STATUS_MAPPING_ERROR;
+    case CUBLAS_STATUS_EXECUTION_FAILED:
+        return HIPSOLVER_STATUS_EXECUTION_FAILED;
+    case CUBLAS_STATUS_INTERNAL_ERROR:
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+    case CUBLAS_STATUS_NOT_SUPPORTED:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    case CUBLAS_STATUS_ARCH_MISMATCH:
+        return HIPSOLVER_STATUS_ARCH_MISMATCH;
+    default:
+        return HIPSOLVER_STATUS_UNKNOWN;
+    }
+}
 
 hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -63,6 +63,8 @@ cusolverDeterministicMode_t hip2cuda_deterministic(hipsolverDeterministicMode_t 
 
 hipsolverDeterministicMode_t cuda2hip_deterministic(cusolverDeterministicMode_t mode);
 #endif
+
+hipsolverStatus_t cuda2hip_status(cublasStatus_t cuStatus);
 
 hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus);
 


### PR DESCRIPTION
## Motivation

This PR adds an API and test suite to hipSOLVER to allow the user to run getrfBatched from hipSOLVER.

## Technical Details

The getrfBatched API diverges from the getrf API, as cuSOLVER provides a different API for the two. The new getrfBatched API is not 1:1 with the getrfBatched API provided by cuSOLVER, if the user wants a 1:1 API, they should look in hipBLAS.

There is some duplication of code in the testing_getrf.hpp file, specifically regarding the _getPerfData, _initData, and _getError functions. These functions were made to accommodate for the different device_vector types (device_strided_batch_vector and device_batch_vector), and the difference in APIs for the hipsolver_getrf and hipsolver_getrfBatched routines.

## Test Plan

Run new and existing GETRF tests in our GTest suite.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
