### PR TITLE
Adding layout test for amdgcn_mma structs

### DIFF
--- a/projects/composablekernel/include/ck_tile/core/arch/mma/wmma/wmma_gfx12.hpp
+++ b/projects/composablekernel/include/ck_tile/core/arch/mma/wmma/wmma_gfx12.hpp
@@ -52,10 +52,10 @@ struct amdgcn_mma<fp16_t,
     static constexpr index_t kBNBlock    = 1;
     static constexpr index_t kAMLane     = 16;
     static constexpr index_t kBNLane     = 16;
-    static constexpr index_t kABKLane    = 8;
+    static constexpr index_t kABKLane    = 2;
     static constexpr index_t kABKPerLane = 8;
     static constexpr index_t kCMLane     = 2;
-    static constexpr index_t kCNLane     = 2;
+    static constexpr index_t kCNLane     = 16;
     static constexpr index_t kCM0PerLane = 4;
     static constexpr index_t kCM1PerLane = 1;
 

--- a/projects/composablekernel/include/ck_tile/core/arch/mma/wmma/wmma_gfx12.hpp
+++ b/projects/composablekernel/include/ck_tile/core/arch/mma/wmma/wmma_gfx12.hpp
@@ -52,10 +52,10 @@ struct amdgcn_mma<fp16_t,
     static constexpr index_t kBNBlock    = 1;
     static constexpr index_t kAMLane     = 16;
     static constexpr index_t kBNLane     = 16;
-    static constexpr index_t kABKLane    = 2;
+    static constexpr index_t kABKLane    = 8;
     static constexpr index_t kABKPerLane = 8;
     static constexpr index_t kCMLane     = 2;
-    static constexpr index_t kCNLane     = 16;
+    static constexpr index_t kCNLane     = 2;
     static constexpr index_t kCM0PerLane = 4;
     static constexpr index_t kCM1PerLane = 1;
 

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/CMakeLists.txt
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/CMakeLists.txt
@@ -13,3 +13,11 @@ if(GPU_TARGETS MATCHES "gfx9")
 else()
     message(DEBUG "Skipping ck_tile_gemm tests for current target")
 endif()
+
+if(GPU_TARGETS MATCHES "gfx9|gfx11|gfx12")
+    add_gtest_executable(test_amdgcn_mma_layout test_amdgcn_mma_layout.cpp)
+    target_compile_options(test_amdgcn_mma_layout PRIVATE ${EXAMPLE_GEMM_COMPILE_OPTIONS})
+else()
+    message(DEBUG "Skipping gfx9|gfx11|gfx12 mma layout validation tests for current target")
+endif()
+

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -1,0 +1,417 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <hip/hip_runtime.h>
+#include <gtest/gtest.h>
+
+#include "ck_tile/host/hip_check_error.hpp"
+#include "ck_tile/host/stream_config.hpp"
+#include "ck_tile/host/device_memory.hpp"
+#include "ck_tile/host/kernel_launch.hpp"
+#include "ck_tile/core/arch/arch.hpp"
+#include "ck_tile/core/utility/env.hpp"
+
+#include "test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+#include <cstddef>
+#include <string>
+
+namespace ck  = ck_tile;
+namespace mma = ck_tile::core::arch::mma;
+
+// MMA register layout validation test for amdgcn_mma structs.
+//
+// Strategy: for every (m, k, n) triple in the tile, the test constructs a pair of input tensors
+// A and B that contain exactly one non-zero element each, placed so that their product
+// contributes to a single output element C(m, n):
+//
+//         A  (M x K)                B  (K x N)              C = A * B  (M x N)
+//      . . . . . . . .           . . . . . . . .           . . . . . . . .
+//      . . . . . . . .           . . . . . . . .           . . . . . . . .
+//      . . . 1 . . . .           . . . . . . . .           . . . . . . . .
+//      . . . . . . . .           . . . 1 . . . .           . . . . . 1 . .
+//      . . . . . . . .           . . . . . . . .           . . . . . . . .
+//         A(m,k) = 1                B(k,n) = 1                C(m,n) = 1
+//
+// The kernel uses RegisterMap to scatter A and B into the correct (lane, vecIdx) positions
+// of the MMA fragment registers, executes the intrinsic, then uses RegisterMap again to
+// gather back into C matrix. The result is compared to a host-side reference GEMM.
+
+namespace {
+
+/**
+ * @class MmaLayoutTestKernel
+ * @brief Device kernel that performs C = AB using a given Mma op
+ *
+ * @tparam ADataType     Data type of tensor A elements
+ * @tparam BDataType     Data type of tensor B elements
+ * @tparam CDataType     Data type of accumulator / output C elements
+ * @tparam BlockM        M-dimension of the MMA tile
+ * @tparam BlockN        N-dimension of the MMA tile
+ * @tparam BlockK        K-dimension of the MMA tile
+ * @tparam LaneGroupSize WaveSize / LaneGroupsPerWave
+ * @tparam BlockSize     HIP block size
+ */
+template <typename ADataType,
+          typename BDataType,
+          typename CDataType,
+          uint32_t BlockM,
+          uint32_t BlockN,
+          uint32_t BlockK,
+          uint32_t LaneGroupSize,
+          uint32_t BlockSize>
+struct MmaLayoutTestKernel
+{
+    static constexpr int kBlockSize = BlockSize;
+
+    __device__ void operator()(ADataType* a, BDataType* b, CDataType* c) const
+    {
+        using Selector =
+            mma::MmaDefaultSelector<ADataType,
+                                    BDataType,
+                                    CDataType,
+                                    BlockM,
+                                    BlockN,
+                                    BlockK,
+                                    decltype(ck_tile::core::arch::get_compiler_target())>;
+        using MmaOp                   = typename Selector::SelectedOp;
+        using MmaTraits               = mma::MmaOpTraits<MmaOp>;
+        using AVecType                = typename MmaTraits::AVecType;
+        using BVecType                = typename MmaTraits::BVecType;
+        using CVecType                = typename MmaTraits::CVecType;
+        constexpr uint32_t a_vec_size = sizeof(AVecType) / sizeof(ADataType);
+        constexpr uint32_t b_vec_size = sizeof(BVecType) / sizeof(BDataType);
+        constexpr uint32_t c_vec_size = sizeof(CVecType) / sizeof(CDataType);
+
+        // LaneGroupSize doesnt equal WaveSize on RDNA3 due to matrix replication
+        const uint32_t lane = threadIdx.x % LaneGroupSize;
+
+        AVecType a_frag{};
+        BVecType b_frag{};
+        CVecType c_frag{};
+
+        constexpr uint32_t TileM = MmaTraits::BlockM;
+        constexpr uint32_t TileN = MmaTraits::BlockN;
+        constexpr uint32_t TileK = MmaTraits::BlockK;
+
+        for(uint32_t m = 0; m < TileM; ++m)
+        {
+            for(uint32_t k = 0; k < TileK; ++k)
+            {
+                auto pos = RegisterMap<MmaOp>::A2RegisterMap(m, k);
+                if(pos.lane == lane && pos.vecIdx < a_vec_size)
+                {
+                    a_frag[pos.vecIdx] = static_cast<ADataType>(a[m * TileK + k]);
+                }
+            }
+        }
+
+        for(uint32_t k = 0; k < TileK; ++k)
+        {
+            for(uint32_t n = 0; n < TileN; ++n)
+            {
+                auto pos = RegisterMap<MmaOp>::B2RegisterMap(k, n);
+                if(pos.lane == lane && pos.vecIdx < b_vec_size)
+                {
+                    b_frag[pos.vecIdx] = static_cast<BDataType>(b[k * TileN + n]);
+                }
+            }
+        }
+
+        c_frag = MmaOp::exec(a_frag, b_frag, c_frag);
+
+        for(uint32_t m = 0; m < TileM; ++m)
+        {
+            for(uint32_t n = 0; n < TileN; ++n)
+            {
+                auto pos = RegisterMap<MmaOp>::C2RegisterMap(m, n);
+                if(pos.lane == threadIdx.x && pos.vecIdx < c_vec_size)
+                {
+                    c[m * TileN + n] = static_cast<CDataType>(c_frag[pos.vecIdx]);
+                }
+            }
+        }
+    }
+};
+
+// host-side reference C=AB op
+template <typename MmaTraits>
+std::array<typename MmaTraits::CDataType, MmaTraits::BlockM * MmaTraits::BlockN>
+compute_reference_tensor(
+    const std::array<typename MmaTraits::ADataType, MmaTraits::BlockM * MmaTraits::BlockK>& a,
+    const std::array<typename MmaTraits::BDataType, MmaTraits::BlockK * MmaTraits::BlockN>& b)
+{
+    constexpr uint32_t TileM = MmaTraits::BlockM;
+    constexpr uint32_t TileN = MmaTraits::BlockN;
+    constexpr uint32_t TileK = MmaTraits::BlockK;
+
+    using AccType = typename MmaTraits::CDataType;
+    std::array<AccType, TileM * TileN> c{};
+
+    for(uint32_t row = 0; row < TileM; ++row)
+    {
+        for(uint32_t column = 0; column < TileN; ++column)
+        {
+            AccType accum = static_cast<AccType>(0);
+            for(uint32_t kk = 0; kk < TileK; ++kk)
+            {
+                accum += static_cast<AccType>(a[row * TileK + kk]) *
+                         static_cast<AccType>(b[kk * TileN + column]);
+            }
+            c[row * TileN + column] = accum;
+        }
+    }
+
+    return c;
+}
+
+struct CaseDim
+{
+    uint32_t m;
+    uint32_t k;
+    uint32_t n;
+};
+
+// debug helper
+template <typename Array>
+void print_tensor(const char* label, const Array& tensor, uint32_t rows, uint32_t columns)
+{
+    std::printf("%s\n", label);
+    for(uint32_t row = 0; row < rows; ++row)
+    {
+        std::printf("    row %2u:", row);
+        for(uint32_t column = 0; column < columns; ++column)
+        {
+            float value = static_cast<float>(tensor[row * columns + column]);
+            std::printf(" %7.3f", value);
+        }
+        std::printf("\n");
+    }
+}
+
+/**
+ * @class MmaLayoutTestConfig
+ * @brief Gathers compile-time parameters needed for one MMA layout test variant.
+ *
+ * @tparam Selector_          MmaDefaultSelector instantiation for the target
+ * @tparam CompilerTarget_    amdgcn_target describing the arch target
+ * @tparam LaneGroupsPerWave_ Number of lane groups per wave
+ */
+template <typename Selector_, typename CompilerTarget_, uint32_t LaneGroupsPerWave_>
+struct MmaLayoutTestConfig
+{
+    using Selector                     = Selector_;
+    using CompilerTarget               = CompilerTarget_;
+    static constexpr uint32_t WaveSize = static_cast<uint32_t>(CompilerTarget::WAVE_SIZE_ID);
+    static constexpr uint32_t LaneGroupsPerWave = LaneGroupsPerWave_;
+    static constexpr uint32_t LaneGroupSize     = WaveSize / LaneGroupsPerWave;
+};
+
+/**
+ * @brief Test driver: runs the test for a given MMA configuration.
+ *
+ * For every (m, k, n) in the tensor it:
+ *   1. Constructs A and B tensors with a single 1 at A(m,k) and B(k,n).
+ *   2. Launches MmaLayoutTestKernel which uses RegisterMap to load fragments, executes the
+ *      MMA intrinsic, and writes C back.
+ *   3. Computes a host-side reference C = AB.
+ *   4. Compares the reference and device C element-by-element.
+ *
+ * @tparam Config An MmaLayoutTestConfig instantiation
+ * @return true if the test ran on hardware; false if skipped (no matching device)
+ */
+template <typename Config>
+bool run_mma_layout_test_case()
+{
+    int device_count = 0;
+    hipDevice_t device{};
+    HIP_CHECK_ERROR(hipGetDevice(&device));
+    HIP_CHECK_ERROR(hipGetDeviceCount(&device_count));
+
+    hipDeviceProp_t props{};
+    HIP_CHECK_ERROR(hipGetDeviceProperties(&props, device));
+
+    const auto runtime_target =
+        ck_tile::core::arch::hip_device_prop_gcn_arch_name_to_amdgcn_target_id(props.gcnArchName);
+    const bool has_device = device_count > 0;
+
+    if(!has_device || runtime_target == ck_tile::core::arch::amdgcn_target_id::HOST ||
+       runtime_target != Config::CompilerTarget::TARGET_ID)
+        return false;
+
+    using Selector   = typename Config::Selector;
+    using MmaOp      = typename Selector::SelectedOp;
+    using MmaTraits  = mma::MmaOpTraits<MmaOp>;
+    using AInputType = typename MmaTraits::ADataType;
+    using BInputType = typename MmaTraits::BDataType;
+    using AccType    = typename MmaTraits::CDataType;
+
+    static_assert(MmaTraits::IsSupported, "Mma layout test requires supported register mappings");
+
+    ck_tile::DeviceMem d_a(MmaTraits::BlockM * MmaTraits::BlockK * sizeof(AInputType));
+    ck_tile::DeviceMem d_b(MmaTraits::BlockK * MmaTraits::BlockN * sizeof(BInputType));
+    ck_tile::DeviceMem d_c(MmaTraits::BlockM * MmaTraits::BlockN * sizeof(AccType));
+    std::array<AInputType, MmaTraits::BlockM * MmaTraits::BlockK> h_a;
+    std::array<BInputType, MmaTraits::BlockK * MmaTraits::BlockN> h_b;
+    std::array<AccType, MmaTraits::BlockM * MmaTraits::BlockN> h_c;
+    std::array<AccType, MmaTraits::BlockM * MmaTraits::BlockN> h_c_result;
+
+    auto* d_a_ptr = static_cast<AInputType*>(d_a.GetDeviceBuffer());
+    auto* d_b_ptr = static_cast<BInputType*>(d_b.GetDeviceBuffer());
+    auto* d_c_ptr = static_cast<AccType*>(d_c.GetDeviceBuffer());
+
+    // test all possible (m, k, n) positions within the tile
+    // e.g. for a 16x16x16 tile this is 4096 test cases
+    std::vector<CaseDim> cases;
+    cases.reserve(MmaTraits::BlockM * MmaTraits::BlockK * MmaTraits::BlockN);
+    for(uint32_t m = 0; m < MmaTraits::BlockM; ++m)
+    {
+        for(uint32_t k = 0; k < MmaTraits::BlockK; ++k)
+        {
+            for(uint32_t n = 0; n < MmaTraits::BlockN; ++n)
+            {
+                cases.push_back({m, k, n});
+            }
+        }
+    }
+
+    for(auto const& test_case : cases)
+    {
+        std::fill(h_a.begin(), h_a.end(), static_cast<AInputType>(0));
+        std::fill(h_b.begin(), h_b.end(), static_cast<BInputType>(0));
+        std::fill(h_c.begin(), h_c.end(), static_cast<AccType>(0));
+
+        // place a single 1 in A(m,k) and B(k,n)
+        h_a[test_case.m * MmaTraits::BlockK + test_case.k] = static_cast<AInputType>(1);
+        h_b[test_case.k * MmaTraits::BlockN + test_case.n] = static_cast<BInputType>(1);
+
+        HIP_CHECK_ERROR(hipMemcpyAsync(
+            d_a_ptr, h_a.data(), h_a.size() * sizeof(AInputType), hipMemcpyHostToDevice));
+        HIP_CHECK_ERROR(hipMemcpyAsync(
+            d_b_ptr, h_b.data(), h_b.size() * sizeof(BInputType), hipMemcpyHostToDevice));
+        HIP_CHECK_ERROR(hipMemcpyAsync(
+            d_c_ptr, h_c.data(), h_c.size() * sizeof(AccType), hipMemcpyHostToDevice));
+
+        using Kernel = MmaLayoutTestKernel<typename MmaTraits::ADataType,
+                                           typename MmaTraits::BDataType,
+                                           typename MmaTraits::CDataType,
+                                           MmaTraits::BlockM,
+                                           MmaTraits::BlockN,
+                                           MmaTraits::BlockK,
+                                           Config::LaneGroupSize,
+                                           Config::WaveSize>;
+
+        (void)hipGetLastError();
+
+        (void)ck_tile::launch_kernel(
+            ck_tile::stream_config{nullptr, false, 0, 0, 1},
+            ck_tile::make_kernel(
+                Kernel{}, dim3(1), dim3(Config::WaveSize), 0, d_a_ptr, d_b_ptr, d_c_ptr));
+
+        HIP_CHECK_ERROR(
+            hipMemcpyAsync(h_c_result.data(), d_c_ptr, d_c.GetBufferSize(), hipMemcpyDeviceToHost));
+        HIP_CHECK_ERROR(hipStreamSynchronize(nullptr));
+
+        const auto h_c_reference = compute_reference_tensor<MmaTraits>(h_a, h_b);
+
+        if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
+        {
+            std::printf("MMA tensors for m=%u k=%u n=%u\n", test_case.m, test_case.k, test_case.n);
+            print_tensor("  Host tensor C", h_c_reference, MmaTraits::BlockM, MmaTraits::BlockN);
+            print_tensor("  Device tensor C", h_c_result, MmaTraits::BlockM, MmaTraits::BlockN);
+        }
+
+        // check if the 1 that was placed A(m,k) and B(k,n) found its way to C(m,n) in the device
+        // tensor
+        const AccType tol = 1.0e-1f; // TODO: this tolerance might not be suitable for all data
+                                     // types and should be revisited if we add more configurations
+        for(uint32_t m = 0; m < MmaTraits::BlockM; ++m)
+        {
+            for(uint32_t n = 0; n < MmaTraits::BlockN; ++n)
+            {
+                EXPECT_NEAR(h_c_result[m * MmaTraits::BlockN + n],
+                            h_c_reference[m * MmaTraits::BlockN + n],
+                            tol)
+                    << "Mismatch at C(" << m << "," << n << ")";
+            }
+        }
+    }
+
+    return true;
+}
+
+} // namespace
+
+// ==================== Test configurations per target ====================
+// TODO: currently we have only 1 specific target per test. This should be revisited to enable all
+// the targets within the family (gfx12, gfx11, gfx9)
+using MmaGfx1201CompilerTarget = decltype(ck_tile::core::arch::make_amdgcn_gfx12_target<
+                                          ck_tile::core::arch::amdgcn_target_id::GFX1201>());
+using MmaGfx90aCompilerTarget  = decltype(ck_tile::core::arch::make_amdgcn_gfx9_target<
+                                          ck_tile::core::arch::amdgcn_target_id::GFX90A>());
+using MmaGfx1100CompilerTarget = decltype(ck_tile::core::arch::make_amdgcn_gfx11_target<
+                                          ck_tile::core::arch::amdgcn_target_id::GFX1100>());
+
+using MmaGfx1201Selector = mma::
+    MmaDefaultSelector<ck::fp16_t, ck::fp16_t, ck::fp32_t, 16u, 16u, 16u, MmaGfx1201CompilerTarget>;
+using MmaGfx90aSelector = mma::
+    MmaDefaultSelector<ck::fp16_t, ck::fp16_t, ck::fp32_t, 16u, 16u, 16u, MmaGfx90aCompilerTarget>;
+using MmaGfx1100Selector = mma::
+    MmaDefaultSelector<ck::fp16_t, ck::fp16_t, ck::fp32_t, 16u, 16u, 16u, MmaGfx1100CompilerTarget>;
+
+struct MmaGfx12Config : MmaLayoutTestConfig<MmaGfx1201Selector,
+                                            MmaGfx1201CompilerTarget,
+                                            1u> // LaneGroupsPerWave
+{
+};
+
+struct MmaGfx9Config : MmaLayoutTestConfig<MmaGfx90aSelector,
+                                           MmaGfx90aCompilerTarget,
+                                           1u> // LaneGroupsPerWave
+{
+};
+
+struct MmaGfx11Config : MmaLayoutTestConfig<MmaGfx1100Selector,
+                                            MmaGfx1100CompilerTarget,
+                                            2u> // LaneGroupsPerWave
+{
+};
+// ========================================================================
+
+TEST(TestMmaLayout, Mma_16x16x16_F16_F16_F32_GFX9)
+{
+    bool executed = run_mma_layout_test_case<MmaGfx9Config>();
+
+    if(!executed)
+    {
+        GTEST_SKIP() << "No gfx90a HIP device found. Skipping test.";
+    }
+}
+
+TEST(TestMmaLayout, Mma_16x16x16_F16_F16_F32_GFX11)
+{
+    bool executed = run_mma_layout_test_case<MmaGfx11Config>();
+
+    if(!executed)
+    {
+        GTEST_SKIP() << "No gfx1100 HIP device found. Skipping test.";
+    }
+}
+
+TEST(TestMmaLayout, Mma_16x16x16_F16_F16_F32_GFX12)
+{
+    bool executed = run_mma_layout_test_case<MmaGfx12Config>();
+
+    if(!executed)
+    {
+        GTEST_SKIP() << "No gfx1201 HIP device found. Skipping test.";
+    }
+}
+

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <cstddef>
 #include <string>
