### PR TITLE
[rel-7.2-rc2] [hipblaslt] Update TF32 NN Equality for gfx942 64cu.

### DIFF
--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aquavanjaram/gfx942_64cu/Equality/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml
@@ -58,6 +58,8 @@
   StochasticRounding: false
   StridedBatched: true
   SupportUserArgs: true
+  SwizzleTensorA: false
+  SwizzleTensorB: false
   TLUA: true
   TLUB: false
   Tensor0: 0
@@ -90,8 +92,9 @@
     BufferLoad: true
     BufferStore: true
     CUCount: null
-    ClusterLocalRead: 1
-    CodeObjectVersion: default
+    CUOccupancy: -1
+    ClusterLocalRead: 0
+    CodeObjectVersion: '4'
     ConvertAfterDS: false
     CustomKernelName: ''
     DebugStreamK: 0
@@ -106,7 +109,9 @@
     EnableF32XdlMathOp: true
     EnableMatrixInstruction: true
     ExpandPointerSwap: 0
+    ExpertSchedulingMode: 0
     ForceDisableShadowInit: false
+    ForceUnrollSubIter: false
     GlobalReadPerMfma: 1
     GlobalReadVectorWidthA: 4
     GlobalReadVectorWidthB: 2
@@ -114,7 +119,7 @@
     GlobalSplitUAlgorithm: MultipleBuffer
     GlobalSplitUCoalesced: false
     GlobalSplitUWorkGroupMappingRoundRobin: false
-    GlobalWriteVectorWidth: 2
+    GlobalWriteVectorWidth: 1
     GroupLoadStore: false
     GuaranteeNoPartialA: false
     GuaranteeNoPartialB: true
@@ -122,11 +127,12 @@
     ISA: [9, 4, 2]
     InnerUnroll: 1
     InterleaveAlpha: 0
-    InternalSupportParams: {SupportCustomStaggerU: true, SupportCustomWGM: true, SupportUserGSU: true,
-      UseUniversalArgs: true}
+    InternalSupportParams: {KernArgsVersion: 2, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseSFC: false, UseUniversalArgs: true}
     Kernel: true
     KernelLanguage: Assembly
-    KernelNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs_MT320x192x16_MI16x16x1_SN_LDSB1_GRVWA4_GRVWB2_K1_LBSPPA2560_LBSPPB128_LPA0_LPB2_LRVW2_MIWT10_6_NLCA5_SVW2_VWA2_VWB2_WG32_8_1
+    KernelNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_HA_S_SAV_UserArgs_MT320x128x16_MI16x16x1_SN_LDSB1_AFC1_AFEM1_AFEM1_ASEM1_CLR0_CADS0_DTLA0_DTLB0_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB2_GSUAMB_GLS0_ISA942_IU1_K1_LDSTI0_LBSPPA2560_LBSPPB256_LBSPPM0_LPA16_LPB2_LPM0_LRVW2_LWPMn1_MIAV0_MIWT5_8_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA5_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SPO0_SRVW0_SSO0_SVW1_SK0_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA1_VWB4_WSGRA0_WSGRB0_WS64_WG64_4_1
+    LDSTrInst: false
     LSCA: 64
     LSCB: 16
     LSPA: 16
@@ -136,28 +142,29 @@
     LVPA: 4
     LVPB: 16
     LdsBlockSizePerPadA: 2560
-    LdsBlockSizePerPadB: 128
+    LdsBlockSizePerPadB: 256
     LdsBlockSizePerPadMetadata: 0
-    LdsBytesNoAmax: 33536
+    LdsBytesNoAmax: 29440
     LdsInitCVgprs: false
-    LdsNumBytes: 33536
-    LdsNumElementsAlignedA: 20480
-    LdsNumElementsAlignedB: 13056
+    LdsNumBytes: 29440
+    LdsNumElementsAlignedA: 20992
+    LdsNumElementsAlignedB: 8448
     LdsNumElementsAlignedMetadata: 0
     LdsOffsetA: 0
-    LdsOffsetA_Blk: 65536
-    LdsOffsetB: 20480
-    LdsOffsetB_Blk: 86016
+    LdsOffsetA_Blk: 32768
+    LdsOffsetB: 20992
+    LdsOffsetB_Blk: 53760
     LdsOffsetBias: 0
     LdsOffsetBiasGSU: 0
     LdsOffsetBiasNonGSU: 0
