### PR TITLE
[MIOpen] Stop mirroring to the old, deprecated repo

### DIFF
--- a/.github/repos-config.json
+++ b/.github/repos-config.json
@@ -6,7 +6,7 @@
       "branch": "develop",
       "category": "projects",
       "auto_subtree_pull": false,
-      "auto_subtree_push": true,
+      "auto_subtree_push": false,
       "monorepo_source_of_truth": true
     },
     {


### PR DESCRIPTION
This mirroring is half-broken, and there is no need to mirror anymore since MIOpen is now delivered as part of rocm-libraries and the rock.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
