### PR TITLE
Fix stream-k with mx scaling

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/GSU.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/GSU.py
@@ -307,9 +307,9 @@ class GSUOn(GSU):
         _DepthU = kernel["_DepthU%s" % tc]
         # swizzle
         if (tP["isSwizzled"] and tc == 'A'):
-            _DepthU = (_DepthU * 16) # MI_M = 16
+            _DepthU = (_DepthU * 16)
         elif (tP["isSwizzled"] and tc == 'B'):
-            _DepthU = (_DepthU * 16) # MI_N = 16
+            _DepthU = (_DepthU * 16)
 
         gsucLabel    = Label(label=writer.labels.getNameInc(f"GSUC_{tc}"), comment="")
         gsucLabelEnd = Label(label=writer.labels.getNameInc(f"GSUC_{tc}_End"), comment="")

--- a/projects/hipblaslt/tensilelite/Tensile/Components/StreamK.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/StreamK.py
@@ -176,15 +176,23 @@ class StreamK(Component):
         return module
 
     @abc.abstractmethod
-    def computeLoadSrd(self, writer, kernel, tc, sTmp):
+    def computeLoadSrd(self, writer, kernel, tP, sTmp):
         pass
 
-    def computeLoadSrdCommon(self, writer, kernel, tc, sTmp):
+    def computeLoadSrdCommon(self, writer, kernel, tP, sTmp):
         module = Module("StreamK Common computeLoadSrd")
+
+        tc = tP["tensorChar"]
+        _DepthU = kernel["_DepthU%s" % tc]
+        # swizzle
+        if (tP["isSwizzled"] and tc == 'A'):
+            _DepthU = (_DepthU * 16) # MI_M = 16
+        elif (tP["isSwizzled"] and tc == 'B'):
+            _DepthU = (_DepthU * 16) # MI_N = 16
 
         tileStart = sTmp + 2
         # StreamK partial tile - offset to tile start index
-        module.add(SMulI32(dst=sgpr(sTmp), src0=sgpr("StreamKLocalStart"), src1=kernel["DepthU"], comment="StreamK tile start offset"))
+        module.add(SMulI32(dst=sgpr(sTmp), src0=sgpr("StreamKLocalStart"), src1=_DepthU, comment="StreamK tile start offset"))
         strideL = writer.strideRef(tc, kernel["ProblemType"]["IndicesSummation"][0])
         module.add(writer.s_mul_u64_u32(sgpr(sTmp), sgpr(sTmp+1), sgpr(sTmp), strideL, comment="StreamK tile start offset"))
         # Overflow check removed
@@ -255,9 +263,16 @@ class StreamK(Component):
         module = Module("StreamK Common graAddresses")
 
         tc = tP["tensorChar"]
+        _DepthU = kernel["_DepthU%s" % tc]
+        # swizzle
+        if (tP["isSwizzled"] and tc == 'A'):
+            _DepthU = (_DepthU * 16) # MI_M = 16
+        elif (tP["isSwizzled"] and tc == 'B'):
+            _DepthU = (_DepthU * 16) # MI_N = 16
+
         # StreamK partial tile - offset to tile start index
         tmpOffset = writer.sgprPool.checkOut(2, "skStartOffset")
-        module.add(SMulI32(dst=sgpr(tmpOffset), src0=sgpr("StreamKLocalStart"), src1=int(kernel["DepthU"] * tP["bpe"]), comment="StreamK tile start offset"))
+        module.add(SMulI32(dst=sgpr(tmpOffset), src0=sgpr("StreamKLocalStart"), src1=int(_DepthU * tP["bpe"]), comment="StreamK tile start offset"))
         strideL = writer.strideRef(tc, kernel["ProblemType"]["IndicesSummation"][0])
         module.add(writer.s_mul_u64_u32(sgpr(tmpOffset), sgpr(tmpOffset+1), sgpr(tmpOffset), strideL, "StreamK tile start offset"))
         # Overflow check removed
@@ -1745,7 +1760,7 @@ class StreamKOff(StreamK):
         module = Module("StreamK Off graWorkGroup")
         return module
 
-    def computeLoadSrd(self, writer, kernel, tc, sTmp):
+    def computeLoadSrd(self, writer, kernel, tP, sTmp):
         module = Module("StreamK Off computeLoadSrd")
         return module
 
@@ -1861,9 +1876,9 @@ class StreamKBasic(StreamK):
 
         return module
 
-    def computeLoadSrd(self, writer, kernel, tc, sTmp):
+    def computeLoadSrd(self, writer, kernel, tP, sTmp):
         module = Module("StreamK Basic computeLoadSrd")
-        module.add(self.computeLoadSrdCommon(writer, kernel, tc, sTmp))
+        module.add(self.computeLoadSrdCommon(writer, kernel, tP, sTmp))
         return module
 
     def computeStoreSrdStart(self, writer, kernel):
@@ -1986,9 +2001,9 @@ class StreamKTwoTileOriginal(StreamK):
 
         return module
 
