### PR TITLE
[CK] Add composablekernel to therock_matrix.py.

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -11,6 +11,7 @@ subtree_to_project_map = {
     "projects/hipblaslt": "blas",
     "projects/hipcub": "prim",
     "projects/hipdnn": "hipdnn",
+    "projects/composablekernel": "composablekernel",
     "projects/hipfft": "fft",
     "projects/hiprand": "rand",
     "projects/hipsolver": "solver",
@@ -53,6 +54,10 @@ project_map = {
             "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
         ],
         "projects_to_test": ["miopen", "miopen_plugin"],
+    },
+    "composablekernel": {
+        "cmake_options": ["-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON"],
+        "projects_to_test": ["composablekernel"],
     },
     "fft": {
         "cmake_options": ["-DTHEROCK_ENABLE_FFT=ON", "-DTHEROCK_ENABLE_RAND=ON"],


### PR DESCRIPTION
## Motivation

We need CI for building the composablekernel project (tests) with TheRock. This will likely fail the first time, but it will shine a light on what needs to be done to move forward.

## Technical Details

Add the standalone project to TheRock's build matrix.

## Test Plan

Ensure TheRock attempts to build the composablekernel project on all the targets it supports e.g., gfx1151 (Windows/Linux), etc

## Test Result

Waiting on CI