### PR TITLE
[rocprim] Fix a call to intrinsics in test_device_reduce_by_key

### DIFF
--- a/projects/rocprim/test/rocprim/test_device_reduce_by_key.cpp
+++ b/projects/rocprim/test/rocprim/test_device_reduce_by_key.cpp
@@ -40,6 +40,7 @@
 #include <rocprim/device/config_types.hpp>
 #include <rocprim/device/device_reduce_by_key.hpp>
 #include <rocprim/functional.hpp>
+#include <rocprim/intrinsics/bit.hpp>
 #include <rocprim/iterator/constant_iterator.hpp>
 #include <rocprim/iterator/counting_iterator.hpp>
 #include <rocprim/iterator/discard_iterator.hpp>
@@ -373,7 +374,7 @@ void large_indices_reduce_by_key()
             {
                 // for i > 0, returns the position of the most significant set bit,
                 // which is equal to the floor of log2
-                return std::numeric_limits<size_t>::digits - 1 - __clzll(static_cast<long long>(i));
+                return std::numeric_limits<size_t>::digits - 1 - rocprim::clz(i);
             });
         // the input values are all one, so the reduction of plus over the segments
         // results in the size of the group


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix a call to __clzll in test_device_reduce_by_key

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
There are a couple of issues in the call to __clzll:
- the argument is cast to `long long`: it should be cast to `unsigned long long` instead
- in rocprim there exists a wrapper for clz, so for better portability rocprim::clz should be used instead.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run test_device_reduce_by_key to verify the test runs correctly.

## Test Result

<!-- Briefly summarize test outcomes. -->
The test passes.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
