### PR TITLE
[miopen-provider] Convert miopen-provider to stream-style logging

### DIFF
--- a/dnn-providers/miopen-provider/CMakeLists.txt
+++ b/dnn-providers/miopen-provider/CMakeLists.txt
@@ -136,8 +136,6 @@ target_compile_definitions(miopen_plugin_impl PRIVATE)
 target_include_directories(miopen_plugin_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(miopen_plugin_impl PUBLIC MIOpen hipdnn_data_sdk hipdnn_plugin_sdk)
 
-# Enable spdlog support via plugin_sdk helper function
-hipdnn_enable_spdlog(miopen_plugin_impl)
 target_compile_options(miopen_plugin_impl PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 set_target_properties(miopen_plugin_impl PROPERTIES
     CXX_VISIBILITY_PRESET hidden
@@ -152,7 +150,7 @@ endif()
 add_library(miopen_plugin_private STATIC $<TARGET_OBJECTS:miopen_plugin_impl>)
 target_compile_definitions(miopen_plugin_private PRIVATE)
 target_include_directories(miopen_plugin_private PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-# Link to miopen_plugin_impl to inherit its PUBLIC properties (including spdlog setup)
+# Link to miopen_plugin_impl to inherit its PUBLIC properties
 target_link_libraries(miopen_plugin_private PUBLIC MIOpen hipdnn_data_sdk hipdnn_plugin_sdk miopen_plugin_impl)
 # Backwards compatibility alias
 add_library(miopen_legacy_plugin_private ALIAS miopen_plugin_private)

--- a/dnn-providers/miopen-provider/HipdnnEnginePluginHandle.hpp
+++ b/dnn-providers/miopen-provider/HipdnnEnginePluginHandle.hpp
@@ -42,13 +42,13 @@ public:
     void storeEngineDetailsDetachedBuffer(const void* ptr,
                                           std::unique_ptr<flatbuffers::DetachedBuffer> buffer)
     {
-        HIPDNN_PLUGIN_LOG_INFO("Storing detached buffer at address: {:p}", ptr);
+        HIPDNN_PLUGIN_LOG_INFO("Storing detached buffer at address: " << ptr);
         _engineDetailsBuffers[ptr] = std::move(buffer);
     }
 
     void removeEngineDetailsDetachedBuffer(const void* ptr)
     {
-        HIPDNN_PLUGIN_LOG_INFO("Removing detached buffer at address: {:p}", ptr);
+        HIPDNN_PLUGIN_LOG_INFO("Removing detached buffer at address: " << ptr);
 
         auto it = _engineDetailsBuffers.find(ptr);
         if(it != _engineDetailsBuffers.end())
@@ -58,10 +58,11 @@ public:
         else
         {
             HIPDNN_PLUGIN_LOG_WARN(
-                "No detached buffer found at address: {:p}. Could not remove engine "
-                "details. Ensure you "
-                "are using the same hipdnn handle you used for engine details creation",
-                ptr);
+                "No detached buffer found at address: "
+                << ptr
+                << ". Could not remove engine "
+                   "details. Ensure you "
+                   "are using the same hipdnn handle you used for engine details creation");
         }
     }
 

--- a/dnn-providers/miopen-provider/MiopenPlugin.cpp
+++ b/dnn-providers/miopen-provider/MiopenPlugin.cpp
@@ -41,53 +41,53 @@ extern "C" {
 
 hipdnnPluginStatus_t hipdnnPluginGetNameImpl(const char** name)
 {
-    LOG_API_ENTRY("name_ptr={:p}", static_cast<void*>(name));
+    LOG_API_ENTRY("name_ptr=" << static_cast<void*>(name));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(name);
 
         *name = pluginName;
 
-        LOG_API_SUCCESS(apiName, "pluginName={:p}", static_cast<void*>(name));
+        LOG_API_SUCCESS(apiName, "pluginName=" << static_cast<void*>(name));
     });
 }
 
 hipdnnPluginStatus_t hipdnnPluginGetVersionImpl(const char** version)
 {
-    LOG_API_ENTRY("versionPtr={:p}", static_cast<void*>(version));
+    LOG_API_ENTRY("versionPtr=" << static_cast<void*>(version));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(version);
 
         *version = pluginVersion;
 
-        LOG_API_SUCCESS(apiName, "version={:p}", static_cast<void*>(version));
+        LOG_API_SUCCESS(apiName, "version=" << static_cast<void*>(version));
     });
 }
 
 hipdnnPluginStatus_t hipdnnPluginGetTypeImpl(hipdnnPluginType_t* type)
 {
-    LOG_API_ENTRY("typePtr={:p}", static_cast<void*>(type));
+    LOG_API_ENTRY("typePtr=" << static_cast<void*>(type));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(type);
 
         *type = HIPDNN_PLUGIN_TYPE_ENGINE;
 
-        LOG_API_SUCCESS(apiName, "type={}", toString(*type));
+        LOG_API_SUCCESS(apiName, "type=" << toString(*type));
     });
 }
 
 void hipdnnPluginGetLastErrorStringImpl(const char** errorStr)
 {
-    LOG_API_ENTRY("errorStrPtr={:p}", static_cast<void*>(errorStr));
+    LOG_API_ENTRY("errorStrPtr=" << static_cast<void*>(errorStr));
 
     hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(errorStr);
 
         *errorStr = PluginLastErrorManager::getLastError();
 
-        LOG_API_SUCCESS(apiName, "errorStr={:p}", static_cast<void*>(errorStr));
+        LOG_API_SUCCESS(apiName, "errorStr=" << static_cast<void*>(errorStr));
     });
 }
 
