### PR TITLE
[hipblaslt-provider] Convert hipblaslt-provider to stream-style logging

### DIFF
--- a/dnn-providers/hipblaslt-provider/CMakeLists.txt
+++ b/dnn-providers/hipblaslt-provider/CMakeLists.txt
@@ -114,8 +114,6 @@ target_compile_definitions(hipblaslt_plugin_private PRIVATE)
 target_include_directories(hipblaslt_plugin_private PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(hipblaslt_plugin_private PUBLIC roc::hipblaslt hipdnn_data_sdk hipdnn_plugin_sdk hip::host)
 
-# Enable spdlog support via plugin_sdk helper function
-hipdnn_enable_spdlog(hipblaslt_plugin_private)
 target_compile_options(hipblaslt_plugin_private PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 
 add_library(hipblaslt_plugin SHARED HipblasltPluginPublic.cpp)

--- a/dnn-providers/hipblaslt-provider/HipblasltPlugin.cpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltPlugin.cpp
@@ -35,53 +35,53 @@ extern "C" {
 
 hipdnnPluginStatus_t hipdnnPluginGetNameImpl(const char** name)
 {
-    LOG_API_ENTRY("name_ptr={:p}", static_cast<void*>(name));
+    LOG_API_ENTRY("name_ptr=" << static_cast<void*>(name));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(name);
 
         *name = pluginName;
 
-        LOG_API_SUCCESS(apiName, "pluginName={:p}", static_cast<void*>(name));
+        LOG_API_SUCCESS(apiName, "pluginName=" << static_cast<void*>(name));
     });
 }
 
 hipdnnPluginStatus_t hipdnnPluginGetVersionImpl(const char** version)
 {
-    LOG_API_ENTRY("versionPtr={:p}", static_cast<void*>(version));
+    LOG_API_ENTRY("versionPtr=" << static_cast<void*>(version));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(version);
 
         *version = pluginVersion;
 
-        LOG_API_SUCCESS(apiName, "version={:p}", static_cast<void*>(version));
+        LOG_API_SUCCESS(apiName, "version=" << static_cast<void*>(version));
     });
 }
 
 hipdnnPluginStatus_t hipdnnPluginGetTypeImpl(hipdnnPluginType_t* type)
 {
-    LOG_API_ENTRY("typePtr={:p}", static_cast<void*>(type));
+    LOG_API_ENTRY("typePtr=" << static_cast<void*>(type));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(type);
 
         *type = HIPDNN_PLUGIN_TYPE_ENGINE;
 
-        LOG_API_SUCCESS(apiName, "type={}", toString(*type));
+        LOG_API_SUCCESS(apiName, "type=" << toString(*type));
     });
 }
 
 void hipdnnPluginGetLastErrorStringImpl(const char** errorStr)
 {
-    LOG_API_ENTRY("errorStrPtr={:p}", static_cast<void*>(errorStr));
+    LOG_API_ENTRY("errorStrPtr=" << static_cast<void*>(errorStr));
 
     hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(errorStr);
 
         *errorStr = PluginLastErrorManager::getLastError();
 
-        LOG_API_SUCCESS(apiName, "errorStr={:p}", static_cast<void*>(errorStr));
+        LOG_API_SUCCESS(apiName, "errorStr=" << static_cast<void*>(errorStr));
     });
 }
 
@@ -91,7 +91,7 @@ hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callbac
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(callback);
         hipdnn_plugin_sdk::logging::initializeCallbackLogging(pluginName, callback);
-        LOG_API_SUCCESS(apiName, "", "");
+        LOG_API_SUCCESS(apiName, "");
     });
 }
 
