### PR TITLE
[rocRoller] Augment resultType with valueCount

### DIFF
--- a/shared/rocroller/lib/include/rocRoller/CodeGen/BranchGenerator_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/CodeGen/BranchGenerator_impl.hpp
@@ -120,7 +120,8 @@ namespace rocRoller
         // Resolve DataFlowTags and evaluate exprs with translate time source operands.
         expr = dataFlowTagPropagation(expr, context);
 
-        auto [conditionRegisterType, conditionVariableType] = Expression::resultType(expr);
+        auto [conditionRegisterType, conditionVariableType, conditionValueCount]
+            = Expression::resultType(expr);
         return conditionVariableType == DataType::Bool ? context->getSCC() : context->getVCC();
     }
 }

--- a/shared/rocroller/lib/include/rocRoller/Expression.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Expression.hpp
@@ -857,10 +857,14 @@ namespace rocRoller
         Register::Type resultRegisterType(Expression const& expr);
         Register::Type resultRegisterType(ExpressionPtr const& expr);
 
+        size_t resultValueCount(Expression const& expr);
+        size_t resultValueCount(ExpressionPtr const& expr);
+
         struct ResultType
         {
             Register::Type regType;
             VariableType   varType;
+            size_t         valueCount;
             bool           operator==(ResultType const&) const = default;
         };
         ResultType resultType(ExpressionPtr const& expr);

--- a/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
@@ -203,7 +203,7 @@ namespace rocRoller
             else
             {
                 Throw<FatalError>("Each operand's value count in an expression must either "
-                                  "be 1 or equal to all other non-1 value counts",
+                                  "be 1 or equal to all other non-1 value counts\n",
                                   ShowValue(lhsValueCount),
                                   ShowValue(rhsValueCount));
             }
@@ -221,7 +221,7 @@ namespace rocRoller
                     else
                         AssertFatal(valueCount == operandValueCount,
                                     "Each operand's value count in an expression must either "
-                                    "be 1 or equal to all other non-1 value counts",
+                                    "be 1 or equal to all other non-1 value counts\n",
                                     ShowValue(valueCount),
                                     ShowValue(operandValueCount));
                 }
@@ -243,7 +243,7 @@ namespace rocRoller
                     else
                         AssertFatal(valueCount == operandValueCount,
                                     "Each operand's value count in an expression must either "
-                                    "be 1 or equal to all other non-1 value counts",
+                                    "be 1 or equal to all other non-1 value counts\n",
                                     ShowValue(valueCount),
                                     ShowValue(operandValueCount));
                 }

--- a/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
@@ -189,69 +189,6 @@ namespace rocRoller
             Throw<FatalError>("Invalid Register::Type combo: ", ShowValue(lhs), ShowValue(rhs));
         }
 
-        constexpr inline size_t broadcastValueCount(size_t lhsValueCount, size_t rhsValueCount)
-        {
-
-            if(lhsValueCount == rhsValueCount || rhsValueCount == 1)
-            {
-                return lhsValueCount;
-            }
-            else if(lhsValueCount == 1)
-            {
-                return rhsValueCount;
-            }
-            else
-            {
-                Throw<FatalError>("Each operand's value count in an expression must either "
-                                  "be 1 or equal to all other non-1 value counts\n",
-                                  ShowValue(lhsValueCount),
-                                  ShowValue(rhsValueCount));
-            }
-        }
-
-        inline size_t broadcastValueCount(std::vector<size_t> operandValueCounts)
-        {
-            size_t valueCount = 1;
-            for(auto operandValueCount : operandValueCounts)
-            {
-                if(operandValueCount != 1)
-                {
-                    if(valueCount == 1)
-                        valueCount = operandValueCount;
-                    else
-                        AssertFatal(valueCount == operandValueCount,
-                                    "Each operand's value count in an expression must either "
-                                    "be 1 or equal to all other non-1 value counts\n",
-                                    ShowValue(valueCount),
-                                    ShowValue(operandValueCount));
-                }
-            }
-
-            return valueCount;
-        }
-
-        inline size_t broadcastValueCount(std::vector<ValuePtr> operands)
-        {
-            size_t valueCount = 1;
-            for(auto operand : operands)
-            {
-                size_t operandValueCount = operand->valueCount();
-                if(operandValueCount != 1)
-                {
-                    if(valueCount == 1)
-                        valueCount = operandValueCount;
-                    else
-                        AssertFatal(valueCount == operandValueCount,
-                                    "Each operand's value count in an expression must either "
-                                    "be 1 or equal to all other non-1 value counts\n",
-                                    ShowValue(valueCount),
-                                    ShowValue(operandValueCount));
-                }
-            }
-
-            return valueCount;
-        }
-
         constexpr inline Type MapSPRTypeToGPRType(Type t)
         {
             switch(t)

--- a/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/InstructionValues/Register_impl.hpp
@@ -189,6 +189,69 @@ namespace rocRoller
             Throw<FatalError>("Invalid Register::Type combo: ", ShowValue(lhs), ShowValue(rhs));
         }
 
+        constexpr inline size_t broadcastValueCount(size_t lhsValueCount, size_t rhsValueCount)
+        {
+
+            if(lhsValueCount == rhsValueCount || rhsValueCount == 1)
+            {
+                return lhsValueCount;
+            }
+            else if(lhsValueCount == 1)
+            {
+                return rhsValueCount;
+            }
+            else
+            {
+                Throw<FatalError>("Each operand's value count in an expression must either "
+                                  "be 1 or equal to all other non-1 value counts",
+                                  ShowValue(lhsValueCount),
+                                  ShowValue(rhsValueCount));
+            }
+        }
+
+        inline size_t broadcastValueCount(std::vector<size_t> operandValueCounts)
+        {
+            size_t valueCount = 1;
+            for(auto operandValueCount : operandValueCounts)
+            {
+                if(operandValueCount != 1)
+                {
+                    if(valueCount == 1)
+                        valueCount = operandValueCount;
+                    else
+                        AssertFatal(valueCount == operandValueCount,
+                                    "Each operand's value count in an expression must either "
+                                    "be 1 or equal to all other non-1 value counts",
+                                    ShowValue(valueCount),
+                                    ShowValue(operandValueCount));
+                }
+            }
+
+            return valueCount;
+        }
+
+        inline size_t broadcastValueCount(std::vector<ValuePtr> operands)
+        {
+            size_t valueCount = 1;
+            for(auto operand : operands)
+            {
+                size_t operandValueCount = operand->valueCount();
+                if(operandValueCount != 1)
+                {
+                    if(valueCount == 1)
+                        valueCount = operandValueCount;
+                    else
+                        AssertFatal(valueCount == operandValueCount,
+                                    "Each operand's value count in an expression must either "
+                                    "be 1 or equal to all other non-1 value counts",
+                                    ShowValue(valueCount),
+                                    ShowValue(operandValueCount));
+                }
+            }
+
+            return valueCount;
+        }
+
         constexpr inline Type MapSPRTypeToGPRType(Type t)
         {
             switch(t)
@@ -615,7 +678,8 @@ namespace rocRoller
         {
             AssertFatal(canUseAsOperand(),
                         "Tried to use unallocated register value!",
-                        ShowValue(this->toString()));
+                        ShowValue(this->toString()),
+                        ShowValue(this->valueCount()));
         }
 
         inline void Value::specialString(std::ostream& os) const

