### PR TITLE
Compile time optimization warp_exchange 

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/warp/warp_exchange.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/warp/warp_exchange.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -502,19 +502,18 @@ private:
         U                  work_array[ItemsPerThread];
 
         ROCPRIM_UNROLL
-        for(unsigned int dst_idx = 0; dst_idx < ItemsPerThread; dst_idx++)
+        for(unsigned int i = 0; i < ItemsPerThread * ItemsPerThread; i++)
         {
-            ROCPRIM_UNROLL
-            for(unsigned int src_idx = 0; src_idx < ItemsPerThread; src_idx++)
+            const unsigned int dst_idx = i / ItemsPerThread;
+            const unsigned int src_idx = i % ItemsPerThread;
+
+            const auto value = ::rocprim::warp_shuffle(
+                input[src_idx],
+                flat_id / ItemsPerThread + dst_idx * (VirtualWaveSize / ItemsPerThread),
+                VirtualWaveSize);
+            if(src_idx == flat_id % ItemsPerThread)
             {
-                const auto value = ::rocprim::warp_shuffle(
-                    input[src_idx],
-                    flat_id / ItemsPerThread + dst_idx * (VirtualWaveSize / ItemsPerThread),
-                    VirtualWaveSize);
-                if(src_idx == flat_id % ItemsPerThread)
-                {
-                    work_array[dst_idx] = value;
-                }
+                work_array[dst_idx] = value;
             }
         }
 
@@ -715,19 +714,18 @@ private:
         U                  work_array[ItemsPerThread];
 
         ROCPRIM_UNROLL
-        for(unsigned int dst_idx = 0; dst_idx < ItemsPerThread; dst_idx++)
+        for(unsigned int i = 0; i < ItemsPerThread * ItemsPerThread; i++)
         {
-            ROCPRIM_UNROLL
-            for(unsigned int src_idx = 0; src_idx < ItemsPerThread; src_idx++)
+            const unsigned int dst_idx = i / ItemsPerThread;
+            const unsigned int src_idx = i % ItemsPerThread;
+
+            const auto value
+                = ::rocprim::warp_shuffle(input[src_idx],
+                                          (ItemsPerThread * flat_id + dst_idx) % VirtualWaveSize,
+                                          VirtualWaveSize);
+            if((flat_id / (VirtualWaveSize / ItemsPerThread)) == src_idx)
             {
-                const auto value = ::rocprim::warp_shuffle(input[src_idx],
-                                                           (ItemsPerThread * flat_id + dst_idx)
-                                                               % VirtualWaveSize,
-                                                           VirtualWaveSize);
-                if(flat_id / (VirtualWaveSize / ItemsPerThread) == src_idx)
-                {
-                    work_array[dst_idx] = value;
-                }
+                work_array[dst_idx] = value;
             }
         }
 

--- a/projects/rocprim/test/rocprim/test_warp_exchange.cpp
+++ b/projects/rocprim/test/rocprim/test_warp_exchange.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -134,78 +134,49 @@ using WarpExchangeTestParams = ::testing::Types<
     Params<rocprim::bfloat16, 64U, 16U, common::StripedToBlockedShuffleOp>,
     Params<float, 2U, 16U, common::StripedToBlockedShuffleOp>>;
 