@@ -99,10 +99,8 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
                                                            uint32_t maxEngines,
                                                            uint32_t* numEngines)
 {
-    LOG_API_ENTRY("engineIds={:p}, maxEngines={}, numEngines={:p}",
-                  static_cast<void*>(engineIds),
-                  maxEngines,
-                  static_cast<void*>(numEngines));
+    LOG_API_ENTRY("engineIds=" << static_cast<void*>(engineIds) << ", maxEngines=" << maxEngines
+                               << ", numEngines=" << static_cast<void*>(numEngines));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         if(maxEngines != 0)
@@ -130,11 +128,10 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
                 if(*numEngines == maxEngines)
                 {
                     *numEngines = static_cast<uint32_t>(allEngineIds.size());
-                    HIPDNN_PLUGIN_LOG_INFO(
-                        "Maximum number of engines reached ({}), ignoring additional "
-                        "engines, numEngines count: {}",
-                        maxEngines,
-                        *numEngines);
+                    HIPDNN_PLUGIN_LOG_INFO("Maximum number of engines reached ("
+                                           << maxEngines
+                                           << "), ignoring additional engines, numEngines count: "
+                                           << *numEngines);
                     break;
                 }
 
@@ -143,13 +140,13 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
             }
         }
 
-        LOG_API_SUCCESS(apiName, "numEngines={}", *numEngines);
+        LOG_API_SUCCESS(apiName, "numEngines=" << *numEngines);
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* handle)
 {
-    LOG_API_ENTRY("handle_ptr={:p}", static_cast<void*>(handle));
+    LOG_API_ENTRY("handle_ptr=" << static_cast<void*>(handle));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -181,13 +178,13 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* ha
             }
         }
 
-        LOG_API_SUCCESS(apiName, "createdHandle={:p}", static_cast<void*>(*handle));
+        LOG_API_SUCCESS(apiName, "createdHandle=" << static_cast<void*>(*handle));
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t handle)
 {
-    LOG_API_ENTRY("handle={:p}", static_cast<void*>(handle));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -196,22 +193,22 @@ hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t ha
         delete handle;
         handle = nullptr;
 
-        LOG_API_SUCCESS(apiName, "", "");
+        LOG_API_SUCCESS(apiName, "");
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginSetStreamImpl(hipdnnEnginePluginHandle_t handle,
                                                      hipStream_t stream)
 {
-    LOG_API_ENTRY(
-        "handle={:p}, stream_id={:p}", static_cast<void*>(handle), static_cast<void*>(stream));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", stream_id=" << static_cast<void*>(stream));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
 
         handle->setStream(stream);
 
-        LOG_API_SUCCESS(apiName, "", "");
+        LOG_API_SUCCESS(apiName, "");
     });
 }
 
@@ -222,12 +219,10 @@ hipdnnPluginStatus_t
                                                  uint32_t maxEngines,
                                                  uint32_t* numEngines)
 {
-    LOG_API_ENTRY("handle={:p}, opGraph={:p}, engineIds={:p}, maxEngines={}, numEngines={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(engineIds),
-                  maxEngines,
-                  static_cast<void*>(numEngines));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", opGraph=" << static_cast<const void*>(opGraph) << ", engineIds="
+                            << static_cast<void*>(engineIds) << ", maxEngines=" << maxEngines
+                            << ", numEngines=" << static_cast<void*>(numEngines));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -249,11 +244,10 @@ hipdnnPluginStatus_t
             if(*numEngines == maxEngines)
             {
                 *numEngines = static_cast<uint32_t>(applicableEngines.size());
-                HIPDNN_PLUGIN_LOG_INFO(
-                    "Maximum number of engines reached ({}), ignoring additional "
-                    "engines, numEngines count: {}",
-                    maxEngines,
-                    *numEngines);
+                HIPDNN_PLUGIN_LOG_INFO("Maximum number of engines reached ("
+                                       << maxEngines
+                                       << "), ignoring additional engines, numEngines count: "
+                                       << *numEngines);
                 break;
             }
 
@@ -261,7 +255,7 @@ hipdnnPluginStatus_t
             (*numEngines)++;
         }
 
-        LOG_API_SUCCESS(apiName, "numEngines={}", *numEngines);
+        LOG_API_SUCCESS(apiName, "numEngines=" << *numEngines);
     });
 }
 