--- a/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
+++ b/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
@@ -716,21 +716,13 @@ namespace rocRoller
             }
 
             Register::ValuePtr resultPlaceholder(ResultType const&    resType,
-                                                 bool                 allowSpecial = true,
-                                                 std::optional<float> packingRatio
-                                                 = std::nullopt) const
+                                                 bool                 allowSpecial = true) const
             {
-                // Calculate the register count of this result, starting with the value count of the result type
-                size_t count = resType.valueCount;
-                // Divide the value count by its packing to obtain the number of registers
-                count /= resType.varType.dataType == DataType::None
-                             ? 1
-                             : DataTypeInfo::Get(resType.varType).packing;
-                // If given a specific packing/unpacking ratio, multiply the value count by this ratio
-                if(packingRatio.has_value())
-                {
-                    count *= packingRatio.value();
-                }
+                // Obtain the register count by dividing the value count of the result type by its packing
+                size_t count = resType.valueCount
+                               / (resType.varType.dataType == DataType::None
+                                      ? 1
+                                      : DataTypeInfo::Get(resType.varType).packing);
 
                 if(Register::IsSpecial(resType.regType) && resType.varType == DataType::Bool)
                 {

--- a/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
+++ b/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
@@ -715,28 +715,37 @@ namespace rocRoller
                 return subset;
             }
 
-            Register::ValuePtr resultPlaceholder(ResultType const& resType,
-                                                 bool              allowSpecial = true,
-                                                 float             packingRatio = 1.f) const
+            Register::ValuePtr resultPlaceholder(ResultType const&    resType,
+                                                 bool                 allowSpecial = true,
+                                                 std::optional<float> packingRatio
+                                                 = std::nullopt) const
             {
-                auto packing = resType.varType.dataType == DataType::None
-                                   ? 1
-                                   : DataTypeInfo::Get(resType.varType).packing;
+                // Calculate the register count of this result
+                size_t count = resType.valueCount;
+                // If given a specific packing/unpacking ratio, multiply the value count by this ratio
+                if(packingRatio.has_value())
+                {
+                    count *= packingRatio.has_value();
+                }
+                // Otherwise, simply divide the value count by its packing
+                else
+                {
+                    auto packing = resType.varType.dataType == DataType::None
+                                       ? 1
+                                       : DataTypeInfo::Get(resType.varType).packing;
+                    count /= packing;
+                }
+
                 if(Register::IsSpecial(resType.regType) && resType.varType == DataType::Bool)
                 {
                     if(allowSpecial)
                         return m_context->getSCC();
                     else
-                        return Register::Value::Placeholder(m_context,
-                                                            Register::Type::Scalar,
-                                                            resType.varType,
-                                                            resType.valueCount * packingRatio
-                                                                / packing);
+                        return Register::Value::Placeholder(
+                            m_context, Register::Type::Scalar, resType.varType, count);
                 }
-                return Register::Value::Placeholder(m_context,
-                                                    resType.regType,
-                                                    resType.varType,
-                                                    resType.valueCount * packingRatio / packing);
+                return Register::Value::Placeholder(
+                    m_context, resType.regType, resType.varType, count);
             }
 
             /**

--- a/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
+++ b/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
@@ -720,12 +720,12 @@ namespace rocRoller
                                                  std::optional<float> packingRatio
                                                  = std::nullopt) const
             {
-                // Calculate the register count of this result
+                // Calculate the register count of this result, starting with the value count of the result type
                 size_t count = resType.valueCount;
                 // If given a specific packing/unpacking ratio, multiply the value count by this ratio
                 if(packingRatio.has_value())
                 {
-                    count *= packingRatio.has_value();
+                    count *= packingRatio.value();
                 }
                 // Otherwise, simply divide the value count by its packing
                 else

--- a/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
+++ b/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
@@ -715,8 +715,8 @@ namespace rocRoller
                 return subset;
             }
 
-            Register::ValuePtr resultPlaceholder(ResultType const&    resType,
-                                                 bool                 allowSpecial = true) const
+            Register::ValuePtr resultPlaceholder(ResultType const& resType,
+                                                 bool              allowSpecial = true) const
             {
                 // Obtain the register count by dividing the value count of the result type by its packing
                 size_t count = resType.valueCount

--- a/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
+++ b/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
@@ -716,8 +716,7 @@ namespace rocRoller
             }
 
             Register::ValuePtr resultPlaceholder(ResultType const& resType,
-                                                 bool              allowSpecial = true,
-                                                 int               valueCount   = 1) const
+                                                 bool              allowSpecial = true) const
             {
                 if(Register::IsSpecial(resType.regType) && resType.varType == DataType::Bool)
                 {
@@ -725,10 +724,10 @@ namespace rocRoller
                         return m_context->getSCC();
                     else
                         return Register::Value::Placeholder(
-                            m_context, Register::Type::Scalar, resType.varType, valueCount);
+                            m_context, Register::Type::Scalar, resType.varType, resType.valueCount);
                 }
                 return Register::Value::Placeholder(
-                    m_context, resType.regType, resType.varType, valueCount);
+                    m_context, resType.regType, resType.varType, resType.valueCount);
             }
 
             /**

--- a/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
+++ b/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
@@ -722,18 +722,14 @@ namespace rocRoller
             {
                 // Calculate the register count of this result, starting with the value count of the result type
                 size_t count = resType.valueCount;
+                // Divide the value count by its packing to obtain the number of registers
+                count /= resType.varType.dataType == DataType::None
+                             ? 1
+                             : DataTypeInfo::Get(resType.varType).packing;
                 // If given a specific packing/unpacking ratio, multiply the value count by this ratio
                 if(packingRatio.has_value())
                 {
                     count *= packingRatio.value();
-                }
-                // Otherwise, simply divide the value count by its packing
-                else
-                {
-                    auto packing = resType.varType.dataType == DataType::None
-                                       ? 1
-                                       : DataTypeInfo::Get(resType.varType).packing;
-                    count /= packing;
                 }
 
                 if(Register::IsSpecial(resType.regType) && resType.varType == DataType::Bool)

--- a/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
+++ b/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
@@ -719,6 +719,9 @@ namespace rocRoller
                                                  bool              allowSpecial = true,
                                                  float             packingRatio = 1.f) const
             {
+                auto packing = resType.varType.dataType == DataType::None
+                                   ? 1
+                                   : DataTypeInfo::Get(resType.varType).packing;
                 if(Register::IsSpecial(resType.regType) && resType.varType == DataType::Bool)
                 {
                     if(allowSpecial)
@@ -727,10 +730,13 @@ namespace rocRoller
                         return Register::Value::Placeholder(m_context,
                                                             Register::Type::Scalar,
                                                             resType.varType,
-                                                            resType.valueCount * packingRatio);
+                                                            resType.valueCount * packingRatio
+                                                                / packing);
                 }
-                return Register::Value::Placeholder(
-                    m_context, resType.regType, resType.varType, resType.valueCount * packingRatio);
+                return Register::Value::Placeholder(m_context,
+                                                    resType.regType,
+                                                    resType.varType,
+                                                    resType.valueCount * packingRatio / packing);
             }
 
             /**

--- a/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
+++ b/shared/rocroller/lib/source/CommonSubexpressionElim.cpp
@@ -716,18 +716,21 @@ namespace rocRoller
             }
 
             Register::ValuePtr resultPlaceholder(ResultType const& resType,
-                                                 bool              allowSpecial = true) const
+                                                 bool              allowSpecial = true,
+                                                 float             packingRatio = 1.f) const
             {
                 if(Register::IsSpecial(resType.regType) && resType.varType == DataType::Bool)
                 {
                     if(allowSpecial)
                         return m_context->getSCC();
                     else
-                        return Register::Value::Placeholder(
-                            m_context, Register::Type::Scalar, resType.varType, resType.valueCount);
+                        return Register::Value::Placeholder(m_context,
+                                                            Register::Type::Scalar,
+                                                            resType.varType,
+                                                            resType.valueCount * packingRatio);
                 }
                 return Register::Value::Placeholder(
-                    m_context, resType.regType, resType.varType, resType.valueCount);
+                    m_context, resType.regType, resType.varType, resType.valueCount * packingRatio);
             }
 
             /**

--- a/shared/rocroller/lib/source/Expression.cpp
+++ b/shared/rocroller/lib/source/Expression.cpp
@@ -630,7 +630,7 @@ namespace rocRoller
 
         std::string toString(ResultType const& obj)
         {
-            return concatenate("{", obj.regType, ", ", obj.varType, "}");
+            return concatenate("{", obj.regType, ", ", obj.varType, ", ", obj.valueCount, "}");
         }
 
         std::ostream& operator<<(std::ostream& stream, ExpressionPtr const& expr)

--- a/shared/rocroller/lib/source/ExpressionTransformations/PositionalArgumentPropagation.cpp
+++ b/shared/rocroller/lib/source/ExpressionTransformations/PositionalArgumentPropagation.cpp
@@ -75,7 +75,7 @@ namespace rocRoller
 
                 auto replacement = m_arguments[expr.slot];
 
-                auto [regType, varType] = resultType(replacement);
+                auto [regType, varType, valueCount] = resultType(replacement);
 
                 if(regType != expr.regType || varType != expr.varType)
                     Log::debug("Type mismatch for PositionalArgument({}):\n"

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -114,6 +114,9 @@ namespace rocRoller
                                                  bool              allowSpecial = true,
                                                  float             packingRatio = 1.f)
             {
+                auto packing = resType.varType.dataType == DataType::None
+                                   ? 1
+                                   : DataTypeInfo::Get(resType.varType).packing;
                 auto regType = resType.regType;
                 if(IsWriteableSpecial(regType))
                 {
@@ -125,7 +128,7 @@ namespace rocRoller
                 return Register::Value::Placeholder(m_context,
                                                     regType,
                                                     resType.varType,
-                                                    resType.valueCount * packingRatio,
+                                                    resType.valueCount * packingRatio / packing,
                                                     Register::AllocationOptions::FullyContiguous());
             }
 
@@ -448,7 +451,7 @@ namespace rocRoller
 
                     auto conversion = resultPlaceholder(resType, true);
 
-                    for(size_t k = 0; k < dest->valueCount(); ++k)
+                    for(size_t k = 0; k < resType.valueCount; ++k)
                     {
                         auto lhsVal = lhs->regType() == Register::Type::Literal
                                               || IsSpecial(lhs->regType()) || lhs->valueCount() == 1
@@ -774,7 +777,7 @@ namespace rocRoller
 
                 dest->setName(dest->name() + results[0]->name());
 
-                if(dest->valueCount() == 1 && results[0]->valueCount() == 1)
+                if(destType.valueCount == 1 && results[0]->valueCount() == 1)
                 {
                     co_yield generateOp<Operation>(dest, results[0], expr);
                 }

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -1,6 +1,7 @@
 // Copyright Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
+#include "rocRoller/Utilities/Error.hpp"
 #include <algorithm>
 #include <numeric>
 #include <queue>
@@ -110,7 +111,8 @@ namespace rocRoller
             using RegisterValue = std::variant<Register::ValuePtr>;
 
             Register::ValuePtr resultPlaceholder(ResultType const& resType,
-                                                 bool              allowSpecial = true)
+                                                 bool              allowSpecial = true,
+                                                 float             packingRatio = 1.f)
             {
                 auto regType = resType.regType;
                 if(IsWriteableSpecial(regType))
@@ -123,7 +125,7 @@ namespace rocRoller
                 return Register::Value::Placeholder(m_context,
                                                     regType,
                                                     resType.varType,
-                                                    resType.valueCount,
+                                                    resType.valueCount * packingRatio,
                                                     Register::AllocationOptions::FullyContiguous());
             }
 
@@ -364,7 +366,7 @@ namespace rocRoller
 
                 if(dest == nullptr)
                 {
-                    dest = resultPlaceholder(resType, true);
+                    dest = resultPlaceholder(resType, true, 1.f / destInfo.packing);
                 }
                 else
                 {
@@ -762,11 +764,11 @@ namespace rocRoller
                     if(isUnpacking)
                     {
                         // unpacking args into (multiple registers) dest
-                        dest = resultPlaceholder(destType, true);
+                        dest = resultPlaceholder(destType, true, packingRatio);
                     }
                     else
                     {
-                        dest = resultPlaceholder(destType, true);
+                        dest = resultPlaceholder(destType, true, 1.f / packingRatio);
                     }
                 }
 

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -110,13 +110,10 @@ namespace rocRoller
 
             using RegisterValue = std::variant<Register::ValuePtr>;
 
-            Register::ValuePtr resultPlaceholder(ResultType const& resType,
-                                                 bool              allowSpecial = true,
-                                                 float             packingRatio = 1.f)
+            Register::ValuePtr resultPlaceholder(ResultType const&    resType,
+                                                 bool                 allowSpecial = true,
+                                                 std::optional<float> packingRatio = std::nullopt)
             {
-                auto packing = resType.varType.dataType == DataType::None
-                                   ? 1
-                                   : DataTypeInfo::Get(resType.varType).packing;
                 auto regType = resType.regType;
                 if(IsWriteableSpecial(regType))
                 {
@@ -125,10 +122,26 @@ namespace rocRoller
                     regType = MapSPRTypeToGPRType(regType);
                 }
 
+                // Calculate the register count of this result
+                size_t count = resType.valueCount;
+                // If given a specific packing/unpacking ratio, multiply the value count by this ratio
+                if(packingRatio.has_value())
+                {
+                    count *= packingRatio.has_value();
+                }
+                // Otherwise, simply divide the value count by its packing
+                else
+                {
+                    auto packing = resType.varType.dataType == DataType::None
+                                       ? 1
+                                       : DataTypeInfo::Get(resType.varType).packing;
+                    count /= packing;
+                }
+
                 return Register::Value::Placeholder(m_context,
                                                     regType,
                                                     resType.varType,
-                                                    resType.valueCount * packingRatio / packing,
+                                                    count,
                                                     Register::AllocationOptions::FullyContiguous());
             }
 
@@ -348,7 +361,6 @@ namespace rocRoller
                 Register::ValuePtr& rhs,
                 ResultType&         resType)
             {
-
                 auto const lhsInfo  = DataTypeInfo::Get(lhs->variableType());
                 auto const rhsInfo  = DataTypeInfo::Get(rhs->variableType());
                 auto const destInfo = DataTypeInfo::Get(resType.varType);
@@ -369,7 +381,7 @@ namespace rocRoller
 
                 if(dest == nullptr)
                 {
-                    dest = resultPlaceholder(resType, true, 1.f / destInfo.packing);
+                    dest = resultPlaceholder(resType, true);
                 }
                 else
                 {

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -1,7 +1,6 @@
 // Copyright Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-#include "rocRoller/InstructionValues/Register_impl.hpp"
 #include <algorithm>
 #include <numeric>
 #include <queue>
@@ -592,20 +591,20 @@ namespace rocRoller
                 std::vector<ExpressionPtr>      subExprs{expr.lhs, expr.r1hs, expr.r2hs};
 
                 co_yield prepareSourceOperands(results, schedulerLockCount, subExprs);
-                auto regType    = promoteRegisterTypes(results);
-                auto valueCount = Register::broadcastValueCount(results);
+                auto resType = resultType(expr);
 
-                if(valueCount > 1 && regType == Register::Type::Accumulator)
+                if(resType.valueCount > 1 && resType.regType == Register::Type::Accumulator)
                 {
                     const auto& arch = m_context->targetArchitecture();
                     AssertFatal(arch.HasCapability(GPUCapability::HasAccCD),
                                 concatenate("Architecture",
                                             arch.target().toString(),
                                             "does not use Accumulator registers."));
-                    regType = Register::Type::Vector;
+                    resType.regType = Register::Type::Vector;
                     for(int i = 0; i < results.size(); ++i)
                     {
-                        co_yield m_context->copier()->ensureType(results[i], results[i], regType);
+                        co_yield m_context->copier()->ensureType(
+                            results[i], results[i], resType.regType);
                     }
                 }
 
@@ -613,10 +612,10 @@ namespace rocRoller
 
                 if(!dest)
                 {
-                    dest = resultPlaceholder({regType, varType, valueCount}, true);
+                    dest = resultPlaceholder(resType, true);
                 }
 
-                for(size_t k = 0; k < valueCount; ++k)
+                for(size_t k = 0; k < resType.valueCount; ++k)
                 {
                     auto lhsVal  = results[0]->regType() == Register::Type::Literal
                                           || results[0]->valueCount() == 1
@@ -649,27 +648,26 @@ namespace rocRoller
                 std::vector<ExpressionPtr>      subExprs{expr.lhs, expr.r1hs, expr.r2hs};
 
                 co_yield prepareSourceOperands(results, schedulerLockCount, subExprs);
-                auto regType    = promoteRegisterTypes(results);
-                auto valueCount = Register::broadcastValueCount(results);
+                auto resType = resultType(expr);
 
-                if(regType == Register::Type::Accumulator)
+                if(resType.regType == Register::Type::Accumulator)
                 {
                     const auto& arch = m_context->targetArchitecture();
                     AssertFatal(arch.HasCapability(GPUCapability::HasAccCD),
                                 concatenate("Architecture",
                                             arch.target().toString(),
                                             "does not use Accumulator registers."));
-                    regType = Register::Type::Vector;
+                    resType.regType = Register::Type::Vector;
                     for(int i = 0; i < results.size(); ++i)
                     {
-                        co_yield m_context->copier()->ensureType(results[i], results[i], regType);
+                        co_yield m_context->copier()->ensureType(
+                            results[i], results[i], resType.regType);
                     }
                 }
 
                 if(!dest)
                 {
-                    auto varType = promoteVariableTypes(results);
-                    dest         = resultPlaceholder({regType, varType, valueCount}, true);
+                    dest = resultPlaceholder(resType, true);
                 }
 
                 //If dest, results have multiple elements, handled inside generateOp
@@ -691,16 +689,14 @@ namespace rocRoller
                 co_yield prepareSourceOperands(results, schedulerLockCount, subExprs);
                 auto cond = results[0];
                 results.erase(results.begin());
-                auto regType    = promoteRegisterTypes(results);
-                auto valueCount = Register::broadcastValueCount(results);
+                auto resType = resultType(expr);
 
                 if(dest == nullptr)
                 {
-                    auto varType = promoteVariableTypes(results);
-                    dest         = resultPlaceholder({regType, varType, valueCount}, true);
+                    dest = resultPlaceholder(resType, true);
                 }
 
-                for(size_t k = 0; k < valueCount; ++k)
+                for(size_t k = 0; k < resType.valueCount; ++k)
                 {
                     auto lhs    = results[0];
                     auto rhs    = results[1];
@@ -801,7 +797,7 @@ namespace rocRoller
                     }
                     else
                     {
-                        for(size_t i = 0; i < dest->valueCount(); i++)
+                        for(size_t i = 0; i < destType.valueCount; i++)
                         {
                             Register::ValuePtr arg;
                             if(argInfo.packing < destInfo.packing)

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -122,12 +122,12 @@ namespace rocRoller
                     regType = MapSPRTypeToGPRType(regType);
                 }
 
-                // Calculate the register count of this result
+                // Calculate the register count of this result, starting with the value count of the result type
                 size_t count = resType.valueCount;
                 // If given a specific packing/unpacking ratio, multiply the value count by this ratio
                 if(packingRatio.has_value())
                 {
-                    count *= packingRatio.has_value();
+                    count *= packingRatio.value();
                 }
                 // Otherwise, simply divide the value count by its packing
                 else
@@ -142,6 +142,26 @@ namespace rocRoller
                                                     regType,
                                                     resType.varType,
                                                     count,
+                                                    Register::AllocationOptions::FullyContiguous());
+            }
+
+            // A special case of resultPlaceholder, for use when the value count in resType should be ignored
+            // and the placeholder should be created with a count of one
+            Register::ValuePtr resultPlaceholderCountOne(ResultType const& resType,
+                                                         bool              allowSpecial = true)
+            {
+                auto regType = resType.regType;
+                if(IsWriteableSpecial(regType))
+                {
+                    if(allowSpecial)
+                        return m_context->getSpecial(regType);
+                    regType = MapSPRTypeToGPRType(regType);
+                }
+
+                return Register::Value::Placeholder(m_context,
+                                                    regType,
+                                                    resType.varType,
+                                                    1,
                                                     Register::AllocationOptions::FullyContiguous());
             }
 
@@ -418,7 +438,7 @@ namespace rocRoller
                     int packingRatio = std::max(lhsInfo.packing, rhsInfo.packing)
                                        / std::min(lhsInfo.packing, rhsInfo.packing);
 
-                    auto conversion = resultPlaceholder(resType, true);
+                    auto conversion = resultPlaceholder(resType, true, packingRatio);
 
                     for(size_t i = 0; i < resType.valueCount; i += packingRatio)
                     {
@@ -461,7 +481,7 @@ namespace rocRoller
                                     || rhs->variableType() == resType.varType,
                                 "Only one floating point argument can be converted");
 
-                    auto conversion = resultPlaceholder(resType, true);
+                    auto conversion = resultPlaceholderCountOne(resType, true);
 
                     for(size_t k = 0; k < resType.valueCount; ++k)
                     {

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -1,7 +1,5 @@
 // Copyright Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
-
-#include "rocRoller/Utilities/Error.hpp"
 #include <algorithm>
 #include <numeric>
 #include <queue>
@@ -137,8 +135,8 @@ namespace rocRoller
             // A special case of resultPlaceholder, for use when the value count in resType should be ignored
             // and the placeholder should be created with a given count
             Register::ValuePtr resultPlaceholderWithCount(ResultType const& resType,
-                                                         size_t            count,
-                                                         bool              allowSpecial = true)
+                                                          size_t            count,
+                                                          bool              allowSpecial = true)
             {
                 auto regType = resType.regType;
                 if(IsWriteableSpecial(regType))
@@ -473,7 +471,7 @@ namespace rocRoller
 
                     auto conversion = resultPlaceholderWithCount(resType, 1, true);
 
-                    for(size_t k = 0; k < resType.valueCount; ++k)
+                    for(size_t k = 0; k < dest->valueCount(); ++k)
                     {
                         auto lhsVal = lhs->regType() == Register::Type::Literal
                                               || IsSpecial(lhs->regType()) || lhs->valueCount() == 1
@@ -789,11 +787,13 @@ namespace rocRoller
                     if(isUnpacking)
                     {
                         // unpacking args into (multiple registers) dest
-                        dest = resultPlaceholderWithCount(destType, results[0]->valueCount() * packingRatio, true);
+                        dest = resultPlaceholderWithCount(
+                            destType, results[0]->valueCount() * packingRatio, true);
                     }
                     else
                     {
-                        dest = resultPlaceholderWithCount(destType, results[0]->valueCount() / packingRatio, true);
+                        dest = resultPlaceholderWithCount(
+                            destType, results[0]->valueCount() / packingRatio, true);
                     }
                 }
 
@@ -824,7 +824,7 @@ namespace rocRoller
                     }
                     else
                     {
-                        for(size_t i = 0; i < destType.valueCount; i++)
+                        for(size_t i = 0; i < dest->valueCount(); i++)
                         {
                             Register::ValuePtr arg;
                             if(argInfo.packing < destInfo.packing)

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -124,18 +124,14 @@ namespace rocRoller
 
                 // Calculate the register count of this result, starting with the value count of the result type
                 size_t count = resType.valueCount;
+                // Divide the value count by its packing to obtain the number of registers
+                count /= resType.varType.dataType == DataType::None
+                             ? 1
+                             : DataTypeInfo::Get(resType.varType).packing;
                 // If given a specific packing/unpacking ratio, multiply the value count by this ratio
                 if(packingRatio.has_value())
                 {
                     count *= packingRatio.value();
-                }
-                // Otherwise, simply divide the value count by its packing
-                else
-                {
-                    auto packing = resType.varType.dataType == DataType::None
-                                       ? 1
-                                       : DataTypeInfo::Get(resType.varType).packing;
-                    count /= packing;
                 }
 
                 return Register::Value::Placeholder(m_context,

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -110,9 +110,8 @@ namespace rocRoller
 
             using RegisterValue = std::variant<Register::ValuePtr>;
 
-            Register::ValuePtr resultPlaceholder(ResultType const&    resType,
-                                                 bool                 allowSpecial = true,
-                                                 std::optional<float> packingRatio = std::nullopt)
+            Register::ValuePtr resultPlaceholder(ResultType const& resType,
+                                                 bool              allowSpecial = true)
             {
                 auto regType = resType.regType;
                 if(IsWriteableSpecial(regType))
@@ -122,17 +121,11 @@ namespace rocRoller
                     regType = MapSPRTypeToGPRType(regType);
                 }
 
-                // Calculate the register count of this result, starting with the value count of the result type
-                size_t count = resType.valueCount;
-                // Divide the value count by its packing to obtain the number of registers
-                count /= resType.varType.dataType == DataType::None
-                             ? 1
-                             : DataTypeInfo::Get(resType.varType).packing;
-                // If given a specific packing/unpacking ratio, multiply the value count by this ratio
-                if(packingRatio.has_value())
-                {
-                    count *= packingRatio.value();
-                }
+                // Obtain the register count by dividing the value count of the result type by its packing
+                size_t count = resType.valueCount
+                               / (resType.varType.dataType == DataType::None
+                                      ? 1
+                                      : DataTypeInfo::Get(resType.varType).packing);
 
                 return Register::Value::Placeholder(m_context,
                                                     regType,
@@ -142,8 +135,9 @@ namespace rocRoller
             }
 
             // A special case of resultPlaceholder, for use when the value count in resType should be ignored
-            // and the placeholder should be created with a count of one
-            Register::ValuePtr resultPlaceholderCountOne(ResultType const& resType,
+            // and the placeholder should be created with a given count
+            Register::ValuePtr resultPlaceholderWithCount(ResultType const& resType,
+                                                         size_t            count,
                                                          bool              allowSpecial = true)
             {
                 auto regType = resType.regType;
@@ -157,7 +151,7 @@ namespace rocRoller
                 return Register::Value::Placeholder(m_context,
                                                     regType,
                                                     resType.varType,
-                                                    1,
+                                                    count,
                                                     Register::AllocationOptions::FullyContiguous());
             }
 
@@ -434,7 +428,7 @@ namespace rocRoller
                     int packingRatio = std::max(lhsInfo.packing, rhsInfo.packing)
                                        / std::min(lhsInfo.packing, rhsInfo.packing);
 
-                    auto conversion = resultPlaceholder(resType, true, packingRatio);
+                    auto conversion = resultPlaceholderWithCount(resType, packingRatio, true);
 
                     for(size_t i = 0; i < resType.valueCount; i += packingRatio)
                     {
@@ -477,7 +471,7 @@ namespace rocRoller
                                     || rhs->variableType() == resType.varType,
                                 "Only one floating point argument can be converted");
 
-                    auto conversion = resultPlaceholderCountOne(resType, true);
+                    auto conversion = resultPlaceholderWithCount(resType, 1, true);
 
                     for(size_t k = 0; k < resType.valueCount; ++k)
                     {
@@ -564,7 +558,7 @@ namespace rocRoller
                 co_yield prepareSourceOperands(results, schedulerLockCount, subExprs);
 
                 // Convert one value at a time
-                dest = resultPlaceholder(resultType(expr), true);
+                dest = resultPlaceholderWithCount(resultType(expr), results[0]->valueCount(), true);
 
                 // Assume the seed is a single scalar value. Consider allowing a
                 // vector of seeds?
@@ -795,11 +789,11 @@ namespace rocRoller
                     if(isUnpacking)
                     {
                         // unpacking args into (multiple registers) dest
-                        dest = resultPlaceholder(destType, true, packingRatio);
+                        dest = resultPlaceholderWithCount(destType, results[0]->valueCount() * packingRatio, true);
                     }
                     else
                     {
-                        dest = resultPlaceholder(destType, true, 1.f / packingRatio);
+                        dest = resultPlaceholderWithCount(destType, results[0]->valueCount() / packingRatio, true);
                     }
                 }
 

--- a/shared/rocroller/lib/source/Expression_generate.cpp
+++ b/shared/rocroller/lib/source/Expression_generate.cpp
@@ -1,6 +1,7 @@
 // Copyright Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
+#include "rocRoller/InstructionValues/Register_impl.hpp"
 #include <algorithm>
 #include <numeric>
 #include <queue>
@@ -110,8 +111,7 @@ namespace rocRoller
             using RegisterValue = std::variant<Register::ValuePtr>;
 
             Register::ValuePtr resultPlaceholder(ResultType const& resType,
-                                                 bool              allowSpecial = true,
-                                                 int               valueCount   = 1)
+                                                 bool              allowSpecial = true)
             {
                 auto regType = resType.regType;
                 if(IsWriteableSpecial(regType))
@@ -124,25 +124,8 @@ namespace rocRoller
                 return Register::Value::Placeholder(m_context,
                                                     regType,
                                                     resType.varType,
-                                                    valueCount,
+                                                    resType.valueCount,
                                                     Register::AllocationOptions::FullyContiguous());
-            }
-
-            int resultValueCount(Register::ValuePtr const&              dest,
-                                 std::vector<Register::ValuePtr> const& operands)
-
-            {
-                if(dest)
-                {
-                    return dest->valueCount();
-                }
-
-                std::vector<int> count;
-                std::transform(
-                    operands.cbegin(), operands.cend(), std::back_inserter(count), [](auto x) {
-                        return x->valueCount() * DataTypeInfo::Get(x->variableType()).packing;
-                    });
-                return *std::max_element(count.cbegin(), count.cend());
             }
 
             Register::Type promoteRegisterTypes(std::vector<Register::ValuePtr> const& regs)
@@ -322,14 +305,12 @@ namespace rocRoller
                 auto const lhsInfo = DataTypeInfo::Get(lhs->variableType());
                 auto const rhsInfo = DataTypeInfo::Get(rhs->variableType());
 
-                int valueCount = resultValueCount(dest, {lhs, rhs});
-
                 if(!dest)
                 {
-                    dest = resultPlaceholder(resType, true, valueCount);
+                    dest = resultPlaceholder(resType, true);
                 }
 
-                for(size_t k = 0; k < dest->valueCount(); ++k)
+                for(size_t k = 0; k < resType.valueCount; ++k)
                 {
                     // TODD: Consolidate with other similar code
                     // that only calls `->element` if conditions are met
@@ -368,11 +349,9 @@ namespace rocRoller
                 auto const rhsInfo  = DataTypeInfo::Get(rhs->variableType());
                 auto const destInfo = DataTypeInfo::Get(resType.varType);
 
-                int valueCount = resultValueCount(dest, {lhs, rhs});
-
                 // TODO: Should this be pushed to arithmetic generators?
                 // If any sources were AGPRs, copy to VGPRs first.
-                if(valueCount > 1 && resType.regType == Register::Type::Accumulator)
+                if(resType.valueCount > 1 && resType.regType == Register::Type::Accumulator)
                 {
                     const auto& arch = m_context->targetArchitecture();
                     AssertFatal(arch.HasCapability(GPUCapability::HasAccCD),
@@ -386,7 +365,7 @@ namespace rocRoller
 
                 if(dest == nullptr)
                 {
-                    dest = resultPlaceholder(resType, true, valueCount / destInfo.packing);
+                    dest = resultPlaceholder(resType, true);
                 }
                 else
                 {
@@ -423,9 +402,9 @@ namespace rocRoller
                     int packingRatio = std::max(lhsInfo.packing, rhsInfo.packing)
                                        / std::min(lhsInfo.packing, rhsInfo.packing);
 
-                    auto conversion = resultPlaceholder(resType, true, packingRatio);
+                    auto conversion = resultPlaceholder(resType, true);
 
-                    for(size_t i = 0; i < valueCount; i += packingRatio)
+                    for(size_t i = 0; i < resType.valueCount; i += packingRatio)
                     {
                         Register::ValuePtr lhsVal, rhsVal;
                         if(lhsInfo.packing < rhsInfo.packing)
@@ -466,7 +445,7 @@ namespace rocRoller
                                     || rhs->variableType() == resType.varType,
                                 "Only one floating point argument can be converted");
 
-                    auto conversion = resultPlaceholder(resType, true, 1);
+                    auto conversion = resultPlaceholder(resType, true);
 
                     for(size_t k = 0; k < dest->valueCount(); ++k)
                     {
@@ -553,7 +532,7 @@ namespace rocRoller
                 co_yield prepareSourceOperands(results, schedulerLockCount, subExprs);
 
                 // Convert one value at a time
-                dest = resultPlaceholder(resultType(expr), true, results[0]->valueCount());
+                dest = resultPlaceholder(resultType(expr), true);
 
                 // Assume the seed is a single scalar value. Consider allowing a
                 // vector of seeds?
@@ -614,7 +593,7 @@ namespace rocRoller
 
                 co_yield prepareSourceOperands(results, schedulerLockCount, subExprs);
                 auto regType    = promoteRegisterTypes(results);
-                auto valueCount = resultValueCount(dest, results);
+                auto valueCount = Register::broadcastValueCount(results);
 
                 if(valueCount > 1 && regType == Register::Type::Accumulator)
                 {
@@ -634,7 +613,7 @@ namespace rocRoller
 
                 if(!dest)
                 {
-                    dest = resultPlaceholder({regType, varType}, true, valueCount);
+                    dest = resultPlaceholder({regType, varType, valueCount}, true);
                 }
 
                 for(size_t k = 0; k < valueCount; ++k)
@@ -671,9 +650,9 @@ namespace rocRoller
 
                 co_yield prepareSourceOperands(results, schedulerLockCount, subExprs);
                 auto regType    = promoteRegisterTypes(results);
-                auto valueCount = resultValueCount(dest, results);
+                auto valueCount = Register::broadcastValueCount(results);
 
-                if(valueCount > 1 && regType == Register::Type::Accumulator)
+                if(regType == Register::Type::Accumulator)
                 {
                     const auto& arch = m_context->targetArchitecture();
                     AssertFatal(arch.HasCapability(GPUCapability::HasAccCD),
@@ -690,7 +669,7 @@ namespace rocRoller
                 if(!dest)
                 {
                     auto varType = promoteVariableTypes(results);
-                    dest         = resultPlaceholder({regType, varType}, true, valueCount);
+                    dest         = resultPlaceholder({regType, varType, valueCount}, true);
                 }
 
                 //If dest, results have multiple elements, handled inside generateOp
@@ -713,12 +692,12 @@ namespace rocRoller
                 auto cond = results[0];
                 results.erase(results.begin());
                 auto regType    = promoteRegisterTypes(results);
-                auto valueCount = resultValueCount(dest, results);
+                auto valueCount = Register::broadcastValueCount(results);
 
                 if(dest == nullptr)
                 {
                     auto varType = promoteVariableTypes(results);
-                    dest         = resultPlaceholder({regType, varType}, true, valueCount);
+                    dest         = resultPlaceholder({regType, varType, valueCount}, true);
                 }
 
                 for(size_t k = 0; k < valueCount; ++k)
@@ -787,13 +766,11 @@ namespace rocRoller
                     if(isUnpacking)
                     {
                         // unpacking args into (multiple registers) dest
-                        dest = resultPlaceholder(
-                            destType, true, results[0]->valueCount() * packingRatio);
+                        dest = resultPlaceholder(destType, true);
                     }
                     else
                     {
-                        dest = resultPlaceholder(
-                            destType, true, results[0]->valueCount() / packingRatio);
+                        dest = resultPlaceholder(destType, true);
                     }
                 }
 

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -118,10 +118,11 @@ namespace rocRoller
             {
                 auto lhsVal  = call(expr.lhs);
                 auto r1hsVal = call(expr.r1hs);
+                auto r2hsVal = call(expr.r2hs);
 
                 auto regType    = Register::PromoteType(lhsVal.regType, r1hsVal.regType);
                 auto varType    = VariableType::Promote(lhsVal.varType, r1hsVal.varType);
-                auto valueCount = broadcastValueCount({lhsVal, r1hsVal});
+                auto valueCount = broadcastValueCount({lhsVal, r1hsVal, r2hsVal});
 
                 return {regType, varType, valueCount};
             }
@@ -129,13 +130,29 @@ namespace rocRoller
             ResultType operator()(ShiftLAdd const& expr)
             {
                 auto lhsVal  = call(expr.lhs);
+                auto r1hsVal = call(expr.r1hs);
                 auto r2hsVal = call(expr.r2hs);
 
                 auto regType    = Register::PromoteType(lhsVal.regType, r2hsVal.regType);
                 auto varType    = VariableType::Promote(lhsVal.varType, r2hsVal.varType);
-                auto valueCount = broadcastValueCount({lhsVal, r2hsVal});
+                auto valueCount = broadcastValueCount({lhsVal, r1hsVal, r2hsVal});
 
                 return {regType, varType, valueCount};
+            }
+
+            ResultType operator()(MatrixMultiply const& expr)
+            {
+                auto matAVal = call(expr.lhs);
+                auto matBVal = call(expr.r1hs);
+                auto matCVal = call(expr.r2hs);
+
+                auto regType = Register::PromoteType(matAVal.regType, matBVal.regType);
+                regType      = Register::PromoteType(regType, matCVal.regType);
+
+                auto varType = VariableType::Promote(matAVal.varType, matBVal.varType);
+                varType      = VariableType::Promote(varType, matCVal.varType);
+
+                return {regType, varType, matCVal.valueCount};
             }
 
             ResultType operator()(ScaledMatrixMultiply const& expr)
@@ -150,9 +167,7 @@ namespace rocRoller
                 auto varType = VariableType::Promote(matAVal.varType, matBVal.varType);
                 varType      = VariableType::Promote(varType, matCVal.varType);
 
-                size_t valueCount = broadcastValueCount({matAVal, matBVal, matCVal});
-
-                return {regType, varType, valueCount};
+                return {regType, varType, matCVal.valueCount};
             }
 
             template <typename T>
@@ -383,7 +398,8 @@ namespace rocRoller
                     actualNumRegister
                         = actualNumRegister + DataTypeInfo::Get(operandVariableType).registerCount;
 
-                    operandValueCount *= DataTypeInfo::Get(operandVariableType).packing;
+                    if(operandVariableType.dataType != DataType::None)
+                        operandValueCount *= DataTypeInfo::Get(operandVariableType).packing;
                     if(operandValueCount != 1)
                     {
                         // Each value count of an operand in an expression

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -26,39 +26,32 @@ namespace rocRoller
 {
     namespace Expression
     {
-        // This function takes in an old value count and a new value count and either returns the old or the new.
+        // This function determines the value count of an expression
+        // based on the value counts of its operands.
         // Note that the value count of each operand in an expression must either be 1
         // or equal to all other non-1 value counts in the expression.
         // For example:
-        //     oldValueCount = 1, newValueCount = 1: Valid, return 1
-        //     oldValueCount = 1, newValueCount = 16: Valid, return 16
-        //     oldValueCount = 8, newValueCount = 1: Valid, return 8
-        //     oldValueCount = 4, newValueCount = 4: Valid, return 4
-        //     oldValueCount = 4, newValueCount = 2: INVALID
-        inline size_t maybeReplaceValueCount(size_t oldValueCount, size_t newValueCount)
-        {
-            if(newValueCount != 1)
-            {
-                if(oldValueCount == 1)
-                    return newValueCount;
-                else
-                    AssertFatal(oldValueCount == newValueCount,
-                                "Each operand's value count in an expression must either "
-                                "be 1 or equal to all other non-1 value counts\n",
-                                ShowValue(oldValueCount),
-                                ShowValue(newValueCount));
-            }
-
-            return oldValueCount;
-        }
-
+        //     lhs.valueCount = 1, rhs.valueCount = 1: Valid, return 1
+        //     lhs.valueCount = 1, rhs.valueCount = 16: Valid, return 16
+        //     lhs.valueCount = 8, rhs.valueCount = 1: Valid, return 8
+        //     lhs.valueCount = 4, rhs.valueCount = 4: Valid, return 4
+        //     lhs.valueCount = 4, rhs.valueCount = 2: INVALID
         inline size_t broadcastValueCount(std::vector<ResultType> operands)
         {
             size_t valueCount = 1;
             for(auto operand : operands)
             {
-                // Decide if we should update our value count based on the value count of this operand
-                valueCount = maybeReplaceValueCount(valueCount, operand.valueCount);
+                if(operand.valueCount != 1)
+                {
+                    if(valueCount == 1)
+                        return valueCount = operand.valueCount;
+                    else
+                        AssertFatal(valueCount == operand.valueCount,
+                                    "Each operand's value count in an expression must either "
+                                    "be 1 or equal to all other non-1 value counts\n",
+                                    ShowValue(valueCount),
+                                    ShowValue(operand.valueCount));
+                }
             }
 
             return valueCount;
@@ -410,8 +403,9 @@ namespace rocRoller
                     actualNumRegister
                         = actualNumRegister + DataTypeInfo::Get(operandVariableType).registerCount;
 
-                    // Decide if we should update our value count based on the value count of this operand
-                    valueCount = maybeReplaceValueCount(valueCount, operandValueCount);
+                    AssertFatal(operandValueCount == 1,
+                                "All operands to Concatenate must have value count 1",
+                                ShowValue(operandValueCount));
                 }
 
                 AssertFatal(expectedNumRegister == actualNumRegister,

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -26,22 +26,39 @@ namespace rocRoller
 {
     namespace Expression
     {
+        // This function takes in an old value count and a new value count and either returns the old or the new.
+        // Note that the value count of each operand in an expression must either be 1
+        // or equal to all other non-1 value counts in the expression.
+        // For example:
+        //     oldValueCount = 1, newValueCount = 1: Valid, return 1
+        //     oldValueCount = 1, newValueCount = 16: Valid, return 16
+        //     oldValueCount = 8, newValueCount = 1: Valid, return 8
+        //     oldValueCount = 4, newValueCount = 4: Valid, return 4
+        //     oldValueCount = 4, newValueCount = 2: INVALID
+        inline bool maybeReplaceValueCount(size_t oldValueCount, size_t newValueCount)
+        {
+            if(newValueCount != 1)
+            {
+                if(oldValueCount == 1)
+                    return newValueCount;
+                else
+                    AssertFatal(oldValueCount == newValueCount,
+                                "Each operand's value count in an expression must either "
+                                "be 1 or equal to all other non-1 value counts\n",
+                                ShowValue(oldValueCount),
+                                ShowValue(newValueCount));
+            }
+
+            return oldValueCount;
+        }
+
         inline size_t broadcastValueCount(std::vector<ResultType> operands)
         {
             size_t valueCount = 1;
             for(auto operand : operands)
             {
-                if(operand.valueCount != 1)
-                {
-                    if(valueCount == 1)
-                        valueCount = operand.valueCount;
-                    else
-                        AssertFatal(valueCount == operand.valueCount,
-                                    "Each operand's value count in an expression must either "
-                                    "be 1 or equal to all other non-1 value counts\n",
-                                    ShowValue(valueCount),
-                                    ShowValue(operand.valueCount));
-                }
+                // Decide if we should update our value count based on the value count of this operand
+                valueCount = maybeReplaceValueCount(valueCount, operand.valueCount);
             }
 
             return valueCount;
@@ -393,19 +410,8 @@ namespace rocRoller
                     actualNumRegister
                         = actualNumRegister + DataTypeInfo::Get(operandVariableType).registerCount;
 
-                    if(operandValueCount != 1)
-                    {
-                        // Each value count of an operand in an expression
-                        // must either be 1 or equal to all other non-1 value counts
-                        if(valueCount == 1)
-                            valueCount = operandValueCount;
-                        else
-                            AssertFatal(valueCount == operandValueCount,
-                                        "Each operand's value count in an expression must either "
-                                        "be 1 or equal to all other non-1 value counts",
-                                        ShowValue(valueCount),
-                                        ShowValue(operandValueCount));
-                    }
+                    // Decide if we should update our value count based on the value count of this operand
+                    valueCount = maybeReplaceValueCount(valueCount, operandValueCount);
                 }
 
                 AssertFatal(expectedNumRegister == actualNumRegister,

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -35,7 +35,7 @@ namespace rocRoller
         //     oldValueCount = 8, newValueCount = 1: Valid, return 8
         //     oldValueCount = 4, newValueCount = 4: Valid, return 4
         //     oldValueCount = 4, newValueCount = 2: INVALID
-        inline bool maybeReplaceValueCount(size_t oldValueCount, size_t newValueCount)
+        inline size_t maybeReplaceValueCount(size_t oldValueCount, size_t newValueCount)
         {
             if(newValueCount != 1)
             {

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -31,20 +31,19 @@ namespace rocRoller
             size_t valueCount = 1;
             for(auto operand : operands)
             {
-                size_t operandPacking    = operand.varType.dataType == DataType::None
-                                               ? 1
-                                               : DataTypeInfo::Get(operand.varType).packing;
-                size_t operandValueCount = operand.valueCount * operandPacking;
-                if(operandValueCount != 1)
+                size_t operandPacking = operand.varType.dataType == DataType::None
+                                            ? 1
+                                            : DataTypeInfo::Get(operand.varType).packing;
+                if(operand.valueCount != 1)
                 {
                     if(valueCount == 1)
-                        valueCount = operandValueCount;
+                        valueCount = operand.valueCount;
                     else
-                        AssertFatal(valueCount == operandValueCount,
+                        AssertFatal(valueCount == operand.valueCount,
                                     "Each operand's value count in an expression must either "
                                     "be 1 or equal to all other non-1 value counts\n",
                                     ShowValue(valueCount),
-                                    ShowValue(operandValueCount),
+                                    ShowValue(operand.valueCount),
                                     ShowValue(operandPacking));
                 }
             }
@@ -428,7 +427,10 @@ namespace rocRoller
                 if(expr == nullptr)
                     return {Register::Type::Count, DataType::Count, 0};
 
-                return {Register::Type::Literal, expr->variableType(), 1};
+                auto packing = expr->variableType().dataType == DataType::None
+                                   ? 1
+                                   : DataTypeInfo::Get(expr->variableType()).packing;
+                return {Register::Type::Literal, expr->variableType(), packing};
             }
 
             ResultType operator()(AssemblyKernelArgumentPtr const& expr)
@@ -436,12 +438,18 @@ namespace rocRoller
                 if(expr == nullptr)
                     return {Register::Type::Count, DataType::Count, 0};
 
-                return {Register::Type::Scalar, expr->getVariableType(), 1};
+                auto packing = expr->getVariableType().dataType == DataType::None
+                                   ? 1
+                                   : DataTypeInfo::Get(expr->getVariableType()).packing;
+                return {Register::Type::Scalar, expr->getVariableType(), packing};
             }
 
             ResultType operator()(CommandArgumentValue const& expr)
             {
-                return {Register::Type::Literal, variableType(expr), 1};
+                auto packing = variableType(expr).dataType == DataType::None
+                                   ? 1
+                                   : DataTypeInfo::Get(variableType(expr)).packing;
+                return {Register::Type::Literal, variableType(expr), packing};
             }
 
             ResultType operator()(Register::ValuePtr const& expr)
@@ -449,18 +457,27 @@ namespace rocRoller
                 if(expr == nullptr)
                     return {Register::Type::Count, DataType::Count, 0};
 
-                m_context = expr->context();
-                return {expr->regType(), expr->variableType(), expr->valueCount()};
+                m_context    = expr->context();
+                auto packing = expr->variableType().dataType == DataType::None
+                                   ? 1
+                                   : DataTypeInfo::Get(expr->variableType()).packing;
+                return {expr->regType(), expr->variableType(), expr->valueCount() * packing};
             }
 
             ResultType operator()(DataFlowTag const& expr)
             {
-                return {expr.regType, expr.varType, 1};
+                auto packing = expr.varType.dataType == DataType::None
+                                   ? 1
+                                   : DataTypeInfo::Get(expr.varType).packing;
+                return {expr.regType, expr.varType, packing};
             }
 
             ResultType operator()(PositionalArgument const& expr)
             {
-                return {expr.regType, expr.varType, 1};
+                auto packing = expr.varType.dataType == DataType::None
+                                   ? 1
+                                   : DataTypeInfo::Get(expr.varType).packing;
+                return {expr.regType, expr.varType, packing};
             }
 
             ResultType operator()(WaveTilePtr const& expr)

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -1,6 +1,8 @@
 // Copyright Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
+#include "rocRoller/InstructionValues/Register_impl.hpp"
+#include "rocRoller/Utilities/Error.hpp"
 #include <variant>
 
 #include <rocRoller/DataTypes/DataTypes.hpp>
@@ -65,7 +67,10 @@ namespace rocRoller
                     varType = VariableType::Promote(lhsVal.varType, rhsVal.varType);
                 }
 
-                return {regType, varType};
+                auto valueCount
+                    = Register::broadcastValueCount(lhsVal.valueCount, rhsVal.valueCount);
+
+                return {regType, varType, valueCount};
             }
 
             template <typename T>
@@ -81,7 +86,10 @@ namespace rocRoller
                 auto varType = VariableType::Promote(lhsVal.varType, r1hsVal.varType);
                 varType      = VariableType::Promote(varType, r2hsVal.varType);
 
-                return {regType, varType};
+                size_t valueCount = Register::broadcastValueCount(
+                    {lhsVal.valueCount, r1hsVal.valueCount, r2hsVal.valueCount});
+
+                return {regType, varType, valueCount};
             }
 
             ResultType operator()(AddShiftL const& expr)
@@ -91,8 +99,10 @@ namespace rocRoller
 
                 auto regType = Register::PromoteType(lhsVal.regType, r1hsVal.regType);
                 auto varType = VariableType::Promote(lhsVal.varType, r1hsVal.varType);
+                auto valueCount
+                    = Register::broadcastValueCount(lhsVal.valueCount, r1hsVal.valueCount);
 
-                return {regType, varType};
+                return {regType, varType, valueCount};
             }
 
             ResultType operator()(ShiftLAdd const& expr)
@@ -102,8 +112,10 @@ namespace rocRoller
 
                 auto regType = Register::PromoteType(lhsVal.regType, r2hsVal.regType);
                 auto varType = VariableType::Promote(lhsVal.varType, r2hsVal.varType);
+                auto valueCount
+                    = Register::broadcastValueCount(lhsVal.valueCount, r2hsVal.valueCount);
 
-                return {regType, varType};
+                return {regType, varType, valueCount};
             }
 
             ResultType operator()(ScaledMatrixMultiply const& expr)
@@ -118,7 +130,10 @@ namespace rocRoller
                 auto varType = VariableType::Promote(matAVal.varType, matBVal.varType);
                 varType      = VariableType::Promote(varType, matCVal.varType);
 
-                return {regType, varType};
+                size_t valueCount = Register::broadcastValueCount(
+                    {matAVal.valueCount, matBVal.valueCount, matCVal.valueCount});
+
+                return {regType, varType, valueCount};
             }
 
             template <typename T>
@@ -127,12 +142,12 @@ namespace rocRoller
                 auto argVal = call(expr.arg);
 
                 if constexpr(std::same_as<T, MagicShifts>)
-                    return {argVal.regType, DataType::Int32};
+                    return {argVal.regType, DataType::Int32, argVal.valueCount};
                 else if constexpr(std::same_as<T, MagicShiftAndSign>)
-                    return {argVal.regType, DataType::UInt32};
+                    return {argVal.regType, DataType::UInt32, argVal.valueCount};
 
                 if constexpr(std::same_as<T, ToScalar>)
-                    return {Register::Type::Scalar, argVal.varType};
+                    return {Register::Type::Scalar, argVal.varType, argVal.valueCount};
 
                 return argVal;
             }
@@ -140,13 +155,13 @@ namespace rocRoller
             ResultType operator()(Convert const& expr)
             {
                 auto argVal = call(expr.arg);
-                return {argVal.regType, expr.destinationType};
+                return {argVal.regType, expr.destinationType, argVal.valueCount};
             }
 
             ResultType operator()(Reinterpret const& expr)
             {
                 auto argVal = call(expr.arg);
-                return {argVal.regType, expr.destinationType};
+                return {argVal.regType, expr.destinationType, argVal.valueCount};
             }
 
             template <DataType DATATYPE>
@@ -155,13 +170,13 @@ namespace rocRoller
                 // SR conversion currently only supports FP8 and BF8
                 static_assert(DATATYPE == DataType::FP8 || DATATYPE == DataType::BF8);
                 auto argVal = call(expr.lhs);
-                return {argVal.regType, DATATYPE};
+                return {argVal.regType, DATATYPE, argVal.valueCount};
             }
 
             ResultType operator()(BitFieldExtract const& expr)
             {
                 auto argVal = call(expr.arg);
-                return {argVal.regType, expr.outputDataType};
+                return {argVal.regType, expr.outputDataType, argVal.valueCount};
             }
 
             template <typename T>
@@ -169,6 +184,9 @@ namespace rocRoller
             {
                 auto lhsVal = call(expr.lhs);
                 auto rhsVal = call(expr.rhs);
+
+                size_t valueCount
+                    = Register::broadcastValueCount(lhsVal.valueCount, rhsVal.valueCount);
 
                 // Can't compare between two different types on the GPU.
                 AssertFatal(lhsVal.regType == Register::Type::Literal
@@ -187,27 +205,27 @@ namespace rocRoller
                 {
                     auto varType = VariableType::Promote(lhsVal.varType, rhsVal.varType);
                     if(varType == DataType::None)
-                        return {inputRegType, DataType::None};
+                        return {inputRegType, DataType::None, valueCount};
                 }
 
                 switch(inputRegType)
                 {
                 case Register::Type::Literal:
-                    return {Register::Type::Literal, DataType::Bool};
+                    return {Register::Type::Literal, DataType::Bool, valueCount};
                 case Register::Type::Scalar:
-                    return {Register::Type::Scalar, DataType::Bool};
+                    return {Register::Type::Scalar, DataType::Bool, valueCount};
                 case Register::Type::Vector:
                     if(auto context = m_context.lock(); context)
                     {
                         if(context->kernel()->wavefront_size() == 32)
-                            return {Register::Type::Scalar, DataType::Bool32};
-                        return {Register::Type::Scalar, DataType::Bool64};
+                            return {Register::Type::Scalar, DataType::Bool32, valueCount};
+                        return {Register::Type::Scalar, DataType::Bool64, valueCount};
                     }
                     // If you are reading this, it probably means that this visitor
                     // was called on an expression with registers that didn't have
                     // a context.
                     // Throw<FatalError>("Need context to determine wavefront size", ShowValue(name(expr)));
-                    return {Register::Type::Scalar, DataType::None};
+                    return {Register::Type::Scalar, DataType::None, valueCount};
                 default:
                     break;
                 }
@@ -226,6 +244,9 @@ namespace rocRoller
 
             ResultType logical(ResultType lhsVal, ResultType rhsVal)
             {
+                size_t valueCount
+                    = Register::broadcastValueCount(lhsVal.valueCount, rhsVal.valueCount);
+
                 if(lhsVal.varType == DataType::Bool
                    && (rhsVal.varType == DataType::Bool32 || rhsVal.varType == DataType::Bool64))
                 {
@@ -298,6 +319,9 @@ namespace rocRoller
                 auto r1hsVal = call(expr.r1hs);
                 auto r2hsVal = call(expr.r2hs);
 
+                size_t valueCount = Register::broadcastValueCount(
+                    {lhsVal.valueCount, r1hsVal.valueCount, r2hsVal.valueCount});
+
                 AssertFatal(r2hsVal.varType == r1hsVal.varType,
                             ShowValue(r1hsVal.varType),
                             ShowValue(r2hsVal.varType));
@@ -308,9 +332,9 @@ namespace rocRoller
                    || r1hsVal.regType == Register::Type::Vector
                    || r2hsVal.regType == Register::Type::Vector)
                 {
-                    return {Register::Type::Vector, varType};
+                    return {Register::Type::Vector, varType, valueCount};
                 }
-                return {Register::Type::Scalar, varType};
+                return {Register::Type::Scalar, varType, valueCount};
             }
 
             ResultType operator()(Concatenate const& expr)
@@ -321,9 +345,12 @@ namespace rocRoller
                 auto expectedNumRegister   = DataTypeInfo::Get(expr.destinationType).registerCount;
                 unsigned actualNumRegister = 0;
 
+                size_t valueCount = 1;
+
                 for(auto const& operand : expr.operands)
                 {
-                    auto&& [operandRegisterType, operandVariableType] = call(operand);
+                    auto&& [operandRegisterType, operandVariableType, operandValueCount]
+                        = call(operand);
                     switch(operandRegisterType)
                     {
                     case Register::Type::Literal:
@@ -339,6 +366,20 @@ namespace rocRoller
                     registerType = Register::PromoteType(registerType, operandRegisterType);
                     actualNumRegister
                         = actualNumRegister + DataTypeInfo::Get(operandVariableType).registerCount;
+
+                    if(operandValueCount != 1)
+                    {
+                        // Each value count of an operand in an expression
+                        // must either be 1 or equal to all other non-1 value counts
+                        if(valueCount == 1)
+                            valueCount = operandValueCount;
+                        else
+                            AssertFatal(valueCount == operandValueCount,
+                                        "Each operand's value count in an expression must either "
+                                        "be 1 or equal to all other non-1 value counts",
+                                        ShowValue(valueCount),
+                                        ShowValue(operandValueCount));
+                    }
                 }
 
                 AssertFatal(expectedNumRegister == actualNumRegister,
@@ -346,47 +387,47 @@ namespace rocRoller
                             ShowValue(expectedNumRegister),
                             ShowValue(actualNumRegister));
 
-                return {registerType, variableType};
+                return {registerType, variableType, valueCount};
             }
 
             ResultType operator()(CommandArgumentPtr const& expr)
             {
                 if(expr == nullptr)
-                    return {Register::Type::Count, DataType::Count};
+                    return {Register::Type::Count, DataType::Count, 0};
 
-                return {Register::Type::Literal, expr->variableType()};
+                return {Register::Type::Literal, expr->variableType(), 1};
             }
 
             ResultType operator()(AssemblyKernelArgumentPtr const& expr)
             {
                 if(expr == nullptr)
-                    return {Register::Type::Count, DataType::Count};
+                    return {Register::Type::Count, DataType::Count, 0};
 
-                return {Register::Type::Scalar, expr->getVariableType()};
+                return {Register::Type::Scalar, expr->getVariableType(), 1};
             }
 
             ResultType operator()(CommandArgumentValue const& expr)
             {
-                return {Register::Type::Literal, variableType(expr)};
+                return {Register::Type::Literal, variableType(expr), 1};
             }
 
             ResultType operator()(Register::ValuePtr const& expr)
             {
                 if(expr == nullptr)
-                    return {Register::Type::Count, DataType::Count};
+                    return {Register::Type::Count, DataType::Count, 0};
 
                 m_context = expr->context();
-                return {expr->regType(), expr->variableType()};
+                return {expr->regType(), expr->variableType(), expr->valueCount()};
             }
 
             ResultType operator()(DataFlowTag const& expr)
             {
-                return {expr.regType, expr.varType};
+                return {expr.regType, expr.varType, 1};
             }
 
             ResultType operator()(PositionalArgument const& expr)
             {
-                return {expr.regType, expr.varType};
+                return {expr.regType, expr.varType, 1};
             }
 
             ResultType operator()(WaveTilePtr const& expr)
@@ -402,7 +443,7 @@ namespace rocRoller
             ResultType call(ExpressionPtr const& expr)
             {
                 if(expr == nullptr)
-                    return {Register::Type::Count, DataType::Count};
+                    return {Register::Type::Count, DataType::Count, 0};
 
                 return call(*expr);
             }
@@ -430,6 +471,18 @@ namespace rocRoller
         {
             ExpressionResultTypeVisitor v;
             return v.call(expr).regType;
+        }
+
+        size_t resultValueCount(Expression const& expr)
+        {
+            ExpressionResultTypeVisitor v;
+            return v.call(expr).valueCount;
+        }
+
+        size_t resultValueCount(ExpressionPtr const& expr)
+        {
+            ExpressionResultTypeVisitor v;
+            return v.call(expr).valueCount;
         }
 
         ResultType resultType(ExpressionPtr const& expr)

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -271,12 +271,12 @@ namespace rocRoller
                        || inputVarType == DataType::Bool32 //
                        || inputVarType == DataType::Bool64)
                     {
-                        return {Register::Type::Scalar, inputVarType};
+                        return {Register::Type::Scalar, inputVarType, valueCount};
                     }
                 case Register::Type::Literal:
                 {
                     if(inputVarType == DataType::Bool)
-                        return {inputRegType, inputVarType};
+                        return {inputRegType, inputVarType, valueCount};
                 }
                 default:
                     break;

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -31,9 +31,6 @@ namespace rocRoller
             size_t valueCount = 1;
             for(auto operand : operands)
             {
-                size_t operandPacking = operand.varType.dataType == DataType::None
-                                            ? 1
-                                            : DataTypeInfo::Get(operand.varType).packing;
                 if(operand.valueCount != 1)
                 {
                     if(valueCount == 1)
@@ -43,8 +40,7 @@ namespace rocRoller
                                     "Each operand's value count in an expression must either "
                                     "be 1 or equal to all other non-1 value counts\n",
                                     ShowValue(valueCount),
-                                    ShowValue(operand.valueCount),
-                                    ShowValue(operandPacking));
+                                    ShowValue(operand.valueCount));
                 }
             }
 
@@ -397,8 +393,6 @@ namespace rocRoller
                     actualNumRegister
                         = actualNumRegister + DataTypeInfo::Get(operandVariableType).registerCount;
 
-                    if(operandVariableType.dataType != DataType::None)
-                        operandValueCount *= DataTypeInfo::Get(operandVariableType).packing;
                     if(operandValueCount != 1)
                     {
                         // Each value count of an operand in an expression

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -26,6 +26,32 @@ namespace rocRoller
 {
     namespace Expression
     {
+        inline size_t broadcastValueCount(std::vector<ResultType> operands)
+        {
+            size_t valueCount = 1;
+            for(auto operand : operands)
+            {
+                size_t operandPacking    = operand.varType.dataType == DataType::None
+                                               ? 1
+                                               : DataTypeInfo::Get(operand.varType).packing;
+                size_t operandValueCount = operand.valueCount * operandPacking;
+                if(operandValueCount != 1)
+                {
+                    if(valueCount == 1)
+                        valueCount = operandValueCount;
+                    else
+                        AssertFatal(valueCount == operandValueCount,
+                                    "Each operand's value count in an expression must either "
+                                    "be 1 or equal to all other non-1 value counts\n",
+                                    ShowValue(valueCount),
+                                    ShowValue(operandValueCount),
+                                    ShowValue(operandPacking));
+                }
+            }
+
+            return valueCount;
+        }
+
         /*
          * result type
          */
@@ -65,8 +91,7 @@ namespace rocRoller
                     varType = VariableType::Promote(lhsVal.varType, rhsVal.varType);
                 }
 
