### PR TITLE
[Hipblaslt][CMS] Reimplement GR issued to early validation

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -52,278 +52,6 @@ def invert_mfma_reorder(mfma_reorder: list[int]) -> dict[int, int]:
     return {orig: new_pos for new_pos, orig in enumerate(mfma_reorder)}
 
 
-def get_most_recent_local_reads(
-    vmfmas: list[int],
-    counts: list[int],
-    history: list[tuple[int, list[str]]],
-) -> list[dict[str, int]]:
-    """
-    For each waitcnt instruction located at `vmfmas[i]`, compute how many
-    of the most recent `counts[i]` local reads come from each of the 4 local read
-    types (LRA0, LRA1, LRB0, LRB1). This is computed by walking backwards through
-    historical local read positions.
-
-    Args:
-        vmfmas:
-            List of vmfma instruction indices where s_waitcnt appears.
-        counts:
-            Number of outstanding operations each waitcnt must account for.
-        history:
-            A list containing all local read events for every vmfma index where
-            at least one local read occured.
-
-    Returns:
-        A list of dicts, of the form:
-            [{"LRA0": int, "LRB0": int, "LRA1": int, "LRB1": int}, ...]
-
-        where each entry corresponds to the number of most-recent local reads
-        attributed to different local read types for that waitcnt.
-    """
-
-    assert len(counts) == len(
-        vmfmas
-    ), "Counts and vmfmas must match in length."
-
-    results: list[dict[str, int]] = []
-    for count, vmfma in zip(counts, vmfmas):
-        idx = 0
-        while idx + 1 < len(history) and history[idx + 1][0] <= vmfma:
-            idx += 1
-        result = {"LRA0": 0, "LRB0": 0, "LRA1": 0, "LRB1": 0}
-        remaining = count
-        while idx >= 0 and remaining > 0:
-            for operand in history[idx][1][::-1]:
-                result[operand] += 1
-                remaining -= 1
-                if remaining == 0:
-                    break
-            idx -= 1
-        results.append(result)
-
-    return results
-
-
-def verify_global_reads_not_too_early_single_code_path(
-    globalReadA: list[int],
-    globalReadB: list[int],
-    localReadA0: list[int],
-    localReadB0: list[int],
-    localReadA1: list[int],
-    localReadB1: list[int],
-    syncIndices: list[int],
-    syncCodes: list,
-    context: dict,
-    positions: dict,
-):
-    """
-    Verifies that:
-      1. All local reads complete before global reads.
-      2. Completion is confirmed by:
-         - s_waitcnt (for wave)
-         - s_barrier (for workgroup)
-
-    Returns:
-        (status: bool, message: str)
-    """
-    assert len(syncIndices) == len(
-        syncCodes
-    ), "Mismatch between number of SYNC vmfmaIndices and number of SYNC codes."
-
-    # indices of waits:
-    vmfmaIndices = []
-
-    # number outstanding of the waits:
-    counts = []
-
-    # indices of the waits with the list of sync codes:
-    indicesOfWaitsInSyncCode = []
-
-    syncCodeIndex = 0
-    for syncIndex, syncCode in zip(syncIndices, syncCodes):
-        if isinstance(syncCode, SWaitCnt):
-            vmfmaIndices.append(syncIndex)
-            counts.append(syncCode.dscnt)
-            indicesOfWaitsInSyncCode.append(syncCodeIndex)
-        syncCodeIndex += 1
-
-
-    # Construct, for every index where a local read occured, the sequence of
-    # local reads that occured, in chronological order.
-    localReads = [
-        ("LRA0", localReadA0),
-        ("LRB0", localReadB0),
-        ("LRA1", localReadA1),
-        ("LRB1", localReadB1),
-    ]
-    localReads.sort(key=lambda x: positions[x[0]])
-
-    history = {}
-    for symbol, values in localReads:
-        for v in values:
-            if v not in history:
-                history[v] = []
-            history[v].append(symbol)
-    history = sorted(history.items(), key=lambda t: t[0])
-
-    preceding = get_most_recent_local_reads(
-        vmfmaIndices,
-        counts,
-        history)
-    for l, g, operand in [
-        (localReadA0, globalReadA, "A"),
-        (localReadB0, globalReadB, "B"),
-    ]:
-        if len(l) == 0 or len(g) == 0:
-            continue
-
-        lastLocal = l[-1]
-        firstGlobal = g[0]
-
-        # Find the first index after the last local read that this wave
-        # completes all the local reads for this operand (if one exists)
-        LRX = "LRA0" if operand == "A" else "LRB0"
-        GRX = "GRA" if operand == "A" else "GRB"
-        local_before_sync = positions[LRX] < positions["SYNC"]
-        global_before_sync = positions[GRX] < positions["SYNC"]
-        closedLowerBound = lastLocal + 1 - local_before_sync
-        openUpperBound = firstGlobal + 1 - global_before_sync
-
-        outstandings = []
-        waveCompleteIndex = None
-        # From the start of the schedule which waitcnt is the current one?
-        waitIndex = 0
-        for syncIndex, precede in zip(vmfmaIndices, preceding):
-            if closedLowerBound <= syncIndex and syncIndex < openUpperBound:
-                count = precede[LRX]
-                outstandings.append(count)
-                if waveCompleteIndex is None and count == 0:
-                    waveCompleteIndex = syncIndex
-                    break
-            waitIndex += 1
-
-        if waveCompleteIndex is None:
-            return False, (
-                f"Failed to verify that all local reads for {operand} ({LRX}) are complete "
-                f"before the first global read for {operand} is issued. "
-                f"Last local read for {operand} issued at vmfma_index:{lastLocal}. "
-                f"First global read for {operand} issued at vmfma_index:{firstGlobal}. "
-                f"{len(outstandings)} waitcnt operation(s) in [{closedLowerBound}, {openUpperBound}) "
-                f"provide upper bounds on the number of outstanding {LRX} operations: "
-                f"{outstandings} <-- none of these is 0."
-            )
-
-        # Check that there is a sync after the wave completion index
-        barrierFound = False
-        syncCodeIndex = indicesOfWaitsInSyncCode[waitIndex]
-        while (
-            syncCodeIndex + 1 < len(syncCodes)
-            and syncIndices[syncCodeIndex + 1] < openUpperBound
-        ):
-            if isinstance(syncCodes[syncCodeIndex + 1], SBarrier):
-                barrierFound = True
-                break
-            syncCodeIndex += 1
-
-        if not barrierFound:
-            return False, (
-                f"Failed to verify that a barrier (to sync waves) exists between completion of "
-                f"local reads for {operand} and the first global read for {operand}. "
-                f"Last local read of {operand} issued at vmfma_index {lastLocal}, "
-                f"first global read of {operand} issued at vmfma_index {firstGlobal}, "
-                f"wave completion at vmfma_index {waveCompleteIndex}. Expected a barrier "
-                f"in the range [{waveCompleteIndex}, {openUpperBound})."
-            )
-
-    return True, ""
-
-
-def verify_global_reads_not_too_early(scheduleInfo, context: dict, code_path: int) -> tuple[bool, str]:
-    """
-    We require the sequence of instructions to be of the form for a single code path:
-
-    last LRA0 instruction
-    [...]
-    SWaitCnt to ensure that all LRA0s are done for this wave
-    [...]
-    SBarrier to ensure that all LRA0s are done for this workgroup
-    [...]
-    First GRA instruction
-
-    Why?
-
-    GRA writes (DDR->LDS) to the LDS that LRA0 reads from (LDS->VGPR).
-
-    We don't know where in LDS GRA writes from. In theory we could determine
-    where exactly each GRA instruction writes to, but currently this is too
-    complicated and so we conservatively assume it always writes everywhere that
-    a thread in the workgroup is reading from in LRA0. Thus we must ensure
-    that every thread in every wave in the workgroup has finished all of its
-    LRA0 instructions before GRA is issued.
-
-    Exactly the same logic applies for the B operand. Note that there are no
-    constraints between LRA0 and GRB, or between LRB0 and GRA, because the LDS
-    used for A and B are completely separate.
-    """
-
-    # Get the relative order of the relevant operations within a vmfma index.
-    positions = {
-        "SYNC": -1,
-        "LRA0": -1,
-        "LRB0": -1,
-        "GRA": -1,
-        "GRB": -1,
-        "LRA1": -1,
-        "LRB1": -1,
-    }
-    index = 0
-    for n in scheduleInfo.optSchedule.keys():
-        positions[n] = index
-        index += 1
-
-    def get(name, codePath):
-        l = scheduleInfo.optSchedule.get(name, [[]])
-        if len(l) == 1:
-            return l[0]
-        return l[codePath]
-
-    globalReadA = get("GRA", code_path)
-    globalReadB = get("GRB", code_path)
-    if context.get("kernel", {}).get("SwapGlobalReadOrder", False):
-        globalReadA, globalReadB = globalReadB, globalReadA
-
-    kernel = context.get("kernel", {})
-    aDirect = kernel.get("DirectToLdsA", False) or kernel.get("DirectToLds", False)
-    bDirect = kernel.get("DirectToLdsB", False) or kernel.get("DirectToLds", False)
-
-    # The actual buffer loads correspond to the indices of the lists
-    # if using DirectToLDS.
-    if aDirect:
-        globalReadA = globalReadA[1::2]
-
-    if bDirect:
-        globalReadB = globalReadB[1::2]
-
-    localReadA0 = get("LRA0", code_path)
-    localReadB0 = get("LRB0", code_path)
-    localReadA1 = get("LRA1", code_path)
-    localReadB1 = get("LRB1", code_path)
-    syncIndices = get("SYNC", code_path)
-    syncCodes = scheduleInfo.syncCode
-
-    status, message = verify_global_reads_not_too_early_single_code_path(
-        globalReadA,
-        globalReadB,
-        localReadA0,
-        localReadB0,
-        localReadA1,
-        localReadB1,
-        syncIndices,
-        syncCodes,
-        context,
-        positions,
-    )
-    return status, message
-
 class ValidatorInstruction(ABC):
     """
     Abstract class with no method just for type hinting purposes.
@@ -487,11 +215,73 @@ class GlobalRead(ValidatorInstruction):
     needed_by: float = float('inf')
     guaranteed_by: Union[int, float] = float('inf')
     barriered_at: list[Union[int, float]] = field(default_factory=list)
+    must_start_after: ValidatorInstruction = field(default_factory=lambda: MFMA(float('-inf')))
+    must_start_after_barriered_at: list[Union[int, float]] = field(default_factory=list)
 
     def done_idx(self) -> Union[int, float]:
         return self.guaranteed_by
 
     def validate(self) -> Optional[str]:
+        # Check must_start_after constraint (GR must start after LR0s are done)
+        must_start_after_error = self._validate_must_start_after()
+        if must_start_after_error:
+            return must_start_after_error
+
+        # Check needed_by constraint (GR must finish before LR1/3)
+        needed_by_error = self._validate_needed_by()
+        if needed_by_error:
+            return needed_by_error
+
+        return None
+
+    def _validate_must_start_after(self) -> Optional[str]:
+        """Validate: last LR0 -> SWaitCnt -> SBarrier -> GR"""
+        # If must_start_after is at -inf, the constraint is not active (e.g. no LR0s).
+        if self.must_start_after.done_idx() == float('-inf'):
+            return None
+
+        name = self._name()
+        issued_at = floor(self.issued_at) % self.num_vmfma
+
+        must_start_after_done = self.must_start_after.done_idx()
+
+        # Happy path: LR0 done before GR, and a barrier exists in between.
+        if must_start_after_done < self.issued_at:
+            if any(must_start_after_done < b < self.issued_at for b in self.must_start_after_barriered_at):
+                return None
+
+        must_start_after_issued_at = floor(self.must_start_after.issued_at) % self.num_vmfma
+
+        context_str = ""
+        if must_start_after_done > self.num_vmfma:
+            context_str = " (of next iteration)"
+
+        # 1. Issued too early (before LR0 is guaranteed done)
+        if self.issued_at <= must_start_after_done:
+            must_start_after_at = floor(must_start_after_done) % self.num_vmfma
+            return (
+                f"{name} @ idx={issued_at} is issued too early. "
+                f"Must be issued after idx={must_start_after_at}{context_str}, which is when {self.must_start_after.name} is guaranteed done."
+            )
+
+        # 2. No barrier between LR0 done and GR
+        if not any(must_start_after_done < b < self.issued_at for b in self.must_start_after_barriered_at):
+            must_start_after_at = floor(must_start_after_done) % self.num_vmfma
+            must_start_after_issued_at = floor(self.must_start_after.issued_at) % self.num_vmfma
+            return (
+                f"There is an SBarrier missing between the SWaitCnt @ idx={must_start_after_at} (which guarantees {self.must_start_after.name} from idx={must_start_after_issued_at} to done) and the {name} @ idx={issued_at}. "
+                f"Order must be {self.must_start_after.name} -> SWait -> SBarrier -> {name}."
+            )
+
+        # TODO: Did we miss a case and will we ever end up here?
+        return f"{name} @ idx={issued_at} is not valid."
+
+    def _validate_needed_by(self) -> Optional[str]:
+        """Validate: GR -> SWait -> SBarrier -> LR1"""
+        # If needed_by is at inf, the constraint is not active (e.g. no LR1s).
+        if self.needed_by == float('inf'):
+            return None
+
         if self.issued_at < self.guaranteed_by < self.needed_by:
             if any(self.guaranteed_by < barriered_at < self.needed_by for barriered_at in self.barriered_at):
                     return None
@@ -503,25 +293,25 @@ class GlobalRead(ValidatorInstruction):
 
         # 1. No SWait
         if self.guaranteed_by == float('inf'):
-            return f"{name} at index {issued_at} is not valid. There are no guarantees on when it will be done."
+            return f"{name} @ idx={issued_at} is not valid. There are no guarantees on when it will be done."
 
         # NOTE: Must do it after the check above to guard against infinity.
         guaranteed_by = floor(self.guaranteed_by) % self.num_vmfma
 
         # 2. No Barrier
         if len(self.barriered_at) == 0:
-            return f"{name} at index {issued_at} is not valid. There is no SBarrier acting on it."
+            return f"{name} @ idx={issued_at} is not valid. There is no SBarrier acting on it."
 
         # 3. Guaranteed after needed
         if self.guaranteed_by > self.needed_by:
-            return f"{name} at index {issued_at} is not valid. It is guaranteed by the SWait @ idx={guaranteed_by} which is after the first corresponding LR1 @ idx={needed_by}. Order must be GR -> SWait -> SBarrier -> LR1."
+            return f"{name} @ idx={issued_at} is not valid. It is guaranteed by the SWait @ idx={guaranteed_by} which is after the first corresponding LR1 @ idx={needed_by}. Order must be {name} -> SWait -> SBarrier -> LR1."
 
         # 4. No Barrier between SWait and LR1
         if not any(self.guaranteed_by < barriered_at < self.needed_by for barriered_at in self.barriered_at):
-            return f"{name} at index {issued_at} is not valid. No SBarrier between SWait @ idx={guaranteed_by} and LR1 @ idx={needed_by}. Order must be GR -> SWait -> SBarrier -> LR1."
+            return f"{name} @ idx={issued_at} is not valid. No SBarrier between SWait @ idx={guaranteed_by} and LR1 @ idx={needed_by}. Order must be {name} -> SWait -> SBarrier -> LR1."
 
         # TODO: Did we miss a case and will we ever end up here?
-        return f"{name} at index {issued_at} is not valid. issued @ idx={issued_at}, guaranteed @ idx={guaranteed_by}, barriered @ idx={[floor(i) for i in self.barriered_at]}, needed @ idx={needed_by} is not valid."
+        return f"{name} @ idx={issued_at} is not valid. issued @ idx={issued_at}, guaranteed @ idx={guaranteed_by}, barriered @ idx={[floor(i) for i in self.barriered_at]}, needed @ idx={needed_by} is not valid."
 
     def _name(self) -> str:
         name = self.name
@@ -861,6 +651,38 @@ def apply_barriers(timeline: Timeline) -> None:
             instruction.barriered_at.append(barrier.issued_at)
 
 
+def apply_must_start_after_barriers(timeline: Timeline) -> None:
+    """
+    Apply the effect of SBarriers to the must_start_after_barriered_at field of GlobalReads.
+    For each GlobalRead, finds SBarrier instructions that occur between must_start_after.done_idx()
+    and the GlobalRead's issued_at. These barriers ensure all waves have completed the LR0s.
+    Timeline is modified in place.
+
+    Args:
+        timeline: The Timeline object containing the instructions.
+    """
+    for i_gr, gr in timeline.get_instructions_combined("GRA"):
+        _apply_must_start_after_barriers_single(timeline, gr, i_gr)
+    for i_gr, gr in timeline.get_instructions_combined("GRB"):
+        _apply_must_start_after_barriers_single(timeline, gr, i_gr)
+
+
+def _apply_must_start_after_barriers_single(timeline: Timeline, gr: GlobalRead, i_gr: int) -> None:
+    """Apply must_start_after barriers for a single GlobalRead instruction."""
+    if gr.must_start_after.done_idx() == float('-inf'):
+        return
+
+    must_start_after_done = gr.must_start_after.done_idx()
+
+    # Walk backwards from the GR to find SBarriers between must_start_after.done_idx() and issued_at.
+    for i_inst in range(i_gr - 1, -1, -1):
+        instruction = timeline.combined_timeline[i_inst]
+        if not isinstance(instruction, Barrier):
+            continue
+        if must_start_after_done < instruction.issued_at < gr.issued_at:
+            gr.must_start_after_barriered_at.append(instruction.issued_at)
+
+
 def apply_swaits(timeline: Timeline) -> None:
     """
     Apply the effect of SWaitCnts to the timeline by updating the guaranteed_by field of LocalReads and GlobalReads.