+#include <tuple>
 
 namespace ck  = ck_tile;
 namespace mma = ck_tile::core::arch::mma;
@@ -158,13 +159,6 @@ struct MmaLayoutTestKernel
     }
 };
 
-struct CaseDim
-{
-    uint32_t m;
-    uint32_t k;
-    uint32_t n;
-};
-
 // debug helper
 template <typename Array>
 void print_tensor(const char* label, const Array& tensor, uint32_t rows, uint32_t columns)
@@ -226,9 +220,10 @@ bool run_mma_layout_test_case()
         ck_tile::core::arch::hip_device_prop_gcn_arch_name_to_amdgcn_target_id(props.gcnArchName);
     const bool has_device = device_count > 0;
 
-    if(!has_device || runtime_target == ck_tile::core::arch::amdgcn_target_id::HOST ||
-       runtime_target != Config::CompilerTarget::TARGET_ID)
+    if(!has_device || runtime_target == ck_tile::core::arch::amdgcn_target_id::HOST || runtime_target != Config::CompilerTarget::TARGET_ID)
+    {
         return false;
+    }
 
     using Selector   = typename Config::Selector;
     using MmaOp      = typename Selector::SelectedOp;
@@ -252,9 +247,9 @@ bool run_mma_layout_test_case()
                                        Config::LaneGroupSize,
                                        Config::WaveSize>;
 
-    (void)hipGetLastError();
+    std::ignore = hipGetLastError();
 
-    (void)ck_tile::launch_kernel(
+    std::ignore = ck_tile::launch_kernel(
         ck_tile::stream_config{nullptr, false, 0, 0, 1},
         ck_tile::make_kernel(
             Kernel{}, dim3(total_cases), dim3(Config::WaveSize), 0, d_error_ptr));

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -141,37 +141,6 @@ struct MmaLayoutTestKernel
     }
 };
 
-// host-side reference C=AB op
-template <typename MmaTraits>
-std::array<typename MmaTraits::CDataType, MmaTraits::BlockM * MmaTraits::BlockN>
-compute_reference_tensor(
-    const std::array<typename MmaTraits::ADataType, MmaTraits::BlockM * MmaTraits::BlockK>& a,
-    const std::array<typename MmaTraits::BDataType, MmaTraits::BlockK * MmaTraits::BlockN>& b)
-{
-    constexpr uint32_t TileM = MmaTraits::BlockM;
-    constexpr uint32_t TileN = MmaTraits::BlockN;
-    constexpr uint32_t TileK = MmaTraits::BlockK;
-
-    using AccType = typename MmaTraits::CDataType;
-    std::array<AccType, TileM * TileN> c{};
-
-    for(uint32_t row = 0; row < TileM; ++row)
-    {
-        for(uint32_t column = 0; column < TileN; ++column)
-        {
-            AccType accum = static_cast<AccType>(0);
-            for(uint32_t kk = 0; kk < TileK; ++kk)
-            {
-                accum += static_cast<AccType>(a[row * TileK + kk]) *
-                         static_cast<AccType>(b[kk * TileN + column]);
-            }
-            c[row * TileN + column] = accum;
-        }
-    }
-
-    return c;
-}
-
 struct CaseDim
 {
     uint32_t m;
@@ -319,12 +288,9 @@ bool run_mma_layout_test_case()
             hipMemcpyAsync(h_c_result.data(), d_c_ptr, d_c.GetBufferSize(), hipMemcpyDeviceToHost));
         HIP_CHECK_ERROR(hipStreamSynchronize(nullptr));
 
-        const auto h_c_reference = compute_reference_tensor<MmaTraits>(h_a, h_b);
-
         if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
         {
             std::printf("MMA tensors for m=%u k=%u n=%u\n", test_case.m, test_case.k, test_case.n);
-            print_tensor("  Host tensor C", h_c_reference, MmaTraits::BlockM, MmaTraits::BlockN);
             print_tensor("  Device tensor C", h_c_result, MmaTraits::BlockM, MmaTraits::BlockN);
         }
 
@@ -336,9 +302,10 @@ bool run_mma_layout_test_case()
         {
             for(uint32_t n = 0; n < MmaTraits::BlockN; ++n)
             {
-                EXPECT_NEAR(h_c_result[m * MmaTraits::BlockN + n],
-                            h_c_reference[m * MmaTraits::BlockN + n],
-                            tol)
+                const AccType expected = (m == test_case.m && n == test_case.n)
+                                             ? static_cast<AccType>(1)
+                                             : static_cast<AccType>(0);
+                EXPECT_NEAR(h_c_result[m * MmaTraits::BlockN + n], expected, tol)
                     << "Mismatch at C(" << m << "," << n << ")";
             }
         }

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -42,7 +42,7 @@ namespace mma = ck_tile::core::arch::mma;
 //
 // The kernel uses RegisterMap to scatter A and B into the correct (lane, vecIdx) positions
 // of the MMA fragment registers, executes the intrinsic, then uses RegisterMap again to