-                auto valueCount
-                    = Register::broadcastValueCount(lhsVal.valueCount, rhsVal.valueCount);
+                auto valueCount = broadcastValueCount({lhsVal, rhsVal});
 
                 return {regType, varType, valueCount};
             }
@@ -84,8 +109,7 @@ namespace rocRoller
                 auto varType = VariableType::Promote(lhsVal.varType, r1hsVal.varType);
                 varType      = VariableType::Promote(varType, r2hsVal.varType);
 
-                size_t valueCount = Register::broadcastValueCount(
-                    {lhsVal.valueCount, r1hsVal.valueCount, r2hsVal.valueCount});
+                size_t valueCount = broadcastValueCount({lhsVal, r1hsVal, r2hsVal});
 
                 return {regType, varType, valueCount};
             }
@@ -95,10 +119,9 @@ namespace rocRoller
                 auto lhsVal  = call(expr.lhs);
                 auto r1hsVal = call(expr.r1hs);
 
-                auto regType = Register::PromoteType(lhsVal.regType, r1hsVal.regType);
-                auto varType = VariableType::Promote(lhsVal.varType, r1hsVal.varType);
-                auto valueCount
-                    = Register::broadcastValueCount(lhsVal.valueCount, r1hsVal.valueCount);
+                auto regType    = Register::PromoteType(lhsVal.regType, r1hsVal.regType);
+                auto varType    = VariableType::Promote(lhsVal.varType, r1hsVal.varType);
+                auto valueCount = broadcastValueCount({lhsVal, r1hsVal});
 
                 return {regType, varType, valueCount};
             }