@@ -977,6 +799,41 @@ def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) 
             _, LR_target = target[0]
             for _, gr in grs:
                 gr.needed_by = LR_target.issued_at
+
+def set_gr_must_start_after_from_lr0s(timeline: Timeline, swap_global_read_order: bool) -> None:
+    """
+    Set the must_start_after field of the first GlobalRead based on the last LR0 of the same loop.
+
+    GRs in iteration N write (DDR->LDS) to the LDS that LR0s of iteration N read from (LDS->VGPR).
+    The first GRA must start after the last LRA0 of the same iteration is guaranteed done
+    (and vice versa for B). If SwapGlobalReadOrder is True, GRA loads B so the first GRA must
+    start after the last LRB0, and the first GRB must start after the last LRA0.
+
+    The LR0's done_idx() is its guaranteed_by (set by apply_swaits), which is the SWaitCnt index.
+
+    Args:
+        timeline: The Timeline object containing the instructions.
+        swap_global_read_order: Whether global read order is swapped.
+    """
+    target_names = {"GRA": "LRA0", "GRB": "LRB0"}
+
+    if swap_global_read_order:
+        target_names["GRA"], target_names["GRB"] = target_names["GRB"], target_names["GRA"]
+
+    for _, loop in enumerate(timeline.loops):
+        for gr_name, lr0_name in target_names.items():
+            grs = timeline.get_instructions(gr_name, loop)
+            if not grs:
+                continue
+
+            lr0s = timeline.get_instructions(lr0_name, loop)
+            if not lr0s:
+                continue
+
+            # The last LR0 of the corresponding type in this loop.
+            _, last_lr0 = lr0s[-1]
+            for _, gr in grs:
+                gr.must_start_after = last_lr0
 
 def find_earliest_mfma_execution(
     is_pack_B: bool,
@@ -2068,6 +1925,33 @@ def verify_grs_finish_before_lrs(schedule_info: 'ScheduleInfo', context: dict, c
     return True, ""
 
 
+def verify_grs_not_too_early(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
+    """
+    Ensure that GlobalReads are not issued before the corresponding LR0s are guaranteed complete.
+
+    Required ordering per operand:
+        last LR0 -> SWaitCnt (ensures LR0 done for wave) -> SBarrier (ensures LR0 done for workgroup) -> first GR
+
+    GRA writes (DDR->LDS) to the LDS that LRA0 reads from (LDS->VGPR).
+    We conservatively assume GRA always writes everywhere that a thread in the workgroup is reading from in LRA0.
+    Thus we must ensure that every thread in every wave in the workgroup has finished all of its LRA0 instructions
+    before GRA is issued. Same logic applies for B. No cross-operand constraints (LRA0 vs GRB are independent).
+    """
+    relevant_names = ["GRA", "GRB", "LRA0", "LRB0", "LRA1", "LRB1", "LRA3", "LRB3", "SYNC"]
+    kernel = context["kernel"]
+    timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
+
+    # apply_swaits must run first so that LR0.guaranteed_by (done_idx) is set before must_start_after hookup.
+    apply_swaits(timeline)
+    set_gr_must_start_after_from_lr0s(timeline, kernel.get("SwapGlobalReadOrder", False))
+    apply_must_start_after_barriers(timeline)
+
+    message = validate_timeline(timeline)
+    if message:
+        return False, message
+    return True, ""
+
+
 def index_for_force_unroll_sub_iter(original_idx: int, M: int, N: int) -> int:
     """
     Map original column-major index to index scheme used by force unroll sub-iter:
@@ -2259,7 +2143,7 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
         verify_ascending_order,
         verify_lrs_finished_before_vmfma,
         verify_packs_start_and_end_at_correct_indices,
-        verify_global_reads_not_too_early,
+        verify_grs_not_too_early,
         verify_grs_finish_before_lrs,
         verify_scc_overlap,
         verify_gr_inc_order

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
@@ -79,7 +79,7 @@ class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, 2, 2, 0,
-            "GRA at index 0 is not valid. There are no guarantees on when it will be done."
+            "GRA @ idx=0 is not valid. There are no guarantees on when it will be done."
         )
 
     def test_no_sbarrier(self): 
@@ -105,7 +105,7 @@ class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, 2, 2, 0,
-            "GRA at index 0 is not valid. There is no SBarrier acting on it."
+            "GRA @ idx=0 is not valid. There is no SBarrier acting on it."
         )
 
     def test_swait_after_sbarrier(self):
@@ -132,7 +132,7 @@ class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, 2, 2, 0,
-            "GRA at index 0 is not valid. No SBarrier between SWait @ idx=3 and LR1 @ idx=6. Order must be GR -> SWait -> SBarrier -> LR1."
+            "GRA @ idx=0 is not valid. No SBarrier between SWait @ idx=3 and LR1 @ idx=6. Order must be GRA -> SWait -> SBarrier -> LR1."
         )
 
     def test_guaranteed_after_first_lr1(self):
@@ -160,7 +160,7 @@ class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
 
         self.validate(
             optSchedule, syncCode, 1, 4, 4, 0,
-            "GRA at index 0 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=3. Order must be GR -> SWait -> SBarrier -> LR1."
+            "GRA @ idx=0 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=3. Order must be GRA -> SWait -> SBarrier -> LR1."
         )
 
     def test_less_than_1_full_iteration_to_complete(self):
@@ -363,7 +363,7 @@ class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, 2, 2, 0,
-            "GRB (Swapped, loading A) at index 3 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=2. Order must be GR -> SWait -> SBarrier -> LR1."
+            "GRB (Swapped, loading A) @ idx=3 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=2. Order must be GRB (Swapped, loading A) -> SWait -> SBarrier -> LR1."
         )
 
     def test_fail_with_odd_number_of_grs(self):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
@@ -20,150 +20,26 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-from Tensile.Components.CMSValidator import verify_global_reads_not_too_early, get_most_recent_local_reads
+from Tensile.Components.CMSValidator import verify_grs_not_too_early
 from rocisa.instruction import SBarrier, SWaitCnt
 from cms_validation_base import CMSValidationTestBase
 
-class TestHelperFunctions:
-    def test_get_most_recent_basic(self):
-        """
-        Test of utility function used to determine how many of the most recent ds_read
-        operations are for A, and how many are for B.
-        """
-
-        def get_most_recent_local_reads_without_lr1(indices, counts, A, B, aBeforeB):
-            """
-            Assume that LRA0 appears before LRB0 within mfma index slots, and
-            don't include LRA1 or LRB1 in the analysis.
-            """
-            positions = {"LRA1": -1, "LRB1": -1, "LRA0": 1 - aBeforeB, "LRB0": aBeforeB}
-
-            localReads = [
-                ("LRA0", A),
-                ("LRB0", B),
-                ("LRA1", []),
-                ("LRB1", []),
-            ]
-            localReads.sort(key=lambda x: positions[x[0]])
-
-            history = {}
-            for symbol, values in localReads:
-                for v in values:
-                    if v not in history:
-                        history[v] = []
-                    history[v].append(symbol)
-            history = sorted(history.items(), key=lambda t: t[0])
-
-            mr = get_most_recent_local_reads(indices, counts, history)
-            filtered = []
-            for l in mr:
-                filtered.append({"A": l["LRA0"], "B": l["LRB0"]})
-            return filtered
-
-        A = [0, 1, 4, 6, 8, 9]
-        B = [2, 6, 7]
-        #         0 1 2 3 4 5 6 7 8 9
-        #         ===================
-        # A       x x     x   x   x x
-        # B           x       x x
-        # index     ^
-        #
-        # Looking backwards from (and including) index=1, find the
-        # counts=2 most recent appearances of A or B. How many
-        # are A and how many are B?
-        indices = [1]
-        counts = [2]
-        aBeforeB = True
-        bBeforeA = not aBeforeB
-        result = get_most_recent_local_reads_without_lr1(
-            indices, counts, A, B, aBeforeB
-        )
-        expected0 = [{"A": 2, "B": 0}]
-        assert result == expected0
-
-        # A similar example, but with a different index and count.
-        #         0 1 2 3 4 5 6 7 8 9
-        #         ===================
-        # A       x x     x   x   x x
-        # B           x       x x
-        # index               ^
-        indices = [6]
-        counts = [4]
-        result = get_most_recent_local_reads_without_lr1(
-            indices, counts, A, B, aBeforeB
-        )
-        expected1 = [{"A": 2, "B": 2}]
-        assert result == expected1
-
-        # Multiple indices and counts are handled independently
-        indices = [1, 6]
-        counts = [2, 4]
-        result = get_most_recent_local_reads_without_lr1(
-            indices, counts, A, B, aBeforeB
-        )
-        assert result == [expected0[0], expected1[0]]
-
-        A = [1, 1, 1]
-        B = [1, 1, 2]
-        #    0 1 2 4 5 ...
-        #    =============
-        # A  0 3 0 0 0 ...
-        # B  0 2 1 0 0 ....
-        indices = [5, 5, 5]
-        counts = [6, 2, 0]
-
-        # index=5, count=6 : A:3 B:3
-        #
-        # index=5, count=2 : the most recent going back from index=5 is a
-        # B at index 2. We need 1 more (count=2), but at index 1 there are
-        # As and Bs. We use that A happens before B within the index (
-        # and so as we're going in reverse chronological order, we take B).
-        #
-        # index=5, count=0: A:0 B:0
-        result = get_most_recent_local_reads_without_lr1(
-            indices, counts, A, B, aBeforeB
-        )
-        assert result == [{"A": 3, "B": 3}, {"A": 0, "B": 2}, {"A": 0, "B": 0}]
-
-        # Changed so that B is before A.
-        result = get_most_recent_local_reads_without_lr1(
-            indices, counts, A, B, bBeforeA
-        )
-        assert result == [{"A": 3, "B": 3}, {"A": 1, "B": 1}, {"A": 0, "B": 0}]
-
-    def test_get_most_recent(self):
-        """
-        Testing that within vmfma index ordering is correctly handled.
-        """
-
-        indices = [10, 10, 10, 10]
-        counts = [1, 2, 3, 4]
-
-        history = [[7, ["LRA0", "LRA1", "LRB0", "LRB1"]]]
-        foo = get_most_recent_local_reads(indices, counts, history)
-        # counts = 1
-        assert foo[0] == {"LRA0": 0, "LRB0": 0, "LRA1": 0, "LRB1": 1}
-        # counts = 2
-        assert foo[1] == {"LRA0": 0, "LRB0": 1, "LRA1": 0, "LRB1": 1}
-        # counts = 3
-        assert foo[2] == {"LRA0": 0, "LRB0": 1, "LRA1": 1, "LRB1": 1}
-        # counts = 4
-        assert foo[3] == {"LRA0": 1, "LRB0": 1, "LRA1": 1, "LRB1": 1}
-
-        history = [[7, ["LRB1", "LRB0", "LRA1", "LRA0"]]]
-        foo = get_most_recent_local_reads(indices, counts, history)
-        assert foo[0] == {"LRA0": 1, "LRB0": 0, "LRA1": 0, "LRB1": 0}
-        assert foo[1] == {"LRA0": 1, "LRB0": 0, "LRA1": 1, "LRB1": 0}
-        assert foo[2] == {"LRA0": 1, "LRB0": 1, "LRA1": 1, "LRB1": 0}
-        assert foo[3] == {"LRA0": 1, "LRB0": 1, "LRA1": 1, "LRB1": 1}
-
 class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
+    """
+    Tests for the Timeline-based verify_grs_not_too_early validation.
+    
+    num_vmfma = 8 for the default kernel (MIWaveTileA=2, MIWaveTileB=2, DepthU=64, MI[2]=32).
+    Valid vmfma indices are [-1, 7].
+
+    Since the Timeline class requires DirectToLds=True, GR schedules must contain
+    paired entries: even indices are m0-pointer-updates (ignored), odd indices are actual
+    buffer_loads. For example, GRA: [[3, 5]] means m0-update at 3, load at 5.
+    """
     def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_global_reads_not_too_early(sched, kernel_dict, codePathIdx)
+        return verify_grs_not_too_early(sched, kernel_dict, codePathIdx)
 
     def setUp(self):
         super().setUp()
-        self.kernel["DirectToLds"] = False
 
     def test_basic(self):
         """
@@ -171,11 +47,12 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         GRA load at 5, GRB load at 6. All safe.
         """
         assert self.num_vmfma == 8
+        assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[3, 4]],
-            "GRA": [[5]],
+            "GRA": [[5, 5]],
             "LRA0": [[0]],
-            "GRB": [[6]],
+            "GRB": [[6, 6]],
             "LRB0": [[1]],
         }
         syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier(comment="")]
@@ -188,9 +65,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[1, 1, 5, 5]],
-            "GRA": [[2]],
+            "GRA": [[2, 2]],
             "LRA0": [[0]],
-            "GRB": [[7]],
+            "GRB": [[7, 7]],
             "LRB0": [[0]],
         }
         syncCode = [
@@ -208,9 +85,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[1, 1, 5, 5]],
-            "GRA": [[7]],
+            "GRA": [[7, 7]],
             "LRA0": [[0]],
-            "GRB": [[2]],
+            "GRB": [[2, 2]],
             "LRB0": [[0]],
         }
         syncCode = [
@@ -221,32 +98,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
-            "Last local read for B issued at vmfma_index:0. "
-            "First global read for B issued at vmfma_index:2. "
-            "1 waitcnt operation(s) in [1, 3) provide upper bounds on the number of outstanding LRB0 operations: [1] <-- none of these is 0."
+            "GRB @ idx=2 is issued too early. "
+            "Must be issued after idx=5, which is when LRB0 is guaranteed done."
         )
-
-    def test_interleave_gr_and_lrs(self):
-        """
-        This is like the preceding test, but now the waitcnt 1 is for an unrelated ds_load
-        """
-        assert self.num_vmfma == 8
-        optSchedule = {
-            "SYNC": [[1, 1, 5, 5]],
-            "GRA": [[6]],
-            "LRA0": [[0]],
-            "GRB": [[2]],
-            "LRB0": [[0]],
-            "LRB1": [[0]],
-        }
-        syncCode = [
-            SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment=""),
-            SBarrier(comment=""),
-            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
-            SBarrier(comment=""),
-        ]
-        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
 
     def test_different_simd_codes(self):
         """
@@ -257,8 +111,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "SYNC": [[3, 4]],
             "LRA0": [[0], [2]],
             "LRB0": [[1]],
-            "GRA": [[5]],
-            "GRB": [[6], [7]],
+            "GRA": [[5, 5]],
+            "GRB": [[6, 6], [7, 7]],
         }
         syncCode = [
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
@@ -276,8 +130,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "SYNC": [[3, 4]],
             "LRA0": [[0], [4]],  # Read for codepath 1 is too late.
             "LRB0": [[1]],
-            "GRA": [[5]],
-            "GRB": [[6], [7]],
+            "GRA": [[5, 5]],
+            "GRB": [[6, 6], [7, 7]],
         }
         syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier()]
 
@@ -289,10 +143,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         # very high. GRA's issued_at < must_start_after.done_idx() -> too early.
         self.validate(
             optSchedule, syncCode, 2, None, None, 1,
-            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
-            "Last local read for A issued at vmfma_index:4. "
-            "First global read for A issued at vmfma_index:5. "
-            "0 waitcnt operation(s) in [5, 6) provide upper bounds on the number of outstanding LRA0 operations: [] <-- none of these is 0."
+            "GRA @ idx=5 is issued too early. "
+            "Must be issued after idx=3 (of next iteration), which is when LRA0 is guaranteed done."
         )
 
     def test_negative_b_too_early(self):
@@ -303,18 +155,16 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[3, 4]],
-            "GRA": [[5]],
+            "GRA": [[5, 5]],
             "LRA0": [[0]],