@@ -97,7 +97,7 @@ hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callbac
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(callback);
         hipdnn_plugin_sdk::logging::initializeCallbackLogging(pluginName, callback);
-        LOG_API_SUCCESS(apiName, "", "");
+        LOG_API_SUCCESS(apiName, "");
     });
 }
 
@@ -105,10 +105,8 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
                                                            uint32_t maxEngines,
                                                            uint32_t* numEngines)
 {
-    LOG_API_ENTRY("engineIds={:p}, maxEngines={}, numEngines={:p}",
-                  static_cast<void*>(engineIds),
-                  maxEngines,
-                  static_cast<void*>(numEngines));
+    LOG_API_ENTRY("engineIds=" << static_cast<void*>(engineIds) << ", maxEngines=" << maxEngines
+                               << ", numEngines=" << static_cast<void*>(numEngines));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         if(maxEngines != 0)
@@ -119,13 +117,13 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
 
         auto totalEngines = MiopenContainer::copyEngineIds(engineIds, maxEngines, *numEngines);
 
-        LOG_API_SUCCESS(apiName, "numEngines={} totalEngines={}", *numEngines, totalEngines);
+        LOG_API_SUCCESS(apiName, "numEngines=" << *numEngines << " totalEngines=" << totalEngines);
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* handle)
 {
-    LOG_API_ENTRY("handle_ptr={:p}", static_cast<void*>(handle));
+    LOG_API_ENTRY("handle_ptr=" << static_cast<void*>(handle));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -157,13 +155,13 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* ha
             }
         }
 
-        LOG_API_SUCCESS(apiName, "createdHandle={:p}", static_cast<void*>(*handle));
+        LOG_API_SUCCESS(apiName, "createdHandle=" << static_cast<void*>(*handle));
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t handle)
 {
-    LOG_API_ENTRY("handle={:p}", static_cast<void*>(handle));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -172,22 +170,22 @@ hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t ha
         delete handle;
         handle = nullptr;
 
-        LOG_API_SUCCESS(apiName, "", "");
+        LOG_API_SUCCESS(apiName, "");
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginSetStreamImpl(hipdnnEnginePluginHandle_t handle,
                                                      hipStream_t stream)
 {
-    LOG_API_ENTRY(
-        "handle={:p}, stream_id={:p}", static_cast<void*>(handle), static_cast<void*>(stream));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", stream_id=" << static_cast<void*>(stream));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
 
         handle->setStream(stream);
 
-        LOG_API_SUCCESS(apiName, "", "");
+        LOG_API_SUCCESS(apiName, "");
     });
 }
 
