### PR TITLE
[hipFFTW] Fix checking of aliased_hipfftw_name

### DIFF
--- a/projects/hipfft/library/CMakeLists.txt
+++ b/projects/hipfft/library/CMakeLists.txt
@@ -165,7 +165,7 @@ endif()
 if (NOT BUILD_WITH_COMPILER STREQUAL "HIP-NVCC")
   rocm_set_soversion(hipfft ${hipfft_SOVERSION})
   get_target_property(aliased_hipfftw_name hipfftw ALIASED_TARGET)
-  if (aliased_hipfftw_name STREQUAL "")
+  if (NOT aliased_hipfftw_name)
     # hipfftw is not an alias
     rocm_set_soversion(hipfftw ${hipfftw_SOVERSION})
   endif()


### PR DESCRIPTION
## Motivation

This complements https://github.com/ROCm/rocm-libraries/pull/2579 and addresses https://github.com/ROCm/rocm-libraries/issues/2400 

## Technical Details

When variable is unset then such statement does not work as intended i.e the if statement is always false and hipfftw stays without so version

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