-            "GRB": [[6]],
+            "GRB": [[6, 6]],
             "LRB0": [[1]],
         }
         syncCode = [SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment=""), SBarrier(comment="")]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
-            "Last local read for B issued at vmfma_index:1. "
-            "First global read for B issued at vmfma_index:6. "
-            "1 waitcnt operation(s) in [2, 7) provide upper bounds on the number of outstanding LRB0 operations: [1] <-- none of these is 0."
+            "GRB @ idx=6 is issued too early. "
+            "Must be issued after idx=3 (of next iteration), which is when LRB0 is guaranteed done."
         )
 
     def test_negative_barrier_before_swait(self):
@@ -325,17 +175,16 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[2, 3]],
-            "GRA": [[5]],
+            "GRA": [[5, 5]],
             "LRA0": [[0]],
-            "GRB": [[6]],
+            "GRB": [[6, 6]],
             "LRB0": [[1]],
         }
         syncCode = [SBarrier(comment=""), SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="")]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that a barrier (to sync waves) exists between completion of local reads for A and the first global read for A. "
-            "Last local read of A issued at vmfma_index 0, first global read of A issued at vmfma_index 5, wave completion at vmfma_index 3. "
-            "Expected a barrier in the range [3, 6)."
+            "There is an SBarrier missing between the SWaitCnt @ idx=3 (which guarantees LRA0 from idx=0 to done) and the GRA @ idx=5. "
+            "Order must be LRA0 -> SWait -> SBarrier -> GRA."
         )
 
     def test_interleave_separate_pairs(self):