-    def computeLoadSrd(self, writer, kernel, tc, sTmp):
+    def computeLoadSrd(self, writer, kernel, tP, sTmp):
         module = Module("StreamK TwoTileOriginal computeLoadSrd")
-        module.add(self.computeLoadSrdCommon(writer, kernel, tc, sTmp))
+        module.add(self.computeLoadSrdCommon(writer, kernel, tP, sTmp))
         return module
 
     def computeStoreSrdStart(self, writer, kernel):
@@ -2256,9 +2271,9 @@ class StreamKTwoTileDPFirst(StreamK):
 
         return module
 
-    def computeLoadSrd(self, writer, kernel, tc, sTmp):
+    def computeLoadSrd(self, writer, kernel, tP, sTmp):
         module = Module("StreamK TwoTileDPFirst computeLoadSrd")
-        module.add(self.computeLoadSrdCommon(writer, kernel, tc, sTmp))
+        module.add(self.computeLoadSrdCommon(writer, kernel, tP, sTmp))
         return module
 
     def computeStoreSrdStart(self, writer, kernel):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/StreamK.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/StreamK.py
@@ -186,9 +186,9 @@ class StreamK(Component):
         _DepthU = kernel["_DepthU%s" % tc]
         # swizzle
         if (tP["isSwizzled"] and tc == 'A'):
-            _DepthU = (_DepthU * 16) # MI_M = 16
+            _DepthU = (_DepthU * 16)
         elif (tP["isSwizzled"] and tc == 'B'):
-            _DepthU = (_DepthU * 16) # MI_N = 16
+            _DepthU = (_DepthU * 16)
 
         tileStart = sTmp + 2
         # StreamK partial tile - offset to tile start index
@@ -266,9 +266,9 @@ class StreamK(Component):
         _DepthU = kernel["_DepthU%s" % tc]
         # swizzle
         if (tP["isSwizzled"] and tc == 'A'):
-            _DepthU = (_DepthU * 16) # MI_M = 16
+            _DepthU = (_DepthU * 16)
         elif (tP["isSwizzled"] and tc == 'B'):
-            _DepthU = (_DepthU * 16) # MI_N = 16
+            _DepthU = (_DepthU * 16)
 
         # StreamK partial tile - offset to tile start index
         tmpOffset = writer.sgprPool.checkOut(2, "skStartOffset")

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -3617,7 +3617,7 @@ class KernelWriterAssembly(KernelWriter):
                     strideF, comment="tlu=0, scaled tile-offset by stride"))
 
         skComponent = Component.StreamK.find(self)