-// gather back into C matrix. The result is compared to a host-side reference GEMM.
+// gather back into C matrix. The position of "1" in C is checked against the expected (m, n) location.
 
 namespace {
 
@@ -71,7 +71,7 @@ struct MmaLayoutTestKernel
 {
     static constexpr int kBlockSize = BlockSize;
 
-    __device__ void operator()(ADataType* a, BDataType* b, CDataType* c) const
+    __device__ void operator()(uint32_t* error_flags) const
     {
         using Selector =
             mma::MmaDefaultSelector<ADataType,
@@ -101,42 +101,59 @@ struct MmaLayoutTestKernel
         constexpr uint32_t TileN = MmaTraits::BlockN;
         constexpr uint32_t TileK = MmaTraits::BlockK;
 
-        for(uint32_t m = 0; m < TileM; ++m)
+        // get (m, k, n), where "1" should be placed for this block 
+        const uint32_t case_idx = static_cast<uint32_t>(blockIdx.x);
+        const uint32_t m = case_idx / (TileK * TileN);
+        const uint32_t k = (case_idx / TileN) % TileK;
+        const uint32_t n = case_idx % TileN;
+
+        // place a single "1" in A/B fragments
+        auto a_pos = RegisterMap<MmaOp>::A2RegisterMap(m, k);
+        if(a_pos.lane == lane && a_pos.vecIdx < a_vec_size)
         {
-            for(uint32_t k = 0; k < TileK; ++k)
-            {
-                auto pos = RegisterMap<MmaOp>::A2RegisterMap(m, k);
-                if(pos.lane == lane && pos.vecIdx < a_vec_size)
-                {
-                    a_frag[pos.vecIdx] = static_cast<ADataType>(a[m * TileK + k]);
-                }
-            }
+            a_frag[a_pos.vecIdx] = static_cast<ADataType>(1);
         }
 
-        for(uint32_t k = 0; k < TileK; ++k)
+        auto b_pos = RegisterMap<MmaOp>::B2RegisterMap(k, n);
+        if(b_pos.lane == lane && b_pos.vecIdx < b_vec_size)
         {
-            for(uint32_t n = 0; n < TileN; ++n)
-            {
-                auto pos = RegisterMap<MmaOp>::B2RegisterMap(k, n);
-                if(pos.lane == lane && pos.vecIdx < b_vec_size)
-                {
-                    b_frag[pos.vecIdx] = static_cast<BDataType>(b[k * TileN + n]);
-                }
-            }
+            b_frag[b_pos.vecIdx] = static_cast<BDataType>(1);
         }
 
         c_frag = MmaOp::exec(a_frag, b_frag, c_frag);
+        __syncthreads();
 
-        for(uint32_t m = 0; m < TileM; ++m)
+        __shared__ uint32_t err;
+        if(threadIdx.x == 0)
         {
-            for(uint32_t n = 0; n < TileN; ++n)
+            err = 0;
+        }
+        __syncthreads();
+
+        const CDataType tol = static_cast<CDataType>(1.0e-1f); // TODO: this tolerance might not be suitable for all data types and should be revisited if we add more configurations
+        for(uint32_t i = 0; i < TileM; ++i)
+        {
+            for(uint32_t j = 0; j < TileN; ++j)
             {
-                auto pos = RegisterMap<MmaOp>::C2RegisterMap(m, n);
+                auto pos = RegisterMap<MmaOp>::C2RegisterMap(i, j);
                 if(pos.lane == threadIdx.x && pos.vecIdx < c_vec_size)
                 {
-                    c[m * TileN + n] = static_cast<CDataType>(c_frag[pos.vecIdx]);
+                    const CDataType expected = (i == m && j == n)
+                                                   ? static_cast<CDataType>(1)
+                                                   : static_cast<CDataType>(0);
+                    const CDataType value = static_cast<CDataType>(c_frag[pos.vecIdx]);
+                    if(fabsf(static_cast<float>(value - expected)) > static_cast<float>(tol))
+                    {
+                        atomicExch(&err, 1);
+                    }
                 }
             }
+        }
+
+        __syncthreads();
+        if(threadIdx.x == 0)
+        {
+            error_flags[case_idx] = err;
         }
     }
 };
@@ -186,12 +203,10 @@ struct MmaLayoutTestConfig
 /**
  * @brief Test driver: runs the test for a given MMA configuration.
  *
- * For every (m, k, n) in the tensor it:
+ * The testlaunches (mkn) test cases (one per block) to check all possible positions of the "1" in the A/B tensors.
  *   1. Constructs A and B tensors with a single 1 at A(m,k) and B(k,n).
- *   2. Launches MmaLayoutTestKernel which uses RegisterMap to load fragments, executes the
- *      MMA intrinsic, and writes C back.
- *   3. Computes a host-side reference C = AB.
- *   4. Compares the reference and device C element-by-element.
+ *   2. Executes MMA intrinsic to compute C tensor.
+ *   3. Checks if C has the 1 in the expected position.
  *
  * @tparam Config An MmaLayoutTestConfig instantiation
  * @return true if the test ran on hardware; false if skipped (no matching device)
@@ -218,97 +233,44 @@ bool run_mma_layout_test_case()
     using Selector   = typename Config::Selector;
     using MmaOp      = typename Selector::SelectedOp;
     using MmaTraits  = mma::MmaOpTraits<MmaOp>;
-    using AInputType = typename MmaTraits::ADataType;
-    using BInputType = typename MmaTraits::BDataType;
-    using AccType    = typename MmaTraits::CDataType;
 
     static_assert(MmaTraits::IsSupported, "Mma layout test requires supported register mappings");
 
-    ck_tile::DeviceMem d_a(MmaTraits::BlockM * MmaTraits::BlockK * sizeof(AInputType));
-    ck_tile::DeviceMem d_b(MmaTraits::BlockK * MmaTraits::BlockN * sizeof(BInputType));
-    ck_tile::DeviceMem d_c(MmaTraits::BlockM * MmaTraits::BlockN * sizeof(AccType));
-    std::array<AInputType, MmaTraits::BlockM * MmaTraits::BlockK> h_a;
-    std::array<BInputType, MmaTraits::BlockK * MmaTraits::BlockN> h_b;
-    std::array<AccType, MmaTraits::BlockM * MmaTraits::BlockN> h_c;
-    std::array<AccType, MmaTraits::BlockM * MmaTraits::BlockN> h_c_result;
+    constexpr uint32_t total_cases =
+        MmaTraits::BlockM * MmaTraits::BlockK * MmaTraits::BlockN;
+    ck_tile::DeviceMem d_errors(total_cases * sizeof(uint32_t));
+    std::vector<uint32_t> h_errors(total_cases, 0u);
 
-    auto* d_a_ptr = static_cast<AInputType*>(d_a.GetDeviceBuffer());
-    auto* d_b_ptr = static_cast<BInputType*>(d_b.GetDeviceBuffer());
-    auto* d_c_ptr = static_cast<AccType*>(d_c.GetDeviceBuffer());
+    auto* d_error_ptr = static_cast<uint32_t*>(d_errors.GetDeviceBuffer());
 
-    // test all possible (m, k, n) positions within the tile
-    // e.g. for a 16x16x16 tile this is 4096 test cases
-    std::vector<CaseDim> cases;
-    cases.reserve(MmaTraits::BlockM * MmaTraits::BlockK * MmaTraits::BlockN);
-    for(uint32_t m = 0; m < MmaTraits::BlockM; ++m)
+    using Kernel = MmaLayoutTestKernel<typename MmaTraits::ADataType,
+                                       typename MmaTraits::BDataType,
+                                       typename MmaTraits::CDataType,
+                                       MmaTraits::BlockM,
+                                       MmaTraits::BlockN,
+                                       MmaTraits::BlockK,
+                                       Config::LaneGroupSize,
+                                       Config::WaveSize>;
+
+    (void)hipGetLastError();
+
+    (void)ck_tile::launch_kernel(
+        ck_tile::stream_config{nullptr, false, 0, 0, 1},
+        ck_tile::make_kernel(
+            Kernel{}, dim3(total_cases), dim3(Config::WaveSize), 0, d_error_ptr));
+
+    HIP_CHECK_ERROR(
+        hipMemcpyAsync(h_errors.data(), d_error_ptr, d_errors.GetBufferSize(), hipMemcpyDeviceToHost));
+    HIP_CHECK_ERROR(hipStreamSynchronize(nullptr));
+
+    for(uint32_t case_idx = 0; case_idx < total_cases; ++case_idx)
     {
-        for(uint32_t k = 0; k < MmaTraits::BlockK; ++k)
-        {
-            for(uint32_t n = 0; n < MmaTraits::BlockN; ++n)
-            {
-                cases.push_back({m, k, n});
-            }
-        }
-    }
+        const uint32_t m = case_idx / (MmaTraits::BlockK * MmaTraits::BlockN);
+        const uint32_t k = (case_idx / MmaTraits::BlockN) % MmaTraits::BlockK;
+        const uint32_t n = case_idx % MmaTraits::BlockN;
 
-    for(auto const& test_case : cases)
-    {
-        std::fill(h_a.begin(), h_a.end(), static_cast<AInputType>(0));
-        std::fill(h_b.begin(), h_b.end(), static_cast<BInputType>(0));
-        std::fill(h_c.begin(), h_c.end(), static_cast<AccType>(0));
-
-        // place a single 1 in A(m,k) and B(k,n)
-        h_a[test_case.m * MmaTraits::BlockK + test_case.k] = static_cast<AInputType>(1);
-        h_b[test_case.k * MmaTraits::BlockN + test_case.n] = static_cast<BInputType>(1);
-
-        HIP_CHECK_ERROR(hipMemcpyAsync(
-            d_a_ptr, h_a.data(), h_a.size() * sizeof(AInputType), hipMemcpyHostToDevice));
-        HIP_CHECK_ERROR(hipMemcpyAsync(
-            d_b_ptr, h_b.data(), h_b.size() * sizeof(BInputType), hipMemcpyHostToDevice));
-        HIP_CHECK_ERROR(hipMemcpyAsync(
-            d_c_ptr, h_c.data(), h_c.size() * sizeof(AccType), hipMemcpyHostToDevice));
-
-        using Kernel = MmaLayoutTestKernel<typename MmaTraits::ADataType,
-                                           typename MmaTraits::BDataType,
-                                           typename MmaTraits::CDataType,
-                                           MmaTraits::BlockM,
-                                           MmaTraits::BlockN,
-                                           MmaTraits::BlockK,
-                                           Config::LaneGroupSize,
-                                           Config::WaveSize>;
-
-        (void)hipGetLastError();
-
-        (void)ck_tile::launch_kernel(
-            ck_tile::stream_config{nullptr, false, 0, 0, 1},
-            ck_tile::make_kernel(
-                Kernel{}, dim3(1), dim3(Config::WaveSize), 0, d_a_ptr, d_b_ptr, d_c_ptr));
-
-        HIP_CHECK_ERROR(
-            hipMemcpyAsync(h_c_result.data(), d_c_ptr, d_c.GetBufferSize(), hipMemcpyDeviceToHost));
-        HIP_CHECK_ERROR(hipStreamSynchronize(nullptr));
-
-        if(ck_tile::EnvIsEnabled(CK_TILE_ENV(CK_TILE_LOGGING)))
-        {
-            std::printf("MMA tensors for m=%u k=%u n=%u\n", test_case.m, test_case.k, test_case.n);
-            print_tensor("  Device tensor C", h_c_result, MmaTraits::BlockM, MmaTraits::BlockN);
-        }
-
-        // check if the 1 that was placed A(m,k) and B(k,n) found its way to C(m,n) in the device
-        // tensor
-        const AccType tol = 1.0e-1f; // TODO: this tolerance might not be suitable for all data
-                                     // types and should be revisited if we add more configurations
-        for(uint32_t m = 0; m < MmaTraits::BlockM; ++m)
-        {
-            for(uint32_t n = 0; n < MmaTraits::BlockN; ++n)
-            {
-                const AccType expected = (m == test_case.m && n == test_case.n)
-                                             ? static_cast<AccType>(1)
-                                             : static_cast<AccType>(0);
-                EXPECT_NEAR(h_c_result[m * MmaTraits::BlockN + n], expected, tol)
-                    << "Mismatch at C(" << m << "," << n << ")";
-            }
-        }
+        EXPECT_EQ(h_errors[case_idx], 0u)
+            << "Mismatch for m=" << m << " k=" << k << " n=" << n;
     }
 
     return true;

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -86,9 +86,9 @@ struct MmaLayoutTestKernel
         using AVecType                = typename MmaTraits::AVecType;
         using BVecType                = typename MmaTraits::BVecType;
         using CVecType                = typename MmaTraits::CVecType;
-        constexpr uint32_t a_vec_size = sizeof(AVecType) / sizeof(ADataType);
-        constexpr uint32_t b_vec_size = sizeof(BVecType) / sizeof(BDataType);
-        constexpr uint32_t c_vec_size = sizeof(CVecType) / sizeof(CDataType);
+        constexpr uint32_t a_vec_size = vector_traits<AVecType>::vector_size;
+        constexpr uint32_t b_vec_size = vector_traits<BVecType>::vector_size;
+        constexpr uint32_t c_vec_size = vector_traits<CVecType>::vector_size;
 
         const uint32_t lane = threadIdx.x;
 
@@ -278,4 +278,3 @@ TYPED_TEST(TestMmaLayout, Mma_16x16x16_F16_F16_F32)
         GTEST_SKIP() << "No supported HIP device found. Skipping test.";
     }
 }
-

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -123,15 +123,8 @@ struct MmaLayoutTestKernel
         }
 
         c_frag = MmaOp::exec(a_frag, b_frag, c_frag);
-        __syncthreads();
 
-        __shared__ uint32_t err;
-        if(threadIdx.x == 0)
-        {
-            err = 0;
-        }
-        __syncthreads();
-
+        uint32_t err = 0;
         const CDataType tol = static_cast<CDataType>(1.0e-1f); // TODO: this tolerance might not be suitable for all data types and should be revisited if we add more configurations
         for(uint32_t v = 0; v < c_vec_size; ++v)
         {
@@ -145,14 +138,14 @@ struct MmaLayoutTestKernel
             const CDataType value = static_cast<CDataType>(c_frag[v]);
             if(fabsf(static_cast<float>(value - expected)) > static_cast<float>(tol))
             {
-                atomicExch(&err, 1);
+                err = 1;
             }
         }
 
-        __syncthreads();
+        const uint32_t any_err = __any(err);
         if(threadIdx.x == 0)
         {
-            error_flags[case_idx] = err;
+            error_flags[case_idx] = any_err;
         }
     }
 };

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -53,7 +53,7 @@ namespace {
  *
  * @tparam ADataType     Data type of tensor A elements
  * @tparam BDataType     Data type of tensor B elements
- * @tparam CDataType     Data type of accumulator / output C elements
+ * @tparam CDataType     Data type of tensor C elements
  * @tparam BlockM        M-dimension of the MMA tile
  * @tparam BlockN        N-dimension of the MMA tile
  * @tparam BlockK        K-dimension of the MMA tile
@@ -150,38 +150,6 @@ struct MmaLayoutTestKernel
     }
 };
 
-// debug helper
-template <typename Array>
-void print_tensor(const char* label, const Array& tensor, uint32_t rows, uint32_t columns)
-{
-    std::printf("%s\n", label);
-    for(uint32_t row = 0; row < rows; ++row)
-    {
-        std::printf("    row %2u:", row);
-        for(uint32_t column = 0; column < columns; ++column)
-        {
-            float value = static_cast<float>(tensor[row * columns + column]);
-            std::printf(" %7.3f", value);
-        }
-        std::printf("\n");
-    }
-}
-
-/**
- * @class MmaLayoutTestConfig
- * @brief Gathers compile-time parameters needed for one MMA layout test variant.
- *
- * @tparam Selector_          MmaDefaultSelector instantiation for the target
- * @tparam CompilerTarget_    amdgcn_target describing the arch target
- */
-template <typename Selector_, typename CompilerTarget_>
-struct MmaLayoutTestConfig
-{
-    using Selector                     = Selector_;
-    using CompilerTarget               = CompilerTarget_;
-    static constexpr uint32_t WaveSize = static_cast<uint32_t>(CompilerTarget::WAVE_SIZE_ID);
-};
-
 /**
  * @brief Test driver: runs the test for a given MMA configuration.
  *
@@ -190,12 +158,23 @@ struct MmaLayoutTestConfig
  *   2. Executes MMA intrinsic to compute C tensor.
  *   3. Checks if C has the 1 in the expected position.
  *
- * @tparam Config An MmaLayoutTestConfig instantiation
- * @return true if the test ran on hardware; false if skipped (no matching device)
+ * @tparam Selector  Selector for the Mma operation
+ * @return true if the test ran on hardware; false if skipped (no device or unsupported)
  */
-template <typename Config>
-bool run_mma_layout_test_case()
+template <typename Selector>
+bool run_mma_layout_test()
 {
+    using MmaOp               = typename Selector::SelectedOp;
+    using MmaTraits           = mma::MmaOpTraits<MmaOp>;
+    using ADataType           = typename MmaTraits::ADataType;
+    using BDataType           = typename MmaTraits::BDataType;
+    using CDataType           = typename MmaTraits::CDataType;
+    constexpr uint32_t BlockM = MmaTraits::BlockM;
+    constexpr uint32_t BlockN = MmaTraits::BlockN;
+    constexpr uint32_t BlockK = MmaTraits::BlockK;
+    constexpr auto selector_target_id = MmaTraits::CompilerTarget::TARGET_ID;
+    constexpr auto selector_wave_size = MmaTraits::CompilerTarget::WAVE_SIZE_ID;
+
     int device_count = 0;
     hipDevice_t device{};
     HIP_CHECK_ERROR(hipGetDevice(&device));
@@ -208,38 +187,27 @@ bool run_mma_layout_test_case()
         ck_tile::core::arch::hip_device_prop_gcn_arch_name_to_amdgcn_target_id(props.gcnArchName);
     const bool has_device = device_count > 0;
 
-    if(!has_device || runtime_target == ck_tile::core::arch::amdgcn_target_id::HOST || runtime_target != Config::CompilerTarget::TARGET_ID)
+    if(!has_device || runtime_target == ck_tile::core::arch::amdgcn_target_id::HOST ||
+       runtime_target != selector_target_id || props.warpSize != static_cast<int>(selector_wave_size))
     {
         return false;
     }
 
-    using Selector   = typename Config::Selector;
-    using MmaOp      = typename Selector::SelectedOp;
-    using MmaTraits  = mma::MmaOpTraits<MmaOp>;
-
-    static_assert(MmaTraits::IsSupported, "Mma layout test requires supported register mappings");
-
-    constexpr uint32_t total_cases =
-        MmaTraits::BlockM * MmaTraits::BlockK * MmaTraits::BlockN;
+    constexpr uint32_t total_cases = BlockM * BlockK * BlockN;
     ck_tile::DeviceMem d_errors(total_cases * sizeof(uint32_t));
     std::vector<uint32_t> h_errors(total_cases, 0u);
 
     auto* d_error_ptr = static_cast<uint32_t*>(d_errors.GetDeviceBuffer());
 
-    using Kernel = MmaLayoutTestKernel<typename MmaTraits::ADataType,
-                                       typename MmaTraits::BDataType,
-                                       typename MmaTraits::CDataType,
-                                       MmaTraits::BlockM,
-                                       MmaTraits::BlockN,
-                                       MmaTraits::BlockK,
-                                       Config::WaveSize>;
-
     std::ignore = hipGetLastError();
+
+
+    using Kernel = MmaLayoutTestKernel<ADataType, BDataType, CDataType,
+                                    BlockM, BlockN, BlockK, static_cast<int>(selector_wave_size)>;
 
     std::ignore = ck_tile::launch_kernel(
         ck_tile::stream_config{nullptr, false, 0, 0, 1},
-        ck_tile::make_kernel(
-            Kernel{}, dim3(total_cases), dim3(Config::WaveSize), 0, d_error_ptr));
+        ck_tile::make_kernel(Kernel{}, dim3(total_cases), dim3(static_cast<int>(selector_wave_size)), 0, d_error_ptr));
 
     HIP_CHECK_ERROR(
         hipMemcpyAsync(h_errors.data(), d_error_ptr, d_errors.GetBufferSize(), hipMemcpyDeviceToHost));
@@ -247,9 +215,9 @@ bool run_mma_layout_test_case()
 
     for(uint32_t case_idx = 0; case_idx < total_cases; ++case_idx)
     {
-        const uint32_t m = case_idx / (MmaTraits::BlockK * MmaTraits::BlockN);
-        const uint32_t k = (case_idx / MmaTraits::BlockN) % MmaTraits::BlockK;
-        const uint32_t n = case_idx % MmaTraits::BlockN;
+        const uint32_t m = case_idx / (BlockK * BlockN);
+        const uint32_t k = (case_idx / BlockN) % BlockK;
+        const uint32_t n = case_idx % BlockN;
 
         EXPECT_EQ(h_errors[case_idx], 0u)
             << "Mismatch for m=" << m << " k=" << k << " n=" << n;
@@ -277,49 +245,28 @@ using MmaGfx90aSelector = mma::
 using MmaGfx1100Selector = mma::
     MmaDefaultSelector<ck::fp16_t, ck::fp16_t, ck::fp32_t, 16u, 16u, 16u, MmaGfx1100CompilerTarget>;
 
-struct MmaGfx12Config : MmaLayoutTestConfig<MmaGfx1201Selector,
-                                            MmaGfx1201CompilerTarget>
+// clang-format off
+using KernelTypes = ::testing::Types<
+    MmaGfx1201Selector,
+    MmaGfx90aSelector,
+    MmaGfx1100Selector
+    >;
+// clang-format on
+
+template <typename Selector>
+class TestMmaLayout : public ::testing::Test
 {
 };
 
-struct MmaGfx9Config : MmaLayoutTestConfig<MmaGfx90aSelector,
-                                           MmaGfx90aCompilerTarget>
-{
-};
+TYPED_TEST_SUITE(TestMmaLayout, KernelTypes);
 
-struct MmaGfx11Config : MmaLayoutTestConfig<MmaGfx1100Selector,
-                                            MmaGfx1100CompilerTarget>
+TYPED_TEST(TestMmaLayout, Mma_16x16x16_F16_F16_F32)
 {
-};
-// ========================================================================
-
-TEST(TestMmaLayout, Mma_16x16x16_F16_F16_F32_GFX9)
-{
-    bool executed = run_mma_layout_test_case<MmaGfx9Config>();
+    bool executed = run_mma_layout_test<TypeParam>();
 
     if(!executed)
     {
-        GTEST_SKIP() << "No gfx90a HIP device found. Skipping test.";
-    }
-}
-
-TEST(TestMmaLayout, Mma_16x16x16_F16_F16_F32_GFX11)
-{
-    bool executed = run_mma_layout_test_case<MmaGfx11Config>();
-
-    if(!executed)
-    {
-        GTEST_SKIP() << "No gfx1100 HIP device found. Skipping test.";
-    }
-}
-
-TEST(TestMmaLayout, Mma_16x16x16_F16_F16_F32_GFX12)
-{
-    bool executed = run_mma_layout_test_case<MmaGfx12Config>();
-
-    if(!executed)
-    {
-        GTEST_SKIP() << "No gfx1201 HIP device found. Skipping test.";
+        GTEST_SKIP() << "No supported HIP device found. Skipping test.";
     }
 }
 

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -57,7 +57,6 @@ namespace {
  * @tparam BlockM        M-dimension of the MMA tile
  * @tparam BlockN        N-dimension of the MMA tile
  * @tparam BlockK        K-dimension of the MMA tile
- * @tparam LaneGroupSize WaveSize / LaneGroupsPerWave
  * @tparam BlockSize     HIP block size
  */
 template <typename ADataType,
@@ -66,7 +65,6 @@ template <typename ADataType,
           uint32_t BlockM,
           uint32_t BlockN,
           uint32_t BlockK,
-          uint32_t LaneGroupSize,
           uint32_t BlockSize>
 struct MmaLayoutTestKernel
 {
@@ -91,34 +89,37 @@ struct MmaLayoutTestKernel
         constexpr uint32_t b_vec_size = sizeof(BVecType) / sizeof(BDataType);
         constexpr uint32_t c_vec_size = sizeof(CVecType) / sizeof(CDataType);
 
-        // LaneGroupSize doesnt equal WaveSize on RDNA3 due to matrix replication
-        const uint32_t lane = threadIdx.x % LaneGroupSize;
+        const uint32_t lane = threadIdx.x;
 
         AVecType a_frag{};
         BVecType b_frag{};
         CVecType c_frag{};
 
-        constexpr uint32_t TileM = MmaTraits::BlockM;
-        constexpr uint32_t TileN = MmaTraits::BlockN;
-        constexpr uint32_t TileK = MmaTraits::BlockK;
-
         // get (m, k, n), where "1" should be placed for this block 
         const uint32_t case_idx = static_cast<uint32_t>(blockIdx.x);
-        const uint32_t m = case_idx / (TileK * TileN);
-        const uint32_t k = (case_idx / TileN) % TileK;
-        const uint32_t n = case_idx % TileN;
+        const uint32_t m = case_idx / (MmaTraits::BlockK * MmaTraits::BlockN);
+        const uint32_t k = (case_idx / MmaTraits::BlockN) % MmaTraits::BlockK;
+        const uint32_t n = case_idx % MmaTraits::BlockN;
 
-        // place a single "1" in A/B fragments
-        auto a_pos = RegisterMap<MmaOp>::A2RegisterMap(m, k);
-        if(a_pos.lane == lane && a_pos.vecIdx < a_vec_size)
+        // place a single "1" in A/B fragments using (lane, vecIdx) -> (row, col) mapping
+        for(uint32_t v = 0; v < a_vec_size; ++v)
         {
-            a_frag[a_pos.vecIdx] = static_cast<ADataType>(1);
+            auto a_coords = RegisterMap<MmaOp>::Register2AMap(lane, v);
+            if(static_cast<uint32_t>(a_coords[0]) == m &&
+               static_cast<uint32_t>(a_coords[1]) == k)
+            {
+                a_frag[v] = static_cast<ADataType>(1);
+            }
         }
 
-        auto b_pos = RegisterMap<MmaOp>::B2RegisterMap(k, n);
-        if(b_pos.lane == lane && b_pos.vecIdx < b_vec_size)
+        for(uint32_t v = 0; v < b_vec_size; ++v)
         {
-            b_frag[b_pos.vecIdx] = static_cast<BDataType>(1);
+            auto b_coords = RegisterMap<MmaOp>::Register2BMap(lane, v);
+            if(static_cast<uint32_t>(b_coords[0]) == n &&
+               static_cast<uint32_t>(b_coords[1]) == k)
+            {
+                b_frag[v] = static_cast<BDataType>(1);
+            }
         }
 
         c_frag = MmaOp::exec(a_frag, b_frag, c_frag);
@@ -132,22 +133,19 @@ struct MmaLayoutTestKernel
         __syncthreads();
 
         const CDataType tol = static_cast<CDataType>(1.0e-1f); // TODO: this tolerance might not be suitable for all data types and should be revisited if we add more configurations
-        for(uint32_t i = 0; i < TileM; ++i)
+        for(uint32_t v = 0; v < c_vec_size; ++v)
         {
-            for(uint32_t j = 0; j < TileN; ++j)
+            auto c_coords = RegisterMap<MmaOp>::Register2CMap(lane, v);
+            const uint32_t i = static_cast<uint32_t>(c_coords[0]);
+            const uint32_t j = static_cast<uint32_t>(c_coords[1]);
+
+            const CDataType expected = (i == m && j == n)
+                                           ? static_cast<CDataType>(1)
+                                           : static_cast<CDataType>(0);
+            const CDataType value = static_cast<CDataType>(c_frag[v]);
+            if(fabsf(static_cast<float>(value - expected)) > static_cast<float>(tol))
             {
-                auto pos = RegisterMap<MmaOp>::C2RegisterMap(i, j);
-                if(pos.lane == threadIdx.x && pos.vecIdx < c_vec_size)
-                {
-                    const CDataType expected = (i == m && j == n)
-                                                   ? static_cast<CDataType>(1)
-                                                   : static_cast<CDataType>(0);
-                    const CDataType value = static_cast<CDataType>(c_frag[pos.vecIdx]);
-                    if(fabsf(static_cast<float>(value - expected)) > static_cast<float>(tol))
-                    {
-                        atomicExch(&err, 1);
-                    }
-                }
+                atomicExch(&err, 1);
             }
         }
 
@@ -182,16 +180,13 @@ void print_tensor(const char* label, const Array& tensor, uint32_t rows, uint32_
  *
  * @tparam Selector_          MmaDefaultSelector instantiation for the target
  * @tparam CompilerTarget_    amdgcn_target describing the arch target
- * @tparam LaneGroupsPerWave_ Number of lane groups per wave
  */
-template <typename Selector_, typename CompilerTarget_, uint32_t LaneGroupsPerWave_>
+template <typename Selector_, typename CompilerTarget_>
 struct MmaLayoutTestConfig
 {
     using Selector                     = Selector_;
     using CompilerTarget               = CompilerTarget_;
     static constexpr uint32_t WaveSize = static_cast<uint32_t>(CompilerTarget::WAVE_SIZE_ID);
-    static constexpr uint32_t LaneGroupsPerWave = LaneGroupsPerWave_;
-    static constexpr uint32_t LaneGroupSize     = WaveSize / LaneGroupsPerWave;
 };
 
 /**
@@ -244,7 +239,6 @@ bool run_mma_layout_test_case()
                                        MmaTraits::BlockM,
                                        MmaTraits::BlockN,
                                        MmaTraits::BlockK,
-                                       Config::LaneGroupSize,
                                        Config::WaveSize>;
 
     std::ignore = hipGetLastError();
@@ -291,20 +285,17 @@ using MmaGfx1100Selector = mma::
     MmaDefaultSelector<ck::fp16_t, ck::fp16_t, ck::fp32_t, 16u, 16u, 16u, MmaGfx1100CompilerTarget>;
 
 struct MmaGfx12Config : MmaLayoutTestConfig<MmaGfx1201Selector,
-                                            MmaGfx1201CompilerTarget,
-                                            1u> // LaneGroupsPerWave
+                                            MmaGfx1201CompilerTarget>
 {
 };
 
 struct MmaGfx9Config : MmaLayoutTestConfig<MmaGfx90aSelector,
-                                           MmaGfx90aCompilerTarget,
-                                           1u> // LaneGroupsPerWave
+                                           MmaGfx90aCompilerTarget>
 {
 };
 
 struct MmaGfx11Config : MmaLayoutTestConfig<MmaGfx1100Selector,
-                                            MmaGfx1100CompilerTarget,
-                                            2u> // LaneGroupsPerWave
+                                            MmaGfx1100CompilerTarget>
 {
 };
 // ========================================================================

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -43,7 +43,8 @@ namespace mma = ck_tile::core::arch::mma;
 //
 // The kernel uses RegisterMap to scatter A and B into the correct (lane, vecIdx) positions
 // of the MMA fragment registers, executes the intrinsic, then uses RegisterMap again to
-// gather back into C matrix. The position of "1" in C is checked against the expected (m, n) location.
+// gather back into C matrix. The position of "1" in C is checked against the expected (m, n)
+// location.
 
 namespace {
 
@@ -95,18 +96,17 @@ struct MmaLayoutTestKernel
         BVecType b_frag{};
         CVecType c_frag{};
 
-        // get (m, k, n), where "1" should be placed for this block 
+        // get (m, k, n), where "1" should be placed for this block
         const uint32_t case_idx = static_cast<uint32_t>(blockIdx.x);
-        const uint32_t m = case_idx / (MmaTraits::BlockK * MmaTraits::BlockN);
-        const uint32_t k = (case_idx / MmaTraits::BlockN) % MmaTraits::BlockK;
-        const uint32_t n = case_idx % MmaTraits::BlockN;
+        const uint32_t m        = case_idx / (MmaTraits::BlockK * MmaTraits::BlockN);
+        const uint32_t k        = (case_idx / MmaTraits::BlockN) % MmaTraits::BlockK;
+        const uint32_t n        = case_idx % MmaTraits::BlockN;
 
         // place a single "1" in A/B fragments using (lane, vecIdx) -> (row, col) mapping
         for(uint32_t v = 0; v < a_vec_size; ++v)
         {
             auto a_coords = RegisterMap<MmaOp>::Register2AMap(lane, v);
-            if(static_cast<uint32_t>(a_coords[0]) == m &&
-               static_cast<uint32_t>(a_coords[1]) == k)
+            if(static_cast<uint32_t>(a_coords[0]) == m && static_cast<uint32_t>(a_coords[1]) == k)
             {
                 a_frag[v] = static_cast<ADataType>(1);
             }
@@ -115,8 +115,7 @@ struct MmaLayoutTestKernel
         for(uint32_t v = 0; v < b_vec_size; ++v)
         {
             auto b_coords = RegisterMap<MmaOp>::Register2BMap(lane, v);
-            if(static_cast<uint32_t>(b_coords[0]) == n &&
-               static_cast<uint32_t>(b_coords[1]) == k)
+            if(static_cast<uint32_t>(b_coords[0]) == n && static_cast<uint32_t>(b_coords[1]) == k)
             {
                 b_frag[v] = static_cast<BDataType>(1);
             }
@@ -124,17 +123,18 @@ struct MmaLayoutTestKernel
 
         c_frag = MmaOp::exec(a_frag, b_frag, c_frag);
 
-        uint32_t err = 0;
-        const CDataType tol = static_cast<CDataType>(1.0e-1f); // TODO: this tolerance might not be suitable for all data types and should be revisited if we add more configurations
+        uint32_t err        = 0;
+        const CDataType tol = static_cast<CDataType>(
+            1.0e-1f); // TODO: this tolerance might not be suitable for all data types and should be
+                      // revisited if we add more configurations
         for(uint32_t v = 0; v < c_vec_size; ++v)
         {
-            auto c_coords = RegisterMap<MmaOp>::Register2CMap(lane, v);
+            auto c_coords    = RegisterMap<MmaOp>::Register2CMap(lane, v);
             const uint32_t i = static_cast<uint32_t>(c_coords[0]);
             const uint32_t j = static_cast<uint32_t>(c_coords[1]);
 
-            const CDataType expected = (i == m && j == n)
-                                           ? static_cast<CDataType>(1)
-                                           : static_cast<CDataType>(0);
+            const CDataType expected =
+                (i == m && j == n) ? static_cast<CDataType>(1) : static_cast<CDataType>(0);
             const CDataType value = static_cast<CDataType>(c_frag[v]);
             if(fabsf(static_cast<float>(value - expected)) > static_cast<float>(tol))
             {
@@ -153,7 +153,8 @@ struct MmaLayoutTestKernel
 /**
  * @brief Test driver: runs the test for a given MMA configuration.
  *
- * The testlaunches (mkn) test cases (one per block) to check all possible positions of the "1" in the A/B tensors.
+ * The testlaunches (mkn) test cases (one per block) to check all possible positions of the "1" in
+ * the A/B tensors.
  *   1. Constructs A and B tensors with a single 1 at A(m,k) and B(k,n).
  *   2. Executes MMA intrinsic to compute C tensor.
  *   3. Checks if C has the 1 in the expected position.
@@ -164,14 +165,14 @@ struct MmaLayoutTestKernel
 template <typename Selector>
 bool run_mma_layout_test()
 {
-    using MmaOp               = typename Selector::SelectedOp;
-    using MmaTraits           = mma::MmaOpTraits<MmaOp>;
-    using ADataType           = typename MmaTraits::ADataType;
-    using BDataType           = typename MmaTraits::BDataType;
-    using CDataType           = typename MmaTraits::CDataType;
-    constexpr uint32_t BlockM = MmaTraits::BlockM;
-    constexpr uint32_t BlockN = MmaTraits::BlockN;
-    constexpr uint32_t BlockK = MmaTraits::BlockK;
+    using MmaOp                       = typename Selector::SelectedOp;
+    using MmaTraits                   = mma::MmaOpTraits<MmaOp>;
+    using ADataType                   = typename MmaTraits::ADataType;
+    using BDataType                   = typename MmaTraits::BDataType;
+    using CDataType                   = typename MmaTraits::CDataType;
+    constexpr uint32_t BlockM         = MmaTraits::BlockM;
+    constexpr uint32_t BlockN         = MmaTraits::BlockN;
+    constexpr uint32_t BlockK         = MmaTraits::BlockK;
     constexpr auto selector_target_id = MmaTraits::CompilerTarget::TARGET_ID;
     constexpr auto selector_wave_size = MmaTraits::CompilerTarget::WAVE_SIZE_ID;
 
@@ -188,7 +189,8 @@ bool run_mma_layout_test()
     const bool has_device = device_count > 0;
 
     if(!has_device || runtime_target == ck_tile::core::arch::amdgcn_target_id::HOST ||
-       runtime_target != selector_target_id || props.warpSize != static_cast<int>(selector_wave_size))
+       runtime_target != selector_target_id ||
+       props.warpSize != static_cast<int>(selector_wave_size))
     {
         return false;
     }
@@ -201,16 +203,24 @@ bool run_mma_layout_test()
 
     std::ignore = hipGetLastError();
 
+    using Kernel = MmaLayoutTestKernel<ADataType,
+                                       BDataType,
+                                       CDataType,
+                                       BlockM,
+                                       BlockN,
+                                       BlockK,
+                                       static_cast<int>(selector_wave_size)>;
 
-    using Kernel = MmaLayoutTestKernel<ADataType, BDataType, CDataType,
-                                    BlockM, BlockN, BlockK, static_cast<int>(selector_wave_size)>;
+    std::ignore =
+        ck_tile::launch_kernel(ck_tile::stream_config{nullptr, false, 0, 0, 1},
+                               ck_tile::make_kernel(Kernel{},
+                                                    dim3(total_cases),
+                                                    dim3(static_cast<int>(selector_wave_size)),
+                                                    0,
+                                                    d_error_ptr));
 
-    std::ignore = ck_tile::launch_kernel(
-        ck_tile::stream_config{nullptr, false, 0, 0, 1},
-        ck_tile::make_kernel(Kernel{}, dim3(total_cases), dim3(static_cast<int>(selector_wave_size)), 0, d_error_ptr));
-
-    HIP_CHECK_ERROR(
-        hipMemcpyAsync(h_errors.data(), d_error_ptr, d_errors.GetBufferSize(), hipMemcpyDeviceToHost));
+    HIP_CHECK_ERROR(hipMemcpyAsync(
+        h_errors.data(), d_error_ptr, d_errors.GetBufferSize(), hipMemcpyDeviceToHost));
     HIP_CHECK_ERROR(hipStreamSynchronize(nullptr));
 
     for(uint32_t case_idx = 0; case_idx < total_cases; ++case_idx)
@@ -219,8 +229,7 @@ bool run_mma_layout_test()
         const uint32_t k = (case_idx / BlockN) % BlockK;
         const uint32_t n = case_idx % BlockN;
 
-        EXPECT_EQ(h_errors[case_idx], 0u)
-            << "Mismatch for m=" << m << " k=" << k << " n=" << n;
+        EXPECT_EQ(h_errors[case_idx], 0u) << "Mismatch for m=" << m << " k=" << k << " n=" << n;
     }
 
     return true;

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout.cpp
@@ -81,71 +81,77 @@ struct MmaLayoutTestKernel
                                     BlockN,
                                     BlockK,
                                     decltype(ck_tile::core::arch::get_compiler_target())>;
-        using MmaOp                   = typename Selector::SelectedOp;
-        using MmaTraits               = mma::MmaOpTraits<MmaOp>;
-        using AVecType                = typename MmaTraits::AVecType;
-        using BVecType                = typename MmaTraits::BVecType;
-        using CVecType                = typename MmaTraits::CVecType;
-        constexpr uint32_t a_vec_size = vector_traits<AVecType>::vector_size;
-        constexpr uint32_t b_vec_size = vector_traits<BVecType>::vector_size;
-        constexpr uint32_t c_vec_size = vector_traits<CVecType>::vector_size;
+        using MmaOp     = typename Selector::SelectedOp;
+        using MmaTraits = mma::MmaOpTraits<MmaOp>;
 
-        const uint32_t lane = threadIdx.x;
-
-        AVecType a_frag{};
-        BVecType b_frag{};
-        CVecType c_frag{};
-
-        // get (m, k, n), where "1" should be placed for this block
-        const uint32_t case_idx = static_cast<uint32_t>(blockIdx.x);
-        const uint32_t m        = case_idx / (MmaTraits::BlockK * MmaTraits::BlockN);
-        const uint32_t k        = (case_idx / MmaTraits::BlockN) % MmaTraits::BlockK;
-        const uint32_t n        = case_idx % MmaTraits::BlockN;
-
-        // place a single "1" in A/B fragments using (lane, vecIdx) -> (row, col) mapping
-        for(uint32_t v = 0; v < a_vec_size; ++v)
+        if constexpr(MmaTraits::IsSupported)
         {
-            auto a_coords = RegisterMap<MmaOp>::Register2AMap(lane, v);
-            if(static_cast<uint32_t>(a_coords[0]) == m && static_cast<uint32_t>(a_coords[1]) == k)
+            using AVecType                = typename MmaTraits::AVecType;
+            using BVecType                = typename MmaTraits::BVecType;
+            using CVecType                = typename MmaTraits::CVecType;
+            constexpr uint32_t a_vec_size = vector_traits<AVecType>::vector_size;
+            constexpr uint32_t b_vec_size = vector_traits<BVecType>::vector_size;
+            constexpr uint32_t c_vec_size = vector_traits<CVecType>::vector_size;
+
+            const uint32_t lane = threadIdx.x;
+
+            AVecType a_frag{};
+            BVecType b_frag{};
+            CVecType c_frag{};
+
+            // get (m, k, n), where "1" should be placed for this block
+            const uint32_t case_idx = static_cast<uint32_t>(blockIdx.x);
+            const uint32_t m        = case_idx / (MmaTraits::BlockK * MmaTraits::BlockN);
+            const uint32_t k        = (case_idx / MmaTraits::BlockN) % MmaTraits::BlockK;
+            const uint32_t n        = case_idx % MmaTraits::BlockN;
+
+            // place a single "1" in A/B fragments using (lane, vecIdx) -> (row, col) mapping
+            for(uint32_t v = 0; v < a_vec_size; ++v)
             {
-                a_frag[v] = static_cast<ADataType>(1);
+                auto a_coords = RegisterMap<MmaOp>::Register2AMap(lane, v);
+                if(static_cast<uint32_t>(a_coords[0]) == m &&
+                   static_cast<uint32_t>(a_coords[1]) == k)
+                {
+                    a_frag[v] = static_cast<ADataType>(1);
+                }
             }
-        }
 
-        for(uint32_t v = 0; v < b_vec_size; ++v)
-        {
-            auto b_coords = RegisterMap<MmaOp>::Register2BMap(lane, v);
-            if(static_cast<uint32_t>(b_coords[0]) == n && static_cast<uint32_t>(b_coords[1]) == k)
+            for(uint32_t v = 0; v < b_vec_size; ++v)
             {
-                b_frag[v] = static_cast<BDataType>(1);
+                auto b_coords = RegisterMap<MmaOp>::Register2BMap(lane, v);
+                if(static_cast<uint32_t>(b_coords[0]) == n &&
+                   static_cast<uint32_t>(b_coords[1]) == k)
+                {
+                    b_frag[v] = static_cast<BDataType>(1);
+                }
             }
-        }
 
-        c_frag = MmaOp::exec(a_frag, b_frag, c_frag);
+            c_frag = MmaOp::exec(a_frag, b_frag, c_frag);
 
-        uint32_t err        = 0;
-        const CDataType tol = static_cast<CDataType>(
-            1.0e-1f); // TODO: this tolerance might not be suitable for all data types and should be
-                      // revisited if we add more configurations
-        for(uint32_t v = 0; v < c_vec_size; ++v)
-        {
-            auto c_coords    = RegisterMap<MmaOp>::Register2CMap(lane, v);
-            const uint32_t i = static_cast<uint32_t>(c_coords[0]);
-            const uint32_t j = static_cast<uint32_t>(c_coords[1]);
-
-            const CDataType expected =
-                (i == m && j == n) ? static_cast<CDataType>(1) : static_cast<CDataType>(0);
-            const CDataType value = static_cast<CDataType>(c_frag[v]);
-            if(fabsf(static_cast<float>(value - expected)) > static_cast<float>(tol))
+            uint32_t err        = 0;
+            const CDataType tol = static_cast<CDataType>(
+                1.0e-1f); // TODO: this tolerance might not be suitable for all data types and
+                          // should be revisited if we add more configurations
+            for(uint32_t v = 0; v < c_vec_size; ++v)
             {
-                err = 1;
-            }
-        }
+                auto c_coords    = RegisterMap<MmaOp>::Register2CMap(lane, v);
+                const uint32_t i = static_cast<uint32_t>(c_coords[0]);
+                const uint32_t j = static_cast<uint32_t>(c_coords[1]);
 
-        const uint32_t any_err = __any(err);
-        if(threadIdx.x == 0)
-        {
-            error_flags[case_idx] = any_err;
+                const CDataType expected =
+                    (i == m && j == n) ? static_cast<CDataType>(1) : static_cast<CDataType>(0);
+                const CDataType value = static_cast<CDataType>(c_frag[v]);
+                if(fabsf(static_cast<float>(value - expected)) > static_cast<float>(tol))
+                {
+                    err = 1;
+                }
+            }
+
+            const uint32_t any_err = __any(err);
+            if(threadIdx.x == 0)
+            {
+                error_flags[case_idx] = any_err;
+            }
         }
     }
 };

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
@@ -1,0 +1,229 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "ck_tile/core/arch/arch.hpp"
+#include "ck_tile/core/arch/mma/amdgcn_mma.hpp"
+#include "ck_tile/core/arch/mma/mma_traits.hpp"
+#include "ck_tile/core/arch/mma/mma_selector.hpp"
+#include "ck_tile/core/numeric/half.hpp"
+#include "ck_tile/core/numeric/vector_type.hpp"
+
+#include <cstdint>
+
+namespace {
+
+/**
+ * @struct RegisterIdxPair
+ * @brief Small helper struct to hold a pair of lane and vector index values
+ */
+struct RegisterIdxPair
+{
+    const uint32_t lane;
+    const uint32_t vecIdx;
+};
+
+/**
+ * @class RegisterMap
+ * @brief Maps matrix coordinates to (lane, vecIdx) pairs for a given MmaOp
+ *
+ * Test-only register mapping utilities for MMA layout validation. Each MMA intrinsic (MFMA, WMMA)
+ * defines a specific mapping from logical matrix coordinates (m, k) or (m, n) to hardware
+ * registers: which lane holds the value and at which vector index within that lane's register.
+ * These mappings are architecture-specific and are encoded here as RegisterMap specializations, one
+ * per target.
+ *
+ * Fails intentionally if left unimplemented.
+ *
+ * @tparam MmaOp amdgcn_mma specialization
+ */
+template <typename MmaOp>
+struct RegisterMap
+{
+    static_assert(false, "RegisterMap always requires a specialization");
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t, const uint32_t)
+    {
+        return {0u, 0u};
+    }
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t, const uint32_t)
+    {
+        return {0u, 0u};
+    }
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t, const uint32_t)
+    {
+        return {0u, 0u};
+    }
+};
+
+/**
+ * @class RegisterMap (GFX12 WMMA specialization)
+ * @brief Register mapping for __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12
+ *
+ * TODO: At the moment, the mapping is hardcoded and derived based on unmerge/merge operations. In
+ * the future, we want to use amdgcn_mma internals to compute it.
+ *
+ * A/B layout unmerge/merge: K{2, 4} L{K1M} V{K2K0}
+ *
+ * Unmerge K = 16 into K0 = K % 4, K1 = (K / 4) % 2, K2 = K / 8
+ *
+ *   lane   = 16 * k1 + m
+ *   vecIdx = k0 + k2 * 2
+ *
+ * C layout descriptor:  M{8} L{M1N} V{M0}
+ *
+ * Unmerge M=16 into (M0 = M % 8) and (M1 = M / 8)
+ *
+ *   lane   = 16 * m1 + n
+ *   vecIdx = m0
+ */
+template <typename CtrlFlags, typename CompilerTarget>
+struct RegisterMap<ck_tile::core::arch::mma::amdgcn_mma<
+    ck_tile::fp16_t,
+    ck_tile::fp16_t,
+    ck_tile::fp32_t,
+    16u,
+    16u,
+    16u,
+    CtrlFlags,
+    CompilerTarget,
+    ck_tile::core::arch::enable_if_target_family_gfx12_t<CompilerTarget>>>
+{
+    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t m, const uint32_t k)
+    {
+        const uint32_t lane   = 16u * ((k / 4u) % 2u) + m;
+        const uint32_t vecIdx = (k % 4) + (k / 8) * 4;
+        return {lane, vecIdx};
+    }
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t k, const uint32_t n)
+    {
+        const uint32_t lane   = 16u * ((k / 4u) % 2u) + n;
+        const uint32_t vecIdx = (k % 4) + (k / 8) * 4;
+        return {lane, vecIdx};
+    }
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t m, const uint32_t n)
+    {
+        const uint32_t lane   = 16u * (m / 8u) + n;
+        const uint32_t vecIdx = m % 8u;
+        return {lane, vecIdx};
+    }
+};
+
+/**
+ * @class RegisterMap (GFX9 MFMA specialization)
+ * @brief Register mapping for __builtin_amdgcn_mfma_f32_16x16x16f16
+ *
+ * TODO: At the moment, the mapping is hardcoded and derived based on unmerge/merge operations. In
+ * the future, we want to use amdgcn_mma internals to compute it.
+ *
+ * A/B layout unmerge/merge: K{4} L{K1 M} V{K0}
+ *
+ * Unmerge K = 16 into (K0 = K % 4) and (K1 = K / 4)
+ *
+ *   lane   = 16 * k1 + m
+ *   vecIdx = k0
+ *
+ * C layout unmerge/merge: M{4} L{M1 N} V{M0}
+ *
+ * Unmerge M = 16 into (M0 = M % 4) and (M1 = M / 4)
+ *
+ *   lane   = 16 * m1 + n
+ *   vecIdx = m0
+ */
+template <typename CtrlFlags, typename CompilerTarget>
+struct RegisterMap<ck_tile::core::arch::mma::amdgcn_mma<
+    ck_tile::fp16_t,
+    ck_tile::fp16_t,
+    ck_tile::fp32_t,
+    16u,
+    16u,
+    16u,
+    CtrlFlags,
+    CompilerTarget,
+    ck_tile::core::arch::enable_if_target_family_gfx9_t<CompilerTarget>>>
+{
+    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t m, const uint32_t k)
+    {
+        const uint32_t lane =
+            16u * (k / 4u) + m; // NOTE: this can be derived with kAMLane * (k / kABKPerLane) + m
+        const uint32_t vecIdx = k % 4u; // NOTE: this can be derived with k % kABKPerLane
+        return {lane, vecIdx};
+    }
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t k, const uint32_t n)
+    {
+        const uint32_t lane =
+            16u * (k / 4u) + n; // NOTE: this can be derived with kAMLane * (k / kABKPerLane) + n
+        const uint32_t vecIdx = k % 4u; // NOTE: this can be derived with k % kABKPerLane
+        return {lane, vecIdx};
+    }
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t m, const uint32_t n)
+    {
+        const uint32_t lane =
+            16u * (m / 4u) + n; // NOTE: this can be derived with kCNLane * (m / kCM1PerLane) + n
+        const uint32_t vecIdx = m % 4u; // NOTE: this can be derived with m % kCM1PerLane
+        return {lane, vecIdx};
+    }
+};
+
+/**
+ * @class RegisterMap (GFX11 WMMA specialization)
+ * @brief Register mapping for __builtin_amdgcn_wmma_f32_16x16x16_f16_w32.
+ *
+ * TODO: At the moment, the mapping is hardcoded and derived based on unmerge/merge operations. In
+ * the future, we want to use amdgcn_mma internals to compute it.
+ *
+ * A/B layout unmerge/merge: L{M} V{K}
+ *
+ *   lane   = m
+ *   vecIdx = k
+ *
+ * C layout unmerge/merge: M{2} L{M0N} V{M1}
+ *
+ * Unmerge M=16 into (M0 = M % 2) and (M1 = M / 2)
+ *
+ *   lane   = 16 * m0 + n
+ *   vecIdx = m1
+ */
+template <typename CtrlFlags, typename CompilerTarget>
+struct RegisterMap<ck_tile::core::arch::mma::amdgcn_mma<
+    ck_tile::fp16_t,
+    ck_tile::fp16_t,
+    ck_tile::fp32_t,
+    16u,
+    16u,
+    16u,
+    CtrlFlags,
+    CompilerTarget,
+    ck_tile::core::arch::enable_if_target_family_gfx11_t<CompilerTarget>>>
+{
+    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t m, const uint32_t k)
+    {
+        const uint32_t lane   = m;
+        const uint32_t vecIdx = k;
+        return {lane, vecIdx};
+    }
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t k, const uint32_t n)
+    {
+        const uint32_t lane   = n;
+        const uint32_t vecIdx = k;
+        return {lane, vecIdx};
+    }
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t m, const uint32_t n)
+    {
+        const uint32_t lane   = (16u * (m % 2u)) + n;
+        const uint32_t vecIdx = m / 2u;
+        return {lane, vecIdx};
+    }
+};
+
+} // namespace
+

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "ck_tile/core.hpp"
 #include "ck_tile/core/arch/arch.hpp"
 #include "ck_tile/core/arch/mma/amdgcn_mma.hpp"
 #include "ck_tile/core/arch/mma/mma_traits.hpp"
