### PR TITLE
[hipDNN] Fix test failures in non-GPU environments by handling hipErrorNoDevice

### DIFF
--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/HipErrorHandler.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/HipErrorHandler.hpp
@@ -26,9 +26,9 @@ public:
         auto hipError = hipGetLastError();
 
         // Special case: hipErrorNoDevice cannot be cleared and persists even after
-        // hipGetLastError() is called. When tests are skipped in non-GPU environments,
-        // we should not fail the test for this specific error.
-        if(testInfo.result()->Skipped() && hipError == hipErrorNoDevice)
+        // hipGetLastError() is called. In non-GPU environments, we should not fail
+        // the test for this specific error.
+        if(hipError == hipErrorNoDevice)
         {
             return;
         }

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/HipErrorHandler.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/HipErrorHandler.hpp
@@ -25,6 +25,14 @@ public:
         // Check and clear standard HIP error state
         auto hipError = hipGetLastError();
 
+        // Special case: hipErrorNoDevice cannot be cleared and persists even after
+        // hipGetLastError() is called. When tests are skipped in non-GPU environments,
+        // we should not fail the test for this specific error.
+        if(testInfo.result()->Skipped() && hipError == hipErrorNoDevice)
+        {
+            return;
+        }
+
         // Check and clear extended HIP error state
         auto hipExtError = hipExtGetLastError();
 


### PR DESCRIPTION
## Motivation

Tests were failing with error code 100 ("no ROCm-capable device is detected") when run in environments without GPUs. This affected all tests, not just GPU-specific ones, making it impossible to run the test suite in non-GPU environments.

In non-GPU environments:
1. Any HIP API call triggers HIP runtime initialization
2. HIP detects no GPU and sets `hipErrorNoDevice` (error 100)
3. This error persists and cannot be cleared, even after calling `hipGetLastError()`
4. The `HipErrorHandler` test listener checks for HIP errors after each test
5. It detected this persistent error and failed all tests

## Technical Details

Modified `HipErrorHandler::OnTestEnd()` to silently accept `hipErrorNoDevice`:

- Check if the error is `hipErrorNoDevice` after calling `hipGetLastError()`
- If true, return early without failing the test
- This allows tests to run in non-GPU environments

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