-template<unsigned int ItemsPerThread, unsigned int LogicalWarpSize, class Op, class T>
-__device__
-auto warp_exchange_test(T* d_input, T* d_output)
-    -> std::enable_if_t<common::device_test_enabled_for_warp_size_v<LogicalWarpSize>>
+template<unsigned int ItemsPerThread,
+         unsigned int LogicalWarpSize,
+         class Op,
+         bool InPlace = true,
+         class T>
+__global__
+void warp_exchange_kernel(T* d_input, T* d_output)
 {
-    using warp_exchange_type         = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
-    constexpr unsigned int num_warps = ::rocprim::arch::wavefront::max_size() / LogicalWarpSize;
-    ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
-
-    T thread_data[ItemsPerThread];
-    for(unsigned int i = 0; i < ItemsPerThread; i++)
+    if constexpr(common::device_test_enabled_for_warp_size_v<LogicalWarpSize>)
     {
-        thread_data[i] = d_input[threadIdx.x * ItemsPerThread + i];
-    }
+        T thread_data[ItemsPerThread];
+        ROCPRIM_UNROLL
+        for(unsigned int i = 0; i < ItemsPerThread; i++)
+        {
+            thread_data[i] = d_input[threadIdx.x * ItemsPerThread + i];
+        }
 
-    const unsigned int warp_id = threadIdx.x / LogicalWarpSize;
-    Op{}(warp_exchange_type(), thread_data, thread_data, storage[warp_id]);
+        using warp_exchange_type = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
+        constexpr unsigned int num_warps = ::rocprim::arch::wavefront::max_size() / LogicalWarpSize;
+        ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
 
-    for(unsigned int i = 0; i < ItemsPerThread; i++)
-    {
-        d_output[threadIdx.x * ItemsPerThread + i] = thread_data[i];
-    }
-}
+        const unsigned int warp_id = threadIdx.x / LogicalWarpSize;
+        if constexpr(InPlace)
+        {
+            Op{}(warp_exchange_type(), thread_data, storage[warp_id]);
 
-template<unsigned int ItemsPerThread, unsigned int LogicalWarpSize, class Op, class T>
-__device__
-auto warp_exchange_test(T* /*d_input*/, T* /*d_output*/)
-    -> std::enable_if_t<!common::device_test_enabled_for_warp_size_v<LogicalWarpSize>>
-{}
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < ItemsPerThread; i++)
+            {
+                d_output[threadIdx.x * ItemsPerThread + i] = thread_data[i];
+            }
+        }
+        else
+        {
+            T output[ItemsPerThread];
+            Op{}(warp_exchange_type(), thread_data, output, storage[warp_id]);
 
-template<unsigned int ItemsPerThread, unsigned int LogicalWarpSize, class Op, class T>
-__device__
-auto warp_exchange_test_not_inplace(T* d_input, T* d_output)
-    -> std::enable_if_t<common::device_test_enabled_for_warp_size_v<LogicalWarpSize>>
-{
-    using warp_exchange_type         = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
-    constexpr unsigned int num_warps = ::rocprim::arch::wavefront::max_size() / LogicalWarpSize;
-    ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
-
-    T thread_data[ItemsPerThread];
-    for(unsigned int i = 0; i < ItemsPerThread; i++)
-    {
-        thread_data[i] = d_input[threadIdx.x * ItemsPerThread + i];
-    }
-
-    T output[ItemsPerThread];
-
-    const unsigned int warp_id = threadIdx.x / LogicalWarpSize;
-    Op{}(warp_exchange_type(), thread_data, output, storage[warp_id]);
-
-    for(unsigned int i = 0; i < ItemsPerThread; i++)
-    {
-        d_output[threadIdx.x * ItemsPerThread + i] = output[i];
-    }
-}
-
-template<unsigned int ItemsPerThread, unsigned int LogicalWarpSize, class Op, class T>
-__device__
-auto warp_exchange_test_not_inplace(T* /*d_input*/, T* /*d_output*/)
-    -> std::enable_if_t<!common::device_test_enabled_for_warp_size_v<LogicalWarpSize>>
-{}
-
-template<unsigned int ItemsPerThread, unsigned int LogicalWarpSize, class Op, class T>
-__global__ void warp_exchange_kernel(T* d_input, T* d_output, bool inplace = true)
-{
-    if(inplace)
-    {
-        warp_exchange_test<ItemsPerThread, LogicalWarpSize, Op>(d_input, d_output);
-    }
-    else
-    {
-        warp_exchange_test_not_inplace<ItemsPerThread, LogicalWarpSize, Op>(d_input, d_output);
+            ROCPRIM_UNROLL
+            for(unsigned int i = 0; i < ItemsPerThread; i++)
+            {
+                d_output[threadIdx.x * ItemsPerThread + i] = output[i];
+            }
+        }
     }
 }
 