@@ -198,12 +196,10 @@ hipdnnPluginStatus_t
                                                  uint32_t maxEngines,
                                                  uint32_t* numEngines)
 {
-    LOG_API_ENTRY("handle={:p}, opGraph={:p}, engineIds={:p}, maxEngines={}, numEngines={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(engineIds),
-                  maxEngines,
-                  static_cast<void*>(numEngines));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", opGraph=" << static_cast<const void*>(opGraph) << ", engineIds="
+                            << static_cast<void*>(engineIds) << ", maxEngines=" << maxEngines
+                            << ", numEngines=" << static_cast<void*>(numEngines));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -225,11 +221,10 @@ hipdnnPluginStatus_t
             if(*numEngines == maxEngines)
             {
                 *numEngines = static_cast<uint32_t>(applicableEngines.size());
-                HIPDNN_PLUGIN_LOG_INFO(
-                    "Maximum number of engines reached ({}), ignoring additional "
-                    "engines, numEngines count: {}",
-                    maxEngines,
-                    *numEngines);
+                HIPDNN_PLUGIN_LOG_INFO("Maximum number of engines reached ("
+                                       << maxEngines
+                                       << "), ignoring additional engines, numEngines count: "
+                                       << *numEngines);
                 break;
             }
 
@@ -237,7 +232,7 @@ hipdnnPluginStatus_t
             (*numEngines)++;
         }
 
-        LOG_API_SUCCESS(apiName, "numEngines={}", *numEngines);
+        LOG_API_SUCCESS(apiName, "numEngines=" << *numEngines);
     });
 }
 
@@ -246,11 +241,9 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHa
                                                             const hipdnnPluginConstData_t* opGraph,
                                                             hipdnnPluginConstData_t* engineDetails)
 {
-    LOG_API_ENTRY("handle={:p}, engineId={}, opGraph={:p}, engineDetails={:p}",
-                  static_cast<void*>(handle),
-                  engineId,
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(engineDetails));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle) << ", engineId=" << engineId
+                            << ", opGraph=" << static_cast<const void*>(opGraph)
+                            << ", engineDetails=" << static_cast<void*>(engineDetails));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -262,7 +255,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHa
 
         engineManager.getEngineDetails(*handle, opGraphWrapper, engineId, *engineDetails);
 
-        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr=" << engineDetails->ptr);
     });
 }
 
@@ -270,9 +263,8 @@ hipdnnPluginStatus_t
     hipdnnEnginePluginDestroyEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
                                                hipdnnPluginConstData_t* engineDetails)
 {
-    LOG_API_ENTRY("handle={:p}, engineDetails={}",
-                  static_cast<void*>(handle),
-                  static_cast<void*>(engineDetails));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", engineDetails=" << static_cast<void*>(engineDetails));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -281,7 +273,7 @@ hipdnnPluginStatus_t
 
         handle->removeEngineDetailsDetachedBuffer(engineDetails->ptr);
 
-        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr=" << engineDetails->ptr);
     });
 }
 
@@ -291,11 +283,10 @@ hipdnnPluginStatus_t
                                            const hipdnnPluginConstData_t* opGraph,
                                            size_t* workspaceSize)
 {
-    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, workspaceSize={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(engineConfig),
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(workspaceSize));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", engineConfig=" << static_cast<const void*>(engineConfig)
+                            << ", opGraph=" << static_cast<const void*>(opGraph)
+                            << ", workspaceSize=" << static_cast<void*>(workspaceSize));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -310,7 +301,7 @@ hipdnnPluginStatus_t
         *workspaceSize = engineManager.getWorkspaceSize(
             *handle, engineConfigWrapper.engineId(), opGraphWrapper);
 
-        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+        LOG_API_SUCCESS(apiName, "workspaceSize=" << *workspaceSize);
     });
 }
 
@@ -320,11 +311,10 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
     const hipdnnPluginConstData_t* opGraph,
     hipdnnEnginePluginExecutionContext_t* executionContext)
 {
-    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, executionContext={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(engineConfig),
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(executionContext));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", engineConfig=" << static_cast<const void*>(engineConfig)
+                            << ", opGraph=" << static_cast<const void*>(opGraph)
+                            << ", executionContext=" << static_cast<void*>(executionContext));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -352,17 +342,16 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
 
         *executionContext = context;
 
-        LOG_API_SUCCESS(
-            apiName, "created_execution_context={:p}", static_cast<void*>(*executionContext));
+        LOG_API_SUCCESS(apiName,
+                        "created_execution_context=" << static_cast<void*>(*executionContext));
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
     hipdnnEnginePluginHandle_t handle, hipdnnEnginePluginExecutionContext_t executionContext)
 {
-    LOG_API_ENTRY("handle={:p}, executionContext={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<void*>(executionContext));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", executionContext=" << static_cast<void*>(executionContext));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -370,7 +359,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
 
         delete executionContext;
 
-        LOG_API_SUCCESS(apiName, "destroyed executionContext", "");
+        LOG_API_SUCCESS(apiName, "destroyed executionContext");
     });
 }
 
