### PR TITLE
[hipDNN] Fix a couple log messages in test plugins broken by recent merge.

### DIFF
--- a/projects/hipdnn/tests/test_plugins/TestKnobConstraintValidationPlugin.cpp
+++ b/projects/hipdnn/tests/test_plugins/TestKnobConstraintValidationPlugin.cpp
@@ -51,7 +51,7 @@ public:
                                 << ", opGraph=" << static_cast<const void*>(opGraph)
                                 << ", engineDetails=" << static_cast<void*>(engineDetails));
 
-        return hipdnn_plugin_sdk::tryCatch([&]() {
+        return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
             hipdnn_plugin_sdk::throwIfNull(handle);
             hipdnn_plugin_sdk::throwIfNull(opGraph);
             hipdnn_plugin_sdk::throwIfNull(engineDetails);
@@ -109,7 +109,7 @@ public:
             engineDetails->ptr = tempBuffer;
             engineDetails->size = serializedDetails.size();
 
-            LOG_API_SUCCESS(__func__, "engineDetails->ptr=" << engineDetails->ptr);
+            LOG_API_SUCCESS(apiName, "engineDetails->ptr=" << engineDetails->ptr);
         });
     }
 

--- a/projects/hipdnn/tests/test_plugins/TestKnobsPlugin.cpp
+++ b/projects/hipdnn/tests/test_plugins/TestKnobsPlugin.cpp
@@ -50,7 +50,7 @@ public:
                                 << ", opGraph=" << static_cast<const void*>(opGraph)
                                 << ", engineDetails=" << static_cast<void*>(engineDetails));
 
-        return hipdnn_plugin_sdk::tryCatch([&]() {
+        return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
             hipdnn_plugin_sdk::throwIfNull(handle);
             hipdnn_plugin_sdk::throwIfNull(opGraph);
             hipdnn_plugin_sdk::throwIfNull(engineDetails);
@@ -120,7 +120,7 @@ public:
             engineDetails->ptr = tempBuffer;
             engineDetails->size = serializedDetails.size();
 
-            LOG_API_SUCCESS(__func__, "engineDetails->ptr=" << engineDetails->ptr);
+            LOG_API_SUCCESS(apiName, "engineDetails->ptr=" << engineDetails->ptr);
         });
     }
 };


### PR DESCRIPTION
## Motivation

Include correct function name in log output.

## Technical Details

Recent code merge incorrect used __func__ directly when generating the log instead of the function name that was to be passed as a parameter.

## Test Plan

View that log includes correct function name.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
