### PR TITLE
[hipTensor] Add IDs of newly added contraction instances with unary ops to Actor-Critic model

### DIFF
--- a/projects/hiptensor/library/src/contraction/contraction_selection.cpp
+++ b/projects/hiptensor/library/src/contraction/contraction_selection.cpp
@@ -3358,4 +3358,1946 @@ namespace hiptensor
         }
         return HIPTENSOR_STATUS_EXECUTION_FAILED;
     }
+
+    // Acotor-Critic model for unary ops
+    template <>
+    struct ActorCriticSelectionUnaryOps<_Float16,
+                                _Float16,
+                                _Float16,
+                                _Float16,
+                                ContractionOpId_t::SCALE,
+                                float>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 7538467540961049787ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 7538467540961049787ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 7538467540961049787ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 7538467540961049787ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 7538467540961049787ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 7538467540961049787ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 5838574146849536063ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 9929579717278416296ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 9929579717278416296ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 9929579717278416296ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 9929579717278416296ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 15431985258997757854ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<_Float16,
+                                _Float16,
+                                _Float16,
+                                _Float16,
+                                ContractionOpId_t::BILINEAR,
+                                float>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 3415378554316130654ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 3415378554316130654ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 3415378554316130654ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 3415378554316130654ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 3415378554316130654ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 3415378554316130654ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 17177484621493380088ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 17177484621493380088ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 17177484621493380088ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 8974719589220802400ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 8974719589220802400ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 17177484621493380088ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<hip_bfloat16,
+                                hip_bfloat16,
+                                hip_bfloat16,
+                                hip_bfloat16,
+                                ContractionOpId_t::SCALE,
+                                float>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 10572640329933031377ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 15510068347583301452ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 10572640329933031377ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 15510068347583301452ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 10572640329933031377ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 10572640329933031377ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 6276769470110182113ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 5827523263153508957ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 5827523263153508957ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 5827523263153508957ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 5827523263153508957ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 6276769470110182113ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<hip_bfloat16,
+                                hip_bfloat16,
+                                hip_bfloat16,
+                                hip_bfloat16,
+                                ContractionOpId_t::BILINEAR,
+                                float>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 12481385650722299445ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 4574287328754767068ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 12481385650722299445ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 12481385650722299445ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 12481385650722299445ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 4574287328754767068ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 2817642069473326068ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 1139053823940322184ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 2817642069473326068ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 1139053823940322184ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 1139053823940322184ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 2817642069473326068ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<float, float, float, float, ContractionOpId_t::SCALE, _Float16>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 10482334011498030239ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 8472864432528069731ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 8472864432528069731ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 8472864432528069731ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 8472864432528069731ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 8472864432528069731ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 4617465351495394743ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 1663480608868680521ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 1663480608868680521ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 1663480608868680521ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 1663480608868680521ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 1663480608868680521ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<float, float, float, float, ContractionOpId_t::BILINEAR, _Float16>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 14762504979677123854ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 14762504979677123854ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 14762504979677123854ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 14762504979677123854ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 14762504979677123854ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 14762504979677123854ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 1158968124405133622ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 6681600076438905506ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 1685602420862754469ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 6681600076438905506ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 6681600076438905506ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 6681600076438905506ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<float, float, float, float, ContractionOpId_t::SCALE, hip_bfloat16>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 4677594781166299396ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 4677594781166299396ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 4677594781166299396ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 4677594781166299396ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 4677594781166299396ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 4677594781166299396ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 5675370401297283233ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 9469902973241888595ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 9469902973241888595ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 9469902973241888595ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 9469902973241888595ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 9469902973241888595ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<float,
+                                float,
+                                float,
+                                float,
+                                ContractionOpId_t::BILINEAR,
+                                hip_bfloat16>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 5704881916563684892ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 2062110410148341538ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 2062110410148341538ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 2062110410148341538ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 2062110410148341538ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 2062110410148341538ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 1580714540240191281ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 1580714540240191281ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 1580714540240191281ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 1580714540240191281ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 1580714540240191281ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 1580714540240191281ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<float, float, float, float, ContractionOpId_t::SCALE, float>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 12160779730984340837ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 12160779730984340837ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 12160779730984340837ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 12160779730984340837ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 12160779730984340837ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 12160779730984340837ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 6103881444342374783ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 3492198639380540417ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 6103881444342374783ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 3492198639380540417ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 3492198639380540417ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 6103881444342374783ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<float, float, float, float, ContractionOpId_t::BILINEAR, float>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 5447850794718128443ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 7828346908127446539ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 5447850794718128443ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 7828346908127446539ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 5447850794718128443ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 5447850794718128443ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 15770210374284736011ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 15770210374284736011ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 15770210374284736011ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 6463641982677566422ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 6463641982677566422ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 15770210374284736011ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<double, double, double, double, ContractionOpId_t::SCALE, float>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 2158644421080291960ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 2158644421080291960ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 2158644421080291960ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 1106420844725934876ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 2158644421080291960ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 2158644421080291960ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 770569218298543735ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 5213105944240361468ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 5213105944240361468ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 5213105944240361468ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 5213105944240361468ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 5213105944240361468ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<double, double, double, double, ContractionOpId_t::BILINEAR, float>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 15689293195218612641ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 15689293195218612641ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 15689293195218612641ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 15689293195218612641ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 15689293195218612641ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 15689293195218612641ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 12362723444598556025ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 2980379434373265690ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 2980379434373265690ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 2980379434373265690ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 2980379434373265690ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 2980379434373265690ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<double, double, double, double, ContractionOpId_t::SCALE, double>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 1818797200832435030ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 6509874686188425969ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 6509874686188425969ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 6509874686188425969ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 6509874686188425969ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 6509874686188425969ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 10063938818899116719ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 16235788987998995137ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 16235788987998995137ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 10063938818899116719ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 16235788987998995137ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 16235788987998995137ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<double, double, double, double, ContractionOpId_t::BILINEAR, double>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 12567580538174379913ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 15173184787179566326ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 15173184787179566326ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 15173184787179566326ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 15173184787179566326ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 15173184787179566326ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 12567580538174379913ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 14694634098178137439ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 14694634098178137439ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 12567580538174379913ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 14694634098178137439ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 12567580538174379913ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+
+    hiptensorStatus_t
+        actorCriticModelUnaryOps(ContractionSolution**                           winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         hiptensorComputeDescriptor_t                            computeType,
+                         const uint64_t                                          workspaceSize)
+    {
+        if(typeA == HIPTENSOR_R_16F && typeB == HIPTENSOR_R_16F && typeD == NONE_TYPE
+           && typeE == HIPTENSOR_R_16F && computeType == HIPTENSOR_COMPUTE_DESC_32F)
+        {
+            return ActorCriticSelectionUnaryOps<_Float16,
+                                        _Float16,
+                                        _Float16,
+                                        _Float16,
+                                        ContractionOpId_t::SCALE,
+                                        float>::selectWinner(winner,
+                                                             candidates,
+                                                             typeA,
+                                                             a_ms_ks_lengths,
+                                                             a_ms_ks_strides,
+                                                             a_ms_ks_modes,
+                                                             typeB,
+                                                             b_ns_ks_lengths,
+                                                             b_ns_ks_strides,
+                                                             b_ns_ks_modes,
+                                                             typeD,
+                                                             d_ms_ns_lengths,
+                                                             d_ms_ns_strides,
+                                                             d_ms_ns_modes,
+                                                             typeE,
+                                                             e_ms_ns_lengths,
+                                                             e_ms_ns_strides,
+                                                             e_ms_ns_modes,
+                                                             workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_16F && typeB == HIPTENSOR_R_16F && typeD == HIPTENSOR_R_16F
+                && typeE == HIPTENSOR_R_16F && computeType == HIPTENSOR_COMPUTE_DESC_32F)
+        {
+            return ActorCriticSelectionUnaryOps<_Float16,
+                                        _Float16,
+                                        _Float16,
+                                        _Float16,
+                                        ContractionOpId_t::BILINEAR,
+                                        float>::selectWinner(winner,
+                                                             candidates,
+                                                             typeA,
+                                                             a_ms_ks_lengths,
+                                                             a_ms_ks_strides,
+                                                             a_ms_ks_modes,
+                                                             typeB,
+                                                             b_ns_ks_lengths,
+                                                             b_ns_ks_strides,
+                                                             b_ns_ks_modes,
+                                                             typeD,
+                                                             d_ms_ns_lengths,
+                                                             d_ms_ns_strides,
+                                                             d_ms_ns_modes,
+                                                             typeE,
+                                                             e_ms_ns_lengths,
+                                                             e_ms_ns_strides,
+                                                             e_ms_ns_modes,
+                                                             workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_16BF && typeB == HIPTENSOR_R_16BF && typeD == NONE_TYPE
+                && typeE == HIPTENSOR_R_16BF && computeType == HIPTENSOR_COMPUTE_DESC_32F)
+        {
+            return ActorCriticSelectionUnaryOps<hip_bfloat16,
+                                        hip_bfloat16,
+                                        hip_bfloat16,
+                                        hip_bfloat16,
+                                        ContractionOpId_t::SCALE,
+                                        float>::selectWinner(winner,
+                                                             candidates,
+                                                             typeA,
+                                                             a_ms_ks_lengths,
+                                                             a_ms_ks_strides,
+                                                             a_ms_ks_modes,
+                                                             typeB,
+                                                             b_ns_ks_lengths,
+                                                             b_ns_ks_strides,
+                                                             b_ns_ks_modes,
+                                                             typeD,
+                                                             d_ms_ns_lengths,
+                                                             d_ms_ns_strides,
+                                                             d_ms_ns_modes,
+                                                             typeE,
+                                                             e_ms_ns_lengths,
+                                                             e_ms_ns_strides,
+                                                             e_ms_ns_modes,
+                                                             workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_16BF && typeB == HIPTENSOR_R_16BF && typeD == HIPTENSOR_R_16BF
+                && typeE == HIPTENSOR_R_16BF && computeType == HIPTENSOR_COMPUTE_DESC_32F)
+        {
+            return ActorCriticSelectionUnaryOps<hip_bfloat16,
+                                        hip_bfloat16,
+                                        hip_bfloat16,
+                                        hip_bfloat16,
+                                        ContractionOpId_t::BILINEAR,
+                                        float>::selectWinner(winner,
+                                                             candidates,
+                                                             typeA,
+                                                             a_ms_ks_lengths,
+                                                             a_ms_ks_strides,
+                                                             a_ms_ks_modes,
+                                                             typeB,
+                                                             b_ns_ks_lengths,
+                                                             b_ns_ks_strides,
+                                                             b_ns_ks_modes,
+                                                             typeD,
+                                                             d_ms_ns_lengths,
+                                                             d_ms_ns_strides,
+                                                             d_ms_ns_modes,
+                                                             typeE,
+                                                             e_ms_ns_lengths,
+                                                             e_ms_ns_strides,
+                                                             e_ms_ns_modes,
+                                                             workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_32F && typeB == HIPTENSOR_R_32F && typeD == NONE_TYPE
+                && typeE == HIPTENSOR_R_32F && computeType == HIPTENSOR_COMPUTE_DESC_16F)
+        {
+            return ActorCriticSelectionUnaryOps<float,
+                                        float,
+                                        float,
+                                        float,
+                                        ContractionOpId_t::SCALE,
+                                        _Float16>::selectWinner(winner,
+                                                                candidates,
+                                                                typeA,
+                                                                a_ms_ks_lengths,
+                                                                a_ms_ks_strides,
+                                                                a_ms_ks_modes,
+                                                                typeB,
+                                                                b_ns_ks_lengths,
+                                                                b_ns_ks_strides,
+                                                                b_ns_ks_modes,
+                                                                typeD,
+                                                                d_ms_ns_lengths,
+                                                                d_ms_ns_strides,
+                                                                d_ms_ns_modes,
+                                                                typeE,
+                                                                e_ms_ns_lengths,
+                                                                e_ms_ns_strides,
+                                                                e_ms_ns_modes,
+                                                                workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_32F && typeB == HIPTENSOR_R_32F && typeD == HIPTENSOR_R_32F
+                && typeE == HIPTENSOR_R_32F && computeType == HIPTENSOR_COMPUTE_DESC_16F)
+        {
+            return ActorCriticSelectionUnaryOps<float,
+                                        float,
+                                        float,
+                                        float,
+                                        ContractionOpId_t::BILINEAR,
+                                        _Float16>::selectWinner(winner,
+                                                                candidates,
+                                                                typeA,
+                                                                a_ms_ks_lengths,
+                                                                a_ms_ks_strides,
+                                                                a_ms_ks_modes,
+                                                                typeB,
+                                                                b_ns_ks_lengths,
+                                                                b_ns_ks_strides,
+                                                                b_ns_ks_modes,
+                                                                typeD,
+                                                                d_ms_ns_lengths,
+                                                                d_ms_ns_strides,
+                                                                d_ms_ns_modes,
+                                                                typeE,
+                                                                e_ms_ns_lengths,
+                                                                e_ms_ns_strides,
+                                                                e_ms_ns_modes,
+                                                                workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_32F && typeB == HIPTENSOR_R_32F && typeD == NONE_TYPE
+                && typeE == HIPTENSOR_R_32F && computeType == HIPTENSOR_R_16BF)
+        {
+            return ActorCriticSelectionUnaryOps<float,
+                                        float,
+                                        float,
+                                        float,
+                                        ContractionOpId_t::SCALE,
+                                        hip_bfloat16>::selectWinner(winner,
+                                                                    candidates,
+                                                                    typeA,
+                                                                    a_ms_ks_lengths,
+                                                                    a_ms_ks_strides,
+                                                                    a_ms_ks_modes,
+                                                                    typeB,
+                                                                    b_ns_ks_lengths,
+                                                                    b_ns_ks_strides,
+                                                                    b_ns_ks_modes,
+                                                                    typeD,
+                                                                    d_ms_ns_lengths,
+                                                                    d_ms_ns_strides,
+                                                                    d_ms_ns_modes,
+                                                                    typeE,
+                                                                    e_ms_ns_lengths,
+                                                                    e_ms_ns_strides,
+                                                                    e_ms_ns_modes,
+                                                                    workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_32F && typeB == HIPTENSOR_R_32F && typeD == HIPTENSOR_R_32F
+                && typeE == HIPTENSOR_R_32F && computeType == HIPTENSOR_R_16BF)
+        {
+            return ActorCriticSelectionUnaryOps<float,
+                                        float,
+                                        float,
+                                        float,
+                                        ContractionOpId_t::BILINEAR,
+                                        hip_bfloat16>::selectWinner(winner,
+                                                                    candidates,
+                                                                    typeA,
+                                                                    a_ms_ks_lengths,
+                                                                    a_ms_ks_strides,
+                                                                    a_ms_ks_modes,
+                                                                    typeB,
+                                                                    b_ns_ks_lengths,
+                                                                    b_ns_ks_strides,
+                                                                    b_ns_ks_modes,
+                                                                    typeD,
+                                                                    d_ms_ns_lengths,
+                                                                    d_ms_ns_strides,
+                                                                    d_ms_ns_modes,
+                                                                    typeE,
+                                                                    e_ms_ns_lengths,
+                                                                    e_ms_ns_strides,
+                                                                    e_ms_ns_modes,
+                                                                    workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_32F && typeB == HIPTENSOR_R_32F && typeD == NONE_TYPE
+                && typeE == HIPTENSOR_R_32F && computeType == HIPTENSOR_COMPUTE_DESC_32F)
+        {
+            return ActorCriticSelectionUnaryOps<float,
+                                        float,
+                                        float,
+                                        float,
+                                        ContractionOpId_t::SCALE,
+                                        float>::selectWinner(winner,
+                                                             candidates,
+                                                             typeA,
+                                                             a_ms_ks_lengths,
+                                                             a_ms_ks_strides,
+                                                             a_ms_ks_modes,
+                                                             typeB,
+                                                             b_ns_ks_lengths,
+                                                             b_ns_ks_strides,
+                                                             b_ns_ks_modes,
+                                                             typeD,
+                                                             d_ms_ns_lengths,
+                                                             d_ms_ns_strides,
+                                                             d_ms_ns_modes,
+                                                             typeE,
+                                                             e_ms_ns_lengths,
+                                                             e_ms_ns_strides,
+                                                             e_ms_ns_modes,
+                                                             workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_32F && typeB == HIPTENSOR_R_32F && typeD == HIPTENSOR_R_32F
+                && typeE == HIPTENSOR_R_32F && computeType == HIPTENSOR_COMPUTE_DESC_32F)
+        {
+            return ActorCriticSelectionUnaryOps<float,
+                                        float,
+                                        float,
+                                        float,
+                                        ContractionOpId_t::BILINEAR,
+                                        float>::selectWinner(winner,
+                                                             candidates,
+                                                             typeA,
+                                                             a_ms_ks_lengths,
+                                                             a_ms_ks_strides,
+                                                             a_ms_ks_modes,
+                                                             typeB,
+                                                             b_ns_ks_lengths,
+                                                             b_ns_ks_strides,
+                                                             b_ns_ks_modes,
+                                                             typeD,
+                                                             d_ms_ns_lengths,
+                                                             d_ms_ns_strides,
+                                                             d_ms_ns_modes,
+                                                             typeE,
+                                                             e_ms_ns_lengths,
+                                                             e_ms_ns_strides,
+                                                             e_ms_ns_modes,
+                                                             workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_64F && typeB == HIPTENSOR_R_64F && typeD == NONE_TYPE
+                && typeE == HIPTENSOR_R_64F && computeType == HIPTENSOR_COMPUTE_DESC_32F)
+        {
+            return ActorCriticSelectionUnaryOps<double,
+                                        double,
+                                        double,
+                                        double,
+                                        ContractionOpId_t::SCALE,
+                                        float>::selectWinner(winner,
+                                                             candidates,
+                                                             typeA,
+                                                             a_ms_ks_lengths,
+                                                             a_ms_ks_strides,
+                                                             a_ms_ks_modes,
+                                                             typeB,
+                                                             b_ns_ks_lengths,
+                                                             b_ns_ks_strides,
+                                                             b_ns_ks_modes,
+                                                             typeD,
+                                                             d_ms_ns_lengths,
+                                                             d_ms_ns_strides,
+                                                             d_ms_ns_modes,
+                                                             typeE,
+                                                             e_ms_ns_lengths,
+                                                             e_ms_ns_strides,
+                                                             e_ms_ns_modes,
+                                                             workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_64F && typeB == HIPTENSOR_R_64F && typeD == HIPTENSOR_R_64F
+                && typeE == HIPTENSOR_R_64F && computeType == HIPTENSOR_COMPUTE_DESC_32F)
+        {
+            return ActorCriticSelectionUnaryOps<double,
+                                        double,
+                                        double,
+                                        double,
+                                        ContractionOpId_t::BILINEAR,
+                                        float>::selectWinner(winner,
+                                                             candidates,
+                                                             typeA,
+                                                             a_ms_ks_lengths,
+                                                             a_ms_ks_strides,
+                                                             a_ms_ks_modes,
+                                                             typeB,
+                                                             b_ns_ks_lengths,
+                                                             b_ns_ks_strides,
+                                                             b_ns_ks_modes,
+                                                             typeD,
+                                                             d_ms_ns_lengths,
+                                                             d_ms_ns_strides,
+                                                             d_ms_ns_modes,
+                                                             typeE,
+                                                             e_ms_ns_lengths,
+                                                             e_ms_ns_strides,
+                                                             e_ms_ns_modes,
+                                                             workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_64F && typeB == HIPTENSOR_R_64F && typeD == NONE_TYPE
+                && typeE == HIPTENSOR_R_64F && computeType == HIPTENSOR_COMPUTE_DESC_64F)
+        {
+            return ActorCriticSelectionUnaryOps<double,
+                                        double,
+                                        double,
+                                        double,
+                                        ContractionOpId_t::SCALE,
+                                        double>::selectWinner(winner,
+                                                              candidates,
+                                                              typeA,
+                                                              a_ms_ks_lengths,
+                                                              a_ms_ks_strides,
+                                                              a_ms_ks_modes,
+                                                              typeB,
+                                                              b_ns_ks_lengths,
+                                                              b_ns_ks_strides,
+                                                              b_ns_ks_modes,
+                                                              typeD,
+                                                              d_ms_ns_lengths,
+                                                              d_ms_ns_strides,
+                                                              d_ms_ns_modes,
+                                                              typeE,
+                                                              e_ms_ns_lengths,
+                                                              e_ms_ns_strides,
+                                                              e_ms_ns_modes,
+                                                              workspaceSize);
+        }
+        else if(typeA == HIPTENSOR_R_64F && typeB == HIPTENSOR_R_64F && typeD == HIPTENSOR_R_64F
+                && typeE == HIPTENSOR_R_64F && computeType == HIPTENSOR_COMPUTE_DESC_64F)
+        {
+            return ActorCriticSelectionUnaryOps<double,
+                                        double,
+                                        double,
+                                        double,
+                                        ContractionOpId_t::BILINEAR,
+                                        double>::selectWinner(winner,
+                                                              candidates,
+                                                              typeA,
+                                                              a_ms_ks_lengths,
+                                                              a_ms_ks_strides,
+                                                              a_ms_ks_modes,
+                                                              typeB,
+                                                              b_ns_ks_lengths,
+                                                              b_ns_ks_strides,
+                                                              b_ns_ks_modes,
+                                                              typeD,
+                                                              d_ms_ns_lengths,
+                                                              d_ms_ns_strides,
+                                                              d_ms_ns_modes,
+                                                              typeE,
+                                                              e_ms_ns_lengths,
+                                                              e_ms_ns_strides,
+                                                              e_ms_ns_modes,
+                                                              workspaceSize);
+        }
+        return HIPTENSOR_STATUS_EXECUTION_FAILED;
+    }
 }

--- a/projects/hiptensor/library/src/contraction/contraction_selection.cpp
+++ b/projects/hiptensor/library/src/contraction/contraction_selection.cpp
@@ -3359,6 +3359,230 @@ namespace hiptensor
         return HIPTENSOR_STATUS_EXECUTION_FAILED;
     }
 
+    template <>
+    struct ActorCriticSelectionUnaryOps<_Float16,
+                                _Float16,
+                                _Float16,
+                                _Float16,
+                                ContractionOpId_t::SCALE,
+                                _Float16>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 6974095321173130927ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 16253689926652332996ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 16253689926652332996ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 6974095321173130927ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 16253689926652332996ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 16253689926652332996ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<_Float16,
+                                _Float16,
+                                _Float16,
+                                _Float16,
+                                ContractionOpId_t::BILINEAR,
+                                _Float16>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 14408154905494010489ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 6974095321173130927ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 16253689926652332996ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 16253689926652332996ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 6974095321173130927ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 16253689926652332996ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 16253689926652332996ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
     // Acotor-Critic model for unary ops
     template <>
     struct ActorCriticSelectionUnaryOps<_Float16,
@@ -3569,6 +3793,230 @@ namespace hiptensor
                 else if(rank == 6)
                 {
                     unique_id = 17177484621493380088ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<hip_bfloat16,
+                                hip_bfloat16,
+                                hip_bfloat16,
+                                hip_bfloat16,
+                                ContractionOpId_t::SCALE,
+                                hip_bfloat16>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 12765469494343230674ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 3753568868518805000ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 12765469494343230674ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 12765469494343230674ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 3753568868518805000ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 12765469494343230674ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 16194744748728374153ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 14950476381367017410ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 14950476381367017410ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 14950476381367017410ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 14950476381367017410ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 14950476381367017410ull;
+                }
+            }
+
+            if(auto candidate = candidates.find(unique_id); candidate != candidates.end())
+            {
+                *winner = candidate->second;
+                return HIPTENSOR_STATUS_SUCCESS;
+            }
+            else
+            {
+                return HIPTENSOR_STATUS_EXECUTION_FAILED;
+            }
+        }
+    };
+
+    template <>
+    struct ActorCriticSelectionUnaryOps<hip_bfloat16,
+                                hip_bfloat16,
+                                hip_bfloat16,
+                                hip_bfloat16,
+                                ContractionOpId_t::BILINEAR,
+                                hip_bfloat16>
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize)
+        {
+            auto   rank      = getRank(a_ms_ks_strides);
+            size_t unique_id = 0;
+
+            auto& options = HiptensorOptions::instance();
+            if(options->isColMajorStrides())
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 12765469494343230674ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 12765469494343230674ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 12765469494343230674ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 12765469494343230674ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 3753568868518805000ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 12765469494343230674ull;
+                }
+            }
+            else
+            {
+                // m1n1k1
+                if(rank == 1)
+                {
+                    unique_id = 16194744748728374153ull;
+                }
+                // m2n2k2
+                else if(rank == 2)
+                {
+                    unique_id = 14950476381367017410ull;
+                }
+                // m3n3k3
+                else if(rank == 3)
+                {
+                    unique_id = 14950476381367017410ull;
+                }
+                // m4n4k4
+                else if(rank == 4)
+                {
+                    unique_id = 16194744748728374153ull;
+                }
+                // m5n5k5
+                else if(rank == 5)
+                {
+                    unique_id = 14950476381367017410ull;
+                }
+                // m6n6k6
+                else if(rank == 6)
+                {
+                    unique_id = 14950476381367017410ull;
                 }
             }
 

--- a/projects/hiptensor/library/src/contraction/contraction_selection.hpp
+++ b/projects/hiptensor/library/src/contraction/contraction_selection.hpp
@@ -108,4 +108,56 @@ namespace hiptensor
                          hiptensorComputeDescriptor_t                            computeType,
                          const uint64_t                                          workspaceSize);
 
+    template <typename A,
+              typename B,
+              typename C,
+              typename D,
+              ContractionOpId_t ContractionOp,
+              typename ComputeType>
+    struct ActorCriticSelectionUnaryOps
+    {
+        static hiptensorStatus_t
+            selectWinner(ContractionSolution**                                   winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         const uint64_t                                          workspaceSize);
+    };
+
+    hiptensorStatus_t
+        actorCriticModelUnaryOps(ContractionSolution**                           winner,
+                         std::unordered_map<size_t, ContractionSolution*> const& candidates,
+                         hiptensorDataType_t                                     typeA,
+                         std::vector<std::size_t> const&                         a_ms_ks_lengths,
+                         std::vector<std::size_t> const&                         a_ms_ks_strides,
+                         std::vector<int32_t> const&                             a_ms_ks_modes,
+                         hiptensorDataType_t                                     typeB,
+                         std::vector<std::size_t> const&                         b_ns_ks_lengths,
+                         std::vector<std::size_t> const&                         b_ns_ks_strides,
+                         std::vector<int32_t> const&                             b_ns_ks_modes,
+                         hiptensorDataType_t                                     typeD,
+                         std::vector<std::size_t> const&                         d_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         d_ms_ns_strides,
+                         std::vector<int32_t> const&                             d_ms_ns_modes,
+                         hiptensorDataType_t                                     typeE,
+                         std::vector<std::size_t> const&                         e_ms_ns_lengths,
+                         std::vector<std::size_t> const&                         e_ms_ns_strides,
+                         std::vector<int32_t> const&                             e_ms_ns_modes,
+                         hiptensorComputeDescriptor_t                            computeType,
+                         const uint64_t                                          workspaceSize);
+
 } // namespace hiptensor

--- a/projects/hiptensor/library/src/contraction/contraction_solution_impl.hpp
+++ b/projects/hiptensor/library/src/contraction/contraction_solution_impl.hpp
@@ -169,11 +169,9 @@ namespace hiptensor
                     = applyCKColMajorStridesOptimizationForContraction(normal_e_ms_ns_lengths);
 
             // Initialize the argument pointer
-            if constexpr(std::
-                             is_same_v<typename Traits::AOp,
-                                       ck::
-                                           tensor_operation::
-                                               element_wise::PassThrough> && std::is_same_v<typename Traits::BOp, ck::tensor_operation::element_wise::PassThrough> && (std::is_same_v<typename Traits::CDEOp, ck::tensor_operation::element_wise::Bilinear> || std::is_same_v<typename Traits::CDEOp, ck::tensor_operation::element_wise::BilinearComplex>))
+            if constexpr(std::is_same_v<typename Traits::AOp, ck::tensor_operation::element_wise::PassThrough> 
+                      && std::is_same_v<typename Traits::BOp, ck::tensor_operation::element_wise::PassThrough> 
+                      &&(std::is_same_v<typename Traits::CDEOp, ck::tensor_operation::element_wise::Bilinear> || std::is_same_v<typename Traits::CDEOp, ck::tensor_operation::element_wise::BilinearComplex>))
             {
                 Base::mInvokerArgPtr = std::move(deviceOp->MakeArgumentPointer(
                     A,

--- a/projects/hiptensor/library/src/contraction/contraction_solution_instances.cpp
+++ b/projects/hiptensor/library/src/contraction/contraction_solution_instances.cpp
@@ -60,6 +60,18 @@ namespace hiptensor
                                           ck::tensor_operation::element_wise::Bilinear,
                                           ck::bhalf_t>());
 
+        registerSolutions(enumerateContractionSolutions<6,
+                                                        6,
+                                                        6,
+                                                        ck::bhalf_t,
+                                                        ck::bhalf_t,
+                                                        ck::Tuple<ck::bhalf_t>,
+                                                        ck::bhalf_t,
+                                                        CkHiptensorUnaryOp,
+                                                        CkHiptensorUnaryOp,
+                                                        CkBilinearUnary,
+                                                        ck::bhalf_t>());
+
         registerSolutions(
             enumerateContractionSolutions<6,
                                           6,
@@ -98,6 +110,18 @@ namespace hiptensor
                                           ck::tensor_operation::element_wise::PassThrough,
                                           ck::tensor_operation::element_wise::Bilinear,
                                           ck::half_t>());
+
+        registerSolutions(enumerateContractionSolutions<6,
+                                                        6,
+                                                        6,
+                                                        ck::half_t,
+                                                        ck::half_t,
+                                                        ck::Tuple<ck::half_t>,
+                                                        ck::half_t,
+                                                        CkHiptensorUnaryOp,
+                                                        CkHiptensorUnaryOp,
+                                                        CkBilinearUnary,
+                                                        ck::half_t>());
 
         registerSolutions(
             enumerateContractionSolutions<6,
@@ -293,6 +317,18 @@ namespace hiptensor
                                           ck::tensor_operation::element_wise::Scale,
                                           ck::bhalf_t>());
 
+        registerSolutions(enumerateContractionSolutions<6,
+                                                        6,
+                                                        6,
+                                                        ck::bhalf_t,
+                                                        ck::bhalf_t,
+                                                        ck::Tuple<>,
+                                                        ck::bhalf_t,
+                                                        CkHiptensorUnaryOp,
+                                                        CkHiptensorUnaryOp,
+                                                        ck::tensor_operation::element_wise::Scale,
+                                                        ck::bhalf_t>());
+
         registerSolutions(
             enumerateContractionSolutions<6,
                                           6,
@@ -331,6 +367,18 @@ namespace hiptensor
                                           ck::tensor_operation::element_wise::PassThrough,
                                           ck::tensor_operation::element_wise::Scale,
                                           ck::half_t>());
+
+        registerSolutions(enumerateContractionSolutions<6,
+                                                        6,
+                                                        6,
+                                                        ck::half_t,
+                                                        ck::half_t,
+                                                        ck::Tuple<>,
+                                                        ck::half_t,
+                                                        CkHiptensorUnaryOp,
+                                                        CkHiptensorUnaryOp,
+                                                        ck::tensor_operation::element_wise::Scale,
+                                                        ck::half_t>());
 
         registerSolutions(
             enumerateContractionSolutions<6,

--- a/projects/hiptensor/library/src/contraction/device/CMakeLists.txt
+++ b/projects/hiptensor/library/src/contraction/device/CMakeLists.txt
@@ -141,6 +141,14 @@
      ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_knnn_instance.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mknn_instance.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_mnnn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_kkn_instance.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_knn_instance.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mkn_instance.cpp
@@ -169,6 +177,14 @@
      ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance.cpp     
      )
 
 add_hiptensor_component(hiptensor_contraction_instances ${CK_CONTRACTION_INSTANCE_SOURCES})

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// k/k/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance =
+    device_contraction_kk_instance<BF16,
+                                   BF16,
+                                   F32,
+                                   BF16,
+                                   BF16_Tuple,
+                                   BF16,
+                                   BF16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkBilinearUnary,
+                                   6>;
+
+void add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           BF16,
+                                                           BF16,
+                                                           BF16_Tuple,
+                                                           BF16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkBilinearUnary,
+                                                           BF16>>>& instances)
+{
+    add_device_operation_instances(
+        instances,
+        device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// k/n/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance =
+    device_contraction_kn_instance<BF16,
+                                   BF16,
+                                   F32,
+                                   BF16,
+                                   BF16_Tuple,
+                                   BF16,
+                                   BF16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkBilinearUnary,
+                                   6>;
+
+void add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           BF16,
+                                                           BF16,
+                                                           BF16_Tuple,
+                                                           BF16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkBilinearUnary,
+                                                           BF16>>>& instances)
+{
+    add_device_operation_instances(
+        instances,
+        device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// m/k/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance =
+    device_contraction_mk_instance<BF16,
+                                   BF16,
+                                   F32,
+                                   BF16,
+                                   BF16_Tuple,
+                                   BF16,
+                                   BF16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkBilinearUnary,
+                                   6>;
+
+void add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           BF16,
+                                                           BF16,
+                                                           BF16_Tuple,
+                                                           BF16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkBilinearUnary,
+                                                           BF16>>>& instances)
+{
+    add_device_operation_instances(
+        instances,
+        device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// m/n/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance =
+    device_contraction_mn_instance<BF16,
+                                   BF16,
+                                   F32,
+                                   BF16,
+                                   BF16_Tuple,
+                                   BF16,
+                                   BF16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkBilinearUnary,
+                                   6>;
+
+void add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           BF16,
+                                                           BF16,
+                                                           BF16_Tuple,
+                                                           BF16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkBilinearUnary,
+                                                           BF16>>>& instances)
+{
+    add_device_operation_instances(
+        instances,
+        device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// k/k/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance =
+    device_contraction_kk_instance<F16,
+                                   F16,
+                                   F32,
+                                   F16,
+                                   F16_Tuple,
+                                   F16,
+                                   F16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkBilinearUnary,
+                                   6>;
+
+void add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           F16,
+                                                           F16,
+                                                           F16_Tuple,
+                                                           F16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkBilinearUnary,
+                                                           F16>>>& instances)
+{
+    add_device_operation_instances(
+        instances,
+        device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// k/n/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance =
+    device_contraction_kn_instance<F16,
+                                   F16,
+                                   F32,
+                                   F16,
+                                   F16_Tuple,
+                                   F16,
+                                   F16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkBilinearUnary,
+                                   6>;
+
+void add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           F16,
+                                                           F16,
+                                                           F16_Tuple,
+                                                           F16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkBilinearUnary,
+                                                           F16>>>& instances)
+{
+    add_device_operation_instances(
+        instances,
+        device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// m/k/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance =
+    device_contraction_mk_instance<F16,
+                                   F16,
+                                   F32,
+                                   F16,
+                                   F16_Tuple,
+                                   F16,
+                                   F16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkBilinearUnary,
+                                   6>;
+
+void add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           F16,
+                                                           F16,
+                                                           F16_Tuple,
+                                                           F16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkBilinearUnary,
+                                                           F16>>>& instances)
+{
+    add_device_operation_instances(
+        instances,
+        device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance.cpp
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// m/n/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance =
+    device_contraction_mn_instance<F16,
+                                   F16,
+                                   F32,
+                                   F16,
+                                   F16_Tuple,
+                                   F16,
+                                   F16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkBilinearUnary,
+                                   6>;
+
+void add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           F16,
+                                                           F16,
+                                                           F16_Tuple,
+                                                           F16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkBilinearUnary,
+                                                           F16>>>& instances)
+{
+    add_device_operation_instances(
+        instances,
+        device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// k/k/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance =
+    device_contraction_kk_instance<BF16,
+                                   BF16,
+                                   F32,
+                                   BF16,
+                                   Empty_Tuple,
+                                   BF16,
+                                   BF16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   Scale,
+                                   6>;
+
+void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           BF16,
+                                                           BF16,
+                                                           Empty_Tuple,
+                                                           BF16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           Scale,
+                                                           BF16>>>& instances)
+{
+    add_device_operation_instances(
+        instances, device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// k/n/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance =
+    device_contraction_kn_instance<BF16,
+                                   BF16,
+                                   F32,
+                                   BF16,
+                                   Empty_Tuple,
+                                   BF16,
+                                   BF16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   Scale,
+                                   6>;
+
+void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           BF16,
+                                                           BF16,
+                                                           Empty_Tuple,
+                                                           BF16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           Scale,
+                                                           BF16>>>& instances)
+{
+    add_device_operation_instances(
+        instances, device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// m/k/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance =
+    device_contraction_mk_instance<BF16,
+                                   BF16,
+                                   F32,
+                                   BF16,
+                                   Empty_Tuple,
+                                   BF16,
+                                   BF16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   Scale,
+                                   6>;
+
+void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           BF16,
+                                                           BF16,
+                                                           Empty_Tuple,
+                                                           BF16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           Scale,
+                                                           BF16>>>& instances)
+{
+    add_device_operation_instances(
+        instances, device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// m/n/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance =
+    device_contraction_mn_instance<BF16,
+                                   BF16,
+                                   F32,
+                                   BF16,
+                                   Empty_Tuple,
+                                   BF16,
+                                   BF16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   Scale,
+                                   6>;
+
+void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           BF16,
+                                                           BF16,
+                                                           Empty_Tuple,
+                                                           BF16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           Scale,
+                                                           BF16>>>& instances)
+{
+    add_device_operation_instances(
+        instances, device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// k/k/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance =
+    device_contraction_kk_instance<F16,
+                                   F16,
+                                   F32,
+                                   F16,
+                                   Empty_Tuple,
+                                   F16,
+                                   F16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   Scale,
+                                   6>;
+
+void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           F16,
+                                                           F16,
+                                                           Empty_Tuple,
+                                                           F16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           Scale,
+                                                           F16>>>& instances)
+{
+    add_device_operation_instances(
+        instances, device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// k/n/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance =
+    device_contraction_kn_instance<F16,
+                                   F16,
+                                   F32,
+                                   F16,
+                                   Empty_Tuple,
+                                   F16,
+                                   F16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   Scale,
+                                   6>;
+
+void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           F16,
+                                                           F16,
+                                                           Empty_Tuple,
+                                                           F16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           Scale,
+                                                           F16>>>& instances)
+{
+    add_device_operation_instances(
+        instances, device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// m/k/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance =
+    device_contraction_mk_instance<F16,
+                                   F16,
+                                   F32,
+                                   F16,
+                                   Empty_Tuple,
+                                   F16,
+                                   F16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   Scale,
+                                   6>;
+
+void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           F16,
+                                                           F16,
+                                                           Empty_Tuple,
+                                                           F16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           Scale,
+                                                           F16>>>& instances)
+{
+    add_device_operation_instances(
+        instances, device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance.cpp
+++ b/projects/hiptensor/library/src/contraction/device/device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance.cpp
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <ck/ck.hpp>
+#include <ck/library/tensor_operation_instance/add_device_operation_instance.hpp>
+#include <ck/library/tensor_operation_instance/gpu/contraction/device_contraction_instance.hpp>
+#include <ck/tensor_operation/gpu/device/device_contraction_multiple_d.hpp>
+#include <ck/tensor_operation/gpu/element/element_wise_operation.hpp>
+
+#include "hiptensor_ck_types.hpp"
+
+namespace ck {
+namespace tensor_operation {
+namespace device {
+namespace instance {
+
+// A[m0, m1, k0, k1] * B[n0, n1, k0, k1] + D[m0, m1, n0, n1] = E[m0, m1, n0, n1]
+// m/n/n/n are the fast changing dimension for A/B/D/E
+using device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance =
+    device_contraction_mn_instance<F16,
+                                   F16,
+                                   F32,
+                                   F16,
+                                   Empty_Tuple,
+                                   F16,
+                                   F16,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   hiptensor::CkHiptensorUnaryOp,
+                                   Scale,
+                                   6>;
+
+void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance(
+    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
+                                                           6,
+                                                           6,
+                                                           F16,
+                                                           F16,
+                                                           Empty_Tuple,
+                                                           F16,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           hiptensor::CkHiptensorUnaryOp,
+                                                           Scale,
+                                                           F16>>>& instances)
+{
+    add_device_operation_instances(
+        instances, device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance{});
+}
+
+} // namespace instance
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/projects/hiptensor/library/src/contraction/device/hiptensor_contraction_bilinear_unary_ops_instances.hpp
+++ b/projects/hiptensor/library/src/contraction/device/hiptensor_contraction_bilinear_unary_ops_instances.hpp
@@ -461,6 +461,126 @@ namespace ck
                                                        hiptensor::CkBilinearUnary,
                                                        F32>>>& instances);
 
+                void
+                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       F16_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkBilinearUnary,
+                                                       F16>>>& instances);
+
+                void
+                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       F16_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkBilinearUnary,
+                                                       F16>>>& instances);
+
+                void
+                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       F16_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkBilinearUnary,
+                                                       F16>>>& instances);
+
+                void
+                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       F16_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkBilinearUnary,
+                                                       F16>>>& instances);
+
+                void
+                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       BF16_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkBilinearUnary,
+                                                       BF16>>>& instances);
+
+                void
+                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       BF16_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkBilinearUnary,
+                                                       BF16>>>& instances);
+
+                void
+                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       BF16_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkBilinearUnary,
+                                                       BF16>>>& instances);
+
+                void
+                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       BF16_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkBilinearUnary,
+                                                       BF16>>>& instances);
+
                 // Contraction + Bilinear
                 template <index_t NumDimM,
                           index_t NumDimN,
@@ -581,7 +701,18 @@ namespace ck
                         {
                             if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
                             {
-                                if constexpr(is_same_v<ComputeDataType, float>)
+                                if constexpr(is_same_v<ComputeDataType, ck::half_t>)
+                                {
+                                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_kknn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_knnn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mknn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_mnnn_instance(
+                                        op_ptrs);
+                                }
+                                else if constexpr(is_same_v<ComputeDataType, float>)
                                 {
                                     add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_f16_compute_f32_kknn_instance(
                                         op_ptrs);
@@ -601,7 +732,18 @@ namespace ck
                         {
                             if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
                             {
-                                if constexpr(is_same_v<ComputeDataType, float>)
+                                if constexpr(is_same_v<ComputeDataType, ck::bhalf_t>)
+                                {
+                                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_kknn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_knnn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mknn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_mnnn_instance(
+                                        op_ptrs);
+                                }
+                                else if constexpr(is_same_v<ComputeDataType, float>)
                                 {
                                     add_device_contraction_bilinear_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_bf16_compute_f32_kknn_instance(
                                         op_ptrs);

--- a/projects/hiptensor/library/src/contraction/device/hiptensor_contraction_scale_unary_ops_instances.hpp
+++ b/projects/hiptensor/library/src/contraction/device/hiptensor_contraction_scale_unary_ops_instances.hpp
@@ -32,525 +32,737 @@
 
 #include "hiptensor_ck_types.hpp"
 
-namespace ck {
-namespace tensor_operation {
-namespace device {
-namespace instance {
-
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);   
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F16>>>& instances);     
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F16>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F16>>>& instances);   
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F16>>>& instances);  
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           BF16>>>& instances);    
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           BF16>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           BF16>>>& instances);     
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F32,
-                                                           F32,
-                                                           Empty_Tuple,
-                                                           F32,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           BF16>>>& instances);  
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F64>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F64>>>& instances); 
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F64>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F64>>>& instances);   
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);  
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F64,
-                                                           F64,
-                                                           Empty_Tuple,
-                                                           F64,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);  
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           F16,
-                                                           F16,
-                                                           Empty_Tuple,
-                                                           F16,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);    
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);    
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);
-                                                           
-void add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance(
-    std::vector<std::unique_ptr<DeviceContractionMultipleD<6,
-                                                           6,
-                                                           6,
-                                                           BF16,
-                                                           BF16,
-                                                           Empty_Tuple,
-                                                           BF16,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           hiptensor::CkHiptensorUnaryOp,
-                                                           Scale,
-                                                           F32>>>& instances);                                                           
-
-// Contraction + Scale
-template <index_t NumDimM,
-          index_t NumDimN,
-          index_t NumDimK,
-          typename AElementwiseOperation,
-          typename BElementwiseOperation,
-          typename ADataType,
-          typename BDataType,
-          typename EDataType,
-          typename ComputeDataType>
-struct DeviceOperationInstanceFactory<ck::tensor_operation::device::DeviceContractionMultipleD<
-    NumDimM,
-    NumDimN,
-    NumDimK,
-    ADataType,
-    BDataType,
-    ck::Tuple<>,
-    EDataType,
-    AElementwiseOperation,
-    BElementwiseOperation,
-    ck::tensor_operation::element_wise::Scale,
-    ComputeDataType>>
+namespace ck
 {
-    using DeviceOp = DeviceContractionMultipleD<NumDimM,
-                                                NumDimN,
-                                                NumDimK,
-                                                ADataType,
-                                                BDataType,
-                                                ck::Tuple<>,
-                                                EDataType,
-                                                AElementwiseOperation,
-                                                BElementwiseOperation,
-                                                ck::tensor_operation::element_wise::Scale,
-                                                ComputeDataType>;
-
-    static auto GetInstances()
+    namespace tensor_operation
     {
-        std::vector<std::unique_ptr<DeviceOp>> op_ptrs;
-
-        if constexpr(is_same_v<ADataType, float> && is_same_v<BDataType, float> &&
-                     is_same_v<EDataType, float>)
+        namespace device
         {
-            if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
+            namespace instance
             {
-                if constexpr(is_same_v<ComputeDataType, float>)
-                {
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_kkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_knn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mnn_instance(
-                        op_ptrs);
-                }
-                else if constexpr(is_same_v<ComputeDataType, ck::half_t>)
-                {
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F16>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F16>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F16>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance(
-                        op_ptrs);
-                }
-                else if constexpr(is_same_v<ComputeDataType, ck::bhalf_t>)
-                {
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F16>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       BF16>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       BF16>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       BF16>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance(
-                        op_ptrs);
-                }
-            }      
-        }
-        if constexpr(is_same_v<ADataType, double> && is_same_v<BDataType, double> &&
-                     is_same_v<EDataType, double>)
-        {
-            if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
-            {
-                if constexpr(is_same_v<ComputeDataType, double>)
-                {
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F32,
+                                                       F32,
+                                                       Empty_Tuple,
+                                                       F32,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       BF16>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_kkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F64,
+                                                       F64,
+                                                       Empty_Tuple,
+                                                       F64,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F64>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_knn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F64,
+                                                       F64,
+                                                       Empty_Tuple,
+                                                       F64,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F64>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F64,
+                                                       F64,
+                                                       Empty_Tuple,
+                                                       F64,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F64>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mnn_instance(
-                        op_ptrs);
-                }
-                else if constexpr(is_same_v<ComputeDataType, float>)
-                {
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F64,
+                                                       F64,
+                                                       Empty_Tuple,
+                                                       F64,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F64>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F64,
+                                                       F64,
+                                                       Empty_Tuple,
+                                                       F64,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F64,
+                                                       F64,
+                                                       Empty_Tuple,
+                                                       F64,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F64,
+                                                       F64,
+                                                       Empty_Tuple,
+                                                       F64,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance(
-                        op_ptrs);
-                }
-            }
-        }
-        if constexpr(is_same_v<ADataType, ck::half_t> && is_same_v<BDataType, ck::half_t> &&
-                     is_same_v<EDataType, ck::half_t>)
-        {
-            if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
-            {
-                if constexpr(is_same_v<ComputeDataType, float>)
-                {
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F64,
+                                                       F64,
+                                                       Empty_Tuple,
+                                                       F64,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       Empty_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       Empty_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       Empty_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance(
-                        op_ptrs);
-                }
-            }
-        }
-        if constexpr(is_same_v<ADataType, ck::bhalf_t> && is_same_v<BDataType, ck::bhalf_t> &&
-                     is_same_v<EDataType, ck::bhalf_t>)
-        {
-            if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
-            {
-                if constexpr(is_same_v<ComputeDataType, float>)
-                {
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       Empty_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       Empty_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       Empty_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance(
-                        op_ptrs);
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       Empty_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
+
+                void
                     add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance(
-                        op_ptrs);
-                }
-            }
-        }
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       Empty_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F32>>>& instances);
 
-        return op_ptrs;
-    }
-};
+                void
+                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       Empty_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F16>>>& instances);
 
-} // namespace instance
-} // namespace device
-} // namespace tensor_operation
+                void
+                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       Empty_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F16>>>& instances);
+
+                void
+                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       Empty_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F16>>>& instances);
+
+                void
+                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       F16,
+                                                       F16,
+                                                       Empty_Tuple,
+                                                       F16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       F16>>>& instances);
+
+                void
+                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       Empty_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       BF16>>>& instances);
+
+                void
+                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       Empty_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       BF16>>>& instances);
+
+                void
+                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       Empty_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       BF16>>>& instances);
+
+                void
+                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance(
+                        std::vector<std::unique_ptr<
+                            DeviceContractionMultipleD<6,
+                                                       6,
+                                                       6,
+                                                       BF16,
+                                                       BF16,
+                                                       Empty_Tuple,
+                                                       BF16,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       hiptensor::CkHiptensorUnaryOp,
+                                                       Scale,
+                                                       BF16>>>& instances);
+
+                // Contraction + Scale
+                template <index_t NumDimM,
+                          index_t NumDimN,
+                          index_t NumDimK,
+                          typename AElementwiseOperation,
+                          typename BElementwiseOperation,
+                          typename ADataType,
+                          typename BDataType,
+                          typename EDataType,
+                          typename ComputeDataType>
+                struct DeviceOperationInstanceFactory<
+                    ck::tensor_operation::device::DeviceContractionMultipleD<
+                        NumDimM,
+                        NumDimN,
+                        NumDimK,
+                        ADataType,
+                        BDataType,
+                        ck::Tuple<>,
+                        EDataType,
+                        AElementwiseOperation,
+                        BElementwiseOperation,
+                        ck::tensor_operation::element_wise::Scale,
+                        ComputeDataType>>
+                {
+                    using DeviceOp
+                        = DeviceContractionMultipleD<NumDimM,
+                                                     NumDimN,
+                                                     NumDimK,
+                                                     ADataType,
+                                                     BDataType,
+                                                     ck::Tuple<>,
+                                                     EDataType,
+                                                     AElementwiseOperation,
+                                                     BElementwiseOperation,
+                                                     ck::tensor_operation::element_wise::Scale,
+                                                     ComputeDataType>;
+
+                    static auto GetInstances()
+                    {
+                        std::vector<std::unique_ptr<DeviceOp>> op_ptrs;
+
+                        if constexpr(
+                            is_same_v<
+                                ADataType,
+                                float> && is_same_v<BDataType, float> && is_same_v<EDataType, float>)
+                        {
+                            if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
+                            {
+                                if constexpr(is_same_v<ComputeDataType, float>)
+                                {
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_kkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_knn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_mnn_instance(
+                                        op_ptrs);
+                                }
+                                else if constexpr(is_same_v<ComputeDataType, ck::half_t>)
+                                {
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_kkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_knn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_f16_mnn_instance(
+                                        op_ptrs);
+                                }
+                                else if constexpr(is_same_v<ComputeDataType, ck::bhalf_t>)
+                                {
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_kkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_knn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f32_f32_f32_compute_bf16_mnn_instance(
+                                        op_ptrs);
+                                }
+                            }
+                        }
+                        if constexpr(
+                            is_same_v<
+                                ADataType,
+                                double> && is_same_v<BDataType, double> && is_same_v<EDataType, double>)
+                        {
+                            if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
+                            {
+                                if constexpr(is_same_v<ComputeDataType, double>)
+                                {
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_kkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_knn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_mnn_instance(
+                                        op_ptrs);
+                                }
+                                else if constexpr(is_same_v<ComputeDataType, float>)
+                                {
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_kkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_knn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f64_f64_f64_compute_f32_mnn_instance(
+                                        op_ptrs);
+                                }
+                            }
+                        }
+                        if constexpr(
+                            is_same_v<
+                                ADataType,
+                                ck::half_t> && is_same_v<BDataType, ck::half_t> && is_same_v<EDataType, ck::half_t>)
+                        {
+                            if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
+                            {
+                                if constexpr(is_same_v<ComputeDataType, ck::half_t>)
+                                {
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_kkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_knn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_mnn_instance(
+                                        op_ptrs);
+                                }
+                                else if constexpr(is_same_v<ComputeDataType, float>)
+                                {
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_kkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_knn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_f16_f16_f16_compute_f32_mnn_instance(
+                                        op_ptrs);
+                                }
+                            }
+                        }
+                        if constexpr(
+                            is_same_v<
+                                ADataType,
+                                ck::bhalf_t> && is_same_v<BDataType, ck::bhalf_t> && is_same_v<EDataType, ck::bhalf_t>)
+                        {
+                            if constexpr(NumDimM == 6 && NumDimN == 6 && NumDimK == 6)
+                            {
+                                if constexpr(is_same_v<ComputeDataType, ck::bhalf_t>)
+                                {
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_kkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_knn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_mnn_instance(
+                                        op_ptrs);
+                                }
+                                else if constexpr(is_same_v<ComputeDataType, float>)
+                                {
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_kkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_knn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mkn_instance(
+                                        op_ptrs);
+                                    add_device_contraction_scale_unary_m6_n6_k6_xdl_c_shuffle_bf16_bf16_bf16_compute_f32_mnn_instance(
+                                        op_ptrs);
+                                }
+                            }
+                        }
+
+                        return op_ptrs;
+                    }
+                };
+
+            } // namespace instance
+        } // namespace device
+    } // namespace tensor_operation
 } // namespace ck

