### PR TITLE
[CI] Bump TheRock CI 20260210

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 55fa089eecd5f20d13357b82b74b5572dda1d67b # 2026-02-03 commit
+          ref: 5028da50db14c24801a7695e754256016d5068db # 2026-02-10 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 55fa089eecd5f20d13357b82b74b5572dda1d67b # 2026-02-03 commit
+          ref: 5028da50db14c24801a7695e754256016d5068db # 2026-02-10 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 55fa089eecd5f20d13357b82b74b5572dda1d67b # 2026-02-03 commit
+          ref: 5028da50db14c24801a7695e754256016d5068db # 2026-02-10 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 55fa089eecd5f20d13357b82b74b5572dda1d67b # 2026-02-03 commit
+          ref: 5028da50db14c24801a7695e754256016d5068db # 2026-02-10 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 55fa089eecd5f20d13357b82b74b5572dda1d67b # 2026-02-03 commit
+          ref: 5028da50db14c24801a7695e754256016d5068db # 2026-02-10 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -31,7 +31,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: 55fa089eecd5f20d13357b82b74b5572dda1d67b # 2026-02-03 commit
+          ref: 5028da50db14c24801a7695e754256016d5068db # 2026-02-10 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 55fa089eecd5f20d13357b82b74b5572dda1d67b # 2026-02-03 commit
+          ref: 5028da50db14c24801a7695e754256016d5068db # 2026-02-10 commit
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
Bump TheRock CI with commit https://github.com/ROCm/TheRock/commit/5028da50db14c24801a7695e754256016d5068db from 02.10.2026 to implement CI job for hipblaslt-provider in the follow-up PR.