@@ -293,8 +264,8 @@ TYPED_TEST(WarpExchangeTest, WarpExchangeNotInplace)
     std::vector<T> input(items_count);
     std::iota(input.begin(), input.end(), static_cast<T>(0));
     auto expected = input;
-    if(std::is_same<exchange_op, common::StripedToBlockedOp>::value
-       || std::is_same<exchange_op, common::StripedToBlockedShuffleOp>::value)
+    if constexpr(std::is_same<exchange_op, common::StripedToBlockedOp>::value
+                 || std::is_same<exchange_op, common::StripedToBlockedShuffleOp>::value)
     {
         input = stripe_vector(input, warp_size, items_per_thread);
     }
@@ -303,15 +274,15 @@ TYPED_TEST(WarpExchangeTest, WarpExchangeNotInplace)
     common::device_ptr<T> d_output(items_count);
     HIP_CHECK(hipMemset(d_output.get(), 0, items_count * sizeof(T)));
 
-    warp_exchange_kernel<items_per_thread, warp_size, exchange_op>
-        <<<dim3(1), dim3(block_size), 0, 0>>>(d_input.get(), d_output.get(), false);
+    warp_exchange_kernel<items_per_thread, warp_size, exchange_op, false>
+        <<<dim3(1), dim3(block_size), 0, 0>>>(d_input.get(), d_output.get());
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
 
     auto output = d_output.load();
 
-    if(std::is_same<exchange_op, common::BlockedToStripedOp>::value
-       || std::is_same<exchange_op, common::BlockedToStripedShuffleOp>::value)
+    if constexpr(std::is_same<exchange_op, common::BlockedToStripedOp>::value
+                 || std::is_same<exchange_op, common::BlockedToStripedShuffleOp>::value)
     {
         expected = stripe_vector(expected, warp_size, items_per_thread);
     }
@@ -334,45 +305,36 @@ public:
 };
 
 template<unsigned int ItemsPerThread, unsigned int LogicalWarpSize, class T, class OffsetT>
