### PR TITLE
[hipBLASLt-provider][CI] Added hipBLASLt-provider to CI

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -42,17 +42,8 @@ project_map = {
         "projects_to_test": ["rocrand", "hiprand"],
     },
     "blas": {
-        "cmake_options": [
-            "-DTHEROCK_ENABLE_BLAS=ON",
-            "-DTHEROCK_ENABLE_HIPBLASLT_PLUGIN=ON",
-        ],
-        "projects_to_test": [
-            "hipblaslt",
-            "rocblas",
-            "hipblas",
-            "rocroller",
-            "hipblaslt_plugin",
-        ],
+        "cmake_options": ["-DTHEROCK_ENABLE_BLAS=ON"],
+        "projects_to_test": ["hipblaslt", "rocblas", "hipblas", "rocroller"],
     },
     "miopen": {
         "cmake_options": [

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -5,6 +5,7 @@ This dictionary is used to map specific file directory changes to the correspond
 import os
 
 subtree_to_project_map = {
+    "dnn-providers/hipblaslt-provider": "hipblaslt-provider",
     "dnn-providers/miopen-provider": "miopen-provider",
     "projects/hipblas": "blas",
     "projects/hipblas-common": "blas",
@@ -41,8 +42,17 @@ project_map = {
         "projects_to_test": ["rocrand", "hiprand"],
     },
     "blas": {
-        "cmake_options": ["-DTHEROCK_ENABLE_BLAS=ON"],
-        "projects_to_test": ["hipblaslt", "rocblas", "hipblas", "rocroller"],
+        "cmake_options": [
+            "-DTHEROCK_ENABLE_BLAS=ON",
+            "-DTHEROCK_ENABLE_HIPBLASLT_PLUGIN=ON",
+        ],
+        "projects_to_test": [
+            "hipblaslt",
+            "rocblas",
+            "hipblas",
+            "rocroller",
+            "hipblaslt_plugin",
+        ],
     },
     "miopen": {
         "cmake_options": [
@@ -82,6 +92,7 @@ additional_options = {
     # due to MIOpen plugin project being inside the hipDNN directory, we cannot have the MIOpen plugin project as a separate project for now https://github.com/ROCm/rocm-libraries/issues/2316
     "hipdnn": {
         "cmake_options": [
+            "-DTHEROCK_ENABLE_HIPBLASLT_PLUGIN=ON",
             "-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON",
             "-DTHEROCK_ENABLE_HIPDNN_SAMPLES=ON",
             "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
@@ -93,6 +104,7 @@ additional_options = {
             "hipdnn_install",
             "hipdnn-samples",
             "miopen_plugin",
+            "hipblaslt_plugin",
         ],
         "project_to_add": "miopen",
     },
@@ -105,6 +117,13 @@ additional_options = {
         ],
         "projects_to_test": ["miopen_plugin"],
         "project_to_add": "miopen",
+    },
+    "hipblaslt-provider": {
+        "cmake_options": [
+            "-DTHEROCK_ENABLE_HIPBLASLT_PLUGIN=ON",
+        ],
+        "projects_to_test": ["hipblaslt_plugin"],
+        "project_to_add": "blas",
     },
 }
 


### PR DESCRIPTION
## Motivation

Add TheRock CI pre-submit checks for hipBLASLt plugin in hipDNN.
Since the PR https://github.com/ROCm/TheRock/pull/3129 with integration of hipBLASLt-provider to TheRock is merged, we can add the plugin check in CI.