@@ -10,9 +11,12 @@
 #include "ck_tile/core/numeric/half.hpp"
 #include "ck_tile/core/numeric/vector_type.hpp"
 
+#include <cassert>
 #include <cstdint>
 
 namespace {
+
+using namespace ck_tile;
 
 /**
  * @struct RegisterIdxPair
@@ -20,68 +24,123 @@ namespace {
  */
 struct RegisterIdxPair
 {
-    const uint32_t lane;
-    const uint32_t vecIdx;
+    uint32_t lane;
+    uint32_t vecIdx;
+};
+
+/**
+ * @class TileDistrEncodingMap
+ * @brief Unified, static methods for register mapping
+ *
+ * Uses tile_distribution_encoding to compute the mapping
+ * from matrix coordinates (m, k) or (m, n) to (lane, vecIdx) pairs.
+ *
+ * @tparam TileDistrEnc tile_distribution_encoding type
+ * @tparam NumLanes Number of lanes in the wave
+ * @tparam NumVecItems Number of vector items per lane
+ */
+template <typename TileDistrEnc, index_t NumLanes, index_t NumVecItems>
+struct TileDistrEncodingMap
+{
+    static constexpr auto distr            = make_static_tile_distribution(TileDistrEnc{});
+    static constexpr auto ps_ys_to_xs_adaptor = distr.get_ps_ys_to_xs_adaptor();
+
+    /**
+     * @brief Convert (lane, vecIdx) to matrix coordinates
+     */
+    CK_TILE_HOST_DEVICE static auto
+    calc_matrix_indices_from_lane_vector(index_t lane_idx, index_t vector_idx)
+    {
+        // Unmerge the Y dimension index into its hidden indices
+        array<index_t, TileDistrEnc::NDimY> y_hidden_idx;
+        index_t vec_tmp = vector_idx;
+        for(index_t i = TileDistrEnc::NDimY - 1; i >= 0; --i)
+        {
+            y_hidden_idx[i] = vec_tmp % TileDistrEnc::detail::ys_lengths_[i];
+            vec_tmp /= TileDistrEnc::detail::ys_lengths_[i];
+        }
+
+        const auto ps_ys_idx = container_concat(array<index_t, 1>{lane_idx}, y_hidden_idx);
+        const auto coord     = make_tensor_adaptor_coordinate(ps_ys_to_xs_adaptor, ps_ys_idx);
+        return coord.get_bottom_index();
+    }
+
+    /**
+     * @brief Convert matrix coordinates to (lane, vecIdx)
+     */
+    CK_TILE_HOST_DEVICE static RegisterIdxPair
+    calc_lane_vector_from_matrix_indices(index_t major_idx, index_t minor_idx)
+    {
+        for(index_t l = 0; l < NumLanes; ++l)
+        {
+            for(index_t v = 0; v < NumVecItems; ++v)
+            {
+                auto res = calc_matrix_indices_from_lane_vector(l, v);
+                if(res[0] == major_idx && res[1] == minor_idx)
+                {
+                    return {static_cast<uint32_t>(l), static_cast<uint32_t>(v)};
+                }
+            }
+        }
+        assert(false && "calc_lane_vector_from_matrix_indices: no mapping found");
+        return {0, 0};
+    }
+};
+
+/**
+ * @class RegisterMapTraits
+ * @brief Traits class that defines tile_distribution_encoding for each MmaOp
+ * @tparam MmaOp amdgcn_mma specialization
+ */
+template <typename MmaOp>
+struct RegisterMapTraits
+{
+    static_assert(sizeof(MmaOp) == 0, "RegisterMapTraits requires a specialization");
 };
 
 /**
  * @class RegisterMap
- * @brief Maps matrix coordinates to (lane, vecIdx) pairs for a given MmaOp
- *
- * Test-only register mapping utilities for MMA layout validation. Each MMA intrinsic (MFMA, WMMA)
- * defines a specific mapping from logical matrix coordinates (m, k) or (m, n) to hardware
- * registers: which lane holds the value and at which vector index within that lane's register.
- * These mappings are architecture-specific and are encoded here as RegisterMap specializations, one
- * per target.
- *
- * Fails intentionally if left unimplemented.
- *
+ * @brief Uses specialized RegisterMapTraits to get the encoding
  * @tparam MmaOp amdgcn_mma specialization
  */
 template <typename MmaOp>
 struct RegisterMap
 {
-    static_assert(false, "RegisterMap always requires a specialization");
+    using Traits = RegisterMapTraits<MmaOp>;
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t, const uint32_t)
+    using AMap =
+        TileDistrEncodingMap<typename Traits::AWarpDstrEncoding, Traits::WaveSize, Traits::AVecSize>;
+    using BMap =
+        TileDistrEncodingMap<typename Traits::BWarpDstrEncoding, Traits::WaveSize, Traits::BVecSize>;
+    using CMap =
+        TileDistrEncodingMap<typename Traits::CWarpDstrEncoding, Traits::WaveSize, Traits::CVecSize>;
+
+    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t m, const uint32_t k)
     {
-        return {0u, 0u};
+        return AMap::calc_lane_vector_from_matrix_indices(static_cast<index_t>(m),
+                                                          static_cast<index_t>(k));
     }
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t, const uint32_t)
+    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t k, const uint32_t n)
     {
-        return {0u, 0u};
+        return BMap::calc_lane_vector_from_matrix_indices(static_cast<index_t>(n),
+                                                          static_cast<index_t>(k));
     }
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t, const uint32_t)
+    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t m, const uint32_t n)
     {
-        return {0u, 0u};
+        return CMap::calc_lane_vector_from_matrix_indices(static_cast<index_t>(m),
+                                                          static_cast<index_t>(n));
     }
 };
 