@@ -379,10 +368,9 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
     hipdnnEnginePluginExecutionContext_t executionContext,
     size_t* workspaceSize)
 {
-    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspaceSize={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(executionContext),
-                  static_cast<void*>(workspaceSize));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", executionContext=" << static_cast<const void*>(executionContext)
+                            << ", workspaceSize=" << static_cast<void*>(workspaceSize));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -391,7 +379,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
 
         *workspaceSize = executionContext->plan().getWorkspaceSize(*handle);
 
-        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+        LOG_API_SUCCESS(apiName, "workspaceSize=" << *workspaceSize);
     });
 }
 
@@ -402,13 +390,10 @@ hipdnnPluginStatus_t
                                          const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                                          uint32_t numDeviceBuffers)
 {
-    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspace={:p}, deviceBuffers={:p}, "
-                  "numDeviceBuffers={}",
-                  static_cast<void*>(handle),
-                  static_cast<void*>(executionContext),
-                  workspace,
-                  static_cast<const void*>(deviceBuffers),
-                  numDeviceBuffers);
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle) << ", executionContext="
+                            << static_cast<void*>(executionContext) << ", workspace=" << workspace
+                            << ", deviceBuffers=" << static_cast<const void*>(deviceBuffers)
+                            << ", numDeviceBuffers=" << numDeviceBuffers);
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -417,7 +402,7 @@ hipdnnPluginStatus_t
 
         executionContext->plan().execute(*handle, deviceBuffers, numDeviceBuffers, workspace);
 
-        LOG_API_SUCCESS(apiName, "executed graph", "");
+        LOG_API_SUCCESS(apiName, "executed graph");
     });
 }
 

--- a/dnn-providers/miopen-provider/MiopenUtils.hpp
+++ b/dnn-providers/miopen-provider/MiopenUtils.hpp
@@ -22,7 +22,7 @@
     {                                                                                           \
         if(status != miopenStatusSuccess)                                                       \
         {                                                                                       \
-            HIPDNN_PLUGIN_LOG_ERROR("MIOpen error occurred: {}", miopenGetErrorString(status)); \
+            HIPDNN_PLUGIN_LOG_ERROR("MIOpen error occurred: " << miopenGetErrorString(status)); \
         }                                                                                       \
     } while(0)
 
@@ -66,8 +66,8 @@ public:
         auto status = miopenGetTuningPolicy(_handle, &_originalPolicy);
         if(status != miopenStatusSuccess)
         {
-            HIPDNN_PLUGIN_LOG_ERROR("Failed to get tuning policy: {}",
-                                    miopenGetErrorString(status));
+            HIPDNN_PLUGIN_LOG_ERROR(
+                "Failed to get tuning policy: " << miopenGetErrorString(status));
             _originalPolicy = miopenTuningPolicyNone; // Fallback
         }
 
@@ -76,8 +76,8 @@ public:
         status = miopenSetTuningPolicy(_handle, policy);
         if(status != miopenStatusSuccess)
         {
-            HIPDNN_PLUGIN_LOG_ERROR("Failed to set tuning policy: {}",
-                                    miopenGetErrorString(status));
+            HIPDNN_PLUGIN_LOG_ERROR(
+                "Failed to set tuning policy: " << miopenGetErrorString(status));
         }
     }
 
@@ -87,8 +87,8 @@ public:
         auto status = miopenSetTuningPolicy(_handle, _originalPolicy);
         if(status != miopenStatusSuccess)
         {
-            HIPDNN_PLUGIN_LOG_ERROR("Failed to restore tuning policy: {}",
-                                    miopenGetErrorString(status));
+            HIPDNN_PLUGIN_LOG_ERROR(
+                "Failed to restore tuning policy: " << miopenGetErrorString(status));
         }
     }
 