--- a/projects/hiptensor/library/src/contraction/hiptensor_contraction.cpp
+++ b/projects/hiptensor/library/src/contraction/hiptensor_contraction.cpp
@@ -580,20 +580,6 @@ hiptensorStatus_t contractionInitPlan(const hiptensorHandle_t              handl
         return HIPTENSOR_STATUS_ARCH_MISMATCH;
     }
 
-    // TODO: before add support for unary operations in Actor-Critic selection algorithm, disable it here
-    if((desc->mOpA != HIPTENSOR_OP_IDENTITY || desc->mOpB != HIPTENSOR_OP_IDENTITY
-        || desc->mOpC != HIPTENSOR_OP_IDENTITY)
-       && pref->mSelectionAlgorithm == HIPTENSOR_ALGO_ACTOR_CRITIC)
-    {
-        auto errorCode = HIPTENSOR_STATUS_NOT_SUPPORTED;
-        snprintf(msg,
-                 sizeof(msg),
-                 "Actor-Critic selection algorithm does not support unary operations (%s)",
-                 hiptensorGetErrorString(errorCode));
-        logger->logError("contractionInitPlan", msg);
-        return errorCode;
-    }
-
     // At this point, we need to format inputs for kernels as they will be tested via selection model.
     // Brute force method currently uses CK kernel format, so we will adjust inputs to that style.
 
