### PR TITLE
[hipBLASLt] Add client fortran option

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -67,6 +67,7 @@ if(HIPBLASLT_ENABLE_CLIENT)
     option(HIPBLASLT_ENABLE_SAMPLES "Build client samples." ON)
     # amd-smi is not presently available on Windows so we do not require it.
     cmake_dependent_option(HIPBLASLT_ENABLE_AMD_SMI "Require amd_smi." ON "NOT WIN32" OFF)
+    cmake_dependent_option(BUILD_FORTRAN_CLIENTS "Build hipBLASLt clients requiring Fortran capabilities" ON "NOT WIN32" OFF)
     option(HIPBLASLT_ENABLE_BLIS "Enable BLIS support." ON)
 endif()
 
@@ -134,10 +135,12 @@ else()
 endif()
 
 if(HIPBLASLT_ENABLE_CLIENT)
-    if (NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC})
-        set(CMAKE_Fortran_COMPILER  "gfortran")
+    if(BUILD_FORTRAN_CLIENTS)
+        if (NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC})
+            set(CMAKE_Fortran_COMPILER  "gfortran")
+        endif()
+        enable_language(Fortran)
     endif()
-    enable_language(Fortran)
 
     if(HIPBLASLT_ENABLE_BLIS)
         find_package(BLIS REQUIRED)


### PR DESCRIPTION
## Motivation

Add cmake variable BUILD_FORTRAN_CLIENTS to control building hipBLASLt Fortran-based clients. 
On non-Windows platforms this option is ON by default. On Windows it is disabled. This avoids forcing Fortran language configuration and prevents incorrect library names on Windows:

-- Installing: C:/hipSDK/lib/libhipblas.dll.a
-- Installing: C:/hipSDK/bin/libhipblas.dll