+// ====================== Specializations per target =====================
+
 /**
- * @class RegisterMap (GFX12 WMMA specialization)
- * @brief Register mapping for __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12
- *
- * TODO: At the moment, the mapping is hardcoded and derived based on unmerge/merge operations. In
- * the future, we want to use amdgcn_mma internals to compute it.
- *
- * A/B layout unmerge/merge: K{2, 4} L{K1M} V{K2K0}
- *
- * Unmerge K = 16 into K0 = K % 4, K1 = (K / 4) % 2, K2 = K / 8
- *
- *   lane   = 16 * k1 + m
- *   vecIdx = k0 + k2 * 2
- *
- * C layout descriptor:  M{8} L{M1N} V{M0}
- *
- * Unmerge M=16 into (M0 = M % 8) and (M1 = M / 8)
- *
- *   lane   = 16 * m1 + n
- *   vecIdx = m0
+ * @brief RegisterMapTraits for GFX12 WMMA 16x16x16_F16_F16_F32_GFX12
  */
 template <typename CtrlFlags, typename CompilerTarget>
-struct RegisterMap<ck_tile::core::arch::mma::amdgcn_mma<
+struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     ck_tile::fp16_t,
     ck_tile::fp16_t,
     ck_tile::fp32_t,
@@ -92,51 +151,58 @@ struct RegisterMap<ck_tile::core::arch::mma::amdgcn_mma<
     CompilerTarget,
     ck_tile::core::arch::enable_if_target_family_gfx12_t<CompilerTarget>>>
 {
-    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t m, const uint32_t k)
-    {
-        const uint32_t lane   = 16u * ((k / 4u) % 2u) + m;
-        const uint32_t vecIdx = (k % 4) + (k / 8) * 4;
-        return {lane, vecIdx};
-    }
+    using MmaOp = ck_tile::core::arch::mma::amdgcn_mma<
+        ck_tile::fp16_t,
+        ck_tile::fp16_t,
+        ck_tile::fp32_t,
+        16u,
+        16u,
+        16u,
+        CtrlFlags,
+        CompilerTarget,
+        ck_tile::core::arch::enable_if_target_family_gfx12_t<CompilerTarget>>;
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t k, const uint32_t n)
-    {
-        const uint32_t lane   = 16u * ((k / 4u) % 2u) + n;
-        const uint32_t vecIdx = (k % 4) + (k / 8) * 4;
-        return {lane, vecIdx};
-    }
+    using MmaTraits = ck_tile::core::arch::mma::MmaOpTraits<MmaOp>;
+    static constexpr index_t WaveSize =
+        static_cast<index_t>(MmaTraits::CompilerTarget::WAVE_SIZE_ID);
+    static constexpr index_t AVecSize =
+        sizeof(typename MmaTraits::AVecType) / sizeof(typename MmaTraits::ADataType);
+    static constexpr index_t BVecSize =
+        sizeof(typename MmaTraits::BVecType) / sizeof(typename MmaTraits::BDataType);
+    static constexpr index_t CVecSize =
+        sizeof(typename MmaTraits::CVecType) / sizeof(typename MmaTraits::CDataType);
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t m, const uint32_t n)
-    {
-        const uint32_t lane   = 16u * (m / 8u) + n;
-        const uint32_t vecIdx = m % 8u;
-        return {lane, vecIdx};
-    }
+    // TODO: express the encoding in terms of amdgcn constants
+    using AWarpDstrEncoding = tile_distribution_encoding<
+        sequence<1>,
+        tuple<sequence<16>, sequence<4, 2, 2>>,
+        tuple<sequence<2, 1>>,
+        tuple<sequence<1, 0>>,
+        sequence<2, 2>,
+        sequence<2, 0>>;
+
+    using BWarpDstrEncoding = tile_distribution_encoding<
+        sequence<1>,
+        tuple<sequence<16>, sequence<4, 2, 2>>,
+        tuple<sequence<2, 1>>,
+        tuple<sequence<1, 0>>,
+        sequence<2, 2>,
+        sequence<2, 0>>;
+
+    using CWarpDstrEncoding = tile_distribution_encoding<
+        sequence<1>,
+        tuple<sequence<2, 8>, sequence<16>>,
+        tuple<sequence<1, 2>>,
+        tuple<sequence<0, 0>>,
+        sequence<1>,
+        sequence<1>>;
 };
 
 /**
- * @class RegisterMap (GFX9 MFMA specialization)
- * @brief Register mapping for __builtin_amdgcn_mfma_f32_16x16x16f16
- *
- * TODO: At the moment, the mapping is hardcoded and derived based on unmerge/merge operations. In
- * the future, we want to use amdgcn_mma internals to compute it.
- *
- * A/B layout unmerge/merge: K{4} L{K1 M} V{K0}
- *
- * Unmerge K = 16 into (K0 = K % 4) and (K1 = K / 4)
- *
- *   lane   = 16 * k1 + m
- *   vecIdx = k0
- *
- * C layout unmerge/merge: M{4} L{M1 N} V{M0}
- *
- * Unmerge M = 16 into (M0 = M % 4) and (M1 = M / 4)
- *
- *   lane   = 16 * m1 + n
- *   vecIdx = m0
+ * @brief RegisterMapTraits for GFX9 MFMA 16x16x16_F16_F16_F32_GFX9
  */
 template <typename CtrlFlags, typename CompilerTarget>