@@ -346,9 +195,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[2, 3, 5, 6]],
-            "GRA": [[4]],
+            "GRA": [[4, 4]],
             "LRA0": [[0]],
-            "GRB": [[7]],
+            "GRB": [[7, 7]],
             "LRB0": [[1]],
         }
         syncCode = [
@@ -367,9 +216,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[4, 4, 6, 6]],
-            "GRA": [[5]],
+            "GRA": [[5, 5]],
             "LRA0": [[0, 2]],
-            "GRB": [[7]],
+            "GRB": [[7, 7]],
             "LRB0": [[1, 3]],
         }
         syncCode = [
@@ -389,9 +238,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[3, 4, 6, 6]],
-            "GRA": [[5]],
+            "GRA": [[5, 5]],
             "LRA0": [[0, 2]],
-            "GRB": [[7]],
+            "GRB": [[7, 7]],
             "LRB0": [[1, 3]],
         }
         syncCode = [
@@ -402,10 +251,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
-            "Last local read for A issued at vmfma_index:2. "
-            "First global read for A issued at vmfma_index:5. "
-            "1 waitcnt operation(s) in [3, 6) provide upper bounds on the number of outstanding LRA0 operations: [1] <-- none of these is 0."
+            "GRA @ idx=5 is issued too early. "
+            "Must be issued after idx=6, which is when LRA0 is guaranteed done."
         )
 
     def test_sync_and_gr_at_same_index(self):