@@ -270,11 +264,9 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHa
                                                             const hipdnnPluginConstData_t* opGraph,
                                                             hipdnnPluginConstData_t* engineDetails)
 {
-    LOG_API_ENTRY("handle={:p}, engineId={}, opGraph={:p}, engineDetails={:p}",
-                  static_cast<void*>(handle),
-                  engineId,
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(engineDetails));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle) << ", engineId=" << engineId
+                            << ", opGraph=" << static_cast<const void*>(opGraph)
+                            << ", engineDetails=" << static_cast<void*>(engineDetails));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -286,7 +278,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHa
 
         engineManager.getEngineDetails(*handle, opGraphWrapper, engineId, *engineDetails);
 
-        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr=" << engineDetails->ptr);
     });
 }
 
@@ -294,9 +286,8 @@ hipdnnPluginStatus_t
     hipdnnEnginePluginDestroyEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
                                                hipdnnPluginConstData_t* engineDetails)
 {
-    LOG_API_ENTRY("handle={:p}, engineDetails={}",
-                  static_cast<void*>(handle),
-                  static_cast<void*>(engineDetails));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", engineDetails=" << static_cast<void*>(engineDetails));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -305,7 +296,7 @@ hipdnnPluginStatus_t
 
         handle->removeEngineDetailsDetachedBuffer(engineDetails->ptr);
 
-        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr=" << engineDetails->ptr);
     });
 }
 
@@ -315,11 +306,10 @@ hipdnnPluginStatus_t
                                            const hipdnnPluginConstData_t* opGraph,
                                            size_t* workspaceSize)
 {
-    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, workspaceSize={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(engineConfig),
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(workspaceSize));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", engineConfig=" << static_cast<const void*>(engineConfig)
+                            << ", opGraph=" << static_cast<const void*>(opGraph)
+                            << ", workspaceSize=" << static_cast<void*>(workspaceSize));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -334,7 +324,7 @@ hipdnnPluginStatus_t
         *workspaceSize = engineManager.getWorkspaceSize(
             *handle, engineConfigWrapper.engineId(), opGraphWrapper);
 
-        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+        LOG_API_SUCCESS(apiName, "workspaceSize=" << *workspaceSize);
     });
 }
 
@@ -344,11 +334,10 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
     const hipdnnPluginConstData_t* opGraph,
     hipdnnEnginePluginExecutionContext_t* executionContext)
 {
-    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, executionContext={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(engineConfig),
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(executionContext));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", engineConfig=" << static_cast<const void*>(engineConfig)
+                            << ", opGraph=" << static_cast<const void*>(opGraph)
+                            << ", executionContext=" << static_cast<void*>(executionContext));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -376,17 +365,16 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
 
         *executionContext = context;
 
-        LOG_API_SUCCESS(
-            apiName, "created_execution_context={:p}", static_cast<void*>(*executionContext));
+        LOG_API_SUCCESS(apiName,
+                        "created_execution_context=" << static_cast<void*>(*executionContext));
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
     hipdnnEnginePluginHandle_t handle, hipdnnEnginePluginExecutionContext_t executionContext)
 {
-    LOG_API_ENTRY("handle={:p}, executionContext={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<void*>(executionContext));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", executionContext=" << static_cast<void*>(executionContext));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -394,7 +382,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
 
         delete executionContext;
 
-        LOG_API_SUCCESS(apiName, "destroyed executionContext", "");
+        LOG_API_SUCCESS(apiName, "destroyed executionContext");
     });
 }
 
@@ -403,10 +391,9 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
     hipdnnEnginePluginExecutionContext_t executionContext,
     size_t* workspaceSize)
 {
-    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspaceSize={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(executionContext),
-                  static_cast<void*>(workspaceSize));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", executionContext=" << static_cast<const void*>(executionContext)
+                            << ", workspaceSize=" << static_cast<void*>(workspaceSize));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -415,7 +402,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
 
         *workspaceSize = executionContext->plan().getWorkspaceSize(*handle);
 
