### PR TITLE
[hipSOLVER] Add 64 bit LARFT API

### DIFF
--- a/projects/hipsolver/CHANGELOG.md
+++ b/projects/hipsolver/CHANGELOG.md
@@ -6,6 +6,12 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ## (Unreleased) hipSOLVER
 
 ### Added
+
+* Added compatibility-only functions:
+  * larft
+    * hipsolverDnXlarft_bufferSize
+    * hipsolverDnXlarft
+
 ### Changed
 ### Removed
 ### Optimized

--- a/projects/hipsolver/clients/common/hipsolver_datatype2string.cpp
+++ b/projects/hipsolver/clients/common/hipsolver_datatype2string.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,6 +105,32 @@ char hipsolver2char_erange(hipsolverEigRange_t value)
         return 'V';
     case HIPSOLVER_EIG_RANGE_I:
         return 'I';
+    default:
+        throw std::invalid_argument("Invalid enum");
+    }
+}
+
+char hipsolver2char_direct(hipsolverDirectMode_t value)
+{
+    switch(value)
+    {
+    case HIPSOLVER_DIRECT_FORWARD:
+        return 'F';
+    case HIPSOLVER_DIRECT_BACKWARD:
+        return 'B';
+    default:
+        throw std::invalid_argument("Invalid enum");
+    }
+}
+
+char hipsolver2char_storev(hipsolverStorevMode_t value)
+{
+    switch(value)
+    {
+    case HIPSOLVER_STOREV_COLUMNWISE:
+        return 'C';
+    case HIPSOLVER_STOREV_ROWWISE:
+        return 'R';
     default:
         throw std::invalid_argument("Invalid enum");
     }

--- a/projects/hipsolver/clients/common/lapack_host_reference.cpp
+++ b/projects/hipsolver/clients/common/lapack_host_reference.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -603,6 +603,96 @@ void zgeqrf_(int*                    m,
              hipsolverDoubleComplex* work,
              int*                    lwork,
              int*                    info);
+
+void sgeqlf_(int* m, int* n, float* A, int* lda, float* ipiv, float* work, int* lwork, int* info);
+void dgeqlf_(
+    int* m, int* n, double* A, int* lda, double* ipiv, double* work, int* lwork, int* info);
+void cgeqlf_(int*              m,
+             int*              n,
+             hipsolverComplex* A,
+             int*              lda,
+             hipsolverComplex* ipiv,
+             hipsolverComplex* work,
+             int*              lwork,
+             int*              info);
+void zgeqlf_(int*                    m,
+             int*                    n,
+             hipsolverDoubleComplex* A,
+             int*                    lda,
+             hipsolverDoubleComplex* ipiv,
+             hipsolverDoubleComplex* work,
+             int*                    lwork,
+             int*                    info);
+
+void sgelqf_(int* m, int* n, float* A, int* lda, float* ipiv, float* work, int* lwork, int* info);
+void dgelqf_(
+    int* m, int* n, double* A, int* lda, double* ipiv, double* work, int* lwork, int* info);
+void cgelqf_(int*              m,
+             int*              n,
+             hipsolverComplex* A,
+             int*              lda,
+             hipsolverComplex* ipiv,
+             hipsolverComplex* work,
+             int*              lwork,
+             int*              info);
+void zgelqf_(int*                    m,
+             int*                    n,
+             hipsolverDoubleComplex* A,
+             int*                    lda,
+             hipsolverDoubleComplex* ipiv,
+             hipsolverDoubleComplex* work,
+             int*                    lwork,
+             int*                    info);
+
+void sgerqf_(int* m, int* n, float* A, int* lda, float* ipiv, float* work, int* lwork, int* info);
+void dgerqf_(
+    int* m, int* n, double* A, int* lda, double* ipiv, double* work, int* lwork, int* info);
+void cgerqf_(int*              m,
+             int*              n,
+             hipsolverComplex* A,
+             int*              lda,
+             hipsolverComplex* ipiv,
+             hipsolverComplex* work,
+             int*              lwork,
+             int*              info);
+void zgerqf_(int*                    m,
+             int*                    n,
+             hipsolverDoubleComplex* A,
+             int*                    lda,
+             hipsolverDoubleComplex* ipiv,
+             hipsolverDoubleComplex* work,
+             int*                    lwork,
+             int*                    info);
+
+void slarft_(
+    char* direct, char* storev, int* n, int* k, float* V, int* ldv, float* tau, float* T, int* ldt);
+void dlarft_(char*   direct,
+             char*   storev,
+             int*    n,
+             int*    k,
+             double* V,
+             int*    ldv,
+             double* tau,
+             double* T,
+             int*    ldt);
+void clarft_(char*             direct,
+             char*             storev,
+             int*              n,
+             int*              k,
+             hipsolverComplex* V,
+             int*              ldv,
+             hipsolverComplex* tau,
+             hipsolverComplex* T,
+             int*              ldt);
+void zlarft_(char*                   direct,
+             char*                   storev,
+             int*                    n,
+             int*                    k,
+             hipsolverDoubleComplex* V,
+             int*                    ldv,
+             hipsolverDoubleComplex* tau,
+             hipsolverDoubleComplex* T,
+             int*                    ldt);
 
 void sgesv_(int* n, int* nrhs, float* A, int* lda, int* ipiv, float* B, int* ldb, int* info);
 void dgesv_(int* n, int* nrhs, double* A, int* lda, int* ipiv, double* B, int* ldb, int* info);
@@ -2165,6 +2255,194 @@ void cpu_geqrf<hipsolverDoubleComplex>(int                     m,
                                        int*                    info)
 {
     zgeqrf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+// geqlf
+template <>
+void cpu_geqlf<float>(
+    int m, int n, float* A, int lda, float* ipiv, float* work, int lwork, int* info)
+{
+    sgeqlf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+template <>
+void cpu_geqlf<double>(
+    int m, int n, double* A, int lda, double* ipiv, double* work, int lwork, int* info)
+{
+    dgeqlf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+template <>
+void cpu_geqlf<hipsolverComplex>(int               m,
+                                 int               n,
+                                 hipsolverComplex* A,
+                                 int               lda,
+                                 hipsolverComplex* ipiv,
+                                 hipsolverComplex* work,
+                                 int               lwork,
+                                 int*              info)
+{
+    cgeqlf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+template <>
+void cpu_geqlf<hipsolverDoubleComplex>(int                     m,
+                                       int                     n,
+                                       hipsolverDoubleComplex* A,
+                                       int                     lda,
+                                       hipsolverDoubleComplex* ipiv,
+                                       hipsolverDoubleComplex* work,
+                                       int                     lwork,
+                                       int*                    info)
+{
+    zgeqlf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+// gelqf
+template <>
+void cpu_gelqf<float>(
+    int m, int n, float* A, int lda, float* ipiv, float* work, int lwork, int* info)
+{
+    sgelqf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+template <>
+void cpu_gelqf<double>(
+    int m, int n, double* A, int lda, double* ipiv, double* work, int lwork, int* info)
+{
+    dgelqf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+template <>
+void cpu_gelqf<hipsolverComplex>(int               m,
+                                 int               n,
+                                 hipsolverComplex* A,
+                                 int               lda,
+                                 hipsolverComplex* ipiv,
+                                 hipsolverComplex* work,
+                                 int               lwork,
+                                 int*              info)
+{
+    cgelqf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+template <>
+void cpu_gelqf<hipsolverDoubleComplex>(int                     m,
+                                       int                     n,
+                                       hipsolverDoubleComplex* A,
+                                       int                     lda,
+                                       hipsolverDoubleComplex* ipiv,
+                                       hipsolverDoubleComplex* work,
+                                       int                     lwork,
+                                       int*                    info)
+{
+    zgelqf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+// gerqf
+template <>
+void cpu_gerqf<float>(
+    int m, int n, float* A, int lda, float* ipiv, float* work, int lwork, int* info)
+{
+    sgerqf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+template <>
+void cpu_gerqf<double>(
+    int m, int n, double* A, int lda, double* ipiv, double* work, int lwork, int* info)
+{
+    dgerqf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+template <>
+void cpu_gerqf<hipsolverComplex>(int               m,
+                                 int               n,
+                                 hipsolverComplex* A,
+                                 int               lda,
+                                 hipsolverComplex* ipiv,
+                                 hipsolverComplex* work,
+                                 int               lwork,
+                                 int*              info)
+{
+    cgerqf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+template <>
+void cpu_gerqf<hipsolverDoubleComplex>(int                     m,
+                                       int                     n,
+                                       hipsolverDoubleComplex* A,
+                                       int                     lda,
+                                       hipsolverDoubleComplex* ipiv,
+                                       hipsolverDoubleComplex* work,
+                                       int                     lwork,
+                                       int*                    info)
+{
+    zgerqf_(&m, &n, A, &lda, ipiv, work, &lwork, info);
+}
+
+// larft
+template <>
+void cpu_larft<float>(hipsolverDirectMode_t directR,
+                      hipsolverStorevMode_t storevR,
+                      int                   n,
+                      int                   k,
+                      float*                V,
+                      int                   ldv,
+                      float*                tau,
+                      float*                T,
+                      int                   ldt)
+{
+    char direct = hipsolver2char_direct(directR);
+    char storev = hipsolver2char_storev(storevR);
+    slarft_(&direct, &storev, &n, &k, V, &ldv, tau, T, &ldt);
+}
+
+template <>
+void cpu_larft<double>(hipsolverDirectMode_t directR,
+                       hipsolverStorevMode_t storevR,
+                       int                   n,
+                       int                   k,
+                       double*               V,
+                       int                   ldv,
+                       double*               tau,
+                       double*               T,
+                       int                   ldt)
+{
+    char direct = hipsolver2char_direct(directR);
+    char storev = hipsolver2char_storev(storevR);
+    dlarft_(&direct, &storev, &n, &k, V, &ldv, tau, T, &ldt);
+}
+
+template <>
+void cpu_larft<hipsolverComplex>(hipsolverDirectMode_t directR,
+                                 hipsolverStorevMode_t storevR,
+                                 int                   n,
+                                 int                   k,
+                                 hipsolverComplex*     V,
+                                 int                   ldv,
+                                 hipsolverComplex*     tau,
+                                 hipsolverComplex*     T,
+                                 int                   ldt)
+{
+    char direct = hipsolver2char_direct(directR);
+    char storev = hipsolver2char_storev(storevR);
+    clarft_(&direct, &storev, &n, &k, V, &ldv, tau, T, &ldt);
+}
+
+template <>
+void cpu_larft<hipsolverDoubleComplex>(hipsolverDirectMode_t   directR,
+                                       hipsolverStorevMode_t   storevR,
+                                       int                     n,
+                                       int                     k,
+                                       hipsolverDoubleComplex* V,
+                                       int                     ldv,
+                                       hipsolverDoubleComplex* tau,
+                                       hipsolverDoubleComplex* T,
+                                       int                     ldt)
+{
+    char direct = hipsolver2char_direct(directR);
+    char storev = hipsolver2char_storev(storevR);
+    zlarft_(&direct, &storev, &n, &k, V, &ldv, tau, T, &ldt);
 }
 
 // gesv

--- a/projects/hipsolver/clients/gtest/CMakeLists.txt
+++ b/projects/hipsolver/clients/gtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -55,6 +55,7 @@ set(hipsolverDn_test_source
   gesvd_gtest.cpp
   gesvda_gtest.cpp
   gesvdj_gtest.cpp
+  larft_gtest.cpp
   potrf_gtest.cpp
   potri_gtest.cpp
   potrs_gtest.cpp

--- a/projects/hipsolver/clients/gtest/larft_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/larft_gtest.cpp
@@ -1,0 +1,126 @@
+/* ************************************************************************
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#include "testing_larft.hpp"
+
+using ::testing::Combine;
+using ::testing::TestWithParam;
+using ::testing::Values;
+using ::testing::ValuesIn;
+using namespace std;
+
+typedef std::tuple<vector<int>, char, char> larft_tuple;
+
+// each size_range is a {n, k, ldv, ldt}
+// if n = -1 and k = -1, then the bad arguments test will be run
+
+// for checkin_lapack tests
+const vector<vector<int>> size_range = {
+    // invalid
+    {-1, -1, 1, 1},
+    // normal (valid) samples
+    {10, 5, 10, 5},
+    {20, 10, 20, 10},
+    {30, 15, 30, 15},
+    {50, 25, 50, 25}};
+
+const vector<char> direct_range = {'F', 'B'};
+
+const vector<char> storev_range = {'C', 'R'};
+
+Arguments larft_setup_arguments(larft_tuple tup)
+{
+    vector<int> size   = std::get<0>(tup);
+    char        direct = std::get<1>(tup);
+    char        storev = std::get<2>(tup);
+
+    Arguments arg;
+
+    arg.set<rocblas_int>("n", size[0]);
+    arg.set<rocblas_int>("k", size[1]);
+    arg.set<rocblas_int>("ldv", size[2]);
+    arg.set<rocblas_int>("ldt", size[3]);
+
+    arg.set<char>("direct", direct);
+    arg.set<char>("storev", storev);
+
+    // only testing standard use case/defaults for strides
+
+    arg.timing = 0;
+
+    return arg;
+}
+
+template <testAPI_t API, typename I, typename SIZE>
+class LARFT_BASE : public ::TestWithParam<larft_tuple>
+{
+protected:
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
+
+    template <bool BATCHED, bool STRIDED, typename T>
+    void run_tests()
+    {
+        Arguments arg = larft_setup_arguments(GetParam());
+
+        if(arg.peek<rocblas_int>("n") == -1 && arg.peek<rocblas_int>("k") == -1)
+            testing_larft_bad_arg<API, BATCHED, STRIDED, T, I, SIZE>();
+
+        arg.batch_count = 1;
+        testing_larft<API, BATCHED, STRIDED, T, I, SIZE>(arg);
+    }
+};
+
+class LARFT_COMPAT_64 : public LARFT_BASE<API_COMPAT, int64_t, size_t>
+{
+};
+
+// non-batch tests
+
+TEST_P(LARFT_COMPAT_64, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(LARFT_COMPAT_64, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(LARFT_COMPAT_64, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(LARFT_COMPAT_64, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         LARFT_COMPAT_64,
+                         Combine(ValuesIn(size_range),
+                                 ValuesIn(direct_range),
+                                 ValuesIn(storev_range)));

--- a/projects/hipsolver/clients/gtest/larft_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/larft_gtest.cpp
@@ -29,10 +29,17 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, char, char> larft_tuple;
+typedef std::tuple<vector<int>, vector<char>> larft_tuple;
 
 // each size_range is a {n, k, ldv, ldt}
 // if n = -1 and k = -1, then the bad arguments test will be run
+
+// each op_range vector is a {direct, storev}
+
+// case when n == -1, k == -1, direct == F, and storev == C will also execute the bad arguments test
+// (null handle, null pointers and invalid values)
+
+const vector<vector<char>> op_range = {{'F', 'C'}, {'F', 'R'}, {'B', 'C'}, {'B', 'R'}};
 
 // for checkin_lapack tests
 const vector<vector<int>> size_range = {
@@ -44,15 +51,14 @@ const vector<vector<int>> size_range = {
     {30, 15, 30, 15},
     {50, 25, 50, 25}};
 
-const vector<char> direct_range = {'F', 'B'};
-
-const vector<char> storev_range = {'C', 'R'};
+// for daily_lapack tests
+// const vector<vector<int>> large_size_range
+//     = {{100, 50, 100, 50}, {200, 100, 200, 100}, {500, 250, 500, 250}, {1000, 500, 1000, 500}};
 
 Arguments larft_setup_arguments(larft_tuple tup)
 {
-    vector<int> size   = std::get<0>(tup);
-    char        direct = std::get<1>(tup);
-    char        storev = std::get<2>(tup);
+    vector<int>  size = std::get<0>(tup);
+    vector<char> op   = std::get<1>(tup);
 
     Arguments arg;
 
@@ -61,8 +67,8 @@ Arguments larft_setup_arguments(larft_tuple tup)
     arg.set<rocblas_int>("ldv", size[2]);
     arg.set<rocblas_int>("ldt", size[3]);
 
-    arg.set<char>("direct", direct);
-    arg.set<char>("storev", storev);
+    arg.set<char>("direct", op[0]);
+    arg.set<char>("storev", op[1]);
 
     // only testing standard use case/defaults for strides
 
@@ -85,7 +91,8 @@ protected:
     {
         Arguments arg = larft_setup_arguments(GetParam());
 
-        if(arg.peek<rocblas_int>("n") == -1 && arg.peek<rocblas_int>("k") == -1)
+        if(arg.peek<rocblas_int>("n") == -1 && arg.peek<rocblas_int>("k") == -1
+           && arg.peek<char>("direct") == 'F' && arg.peek<char>("storev") == 'C')
             testing_larft_bad_arg<API, BATCHED, STRIDED, T, I, SIZE>();
 
         arg.batch_count = 1;
@@ -119,8 +126,10 @@ TEST_P(LARFT_COMPAT_64, __double_complex)
     run_tests<false, false, rocblas_double_complex>();
 }
 
+// INSTANTIATE_TEST_SUITE_P(daily_lapack,
+//                          LARFT_COMPAT_64,
+//                          Combine(ValuesIn(large_size_range), ValuesIn(op_range)));
+
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          LARFT_COMPAT_64,
-                         Combine(ValuesIn(size_range),
-                                 ValuesIn(direct_range),
-                                 ValuesIn(storev_range)));
+                         Combine(ValuesIn(size_range), ValuesIn(op_range)));

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -9735,6 +9735,368 @@ inline hipsolverStatus_t hipsolver_sytrf(testAPI_t               API,
     case API_COMPAT:
         return hipsolverDnZsytrf(
             handle, uplo, n, (hipDoubleComplex*)A, lda, ipiv, (hipDoubleComplex*)work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+/******************** LARFT ********************/
+// 64-bit API only (API_COMPAT)
+inline hipsolverStatus_t hipsolver_larft_bufferSize(testAPI_t             API,
+                                                    hipsolverHandle_t     handle,
+                                                    hipsolverDnParams_t   params,
+                                                    hipsolverDirectMode_t direct,
+                                                    hipsolverStorevMode_t storev,
+                                                    int64_t               n,
+                                                    int64_t               k,
+                                                    float*                V,
+                                                    int64_t               ldv,
+                                                    float*                tau,
+                                                    float*                T,
+                                                    int64_t               ldt,
+                                                    size_t*               lworkOnDevice,
+                                                    size_t*               lworkOnHost)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXlarft_bufferSize(handle,
+                                            params,
+                                            direct,
+                                            storev,
+                                            n,
+                                            k,
+                                            HIP_R_32F,
+                                            V,
+                                            ldv,
+                                            HIP_R_32F,
+                                            tau,
+                                            HIP_R_32F,
+                                            T,
+                                            ldt,
+                                            HIP_R_32F,
+                                            lworkOnDevice,
+                                            lworkOnHost);
+    default:
+        *lworkOnDevice = 0;
+        *lworkOnHost   = 0;
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_larft_bufferSize(testAPI_t             API,
+                                                    hipsolverHandle_t     handle,
+                                                    hipsolverDnParams_t   params,
+                                                    hipsolverDirectMode_t direct,
+                                                    hipsolverStorevMode_t storev,
+                                                    int64_t               n,
+                                                    int64_t               k,
+                                                    double*               V,
+                                                    int64_t               ldv,
+                                                    double*               tau,
+                                                    double*               T,
+                                                    int64_t               ldt,
+                                                    size_t*               lworkOnDevice,
+                                                    size_t*               lworkOnHost)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXlarft_bufferSize(handle,
+                                            params,
+                                            direct,
+                                            storev,
+                                            n,
+                                            k,
+                                            HIP_R_64F,
+                                            V,
+                                            ldv,
+                                            HIP_R_64F,
+                                            tau,
+                                            HIP_R_64F,
+                                            T,
+                                            ldt,
+                                            HIP_R_64F,
+                                            lworkOnDevice,
+                                            lworkOnHost);
+    default:
+        *lworkOnDevice = 0;
+        *lworkOnHost   = 0;
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_larft_bufferSize(testAPI_t             API,
+                                                    hipsolverHandle_t     handle,
+                                                    hipsolverDnParams_t   params,
+                                                    hipsolverDirectMode_t direct,
+                                                    hipsolverStorevMode_t storev,
+                                                    int64_t               n,
+                                                    int64_t               k,
+                                                    hipsolverComplex*     V,
+                                                    int64_t               ldv,
+                                                    hipsolverComplex*     tau,
+                                                    hipsolverComplex*     T,
+                                                    int64_t               ldt,
+                                                    size_t*               lworkOnDevice,
+                                                    size_t*               lworkOnHost)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXlarft_bufferSize(handle,
+                                            params,
+                                            direct,
+                                            storev,
+                                            n,
+                                            k,
+                                            HIP_C_32F,
+                                            V,
+                                            ldv,
+                                            HIP_C_32F,
+                                            tau,
+                                            HIP_C_32F,
+                                            T,
+                                            ldt,
+                                            HIP_C_32F,
+                                            lworkOnDevice,
+                                            lworkOnHost);
+    default:
+        *lworkOnDevice = 0;
+        *lworkOnHost   = 0;
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_larft_bufferSize(testAPI_t               API,
+                                                    hipsolverHandle_t       handle,
+                                                    hipsolverDnParams_t     params,
+                                                    hipsolverDirectMode_t   direct,
+                                                    hipsolverStorevMode_t   storev,
+                                                    int64_t                 n,
+                                                    int64_t                 k,
+                                                    hipsolverDoubleComplex* V,
+                                                    int64_t                 ldv,
+                                                    hipsolverDoubleComplex* tau,
+                                                    hipsolverDoubleComplex* T,
+                                                    int64_t                 ldt,
+                                                    size_t*                 lworkOnDevice,
+                                                    size_t*                 lworkOnHost)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXlarft_bufferSize(handle,
+                                            params,
+                                            direct,
+                                            storev,
+                                            n,
+                                            k,
+                                            HIP_C_64F,
+                                            V,
+                                            ldv,
+                                            HIP_C_64F,
+                                            tau,
+                                            HIP_C_64F,
+                                            T,
+                                            ldt,
+                                            HIP_C_64F,
+                                            lworkOnDevice,
+                                            lworkOnHost);
+    default:
+        *lworkOnDevice = 0;
+        *lworkOnHost   = 0;
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_larft(testAPI_t             API,
+                                         hipsolverHandle_t     handle,
+                                         hipsolverDnParams_t   params,
+                                         hipsolverDirectMode_t direct,
+                                         hipsolverStorevMode_t storev,
+                                         int64_t               n,
+                                         int64_t               k,
+                                         float*                V,
+                                         int64_t               ldv,
+                                         int64_t               stV,
+                                         float*                tau,
+                                         int64_t               stT,
+                                         float*                T,
+                                         int64_t               ldt,
+                                         int64_t               stW,
+                                         float*                workOnDevice,
+                                         size_t                lworkOnDevice,
+                                         float*                workOnHost,
+                                         size_t                lworkOnHost,
+                                         int                   bc)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXlarft(handle,
+                                 params,
+                                 direct,
+                                 storev,
+                                 n,
+                                 k,
+                                 HIP_R_32F,
+                                 V,
+                                 ldv,
+                                 HIP_R_32F,
+                                 tau,
+                                 HIP_R_32F,
+                                 T,
+                                 ldt,
+                                 HIP_R_32F,
+                                 workOnDevice,
+                                 lworkOnDevice,
+                                 workOnHost,
+                                 lworkOnHost);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_larft(testAPI_t             API,
+                                         hipsolverHandle_t     handle,
+                                         hipsolverDnParams_t   params,
+                                         hipsolverDirectMode_t direct,
+                                         hipsolverStorevMode_t storev,
+                                         int64_t               n,
+                                         int64_t               k,
+                                         double*               V,
+                                         int64_t               ldv,
+                                         int64_t               stV,
+                                         double*               tau,
+                                         int64_t               stT,
+                                         double*               T,
+                                         int64_t               ldt,
+                                         int64_t               stW,
+                                         double*               workOnDevice,
+                                         size_t                lworkOnDevice,
+                                         double*               workOnHost,
+                                         size_t                lworkOnHost,
+                                         int                   bc)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXlarft(handle,
+                                 params,
+                                 direct,
+                                 storev,
+                                 n,
+                                 k,
+                                 HIP_R_64F,
+                                 V,
+                                 ldv,
+                                 HIP_R_64F,
+                                 tau,
+                                 HIP_R_64F,
+                                 T,
+                                 ldt,
+                                 HIP_R_64F,
+                                 workOnDevice,
+                                 lworkOnDevice,
+                                 workOnHost,
+                                 lworkOnHost);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_larft(testAPI_t             API,
+                                         hipsolverHandle_t     handle,
+                                         hipsolverDnParams_t   params,
+                                         hipsolverDirectMode_t direct,
+                                         hipsolverStorevMode_t storev,
+                                         int64_t               n,
+                                         int64_t               k,
+                                         hipsolverComplex*     V,
+                                         int64_t               ldv,
+                                         int64_t               stV,
+                                         hipsolverComplex*     tau,
+                                         int64_t               stT,
+                                         hipsolverComplex*     T,
+                                         int64_t               ldt,
+                                         int64_t               stW,
+                                         hipsolverComplex*     workOnDevice,
+                                         size_t                lworkOnDevice,
+                                         hipsolverComplex*     workOnHost,
+                                         size_t                lworkOnHost,
+                                         int                   bc)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXlarft(handle,
+                                 params,
+                                 direct,
+                                 storev,
+                                 n,
+                                 k,
+                                 HIP_C_32F,
+                                 V,
+                                 ldv,
+                                 HIP_C_32F,
+                                 tau,
+                                 HIP_C_32F,
+                                 T,
+                                 ldt,
+                                 HIP_C_32F,
+                                 workOnDevice,
+                                 lworkOnDevice,
+                                 workOnHost,
+                                 lworkOnHost);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_larft(testAPI_t               API,
+                                         hipsolverHandle_t       handle,
+                                         hipsolverDnParams_t     params,
+                                         hipsolverDirectMode_t   direct,
+                                         hipsolverStorevMode_t   storev,
+                                         int64_t                 n,
+                                         int64_t                 k,
+                                         hipsolverDoubleComplex* V,
+                                         int64_t                 ldv,
+                                         int64_t                 stV,
+                                         hipsolverDoubleComplex* tau,
+                                         int64_t                 stT,
+                                         hipsolverDoubleComplex* T,
+                                         int64_t                 ldt,
+                                         int64_t                 stW,
+                                         hipsolverDoubleComplex* workOnDevice,
+                                         size_t                  lworkOnDevice,
+                                         hipsolverDoubleComplex* workOnHost,
+                                         size_t                  lworkOnHost,
+                                         int                     bc)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXlarft(handle,
+                                 params,
+                                 direct,
+                                 storev,
+                                 n,
+                                 k,
+                                 HIP_C_64F,
+                                 V,
+                                 ldv,
+                                 HIP_C_64F,
+                                 tau,
+                                 HIP_C_64F,
+                                 T,
+                                 ldt,
+                                 HIP_C_64F,
+                                 workOnDevice,
+                                 lworkOnDevice,
+                                 workOnHost,
+                                 lworkOnHost);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }

--- a/projects/hipsolver/clients/include/hipsolver_datatype2string.hpp
+++ b/projects/hipsolver/clients/include/hipsolver_datatype2string.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -89,6 +89,10 @@ char hipsolver2char_evect(hipsolverEigMode_t value);
 char hipsolver2char_eform(hipsolverEigType_t value);
 
 char hipsolver2char_erange(hipsolverEigRange_t value);
+
+char hipsolver2char_direct(hipsolverDirectMode_t value);
+
+char hipsolver2char_storev(hipsolverStorevMode_t value);
 
 /* ============================================================================================ */
 /*  Convert lapack char constants to hipsolver type. */

--- a/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
+++ b/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@
 #include "testing_gesvdj.hpp"
 #include "testing_getrf.hpp"
 #include "testing_getrs.hpp"
+#include "testing_larft.hpp"
 #include "testing_orgbr_ungbr.hpp"
 #include "testing_orgqr_ungqr.hpp"
 #include "testing_orgtr_ungtr.hpp"
@@ -90,6 +91,7 @@ class hipsolver_dispatcher
             {"getrf_64", testing_getrf<API_COMPAT, false, false, false, T, int64_t, size_t>},
             {"getrs", testing_getrs<API_NORMAL, false, false, T, int, int>},
             {"getrs_64", testing_getrs<API_COMPAT, false, false, T, int64_t, size_t>},
+            {"larft_64", testing_larft<API_COMPAT, false, false, T, int64_t, size_t>},
             {"potrf", testing_potrf<API_NORMAL, false, false, T>},
             {"potrf_batched", testing_potrf<API_NORMAL, true, false, T>},
             {"potri", testing_potri<API_NORMAL, false, false, T>},

--- a/projects/hipsolver/clients/include/lapack_host_reference.hpp
+++ b/projects/hipsolver/clients/include/lapack_host_reference.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -172,6 +172,26 @@ void cpu_gels(hipsolverOperation_t transR,
 
 template <typename T>
 void cpu_geqrf(int m, int n, T* A, int lda, T* ipiv, T* work, int sizeW, int* info);
+
+template <typename T>
+void cpu_geqlf(int m, int n, T* A, int lda, T* ipiv, T* work, int sizeW, int* info);
+
+template <typename T>
+void cpu_gelqf(int m, int n, T* A, int lda, T* ipiv, T* work, int sizeW, int* info);
+
+template <typename T>
+void cpu_gerqf(int m, int n, T* A, int lda, T* ipiv, T* work, int sizeW, int* info);
+
+template <typename T>
+void cpu_larft(hipsolverDirectMode_t direct,
+               hipsolverStorevMode_t storev,
+               int                   n,
+               int                   k,
+               T*                    V,
+               int                   ldv,
+               T*                    tau,
+               T*                    T_,
+               int                   ldt);
 
 template <typename T>
 void cpu_gesv(int n, int nrhs, T* A, int lda, int* ipiv, T* B, int ldb, int* info);

--- a/projects/hipsolver/clients/include/testing_larft.hpp
+++ b/projects/hipsolver/clients/include/testing_larft.hpp
@@ -665,9 +665,10 @@ void testing_larft(Arguments& argus)
     I                      k       = argus.get<rocblas_int>("k", n);
     I                      ldv     = argus.get<rocblas_int>("ldv", n);
     I                      ldt     = argus.get<rocblas_int>("ldt", k);
-    I                      stV     = argus.get<rocblas_int>("strideV", ldv * k);
-    I                      stTau   = argus.get<rocblas_int>("strideTau", k);
-    I                      stT     = argus.get<rocblas_int>("strideT", ldt * k);
+    I                      stV
+        = argus.get<rocblas_int>("strideV", (storevC == 'C' || storevC == 'c') ? ldv * k : ldv * n);
+    I stTau = argus.get<rocblas_int>("strideTau", k);
+    I stT   = argus.get<rocblas_int>("strideT", ldt * k);
 
     hipsolverDirectMode_t direct
         = (directC == 'F' || directC == 'f') ? HIPSOLVER_DIRECT_FORWARD : HIPSOLVER_DIRECT_BACKWARD;
@@ -682,10 +683,68 @@ void testing_larft(Arguments& argus)
     I stTRes   = (argus.unit_check || argus.norm_check) ? stT : 0;
 
     // check non-supported values
-    // N/A
+#if !defined(__HIP_PLATFORM_HCC__) && !defined(__HIP_PLATFORM_AMD__)
+    if(storev != HIPSOLVER_STOREV_COLUMNWISE)
+    {
+        if(BATCHED)
+        {
+            // EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+            //                                       handle,
+            //                                       params,
+            //                                       direct,
+            //                                       storev,
+            //                                       n,
+            //                                       k,
+            //                                       (T*)nullptr,
+            //                                       ldv,
+            //                                       stV,
+            //                                       (T*)nullptr,
+            //                                       stTau,
+            //                                       (T*)nullptr,
+            //                                       ldt,
+            //                                       stT,
+            //                                       (T*)nullptr,
+            //                                       0,
+            //                                       (T*)nullptr,
+            //                                       0,
+            //                                       bc),
+            //                       HIPSOLVER_STATUS_NOT_SUPPORTED);
+        }
+        else
+        {
+            EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                                  handle,
+                                                  params,
+                                                  direct,
+                                                  storev,
+                                                  n,
+                                                  k,
+                                                  (T*)nullptr,
+                                                  ldv,
+                                                  stV,
+                                                  (T*)nullptr,
+                                                  stTau,
+                                                  (T*)nullptr,
+                                                  ldt,
+                                                  stT,
+                                                  (T*)nullptr,
+                                                  0,
+                                                  (T*)nullptr,
+                                                  0,
+                                                  bc),
+                                  HIPSOLVER_STATUS_NOT_SUPPORTED);
+        }
+
+        if(argus.timing)
+            rocsolver_bench_inform(inform_invalid_args);
+
+        return;
+    }
+#endif
 
     // determine sizes
-    size_t size_V    = size_t(ldv) * k;
+    bool   col       = (storev == HIPSOLVER_STOREV_COLUMNWISE);
+    size_t size_V    = col ? size_t(ldv) * k : size_t(ldv) * n;
     size_t size_Tau  = size_t(k);
     size_t size_T    = size_t(ldt) * k;
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
@@ -695,7 +754,8 @@ void testing_larft(Arguments& argus)
     size_t size_TRes   = (argus.unit_check || argus.norm_check) ? size_T : 0;
 
     // check invalid sizes
-    bool invalid_size = (n < 0 || k < 0 || k > n || ldv < n || ldt < k || bc < 0);
+    bool invalid_size = col ? (n < 0 || k < 0 || k > n || ldv < n || ldt < k || bc < 0)
+                            : (n < 0 || k < 0 || k > n || ldv < k || ldt < k || bc < 0);
     if(invalid_size)
     {
         if(BATCHED)

--- a/projects/hipsolver/clients/include/testing_larft.hpp
+++ b/projects/hipsolver/clients/include/testing_larft.hpp
@@ -1,0 +1,926 @@
+/* ************************************************************************
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#pragma once
+
+#include <vector>
+
+#include "clientcommon.hpp"
+
+template <testAPI_t API, typename I, typename SIZE, typename Td, typename Th>
+void larft_checkBadArgs(const hipsolverHandle_t     handle,
+                        const hipsolverDnParams_t   params,
+                        const hipsolverDirectMode_t direct,
+                        const hipsolverStorevMode_t storev,
+                        const I                     n,
+                        const I                     k,
+                        Td                          dV,
+                        const I                     ldv,
+                        const I                     stV,
+                        Td                          dTau,
+                        const I                     stTau,
+                        Td                          dT,
+                        const I                     ldt,
+                        const I                     stT,
+                        Td                          dWork,
+                        const SIZE                  dlwork,
+                        Th                          hWork,
+                        const SIZE                  hlwork,
+                        const int                   bc)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                          nullptr,
+                                          params,
+                                          direct,
+                                          storev,
+                                          n,
+                                          k,
+                                          dV,
+                                          ldv,
+                                          stV,
+                                          dTau,
+                                          stTau,
+                                          dT,
+                                          ldt,
+                                          stT,
+                                          dWork,
+                                          dlwork,
+                                          hWork,
+                                          hlwork,
+                                          bc),
+                          HIPSOLVER_STATUS_NOT_INITIALIZED);
+
+    // values
+    EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                          handle,
+                                          params,
+                                          hipsolverDirectMode_t(-1),
+                                          storev,
+                                          n,
+                                          k,
+                                          dV,
+                                          ldv,
+                                          stV,
+                                          dTau,
+                                          stTau,
+                                          dT,
+                                          ldt,
+                                          stT,
+                                          dWork,
+                                          dlwork,
+                                          hWork,
+                                          hlwork,
+                                          bc),
+                          HIPSOLVER_STATUS_INVALID_ENUM);
+    EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                          handle,
+                                          params,
+                                          direct,
+                                          hipsolverStorevMode_t(-1),
+                                          n,
+                                          k,
+                                          dV,
+                                          ldv,
+                                          stV,
+                                          dTau,
+                                          stTau,
+                                          dT,
+                                          ldt,
+                                          stT,
+                                          dWork,
+                                          dlwork,
+                                          hWork,
+                                          hlwork,
+                                          bc),
+                          HIPSOLVER_STATUS_INVALID_ENUM);
+    // N/A
+
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
+    // pointers
+    if constexpr(!std::is_same<I, int>::value)
+        EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                              handle,
+                                              (hipsolverDnParams_t) nullptr,
+                                              direct,
+                                              storev,
+                                              n,
+                                              k,
+                                              dV,
+                                              ldv,
+                                              stV,
+                                              dTau,
+                                              stTau,
+                                              dT,
+                                              ldt,
+                                              stT,
+                                              dWork,
+                                              dlwork,
+                                              hWork,
+                                              hlwork,
+                                              bc),
+                              HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                          handle,
+                                          params,
+                                          direct,
+                                          storev,
+                                          n,
+                                          k,
+                                          (Td) nullptr,
+                                          ldv,
+                                          stV,
+                                          dTau,
+                                          stTau,
+                                          dT,
+                                          ldt,
+                                          stT,
+                                          dWork,
+                                          dlwork,
+                                          hWork,
+                                          hlwork,
+                                          bc),
+                          HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                          handle,
+                                          params,
+                                          direct,
+                                          storev,
+                                          n,
+                                          k,
+                                          dV,
+                                          ldv,
+                                          stV,
+                                          (Td) nullptr,
+                                          stTau,
+                                          dT,
+                                          ldt,
+                                          stT,
+                                          dWork,
+                                          dlwork,
+                                          hWork,
+                                          hlwork,
+                                          bc),
+                          HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                          handle,
+                                          params,
+                                          direct,
+                                          storev,
+                                          n,
+                                          k,
+                                          dV,
+                                          ldv,
+                                          stV,
+                                          dTau,
+                                          stTau,
+                                          (Td) nullptr,
+                                          ldt,
+                                          stT,
+                                          dWork,
+                                          dlwork,
+                                          hWork,
+                                          hlwork,
+                                          bc),
+                          HIPSOLVER_STATUS_INVALID_VALUE);
+#endif
+}
+
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T, typename I, typename SIZE>
+void testing_larft_bad_arg()
+{
+    // safe arguments
+    hipsolver_local_handle handle;
+    hipsolver_local_params params;
+    hipsolverDirectMode_t  direct = HIPSOLVER_DIRECT_FORWARD;
+    hipsolverStorevMode_t  storev = HIPSOLVER_STOREV_COLUMNWISE;
+    I                      n      = 10;
+    I                      k      = 5;
+    I                      ldv    = 10;
+    I                      ldt    = 5;
+    I                      stV    = 1;
+    I                      stTau  = 1;
+    I                      stT    = 1;
+    int                    bc     = 1;
+
+    if(BATCHED)
+    {
+        // memory allocations
+        // device_batch_vector<T>         dV(1, 1, 1);
+        // device_strided_batch_vector<T> dTau(1, 1, 1, 1);
+        // device_strided_batch_vector<T> dT(1, 1, 1, 1);
+        // CHECK_HIP_ERROR(dV.memcheck());
+        // CHECK_HIP_ERROR(dTau.memcheck());
+        // CHECK_HIP_ERROR(dT.memcheck());
+
+        // SIZE size_dW, size_hW;
+        // hipsolver_larft_bufferSize(
+        //     API, handle, params, direct, storev, n, k, dV.data(), ldv, dTau.data(), dT.data(), ldt, &size_dW, &size_hW);
+        // host_strided_batch_vector<T>   hWork(size_hW, 1, size_hW, 1);
+        // device_strided_batch_vector<T> dWork(size_dW, 1, size_dW, 1);
+        // if(size_dW)
+        //     CHECK_HIP_ERROR(dWork.memcheck());
+
+        // // check bad arguments
+        // larft_checkBadArgs<API>(handle,
+        //                         params,
+        //                         direct,
+        //                         storev,
+        //                         n,
+        //                         k,
+        //                         dV.data(),
+        //                         ldv,
+        //                         stV,
+        //                         dTau.data(),
+        //                         stTau,
+        //                         dT.data(),
+        //                         ldt,
+        //                         stT,
+        //                         dWork.data(),
+        //                         size_dW,
+        //                         hWork.data(),
+        //                         size_hW,
+        //                         bc);
+    }
+    else
+    {
+        // memory allocations
+        device_strided_batch_vector<T> dV(1, 1, 1, 1);
+        device_strided_batch_vector<T> dTau(1, 1, 1, 1);
+        device_strided_batch_vector<T> dT(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dV.memcheck());
+        CHECK_HIP_ERROR(dTau.memcheck());
+        CHECK_HIP_ERROR(dT.memcheck());
+
+        SIZE size_dW, size_hW;
+        hipsolver_larft_bufferSize(API,
+                                   handle,
+                                   params,
+                                   direct,
+                                   storev,
+                                   n,
+                                   k,
+                                   dV.data(),
+                                   ldv,
+                                   dTau.data(),
+                                   dT.data(),
+                                   ldt,
+                                   &size_dW,
+                                   &size_hW);
+        host_strided_batch_vector<T>   hWork(size_hW, 1, size_hW, 1);
+        device_strided_batch_vector<T> dWork(size_dW, 1, size_dW, 1);
+        if(size_dW)
+            CHECK_HIP_ERROR(dWork.memcheck());
+
+        // check bad arguments
+        larft_checkBadArgs<API>(handle,
+                                params,
+                                direct,
+                                storev,
+                                n,
+                                k,
+                                dV.data(),
+                                ldv,
+                                stV,
+                                dTau.data(),
+                                stTau,
+                                dT.data(),
+                                ldt,
+                                stT,
+                                dWork.data(),
+                                size_dW,
+                                hWork.data(),
+                                size_hW,
+                                bc);
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void larft_initData(const hipsolverHandle_t     handle,
+                    const hipsolverDirectMode_t direct,
+                    const hipsolverStorevMode_t storev,
+                    const int                   n,
+                    const int                   k,
+                    Td&                         dV,
+                    const int                   ldv,
+                    const int                   stV,
+                    Td&                         dTau,
+                    const int                   stTau,
+                    Td&                         dT,
+                    const int                   ldt,
+                    const int                   stT,
+                    const int                   bc,
+                    Th&                         hV,
+                    Th&                         hTau,
+                    Th&                         hT,
+                    std::vector<T>&             hw,
+                    size_t                      size_w)
+{
+    if(CPU)
+    {
+        rocblas_init<T>(hV, true);
+
+        // scale to avoid singularities
+        // and create householder reflectors
+        if(storev == HIPSOLVER_STOREV_COLUMNWISE)
+        {
+            for(int j = 0; j < k; ++j)
+            {
+                for(int i = 0; i < n; ++i)
+                {
+                    if(i == j)
+                        hV[0][i + j * ldv] += 400;
+                    else
+                        hV[0][i + j * ldv] -= 4;
+                }
+            }
+
+            int info;
+            if(direct == HIPSOLVER_DIRECT_FORWARD)
+                cpu_geqrf(n, k, hV[0], ldv, hTau[0], hw.data(), size_w, &info);
+            else
+                cpu_geqlf(n, k, hV[0], ldv, hTau[0], hw.data(), size_w, &info);
+        }
+        else
+        {
+            for(int j = 0; j < n; ++j)
+            {
+                for(int i = 0; i < k; ++i)
+                {
+                    if(i == j)
+                        hV[0][i + j * ldv] += 400;
+                    else
+                        hV[0][i + j * ldv] -= 4;
+                }
+            }
+
+            int info;
+            if(direct == HIPSOLVER_DIRECT_FORWARD)
+                cpu_gelqf(k, n, hV[0], ldv, hTau[0], hw.data(), size_w, &info);
+            else
+                cpu_gerqf(k, n, hV[0], ldv, hTau[0], hw.data(), size_w, &info);
+        }
+    }
+
+    if(GPU)
+    {
+        // copy data from CPU to device
+        CHECK_HIP_ERROR(dV.transfer_from(hV));
+        CHECK_HIP_ERROR(dTau.transfer_from(hTau));
+    }
+}
+
+template <testAPI_t API, typename I, typename SIZE, typename T, typename Td, typename Th>
+void larft_getError(const hipsolverHandle_t     handle,
+                    const hipsolverDnParams_t   params,
+                    const hipsolverDirectMode_t direct,
+                    const hipsolverStorevMode_t storev,
+                    const I                     n,
+                    const I                     k,
+                    Td&                         dV,
+                    const I                     ldv,
+                    const I                     stV,
+                    Td&                         dTau,
+                    const I                     stTau,
+                    Td&                         dT,
+                    const I                     ldt,
+                    const I                     stT,
+                    Td&                         dWork,
+                    const SIZE                  dlwork,
+                    Th&                         hWork,
+                    const SIZE                  hlwork,
+                    const int                   bc,
+                    Th&                         hV,
+                    Th&                         hTau,
+                    Th&                         hT,
+                    Th&                         hTRes,
+                    double*                     max_err)
+{
+    size_t         size_w = size_t(k);
+    std::vector<T> hw(size_w);
+
+    // input data initialization
+    larft_initData<true, true, T>(handle,
+                                  direct,
+                                  storev,
+                                  n,
+                                  k,
+                                  dV,
+                                  ldv,
+                                  stV,
+                                  dTau,
+                                  stTau,
+                                  dT,
+                                  ldt,
+                                  stT,
+                                  bc,
+                                  hV,
+                                  hTau,
+                                  hT,
+                                  hw,
+                                  size_w);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(hipsolver_larft(API,
+                                        handle,
+                                        params,
+                                        direct,
+                                        storev,
+                                        n,
+                                        k,
+                                        dV.data(),
+                                        ldv,
+                                        stV,
+                                        dTau.data(),
+                                        stTau,
+                                        dT.data(),
+                                        ldt,
+                                        stT,
+                                        dWork.data(),
+                                        dlwork,
+                                        hWork.data(),
+                                        hlwork,
+                                        bc));
+    CHECK_HIP_ERROR(hTRes.transfer_from(dT));
+
+    // CPU lapack
+    cpu_larft(direct, storev, n, k, hV[0], ldv, hTau[0], hT[0], ldt);
+
+    // error is ||hT - hTRes|| / ||hT||
+    // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
+    // IT MIGHT BE REVISITED IN THE FUTURE)
+    // using frobenius norm
+    *max_err = (direct == HIPSOLVER_DIRECT_FORWARD)
+                   ? norm_error_upperTr('F', k, k, ldt, hT[0], hTRes[0])
+                   : norm_error_lowerTr('F', k, k, ldt, hT[0], hTRes[0]);
+}
+
+template <testAPI_t API, typename I, typename SIZE, typename T, typename Td, typename Th>
+void larft_getPerfData(const hipsolverHandle_t     handle,
+                       const hipsolverDnParams_t   params,
+                       const hipsolverDirectMode_t direct,
+                       const hipsolverStorevMode_t storev,
+                       const I                     n,
+                       const I                     k,
+                       Td&                         dV,
+                       const I                     ldv,
+                       const I                     stV,
+                       Td&                         dTau,
+                       const I                     stTau,
+                       Td&                         dT,
+                       const I                     ldt,
+                       const I                     stT,
+                       Td&                         dWork,
+                       const SIZE                  dlwork,
+                       Th&                         hWork,
+                       const SIZE                  hlwork,
+                       const int                   bc,
+                       Th&                         hV,
+                       Th&                         hTau,
+                       Th&                         hT,
+                       double*                     gpu_time_used,
+                       double*                     cpu_time_used,
+                       const int                   hot_calls,
+                       const bool                  perf)
+{
+    size_t         size_w = size_t(k);
+    std::vector<T> hw(size_w);
+
+    if(!perf)
+    {
+        larft_initData<true, false, T>(handle,
+                                       direct,
+                                       storev,
+                                       n,
+                                       k,
+                                       dV,
+                                       ldv,
+                                       stV,
+                                       dTau,
+                                       stTau,
+                                       dT,
+                                       ldt,
+                                       stT,
+                                       bc,
+                                       hV,
+                                       hTau,
+                                       hT,
+                                       hw,
+                                       size_w);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us_no_sync();
+        cpu_larft(direct, storev, n, k, hV[0], ldv, hTau[0], hT[0], ldt);
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
+    }
+
+    larft_initData<true, false, T>(handle,
+                                   direct,
+                                   storev,
+                                   n,
+                                   k,
+                                   dV,
+                                   ldv,
+                                   stV,
+                                   dTau,
+                                   stTau,
+                                   dT,
+                                   ldt,
+                                   stT,
+                                   bc,
+                                   hV,
+                                   hTau,
+                                   hT,
+                                   hw,
+                                   size_w);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        larft_initData<false, true, T>(handle,
+                                       direct,
+                                       storev,
+                                       n,
+                                       k,
+                                       dV,
+                                       ldv,
+                                       stV,
+                                       dTau,
+                                       stTau,
+                                       dT,
+                                       ldt,
+                                       stT,
+                                       bc,
+                                       hV,
+                                       hTau,
+                                       hT,
+                                       hw,
+                                       size_w);
+
+        CHECK_ROCBLAS_ERROR(hipsolver_larft(API,
+                                            handle,
+                                            params,
+                                            direct,
+                                            storev,
+                                            n,
+                                            k,
+                                            dV.data(),
+                                            ldv,
+                                            stV,
+                                            dTau.data(),
+                                            stTau,
+                                            dT.data(),
+                                            ldt,
+                                            stT,
+                                            dWork.data(),
+                                            dlwork,
+                                            hWork.data(),
+                                            hlwork,
+                                            bc));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(hipsolverGetStream(handle, &stream));
+    double start;
+
+    for(int iter = 0; iter < hot_calls; iter++)
+    {
+        larft_initData<false, true, T>(handle,
+                                       direct,
+                                       storev,
+                                       n,
+                                       k,
+                                       dV,
+                                       ldv,
+                                       stV,
+                                       dTau,
+                                       stTau,
+                                       dT,
+                                       ldt,
+                                       stT,
+                                       bc,
+                                       hV,
+                                       hTau,
+                                       hT,
+                                       hw,
+                                       size_w);
+
+        start = get_time_us_sync(stream);
+        hipsolver_larft(API,
+                        handle,
+                        params,
+                        direct,
+                        storev,
+                        n,
+                        k,
+                        dV.data(),
+                        ldv,
+                        stV,
+                        dTau.data(),
+                        stTau,
+                        dT.data(),
+                        ldt,
+                        stT,
+                        dWork.data(),
+                        dlwork,
+                        hWork.data(),
+                        hlwork,
+                        bc);
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T, typename I, typename SIZE>
+void testing_larft(Arguments& argus)
+{
+    // get arguments
+    hipsolver_local_handle handle;
+    hipsolver_local_params params;
+    char                   directC = argus.get<char>("direct");
+    char                   storevC = argus.get<char>("storev");
+    I                      n       = argus.get<rocblas_int>("n");
+    I                      k       = argus.get<rocblas_int>("k", n);
+    I                      ldv     = argus.get<rocblas_int>("ldv", n);
+    I                      ldt     = argus.get<rocblas_int>("ldt", k);
+    I                      stV     = argus.get<rocblas_int>("strideV", ldv * k);
+    I                      stTau   = argus.get<rocblas_int>("strideTau", k);
+    I                      stT     = argus.get<rocblas_int>("strideT", ldt * k);
+
+    hipsolverDirectMode_t direct
+        = (directC == 'F' || directC == 'f') ? HIPSOLVER_DIRECT_FORWARD : HIPSOLVER_DIRECT_BACKWARD;
+    hipsolverStorevMode_t storev = (storevC == 'C' || storevC == 'c') ? HIPSOLVER_STOREV_COLUMNWISE
+                                                                      : HIPSOLVER_STOREV_ROWWISE;
+
+    int bc        = argus.batch_count;
+    int hot_calls = argus.iters;
+
+    I stVRes   = (argus.unit_check || argus.norm_check) ? stV : 0;
+    I stTauRes = (argus.unit_check || argus.norm_check) ? stTau : 0;
+    I stTRes   = (argus.unit_check || argus.norm_check) ? stT : 0;
+
+    // check non-supported values
+    // N/A
+
+    // determine sizes
+    size_t size_V    = size_t(ldv) * k;
+    size_t size_Tau  = size_t(k);
+    size_t size_T    = size_t(ldt) * k;
+    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+
+    size_t size_VRes   = (argus.unit_check || argus.norm_check) ? size_V : 0;
+    size_t size_TauRes = (argus.unit_check || argus.norm_check) ? size_Tau : 0;
+    size_t size_TRes   = (argus.unit_check || argus.norm_check) ? size_T : 0;
+
+    // check invalid sizes
+    bool invalid_size = (n < 0 || k < 0 || k > n || ldv < n || ldt < k || bc < 0);
+    if(invalid_size)
+    {
+        if(BATCHED)
+        {
+            // EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+            //                                       handle,
+            //                                       params,
+            //                                       direct,
+            //                                       storev,
+            //                                       n,
+            //                                       k,
+            //                                       (T*)nullptr,
+            //                                       ldv,
+            //                                       stV,
+            //                                       (T*)nullptr,
+            //                                       stTau,
+            //                                       (T*)nullptr,
+            //                                       ldt,
+            //                                       stT,
+            //                                       (T*)nullptr,
+            //                                       0,
+            //                                       (T*)nullptr,
+            //                                       0,
+            //                                       bc),
+            //                       HIPSOLVER_STATUS_INVALID_VALUE);
+        }
+        else
+        {
+            EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                                  handle,
+                                                  params,
+                                                  direct,
+                                                  storev,
+                                                  n,
+                                                  k,
+                                                  (T*)nullptr,
+                                                  ldv,
+                                                  stV,
+                                                  (T*)nullptr,
+                                                  stTau,
+                                                  (T*)nullptr,
+                                                  ldt,
+                                                  stT,
+                                                  (T*)nullptr,
+                                                  0,
+                                                  (T*)nullptr,
+                                                  0,
+                                                  bc),
+                                  HIPSOLVER_STATUS_INVALID_VALUE);
+        }
+
+        if(argus.timing)
+            rocsolver_bench_inform(inform_invalid_size);
+
+        return;
+    }
+
+    // memory size query
+    SIZE size_dW, size_hW;
+    hipsolver_larft_bufferSize(API,
+                               handle,
+                               params,
+                               direct,
+                               storev,
+                               n,
+                               k,
+                               (T*)nullptr,
+                               ldv,
+                               (T*)nullptr,
+                               (T*)nullptr,
+                               ldt,
+                               &size_dW,
+                               &size_hW);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_dW);
+        return;
+    }
+
+    // memory allocations
+    host_strided_batch_vector<T>   hV(size_V, 1, stV, bc);
+    host_strided_batch_vector<T>   hTau(size_Tau, 1, stTau, bc);
+    host_strided_batch_vector<T>   hT(size_T, 1, stT, bc);
+    host_strided_batch_vector<T>   hTRes(size_TRes, 1, stTRes, bc);
+    host_strided_batch_vector<T>   hWork(size_hW, 1, size_hW, 1);
+    device_strided_batch_vector<T> dV(size_V, 1, stV, bc);
+    device_strided_batch_vector<T> dTau(size_Tau, 1, stTau, bc);
+    device_strided_batch_vector<T> dT(size_T, 1, stT, bc);
+    device_strided_batch_vector<T> dWork(size_dW, 1, size_dW, 1);
+    if(size_V)
+        CHECK_HIP_ERROR(dV.memcheck());
+    if(size_Tau)
+        CHECK_HIP_ERROR(dTau.memcheck());
+    if(size_T)
+        CHECK_HIP_ERROR(dT.memcheck());
+    if(size_dW)
+        CHECK_HIP_ERROR(dWork.memcheck());
+
+    // check quick return
+    if(n == 0 || k == 0 || bc == 0)
+    {
+        EXPECT_ROCBLAS_STATUS(hipsolver_larft(API,
+                                              handle,
+                                              params,
+                                              direct,
+                                              storev,
+                                              n,
+                                              k,
+                                              dV.data(),
+                                              ldv,
+                                              stV,
+                                              dTau.data(),
+                                              stTau,
+                                              dT.data(),
+                                              ldt,
+                                              stT,
+                                              dWork.data(),
+                                              size_dW,
+                                              hWork.data(),
+                                              size_hW,
+                                              bc),
+                              HIPSOLVER_STATUS_SUCCESS);
+
+        if(argus.timing)
+            rocsolver_bench_inform(inform_quick_return);
+
+        return;
+    }
+
+    // check computations
+    if(argus.unit_check || argus.norm_check)
+        larft_getError<API, I, SIZE, T>(handle,
+                                        params,
+                                        direct,
+                                        storev,
+                                        n,
+                                        k,
+                                        dV,
+                                        ldv,
+                                        stV,
+                                        dTau,
+                                        stTau,
+                                        dT,
+                                        ldt,
+                                        stT,
+                                        dWork,
+                                        size_dW,
+                                        hWork,
+                                        size_hW,
+                                        bc,
+                                        hV,
+                                        hTau,
+                                        hT,
+                                        hTRes,
+                                        &max_error);
+
+    // collect performance data
+    if(argus.timing)
+        larft_getPerfData<API, I, SIZE, T>(handle,
+                                           params,
+                                           direct,
+                                           storev,
+                                           n,
+                                           k,
+                                           dV,
+                                           ldv,
+                                           stV,
+                                           dTau,
+                                           stTau,
+                                           dT,
+                                           ldt,
+                                           stT,
+                                           dWork,
+                                           size_dW,
+                                           hWork,
+                                           size_hW,
+                                           bc,
+                                           hV,
+                                           hTau,
+                                           hT,
+                                           &gpu_time_used,
+                                           &cpu_time_used,
+                                           hot_calls,
+                                           argus.perf);
+
+    // validate results for rocsolver-test
+    // using n * machine_precision as tolerance
+    if(argus.unit_check)
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
+
+    // output results for rocsolver test
+    if(argus.timing)
+    {
+        if(!argus.perf)
+        {
+            std::cerr << "\n============================================\n";
+            std::cerr << "Arguments:\n";
+            std::cerr << "============================================\n";
+            rocsolver_bench_output("direct", "storev", "n", "k", "ldv", "ldt");
+            rocsolver_bench_output(directC, storevC, n, k, ldv, ldt);
+            std::cerr << "\n============================================\n";
+            std::cerr << "Results:\n";
+            std::cerr << "============================================\n";
+            if(argus.norm_check)
+            {
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
+            }
+            else
+            {
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used);
+            }
+            std::cerr << std::endl;
+        }
+        else
+        {
+            if(argus.norm_check)
+                rocsolver_bench_output(gpu_time_used, max_error);
+            else
+                rocsolver_bench_output(gpu_time_used);
+        }
+    }
+
+    // ensure all arguments were consumed
+    argus.validate_consumed();
+}

--- a/projects/hipsolver/library/include/internal/hipsolver-dense64.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-dense64.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #ifndef HIPSOLVER_DENSE64_H
@@ -144,6 +144,45 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXpotrs(hipsolverDnHandle_t handle,
                                                      void*               B,
                                                      int64_t             ldb,
                                                      int*                info);
+
+// larft
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXlarft_bufferSize(hipsolverDnHandle_t   handle,
+                                                                hipsolverDnParams_t   params,
+                                                                hipsolverDirectMode_t direct,
+                                                                hipsolverStorevMode_t storev,
+                                                                int64_t               n,
+                                                                int64_t               k,
+                                                                hipDataType           dataTypeV,
+                                                                const void*           V,
+                                                                int64_t               ldv,
+                                                                hipDataType           dataTypeTau,
+                                                                const void*           tau,
+                                                                hipDataType           dataTypeT,
+                                                                void*                 T,
+                                                                int64_t               ldt,
+                                                                hipDataType           computeType,
+                                                                size_t*               lworkOnDevice,
+                                                                size_t*               lworkOnHost);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXlarft(hipsolverDnHandle_t   handle,
+                                                     hipsolverDnParams_t   params,
+                                                     hipsolverDirectMode_t direct,
+                                                     hipsolverStorevMode_t storev,
+                                                     int64_t               n,
+                                                     int64_t               k,
+                                                     hipDataType           dataTypeV,
+                                                     void*                 V,
+                                                     int64_t               ldv,
+                                                     hipDataType           dataTypeTau,
+                                                     void*                 tau,
+                                                     hipDataType           dataTypeT,
+                                                     void*                 T,
+                                                     int64_t               ldt,
+                                                     hipDataType           computeType,
+                                                     void*                 workOnDevice,
+                                                     size_t                lworkOnDevice,
+                                                     void*                 workOnHost,
+                                                     size_t                lworkOnHost);
 
 #ifdef __cplusplus
 }

--- a/projects/hipsolver/library/include/internal/hipsolver-types.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-types.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
@@ -131,6 +131,18 @@ typedef enum
     HIPSOLVER_DETERMINISTIC_RESULTS           = 241,
     HIPSOLVER_ALLOW_NON_DETERMINISTIC_RESULTS = 242,
 } hipsolverDeterministicMode_t;
+
+typedef enum
+{
+    HIPSOLVER_DIRECT_FORWARD  = 251,
+    HIPSOLVER_DIRECT_BACKWARD = 252,
+} hipsolverDirectMode_t;
+
+typedef enum
+{
+    HIPSOLVER_STOREV_COLUMNWISE = 261,
+    HIPSOLVER_STOREV_ROWWISE    = 262,
+} hipsolverStorevMode_t;
 
 // Aliases for hipBLAS enums
 

--- a/projects/hipsolver/library/src/amd_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver_conversions.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -204,6 +204,32 @@ rocblas_storev_ hip2rocblas_side2storev(hipsolverSideMode_t side)
     case HIPSOLVER_SIDE_LEFT:
         return rocblas_column_wise;
     case HIPSOLVER_SIDE_RIGHT:
+        return rocblas_row_wise;
+    default:
+        throw HIPSOLVER_STATUS_INVALID_ENUM;
+    }
+}
+
+rocblas_direct hip2rocblas_direct(hipsolverDirectMode_t direct)
+{
+    switch(direct)
+    {
+    case HIPSOLVER_DIRECT_FORWARD:
+        return rocblas_forward_direction;
+    case HIPSOLVER_DIRECT_BACKWARD:
+        return rocblas_backward_direction;
+    default:
+        throw HIPSOLVER_STATUS_INVALID_ENUM;
+    }
+}
+
+rocblas_storev hip2rocblas_storev(hipsolverStorevMode_t storev)
+{
+    switch(storev)
+    {
+    case HIPSOLVER_STOREV_COLUMNWISE:
+        return rocblas_column_wise;
+    case HIPSOLVER_STOREV_ROWWISE:
         return rocblas_row_wise;
     default:
         throw HIPSOLVER_STATUS_INVALID_ENUM;

--- a/projects/hipsolver/library/src/amd_detail/hipsolver_conversions.hpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver_conversions.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,6 +65,10 @@ rocblas_atomics_mode_ hip2rocblas_deterministic(hipsolverDeterministicMode_t mod
 hipsolverDeterministicMode_t rocblas2hip_deterministic(rocblas_atomics_mode_ mode);
 
 rocblas_svect_ char2rocblas_svect(signed char svect);
+
+rocblas_direct hip2rocblas_direct(hipsolverDirectMode_t direct);
+
+rocblas_storev hip2rocblas_storev(hipsolverStorevMode_t storev);
 
 hipsolverStatus_t rocblas2hip_status(rocblas_status_ error);
 

--- a/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
@@ -940,6 +940,12 @@ try
         return HIPSOLVER_STATUS_INVALID_VALUE;
     if(!lworkOnDevice || !lworkOnHost)
         return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(n < 0 || k < 0 || k > n || ldt < k)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(storev == HIPSOLVER_STOREV_COLUMNWISE && ldv < n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(storev == HIPSOLVER_STOREV_ROWWISE && ldv < k)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lworkOnDevice = 0;
     *lworkOnHost   = 0;
@@ -1044,6 +1050,12 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(!params)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(n < 0 || k < 0 || k > n || ldt < k)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(storev == HIPSOLVER_STOREV_COLUMNWISE && ldv < n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(storev == HIPSOLVER_STOREV_ROWWISE && ldv < k)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     if(workOnDevice && lworkOnDevice)

--- a/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -132,6 +132,50 @@ rocblas_status rocsolver_zpotrf_info32(rocblas_handle          handle,
                                        rocblas_double_complex* A,
                                        const int64_t           lda,
                                        rocblas_int*            info);
+
+rocblas_status rocsolver_slarft_64(rocblas_handle       handle,
+                                   const rocblas_direct direct,
+                                   const rocblas_storev storev,
+                                   const int64_t        n,
+                                   const int64_t        k,
+                                   float*               V,
+                                   const int64_t        ldv,
+                                   float*               tau,
+                                   float*               T,
+                                   const int64_t        ldt);
+
+rocblas_status rocsolver_dlarft_64(rocblas_handle       handle,
+                                   const rocblas_direct direct,
+                                   const rocblas_storev storev,
+                                   const int64_t        n,
+                                   const int64_t        k,
+                                   double*              V,
+                                   const int64_t        ldv,
+                                   double*              tau,
+                                   double*              T,
+                                   const int64_t        ldt);
+
+rocblas_status rocsolver_clarft_64(rocblas_handle         handle,
+                                   const rocblas_direct   direct,
+                                   const rocblas_storev   storev,
+                                   const int64_t          n,
+                                   const int64_t          k,
+                                   rocblas_float_complex* V,
+                                   const int64_t          ldv,
+                                   rocblas_float_complex* tau,
+                                   rocblas_float_complex* T,
+                                   const int64_t          ldt);
+
+rocblas_status rocsolver_zlarft_64(rocblas_handle          handle,
+                                   const rocblas_direct    direct,
+                                   const rocblas_storev    storev,
+                                   const int64_t           n,
+                                   const int64_t           k,
+                                   rocblas_double_complex* V,
+                                   const int64_t           ldv,
+                                   rocblas_double_complex* tau,
+                                   rocblas_double_complex* T,
+                                   const int64_t           ldt);
 
 /******************** PARAMS ********************/
 struct hipsolverParams
@@ -864,6 +908,235 @@ try
     }
     else
         return HIPSOLVER_STATUS_INVALID_ENUM;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** LARFT ********************/
+hipsolverStatus_t hipsolverDnXlarft_bufferSize(hipsolverDnHandle_t   handle,
+                                               hipsolverDnParams_t   params,
+                                               hipsolverDirectMode_t direct,
+                                               hipsolverStorevMode_t storev,
+                                               int64_t               n,
+                                               int64_t               k,
+                                               hipDataType           dataTypeV,
+                                               const void*           V,
+                                               int64_t               ldv,
+                                               hipDataType           dataTypeTau,
+                                               const void*           tau,
+                                               hipDataType           dataTypeT,
+                                               void*                 T,
+                                               int64_t               ldt,
+                                               hipDataType           computeType,
+                                               size_t*               lworkOnDevice,
+                                               size_t*               lworkOnHost)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!params)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!lworkOnDevice || !lworkOnHost)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lworkOnDevice = 0;
+    *lworkOnHost   = 0;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status;
+
+    if(dataTypeV == HIP_R_32F && dataTypeTau == HIP_R_32F && dataTypeT == HIP_R_32F
+       && computeType == HIP_R_32F)
+    {
+        status = hipsolver::rocblas2hip_status(
+            rocsolver_slarft_64((rocblas_handle)handle,
+                                hipsolver::hip2rocblas_direct(direct),
+                                hipsolver::hip2rocblas_storev(storev),
+                                n,
+                                k,
+                                nullptr,
+                                ldv,
+                                nullptr,
+                                nullptr,
+                                ldt));
+    }
+    else if(dataTypeV == HIP_R_64F && dataTypeTau == HIP_R_64F && dataTypeT == HIP_R_64F
+            && computeType == HIP_R_64F)
+    {
+        status = hipsolver::rocblas2hip_status(
+            rocsolver_dlarft_64((rocblas_handle)handle,
+                                hipsolver::hip2rocblas_direct(direct),
+                                hipsolver::hip2rocblas_storev(storev),
+                                n,
+                                k,
+                                nullptr,
+                                ldv,
+                                nullptr,
+                                nullptr,
+                                ldt));
+    }
+    else if(dataTypeV == HIP_C_32F && dataTypeTau == HIP_C_32F && dataTypeT == HIP_C_32F
+            && computeType == HIP_C_32F)
+    {
+        status = hipsolver::rocblas2hip_status(
+            rocsolver_clarft_64((rocblas_handle)handle,
+                                hipsolver::hip2rocblas_direct(direct),
+                                hipsolver::hip2rocblas_storev(storev),
+                                n,
+                                k,
+                                nullptr,
+                                ldv,
+                                nullptr,
+                                nullptr,
+                                ldt));
+    }
+    else if(dataTypeV == HIP_C_64F && dataTypeTau == HIP_C_64F && dataTypeT == HIP_C_64F
+            && computeType == HIP_C_64F)
+    {
+        status = hipsolver::rocblas2hip_status(
+            rocsolver_zlarft_64((rocblas_handle)handle,
+                                hipsolver::hip2rocblas_direct(direct),
+                                hipsolver::hip2rocblas_storev(storev),
+                                n,
+                                k,
+                                nullptr,
+                                ldv,
+                                nullptr,
+                                nullptr,
+                                ldt));
+    }
+    else
+    {
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, lworkOnDevice);
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDnXlarft(hipsolverDnHandle_t   handle,
+                                    hipsolverDnParams_t   params,
+                                    hipsolverDirectMode_t direct,
+                                    hipsolverStorevMode_t storev,
+                                    int64_t               n,
+                                    int64_t               k,
+                                    hipDataType           dataTypeV,
+                                    void*                 V,
+                                    int64_t               ldv,
+                                    hipDataType           dataTypeTau,
+                                    void*                 tau,
+                                    hipDataType           dataTypeT,
+                                    void*                 T,
+                                    int64_t               ldt,
+                                    hipDataType           computeType,
+                                    void*                 workOnDevice,
+                                    size_t                lworkOnDevice,
+                                    void*                 workOnHost,
+                                    size_t                lworkOnHost)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!params)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    if(workOnDevice && lworkOnDevice)
+        CHECK_ROCBLAS_ERROR(
+            rocblas_set_workspace((rocblas_handle)handle, workOnDevice, lworkOnDevice));
+    else
+    {
+        size_t lwork_device, lwork_host;
+        CHECK_HIPSOLVER_ERROR(hipsolverDnXlarft_bufferSize(handle,
+                                                           params,
+                                                           direct,
+                                                           storev,
+                                                           n,
+                                                           k,
+                                                           dataTypeV,
+                                                           V,
+                                                           ldv,
+                                                           dataTypeTau,
+                                                           tau,
+                                                           dataTypeT,
+                                                           T,
+                                                           ldt,
+                                                           computeType,
+                                                           &lwork_device,
+                                                           &lwork_host));
+        if(lwork_device > 0)
+            CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork_device));
+    }
+
+    if(dataTypeV == HIP_R_32F && dataTypeTau == HIP_R_32F && dataTypeT == HIP_R_32F
+       && computeType == HIP_R_32F)
+    {
+        return hipsolver::rocblas2hip_status(
+            rocsolver_slarft_64((rocblas_handle)handle,
+                                hipsolver::hip2rocblas_direct(direct),
+                                hipsolver::hip2rocblas_storev(storev),
+                                n,
+                                k,
+                                (float*)V,
+                                ldv,
+                                (float*)tau,
+                                (float*)T,
+                                ldt));
+    }
+    else if(dataTypeV == HIP_R_64F && dataTypeTau == HIP_R_64F && dataTypeT == HIP_R_64F
+            && computeType == HIP_R_64F)
+    {
+        return hipsolver::rocblas2hip_status(
+            rocsolver_dlarft_64((rocblas_handle)handle,
+                                hipsolver::hip2rocblas_direct(direct),
+                                hipsolver::hip2rocblas_storev(storev),
+                                n,
+                                k,
+                                (double*)V,
+                                ldv,
+                                (double*)tau,
+                                (double*)T,
+                                ldt));
+    }
+    else if(dataTypeV == HIP_C_32F && dataTypeTau == HIP_C_32F && dataTypeT == HIP_C_32F
+            && computeType == HIP_C_32F)
+    {
+        return hipsolver::rocblas2hip_status(
+            rocsolver_clarft_64((rocblas_handle)handle,
+                                hipsolver::hip2rocblas_direct(direct),
+                                hipsolver::hip2rocblas_storev(storev),
+                                n,
+                                k,
+                                (rocblas_float_complex*)V,
+                                ldv,
+                                (rocblas_float_complex*)tau,
+                                (rocblas_float_complex*)T,
+                                ldt));
+    }
+    else if(dataTypeV == HIP_C_64F && dataTypeTau == HIP_C_64F && dataTypeT == HIP_C_64F
+            && computeType == HIP_C_64F)
+    {
+        return hipsolver::rocblas2hip_status(
+            rocsolver_zlarft_64((rocblas_handle)handle,
+                                hipsolver::hip2rocblas_direct(direct),
+                                hipsolver::hip2rocblas_storev(storev),
+                                n,
+                                k,
+                                (rocblas_double_complex*)V,
+                                ldv,
+                                (rocblas_double_complex*)tau,
+                                (rocblas_double_complex*)T,
+                                ldt));
+    }
+    else
+    {
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
@@ -269,9 +269,9 @@ cusolverStorevMode_t hip2cuda_storev(hipsolverStorevMode_t storev)
     switch(storev)
     {
     case HIPSOLVER_STOREV_COLUMNWISE:
-        return CUSOLVER_STOREV_COLUMNWISE;
+        return CUBLAS_STOREV_COLUMNWISE;
     case HIPSOLVER_STOREV_ROWWISE:
-        return CUSOLVER_STOREV_ROWWISE;
+        return CUBLAS_STOREV_ROWWISE;
     default:
         throw HIPSOLVER_STATUS_INVALID_ENUM;
     }

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -250,6 +250,32 @@ hipsolverDeterministicMode_t cuda2hip_deterministic(cusolverDeterministicMode_t 
     }
 }
 #endif
+
+cusolverDirectMode_t hip2cuda_direct(hipsolverDirectMode_t direct)
+{
+    switch(direct)
+    {
+    case HIPSOLVER_DIRECT_FORWARD:
+        return CUSOLVER_DIRECT_FORWARD;
+    case HIPSOLVER_DIRECT_BACKWARD:
+        return CUSOLVER_DIRECT_BACKWARD;
+    default:
+        throw HIPSOLVER_STATUS_INVALID_ENUM;
+    }
+}
+
+cusolverStorevMode_t hip2cuda_storev(hipsolverStorevMode_t storev)
+{
+    switch(storev)
+    {
+    case HIPSOLVER_STOREV_COLUMNWISE:
+        return CUSOLVER_STOREV_COLUMNWISE;
+    case HIPSOLVER_STOREV_ROWWISE:
+        return CUSOLVER_STOREV_ROWWISE;
+    default:
+        throw HIPSOLVER_STATUS_INVALID_ENUM;
+    }
+}
 
 hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
@@ -256,9 +256,9 @@ cusolverDirectMode_t hip2cuda_direct(hipsolverDirectMode_t direct)
     switch(direct)
     {
     case HIPSOLVER_DIRECT_FORWARD:
-        return CUSOLVER_DIRECT_FORWARD;
+        return CUBLAS_DIRECT_FORWARD;
     case HIPSOLVER_DIRECT_BACKWARD:
-        return CUSOLVER_DIRECT_BACKWARD;
+        return CUBLAS_DIRECT_BACKWARD;
     default:
         throw HIPSOLVER_STATUS_INVALID_ENUM;
     }

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -63,6 +63,10 @@ cusolverDeterministicMode_t hip2cuda_deterministic(hipsolverDeterministicMode_t 
 
 hipsolverDeterministicMode_t cuda2hip_deterministic(cusolverDeterministicMode_t mode);
 #endif
+
+cusolverDirectMode_t hip2cuda_direct(hipsolverDirectMode_t direct);
+
+cusolverStorevMode_t hip2cuda_storev(hipsolverStorevMode_t storev);
 
 hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus);
 

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_dense64.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_dense64.cpp
@@ -408,6 +408,15 @@ try
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(!params)
         return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!lworkOnDevice || !lworkOnHost)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(storev != HIPSOLVER_STOREV_COLUMNWISE)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    if(n < 0 || k < 0 || k > n || ldv < n || ldt < k)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lworkOnDevice = 0;
+    *lworkOnHost   = 0;
 
     return hipsolver::cuda2hip_status(
         cusolverDnXlarft_bufferSize((cusolverDnHandle_t)handle,
@@ -457,6 +466,10 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(!params)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(storev != HIPSOLVER_STOREV_COLUMNWISE)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    if(n < 0 || k < 0 || k > n || ldv < n || ldt < k)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     return hipsolver::cuda2hip_status(cusolverDnXlarft((cusolverDnHandle_t)handle,

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_dense64.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_dense64.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -378,6 +378,106 @@ try
                                                        B,
                                                        ldb,
                                                        info));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** LARFT ********************/
+hipsolverStatus_t hipsolverDnXlarft_bufferSize(hipsolverDnHandle_t   handle,
+                                               hipsolverDnParams_t   params,
+                                               hipsolverDirectMode_t direct,
+                                               hipsolverStorevMode_t storev,
+                                               int64_t               n,
+                                               int64_t               k,
+                                               hipDataType           dataTypeV,
+                                               const void*           V,
+                                               int64_t               ldv,
+                                               hipDataType           dataTypeTau,
+                                               const void*           tau,
+                                               hipDataType           dataTypeT,
+                                               void*                 T,
+                                               int64_t               ldt,
+                                               hipDataType           computeType,
+                                               size_t*               lworkOnDevice,
+                                               size_t*               lworkOnHost)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!params)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(
+        cusolverDnXlarft_bufferSize((cusolverDnHandle_t)handle,
+                                    (cusolverDnParams_t)params,
+                                    hipsolver::hip2cuda_direct(direct),
+                                    hipsolver::hip2cuda_storev(storev),
+                                    n,
+                                    k,
+                                    dataTypeV,
+                                    V,
+                                    ldv,
+                                    dataTypeTau,
+                                    tau,
+                                    dataTypeT,
+                                    T,
+                                    ldt,
+                                    computeType,
+                                    lworkOnDevice,
+                                    lworkOnHost));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDnXlarft(hipsolverDnHandle_t   handle,
+                                    hipsolverDnParams_t   params,
+                                    hipsolverDirectMode_t direct,
+                                    hipsolverStorevMode_t storev,
+                                    int64_t               n,
+                                    int64_t               k,
+                                    hipDataType           dataTypeV,
+                                    void*                 V,
+                                    int64_t               ldv,
+                                    hipDataType           dataTypeTau,
+                                    void*                 tau,
+                                    hipDataType           dataTypeT,
+                                    void*                 T,
+                                    int64_t               ldt,
+                                    hipDataType           computeType,
+                                    void*                 workOnDevice,
+                                    size_t                lworkOnDevice,
+                                    void*                 workOnHost,
+                                    size_t                lworkOnHost)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!params)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cusolverDnXlarft((cusolverDnHandle_t)handle,
+                                                       (cusolverDnParams_t)params,
+                                                       hipsolver::hip2cuda_direct(direct),
+                                                       hipsolver::hip2cuda_storev(storev),
+                                                       n,
+                                                       k,
+                                                       dataTypeV,
+                                                       V,
+                                                       ldv,
+                                                       dataTypeTau,
+                                                       tau,
+                                                       dataTypeT,
+                                                       T,
+                                                       ldt,
+                                                       computeType,
+                                                       workOnDevice,
+                                                       lworkOnDevice,
+                                                       workOnHost,
+                                                       lworkOnHost));
 }
 catch(...)
 {


### PR DESCRIPTION
## Motivation

We want an API for LARFT to match cuSOLVER's 64 bit API.

## Technical Details

This PR is built upon the infrastructure proposed in the following PR: https://github.com/ROCm/rocm-libraries/pull/4461/changes#diff-63748558782a62afa33a1ed95a2d9e316874fee3a8cc25986c95501630ecca31

Should a 32 bit API be added as well, since rocSOLVER is complete with one?

## Test Plan

Add tests for the new LARFT API. (WIP)

## Test Result

WIP

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