@@ -417,9 +264,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[1, 1, 5, 5]],
-            "GRA": [[1, 6]],
+            "GRA": [[1, 1, 6, 6]],
             "LRA0": [[0]],
-            "GRB": [[5, 6]],
+            "GRB": [[5, 5, 6, 6]],
             "LRB0": [[4]],
         }
         syncCode = [
@@ -439,9 +286,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[1, 2, 3, 4, 5, 5, 5]],
-            "GRA": [[5, 7]],
+            "GRA": [[5, 5, 7, 7]],
             "LRA0": [[0]],
-            "GRB": [[7, 7]],
+            "GRB": [[7, 7, 7, 7]],
             "LRB0": [[4]],
         }
         syncCode = [
@@ -455,73 +302,6 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ]
         self.validate(optSchedule, syncCode, 1, None, None, 0, None)
 
-    def test_direct_to_lds_a(self):
-        """
-        When using direct to LDS, the instructions in GRA and GRB are of the form
-
-        0: update the m0 register,
-        1: issue buffer_load,
-        2: update the m0 register,
-        3: issue buffer_load
-
-        etc. Therefore the instructions at the even indices can be ignored.
-        In this test, the first GRA instruction, issued in mfma vmfma_index 3,
-        is not a buffer_load, and so we don't need to ensure the LRA0 instructions
-        are complete yet for it.
-        """
-        assert self.num_vmfma == 8
-        optSchedule = {
-            "SYNC": [[5, 6]],
-            "GRA": [[3, 7]],
-            "LRA0": [[2]]
-        }
-        syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier(comment="")]
-
-        self.kernel["DirectToLdsA"] = True
-        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
-
-    def test_direct_to_lds(self):
-        """
-        When using direct to LDS, the instructions in GRA and GRB are of the form
-
-        0: update the m0 register,
-        1: issue buffer_load,
-        2: update the m0 register,
-        3: issue buffer_load
-
-        etc. Therefore the instructions at the even indices can be ignored.
-        In this test, the first GRA instruction, issued in mfma vmfma_index 3,
-        is not a buffer_load, and so we don't need to ensure the LRA0 instructions
-        are complete yet for it.
-        """
-        assert self.num_vmfma == 8
-        optSchedule = {
-            "SYNC": [[5, 6]],
-            "GRA": [[3, 7]],
-            "LRA0": [[2]],
-        }
-        syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier(comment="")]
-
-        self.kernel["DirectToLds"] = True
-        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
-
-    def test_negative_direct_to_lds_b(self):
-        optSchedule = {
-            "SYNC": [[5, 6]],
-            "GRB": [[3, 4]],
-            "LRB0": [[2]],
-        }
-        syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier(comment="")]
-
-        self.kernel["DirectToLdsB"] = True
-        self.validate(
-            optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
-            "Last local read for B issued at vmfma_index:2. "
-            "First global read for B issued at vmfma_index:4. "
-            "0 waitcnt operation(s) in [3, 5) provide upper bounds on the number of outstanding LRB0 operations: [] <-- none of these is 0."
-        )
-
     def test_swap_global_read_order(self):
         """
         SwapGlobalReadOrder: GRA loads B -> must start after LRB0,
@@ -530,9 +310,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[1, 2, 5, 6]],
-            "GRA": [[7]],
+            "GRA": [[6, 7]],
             "LRA0": [[0]],
-            "GRB": [[3]],
+            "GRB": [[2, 3]],
             "LRB0": [[4]],
         }
         syncCode = [
@@ -553,9 +333,9 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         assert self.num_vmfma == 8
         optSchedule = {
             "SYNC": [[1, 2, 5, 6]],
-            "GRA": [[3]],
+            "GRA": [[3, 3]],
             "LRA0": [[0]],
-            "GRB": [[7]],
+            "GRB": [[7, 7]],
             "LRB0": [[4]],
         }
         syncCode = [
@@ -567,10 +347,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         self.kernel["SwapGlobalReadOrder"] = True
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
-            "Last local read for B issued at vmfma_index:4. "
-            "First global read for B issued at vmfma_index:3. "
-            "0 waitcnt operation(s) in [5, 4) provide upper bounds on the number of outstanding LRB0 operations: [] <-- none of these is 0."
+            "GRA (Swapped, loading B) @ idx=3 is issued too early. "
+            "Must be issued after idx=5, which is when LRB0 is guaranteed done."
         )
 
     def test_ab_tiebreaking_lra0_before_lrb0(self):
@@ -582,8 +360,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRA0": [[2]],
             "LRB0": [[2]],
             "SYNC": [[3, 3]],
-            "GRA": [[4]],  # The read for A is safe, LRA0 appears before LRB0.
-            "GRB": [[7]],
+            "GRA": [[4,4]],  # The read for A is safe, LRA0 appears before LRB0.
+            "GRB": [[7,7]],
         }
         syncCode = [
             SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment=""),
@@ -591,10 +369,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
-            "Last local read for B issued at vmfma_index:2. "
-            "First global read for B issued at vmfma_index:7. "
-            "1 waitcnt operation(s) in [2, 8) provide upper bounds on the number of outstanding LRB0 operations: [1] <-- none of these is 0."
+            "GRB @ idx=7 is issued too early. "
+            "Must be issued after idx=3 (of next iteration), which is when LRB0 is guaranteed done."
         )
 
     def test_ab_tiebreaking_lrb0_before_lra0(self):
@@ -608,8 +384,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRB0": [[2]],
             "LRA0": [[2]],
             "SYNC": [[3, 3]],
-            "GRA": [[4]],  # The read for A is NOT safe, LRA0 appears after LRB0.
-            "GRB": [[7]],
+            "GRA": [[4,4]],  # The read for A is NOT safe, LRA0 appears after LRB0.
+            "GRB": [[7,7]],
         }
         syncCode = [
             SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment=""),
@@ -617,10 +393,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
-            "Last local read for A issued at vmfma_index:2. "
-            "First global read for A issued at vmfma_index:4. "
-            "1 waitcnt operation(s) in [2, 5) provide upper bounds on the number of outstanding LRA0 operations: [1] <-- none of these is 0."
+            "GRA @ idx=4 is issued too early. "
+            "Must be issued after idx=3 (of next iteration), which is when LRA0 is guaranteed done."
         )
 
     def test_waitcnt_barrier_relative_order_barrier_too_late_for_a(self):
@@ -633,8 +407,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRB0": [[5]],
             # The first barrier after the waitcnt is at index 6. Too late.
             "SYNC": [[1, 5, 5, 5, 6]],
-            "GRA": [[5]],
-            "GRB": [[5]],
+            "GRA": [[5,5]],
+            "GRB": [[5,5]],
         }
         syncCode = [
             SBarrier(),
@@ -644,9 +418,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             SBarrier(),
         ]
         self.validate(optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that a barrier (to sync waves) exists between completion of local reads for A and the first global read for A. "
-            "Last local read of A issued at vmfma_index 5, first global read of A issued at vmfma_index 5, wave completion at vmfma_index 5. "
-            "Expected a barrier in the range [5, 6)."
+            "There is an SBarrier missing between the SWaitCnt @ idx=5 (which guarantees LRA0 from idx=5 to done) and the GRA @ idx=5. "
+            "Order must be LRA0 -> SWait -> SBarrier -> GRA."
         )
 
     def test_waitcnt_barrier_relative_order_barrier_too_late_for_b(self):
@@ -659,8 +432,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRB0": [[2]],
             # The first barrier after the required waitcnt is at index 6. Too late.
             "SYNC": [[5, 5, 5, 5, 6]],
-            "GRA": [[7]],
-            "GRB": [[5]],
+            "GRA": [[7,7]],
+            "GRB": [[5,5]],
         }
         syncCode = [
             SBarrier(),
@@ -671,14 +444,13 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that a barrier (to sync waves) exists between completion of local reads for B and the first global read for B. "
-            "Last local read of B issued at vmfma_index 2, first global read of B issued at vmfma_index 5, wave completion at vmfma_index 5. "
-            "Expected a barrier in the range [5, 6)."
+            "There is an SBarrier missing between the SWaitCnt @ idx=5 (which guarantees LRB0 from idx=2 to done) and the GRB @ idx=5. "
+            "Order must be LRB0 -> SWait -> SBarrier -> GRB."
         )
 
     def test_within_mfma_index_order_local_reads_before_syncs_before_global_read(self):
         """
