### PR TITLE
[hipfft] Fix Doxygen comments that cause cyclic ref errors

### DIFF
--- a/projects/hipfft/library/include/hipfft/hipfftXt.h
+++ b/projects/hipfft/library/include/hipfft/hipfftXt.h
@@ -279,7 +279,7 @@ typedef enum hipfftXtSubFormat_t
 /*! @brief Allocate memory on multiple devices.
  *
  *  Allocate memory on multiple devices for the specified plan.
- *  Returns a \ref hipLibXtDesc_t descriptor which includes pointers
+ *  Returns a \ref hipLibXtDesc descriptor which includes pointers
  *  to the allocated memory, devices that memory resides on, and
  *  sizes allocated.
  *
@@ -298,13 +298,13 @@ HIPFFT_EXPORT hipfftResult hipfftXtMalloc(hipfftHandle      plan,
                                           hipLibXtDesc**    desc,
                                           hipfftXtSubFormat format);
 
-/*! @brief Copy data to/from \ref hipLibXtDesc_t descriptors.
+/*! @brief Copy data to/from \ref hipLibXtDesc descriptors.
  *
- *  Copy data according to the hipfftXtCopyType_t
+ *  Copy data according to the hipfftXtCopyType
  *
- *  - ::HIPFFT_COPY_HOST_TO_DEVICE: dest points to a \ref hipLibXtDesc_t structure that describes multi-device memory layout.  src points to a host memory buffer.
- *  - ::HIPFFT_COPY_DEVICE_TO_HOST: src points to a \ref hipLibXtDesc_t structure that describes multi-device memory layout.  dest points to a host memory buffer.
- *  - ::HIPFFT_COPY_DEVICE_TO_DEVICE: Both dest and src point to a \ref hipLibXtDesc_t structure that describes multi-device memory layout.  The two structures must describe memory with the same number of devices and memory sizes.
+ *  - ::HIPFFT_COPY_HOST_TO_DEVICE: dest points to a \ref hipLibXtDesc structure that describes multi-device memory layout.  src points to a host memory buffer.
+ *  - ::HIPFFT_COPY_DEVICE_TO_HOST: src points to a \ref hipLibXtDesc structure that describes multi-device memory layout.  dest points to a host memory buffer.
+ *  - ::HIPFFT_COPY_DEVICE_TO_DEVICE: Both dest and src point to a \ref hipLibXtDesc structure that describes multi-device memory layout.  The two structures must describe memory with the same number of devices and memory sizes.
  * 
  * @param[in] plan Plan which has the descriptor.
  * @param[out] dest Buffer that will be populated.
@@ -326,10 +326,10 @@ HIPFFT_EXPORT hipfftResult hipfftXtMemcpy(hipfftHandle     plan,
  */
 HIPFFT_EXPORT hipfftResult hipfftXtFree(hipLibXtDesc* desc);
 
-/** @defgroup hipfftXtExecDescriptor Execute FFTs using \ref hipLibXtDesc_t descriptors.
+/** @defgroup hipfftXtExecDescriptor Execute FFTs using hipLibXtDesc descriptors.
  *
- *  Execute FFTs using \ref hipLibXtDesc_t descriptors.  Inputs and
- *  outputs are pointers to \ref hipLibXtDesc_t descriptors.
+ *  Execute FFTs using hipLibXtDesc descriptors.  Inputs and
+ *  outputs are pointers to hipLibXtDesc descriptors.
  *  In-place transforms are performed by passing the same pointer for
  *  input and output.
  * 

--- a/projects/hipfft/library/include/hipfft/hiplibxt.h
+++ b/projects/hipfft/library/include/hipfft/hiplibxt.h
@@ -26,7 +26,7 @@
 
 #define MAX_HIP_DESCRIPTOR_GPUS 64
 
-/*! @struct hipXtDesc_t
+/*!
  * @brief Struct for single-process multi-GPU transform
  *
  * This struct holds pointers to device memory, including the device
@@ -55,10 +55,10 @@ typedef enum hiplibFormat_t
     HIPLIB_FORMAT_UNDEFINED = 0x1
 } hiplibFormat;
 
-/*! @struct hipLibXtDesc_t
+/*!
  * @brief Struct for single-process multi-GPU transform
  *
- * This struct holds \ref hipXtDesc_t structures that define blocks
+ * This struct holds \ref hipXtDesc structures that define blocks
  * of memory for use in a transform.
  *
  * @warning Experimental


### PR DESCRIPTION
## Motivation

Fix incorrect Doxygen comments that cause cyclic ref errors when generating docs with sphinx via rocm-docs-build

## Technical Details

Fix incorrect Doxygen \ref usage that caused cyclic reference errors when generating docs with sphinx via rocm-docs-build. Update comments to reference the correct public types and remove invalid struct annotations.
No API or functional changes intended.

Simply changing WARN_AS_ERROR to NO in Doxyfile would not solve the issue as at the end of the Doxygen process Doxygen will return with a non-zero status which sphinx will not tolerate.

Log:
```
.
.
Sorting member lists...
Setting anonymous enum type...
Computing dependencies between directories...
Generating citations page...
Counting members...
Counting data structures...
Resolving user defined references...
Finding anchors and sections in the documentation...
Transferring function references...
Combining using relations...
Adding members to index pages...
Correcting members for VHDL...
Computing tooltip texts...
Generating style sheet...
Generating search indices...
<PATH>/hipfft/hipfft/library/include/hipfft/hipfftXt.h:0: error: Potential recursion while resolving \ref command! (warning treated as error, aborting now)
Exiting...

Extension error (rocm_docs.doxygen)!

Versions
========

* Platform:         linux; (Linux-6.14.0-37-generic-x86_64-with-glibc2.42)
* Python version:   3.13.11 (CPython)
* Sphinx version:   8.2.3
* Docutils version: 0.22.4
* Jinja2 version:   3.1.6
* Pygments version: 2.18.0

Last Messages
=============

None.

Loaded Extensions
=================

None.

Traceback
=========

      File "/usr/lib/python3/dist-packages/sphinx/events.py", line 415, in emit
        raise ExtensionError(
        ...<4 lines>...
        ) from exc
    sphinx.errors.ExtensionError: Handler <function _run_doxygen at 0x73c134117ba0> for event 'config-inited' threw an exception (exception: Failed when running doxygen)
```

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
