### PR TITLE
[hipblaslt] Fix miLatency for xf32 by passing MI input type to rocisa

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -45,6 +45,7 @@ from .Component import Component, LraTileProperties
 from .Components.Signature import UserArgumentsInfo
 from .Components.CustomSchedule import customMainLoopSchedule
 from .SolutionStructs import Solution, isPackedIndex
+from .SolutionStructs.Utilities import getMiInputType
 from .AsmMemoryInstruction import MemoryInstruction
 from .Activation import ActivationModule
 from .Common import printWarning, roundUp, print2, DebugConfig, DataDirection, \
@@ -6115,16 +6116,19 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     if kernel["EnableMatrixInstruction"]:
       from rocisa.instruction import getMFMAIssueLatency, getSMFMAIssueLatency
-      datatype = kernel["ProblemType"]["DataType"]
-      if kernel["UseF32XEmulation"]:
-        datatype = DataType(DataTypeEnum.BFloat16)
-      self.states.miLatency, miIssueLatency = getSMFMAIssueLatency(datatype.toEnum(), kernel["MatrixInstM"], kernel["MatrixInstB"]) if kernel["ProblemType"]["Sparse"] else \
-                                              getMFMAIssueLatency(datatype.toEnum(), kernel["MatrixInstM"], kernel["MatrixInstB"])
+      miInputType = getMiInputType(kernel)
+
+      if kernel["ProblemType"]["Sparse"]:
+        self.states.miLatency, miIssueLatency = getSMFMAIssueLatency(
+            miInputType.toEnum(), kernel["MatrixInstM"], kernel["MatrixInstB"])
+      else:
+        self.states.miLatency, miIssueLatency = getMFMAIssueLatency(
+            miInputType.toEnum(), kernel["MatrixInstM"], kernel["MatrixInstB"])
       # TODO: Avoid the logic which does not make sense.
       # For gfx950, we can't issue any VALU or DS instruction in next 4 cycles.
       # Changed the value based on this and also to mitigate some instruction scheduling issues.
       # Invalidate this adjustment if ExtraMiLatencyLeft is >= 0
-      if not kernel["ProblemType"]["Sparse"] and kernel['ISA'] == IsaVersion(9,5,0) and datatype.numBytes() == 2 and kernel["ExtraMiLatencyLeft"]== -1:
+      if not kernel["ProblemType"]["Sparse"] and kernel['ISA'] == IsaVersion(9,5,0) and miInputType.numBytes() == 2 and kernel["ExtraMiLatencyLeft"]== -1:
         self.states.miLatency = kernel["MatrixInstM"] // 2
         miIssueLatency = 2
 

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Utilities.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Utilities.py
@@ -25,6 +25,27 @@
 import sys
 import math
 