@@ -108,10 +131,9 @@ namespace rocRoller
                 auto lhsVal  = call(expr.lhs);
                 auto r2hsVal = call(expr.r2hs);
 
-                auto regType = Register::PromoteType(lhsVal.regType, r2hsVal.regType);
-                auto varType = VariableType::Promote(lhsVal.varType, r2hsVal.varType);
-                auto valueCount
-                    = Register::broadcastValueCount(lhsVal.valueCount, r2hsVal.valueCount);
+                auto regType    = Register::PromoteType(lhsVal.regType, r2hsVal.regType);
+                auto varType    = VariableType::Promote(lhsVal.varType, r2hsVal.varType);
+                auto valueCount = broadcastValueCount({lhsVal, r2hsVal});
 
                 return {regType, varType, valueCount};
             }
@@ -128,8 +150,7 @@ namespace rocRoller
                 auto varType = VariableType::Promote(matAVal.varType, matBVal.varType);
                 varType      = VariableType::Promote(varType, matCVal.varType);
 
-                size_t valueCount = Register::broadcastValueCount(
-                    {matAVal.valueCount, matBVal.valueCount, matCVal.valueCount});
+                size_t valueCount = broadcastValueCount({matAVal, matBVal, matCVal});
 
                 return {regType, varType, valueCount};
             }
