### PR TITLE
[MIOpen] Fixed CK Builder test name CI failure

### DIFF
--- a/projects/miopen/test/gtest/ck_builder_xdl.cpp
+++ b/projects/miopen/test/gtest/ck_builder_xdl.cpp
@@ -51,12 +51,12 @@ void CompareInstanceLists()
     compare_instance_vectors(ckFactoryInstances, builderFactoryInstances);
 }
 
-TEST(CKBuilderGroupedFwdConv2D, CompareInstanceListsFloat) { CompareInstanceLists<float>(); }
+TEST(CPU_CKBuilderGroupedFwdConv2D_FP32, CompareInstanceListsFloat) { CompareInstanceLists<float>(); }
 
 /*
-TEST(CKBuilderGroupedFwdConv2D, CompareInstanceListsHalf) { CompareInstanceLists<ck::half_t>(); }
+TEST(CPU_CKBuilderGroupedFwdConv2D_FP16, CompareInstanceListsHalf) { CompareInstanceLists<ck::half_t>(); }
 
-TEST(CKBuilderGroupedFwdConv2D, CompareInstanceListsBHalf) { CompareInstanceLists<ck::bhalf_t>(); }
+TEST(CPU_CKBuilderGroupedFwdConv2D_BFP16, CompareInstanceListsBHalf) { CompareInstanceLists<ck::bhalf_t>(); }
 
-TEST(CKBuilderGroupedFwdConv2D, CompareInstanceListsInt8) { CompareInstanceLists<int8_t>(); }
+TEST(CPU_CKBuilderGroupedFwdConv2D_I8, CompareInstanceListsInt8) { CompareInstanceLists<int8_t>(); }
 */

--- a/projects/miopen/test/gtest/ck_builder_xdl.cpp
+++ b/projects/miopen/test/gtest/ck_builder_xdl.cpp
@@ -51,12 +51,17 @@ void CompareInstanceLists()
     compare_instance_vectors(ckFactoryInstances, builderFactoryInstances);
 }
 
-TEST(CPU_CKBuilderGroupedFwdConv2D_FP32, CompareInstanceListsFloat) { CompareInstanceLists<float>(); }
+TEST(CPU_CKBuilderGroupedFwdConv2D_FP32, CompareInstanceListsFloat)
+{
+    CompareInstanceLists<float>();
+}
 
 /*
-TEST(CPU_CKBuilderGroupedFwdConv2D_FP16, CompareInstanceListsHalf) { CompareInstanceLists<ck::half_t>(); }
+TEST(CPU_CKBuilderGroupedFwdConv2D_FP16, CompareInstanceListsHalf) {
+CompareInstanceLists<ck::half_t>(); }
 
-TEST(CPU_CKBuilderGroupedFwdConv2D_BFP16, CompareInstanceListsBHalf) { CompareInstanceLists<ck::bhalf_t>(); }
+TEST(CPU_CKBuilderGroupedFwdConv2D_BFP16, CompareInstanceListsBHalf) {
+CompareInstanceLists<ck::bhalf_t>(); }
 
 TEST(CPU_CKBuilderGroupedFwdConv2D_I8, CompareInstanceListsInt8) { CompareInstanceLists<int8_t>(); }
 */


### PR DESCRIPTION
## Motivation

Newly added tests for CK Builder integration had invalid names.

## Technical Details

Fix the names

## Test Plan

Run the name validation

## Test Result

Waiting for results

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