+def getMiInputType(kernel: dict):
+  """Select the effective MI operand type for MFMA latency lookup.
+
+  Handles three cases based on kernel flags:
+    1. EnableF32XdlMathOp + UseF32XEmulation → BFloat16 (BF16 emulation)
+    2. EnableF32XdlMathOp only               → F32XdlMathOp (native XF32)
+    3. Neither                               → DataType (plain)
+
+  UseF32XEmulation implies EnableF32XdlMathOp (guaranteed by Solution.__init__).
+
+  Raises:
+      KeyError: If EnableF32XdlMathOp or UseF32XEmulation is missing from the kernel dict.
+  """
+  if kernel["EnableF32XdlMathOp"]:
+    if kernel["UseF32XEmulation"]:
+      from rocisa.enum import DataTypeEnum
+      from Tensile.Common.DataType import DataType
+      return DataType(DataTypeEnum.BFloat16)
+    return kernel["ProblemType"]["F32XdlMathOp"]
+  return kernel["ProblemType"]["DataType"]
+
 def reject(state: dict, printSolutionRejectionReason: bool = True, *args) -> bool:
   """
   Reject a solution based on its internal state.

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_SolutionStructsUtilities.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_SolutionStructsUtilities.py
@@ -1,0 +1,95 @@
+################################################################################
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+################################################################################
+import pytest
+
+from rocisa.enum import DataTypeEnum
+
+from Tensile.Common.DataType import DataType
+from Tensile.SolutionStructs.Utilities import getMiInputType
+
+
+def _build_kernel(*, enable_f32_xdl_math_op=False, use_f32x_emulation=False,
+                  data_type=None, f32_xdl_math_op=None):
+    """Build a minimal kernel dict for getMiInputType tests."""
+    return {
+        "EnableF32XdlMathOp": enable_f32_xdl_math_op,
+        "UseF32XEmulation": use_f32x_emulation,
+        "ProblemType": {
+            "DataType": data_type or DataType(DataTypeEnum.Float),
+            "F32XdlMathOp": f32_xdl_math_op or DataType(DataTypeEnum.XFloat32),
+        },
+    }
+
+
+class TestGetMiInputType:
+    """Verify getMiInputType selects the correct MFMA operand type.
+
+    EnableF32XdlMathOp=False                         → ProblemType["DataType"]
+    EnableF32XdlMathOp=True,  UseF32XEmulation=False → ProblemType["F32XdlMathOp"]
+    EnableF32XdlMathOp=True,  UseF32XEmulation=True  → DataType(BFloat16)
+    """
+
+    def test_plain_datatype(self):
+        """Neither flag set → returns ProblemType.DataType."""
+        kernel = _build_kernel()
+
+        result = getMiInputType(kernel)
+
+        assert result == DataType(DataTypeEnum.Float)
+
+    def test_native_xf32(self):
+        """EnableF32XdlMathOp without emulation → returns F32XdlMathOp."""
+        kernel = _build_kernel(enable_f32_xdl_math_op=True)
+
+        result = getMiInputType(kernel)
+
+        assert result == DataType(DataTypeEnum.XFloat32)
+
+    def test_use_f32x_emulation(self):
+        """UseF32XEmulation + EnableF32XdlMathOp → returns DataType(BFloat16)."""
+        kernel = _build_kernel(
+            enable_f32_xdl_math_op=True,
+            use_f32x_emulation=True,
+        )
+
+        result = getMiInputType(kernel)
+
+        assert result == DataType(DataTypeEnum.BFloat16)
+
+    def test_missing_enable_flag_raises(self):
+        """EnableF32XdlMathOp must exist; absent key means broken caller."""
+        kernel = _build_kernel()
+        del kernel["EnableF32XdlMathOp"]
+
+        with pytest.raises(KeyError):
+            getMiInputType(kernel)
+
+    def test_missing_emulation_flag_raises(self):
+        """UseF32XEmulation must exist; absent key means broken caller."""
+        kernel = _build_kernel(enable_f32_xdl_math_op=True)
+        del kernel["UseF32XEmulation"]
+
+        with pytest.raises(KeyError):
+            getMiInputType(kernel)


### PR DESCRIPTION
KernelWriter was passing ProblemType[DataType] to getMFMAIssueLatency/getSMFMAIssueLatency. 
For xf32 kernels DataType is Float while the MFMA uses XFloat32, so rocisa never applied the XFloat32 latency rules. 
That produced wrong (miLatency, miLatencyLeft) and changed scheduling and generated assembly.
Add unit tests for getMiInputType.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

tox -e unit -- Tensile/Tests/unit/test_SolutionStructsUtilities.py -v
```
Tensile/Tests/unit/test_SolutionStructsUtilities.py::TestGetMiInputType::test_plain_datatype PASSED                                                                                 [ 20%]
Tensile/Tests/unit/test_SolutionStructsUtilities.py::TestGetMiInputType::test_native_xf32 PASSED                                                                                    [ 40%]
Tensile/Tests/unit/test_SolutionStructsUtilities.py::TestGetMiInputType::test_use_f32x_emulation PASSED                                                                             [ 60%]
Tensile/Tests/unit/test_SolutionStructsUtilities.py::TestGetMiInputType::test_missing_enable_flag_raises PASSED                                                                     [ 80%]
Tensile/Tests/unit/test_SolutionStructsUtilities.py::TestGetMiInputType::test_missing_emulation_flag_raises PASSED                                                                  [100%]

==================================================================================== 5 passed in 0.32s ===================================================================================
```

tox -e py3 -- Tensile/Tests -m common
```
103 passed, 80 skipped, 2 warnings in 2855.00s (0:47:35) 
```

hipblaslt-test
```
[----------] Global test environment tear-down
[==========] 63853 tests from 11 test suites ran. (2809179 ms total)
[  PASSED  ] 63853 tests.
hipBLASLt version: 100200
```
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