@@ -183,8 +204,7 @@ namespace rocRoller
                 auto lhsVal = call(expr.lhs);
                 auto rhsVal = call(expr.rhs);
 
-                size_t valueCount
-                    = Register::broadcastValueCount(lhsVal.valueCount, rhsVal.valueCount);
+                size_t valueCount = broadcastValueCount({lhsVal, rhsVal});
 
                 // Can't compare between two different types on the GPU.
                 AssertFatal(lhsVal.regType == Register::Type::Literal
@@ -242,8 +262,7 @@ namespace rocRoller
 
             ResultType logical(ResultType lhsVal, ResultType rhsVal)
             {
-                size_t valueCount
-                    = Register::broadcastValueCount(lhsVal.valueCount, rhsVal.valueCount);
+                size_t valueCount = broadcastValueCount({lhsVal, rhsVal});
 
                 if(lhsVal.varType == DataType::Bool
                    && (rhsVal.varType == DataType::Bool32 || rhsVal.varType == DataType::Bool64))
@@ -317,13 +336,12 @@ namespace rocRoller
                 auto r1hsVal = call(expr.r1hs);
                 auto r2hsVal = call(expr.r2hs);
 
-                size_t valueCount = Register::broadcastValueCount(
-                    {lhsVal.valueCount, r1hsVal.valueCount, r2hsVal.valueCount});
-
                 AssertFatal(r2hsVal.varType == r1hsVal.varType,
                             ShowValue(r1hsVal.varType),
                             ShowValue(r2hsVal.varType));
                 auto varType = r2hsVal.varType;
+
+                size_t valueCount = broadcastValueCount({lhsVal, r1hsVal, r2hsVal});
 
                 if(lhsVal.varType == DataType::Bool32 || lhsVal.varType == DataType::Bool64
                    || lhsVal.regType == Register::Type::Vector
@@ -365,6 +383,7 @@ namespace rocRoller
                     actualNumRegister
                         = actualNumRegister + DataTypeInfo::Get(operandVariableType).registerCount;
 
+                    operandValueCount *= DataTypeInfo::Get(operandVariableType).packing;
                     if(operandValueCount != 1)
                     {
                         // Each value count of an operand in an expression

--- a/shared/rocroller/lib/source/Expression_resultType.cpp
+++ b/shared/rocroller/lib/source/Expression_resultType.cpp
@@ -1,8 +1,6 @@
 // Copyright Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-#include "rocRoller/InstructionValues/Register_impl.hpp"
-#include "rocRoller/Utilities/Error.hpp"
 #include <variant>
 
 #include <rocRoller/DataTypes/DataTypes.hpp>

--- a/shared/rocroller/test/catch/ExpressionTest.cpp
+++ b/shared/rocroller/test/catch/ExpressionTest.cpp
@@ -1458,6 +1458,7 @@ namespace ExpressionTest
 
         SECTION("Arguments")
         {
+            size_t       valueCount = 1;
             VariableType doubleVal{DataType::Double, PointerType::Value};
             auto         ca = std::make_shared<CommandArgument>(nullptr, doubleVal, 0);
             auto         cb = std::make_shared<CommandArgument>(nullptr, doubleVal, 8);
@@ -1476,7 +1477,7 @@ namespace ExpressionTest
             } args;
             RuntimeArguments runtimeArgs((uint8_t*)&args, sizeof(args));
 
-            Expression::ResultType expected{Register::Type::Literal, DataType::Double};
+            Expression::ResultType expected{Register::Type::Literal, DataType::Double, valueCount};
             CHECK(expected == resultType(expr2));
             CHECK(6.0 == std::get<double>(evaluate(expr2, runtimeArgs)));
 
@@ -1498,6 +1499,7 @@ namespace ExpressionTest
 
     TEST_CASE("Expression test evaluate mixed types", "[expression]")
     {
+        size_t valueCount = 1;
         using Expression::literal;
         auto one          = literal(1.0);
         auto two          = literal(2.0f);
@@ -1551,9 +1553,9 @@ namespace ExpressionTest
         auto eight75Half = convert(DataType::Half, eightPoint75);
         CHECK(Half(8.75) == std::get<Half>(evaluate(eight75Half)));
 
-        Expression::ResultType litDouble{Register::Type::Literal, DataType::Double};
-        Expression::ResultType litFloat{Register::Type::Literal, DataType::Float};
-        Expression::ResultType litBool{Register::Type::Literal, DataType::Bool};
+        Expression::ResultType litDouble{Register::Type::Literal, DataType::Double, valueCount};
+        Expression::ResultType litFloat{Register::Type::Literal, DataType::Float, valueCount};
+        Expression::ResultType litBool{Register::Type::Literal, DataType::Bool, valueCount};
 
         CHECK(litDouble == resultType(exprSix));
         // Result type not (yet?) defined for mixed integral/floating point types.

--- a/shared/rocroller/test/catch/ExpressionTest.cpp
+++ b/shared/rocroller/test/catch/ExpressionTest.cpp
@@ -899,123 +899,128 @@ namespace ExpressionTest
 
     TEST_CASE("Expression result types", "[expression]")
     {
-        auto context = TestContext::ForDefaultTarget();
+        auto   context    = TestContext::ForDefaultTarget();
+        size_t valueCount = 1;
 
         auto vgprFloat = Register::Value::Placeholder(
-                             context.get(), Register::Type::Vector, DataType::Float, 1)
+                             context.get(), Register::Type::Vector, DataType::Float, valueCount)
                              ->expression();
         auto vgprDouble = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::Double, 1)
+                              context.get(), Register::Type::Vector, DataType::Double, valueCount)
                               ->expression();
         auto vgprInt32 = Register::Value::Placeholder(
-                             context.get(), Register::Type::Vector, DataType::Int32, 1)
+                             context.get(), Register::Type::Vector, DataType::Int32, valueCount)
                              ->expression();
         auto vgprInt64 = Register::Value::Placeholder(
-                             context.get(), Register::Type::Vector, DataType::Int64, 1)
+                             context.get(), Register::Type::Vector, DataType::Int64, valueCount)
                              ->expression();
         auto vgprUInt32 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::UInt32, 1)