-    LdsOffsetMetadata: 33536
-    LdsOffsetMetadata_Blk: 86016
-    LdsPadA: 0
+    LdsOffsetMetadata: 29440
+    LdsOffsetMetadata_Blk: 53760
+    LdsPadA: 16
     LdsPadB: 2
     LdsPadMetadata: 0
     LocalReadVectorWidth: 2
     LocalSplitU: 1
+    LocalSplitUReuseLDS: 1
     LocalWritePerMfma: -1
     LocalWriteUseSgprA: false
     LocalWriteUseSgprB: false
@@ -172,16 +179,17 @@
     MIInputPerThreadMetadata: 2
     MIOutputVectorWidth: 4
     MIRegPerOut: 1
-    MIWaveGroup: [2, 2]
-    MIWaveTile: [10, 6]
-    MIWaveTileA: 10
-    MIWaveTileB: 6
+    MIWaveGroup: [4, 1]
+    MIWaveTile: [5, 8]
+    MIWaveTileA: 5
+    MIWaveTileB: 8
     MIWaveTileMetadata: 0
     MacroTile0: 320
-    MacroTile1: 192
+    MacroTile1: 128
     MacroTileA: 320
-    MacroTileB: 192
+    MacroTileB: 128
     MagicDivAlg: 2
+    MathClocksUnrolledLoop: 0
     MatrixInstB: 1
     MatrixInstBM: 1
     MatrixInstBN: 1
@@ -189,30 +197,36 @@
     MatrixInstM: 16
     MatrixInstN: 16
     MatrixInstruction: [16, 16, 8, 1]
+    MaxLDS: 65536
     MaxOccupancy: 40
-    MaxVgprNumber: 256
-    MinVgprNumber: 0
+    MbskPrefetchMethod: 0
+    MfmaInitCVgprs: false
     NoLdsWriteCode: false
     NoReject: false
     NoTailLoop: false
+    NonDTLTailLoopA: false
+    NonDTLTailLoopB: false
     NonTemporal: -1
     NonTemporalA: 0
     NonTemporalB: 0
     NonTemporalC: 0
-    NonTemporalD: 0
+    NonTemporalD: 4
     NonTemporalE: 0
     NonTemporalMetadata: 0
     NonTemporalWS: 0
-    NumElementsPerBatchStore: 16
-    NumElementsPerThread: 240
-    NumGlobalWriteVectorsPerThread: 120
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 160
+    NumGlobalWriteVectorsPerThread: 160
     NumLoadsA: 5
-    NumLoadsB: 6
+    NumLoadsB: 4
     NumLoadsCoalescedA: 5
     NumLoadsCoalescedB: 1
     NumLoadsPerpendicularA: 1
-    NumLoadsPerpendicularB: 6
+    NumLoadsPerpendicularB: 4
     NumThreads: 256
+    NumTotalPackedLoadsA: -1
+    NumTotalPackedLoadsB: -1
+    NumWaveSplitK: 1
     OptNoLoadLoop: 1
     PackedC0IdxChars: [I]
     PackedC0IndicesX: [0]
@@ -221,33 +235,39 @@
     PrefetchGlobalRead: 2
     PrefetchLocalRead: 1
     PreloadKernArgs: true
+    SFCWGM:
+    - [1, 1]
+    - [1, 1]
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 3
     ScheduleLocalWrite: 1
     SolutionIndex: 0
-    SolutionNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs_MT320x192x16_MI16x16x1_SN_LDSB1_GRVWA4_GRVWB2_GSU1_GSUC0_GSUWGMRR0_K1_LBSPPA2560_LBSPPB128_LPA0_LPB2_LRVW2_MIWT10_6_NLCA5_SU8_SUM1_SUS64_SVW2_VWA2_VWB2_WG32_8_1_WGM6_WGMXCC8_WGMXCCG304
-    SourceSwap: 1
-    StaggerU: 8
+    SolutionNameMin: Cijk_Ailk_Bljk_S_MX_B_Bias_HA_S_SAV_UserArgs_MT320x128x16_MI16x16x1_SN_LDSB1_AFC1_AFEM1_AFEM1_ASEM1_CLR0_CADS0_DTLA0_DTLB0_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA4_GRVWB2_GSU1_GSUAMB_GSUC0_GSUWGMRR0_GLS0_ISA942_IU1_K1_LDSTI0_LBSPPA2560_LBSPPB256_LBSPPM0_LPA16_LPB2_LPM0_LRVW2_LWPMn1_MIAV0_MIWT5_8_MO40_NTn1_NTA0_NTB0_NTC0_NTD4_NTM0_NEPBS0_NLCA5_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SU4_SUM1_SUS64_SPO0_SRVW0_SSO0_SVW1_SK0_SKFTR0_SKXCCM0_TLDS1_ULSGRO0_USL1_UIOFGRO0_USFGRO0_VSn1_VWA1_VWB4_WSGRA0_WSGRB0_WS64_WG64_4_1_WGM4_WGMXCC16_WGMXCCGn1
+    SourceSwap: true
+    SpaceFillingAlgo: []
+    StaggerU: 4
     StaggerUMapping: 1
     StaggerUStride: 64
     StorePriorityOpt: false
     StoreRemapVectorWidth: 0