-        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+        LOG_API_SUCCESS(apiName, "workspaceSize=" << *workspaceSize);
     });
 }
 
@@ -426,13 +413,10 @@ hipdnnPluginStatus_t
                                          const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                                          uint32_t numDeviceBuffers)
 {
-    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspace={:p}, deviceBuffers={:p}, "
-                  "numDeviceBuffers={}",
-                  static_cast<void*>(handle),
-                  static_cast<void*>(executionContext),
-                  workspace,
-                  static_cast<const void*>(deviceBuffers),
-                  numDeviceBuffers);
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle) << ", executionContext="
+                            << static_cast<void*>(executionContext) << ", workspace=" << workspace
+                            << ", deviceBuffers=" << static_cast<const void*>(deviceBuffers)
+                            << ", numDeviceBuffers=" << numDeviceBuffers);
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -441,7 +425,7 @@ hipdnnPluginStatus_t
 
         executionContext->plan().execute(*handle, deviceBuffers, numDeviceBuffers, workspace);
 
-        LOG_API_SUCCESS(apiName, "executed graph", "");
+        LOG_API_SUCCESS(apiName, "executed graph");
     });
 }
 

--- a/dnn-providers/hipblaslt-provider/HipblasltUtils.hpp
+++ b/dnn-providers/hipblaslt-provider/HipblasltUtils.hpp
@@ -13,15 +13,15 @@
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <string>
 
-#define LOG_ON_HIPBLASLT_FAILURE(status)                                              \
-    do                                                                                \
-    {                                                                                 \
-        if(status != HIPBLAS_STATUS_SUCCESS)                                          \
-        {                                                                             \
-            HIPDNN_PLUGIN_LOG_ERROR(                                                  \
-                "hipBLASLt error occurred: {}",                                       \
-                hipblaslt_plugin::hipblaslt_utils::hipblas_status_to_string(status)); \
-        }                                                                             \
+#define LOG_ON_HIPBLASLT_FAILURE(status)                                                 \
+    do                                                                                   \
+    {                                                                                    \
+        if(status != HIPBLAS_STATUS_SUCCESS)                                             \
+        {                                                                                \
+            HIPDNN_PLUGIN_LOG_ERROR(                                                     \
+                "hipBLASLt error occurred: "                                             \
+                << hipblaslt_plugin::hipblaslt_utils::hipblas_status_to_string(status)); \
+        }                                                                                \
     } while(0)
 
 #define THROW_ON_HIPBLASLT_FAILURE(status)                                                     \

--- a/dnn-providers/hipblaslt-provider/HipdnnEnginePluginHandle.hpp
+++ b/dnn-providers/hipblaslt-provider/HipdnnEnginePluginHandle.hpp
@@ -41,13 +41,13 @@ public:
     void storeEngineDetailsDetachedBuffer(const void* ptr,
                                           std::unique_ptr<flatbuffers::DetachedBuffer> buffer)
     {
-        HIPDNN_PLUGIN_LOG_INFO("Storing detached buffer at address: {:p}", ptr);
+        HIPDNN_PLUGIN_LOG_INFO("Storing detached buffer at address: " << ptr);
         _engineDetailsBuffers[ptr] = std::move(buffer);
     }
 
     void removeEngineDetailsDetachedBuffer(const void* ptr)
     {
-        HIPDNN_PLUGIN_LOG_INFO("Removing detached buffer at address: {:p}", ptr);
+        HIPDNN_PLUGIN_LOG_INFO("Removing detached buffer at address: " << ptr);
 
         auto it = _engineDetailsBuffers.find(ptr);
         if(it != _engineDetailsBuffers.end())
@@ -57,10 +57,11 @@ public:
         else
         {
             HIPDNN_PLUGIN_LOG_WARN(
-                "No detached buffer found at address: {:p}. Could not remove engine "
-                "details. Ensure you "
-                "are using the same hipdnn handle you used for engine details creation",
-                ptr);
+                "No detached buffer found at address: "
+                << ptr
+                << ". Could not remove engine "
+                   "details. Ensure you "
+                   "are using the same hipdnn handle you used for engine details creation");
         }
     }
 