+                              context.get(), Register::Type::Vector, DataType::UInt32, valueCount)
                               ->expression();
         auto vgprUInt64 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::UInt64, 1)
+                              context.get(), Register::Type::Vector, DataType::UInt64, valueCount)
                               ->expression();
-        auto vgprHalf
-            = Register::Value::Placeholder(context.get(), Register::Type::Vector, DataType::Half, 1)
-                  ->expression();
+        auto vgprHalf = Register::Value::Placeholder(
+                            context.get(), Register::Type::Vector, DataType::Half, valueCount)
+                            ->expression();
         auto vgprHalfx2 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::Halfx2, 1)
+                              context.get(), Register::Type::Vector, DataType::Halfx2, valueCount)
                               ->expression();
         auto vgprBool32 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::Bool32, 1)
+                              context.get(), Register::Type::Vector, DataType::Bool32, valueCount)
                               ->expression();
-        auto vgprBool
-            = Register::Value::Placeholder(context.get(), Register::Type::Vector, DataType::Bool, 1)
-                  ->expression();
+        auto vgprBool = Register::Value::Placeholder(
+                            context.get(), Register::Type::Vector, DataType::Bool, valueCount)
+                            ->expression();
 
         auto sgprFloat = Register::Value::Placeholder(
-                             context.get(), Register::Type::Scalar, DataType::Float, 1)
+                             context.get(), Register::Type::Scalar, DataType::Float, valueCount)
                              ->expression();
         auto sgprDouble = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::Double, 1)