-struct RegisterMap<ck_tile::core::arch::mma::amdgcn_mma<
+struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     ck_tile::fp16_t,
     ck_tile::fp16_t,
     ck_tile::fp32_t,
@@ -147,52 +213,58 @@ struct RegisterMap<ck_tile::core::arch::mma::amdgcn_mma<
     CompilerTarget,
     ck_tile::core::arch::enable_if_target_family_gfx9_t<CompilerTarget>>>
 {
-    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t m, const uint32_t k)
-    {
-        const uint32_t lane =
-            16u * (k / 4u) + m; // NOTE: this can be derived with kAMLane * (k / kABKPerLane) + m
-        const uint32_t vecIdx = k % 4u; // NOTE: this can be derived with k % kABKPerLane
-        return {lane, vecIdx};
-    }
+    using MmaOp = ck_tile::core::arch::mma::amdgcn_mma<
+        ck_tile::fp16_t,
+        ck_tile::fp16_t,
+        ck_tile::fp32_t,
+        16u,
+        16u,
+        16u,
+        CtrlFlags,
+        CompilerTarget,
+        ck_tile::core::arch::enable_if_target_family_gfx9_t<CompilerTarget>>;
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t k, const uint32_t n)
-    {
-        const uint32_t lane =
-            16u * (k / 4u) + n; // NOTE: this can be derived with kAMLane * (k / kABKPerLane) + n
-        const uint32_t vecIdx = k % 4u; // NOTE: this can be derived with k % kABKPerLane
-        return {lane, vecIdx};
-    }
+    using MmaTraits = ck_tile::core::arch::mma::MmaOpTraits<MmaOp>;
+    static constexpr index_t WaveSize =
+        static_cast<index_t>(MmaTraits::CompilerTarget::WAVE_SIZE_ID);
+    static constexpr index_t AVecSize =
+        sizeof(typename MmaTraits::AVecType) / sizeof(typename MmaTraits::ADataType);
+    static constexpr index_t BVecSize =
+        sizeof(typename MmaTraits::BVecType) / sizeof(typename MmaTraits::BDataType);
+    static constexpr index_t CVecSize =
+        sizeof(typename MmaTraits::CVecType) / sizeof(typename MmaTraits::CDataType);
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t m, const uint32_t n)
-    {
-        const uint32_t lane =
-            16u * (m / 4u) + n; // NOTE: this can be derived with kCNLane * (m / kCM1PerLane) + n
-        const uint32_t vecIdx = m % 4u; // NOTE: this can be derived with m % kCM1PerLane
-        return {lane, vecIdx};
-    }
+    // TODO: express the encoding in terms of amdgcn constants
+    using AWarpDstrEncoding = tile_distribution_encoding<
+        sequence<1>,
+        tuple<sequence<16>, sequence<4, 4>>,
+        tuple<sequence<2, 1>>,
+        tuple<sequence<0, 0>>,
+        sequence<2>,
+        sequence<1>>;
+
+    using BWarpDstrEncoding = tile_distribution_encoding<
+        sequence<1>,
+        tuple<sequence<16>, sequence<4, 4>>,
+        tuple<sequence<2, 1>>,
+        tuple<sequence<0, 0>>,
+        sequence<2>,
+        sequence<1>>;
+
+    using CWarpDstrEncoding = tile_distribution_encoding<
+        sequence<1>,
+        tuple<sequence<4, 4>, sequence<16>>,
+        tuple<sequence<1, 2>>,
+        tuple<sequence<0, 0>>,
+        sequence<1>,
+        sequence<1>>;
 };
 
 /**
- * @class RegisterMap (GFX11 WMMA specialization)
- * @brief Register mapping for __builtin_amdgcn_wmma_f32_16x16x16_f16_w32.
- *
- * TODO: At the moment, the mapping is hardcoded and derived based on unmerge/merge operations. In
- * the future, we want to use amdgcn_mma internals to compute it.
- *
- * A/B layout unmerge/merge: L{M} V{K}
- *
- *   lane   = m
- *   vecIdx = k
- *
- * C layout unmerge/merge: M{2} L{M0N} V{M1}
- *
- * Unmerge M=16 into (M0 = M % 2) and (M1 = M / 2)
- *
- *   lane   = 16 * m0 + n
- *   vecIdx = m1
+ * @brief RegisterMapTraits for GFX11 WMMA 16x16x16_F16_F16_F32_GFX11
  */
 template <typename CtrlFlags, typename CompilerTarget>
-struct RegisterMap<ck_tile::core::arch::mma::amdgcn_mma<
+struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     ck_tile::fp16_t,
     ck_tile::fp16_t,
     ck_tile::fp32_t,
@@ -203,27 +275,54 @@ struct RegisterMap<ck_tile::core::arch::mma::amdgcn_mma<
     CompilerTarget,
     ck_tile::core::arch::enable_if_target_family_gfx11_t<CompilerTarget>>>
 {
-    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t m, const uint32_t k)
-    {
-        const uint32_t lane   = m;
-        const uint32_t vecIdx = k;
-        return {lane, vecIdx};
-    }
+    using MmaOp = ck_tile::core::arch::mma::amdgcn_mma<
+        ck_tile::fp16_t,
+        ck_tile::fp16_t,
+        ck_tile::fp32_t,
+        16u,
+        16u,
+        16u,
+        CtrlFlags,
+        CompilerTarget,
+        ck_tile::core::arch::enable_if_target_family_gfx11_t<CompilerTarget>>;
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t k, const uint32_t n)
-    {
-        const uint32_t lane   = n;
-        const uint32_t vecIdx = k;
-        return {lane, vecIdx};
-    }
+    using MmaTraits = ck_tile::core::arch::mma::MmaOpTraits<MmaOp>;
+    static constexpr index_t WaveSize =
+        static_cast<index_t>(MmaTraits::CompilerTarget::WAVE_SIZE_ID);
+    static constexpr index_t AVecSize =
+        sizeof(typename MmaTraits::AVecType) / sizeof(typename MmaTraits::ADataType);
+    static constexpr index_t BVecSize =
+        sizeof(typename MmaTraits::BVecType) / sizeof(typename MmaTraits::BDataType);
+    static constexpr index_t CVecSize =
+        sizeof(typename MmaTraits::CVecType) / sizeof(typename MmaTraits::CDataType);
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t m, const uint32_t n)
-    {
-        const uint32_t lane   = (16u * (m % 2u)) + n;
-        const uint32_t vecIdx = m / 2u;
-        return {lane, vecIdx};
-    }
+    // TODO: express the encoding in terms of amdgcn constants
+    using AWarpDstrEncoding = tile_distribution_encoding<
+        sequence<2>,
+        tuple<sequence<16>, sequence<16>>,
+        tuple<sequence<0, 1>>,
+        tuple<sequence<0, 0>>,
+        sequence<2>,
+        sequence<0>>;
+
+    using BWarpDstrEncoding = tile_distribution_encoding<
+        sequence<2>,
+        tuple<sequence<16>, sequence<16>>,
+        tuple<sequence<0, 1>>,
+        tuple<sequence<0, 0>>,
+        sequence<2>,
+        sequence<0>>;
+
+    using CWarpDstrEncoding = tile_distribution_encoding<
+        sequence<1>,
+        tuple<sequence<8, 2>, sequence<16>>,
+        tuple<sequence<1, 2>>,
+        tuple<sequence<1, 0>>,
+        sequence<1>,
+        sequence<0>>;
 };