--- a/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.cpp
+++ b/dnn-providers/hipblaslt-provider/engines/plans/HipblasltMatmulPlanBuilder.cpp
@@ -119,7 +119,7 @@ void HipblasltMatmulPlanBuilder::buildPlan(
     validateGraphConfiguration(opGraph);
 
     const auto& nodeWrapper = opGraph.getNodeWrapper(0);
-    HIPDNN_PLUGIN_LOG_INFO("Building matmul plan for node: {}", nodeWrapper.name());
+    HIPDNN_PLUGIN_LOG_INFO("Building matmul plan for node: " << nodeWrapper.name());
 
     const auto& attr = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::MatmulAttributes>();
     MatmulParams params(attr, opGraph.getTensorMap());

--- a/dnn-providers/hipblaslt-provider/integration_tests/CMakeLists.txt
+++ b/dnn-providers/hipblaslt-provider/integration_tests/CMakeLists.txt
@@ -25,9 +25,6 @@ target_link_libraries(
     hipblaslt_plugin_integration_tests PUBLIC GTest::gtest hip::host hipdnn_test_sdk hipdnn_plugin_sdk Threads::Threads
 )
 
-# Enable spdlog support for fmt-style logging
-hipdnn_enable_spdlog(hipblaslt_plugin_integration_tests)
-
 # Ensure that the hipblaslt_plugin is built before the hipblaslt_plugin_integration_tests, as the
 # integration tests depend on the hipBLASLt Provider Plugin
 add_dependencies(hipblaslt_plugin_integration_tests hipblaslt_plugin)

--- a/dnn-providers/hipblaslt-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/hipblaslt-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -89,7 +89,7 @@ protected:
             << "At least one output tensor id must be specified for "
                "validation.";
 
-        HIPDNN_PLUGIN_LOG_INFO("Validating {} output tensors", outputTensorIds.size());
+        HIPDNN_PLUGIN_LOG_INFO("Validating " << outputTensorIds.size() << " output tensors");
 
         // Lazily register validators after graph execution since tensor Ids and types may be inferred during graph finalization
         for(const auto& registerValidator : _deferredValidators)

--- a/dnn-providers/hipblaslt-provider/integration_tests/main.cpp
+++ b/dnn-providers/hipblaslt-provider/integration_tests/main.cpp
@@ -4,7 +4,6 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
-#include <spdlog/spdlog.h>
 
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
@@ -19,7 +18,5 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    auto result = RUN_ALL_TESTS();
-    spdlog::shutdown();
-    return result;
+    return RUN_ALL_TESTS();
 }

--- a/dnn-providers/hipblaslt-provider/tests/main.cpp
+++ b/dnn-providers/hipblaslt-provider/tests/main.cpp
@@ -4,7 +4,6 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
-#include <spdlog/spdlog.h>
 
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
@@ -20,7 +19,5 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    auto result = RUN_ALL_TESTS();
-    spdlog::shutdown();
-    return result;
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Motivation

Remove spdlog/fmt dependency from hipblaslt-provider.
This change is part of removing spdlog/fmt from plugin_sdk.

## Technical Details

Changes:
- Convert logging to stream based style
- Remove hipdnn_enable_spdlog() calls from CMakeLists.txt files
- Remove spdlog includes and shutdown calls from test main.cpp files

## Test Plan

Build and tests are working locally (CI not enabled for hipblaslt-provider yet).
Logs are properly output (unchanged).

## Test Result

Build and tests are continuing to pass.
Logs are printing properly.

---

### Note

Off the logging clean-up branch (PR #4423) that is about to be merged. 
This ensures we have the latest namespaces, and other clean-up changes for this work.