+                              context.get(), Register::Type::Scalar, DataType::Double, valueCount)
                               ->expression();
         auto sgprInt32 = Register::Value::Placeholder(
-                             context.get(), Register::Type::Scalar, DataType::Int32, 1)
+                             context.get(), Register::Type::Scalar, DataType::Int32, valueCount)
                              ->expression();
         auto sgprInt64 = Register::Value::Placeholder(
-                             context.get(), Register::Type::Scalar, DataType::Int64, 1)
+                             context.get(), Register::Type::Scalar, DataType::Int64, valueCount)
                              ->expression();
         auto sgprUInt32 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::UInt32, 1)
+                              context.get(), Register::Type::Scalar, DataType::UInt32, valueCount)
                               ->expression();
         auto sgprUInt64 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::UInt64, 1)
+                              context.get(), Register::Type::Scalar, DataType::UInt64, valueCount)
                               ->expression();
-        auto sgprHalf
-            = Register::Value::Placeholder(context.get(), Register::Type::Scalar, DataType::Half, 1)
-                  ->expression();
+        auto sgprHalf = Register::Value::Placeholder(
+                            context.get(), Register::Type::Scalar, DataType::Half, valueCount)
+                            ->expression();
         auto sgprHalfx2 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::Halfx2, 1)
+                              context.get(), Register::Type::Scalar, DataType::Halfx2, valueCount)
                               ->expression();
         auto sgprBool64 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::Bool64, 1)
+                              context.get(), Register::Type::Scalar, DataType::Bool64, valueCount)
                               ->expression();
         auto sgprBool32 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::Bool32, 1)
+                              context.get(), Register::Type::Scalar, DataType::Bool32, valueCount)
                               ->expression();
-        auto sgprBool
-            = Register::Value::Placeholder(context.get(), Register::Type::Scalar, DataType::Bool, 1)
-                  ->expression();
+        auto sgprBool = Register::Value::Placeholder(
+                            context.get(), Register::Type::Scalar, DataType::Bool, valueCount)
+                            ->expression();
         auto sgprWavefrontSized
             = Register::Value::Placeholder(context.get(),
                                            Register::Type::Scalar,
                                            context.get()->kernel()->wavefront_size() == 64
                                                ? DataType::Bool64
                                                : DataType::Bool32,
-                                           1)
+                                           valueCount)
                   ->expression();
 
-        auto agprFloat = Register::Value::Placeholder(
-                             context.get(), Register::Type::Accumulator, DataType::Float, 1)
-                             ->expression();
-        auto agprDouble = Register::Value::Placeholder(
-                              context.get(), Register::Type::Accumulator, DataType::Double, 1)
-                              ->expression();
+        auto agprFloat
+            = Register::Value::Placeholder(
+                  context.get(), Register::Type::Accumulator, DataType::Float, valueCount)
+                  ->expression();
+        auto agprDouble
+            = Register::Value::Placeholder(
+                  context.get(), Register::Type::Accumulator, DataType::Double, valueCount)
+                  ->expression();
 
         auto litInt32  = Expression::literal<int32_t>(5);
         auto litInt64  = Expression::literal<int64_t>(5);
         auto litFloat  = Expression::literal(5.0f);
         auto litDouble = Expression::literal(5.0);
 
-        Expression::ResultType rVgprFloat{Register::Type::Vector, DataType::Float};
-        Expression::ResultType rVgprDouble{Register::Type::Vector, DataType::Double};
-        Expression::ResultType rVgprInt32{Register::Type::Vector, DataType::Int32};
-        Expression::ResultType rVgprInt64{Register::Type::Vector, DataType::Int64};
-        Expression::ResultType rVgprUInt32{Register::Type::Vector, DataType::UInt32};
-        Expression::ResultType rVgprUInt64{Register::Type::Vector, DataType::UInt64};
-        Expression::ResultType rVgprHalf{Register::Type::Vector, DataType::Half};
-        Expression::ResultType rVgprHalfx2{Register::Type::Vector, DataType::Halfx2};
-        Expression::ResultType rVgprBool32{Register::Type::Vector, DataType::Bool32};
+        Expression::ResultType rVgprFloat{Register::Type::Vector, DataType::Float, valueCount};
+        Expression::ResultType rVgprDouble{Register::Type::Vector, DataType::Double, valueCount};
+        Expression::ResultType rVgprInt32{Register::Type::Vector, DataType::Int32, valueCount};
+        Expression::ResultType rVgprInt64{Register::Type::Vector, DataType::Int64, valueCount};
+        Expression::ResultType rVgprUInt32{Register::Type::Vector, DataType::UInt32, valueCount};
+        Expression::ResultType rVgprUInt64{Register::Type::Vector, DataType::UInt64, valueCount};
+        Expression::ResultType rVgprHalf{Register::Type::Vector, DataType::Half, valueCount};
+        Expression::ResultType rVgprHalfx2{Register::Type::Vector, DataType::Halfx2, valueCount};
+        Expression::ResultType rVgprBool32{Register::Type::Vector, DataType::Bool32, valueCount};
 
-        Expression::ResultType rSgprFloat{Register::Type::Scalar, DataType::Float};
-        Expression::ResultType rSgprDouble{Register::Type::Scalar, DataType::Double};
-        Expression::ResultType rSgprInt32{Register::Type::Scalar, DataType::Int32};
-        Expression::ResultType rSgprInt64{Register::Type::Scalar, DataType::Int64};
-        Expression::ResultType rSgprUInt32{Register::Type::Scalar, DataType::UInt32};
-        Expression::ResultType rSgprUInt64{Register::Type::Scalar, DataType::UInt64};
-        Expression::ResultType rSgprHalf{Register::Type::Scalar, DataType::Half};
-        Expression::ResultType rSgprHalfx2{Register::Type::Scalar, DataType::Halfx2};
-        Expression::ResultType rSgprBool32{Register::Type::Scalar, DataType::Bool32};
-        Expression::ResultType rSgprBool64{Register::Type::Scalar, DataType::Bool64};
-        Expression::ResultType rSgprBool{Register::Type::Scalar, DataType::Bool};
+        Expression::ResultType rSgprFloat{Register::Type::Scalar, DataType::Float, valueCount};
+        Expression::ResultType rSgprDouble{Register::Type::Scalar, DataType::Double, valueCount};
+        Expression::ResultType rSgprInt32{Register::Type::Scalar, DataType::Int32, valueCount};
+        Expression::ResultType rSgprInt64{Register::Type::Scalar, DataType::Int64, valueCount};
+        Expression::ResultType rSgprUInt32{Register::Type::Scalar, DataType::UInt32, valueCount};
+        Expression::ResultType rSgprUInt64{Register::Type::Scalar, DataType::UInt64, valueCount};
+        Expression::ResultType rSgprHalf{Register::Type::Scalar, DataType::Half, valueCount};
+        Expression::ResultType rSgprHalfx2{Register::Type::Scalar, DataType::Halfx2, valueCount};
+        Expression::ResultType rSgprBool32{Register::Type::Scalar, DataType::Bool32, valueCount};
+        Expression::ResultType rSgprBool64{Register::Type::Scalar, DataType::Bool64, valueCount};
+        Expression::ResultType rSgprBool{Register::Type::Scalar, DataType::Bool, valueCount};
         Expression::ResultType rSgprWavefrontSized{
             Register::Type::Scalar,
-            context.get()->kernel()->wavefront_size() == 64 ? DataType::Bool64 : DataType::Bool32};
+            context.get()->kernel()->wavefront_size() == 64 ? DataType::Bool64 : DataType::Bool32,
+            valueCount};
 
-        Expression::ResultType rVCC{Register::Type::VCC, DataType::Bool32};
-        Expression::ResultType rSCC{Register::Type::SCC, DataType::Bool};
+        Expression::ResultType rVCC{Register::Type::VCC, DataType::Bool32, valueCount};
+        Expression::ResultType rSCC{Register::Type::SCC, DataType::Bool, valueCount};
 
-        Expression::ResultType rAgprFloat{Register::Type::Accumulator, DataType::Float};
-        Expression::ResultType rAgprDouble{Register::Type::Accumulator, DataType::Double};
+        Expression::ResultType rAgprFloat{Register::Type::Accumulator, DataType::Float, valueCount};
+        Expression::ResultType rAgprDouble{
+            Register::Type::Accumulator, DataType::Double, valueCount};
 
         SECTION("Value expressions")
         {

--- a/shared/rocroller/test/catch/ExpressionTest.cpp
+++ b/shared/rocroller/test/catch/ExpressionTest.cpp
@@ -899,128 +899,124 @@ namespace ExpressionTest
 
     TEST_CASE("Expression result types", "[expression]")
     {
-        auto   context    = TestContext::ForDefaultTarget();
-        size_t valueCount = 1;
+        auto context = TestContext::ForDefaultTarget();
 
         auto vgprFloat = Register::Value::Placeholder(
-                             context.get(), Register::Type::Vector, DataType::Float, valueCount)
+                             context.get(), Register::Type::Vector, DataType::Float, 1)
                              ->expression();
         auto vgprDouble = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::Double, valueCount)
+                              context.get(), Register::Type::Vector, DataType::Double, 1)
                               ->expression();
         auto vgprInt32 = Register::Value::Placeholder(
-                             context.get(), Register::Type::Vector, DataType::Int32, valueCount)
+                             context.get(), Register::Type::Vector, DataType::Int32, 1)
                              ->expression();
         auto vgprInt64 = Register::Value::Placeholder(
-                             context.get(), Register::Type::Vector, DataType::Int64, valueCount)
+                             context.get(), Register::Type::Vector, DataType::Int64, 1)
                              ->expression();
         auto vgprUInt32 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::UInt32, valueCount)
+                              context.get(), Register::Type::Vector, DataType::UInt32, 1)
                               ->expression();
         auto vgprUInt64 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::UInt64, valueCount)
+                              context.get(), Register::Type::Vector, DataType::UInt64, 1)
                               ->expression();
-        auto vgprHalf = Register::Value::Placeholder(
-                            context.get(), Register::Type::Vector, DataType::Half, valueCount)
-                            ->expression();
+        auto vgprHalf
+            = Register::Value::Placeholder(context.get(), Register::Type::Vector, DataType::Half, 1)
+                  ->expression();
         auto vgprHalfx2 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::Halfx2, valueCount)
+                              context.get(), Register::Type::Vector, DataType::Halfx2, 1)
                               ->expression();
         auto vgprBool32 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Vector, DataType::Bool32, valueCount)
+                              context.get(), Register::Type::Vector, DataType::Bool32, 1)
                               ->expression();
-        auto vgprBool = Register::Value::Placeholder(
-                            context.get(), Register::Type::Vector, DataType::Bool, valueCount)
-                            ->expression();
+        auto vgprBool
+            = Register::Value::Placeholder(context.get(), Register::Type::Vector, DataType::Bool, 1)
+                  ->expression();
 
         auto sgprFloat = Register::Value::Placeholder(
-                             context.get(), Register::Type::Scalar, DataType::Float, valueCount)
+                             context.get(), Register::Type::Scalar, DataType::Float, 1)
                              ->expression();
         auto sgprDouble = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::Double, valueCount)
+                              context.get(), Register::Type::Scalar, DataType::Double, 1)
                               ->expression();
         auto sgprInt32 = Register::Value::Placeholder(
-                             context.get(), Register::Type::Scalar, DataType::Int32, valueCount)
+                             context.get(), Register::Type::Scalar, DataType::Int32, 1)
                              ->expression();
         auto sgprInt64 = Register::Value::Placeholder(
-                             context.get(), Register::Type::Scalar, DataType::Int64, valueCount)
+                             context.get(), Register::Type::Scalar, DataType::Int64, 1)
                              ->expression();
         auto sgprUInt32 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::UInt32, valueCount)
+                              context.get(), Register::Type::Scalar, DataType::UInt32, 1)
                               ->expression();
         auto sgprUInt64 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::UInt64, valueCount)
+                              context.get(), Register::Type::Scalar, DataType::UInt64, 1)
                               ->expression();
-        auto sgprHalf = Register::Value::Placeholder(
-                            context.get(), Register::Type::Scalar, DataType::Half, valueCount)
-                            ->expression();
+        auto sgprHalf
+            = Register::Value::Placeholder(context.get(), Register::Type::Scalar, DataType::Half, 1)
+                  ->expression();
         auto sgprHalfx2 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::Halfx2, valueCount)
+                              context.get(), Register::Type::Scalar, DataType::Halfx2, 1)
                               ->expression();
         auto sgprBool64 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::Bool64, valueCount)
+                              context.get(), Register::Type::Scalar, DataType::Bool64, 1)
                               ->expression();
         auto sgprBool32 = Register::Value::Placeholder(
-                              context.get(), Register::Type::Scalar, DataType::Bool32, valueCount)
+                              context.get(), Register::Type::Scalar, DataType::Bool32, 1)
                               ->expression();