-        Within-index dict ordering: LR0 < SYNC < GR. At index 5, LR0 is issued,
+        Within-index dict ordering: LR0 < SYNC < GR. At index 3, LR0 is issued,
         then SWaitCnt+SBarrier, then GR. Safe.
         """
         assert self.num_vmfma == 8
@@ -686,8 +458,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRA0": [[5]],
             "LRB0": [[5]],
             "SYNC": [[5, 5]],
-            "GRA": [[5]],
-            "GRB": [[5]],
+            "GRA": [[5,5]],
+            "GRB": [[5,5]],
         }
         syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier()]
         self.validate(optSchedule, syncCode, 1, None, None, 0, None)
@@ -700,17 +472,15 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         optSchedule = {
             "LRA0": [[5]],
             "LRB0": [[5]],
-            "GRB": [[5]],
+            "GRB": [[5,5]],
             "SYNC": [[5,5]],
-            "GRA": [[5]],
+            "GRA": [[5,5]],
         }
         syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier()]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for B (LRB0) are complete before the first global read for B is issued. "
-            "Last local read for B issued at vmfma_index:5. "
-            "First global read for B issued at vmfma_index:5. "
-            "0 waitcnt operation(s) in [5, 5) provide upper bounds on the number of outstanding LRB0 operations: [] <-- none of these is 0."
+            "GRB @ idx=5 is issued too early. "
+            "Must be issued after idx=5, which is when LRB0 is guaranteed done."
         )
 
     def test_within_mfma_index_order_sync_before_local_read_for_a(self):
@@ -723,16 +493,14 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRB0": [[5]],
             "SYNC": [[5,5]],
             "LRA0": [[5]],
-            "GRA": [[5]],
-            "GRB": [[5]],
+            "GRA": [[5,5]],
+            "GRB": [[5,5]],
         }
         syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier()]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
-            "Last local read for A issued at vmfma_index:5. "
-            "First global read for A issued at vmfma_index:5. "
-            "0 waitcnt operation(s) in [6, 6) provide upper bounds on the number of outstanding LRA0 operations: [] <-- none of these is 0."
+            "GRA @ idx=5 is issued too early. "
+            "Must be issued after idx=5 (of next iteration), which is when LRA0 is guaranteed done."
         )
 
     def test_within_mfma_index_order_no_sync_for_global_read_a(self):
@@ -745,8 +513,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "SYNC": [[5, 5, 6, 6]],
             "LRB0": [[5]],
             "LRA0": [[5]],
-            "GRA": [[5]],
-            "GRB": [[7]],
+            "GRA": [[5,5]],
+            "GRB": [[7,7]],
         }
         syncCode = [
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
@@ -756,10 +524,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
-            "Last local read for A issued at vmfma_index:5. "
-            "First global read for A issued at vmfma_index:5. "
-            "0 waitcnt operation(s) in [6, 6) provide upper bounds on the number of outstanding LRA0 operations: [] <-- none of these is 0."
+            "GRA @ idx=5 is issued too early. "
+            "Must be issued after idx=6, which is when LRA0 is guaranteed done."
         )
 
     def test_within_mfma_index_order_sync_after_gra_too_late(self):
@@ -772,16 +538,15 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         optSchedule = {
             "LRA0": [[5]],
             "LRB0": [[5]],
-            "GRB": [[7]],
-            "GRA": [[6]],
+            "GRB": [[7,7]],
+            "GRA": [[6,6]],
             "SYNC": [[5, 6]],
         }
         syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier()]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that a barrier (to sync waves) exists between completion of local reads for A and the first global read for A. "
-            "Last local read of A issued at vmfma_index 5, first global read of A issued at vmfma_index 6, wave completion at vmfma_index 5. "
-            "Expected a barrier in the range [5, 6)."
+            "There is an SBarrier missing between the SWaitCnt @ idx=5 (which guarantees LRA0 from idx=5 to done) and the GRA @ idx=6. "
+            "Order must be LRA0 -> SWait -> SBarrier -> GRA."
         )
 
     def test_on_the_edge(self):
@@ -794,8 +559,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRA0": [[0, 1, 2, 3]],
             "LRB0": [[2, 3, 4, 5]],
             "SYNC": [[4, 4, 6, 6]],
-            "GRA": [[5]],
-            "GRB": [[7]],
+            "GRA": [[5, 5]],
+            "GRB": [[7, 7]],
         }
         syncCode = [
             SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment=""),
@@ -816,8 +581,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRA0": [[0, 1, 2, 3]],
             "LRB0": [[2, 3, 4, 5]],
             "SYNC": [[4, 4, 6, 6]],
-            "GRA": [[5]],
-            "GRB": [[7]],
+            "GRA": [[5, 5]],
+            "GRB": [[7, 7]],
         }
         syncCode = [
             SWaitCnt(dscnt=3, vlcnt=-1, vscnt=-1, comment=""),
@@ -827,10 +592,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
-            "Last local read for A issued at vmfma_index:3. "
-            "First global read for A issued at vmfma_index:5. "
-            "1 waitcnt operation(s) in [3, 6) provide upper bounds on the number of outstanding LRA0 operations: [1] <-- none of these is 0."
+            "GRA @ idx=5 is issued too early. "
+            "Must be issued after idx=6, which is when LRA0 is guaranteed done."
         )
 
     def test_on_the_edge_tipped_by_a_saved_by_lr1(self):
@@ -844,8 +607,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRA1": [[3, 4]],
             "LRB0": [[3, 4]],
             "SYNC": [[4,4, 6,6]],
-            "GRA": [[4]],
-            "GRB": [[7]],
+            "GRA": [[4,4]],
+            "GRB": [[7,7]],
         }
         syncCode = [
             SWaitCnt(dscnt=4, vlcnt=-1, vscnt=-1, comment=""),
@@ -865,7 +628,7 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRA1": [3 * [3]],
             "LRB1": [4 * [3]],
             "SYNC": [[3, 3]],
-            "GRA": [[4]],
+            "GRA": [[4,4]],
         }
         syncCode = [
             # 3 LRA1 and 4 LRB1 can be outstanding.
@@ -874,10 +637,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
-            "Last local read for A issued at vmfma_index:3. "
-            "First global read for A issued at vmfma_index:4. "
-            "1 waitcnt operation(s) in [3, 5) provide upper bounds on the number of outstanding LRA0 operations: [1] <-- none of these is 0."
+            "GRA @ idx=4 is issued too early. "
+            "Must be issued after idx=3 (of next iteration), which is when LRA0 is guaranteed done."
         )
 
     def test_multiple_grs_all_safe(self):
@@ -889,8 +650,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "LRA0": [[0]],
             "LRB0": [[1]],
             "SYNC": [[2, 3]],
-            "GRA": [[4, 5, 6]],
-            "GRB": [[7]],
+            "GRA": [[3, 4, 4, 5, 5, 6]],
+            "GRB": [[6, 7]],
         }
         syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier(comment="")]
         self.validate(optSchedule, syncCode, 1, None, None, 0, None)
@@ -903,17 +664,15 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         optSchedule = {
             "LRA0": [[0]],
             "LRB0": [[1]],
-            "GRA": [[2, 6, 7]],
+            "GRA": [[1, 2, 5, 6, 6, 7]],
             "SYNC": [[3, 4]],
-            "GRB": [[7]],
+            "GRB": [[6, 7]],
         }
         syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier(comment="")]
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for A (LRA0) are complete before the first global read for A is issued. "
-            "Last local read for A issued at vmfma_index:0. "
-            "First global read for A issued at vmfma_index:2. "
-            "0 waitcnt operation(s) in [0, 2) provide upper bounds on the number of outstanding LRA0 operations: [] <-- none of these is 0."
+            "GRA @ idx=2 is issued too early. "
+            "Must be issued after idx=3, which is when LRA0 is guaranteed done."
         )
 
     def test_negative_lrb0_not_guaranteed_by_waitcnt_at_same_index_as_lra0(self):
@@ -923,30 +682,30 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         ordering -- is incorrectly counted as a "recent" read by the SWaitCnt.
 
         Setup (modelled after 256x160x64 TN code path 1):
-          - LRB0 issued at vmfma [1, 3, 4, 5, 6]  (5 reads, all before the sync)
-          - LRA0 issued at vmfma [14]               (1 read, same index as the sync)
-          - SYNC at vmfma 14: SWaitCnt(dscnt=1) then SBarrier
-          - GRB starts at vmfma 15
+          - LRB0 issued at vmfma [0, 1]  (2 reads, all before the sync)
+          - LRA0 issued at vmfma [2]    (1 read, same index as the sync)
+          - SYNC at vmfma 2: SWaitCnt(dscnt=1) then SBarrier
+          - GRB starts at vmfma 3
 
         Dict key order: SYNC < LRB0 < LRA0 < GRB, so within vmfma 14 the
         execution order is:  SWaitCnt -> SBarrier -> (LRB0: nothing) -> LRA0 -> ...
 
-        At the moment the SWaitCnt(dscnt=1) fires, only 5 LRB0 reads are outstanding
-        (LRA0 at vmfma 14 hasn't been issued yet).  After dscnt=1, at most 1 remains,
-        and that 1 is a LRB0.  GRB at vmfma 15 therefore starts while 1 LRB0 may
+        At the moment the SWaitCnt(dscnt=1) fires, only 2 LRB0 reads are outstanding
+        (LRA0 at vmfma 2 hasn't been issued yet).  After dscnt=1, at most 1 remains,
+        and that 1 is a LRB0.  GRB at vmfma 3 therefore starts while 1 LRB0 may
         still be in flight -- a data hazard.
 
-        The validator incorrectly passes because get_most_recent_local_reads sees
-        LRA0 at vmfma 14 in its history and attributes the 1 outstanding to LRA0
+        The validator used to incorrectly pass because get_most_recent_local_reads saw
+        LRA0 at vmfma 3 in its history and attributes the 1 outstanding read to it.
         (reporting LRB0: 0 outstanding).
         """
         assert self.num_vmfma == 8
 
         optSchedule = {
             "SYNC": [[-1, 2, 2]],
-            "LRB0": [[0,1]],
+            "LRB0": [[0, 1]],
             "LRA0": [[2]],
-            "GRB":  [[3]],
+            "GRB":  [[3, 3]],
         }
         syncCode = [
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="pre-loop wait"),
@@ -956,10 +715,6 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         # Should FAIL: dscnt=1 leaves 1 LRB0 outstanding when GRB starts at 15.
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
-            "Failed to verify that all local reads for B (LRB0) are complete "
-            "before the first global read for B is issued. "
-            "Last local read for B issued at vmfma_index:6. "
-            "First global read for B issued at vmfma_index:15. "
-            "1 waitcnt operation(s) in [7, 16) provide upper bounds on the number "
-            "of outstanding LRB0 operations: [1] <-- none of these is 0."
+            "GRB @ idx=3 is issued too early. "
+            "Must be issued after idx=7, which is when LRB0 is guaranteed done."
         )

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
@@ -915,3 +915,51 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             "First global read for A issued at vmfma_index:2. "
             "0 waitcnt operation(s) in [0, 2) provide upper bounds on the number of outstanding LRA0 operations: [] <-- none of these is 0."
         )
