### PR TITLE
[ci] Adding exclusion for gfx950 due to lack of machines

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -145,6 +145,8 @@ jobs:
   therock-test-linux:
     name: Test (${{ inputs.amdgpu_families }})
     needs: [therock-build-linux]
+    # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
+    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu'}}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: ${{ inputs.projects_to_test }}


### PR DESCRIPTION
To remediate queue times, we are turning off test machines for gfx950 for rocm-libraries. We will re-enable once we get capacity, noted here: https://github.com/ROCm/TheRock/issues/3288

gfx950 tests will continue to run for TheRock to get some signal