+    StoreSwapAddr: false
     StoreSyncOpt: 0
-    StoreVectorWidth: 2
+    StoreVectorWidth: 1
     StreamK: 0
     StreamKAtomic: 0
+    StreamKFixupTreeReduction: 0
     StreamKXCCMapping: 0
-    SubGroup0: 8
-    SubGroup1: 32
-    SubGroupA: 8
-    SubGroupB: 32
+    SubGroup0: 16
+    SubGroup1: 16
+    SubGroupA: 16
+    SubGroupB: 16
     SuppressNoLoadLoop: false
+    SwapGlobalReadOrder: false
     ThreadTile: [1, 1]
-    ThreadTile0: 40
-    ThreadTile1: 6
-    ThreadTileA: 40
-    ThreadTileB: 6
-    TotalVgprNumber: 512
+    ThreadTile0: 20
+    ThreadTile1: 8
+    ThreadTileA: 20
+    ThreadTileB: 8
     TransposeLDS: 1
     TransposeLDSMetadata: true
     ULSGRODoubleG2L: 0
@@ -256,20 +276,30 @@
     UnrollMajorLDSB: true
     UnrollMajorLDSMetadata: true
     Use64bShadowLimit: 1
+    UseCustomMainLoopSchedule: false
+    UseDirect32XEmulation: false
+    UseDot2F32XEmulation: false
+    UseDotInstruction: false
+    UseF32XEmulation: false
+    UseGeneralizedNLCOneA: false
+    UseGeneralizedNLCOneB: false
+    UseGeneralizedNLCOneMetadata: false
     UseInstOffsetForGRO: 0
-    UseSgprForGRO: -1
+    UsePLRPack: false
+    UseSgprForGRO: 0
     Valid: true
     VectorStore: -1
-    VectorWidthA: 2
-    VectorWidthB: 2
+    VectorWidthA: 1
+    VectorWidthB: 4
     WaveSeparateGlobalReadA: 0
     WaveSeparateGlobalReadB: 0
     WaveSeparateGlobalReadMetadata: 0
+    WaveSplitK: false
     WavefrontSize: 64
-    WorkGroup: [32, 8, 1]
-    WorkGroupMapping: 6
-    WorkGroupMappingXCC: 8
-    WorkGroupMappingXCCGroup: 304
+    WorkGroup: [64, 4, 1]
+    WorkGroupMapping: 4
+    WorkGroupMappingXCC: 16
+    WorkGroupMappingXCCGroup: -1
     WorkGroupReduction: false
     WorkspaceCheck: [4, 0, 1]
     _DepthU: 16
@@ -277,11 +307,20 @@
     _DepthUB: 16
     _DepthUMetadata: 16
     _GlobalAccumulation: MultipleBuffer
-    _UseSgprForGRO: false
+    _UseSgprForGRO: 0
     _VectorStore: 1
     _WorkspaceSizePerElemBias: 0
     _WorkspaceSizePerElemC: 4
     _staggerStrideShift: 0
+    enableGLTrA: false
+    enableGLTrB: false
+    enableLDSTrA: false
+    enableLDSTrB: false
+    numSubTiles: 1
+    reorderGRInstForDTVA: false
+    reorderGRInstForDTVB: false
+    tailLoopOptA: true
+    tailLoopOptB: true
 - [2, 3, 0, 1]
 - - - [8192, 12288, 1, 4096]
     - [0, 0.0]


### PR DESCRIPTION
## Motivation

To address ROCM-2619, update TF32/NN equality yaml for gfx942 64cu.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

performance test and unittest.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

performance uplift 122%
unittest:
```
[==========] 63853 tests from 11 test suites ran. (2933462 ms total)
[  PASSED  ] 63853 tests.
hipBLASLt version: 100202
```

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