+
+    def test_negative_lrb0_not_guaranteed_by_waitcnt_at_same_index_as_lra0(self):
+        """
+        Exercises a bug in get_most_recent_local_reads where a local read (LRA0)
+        issued at the same vmfma index as a SWaitCnt -- but AFTER it in within-index
+        ordering -- is incorrectly counted as a "recent" read by the SWaitCnt.
+
+        Setup (modelled after 256x160x64 TN code path 1):
+          - LRB0 issued at vmfma [1, 3, 4, 5, 6]  (5 reads, all before the sync)
+          - LRA0 issued at vmfma [14]               (1 read, same index as the sync)
+          - SYNC at vmfma 14: SWaitCnt(dscnt=1) then SBarrier
+          - GRB starts at vmfma 15
+
+        Dict key order: SYNC < LRB0 < LRA0 < GRB, so within vmfma 14 the
+        execution order is:  SWaitCnt -> SBarrier -> (LRB0: nothing) -> LRA0 -> ...
+
+        At the moment the SWaitCnt(dscnt=1) fires, only 5 LRB0 reads are outstanding
+        (LRA0 at vmfma 14 hasn't been issued yet).  After dscnt=1, at most 1 remains,
+        and that 1 is a LRB0.  GRB at vmfma 15 therefore starts while 1 LRB0 may
+        still be in flight -- a data hazard.
+
+        The validator incorrectly passes because get_most_recent_local_reads sees
+        LRA0 at vmfma 14 in its history and attributes the 1 outstanding to LRA0
+        (reporting LRB0: 0 outstanding).
+        """
+        assert self.num_vmfma == 8
+
+        optSchedule = {
+            "SYNC": [[-1, 2, 2]],
+            "LRB0": [[0,1]],
+            "LRA0": [[2]],
+            "GRB":  [[3]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment="pre-loop wait"),
+            SWaitCnt(dscnt=1, vlcnt=-1, vscnt=-1, comment="Wait for LRB0 -- but leaves 1 outstanding"),
+            SBarrier(comment=""),
+        ]
+        # Should FAIL: dscnt=1 leaves 1 LRB0 outstanding when GRB starts at 15.
+        self.validate(
+            optSchedule, syncCode, 1, None, None, 0,
+            "Failed to verify that all local reads for B (LRB0) are complete "
+            "before the first global read for B is issued. "
+            "Last local read for B issued at vmfma_index:6. "
+            "First global read for B issued at vmfma_index:15. "
+            "1 waitcnt operation(s) in [7, 16) provide upper bounds on the number "
+            "of outstanding LRB0 operations: [1] <-- none of these is 0."
+        )

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -71,7 +71,7 @@ class TestValidateNgl(CMSValidationTestBase):
         shift_value = 3 + 3 - 1  # 3 GRAs and 3 GRBs - 1
         optSchedule, syncCode = self.make_simple_schedule_and_sync()
         self.validate(optSchedule, syncCode, 1, shift_value, shift_value, 0,
-                                         "GRB at index 2 is not valid. There are no guarantees on when it will be done.")
+                                         "GRB @ idx=2 is not valid. There are no guarantees on when it will be done.")
 
     def test_simple_case_success_too_high(self):
         """


### PR DESCRIPTION
## Motivation
Original validator missed the scenario found in https://github.com/ROCm/rocm-libraries/pull/4115#discussion_r2772104726. Using this opportunity to reimplement this pass to use the same approach as the majority of other passes.

The reimplemented approach also surfaced another overlooked data hazard (#4422).

**Note:** The original implementation also supported the `DirectToLDS=False` case. This version **does not**. All of our current CMS implementation use `DirectToLDS=True`, and presumably all new ones will to. The validator will error our if a `DirectToLDS=False` schedule is passed in, and this path can also be re-implemented if the need arises in the future.

Depends on #4511.

## Technical Details

Use must_start_after functionality and tracking of Sbarriers. Same approach as for making sure the LR1/3 don't start too early.

## Test Plan

1. Add failing test for missed case.
2. Run existing test.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
