### PR TITLE
fix  CMS for 224x128x64 NT bf16 

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -1741,7 +1741,7 @@ def _get_schedule_224x128x64_16bit(kernel, useLDSTr, TLDS):
             3,  SWaitCnt(dscnt=2, vlcnt=-1, vscnt=-1, comment="Wait for prior LRA1/LRB1 for the remaining main loop"),
 
             # GRB must wait for LRB0 (interleave LRA0 + GRB safely)
-            15, SWaitCnt(dscnt=6, vlcnt=-1, vscnt=-1, comment="Wait for LRB0 to complete to start GRB"),
+            15, SWaitCnt(dscnt=5, vlcnt=-1, vscnt=-1, comment="Wait for LRB0 to complete to start GRB"),
             15, SBarrier(comment=""),
 
             # GRA must wait for LRA0; LRB1 can be interleaved with GRA after this fence


### PR DESCRIPTION
Fixes issue #4422 by reducing the dscnt (follow-up from #4137)

No impact to performance in Tensile.

Tested with tensile-client
```
        - ProblemSizes:
          - Exact: [3584, 2048, 1, 8192]
          - Range: [[224], [128], [1], [1, 16, 64]]
          - Range: [[224], [128], [1], [32, 64, 256]]
```
hipblaslt-test also passes
```
[==========] 21891 tests from 12 test suites ran. (1441926 ms total)
[  PASSED  ] 21891 tests.
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