-__device__
-auto warp_exchange_scatter_test(T* d_input, T* d_output, OffsetT* d_ranks)
-    -> std::enable_if_t<common::device_test_enabled_for_warp_size_v<LogicalWarpSize>>
+__global__
+void warp_exchange_scatter_kernel(T* d_input, T* d_output, OffsetT* d_ranks)
 {
-    using warp_exchange_type = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
-
-    constexpr unsigned int num_warps = ::rocprim::arch::wavefront::max_size() / LogicalWarpSize;
-    ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
-
-    T thread_data[ItemsPerThread];
-    OffsetT thread_ranks[ItemsPerThread];
-    for(unsigned int i = 0; i < ItemsPerThread; i++)
+    if constexpr(common::device_test_enabled_for_warp_size_v<LogicalWarpSize>)
     {
-        thread_data[i]  = d_input[threadIdx.x * ItemsPerThread + i];
-        thread_ranks[i] = d_ranks[threadIdx.x * ItemsPerThread + i];
+
+        using warp_exchange_type = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
+
+        constexpr unsigned int num_warps = ::rocprim::arch::wavefront::max_size() / LogicalWarpSize;
+        ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
+
+        T       thread_data[ItemsPerThread];
+        OffsetT thread_ranks[ItemsPerThread];
+        for(unsigned int i = 0; i < ItemsPerThread; i++)
+        {
+            thread_data[i]  = d_input[threadIdx.x * ItemsPerThread + i];
+            thread_ranks[i] = d_ranks[threadIdx.x * ItemsPerThread + i];
+        }
+
+        const unsigned int warp_id = threadIdx.x / LogicalWarpSize;
+        warp_exchange_type{}.scatter_to_striped(thread_data,
+                                                thread_data,
+                                                thread_ranks,
+                                                storage[warp_id]);
+
+        for(unsigned int i = 0; i < ItemsPerThread; i++)
+        {
+            d_output[threadIdx.x * ItemsPerThread + i] = thread_data[i];
+        }
     }
-
-    const unsigned int warp_id = threadIdx.x / LogicalWarpSize;
-    warp_exchange_type{}.scatter_to_striped(thread_data,
-                                            thread_data,
-                                            thread_ranks,
-                                            storage[warp_id]);
-
-    for(unsigned int i = 0; i < ItemsPerThread; i++)
-    {
-        d_output[threadIdx.x * ItemsPerThread + i] = thread_data[i];
-    }
-}
-
-template<unsigned int ItemsPerThread, unsigned int LogicalWarpSize, class T, class OffsetT>
-__device__
-auto warp_exchange_scatter_test(T* /*d_input*/, T* /*d_output*/, OffsetT* /*d_ranks*/)
-    -> std::enable_if_t<!common::device_test_enabled_for_warp_size_v<LogicalWarpSize>>
-{}
-
-template<unsigned int ItemsPerThread, unsigned int LogicalWarpSize, class T, class OffsetT>
-__global__ void warp_exchange_scatter_kernel(T* d_input, T* d_output, OffsetT* d_ranks)
-{
-    warp_exchange_scatter_test<ItemsPerThread, LogicalWarpSize>(d_input, d_output, d_ranks);
 }
 
 TYPED_TEST_SUITE(WarpExchangeScatterTest, WarpExchangeScatterTestParams);

--- a/projects/rocprim/test/rocprim/test_warp_exchange.cpp
+++ b/projects/rocprim/test/rocprim/test_warp_exchange.cpp
@@ -153,7 +153,8 @@ void warp_exchange_kernel(T* d_input, T* d_output)
 
         using warp_exchange_type = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
         constexpr unsigned int num_warps = ::rocprim::arch::wavefront::max_size() / LogicalWarpSize;
-        ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
+        ROCPRIM_SHARED_MEMORY
+        typename warp_exchange_type::storage_type storage[num_warps];
 
         const unsigned int warp_id = threadIdx.x / LogicalWarpSize;
         if constexpr(InPlace)
@@ -314,7 +315,8 @@ void warp_exchange_scatter_kernel(T* d_input, T* d_output, OffsetT* d_ranks)
         using warp_exchange_type = ::rocprim::warp_exchange<T, ItemsPerThread, LogicalWarpSize>;
 
         constexpr unsigned int num_warps = ::rocprim::arch::wavefront::max_size() / LogicalWarpSize;
-        ROCPRIM_SHARED_MEMORY typename warp_exchange_type::storage_type storage[num_warps];
+        ROCPRIM_SHARED_MEMORY
+        typename warp_exchange_type::storage_type storage[num_warps];
 
         T       thread_data[ItemsPerThread];
         OffsetT thread_ranks[ItemsPerThread];


### PR DESCRIPTION
## Motivation

The Params<int8_t, 32U, 64U, common::StripedToBlockedShuffleOp>, case takes a very long time to compile. This gave problems for both compiling voor non-spirv as for running with spirv, some compilation is done at run time for spirv. The nested loops with a if branch in items divide warp are the cause (It only seems to effect (u)int8_t). This could be solved by either changing the if statement to a ternary or merging the nested loops to one loop. The ternary gave far more changes to the assembly. The merging the loops gave effectively the same assembly output. So I choose for the second option.

I also changed the test_warp_exchange to make use of if constexpr, to simplify some logic.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Compare compilation time before and after change.

## Test Result

Compilation time test_warp_exchange before change: 26m43.830s
Compilation time test_warp_exchange after change: 0m35.607s

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
