### PR TITLE
[ci] Adding mi350 required group ID

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -30,6 +30,7 @@ jobs:
         --device /dev/kfd
         --device /dev/dri
         --group-add 992
+        --group-add 110
         --env-file /etc/podinfo/gha-gpu-isolation-settings
     strategy:
       fail-fast: false

--- a/projects/composablekernel/.github/workflows/therock-test-component.yml
+++ b/projects/composablekernel/.github/workflows/therock-test-component.yml
@@ -30,6 +30,7 @@ jobs:
         --device /dev/kfd
         --device /dev/dri
         --group-add 992
+        --group-add 110
         --env-file /etc/podinfo/gha-gpu-isolation-settings
     strategy:
       fail-fast: false


### PR DESCRIPTION
After updating mi325 group-id, we are noticing errors for mi350.

Tested here for mi350: https://github.com/ROCm/TheRock/actions/runs/21733399385/job/62692971370
Tested here for mi325: https://github.com/ROCm/TheRock/actions/runs/21759203211/job/62778060417

Adding both work properly