-        auto sgprBool = Register::Value::Placeholder(
-                            context.get(), Register::Type::Scalar, DataType::Bool, valueCount)
-                            ->expression();
+        auto sgprBool
+            = Register::Value::Placeholder(context.get(), Register::Type::Scalar, DataType::Bool, 1)
+                  ->expression();
         auto sgprWavefrontSized
             = Register::Value::Placeholder(context.get(),
                                            Register::Type::Scalar,
                                            context.get()->kernel()->wavefront_size() == 64
                                                ? DataType::Bool64
                                                : DataType::Bool32,
-                                           valueCount)
+                                           1)
                   ->expression();
 
-        auto agprFloat
-            = Register::Value::Placeholder(
-                  context.get(), Register::Type::Accumulator, DataType::Float, valueCount)
-                  ->expression();
-        auto agprDouble
-            = Register::Value::Placeholder(
-                  context.get(), Register::Type::Accumulator, DataType::Double, valueCount)
-                  ->expression();
+        auto agprFloat = Register::Value::Placeholder(
+                             context.get(), Register::Type::Accumulator, DataType::Float, 1)
+                             ->expression();
+        auto agprDouble = Register::Value::Placeholder(
+                              context.get(), Register::Type::Accumulator, DataType::Double, 1)
+                              ->expression();
 
         auto litInt32  = Expression::literal<int32_t>(5);
         auto litInt64  = Expression::literal<int64_t>(5);
         auto litFloat  = Expression::literal(5.0f);
         auto litDouble = Expression::literal(5.0);
 
-        Expression::ResultType rVgprFloat{Register::Type::Vector, DataType::Float, valueCount};
-        Expression::ResultType rVgprDouble{Register::Type::Vector, DataType::Double, valueCount};
-        Expression::ResultType rVgprInt32{Register::Type::Vector, DataType::Int32, valueCount};
-        Expression::ResultType rVgprInt64{Register::Type::Vector, DataType::Int64, valueCount};
-        Expression::ResultType rVgprUInt32{Register::Type::Vector, DataType::UInt32, valueCount};
-        Expression::ResultType rVgprUInt64{Register::Type::Vector, DataType::UInt64, valueCount};
-        Expression::ResultType rVgprHalf{Register::Type::Vector, DataType::Half, valueCount};
-        Expression::ResultType rVgprHalfx2{Register::Type::Vector, DataType::Halfx2, valueCount};
-        Expression::ResultType rVgprBool32{Register::Type::Vector, DataType::Bool32, valueCount};
+        Expression::ResultType rVgprFloat{Register::Type::Vector, DataType::Float, 1};
+        Expression::ResultType rVgprDouble{Register::Type::Vector, DataType::Double, 1};
+        Expression::ResultType rVgprInt32{Register::Type::Vector, DataType::Int32, 1};
+        Expression::ResultType rVgprInt64{Register::Type::Vector, DataType::Int64, 1};
+        Expression::ResultType rVgprUInt32{Register::Type::Vector, DataType::UInt32, 1};
+        Expression::ResultType rVgprUInt64{Register::Type::Vector, DataType::UInt64, 1};
+        Expression::ResultType rVgprHalf{Register::Type::Vector, DataType::Half, 1};
+        Expression::ResultType rVgprHalfx2{Register::Type::Vector, DataType::Halfx2, 2};
+        Expression::ResultType rVgprBool32{Register::Type::Vector, DataType::Bool32, 1};
 
-        Expression::ResultType rSgprFloat{Register::Type::Scalar, DataType::Float, valueCount};
-        Expression::ResultType rSgprDouble{Register::Type::Scalar, DataType::Double, valueCount};
-        Expression::ResultType rSgprInt32{Register::Type::Scalar, DataType::Int32, valueCount};
-        Expression::ResultType rSgprInt64{Register::Type::Scalar, DataType::Int64, valueCount};
-        Expression::ResultType rSgprUInt32{Register::Type::Scalar, DataType::UInt32, valueCount};
-        Expression::ResultType rSgprUInt64{Register::Type::Scalar, DataType::UInt64, valueCount};
-        Expression::ResultType rSgprHalf{Register::Type::Scalar, DataType::Half, valueCount};
-        Expression::ResultType rSgprHalfx2{Register::Type::Scalar, DataType::Halfx2, valueCount};
-        Expression::ResultType rSgprBool32{Register::Type::Scalar, DataType::Bool32, valueCount};
-        Expression::ResultType rSgprBool64{Register::Type::Scalar, DataType::Bool64, valueCount};
-        Expression::ResultType rSgprBool{Register::Type::Scalar, DataType::Bool, valueCount};
+        Expression::ResultType rSgprFloat{Register::Type::Scalar, DataType::Float, 1};
+        Expression::ResultType rSgprDouble{Register::Type::Scalar, DataType::Double, 1};
+        Expression::ResultType rSgprInt32{Register::Type::Scalar, DataType::Int32, 1};
+        Expression::ResultType rSgprInt64{Register::Type::Scalar, DataType::Int64, 1};
+        Expression::ResultType rSgprUInt32{Register::Type::Scalar, DataType::UInt32, 1};
+        Expression::ResultType rSgprUInt64{Register::Type::Scalar, DataType::UInt64, 1};
+        Expression::ResultType rSgprHalf{Register::Type::Scalar, DataType::Half, 1};
+        Expression::ResultType rSgprHalfx2{Register::Type::Scalar, DataType::Halfx2, 2};
+        Expression::ResultType rSgprBool32{Register::Type::Scalar, DataType::Bool32, 1};
+        Expression::ResultType rSgprBool64{Register::Type::Scalar, DataType::Bool64, 1};
+        Expression::ResultType rSgprBool{Register::Type::Scalar, DataType::Bool, 1};
         Expression::ResultType rSgprWavefrontSized{
             Register::Type::Scalar,
             context.get()->kernel()->wavefront_size() == 64 ? DataType::Bool64 : DataType::Bool32,
-            valueCount};
+            1};
 
-        Expression::ResultType rVCC{Register::Type::VCC, DataType::Bool32, valueCount};
-        Expression::ResultType rSCC{Register::Type::SCC, DataType::Bool, valueCount};
+        Expression::ResultType rVCC{Register::Type::VCC, DataType::Bool32, 1};
+        Expression::ResultType rSCC{Register::Type::SCC, DataType::Bool, 1};
 
-        Expression::ResultType rAgprFloat{Register::Type::Accumulator, DataType::Float, valueCount};
-        Expression::ResultType rAgprDouble{
-            Register::Type::Accumulator, DataType::Double, valueCount};
+        Expression::ResultType rAgprFloat{Register::Type::Accumulator, DataType::Float, 1};
+        Expression::ResultType rAgprDouble{Register::Type::Accumulator, DataType::Double, 1};
 
         SECTION("Value expressions")
         {
@@ -1117,7 +1113,9 @@ namespace ExpressionTest
             CHECK(rVgprInt32 == resultType(op(vgprUInt32)));
             CHECK(rVgprInt32 == resultType(op(vgprUInt64)));
             CHECK(rVgprInt32 == resultType(op(vgprHalf)));
-            CHECK(rVgprInt32 == resultType(op(vgprHalfx2)));
+            CHECK(Expression::ResultType(
+                      rVgprInt32.regType, rVgprInt32.varType, rVgprInt32.valueCount * 2)
+                  == resultType(op(vgprHalfx2)));
             CHECK(rVgprInt32 == resultType(op(vgprBool32)));
 
             CHECK(rSgprInt32 == resultType(op(sgprFloat)));
@@ -1127,7 +1125,9 @@ namespace ExpressionTest
             CHECK(rSgprInt32 == resultType(op(sgprUInt32)));
             CHECK(rSgprInt32 == resultType(op(sgprUInt64)));
             CHECK(rSgprInt32 == resultType(op(sgprHalf)));
-            CHECK(rSgprInt32 == resultType(op(sgprHalfx2)));
+            CHECK(Expression::ResultType(
+                      rSgprInt32.regType, rSgprInt32.varType, rSgprInt32.valueCount * 2)
+                  == resultType(op(sgprHalfx2)));
             CHECK(rSgprInt32 == resultType(op(sgprBool32)));
         }
 
@@ -1141,7 +1141,9 @@ namespace ExpressionTest
             CHECK(rVgprUInt32 == resultType(op(vgprUInt32)));
             CHECK(rVgprUInt32 == resultType(op(vgprUInt64)));
             CHECK(rVgprUInt32 == resultType(op(vgprHalf)));
-            CHECK(rVgprUInt32 == resultType(op(vgprHalfx2)));
+            CHECK(Expression::ResultType(
+                      rVgprUInt32.regType, rVgprUInt32.varType, rVgprUInt32.valueCount * 2)
+                  == resultType(op(vgprHalfx2)));
             CHECK(rVgprUInt32 == resultType(op(vgprBool32)));
 
             CHECK(rSgprUInt32 == resultType(op(sgprFloat)));
@@ -1151,7 +1153,9 @@ namespace ExpressionTest
             CHECK(rSgprUInt32 == resultType(op(sgprUInt32)));
             CHECK(rSgprUInt32 == resultType(op(sgprUInt64)));
             CHECK(rSgprUInt32 == resultType(op(sgprHalf)));
-            CHECK(rSgprUInt32 == resultType(op(sgprHalfx2)));
+            CHECK(Expression::ResultType(
+                      rSgprUInt32.regType, rSgprUInt32.varType, rSgprUInt32.valueCount * 2)
+                  == resultType(op(sgprHalfx2)));
             CHECK(rSgprUInt32 == resultType(op(sgprBool32)));
         }
 
@@ -1172,7 +1176,10 @@ namespace ExpressionTest
             CHECK(rSgprWavefrontSized == resultType(op(vgprUInt32, vgprUInt32)));
             CHECK(rSgprWavefrontSized == resultType(op(vgprUInt64, vgprUInt64)));
             CHECK(rSgprWavefrontSized == resultType(op(vgprHalf, vgprHalf)));
-            CHECK(rSgprWavefrontSized == resultType(op(vgprHalfx2, vgprHalfx2)));
+            CHECK(Expression::ResultType(rSgprWavefrontSized.regType,
+                                         rSgprWavefrontSized.varType,
+                                         rSgprWavefrontSized.valueCount * 2)
+                  == resultType(op(vgprHalfx2, vgprHalfx2)));
             CHECK(rSgprWavefrontSized == resultType(op(vgprBool32, vgprBool32)));
             CHECK(rSgprWavefrontSized == resultType(op(vgprBool, vgprBool)));
 
@@ -1183,7 +1190,9 @@ namespace ExpressionTest
             CHECK(rSgprBool == resultType(op(sgprUInt32, sgprUInt32)));
             CHECK(rSgprBool == resultType(op(sgprUInt64, sgprUInt64)));
             CHECK(rSgprBool == resultType(op(sgprHalf, sgprHalf)));
-            CHECK(rSgprBool == resultType(op(sgprHalfx2, sgprHalfx2)));
+            CHECK(Expression::ResultType(
+                      rSgprBool.regType, rSgprBool.varType, rSgprBool.valueCount * 2)
+                  == resultType(op(sgprHalfx2, sgprHalfx2)));
             CHECK(rSgprBool == resultType(op(sgprBool32, sgprBool32)));
             CHECK(rSgprBool == resultType(op(sgprBool, sgprBool)));
         }


### PR DESCRIPTION
AIROCROLL-1578

## Motivation

This PR moves `valueCount` into `ResultType`, giving it a home where it can be centrally managed alongside the expression that it represents the value count of.

## Technical Details

- Add field `valueCount` to `ResultType` struct.
- Calculate and broadcast value counts for expressions in `Expression_resultType.cpp`.
    - When calculating value counts for "leaf" expressions, take the packing of the expression's data type into account (e.g. a single `Halfx2` consists of two 16 bit floats packed into one 32 bit register -> packing = 2 -> valueCount = 2).
    - When broadcasting value counts for expressions based on their operands, the value count of each operand must either be 1 or equal to all other non-1 value counts in the expression.
        - For example, when scaling a matrix consisting of 16 float elements, the matrix will have a value count of 16, and the scaling factor will have a value count of 1. When we generate code for this scaling, 16 instructions will be generated, where the same scaling factor will be multiplied by each element of the matrix.
        - You can see how there is no obvious way to support a situation where the scaling factor has a value count of, say, 2.
        - Matrix multiplication is a special case to this broadcasting rule, where `lhs` and `r1hs`, the matrices that will be multiplied together, can have a different value count than `r2hs`, the matrix that will be added to the result. In this case, the result of the matrix multiply should have the same value count as `r2hs`.
        - Concatenation is also sort of a special case, it technically follows the regular broadcasting rule but currently we only support operands with a value count of 1, so a fatal assert has been added to ensure that condition is satisfied and the resulting broadcasted value count is always 1.
- Change `resultPlaceholder` functions in `Expression_generate.cpp` and `CommonSubexpressionElimination.cpp` to use the value count now stored in the `ResultType` argument instead of one passed into the function separately (making sure that you divide the packing of the data type back out, since here we only care about the number of registers to allocate).
- Add a new function `resultPlaceholderWithCount` which allows you to ignore the `valueCount` in `ResultType` and pass in a custom value. To be clear, this is exactly what `resultPlaceholder` used to do. This change was made so that using the `valueCount` in `ResultType` is the default behaviour, and you can only override that by explicitly acknowledging that you want to do something different. This is particularly useful in situations where you need to allocate some non-destination registers as helpers while generating an expression.

## Test Plan

- Update `ResultType` tests in `ExpressionTest.cpp` to include value counts.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