@@ -697,26 +683,48 @@ hiptensorStatus_t contractionInitPlan(const hiptensorHandle_t              handl
         }
         else if(pref->mSelectionAlgorithm == HIPTENSOR_ALGO_ACTOR_CRITIC)
         {
-            result = hiptensor::actorCriticModel(&winner,
-                                                 solutionQ.solutions(),
-                                                 ADataType,
-                                                 hiptensor::getTensorLengths(desc->mDescA),
-                                                 hiptensor::getTensorStrides(desc->mDescA),
-                                                 desc->mModeA,
-                                                 BDataType,
-                                                 hiptensor::getTensorLengths(desc->mDescB),
-                                                 hiptensor::getTensorStrides(desc->mDescB),
-                                                 desc->mModeB,
-                                                 DDataType,
-                                                 hiptensor::getTensorLengths(desc->mDescC),
-                                                 hiptensor::getTensorStrides(desc->mDescC),
-                                                 desc->mModeC,
-                                                 EDataType,
-                                                 hiptensor::getTensorLengths(desc->mDescD),
-                                                 hiptensor::getTensorStrides(desc->mDescD),
-                                                 desc->mModeC,
-                                                 desc->mDescCompute,
-                                                 workspaceSizeLimit);
+            if(hasUnaryOp)
+                result = hiptensor::actorCriticModelUnaryOps(&winner,
+                                                             solutionQ.solutions(),
+                                                             ADataType,
+                                                             hiptensor::getTensorLengths(desc->mDescA),
+                                                             hiptensor::getTensorStrides(desc->mDescA),
+                                                             desc->mModeA,
+                                                             BDataType,
+                                                             hiptensor::getTensorLengths(desc->mDescB),
+                                                             hiptensor::getTensorStrides(desc->mDescB),
+                                                             desc->mModeB,
+                                                             DDataType,
+                                                             hiptensor::getTensorLengths(desc->mDescC),
+                                                             hiptensor::getTensorStrides(desc->mDescC),
+                                                             desc->mModeC,
+                                                             EDataType,
+                                                             hiptensor::getTensorLengths(desc->mDescD),
+                                                             hiptensor::getTensorStrides(desc->mDescD),
+                                                             desc->mModeC,
+                                                             desc->mDescCompute,
+                                                             workspaceSizeLimit);
+            else
+                result = hiptensor::actorCriticModel(&winner,
+                                                     solutionQ.solutions(),
+                                                     ADataType,
+                                                     hiptensor::getTensorLengths(desc->mDescA),
+                                                     hiptensor::getTensorStrides(desc->mDescA),
+                                                     desc->mModeA,
+                                                     BDataType,
+                                                     hiptensor::getTensorLengths(desc->mDescB),
+                                                     hiptensor::getTensorStrides(desc->mDescB),
+                                                     desc->mModeB,
+                                                     DDataType,
+                                                     hiptensor::getTensorLengths(desc->mDescC),
+                                                     hiptensor::getTensorStrides(desc->mDescC),
+                                                     desc->mModeC,
+                                                     EDataType,
+                                                     hiptensor::getTensorLengths(desc->mDescD),
+                                                     hiptensor::getTensorStrides(desc->mDescD),
+                                                     desc->mModeC,
+                                                     desc->mDescCompute,
+                                                     workspaceSizeLimit);
         }
     }
 


### PR DESCRIPTION
## Motivation

Add IDs of newly added contraction instances with unary ops to Actor-Critic model and add new contraction instances with unary ops for f16-input-f16-compute and bf16-input-bf16-compute contractions

## Technical Details

1. Since Estevan has added f16-input-f16-compute and bf16-input-bf16-compute contraction instances (supported by gfx11 and gfx12 architectures) in CK,  add new contraction instances with unary ops for these two combinations in hipTensor as well.
2. Add IDs of newly added contraction instances with unary ops to Actor-Critic model. These IDs are best-performance instances selected from benchmark tests results on MI300X GPU and Navi4x GPU.

## Test Plan

run regular tests.

## Test Result

all tests are passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