-        module.add(skComponent.computeLoadSrd(self, kernel, tc, stmp))
+        module.add(skComponent.computeLoadSrd(self, kernel, tP, stmp))
 
         gsuComponent = Component.GSU.find(self)
         module.add(gsuComponent.computeLoadSrd(self, kernel, tP, stmp, tileStart))

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_mx32f4_quick.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_mx32f4_quick.yaml
@@ -1,0 +1,165 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201]
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  MinimumRequiredVersion: 5.0.0
+  PrintLevel: 1
+  # PrintSolutionRejectionReason: True
+  Device: 0
+  CMakeBuildType: Debug
+#  MergeFiles: False
+  KernelTime: True
+  MaxWorkspaceSize: 13421772800
+  DataInitTypeA: 3
+  DataInitTypeB: 3
+  DataInitTypeC: 0
+  DataInitTypeMXSA: 3
+  DataInitTypeMXSB: 3
+  DataInitTypeAlpha: 1
+  DataInitTypeBeta: 0
+  NumElementsToValidate: -1
+  BoundsCheck: 0
+  KeepBuildTmp: True
+  MaxFileName: 128
+  DeviceLDS: 163840
+  MaxLDS: 163840
+#  PrintTensorA: True
+#  PrintTensorB: True
+#  PrintTensorC: True
+#  PrintTensorD: True
+#  PrintTensorRef: True
+
+BenchmarkProblems:
+  ########################################
+  # FP8HS with ScaleABCD
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: F8
+      DestDataType: S
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      MXBlockA: 32
+      MXBlockB: 32
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+      Activation: True
+      ActivationType: hipblaslt_all
+#      UseScaleAB: "Scalar"
+#      UseScaleCD: True
+      UseScaleAlphaVec: 1
+      UseBias: 1
+      BiasDataTypeList: [s]
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16, 16, 128, 1, 1, 1,1, 1,1]  # 64x64
+          # - [16, 16, 128, 1, 1, 4,2, 2,2]  # 64x64
+          - [16, 16, 128, 1, 1, 2,4, 2,2]  # 64x64
+          # - [16, 16, 128, 1, 1, 8,8, 2,2]  # 64x64
+          # - [32, 32,  64, 1, 1, 1,1, 1,1]  # 64x64
+          - [32, 32,  64, 1, 1, 2,2, 2,2]  # 64x64
+          # - [32, 32,  64, 1, 1, 4,2, 2,2]  # 64x64
+          # - [32, 32,  64, 1, 1, 2,4, 2,2]  # 64x64
+        - ForceDisableShadowInit: [True, False]
+        # - UseSgprForGRO: [0,1]
+        - UseSgprForGRO: [0]
+        # - DepthU: [64, 128]
+        - DepthU: [128]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [64]
+        - LocalReadVectorWidth: [16]
+        # - PrefetchGlobalRead: [0,1,2]
+        - PrefetchGlobalRead: [2]
+        # - PrefetchLocalRead: [0,1]
+        - PrefetchLocalRead: [1]
+        # - PreloadKernArgs: [0,1]
+        - PreloadKernArgs: [1]
+        # - ClusterLocalRead: [0,1]
+        - ClusterLocalRead: [1]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - GlobalReadVectorWidthA: [16]
+        - GlobalReadVectorWidthB: [16]
+        # - ScheduleIterAlg: [1,2,3]
+        - ScheduleIterAlg: [3]
+        - InnerUnroll: [1]
+        # - ExpandPointerSwap: [0,1]
+#        - LdsBlockSizePerPadA: [0]
+#        - LdsBlockSizePerPadB: [0]
+        - TransposeLDS: [1]
+#        - LdsPadA: [0]
+#        - LdsPadB: [0]
+        - WaveSeparateGlobalReadA: [0]
+        - WaveSeparateGlobalReadB: [0]
+        - 1LDSBuffer: [0]
+        # - GlobalSplitU: [1,2]
+#        - GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
+        - GlobalReadPerMfma: [1]
+        - LocalWritePerMfma: [-1]
+        - StoreVectorWidth: [-1]
+        - SourceSwap: [1]
+        - StreamK: [3]
+        # - GlobalSplitU: [2]
+        # - GlobalSplitUAlgorithm: ["MultipleBufferSingleKernel"]
+#        - NumElementsPerBatchStore: [0]
+#        - StorePriorityOpt: [0]
+#        - StaggerU: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          # - Exact: [16, 16, 1, 128]
+          # - Exact: [32, 16, 1, 1024]
+          # - Exact: [256, 256, 1, 64]
+          - Exact: [1025, 513, 1, 2048]
+#          - Exact: [1026, 514, 1, 2048]
+#          - Exact: [1027, 515, 1, 2048]
+#          - Exact: [1028, 516, 1, 2048]
+#          - Exact: [1029, 517, 1, 2048]
+#          - Exact: [1030, 518, 1, 2048]
+#          - Exact: [1031, 519, 1, 2048]
+#          - Exact: [1032, 520, 1, 2048]
+#          - Exact: [1033, 521, 1, 2048]
+#          - Exact: [1034, 522, 1, 2048]
+#          - Exact: [1035, 523, 1, 2048]
+#          - Exact: [1036, 524, 1, 2048]
+#          - Exact: [1037, 525, 1, 2048]
+#          - Exact: [1038, 526, 1, 2048]
+#          - Exact: [1039, 527, 1, 2048]
+#          - Exact: [1040, 528, 1, 2048]
+#          - Exact: [1041, 529, 1, 2048]
+#          - Exact: [1042, 530, 1, 2048]
+#          - Exact: [1043, 531, 1, 2048]
+          - Exact: [1044, 532, 1, 2048]
+          - Exact: [127, 127, 1, 640] #special cleanup case
+          - Exact: [128, 128, 1, 128]
+          - Exact: [129, 129, 1, 640]
+          # - Exact: [128, 128, 1, 127]
+          # - Exact: [128, 128, 1, 129]
+          # - Exact: [111, 111, 1, 111]
+          # - Exact: [777, 777, 1, 777]
+          # - Exact: [128, 128, 1, 512]
+          # #- Range: [[128], [128], [1], [1024,32,1280]]
+          # - Range: [[128], [128], [1], [1024,64,1280]] #passed for DepthU = 64 but failed for DepthU = 128 since we currently don't support tailloop in MX feature.
+          # - Range: [[128,1,256], [128], [1], [1024]]
+          # - Range: [[128], [128,1,256], [1], [1024]]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]
+
+# LibraryLogic:
+#     ScheduleName: "aquavanjaram"
+#     DeviceNames: ["Device 0049"]
+#     ArchitectureName: "gfx950"
+#     LibraryType: "GridBased"
+#
+# LibraryClient:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_mx32f8_quick.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_mx32f8_quick.yaml
@@ -27,12 +27,12 @@ GlobalParameters:
 
 BenchmarkProblems:
   ########################################
-  # FP4SS
+  # FP8SS
   ########################################
   -
     - # ProblemType
       OperationType: GEMM
-      DataType: F4
+      DataType: F8
       DestDataType: S
       ComputeDataType: S
       HighPrecisionAccumulate: True


### PR DESCRIPTION
## Motivation

Fix stream-k support for mx types with scaling.

## Technical Details

Fixes global read address offset calculation for stream-k partial tiles.

## Test Plan

Works in initial batch of local tests. More testing with other parameter combinations to be done, and a new test case to be added for CI.