+
+// ========================================================================
 
 } // namespace
 

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
@@ -42,14 +42,14 @@ struct RegisterIdxPair
 template <typename TileDistrEnc, index_t NumLanes, index_t NumVecItems>
 struct TileDistrEncodingMap
 {
-    static constexpr auto distr            = make_static_tile_distribution(TileDistrEnc{});
+    static constexpr auto distr               = make_static_tile_distribution(TileDistrEnc{});
     static constexpr auto ps_ys_to_xs_adaptor = distr.get_ps_ys_to_xs_adaptor();
 
     /**
      * @brief Convert (lane, vecIdx) to matrix coordinates
      */
-    CK_TILE_HOST_DEVICE static auto
-    calc_matrix_indices_from_lane_vector(index_t lane_idx, index_t vector_idx)
+    CK_TILE_HOST_DEVICE static auto calc_matrix_indices_from_lane_vector(index_t lane_idx,
+                                                                         index_t vector_idx)
     {
         // Unmerge the Y dimension index into its hidden indices
         array<index_t, TileDistrEnc::NDimY> y_hidden_idx;
@@ -87,12 +87,15 @@ struct RegisterMap
 {
     using Traits = RegisterMapTraits<MmaOp>;
 
-    using AMap =
-        TileDistrEncodingMap<typename Traits::AWarpDstrEncoding, Traits::WaveSize, Traits::AVecSize>;
-    using BMap =
-        TileDistrEncodingMap<typename Traits::BWarpDstrEncoding, Traits::WaveSize, Traits::BVecSize>;
-    using CMap =
-        TileDistrEncodingMap<typename Traits::CWarpDstrEncoding, Traits::WaveSize, Traits::CVecSize>;
+    using AMap = TileDistrEncodingMap<typename Traits::AWarpDstrEncoding,
+                                      Traits::WaveSize,
+                                      Traits::AVecSize>;
+    using BMap = TileDistrEncodingMap<typename Traits::BWarpDstrEncoding,
+                                      Traits::WaveSize,
+                                      Traits::BVecSize>;
+    using CMap = TileDistrEncodingMap<typename Traits::CWarpDstrEncoding,
+                                      Traits::WaveSize,
+                                      Traits::CVecSize>;
 
     CK_TILE_HOST_DEVICE static auto Register2AMap(const uint32_t lane, const uint32_t vecIdx)
     {
@@ -175,8 +178,7 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
 
     using AWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<kAMLane>,
-              sequence<kABK0PerLane, kABKLane, kABK1PerLane>>, // <16>, <1, 2, 8>
+        tuple<sequence<kAMLane>, sequence<kABK0PerLane, kABKLane, kABK1PerLane>>, // <16>, <1, 2, 8>
         tuple<kABPs2RHssMajor>,
         tuple<kABPs2RHssMinor>,
         kABYs2RHsMajor,
@@ -184,21 +186,20 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
 
     using BWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<kBNLane>,
-              sequence<kABK0PerLane, kABKLane, kABK1PerLane>>, // <16>, <1, 2, 8>
+        tuple<sequence<kBNLane>, sequence<kABK0PerLane, kABKLane, kABK1PerLane>>, // <16>, <1, 2, 8>
         tuple<kABPs2RHssMajor>,
         tuple<kABPs2RHssMinor>,
         kABYs2RHsMajor,
         kABYs2RHsMinor>;
 
-    using CWarpDstrEncoding = tile_distribution_encoding<
-        sequence<1>,
-        tuple<sequence<kCM0PerLane, kCMLane, kCM1PerLane>,
-              sequence<kCNLane>>, // <1, 2, 8>, <16>
-        tuple<kCPs2RHssMajor>,
-        tuple<kCPs2RHssMinor>,
-        kCYs2RHsMajor,
-        kCYs2RHsMinor>;
+    using CWarpDstrEncoding =
+        tile_distribution_encoding<sequence<1>,
+                                   tuple<sequence<kCM0PerLane, kCMLane, kCM1PerLane>,
+                                         sequence<kCNLane>>, // <1, 2, 8>, <16>
+                                   tuple<kCPs2RHssMajor>,
+                                   tuple<kCPs2RHssMinor>,
+                                   kCYs2RHsMajor,
+                                   kCYs2RHsMinor>;
 };
 
 /**
@@ -241,15 +242,14 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     using kABPs2RHssMinor = sequence<0, 0>;
     using kABYs2RHsMajor  = sequence<2>;
     using kABYs2RHsMinor  = sequence<1>;
-    using kCPs2RHssMajor = sequence<1, 2>;
-    using kCPs2RHssMinor = sequence<0, 0>;
-    using kCYs2RHsMajor  = sequence<1>;
-    using kCYs2RHsMinor  = sequence<1>;
+    using kCPs2RHssMajor  = sequence<1, 2>;
+    using kCPs2RHssMinor  = sequence<0, 0>;
+    using kCYs2RHsMajor   = sequence<1>;
+    using kCYs2RHsMinor   = sequence<1>;
 
     using AWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<MmaOp::kAMLane>,
-              sequence<MmaOp::kABKLane, MmaOp::kABKPerLane>>,
+        tuple<sequence<MmaOp::kAMLane>, sequence<MmaOp::kABKLane, MmaOp::kABKPerLane>>,
         tuple<kABPs2RHssMajor>,
         tuple<kABPs2RHssMinor>,
         kABYs2RHsMajor,
@@ -257,8 +257,7 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
 
     using BWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<MmaOp::kBNLane>,
-              sequence<MmaOp::kABKLane, MmaOp::kABKPerLane>>,
+        tuple<sequence<MmaOp::kBNLane>, sequence<MmaOp::kABKLane, MmaOp::kABKPerLane>>,
         tuple<kABPs2RHssMajor>,
         tuple<kABPs2RHssMinor>,
         kABYs2RHsMajor,
@@ -266,8 +265,7 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
 
     using CWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<MmaOp::kCMLane, MmaOp::kCM1PerLane>,
-              sequence<MmaOp::kCNLane>>,
+        tuple<sequence<MmaOp::kCMLane, MmaOp::kCM1PerLane>, sequence<MmaOp::kCNLane>>,
         tuple<kCPs2RHssMajor>,
         tuple<kCPs2RHssMinor>,
         kCYs2RHsMajor,
@@ -320,44 +318,41 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     using kCYs2RHsMinor   = sequence<0>;
 
     // TODO:  remove these and fix constants in amdgcn_mma
-    static constexpr index_t kAMBlock    = 1;
-    static constexpr index_t kBNBlock    = 1;
-    static constexpr index_t kAMLane     = 16;
-    static constexpr index_t kBNLane     = 16;
+    static constexpr index_t kAMBlock     = 1;
+    static constexpr index_t kBNBlock     = 1;
+    static constexpr index_t kAMLane      = 16;
+    static constexpr index_t kBNLane      = 16;
     static constexpr index_t kABK0PerLane = 1;
     static constexpr index_t kABKLane     = 1;
     static constexpr index_t kABK1PerLane = 16;
-    static constexpr index_t kCMLane     = 2;
-    static constexpr index_t kCNLane     = 16;
-    static constexpr index_t kCM0PerLane = 8;
-    static constexpr index_t kCM1PerLane = 1;
+    static constexpr index_t kCMLane      = 2;
+    static constexpr index_t kCNLane      = 16;
+    static constexpr index_t kCM0PerLane  = 8;
+    static constexpr index_t kCM1PerLane  = 1;
 
-    using AWarpDstrEncoding = tile_distribution_encoding<
-        sequence<2>, // kRepeat
-        tuple<sequence<kAMLane>,
-              sequence<kABK1PerLane>>,
-        tuple<kABPs2RHssMajor>,
-        tuple<kABPs2RHssMinor>,
-        kABYs2RHsMajor,
-        kABYs2RHsMinor>;
+    using AWarpDstrEncoding =
+        tile_distribution_encoding<sequence<2>, // kRepeat
+                                   tuple<sequence<kAMLane>, sequence<kABK1PerLane>>,
+                                   tuple<kABPs2RHssMajor>,
+                                   tuple<kABPs2RHssMinor>,
+                                   kABYs2RHsMajor,
+                                   kABYs2RHsMinor>;
 
-    using BWarpDstrEncoding = tile_distribution_encoding<
-        sequence<2>, // kRepeat
-        tuple<sequence<kBNLane>,
-              sequence<kABK1PerLane>>,
-        tuple<kABPs2RHssMajor>,
-        tuple<kABPs2RHssMinor>,
-        kABYs2RHsMajor,
-        kABYs2RHsMinor>;
+    using BWarpDstrEncoding =
+        tile_distribution_encoding<sequence<2>, // kRepeat
+                                   tuple<sequence<kBNLane>, sequence<kABK1PerLane>>,
+                                   tuple<kABPs2RHssMajor>,
+                                   tuple<kABPs2RHssMinor>,
+                                   kABYs2RHsMajor,
+                                   kABYs2RHsMinor>;
 
-    using CWarpDstrEncoding = tile_distribution_encoding<
-        sequence<1>,
-        tuple<sequence<kCM0PerLane, kCMLane>,
-              sequence<kCNLane>>,
-        tuple<kCPs2RHssMajor>,
-        tuple<kCPs2RHssMinor>,
-        kCYs2RHsMajor,
-        kCYs2RHsMinor>;
+    using CWarpDstrEncoding =
+        tile_distribution_encoding<sequence<1>,
+                                   tuple<sequence<kCM0PerLane, kCMLane>, sequence<kCNLane>>,
+                                   tuple<kCPs2RHssMajor>,
+                                   tuple<kCPs2RHssMinor>,
+                                   kCYs2RHsMajor,
+                                   kCYs2RHsMinor>;
 };
 
 // ========================================================================

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
@@ -172,30 +172,54 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     static constexpr index_t CVecSize =
         sizeof(typename MmaTraits::CVecType) / sizeof(typename MmaTraits::CDataType);
 
-    // TODO: express the encoding in terms of amdgcn constants
+    using kABPs2RHssMajor = sequence<2, 1>;
+    using kABPs2RHssMinor = sequence<1, 0>;
+    using kABYs2RHsMajor  = sequence<2, 2>;
+    using kABYs2RHsMinor  = sequence<0, 2>;
+    using kCPs2RHssMajor  = sequence<1, 2>;
+    using kCPs2RHssMinor  = sequence<1, 0>;
+    using kCYs2RHsMajor   = sequence<1, 1>;
+    using kCYs2RHsMinor   = sequence<0, 2>;
+
+    // TODO:  remove these and fix constants in amdgcn_mma
+    static constexpr index_t kAMBlock     = 1;
+    static constexpr index_t kBNBlock     = 1;
+    static constexpr index_t kAMLane      = 16;
+    static constexpr index_t kBNLane      = 16;
+    static constexpr index_t kABK0PerLane = 1;
+    static constexpr index_t kABKLane     = 2;
+    static constexpr index_t kABK1PerLane = 8;
+    static constexpr index_t kCMLane      = 2;
+    static constexpr index_t kCNLane      = 16;
+    static constexpr index_t kCM0PerLane  = 1;
+    static constexpr index_t kCM1PerLane  = 8;
+
     using AWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<16>, sequence<4, 2, 2>>,
-        tuple<sequence<2, 1>>,
-        tuple<sequence<1, 0>>,
-        sequence<2, 2>,
-        sequence<2, 0>>;
+        tuple<sequence<kAMLane>,
+              sequence<kABK0PerLane, kABKLane, kABK1PerLane>>, // <16>, <1, 2, 8>
+        tuple<kABPs2RHssMajor>,
+        tuple<kABPs2RHssMinor>,
+        kABYs2RHsMajor,
+        kABYs2RHsMinor>;
 
     using BWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<16>, sequence<4, 2, 2>>,
-        tuple<sequence<2, 1>>,
-        tuple<sequence<1, 0>>,
-        sequence<2, 2>,
-        sequence<2, 0>>;
+        tuple<sequence<kBNLane>,
+              sequence<kABK0PerLane, kABKLane, kABK1PerLane>>, // <16>, <1, 2, 8>
+        tuple<kABPs2RHssMajor>,
+        tuple<kABPs2RHssMinor>,
+        kABYs2RHsMajor,
+        kABYs2RHsMinor>;
 
     using CWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<2, 8>, sequence<16>>,
-        tuple<sequence<1, 2>>,
-        tuple<sequence<0, 0>>,
-        sequence<1>,
-        sequence<1>>;
+        tuple<sequence<kCM0PerLane, kCMLane, kCM1PerLane>,
+              sequence<kCNLane>>, // <1, 2, 8>, <16>
+        tuple<kCPs2RHssMajor>,
+        tuple<kCPs2RHssMinor>,
+        kCYs2RHsMajor,
+        kCYs2RHsMinor>;
 };
 
 /**
@@ -234,30 +258,41 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     static constexpr index_t CVecSize =
         sizeof(typename MmaTraits::CVecType) / sizeof(typename MmaTraits::CDataType);
 
-    // TODO: express the encoding in terms of amdgcn constants
+    using kABPs2RHssMajor = sequence<2, 1>;
+    using kABPs2RHssMinor = sequence<0, 0>;
+    using kABYs2RHsMajor  = sequence<2>;
+    using kABYs2RHsMinor  = sequence<1>;
+    using kCPs2RHssMajor = sequence<1, 2>;
+    using kCPs2RHssMinor = sequence<0, 0>;
+    using kCYs2RHsMajor  = sequence<1>;
+    using kCYs2RHsMinor  = sequence<1>;
+
     using AWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<16>, sequence<4, 4>>,
-        tuple<sequence<2, 1>>,
-        tuple<sequence<0, 0>>,
-        sequence<2>,
-        sequence<1>>;
+        tuple<sequence<MmaOp::kAMLane>,
+              sequence<MmaOp::kABKLane, MmaOp::kABKPerLane>>,
+        tuple<kABPs2RHssMajor>,
+        tuple<kABPs2RHssMinor>,
+        kABYs2RHsMajor,
+        kABYs2RHsMinor>;
 
     using BWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<16>, sequence<4, 4>>,
-        tuple<sequence<2, 1>>,
-        tuple<sequence<0, 0>>,
-        sequence<2>,
-        sequence<1>>;
+        tuple<sequence<MmaOp::kBNLane>,
+              sequence<MmaOp::kABKLane, MmaOp::kABKPerLane>>,
+        tuple<kABPs2RHssMajor>,
+        tuple<kABPs2RHssMinor>,
+        kABYs2RHsMajor,
+        kABYs2RHsMinor>;
 
     using CWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<4, 4>, sequence<16>>,
-        tuple<sequence<1, 2>>,
-        tuple<sequence<0, 0>>,
-        sequence<1>,
-        sequence<1>>;
+        tuple<sequence<MmaOp::kCMLane, MmaOp::kCM1PerLane>,
+              sequence<MmaOp::kCNLane>>,
+        tuple<kCPs2RHssMajor>,
+        tuple<kCPs2RHssMinor>,
+        kCYs2RHsMajor,
+        kCYs2RHsMinor>;
 };
 
 /**
@@ -296,30 +331,54 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     static constexpr index_t CVecSize =
         sizeof(typename MmaTraits::CVecType) / sizeof(typename MmaTraits::CDataType);
 
-    // TODO: express the encoding in terms of amdgcn constants
+    using kABPs2RHssMajor = sequence<0, 1>;
+    using kABPs2RHssMinor = sequence<0, 0>;
+    using kABYs2RHsMajor  = sequence<2>;
+    using kABYs2RHsMinor  = sequence<0>;
+    using kCPs2RHssMajor  = sequence<1, 2>;
+    using kCPs2RHssMinor  = sequence<1, 0>;
+    using kCYs2RHsMajor   = sequence<1>;
+    using kCYs2RHsMinor   = sequence<0>;
+
+    // TODO:  remove these and fix constants in amdgcn_mma
+    static constexpr index_t kAMBlock    = 1;
+    static constexpr index_t kBNBlock    = 1;
+    static constexpr index_t kAMLane     = 16;
+    static constexpr index_t kBNLane     = 16;
+    static constexpr index_t kABK0PerLane = 1;
+    static constexpr index_t kABKLane     = 1;
+    static constexpr index_t kABK1PerLane = 16;
+    static constexpr index_t kCMLane     = 2;
+    static constexpr index_t kCNLane     = 16;
+    static constexpr index_t kCM0PerLane = 8;
+    static constexpr index_t kCM1PerLane = 1;
+
     using AWarpDstrEncoding = tile_distribution_encoding<
-        sequence<2>,
-        tuple<sequence<16>, sequence<16>>,
-        tuple<sequence<0, 1>>,
-        tuple<sequence<0, 0>>,
-        sequence<2>,
-        sequence<0>>;
+        sequence<2>, // kRepeat
+        tuple<sequence<kAMLane>,
+              sequence<kABK1PerLane>>,
+        tuple<kABPs2RHssMajor>,
+        tuple<kABPs2RHssMinor>,
+        kABYs2RHsMajor,
+        kABYs2RHsMinor>;
 
     using BWarpDstrEncoding = tile_distribution_encoding<
-        sequence<2>,
-        tuple<sequence<16>, sequence<16>>,
-        tuple<sequence<0, 1>>,
-        tuple<sequence<0, 0>>,
-        sequence<2>,
-        sequence<0>>;
+        sequence<2>, // kRepeat
+        tuple<sequence<kBNLane>,
+              sequence<kABK1PerLane>>,
+        tuple<kABPs2RHssMajor>,
+        tuple<kABPs2RHssMinor>,
+        kABYs2RHsMajor,
+        kABYs2RHsMinor>;
 
     using CWarpDstrEncoding = tile_distribution_encoding<
         sequence<1>,
-        tuple<sequence<8, 2>, sequence<16>>,
-        tuple<sequence<1, 2>>,
-        tuple<sequence<1, 0>>,
-        sequence<1>,
-        sequence<0>>;
+        tuple<sequence<kCM0PerLane, kCMLane>,
+              sequence<kCNLane>>,
+        tuple<kCPs2RHssMajor>,
+        tuple<kCPs2RHssMinor>,
+        kCYs2RHsMajor,
+        kCYs2RHsMinor>;
 };
 
 // ========================================================================

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
@@ -64,27 +64,6 @@ struct TileDistrEncodingMap
         const auto coord     = make_tensor_adaptor_coordinate(ps_ys_to_xs_adaptor, ps_ys_idx);
         return coord.get_bottom_index();
     }
-
-    /**
-     * @brief Convert matrix coordinates to (lane, vecIdx)
-     */
-    CK_TILE_HOST_DEVICE static RegisterIdxPair
-    calc_lane_vector_from_matrix_indices(index_t major_idx, index_t minor_idx)
-    {
-        for(index_t l = 0; l < NumLanes; ++l)
-        {
-            for(index_t v = 0; v < NumVecItems; ++v)
-            {
-                auto res = calc_matrix_indices_from_lane_vector(l, v);
-                if(res[0] == major_idx && res[1] == minor_idx)
-                {
-                    return {static_cast<uint32_t>(l), static_cast<uint32_t>(v)};
-                }
-            }
-        }
-        assert(false && "calc_lane_vector_from_matrix_indices: no mapping found");
-        return {0, 0};
-    }
 };
 
 /**
@@ -115,22 +94,22 @@ struct RegisterMap
     using CMap =
         TileDistrEncodingMap<typename Traits::CWarpDstrEncoding, Traits::WaveSize, Traits::CVecSize>;
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair A2RegisterMap(const uint32_t m, const uint32_t k)
+    CK_TILE_HOST_DEVICE static auto Register2AMap(const uint32_t lane, const uint32_t vecIdx)
     {
-        return AMap::calc_lane_vector_from_matrix_indices(static_cast<index_t>(m),
-                                                          static_cast<index_t>(k));
+        return AMap::calc_matrix_indices_from_lane_vector(static_cast<index_t>(lane),
+                                                          static_cast<index_t>(vecIdx));
     }
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair B2RegisterMap(const uint32_t k, const uint32_t n)
+    CK_TILE_HOST_DEVICE static auto Register2BMap(const uint32_t lane, const uint32_t vecIdx)
     {
-        return BMap::calc_lane_vector_from_matrix_indices(static_cast<index_t>(n),
-                                                          static_cast<index_t>(k));
+        return BMap::calc_matrix_indices_from_lane_vector(static_cast<index_t>(lane),
+                                                          static_cast<index_t>(vecIdx));
     }
 
-    CK_TILE_HOST_DEVICE static RegisterIdxPair C2RegisterMap(const uint32_t m, const uint32_t n)
+    CK_TILE_HOST_DEVICE static auto Register2CMap(const uint32_t lane, const uint32_t vecIdx)
     {
-        return CMap::calc_lane_vector_from_matrix_indices(static_cast<index_t>(m),
-                                                          static_cast<index_t>(n));
+        return CMap::calc_matrix_indices_from_lane_vector(static_cast<index_t>(lane),
+                                                          static_cast<index_t>(vecIdx));
     }
 };
 

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
@@ -10,6 +10,7 @@
 #include "ck_tile/core/arch/mma/mma_selector.hpp"
 #include "ck_tile/core/numeric/half.hpp"
 #include "ck_tile/core/numeric/vector_type.hpp"
+#include "ck_tile/core/arch/mma/utility/tile_distribution_encoding_register_mapper.hpp"
 
 #include <cassert>
 #include <cstdint>
@@ -17,54 +18,6 @@
 namespace {
 
 using namespace ck_tile;
-
-/**
- * @struct RegisterIdxPair
- * @brief Small helper struct to hold a pair of lane and vector index values
- */
-struct RegisterIdxPair
-{
-    uint32_t lane;
-    uint32_t vecIdx;
-};
-
-/**
- * @class TileDistrEncodingMap
- * @brief Unified, static methods for register mapping
- *
- * Uses tile_distribution_encoding to compute the mapping
- * from matrix coordinates (m, k) or (m, n) to (lane, vecIdx) pairs.
- *
- * @tparam TileDistrEnc tile_distribution_encoding type
- * @tparam NumLanes Number of lanes in the wave
- * @tparam NumVecItems Number of vector items per lane
- */
-template <typename TileDistrEnc, index_t NumLanes, index_t NumVecItems>
-struct TileDistrEncodingMap
-{
-    static constexpr auto distr               = make_static_tile_distribution(TileDistrEnc{});
-    static constexpr auto ps_ys_to_xs_adaptor = distr.get_ps_ys_to_xs_adaptor();
-
-    /**
-     * @brief Convert (lane, vecIdx) to matrix coordinates
-     */
-    CK_TILE_HOST_DEVICE static auto calc_matrix_indices_from_lane_vector(index_t lane_idx,
-                                                                         index_t vector_idx)
-    {
-        // Unmerge the Y dimension index into its hidden indices
-        array<index_t, TileDistrEnc::NDimY> y_hidden_idx;
-        index_t vec_tmp = vector_idx;
-        for(index_t i = TileDistrEnc::NDimY - 1; i >= 0; --i)
-        {
-            y_hidden_idx[i] = vec_tmp % TileDistrEnc::detail::ys_lengths_[i];
-            vec_tmp /= TileDistrEnc::detail::ys_lengths_[i];
-        }
-
-        const auto ps_ys_idx = container_concat(array<index_t, 1>{lane_idx}, y_hidden_idx);
-        const auto coord     = make_tensor_adaptor_coordinate(ps_ys_to_xs_adaptor, ps_ys_idx);
-        return coord.get_bottom_index();
-    }
-};
 
 /**
  * @class RegisterMapTraits
@@ -87,15 +40,9 @@ struct RegisterMap
 {
     using Traits = RegisterMapTraits<MmaOp>;
 
-    using AMap = TileDistrEncodingMap<typename Traits::AWarpDstrEncoding,
-                                      Traits::WaveSize,
-                                      Traits::AVecSize>;
-    using BMap = TileDistrEncodingMap<typename Traits::BWarpDstrEncoding,
-                                      Traits::WaveSize,
-                                      Traits::BVecSize>;
-    using CMap = TileDistrEncodingMap<typename Traits::CWarpDstrEncoding,
-                                      Traits::WaveSize,
-                                      Traits::CVecSize>;
+    using AMap = core::arch::mma::TileDistrEncRegMap<typename Traits::AWarpDstrEncoding>;
+    using BMap = core::arch::mma::TileDistrEncRegMap<typename Traits::BWarpDstrEncoding>;
+    using CMap = core::arch::mma::TileDistrEncRegMap<typename Traits::CWarpDstrEncoding>;
 
     CK_TILE_HOST_DEVICE static auto Register2AMap(const uint32_t lane, const uint32_t vecIdx)
     {

--- a/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
+++ b/projects/composablekernel/test/ck_tile/core/arch/mma/test_amdgcn_mma_layout_util.hpp
@@ -133,26 +133,21 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     CompilerTarget,
     ck_tile::core::arch::enable_if_target_family_gfx12_t<CompilerTarget>>>
 {
-    using MmaOp = ck_tile::core::arch::mma::amdgcn_mma<
-        ck_tile::fp16_t,
-        ck_tile::fp16_t,
-        ck_tile::fp32_t,
-        16u,
-        16u,
-        16u,
-        CtrlFlags,
-        CompilerTarget,
-        ck_tile::core::arch::enable_if_target_family_gfx12_t<CompilerTarget>>;
+    using MmaOp = ck_tile::core::arch::mma::amdgcn_mma<ck_tile::fp16_t,
+                                                       ck_tile::fp16_t,
+                                                       ck_tile::fp32_t,
+                                                       16u,
+                                                       16u,
+                                                       16u,
+                                                       CtrlFlags,
+                                                       CompilerTarget>;
 
     using MmaTraits = ck_tile::core::arch::mma::MmaOpTraits<MmaOp>;
     static constexpr index_t WaveSize =
         static_cast<index_t>(MmaTraits::CompilerTarget::WAVE_SIZE_ID);
-    static constexpr index_t AVecSize =
-        sizeof(typename MmaTraits::AVecType) / sizeof(typename MmaTraits::ADataType);
-    static constexpr index_t BVecSize =
-        sizeof(typename MmaTraits::BVecType) / sizeof(typename MmaTraits::BDataType);
-    static constexpr index_t CVecSize =
-        sizeof(typename MmaTraits::CVecType) / sizeof(typename MmaTraits::CDataType);
+    static constexpr index_t AVecSize = vector_traits<typename MmaTraits::AVecType>::vector_size;
+    static constexpr index_t BVecSize = vector_traits<typename MmaTraits::BVecType>::vector_size;
+    static constexpr index_t CVecSize = vector_traits<typename MmaTraits::CVecType>::vector_size;
 
     using kABPs2RHssMajor = sequence<2, 1>;
     using kABPs2RHssMinor = sequence<1, 0>;
@@ -217,26 +212,21 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     CompilerTarget,
     ck_tile::core::arch::enable_if_target_family_gfx9_t<CompilerTarget>>>
 {
-    using MmaOp = ck_tile::core::arch::mma::amdgcn_mma<
-        ck_tile::fp16_t,
-        ck_tile::fp16_t,
-        ck_tile::fp32_t,
-        16u,
-        16u,
-        16u,
-        CtrlFlags,
-        CompilerTarget,
-        ck_tile::core::arch::enable_if_target_family_gfx9_t<CompilerTarget>>;
+    using MmaOp = ck_tile::core::arch::mma::amdgcn_mma<ck_tile::fp16_t,
+                                                       ck_tile::fp16_t,
+                                                       ck_tile::fp32_t,
+                                                       16u,
+                                                       16u,
+                                                       16u,
+                                                       CtrlFlags,
+                                                       CompilerTarget>;
 
     using MmaTraits = ck_tile::core::arch::mma::MmaOpTraits<MmaOp>;
     static constexpr index_t WaveSize =
         static_cast<index_t>(MmaTraits::CompilerTarget::WAVE_SIZE_ID);
-    static constexpr index_t AVecSize =
-        sizeof(typename MmaTraits::AVecType) / sizeof(typename MmaTraits::ADataType);
-    static constexpr index_t BVecSize =
-        sizeof(typename MmaTraits::BVecType) / sizeof(typename MmaTraits::BDataType);
-    static constexpr index_t CVecSize =
-        sizeof(typename MmaTraits::CVecType) / sizeof(typename MmaTraits::CDataType);
+    static constexpr index_t AVecSize = vector_traits<typename MmaTraits::AVecType>::vector_size;
+    static constexpr index_t BVecSize = vector_traits<typename MmaTraits::BVecType>::vector_size;
+    static constexpr index_t CVecSize = vector_traits<typename MmaTraits::CVecType>::vector_size;
 
     using kABPs2RHssMajor = sequence<2, 1>;
     using kABPs2RHssMinor = sequence<0, 0>;
@@ -287,26 +277,21 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
     CompilerTarget,
     ck_tile::core::arch::enable_if_target_family_gfx11_t<CompilerTarget>>>
 {
-    using MmaOp = ck_tile::core::arch::mma::amdgcn_mma<
-        ck_tile::fp16_t,
-        ck_tile::fp16_t,
-        ck_tile::fp32_t,
-        16u,
-        16u,
-        16u,
-        CtrlFlags,
-        CompilerTarget,
-        ck_tile::core::arch::enable_if_target_family_gfx11_t<CompilerTarget>>;
+    using MmaOp = ck_tile::core::arch::mma::amdgcn_mma<ck_tile::fp16_t,
+                                                       ck_tile::fp16_t,
+                                                       ck_tile::fp32_t,
+                                                       16u,
+                                                       16u,
+                                                       16u,
+                                                       CtrlFlags,
+                                                       CompilerTarget>;
 
     using MmaTraits = ck_tile::core::arch::mma::MmaOpTraits<MmaOp>;
     static constexpr index_t WaveSize =
         static_cast<index_t>(MmaTraits::CompilerTarget::WAVE_SIZE_ID);
-    static constexpr index_t AVecSize =
-        sizeof(typename MmaTraits::AVecType) / sizeof(typename MmaTraits::ADataType);
-    static constexpr index_t BVecSize =
-        sizeof(typename MmaTraits::BVecType) / sizeof(typename MmaTraits::BDataType);
-    static constexpr index_t CVecSize =
-        sizeof(typename MmaTraits::CVecType) / sizeof(typename MmaTraits::CDataType);
+    static constexpr index_t AVecSize = vector_traits<typename MmaTraits::AVecType>::vector_size;
+    static constexpr index_t BVecSize = vector_traits<typename MmaTraits::BVecType>::vector_size;
+    static constexpr index_t CVecSize = vector_traits<typename MmaTraits::CVecType>::vector_size;
 
     using kABPs2RHssMajor = sequence<0, 1>;
     using kABPs2RHssMinor = sequence<0, 0>;
@@ -358,4 +343,3 @@ struct RegisterMapTraits<ck_tile::core::arch::mma::amdgcn_mma<
 // ========================================================================
 
 } // namespace
-


### PR DESCRIPTION
## Motivation

Currently, the test suite for `amdgcn_mma` focuses on the design (e.g. choosing the correct specialization based on SFINAE) and a single live test that checks if selected MmaOp runs. This PR adds a simplified GEMM test kernel that checks the exact layout of the selected MmaOp.

## Technical Details

The test in `test_amdgcn_mma_layout.cpp` launches MxKxN test cases (one per block), where each case:
  1. Constructs A and B tensors on a device with a single 1 at A(m,k) and B(k,n) (rest is all 0s)
  2. Executes the MMA intrinsic.
  3.  Checks if C has the "1" on the excpeted position.

For the MMA instrinsic, it pulls a Mma op from amdgcn_mma specialization based on a given input (tile dimension, data types).

Note 1: As a helper, in `test_amdgcn_mma_layout_util.hpp` we add register map for a given amdgcn_mma specialization. Register mapping is currently  based on the `tile_distribution_encoding`.

Note 2: Everything is added to the test suite, no additions to the actual `amdgcn_mma` structs. All the extra information that is needed, but not yet provided by `amdgcn_mma` structs, is added as a boilerplate to the header. TODO: Rebase this PR on top of the `amdgcn_mma` refactor or clean it up after merge.   

## Test Plan

This PR solely adds a new test to the existing code.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