--- a/dnn-providers/miopen-provider/engines/MiopenEngine.cpp
+++ b/dnn-providers/miopen-provider/engines/MiopenEngine.cpp
@@ -118,8 +118,8 @@ void MiopenEngine::initializeExecutionContext(
             else
             {
                 HIPDNN_PLUGIN_LOG_WARN(
-                    "Benchmarking knob setting value is not an integer. Type: {}",
-                    hipdnn_data_sdk::data_objects::EnumNameKnobValue(knobSetting.valueType()));
+                    "Benchmarking knob setting value is not an integer. Type: "
+                    << hipdnn_data_sdk::data_objects::EnumNameKnobValue(knobSetting.valueType()));
             }
         }
     }

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlan.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormFwdTrainingPlan.cpp
@@ -237,8 +237,8 @@ void BatchnormFwdTrainingPlan::execute(const HipdnnEnginePluginHandle& handle,
     if(_trainingParams.hasRunningStats())
     {
         expAvgFactor = _trainingParams.momentumValue();
-        HIPDNN_PLUGIN_LOG_INFO("BatchnormFwdTrainingPlan: expAvgFactor (momentum) = {}",
-                               expAvgFactor);
+        HIPDNN_PLUGIN_LOG_INFO(
+            "BatchnormFwdTrainingPlan: expAvgFactor (momentum) = " << expAvgFactor);
     }
 
     // Get all required device buffers

--- a/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenBatchnormPlanBuilder.cpp
@@ -590,8 +590,8 @@ bool MiopenBatchnormPlanBuilder::isApplicable(
     {
         HIPDNN_PLUGIN_LOG_INFO(
             "Batchnorm plan builder is applicable only for 1, 2 or 3 node graphs. "
-            "Graph has {} nodes",
-            opGraph.nodeCount());
+            "Graph has "
+            << opGraph.nodeCount() << " nodes");
         return false;
     }
     }
@@ -760,20 +760,20 @@ void MiopenBatchnormPlanBuilder::buildPlan(
     switch(nodeWrapper.attributesType())
     {
     case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
-        HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd inference plan for node: {}", nodeName);
+        HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd inference plan for node: " << nodeName);
         buildPlanInferenceSingleNode(handle, opGraph, nodeWrapper, executionContext);
         break;
     case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt:
-        HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd inference with variance plan for node: {}",
-                               nodeName);
+        HIPDNN_PLUGIN_LOG_INFO(
+            "Building batchnorm fwd inference with variance plan for node: " << nodeName);
         buildPlanInferenceWithVarianceSingleNode(handle, opGraph, nodeWrapper, executionContext);
         break;
     case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes:
-        HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd training plan for node: {}", nodeName);
+        HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd training plan for node: " << nodeName);
         buildPlanFwdTrainingSingleNode(handle, opGraph, nodeWrapper, executionContext);
         break;
     case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes:
-        HIPDNN_PLUGIN_LOG_INFO("Building batchnorm backward plan for node: {}", nodeName);
+        HIPDNN_PLUGIN_LOG_INFO("Building batchnorm backward plan for node: " << nodeName);
         buildPlanBwdSingleNode(handle, opGraph, nodeWrapper, executionContext);
         break;
     default:

--- a/dnn-providers/miopen-provider/engines/plans/MiopenConvPlanBuilder.cpp
+++ b/dnn-providers/miopen-provider/engines/plans/MiopenConvPlanBuilder.cpp
@@ -233,8 +233,8 @@ bool MiopenConvPlanBuilder::isApplicable(
     {
         HIPDNN_PLUGIN_LOG_INFO(
             "Convolution plan builder is applicable only for single node graphs. Graph "
-            "has {} nodes",
-            opGraph.nodeCount());
+            "has "
+            << opGraph.nodeCount() << " nodes");
         return false;
     }
 
@@ -335,15 +335,15 @@ void MiopenConvPlanBuilder::buildPlan(
     switch(nodeWrapper.attributesType())
     {
     case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionFwdAttributes:
-        HIPDNN_PLUGIN_LOG_INFO("Building convolution fwd plan for node: {}", nodeName);
+        HIPDNN_PLUGIN_LOG_INFO("Building convolution fwd plan for node: " << nodeName);
         buildPlanFwd(handle, opGraph, executionContext);
         break;
     case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionBwdAttributes:
-        HIPDNN_PLUGIN_LOG_INFO("Building convolution bwd plan for node: {}", nodeName);
+        HIPDNN_PLUGIN_LOG_INFO("Building convolution bwd plan for node: " << nodeName);
         buildPlanBwd(handle, opGraph, executionContext);
         break;
     case hipdnn_data_sdk::data_objects::NodeAttributes::ConvolutionWrwAttributes:
-        HIPDNN_PLUGIN_LOG_INFO("Building convolution wrw plan for node: {}", nodeName);
+        HIPDNN_PLUGIN_LOG_INFO("Building convolution wrw plan for node: " << nodeName);
         buildPlanWrw(handle, opGraph, executionContext);
         break;
     default:

--- a/dnn-providers/miopen-provider/integration_tests/CMakeLists.txt
+++ b/dnn-providers/miopen-provider/integration_tests/CMakeLists.txt
@@ -39,9 +39,6 @@ target_link_libraries(
     miopen_plugin_integration_tests PUBLIC GTest::gtest hip::host hipdnn_test_sdk hipdnn_plugin_sdk Threads::Threads
 )
 
-# Enable spdlog support for fmt-style logging
-hipdnn_enable_spdlog(miopen_plugin_integration_tests)
-
 # Ensure that the miopen_plugin is built before the integration tests
 add_dependencies(miopen_plugin_integration_tests miopen_plugin)
 

--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormForwardTraining.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormForwardTraining.cpp
@@ -63,7 +63,7 @@ protected:
     {
         const TestCaseType& testCase = this->GetParam();
 
-        HIPDNN_PLUGIN_LOG_INFO("Test is using {} for its random seed", testCase.seed);
+        HIPDNN_PLUGIN_LOG_INFO("Test is using " << testCase.seed << " for its random seed");
 
         hipdnn_frontend::graph::Graph graphObj;
         graphObj.set_name("BatchnormForwardTrainingTest");

--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormFwdTrainingActiv.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuBatchnormFwdTrainingActiv.cpp
@@ -68,7 +68,7 @@ protected:
     {
         const auto& [bnTestCase, activTestCase] = this->GetParam();
 
-        HIPDNN_PLUGIN_LOG_INFO("Test is using {} for its random seed", bnTestCase.seed);
+        HIPDNN_PLUGIN_LOG_INFO("Test is using " << bnTestCase.seed << " for its random seed");
 
         hipdnn_frontend::graph::Graph graphObj;
         graphObj.set_name("BatchnormFwdTrainingActivTest");

--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -90,7 +90,7 @@ protected:
             << "At least one output tensor id must be specified for "
                "validation.";
 
-        HIPDNN_PLUGIN_LOG_INFO("Validating {} output tensors", outputTensorIds.size());
+        HIPDNN_PLUGIN_LOG_INFO("Validating " << outputTensorIds.size() << " output tensors");
 
         // Lazily register validators after graph execution since tensor Ids and types may be inferred during graph finalization
         for(const auto& registerValidator : _deferredValidators)

--- a/dnn-providers/miopen-provider/integration_tests/main.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/main.cpp
@@ -4,7 +4,6 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
-#include <spdlog/spdlog.h>
 
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
@@ -19,7 +18,5 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    auto result = RUN_ALL_TESTS();
-    spdlog::shutdown();
-    return result;
+    return RUN_ALL_TESTS();
 }

--- a/dnn-providers/miopen-provider/tests/main.cpp
+++ b/dnn-providers/miopen-provider/tests/main.cpp
@@ -4,7 +4,6 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
-#include <spdlog/spdlog.h>
 
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
@@ -20,7 +19,5 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    auto result = RUN_ALL_TESTS();
-    spdlog::shutdown();
-    return result;
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Motivation

Remove spdlog/fmt dependency from miopen-provider.
This change is part of removing spdlog/fmt from plugin_sdk.

## Technical Details

Changes:
- Convert logging to stream based style
- Remove hipdnn_enable_spdlog() calls from CMakeLists.txt files
- Remove spdlog includes and shutdown calls from test main.cpp files

## Test Plan

Build and tests are working locally and in CI.
Sanity check logging to ensure it's functioning same as before for samples, and tests.

## Test Result

Build and tests are continuing to pass.
Logs are printing properly.
Waiting on CI signal.

---

### Note

Off the logging clean-up branch (PR #4423) that is about to be merged. 
This ensures we have the latest namespaces, and other clean-up changes for this work.