### PR TITLE
Add Batchnorm Fwd Inference Support

### DIFF
--- a/dnn-providers/hip-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/CMakeLists.txt
@@ -80,6 +80,7 @@ list(
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH} ${ROCM_PATH}/hip)
 
 find_package(hip REQUIRED)
+find_package(hiprtc REQUIRED)
 find_package(hipdnn_data_sdk CONFIG REQUIRED)
 find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
 
@@ -101,6 +102,92 @@ message(STATUS "Plugin build directory: ${HIPDNN_BUILD_PLUGIN_ENGINE_DIR}")
 message(STATUS "Plugin install directory: ${HIPDNN_INSTALL_PLUGIN_ENGINE_DIR}")
 file(MAKE_DIRECTORY ${HIPDNN_BUILD_PLUGIN_ENGINE_DIR})
 
+# Function to embed kernel sources as C++ strings at configure time
+function(embed_kernel_sources OUTPUT_SRCS_CPP OUTPUT_SRCS_HPP OUTPUT_INCS_CPP OUTPUT_INCS_HPP KERNEL_FILES)
+    set(KERNEL_DECLARATIONS "")
+    set(KERNEL_DEFINITIONS "")
+    set(KERNEL_MAP_ENTRIES "")
+    set(HEADER_DECLARATIONS "")
+    set(HEADER_DEFINITIONS "")
+    set(HEADER_MAP_ENTRIES "")
+    set(HEADER_FILENAMES "")
+
+    foreach(KERNEL_FILE ${KERNEL_FILES})
+        file(READ ${KERNEL_FILE} KERNEL_CONTENT)
+        get_filename_component(KERNEL_NAME ${KERNEL_FILE} NAME_WE)
+        get_filename_component(KERNEL_FILENAME ${KERNEL_FILE} NAME)
+        get_filename_component(KERNEL_EXT ${KERNEL_FILE} EXT)
+        string(TOUPPER ${KERNEL_NAME} KERNEL_VAR_NAME)
+
+        # Check if this is a header file
+        if(KERNEL_EXT STREQUAL ".h" OR KERNEL_EXT STREQUAL ".hpp")
+            # Build declarations for header includes
+            string(APPEND HEADER_DECLARATIONS "extern const char* const ${KERNEL_VAR_NAME}_SOURCE;\n")
+
+            # Build definitions for header includes
+            string(APPEND HEADER_DEFINITIONS "const char* const ${KERNEL_VAR_NAME}_SOURCE = R\"KERNEL_SOURCE(\n")
+            string(APPEND HEADER_DEFINITIONS "${KERNEL_CONTENT}")
+            string(APPEND HEADER_DEFINITIONS "\n)KERNEL_SOURCE\";\n\n")
+
+            # Build map entry for GetKernelInc lookup
+            string(APPEND HEADER_MAP_ENTRIES "        {\"${KERNEL_FILENAME}\", ${KERNEL_VAR_NAME}_SOURCE},\n")
+
+            # Build list of header filenames
+            string(APPEND HEADER_FILENAMES "        \"${KERNEL_FILENAME}\",\n")
+        else()
+            # Build declarations for kernel sources
+            string(APPEND KERNEL_DECLARATIONS "extern const char* const ${KERNEL_VAR_NAME}_SOURCE;\n")
+
+            # Build definitions for kernel sources
+            string(APPEND KERNEL_DEFINITIONS "const char* const ${KERNEL_VAR_NAME}_SOURCE = R\"KERNEL_SOURCE(\n")
+            string(APPEND KERNEL_DEFINITIONS "${KERNEL_CONTENT}")
+            string(APPEND KERNEL_DEFINITIONS "\n)KERNEL_SOURCE\";\n\n")
+
+            # Build map entry for getKernelSrc lookup
+            string(APPEND KERNEL_MAP_ENTRIES "        {\"${KERNEL_FILENAME}\", ${KERNEL_VAR_NAME}_SOURCE},\n")
+        endif()
+    endforeach()
+
+    # Generate kernel source files
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_sources.hpp.in
+        ${OUTPUT_SRCS_HPP}
+        @ONLY
+    )
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_sources.cpp.in
+        ${OUTPUT_SRCS_CPP}
+        @ONLY
+    )
+
+    # Generate kernel include files
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_includes.hpp.in
+        ${OUTPUT_INCS_HPP}
+        @ONLY
+    )
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_includes.cpp.in
+        ${OUTPUT_INCS_CPP}
+        @ONLY
+    )
+endfunction()
+
+# List kernel files to embed
+set(KERNEL_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/kernels/BatchNormFwdInferSpatial.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/kernels/vector_add.cpp
+)
+
+# Generate embedded kernel sources and includes at configure time
+embed_kernel_sources(
+    ${CMAKE_BINARY_DIR}/kernel_sources.cpp
+    ${CMAKE_BINARY_DIR}/kernel_sources.hpp
+    ${CMAKE_BINARY_DIR}/kernel_includes.cpp
+    ${CMAKE_BINARY_DIR}/kernel_includes.hpp
+    "${KERNEL_FILES}"
+)
+
 # OBJECT library for hip kernel plugin implementation
 add_library(
     hip_kernel_plugin_impl OBJECT
@@ -109,12 +196,19 @@ add_library(
     HipKernelPluginPublic.cpp
     HipKernelContainer.cpp
     engines/HipKernelEngine.cpp
+    hip/HipProgram.cpp
+    hip/HipKernel.cpp
+    ${CMAKE_BINARY_DIR}/kernel_sources.cpp
+    ${CMAKE_BINARY_DIR}/kernel_includes.cpp
 )
 target_compile_definitions(
     hip_kernel_plugin_impl PRIVATE COMPONENT_NAME="hip_kernel_plugin"
 )
-target_include_directories(hip_kernel_plugin_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(hip_kernel_plugin_impl PUBLIC hipdnn_data_sdk hipdnn_plugin_sdk)
+target_include_directories(hip_kernel_plugin_impl PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_BINARY_DIR}
+)
+target_link_libraries(hip_kernel_plugin_impl PUBLIC hipdnn_data_sdk hipdnn_plugin_sdk hiprtc::hiprtc)
 target_compile_options(hip_kernel_plugin_impl PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 set_target_properties(hip_kernel_plugin_impl PROPERTIES
     CXX_VISIBILITY_PRESET hidden
@@ -125,12 +219,12 @@ set_target_properties(hip_kernel_plugin_impl PROPERTIES
 add_library(hip_kernel_plugin_private STATIC $<TARGET_OBJECTS:hip_kernel_plugin_impl>)
 target_compile_definitions(hip_kernel_plugin_private PRIVATE COMPONENT_NAME="hip_kernel_plugin")
 target_include_directories(hip_kernel_plugin_private PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(hip_kernel_plugin_private PUBLIC hipdnn_data_sdk hipdnn_plugin_sdk)
+target_link_libraries(hip_kernel_plugin_private PUBLIC hipdnn_data_sdk hipdnn_plugin_sdk hiprtc::hiprtc)
 
 # Shared library for hip kernel plugin
 add_library(hip_kernel_plugin SHARED $<TARGET_OBJECTS:hip_kernel_plugin_impl>)
 target_compile_definitions(hip_kernel_plugin PRIVATE COMPONENT_NAME="hip_kernel_plugin")
-target_link_libraries(hip_kernel_plugin PRIVATE hipdnn_data_sdk hipdnn_plugin_sdk)
+target_link_libraries(hip_kernel_plugin PRIVATE hipdnn_data_sdk hipdnn_plugin_sdk hiprtc::hiprtc)
 target_link_libraries(hip_kernel_plugin PRIVATE "-Xlinker --exclude-libs=ALL")
 target_compile_options(hip_kernel_plugin PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})
 set_target_properties(

--- a/dnn-providers/hip-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/CMakeLists.txt
@@ -177,6 +177,11 @@ endfunction()
 set(KERNEL_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/BatchNormFwdInferSpatial.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/vector_add.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/kernels/FloatTypes.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/kernels/VectorTypes.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/kernels/Bfloat16Dev.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/kernels/BatchnormActivation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/kernels/HipKernelMath.hpp
 )
 
 # Generate embedded kernel sources and includes at configure time
@@ -195,11 +200,15 @@ add_library(
     HipKernelPlugin.cpp
     HipKernelPluginPublic.cpp
     HipKernelContainer.cpp
+    HipKernelUtils.cpp
     engines/HipKernelEngine.cpp
     hip/HipProgram.cpp
     hip/HipKernel.cpp
     ${CMAKE_BINARY_DIR}/kernel_sources.cpp
     ${CMAKE_BINARY_DIR}/kernel_includes.cpp
+    engines/plans/BatchnormPlanBuilder.cpp
+    engines/plans/BatchnormFwdInferencePlan.cpp
+    engines/plans/BatchnormApplicabilityChecks.cpp
 )
 target_compile_definitions(
     hip_kernel_plugin_impl PRIVATE COMPONENT_NAME="hip_kernel_plugin"

--- a/dnn-providers/hip-kernel-provider/HipKernelContainer.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelContainer.cpp
@@ -89,7 +89,7 @@ uint32_t
 
 HipKernelContainer::HipKernelContainer()
 {
-    HIPDNN_LOG_INFO("Creating HipKernelContainer");
+    HIPDNN_PLUGIN_LOG_INFO("Creating HipKernelContainer");
 
     _engineManager = std::make_unique<EngineManager>();
 
@@ -101,7 +101,7 @@ HipKernelContainer::HipKernelContainer()
 
 HipKernelContainer::~HipKernelContainer()
 {
-    HIPDNN_LOG_INFO("Destroying HipKernelContainer");
+    HIPDNN_PLUGIN_LOG_INFO("Destroying HipKernelContainer");
 }
 
 EngineManager& HipKernelContainer::getEngineManager()

--- a/dnn-providers/hip-kernel-provider/HipKernelContainer.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelContainer.cpp
@@ -4,6 +4,7 @@
 #include "HipKernelContainer.hpp"
 #include "EngineManager.hpp"
 #include "engines/HipKernelEngine.hpp"
+#include "engines/plans/BatchnormPlanBuilder.hpp"
 
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/utilities/EngineNames.hpp>
@@ -34,6 +35,7 @@ const std::vector<HipKernelContainer::EngineDefinition>& HipKernelContainer::get
         {HIP_KERNEL_ENGINE_ID,
          []() -> std::unique_ptr<IEngine> {
              auto engine = std::make_unique<HipKernelEngine>(HIP_KERNEL_ENGINE_ID);
+             engine->addPlanBuilder(std::make_unique<BatchnormPlanBuilder>());
              // add more plan builders here as they are created, for example:
              // engine->addPlanBuilder(std::make_unique<HipKernelBatchnormPlanBuilder>());
              return engine;

--- a/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
@@ -38,53 +38,53 @@ extern "C" {
 
 hipdnnPluginStatus_t hipdnnPluginGetNameImpl(const char** name)
 {
-    LOG_API_ENTRY("name_ptr={:p}", static_cast<void*>(name));
+    LOG_API_ENTRY("name_ptr=" << static_cast<const void*>(name));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(name);
 
         *name = pluginName;
 
-        LOG_API_SUCCESS(apiName, "pluginName={:p}", static_cast<void*>(name));
+        LOG_API_SUCCESS(apiName, "pluginName=" << static_cast<const void*>(name));
     });
 }
 
 hipdnnPluginStatus_t hipdnnPluginGetVersionImpl(const char** version)
 {
-    LOG_API_ENTRY("versionPtr={:p}", static_cast<void*>(version));
+    LOG_API_ENTRY("versionPtr=" << static_cast<const void*>(version));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(version);
 
         *version = pluginVersion;
 
-        LOG_API_SUCCESS(apiName, "version={:p}", static_cast<void*>(version));
+        LOG_API_SUCCESS(apiName, "version=" << static_cast<const void*>(version));
     });
 }
 
 hipdnnPluginStatus_t hipdnnPluginGetTypeImpl(hipdnnPluginType_t* type)
 {
-    LOG_API_ENTRY("typePtr={:p}", static_cast<void*>(type));
+    LOG_API_ENTRY("typePtr=" << static_cast<void*>(type));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(type);
 
         *type = HIPDNN_PLUGIN_TYPE_ENGINE;
 
-        LOG_API_SUCCESS(apiName, "type={}", *type);
+        LOG_API_SUCCESS(apiName, "type=" << *type);
     });
 }
 
 void hipdnnPluginGetLastErrorStringImpl(const char** errorStr)
 {
-    LOG_API_ENTRY("errorStrPtr={:p}", static_cast<void*>(errorStr));
+    LOG_API_ENTRY("errorStrPtr=" << static_cast<void*>(errorStr));
 
     hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(errorStr);
 
         *errorStr = PluginLastErrorManager::getLastError();
 
-        LOG_API_SUCCESS(apiName, "errorStr={:p}", static_cast<void*>(errorStr));
+        LOG_API_SUCCESS(apiName, "errorStr=" << static_cast<void*>(errorStr));
     });
 }
 
@@ -94,7 +94,7 @@ hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callbac
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(callback);
         hipdnn::logging::initializeCallbackLogging(pluginName, callback);
-        LOG_API_SUCCESS(apiName, "", "");
+        LOG_API_SUCCESS(apiName, "");
     });
 }
 
@@ -102,10 +102,8 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
                                                            uint32_t maxEngines,
                                                            uint32_t* numEngines)
 {
-    LOG_API_ENTRY("engineIds={:p}, maxEngines={}, numEngines={:p}",
-                  static_cast<void*>(engineIds),
-                  maxEngines,
-                  static_cast<void*>(numEngines));
+    LOG_API_ENTRY("engineIds=" << static_cast<void*>(engineIds) << ", maxEngines=" << maxEngines
+                               << ", numEngines=" << static_cast<void*>(numEngines));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         if(maxEngines != 0)
@@ -116,13 +114,13 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetAllEngineIdsImpl(int64_t* engineIds,
 
         auto totalEngines = HipKernelContainer::copyEngineIds(engineIds, maxEngines, *numEngines);
 
-        LOG_API_SUCCESS(apiName, "numEngines={} totalEngines={}", *numEngines, totalEngines);
+        LOG_API_SUCCESS(apiName, "numEngines=" << *numEngines << " totalEngines=" << totalEngines);
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* handle)
 {
-    LOG_API_ENTRY("handle_ptr={:p}", static_cast<void*>(handle));
+    LOG_API_ENTRY("handle_ptr=" << static_cast<void*>(handle));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -154,13 +152,13 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateImpl(hipdnnEnginePluginHandle_t* ha
             }
         }
 
-        LOG_API_SUCCESS(apiName, "createdHandle={:p}", static_cast<void*>(*handle));
+        LOG_API_SUCCESS(apiName, "createdHandle=" << static_cast<void*>(*handle));
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t handle)
 {
-    LOG_API_ENTRY("handle={:p}", static_cast<void*>(handle));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -168,22 +166,22 @@ hipdnnPluginStatus_t hipdnnEnginePluginDestroyImpl(hipdnnEnginePluginHandle_t ha
         delete handle;
         handle = nullptr;
 
-        LOG_API_SUCCESS(apiName, "", "");
+        LOG_API_SUCCESS(apiName, "");
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginSetStreamImpl(hipdnnEnginePluginHandle_t handle,
                                                      hipStream_t stream)
 {
-    LOG_API_ENTRY(
-        "handle={:p}, stream_id={:p}", static_cast<void*>(handle), static_cast<void*>(stream));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", stream_id=" << static_cast<void*>(stream));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
 
         handle->setStream(stream);
 
-        LOG_API_SUCCESS(apiName, "", "");
+        LOG_API_SUCCESS(apiName, "");
     });
 }
 
@@ -194,12 +192,10 @@ hipdnnPluginStatus_t
                                                  uint32_t maxEngines,
                                                  uint32_t* numEngines)
 {
-    LOG_API_ENTRY("handle={:p}, opGraph={:p}, engineIds={:p}, maxEngines={}, numEngines={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(engineIds),
-                  maxEngines,
-                  static_cast<void*>(numEngines));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", opGraph=" << static_cast<const void*>(opGraph) << ", engineIds="
+                            << static_cast<void*>(engineIds) << ", maxEngines=" << maxEngines
+                            << ", numEngines=" << static_cast<void*>(numEngines));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -221,10 +217,10 @@ hipdnnPluginStatus_t
             if(*numEngines == maxEngines)
             {
                 *numEngines = static_cast<uint32_t>(applicableEngines.size());
-                HIPDNN_LOG_INFO("Maximum number of engines reached ({}), ignoring additional "
-                                "engines, numEngines count: {}",
-                                maxEngines,
-                                *numEngines);
+                HIPDNN_PLUGIN_LOG_INFO("Maximum number of engines reached ("
+                                       << maxEngines
+                                       << "), ignoring additional engines, numEngines count: "
+                                       << *numEngines);
                 break;
             }
 
@@ -232,7 +228,7 @@ hipdnnPluginStatus_t
             (*numEngines)++;
         }
 
-        LOG_API_SUCCESS(apiName, "numEngines={}", *numEngines);
+        LOG_API_SUCCESS(apiName, "numEngines=" << *numEngines);
     });
 }
 
@@ -241,11 +237,9 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHa
                                                             const hipdnnPluginConstData_t* opGraph,
                                                             hipdnnPluginConstData_t* engineDetails)
 {
-    LOG_API_ENTRY("handle={:p}, engineId={}, opGraph={:p}, engineDetails={:p}",
-                  static_cast<void*>(handle),
-                  engineId,
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(engineDetails));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle) << ", engineId=" << engineId
+                            << ", opGraph=" << static_cast<const void*>(opGraph)
+                            << ", engineDetails=" << static_cast<void*>(engineDetails));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -257,7 +251,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetEngineDetailsImpl(hipdnnEnginePluginHa
 
         engineManager.getEngineDetails(*handle, opGraphWrapper, engineId, *engineDetails);
 
-        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr=" << engineDetails->ptr);
     });
 }
 
@@ -265,9 +259,8 @@ hipdnnPluginStatus_t
     hipdnnEnginePluginDestroyEngineDetailsImpl(hipdnnEnginePluginHandle_t handle,
                                                hipdnnPluginConstData_t* engineDetails)
 {
-    LOG_API_ENTRY("handle={:p}, engineDetails={}",
-                  static_cast<void*>(handle),
-                  static_cast<void*>(engineDetails));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", engineDetails=" << static_cast<void*>(engineDetails));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -276,7 +269,7 @@ hipdnnPluginStatus_t
 
         handle->removeEngineDetailsDetachedBuffer(engineDetails->ptr);
 
-        LOG_API_SUCCESS(apiName, "engineDetails->ptr={:p}", engineDetails->ptr);
+        LOG_API_SUCCESS(apiName, "engineDetails->ptr=" << engineDetails->ptr);
     });
 }
 
@@ -286,11 +279,10 @@ hipdnnPluginStatus_t
                                            const hipdnnPluginConstData_t* opGraph,
                                            size_t* workspaceSize)
 {
-    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, workspaceSize={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(engineConfig),
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(workspaceSize));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", engineConfig=" << static_cast<const void*>(engineConfig)
+                            << ", opGraph=" << static_cast<const void*>(opGraph)
+                            << ", workspaceSize=" << static_cast<void*>(workspaceSize));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -305,7 +297,7 @@ hipdnnPluginStatus_t
         *workspaceSize = engineManager.getWorkspaceSize(
             *handle, engineConfigWrapper.engineId(), opGraphWrapper);
 
-        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+        LOG_API_SUCCESS(apiName, "workspaceSize=" << *workspaceSize);
     });
 }
 
@@ -315,11 +307,10 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
     const hipdnnPluginConstData_t* opGraph,
     hipdnnEnginePluginExecutionContext_t* executionContext)
 {
-    LOG_API_ENTRY("handle={:p}, engineConfig={:p}, opGraph={:p}, executionContext={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(engineConfig),
-                  static_cast<const void*>(opGraph),
-                  static_cast<void*>(executionContext));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", engineConfig=" << static_cast<const void*>(engineConfig)
+                            << ", opGraph=" << static_cast<const void*>(opGraph)
+                            << ", executionContext=" << static_cast<void*>(executionContext));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -347,17 +338,16 @@ hipdnnPluginStatus_t hipdnnEnginePluginCreateExecutionContextImpl(
 
         *executionContext = context;
 
-        LOG_API_SUCCESS(
-            apiName, "created_execution_context={:p}", static_cast<void*>(*executionContext));
+        LOG_API_SUCCESS(apiName,
+                        "created_execution_context=" << static_cast<void*>(*executionContext));
     });
 }
 
 hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
     hipdnnEnginePluginHandle_t handle, hipdnnEnginePluginExecutionContext_t executionContext)
 {
-    LOG_API_ENTRY("handle={:p}, executionContext={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<void*>(executionContext));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", executionContext=" << static_cast<void*>(executionContext));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -365,7 +355,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginDestroyExecutionContextImpl(
 
         delete executionContext;
 
-        LOG_API_SUCCESS(apiName, "destroyed executionContext", "");
+        LOG_API_SUCCESS(apiName, "destroyed executionContext");
     });
 }
 
@@ -374,10 +364,9 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
     hipdnnEnginePluginExecutionContext_t executionContext,
     size_t* workspaceSize)
 {
-    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspaceSize={:p}",
-                  static_cast<void*>(handle),
-                  static_cast<const void*>(executionContext),
-                  static_cast<void*>(workspaceSize));
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle)
+                            << ", executionContext=" << static_cast<const void*>(executionContext)
+                            << ", workspaceSize=" << static_cast<void*>(workspaceSize));
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -386,7 +375,7 @@ hipdnnPluginStatus_t hipdnnEnginePluginGetWorkspaceSizeFromExecutionContextImpl(
 
         *workspaceSize = executionContext->plan().getWorkspaceSize(*handle);
 
-        LOG_API_SUCCESS(apiName, "workspaceSize={}", *workspaceSize);
+        LOG_API_SUCCESS(apiName, "workspaceSize=" << *workspaceSize);
     });
 }
 
@@ -397,13 +386,10 @@ hipdnnPluginStatus_t
                                          const hipdnnPluginDeviceBuffer_t* deviceBuffers,
                                          uint32_t numDeviceBuffers)
 {
-    LOG_API_ENTRY("handle={:p}, executionContext={:p}, workspace={:p}, deviceBuffers={:p}, "
-                  "numDeviceBuffers={}",
-                  static_cast<void*>(handle),
-                  static_cast<void*>(executionContext),
-                  workspace,
-                  static_cast<const void*>(deviceBuffers),
-                  numDeviceBuffers);
+    LOG_API_ENTRY("handle=" << static_cast<void*>(handle) << ", executionContext="
+                            << static_cast<void*>(executionContext) << ", workspace=" << workspace
+                            << ", deviceBuffers=" << static_cast<const void*>(deviceBuffers)
+                            << ", numDeviceBuffers=" << numDeviceBuffers);
 
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(handle);
@@ -412,7 +398,7 @@ hipdnnPluginStatus_t
 
         executionContext->plan().execute(*handle, deviceBuffers, numDeviceBuffers, workspace);
 
-        LOG_API_SUCCESS(apiName, "executed graph", "");
+        LOG_API_SUCCESS(apiName, "executed graph");
     });
 }
 

--- a/dnn-providers/hip-kernel-provider/HipKernelPluginPublic.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPluginPublic.cpp
@@ -34,6 +34,22 @@ hipdnnPluginStatus_t hipdnnPluginSetLoggingCallback(hipdnnCallback_t callback)
     return hipdnnPluginSetLoggingCallbackImpl(callback);
 }
 
+hipdnnPluginStatus_t
+    hipdnnEnginePluginGetAllEngineIds(int64_t* engineIds, uint32_t maxEngines, uint32_t* numEngines)
+{
+    return hipdnnEnginePluginGetAllEngineIdsImpl(engineIds, maxEngines, numEngines);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginCreate(hipdnnEnginePluginHandle_t* handle)
+{
+    return hipdnnEnginePluginCreateImpl(handle);
+}
+
+hipdnnPluginStatus_t hipdnnEnginePluginDestroy(hipdnnEnginePluginHandle_t handle)
+{
+    return hipdnnEnginePluginDestroyImpl(handle);
+}
+
 hipdnnPluginStatus_t hipdnnEnginePluginSetStream(hipdnnEnginePluginHandle_t handle,
                                                  hipStream_t stream)
 {

--- a/dnn-providers/hip-kernel-provider/HipKernelUtils.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelUtils.cpp
@@ -1,0 +1,112 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipKernelUtils.hpp"
+
+namespace hip_kernel_plugin::hip_kernel_utils
+{
+
+ActivationParams parseActivation(const hipdnn_data_sdk::data_objects::PointwiseAttributes& attrs)
+{
+    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+
+    switch(attrs.operation())
+    {
+    case PM::RELU_FWD:
+    case PM::RELU_BWD:
+    {
+        if(attrs.relu_lower_clip() && attrs.relu_upper_clip())
+        {
+            return ActivationParams{ActivationMode::CLAMP,
+                                    static_cast<double>(*attrs.relu_lower_clip()),
+                                    static_cast<double>(*attrs.relu_upper_clip()),
+                                    0.0};
+        }
+        if(attrs.relu_upper_clip())
+        {
+            return ActivationParams{ActivationMode::CLIPPED_RELU,
+                                    static_cast<double>(*attrs.relu_upper_clip()),
+                                    0.0,
+                                    0.0};
+        }
+        if(attrs.relu_lower_clip_slope())
+        {
+            return ActivationParams{ActivationMode::LEAKY_RELU,
+                                    static_cast<double>(*attrs.relu_lower_clip_slope()),
+                                    0.0,
+                                    0.0};
+        }
+        if(attrs.relu_lower_clip().has_value() && attrs.relu_lower_clip().value() != 0.f)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Standard relu with a non-zero lower_clip is not supported");
+        }
+        return ActivationParams{ActivationMode::RELU, 0.0, 0.0, 0.0};
+    }
+    case PM::SIGMOID_FWD:
+    case PM::SIGMOID_BWD:
+        return ActivationParams{ActivationMode::LOGISTIC, 0.0, 0.0, 0.0};
+    case PM::TANH_FWD:
+    case PM::TANH_BWD:
+        return ActivationParams{ActivationMode::TANH, 1.0, 1.0, 0.0};
+    case PM::ELU_FWD:
+    case PM::ELU_BWD:
+    {
+        double alpha = attrs.elu_alpha() ? static_cast<double>(*attrs.elu_alpha()) : 1.0;
+        return ActivationParams{ActivationMode::ELU, alpha, 0.0, 0.0};
+    }
+    case PM::SOFTPLUS_FWD:
+    case PM::SOFTPLUS_BWD:
+        if(attrs.softplus_beta())
+        {
+            if(static_cast<double>(*attrs.softplus_beta()) != 1.0)
+            {
+                throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                               "Softplus only supports beta = 1.0");
+            }
+        }
+        return ActivationParams{ActivationMode::SOFTRELU, 0.0, 0.0, 0.0};
+    case PM::ABS:
+        return ActivationParams{ActivationMode::ABS, 0.0, 0.0, 0.0};
+    case PM::IDENTITY:
+        return ActivationParams{ActivationMode::PASTHRU, 0.0, 0.0, 0.0};
+    default:
+        throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                       "Unsupported activation operation");
+    }
+}
+
+hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
+                                            const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                            uint32_t numDeviceBuffers)
+{
+    for(uint32_t i = 0; i < numDeviceBuffers; i++)
+    {
+        if(uid == deviceBuffers[i].uid)
+        {
+            return deviceBuffers[i];
+        }
+    }
+
+    throw hipdnn_plugin_sdk::HipdnnPluginException(
+        HIPDNN_PLUGIN_STATUS_INVALID_VALUE,
+        "Device buffer with the uid: " + std::to_string(uid)
+            + " not found in the provided device buffers.");
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    int64_t uid)
+{
+    if(auto tensorAttr = tensorMap.find(uid); tensorAttr != tensorMap.end())
+    {
+        return *tensorAttr->second;
+    }
+
+    throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                                                   "Failed to find tensor with UID in tensorMap: "
+                                                       + std::to_string(uid));
+}
+}

--- a/dnn-providers/hip-kernel-provider/HipKernelUtils.hpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelUtils.hpp
@@ -1,0 +1,54 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <optional>
+#include <unordered_map>
+
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
+
+#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+namespace hip_kernel_plugin::hip_kernel_utils
+{
+
+enum class ActivationMode : int
+{
+    PASTHRU = 0,
+    LOGISTIC = 1, // sigmoid
+    TANH = 2,
+    RELU = 3,
+    SOFTRELU = 4, // softplus
+    ABS = 5,
+    POWER = 6,
+    CLIPPED_RELU = 7,
+    LEAKY_RELU = 8,
+    ELU = 9,
+    CLAMP = 10
+};
+
+struct ActivationParams
+{
+    ActivationMode mode;
+    double alpha;
+    double beta;
+    double gamma;
+};
+
+ActivationParams parseActivation(const hipdnn_data_sdk::data_objects::PointwiseAttributes& attrs);
+
+hipdnnPluginDeviceBuffer_t findDeviceBuffer(int64_t uid,
+                                            const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                            uint32_t numDeviceBuffers);
+
+const hipdnn_data_sdk::data_objects::TensorAttributes& findTensorAttributes(
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    int64_t uid);
+}

--- a/dnn-providers/hip-kernel-provider/HipdnnEnginePluginHandle.hpp
+++ b/dnn-providers/hip-kernel-provider/HipdnnEnginePluginHandle.hpp
@@ -10,6 +10,7 @@
 #include <hip/hip_runtime.h>
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
 
 #include "HipKernelContainer.hpp"
 
@@ -37,13 +38,13 @@ public:
     void storeEngineDetailsDetachedBuffer(const void* ptr,
                                           std::unique_ptr<flatbuffers::DetachedBuffer> buffer)
     {
-        HIPDNN_LOG_INFO("Storing detached buffer at address: {:p}", ptr);
+        HIPDNN_PLUGIN_LOG_INFO("Storing detached buffer at address: " << ptr);
         _engineDetailsBuffers[ptr] = std::move(buffer);
     }
 
     void removeEngineDetailsDetachedBuffer(const void* ptr)
     {
-        HIPDNN_LOG_INFO("Removing detached buffer at address: {:p}", ptr);
+        HIPDNN_PLUGIN_LOG_INFO("Removing detached buffer at address: " << ptr);
 
         auto it = _engineDetailsBuffers.find(ptr);
         if(it != _engineDetailsBuffers.end())
@@ -52,10 +53,10 @@ public:
         }
         else
         {
-            HIPDNN_LOG_WARN("No detached buffer found at address: {:p}. Could not remove engine "
-                            "details. Ensure you "
-                            "are using the same hipdnn handle you used for engine details creation",
-                            ptr);
+            HIPDNN_PLUGIN_LOG_WARN(
+                "No detached buffer found at address: "
+                << ptr << ". Could not remove engine details. Ensure you "
+                << "are using the same hipdnn handle you used for engine details creation");
         }
     }
 

--- a/dnn-providers/hip-kernel-provider/cmake/scripts/test_name_validator.py
+++ b/dnn-providers/hip-kernel-provider/cmake/scripts/test_name_validator.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from typing import List, Dict, Tuple
+from re import Pattern
+
+
+class TestNameValidator:
+
+    KEYWORDS: Dict[str, List[str]] = {
+        "test_types": ["Test", "Integration"],
+        "gpu": ["Gpu"],
+        "datatypes": ["Bfp16", "Fp16", "Fp32", "Fp64"],
+        "shapes": ["Nhwc", "Nchw", "Ndhwc", "Ncdhw"],
+    }
+
+    FLATTENED_KEYWORDS: List[str] = [
+        kw for sublist in KEYWORDS.values() for kw in sublist
+    ]
+
+    POSITIONAL_KEYWORDS: List[str] = (
+        KEYWORDS["test_types"] + KEYWORDS["datatypes"] + KEYWORDS["gpu"]
+    )
+
+    FULL_NAME_RE: Pattern[str] = re.compile(
+        r"^(?:(?P<prefix>[A-Z][A-Za-z0-9]*)/)?"
+        r"(?P<suite>[A-Z][A-Za-z0-9]*)"
+        r"\.(?P<case>(?:DISABLED_[A-Z][A-Za-z0-9]+|[A-Z][A-Za-z0-9]*))"
+        r"(?:/.*)?$"
+    )
+
+    def _validate_test_case(self, case_name: str) -> List[str]:
+        """
+        Validate a test case name.
+        Returns a list of issues found, or empty list if valid.
+        """
+        issues = []
+
+        if case_name.startswith("DISABLED_"):
+            case_name = case_name[9:]
+
+        # Check for disallowed positional keywords
+        found_keywords = [kw for kw in self.POSITIONAL_KEYWORDS if kw in case_name]
+        if found_keywords:
+            issues.append(
+                f"Test case name should not contain keywords: {', '.join(found_keywords)}. These belong in the test suite name."
+            )
+
+        return issues
+
+    def _validate_suite_structure(self, suite_name: str) -> List[str]:
+        """
+        Validate the structure of a test suite name.
+        Returns a list of issues found, or empty list if valid.
+        """
+        issues = []
+
+        prefix_part = f"({'|'.join(self.KEYWORDS['test_types'])})"
+        gpu_part = f"({self.KEYWORDS['gpu'][0]})?"
+        feature_part = r"(?P<feature>[A-Z][a-zA-Z0-9]*?)"
+        datatypes_part = f"({'|'.join(self.KEYWORDS['datatypes'])})?"
+
+        structure_regex = re.compile(
+            f"^{prefix_part}{gpu_part}{feature_part}{datatypes_part}$"
+        )
+
+        match = structure_regex.match(suite_name)
+
+        if not match:
+            issues.append(
+                "Suite name does not follow the structure: (Test|Integration)[Gpu?]FeatureName[Datatype?]"
+            )
+            return issues
+
+        feature_name = match.group("feature")
+
+        for keyword in self.POSITIONAL_KEYWORDS:
+            if keyword in feature_name:
+                issues.append(
+                    f"Keyword '{keyword}' is misplaced and should not be in the middle of the suite name."
+                )
+
+        return issues
+
+    def validate_test_name(self, test_name: str) -> List[str]:
+        """
+        Validate a single full test name.
+        Returns a list of issues found, or empty list if valid
+        """
+        issues = []
+
+        parsed_match = self.FULL_NAME_RE.match(test_name)
+        if not parsed_match:
+            issues.append(
+                "Test name does not match expected PascalCase format 'TestSuite.TestCase' or 'TestSuite/Instance.TestCase' without special characters."
+            )
+            return issues
+
+        prefix = parsed_match.group("prefix") or ""
+        suite_name = parsed_match.group("suite")
+        case_name = parsed_match.group("case")
+
+        for keyword in self.FLATTENED_KEYWORDS:
+            matches = re.findall(
+                re.escape(keyword), f"{prefix}/{suite_name}.{case_name}", re.IGNORECASE
+            )
+
+            valid_matches = [m for m in matches if m == keyword or m == keyword.upper()]
+            # Check capitalization
+            issues.extend(
+                [
+                    f"Keyword '{match}' should be capitalized as '{keyword}'"
+                    for match in valid_matches
+                    if match != keyword
+                ]
+            )
+
+            # Check duplicates
+            if len(valid_matches) > 1:
+                issues.append(
+                    f"Keyword '{keyword}' appears more than once."
+                )  # Potentially useful to make test names more concise
+
+        issues.extend(self._validate_suite_structure(suite_name))
+        issues.extend(self._validate_test_case(case_name))
+
+        return issues
+
+    @staticmethod
+    def extract_test_names_from_ctest_json(json_path: Path) -> List[str]:
+        """Extract test names from CTest JSON output."""
+        try:
+            with open(json_path, "r") as f:
+                data = json.load(f)
+
+            test_names = []
+            if "tests" in data:
+                for test in data["tests"]:
+                    if "name" in test:
+                        test_names.append(test["name"].split("#")[0].strip())
+
+            return test_names
+        except FileNotFoundError:
+            print(f"Error: CTest JSON file not found: {json_path}", file=sys.stderr)
+            return []
+        except json.JSONDecodeError as e:
+            print(f"Error: Invalid JSON in file {json_path}: {e}", file=sys.stderr)
+            return []
+        except Exception as e:
+            print(f"Unexpected error reading CTest JSON file: {e}", file=sys.stderr)
+            return []
+
+    @staticmethod
+    def extract_test_names_from_executables(
+        executables_file: Path, build_dir: Path, verbose: bool = False
+    ) -> List[str]:
+        """Extract test names by running executables with --gtest_list_tests."""
+        test_names = []
+
+        try:
+            with open(executables_file, "r") as f:
+                executables = [line.strip() for line in f if line.strip()]
+                if verbose:
+                    print(f"Found {len(executables)} test executables to process.")
+                    print(f"Executables: {executables}")
+        except FileNotFoundError:
+            print(
+                f"Error: Executables file not found: {executables_file}",
+                file=sys.stderr,
+            )
+            return []
+
+        for executable in executables:
+            exec_path = (build_dir / executable).resolve()
+            if not exec_path.exists() or not exec_path.is_file():
+                print(f"Warning: Executable not found: {exec_path}", file=sys.stderr)
+                continue
+
+            try:
+                result = subprocess.run(
+                    [str(exec_path), "--gtest_list_tests"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    cwd=str(exec_path.parent),
+                )
+
+                if result.returncode != 0:
+                    print(
+                        f"Warning: Failed to list tests from {executable}: {result.stderr}",
+                        file=sys.stderr,
+                    )
+                    continue
+
+                current_suite = None
+                for line in result.stdout.splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    if line.endswith(".") and not line.endswith("..."):
+                        current_suite = line[:-1]
+                    elif line and current_suite:
+                        test_case = line.strip()
+                        test_names.append(
+                            f"{current_suite}.{test_case.split("#")[0].strip()}"
+                        )
+
+            except subprocess.TimeoutExpired:
+                print(f"Warning: Timeout running {executable}", file=sys.stderr)
+            except Exception as e:
+                print(f"Warning: Error running {executable}: {e}", file=sys.stderr)
+
+        return test_names
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate test names against hipDNN rules",
+        epilog="At least one of --ctest-json or --test-executables must be provided.",
+    )
+
+    input_group = parser.add_argument_group(
+        "input methods", "Specify one or both methods to gather test names"
+    )
+
+    input_group.add_argument(
+        "--ctest-json",
+        type=Path,
+        help="Path to CTest JSON output (from ctest --show-only=json-v1)",
+    )
+
+    input_group.add_argument(
+        "--test-executables",
+        type=Path,
+        help="Path to file containing list of test executables",
+    )
+
+    input_group.add_argument(
+        "--build-dir",
+        type=Path,
+        help="Build directory where test executables are located. Required if --test-executables is provided.",
+    )
+
+    options_group = parser.add_argument_group("options")
+
+    options_group.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with non-zero status if any test names are invalid",
+        default=False,
+    )
+
+    options_group.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show all test names, not just invalid ones",
+        default=False,
+    )
+
+    options_group.add_argument(
+        "--run-tests",
+        action="store_true",
+        help="Run unit tests for this validator",
+        default=False,
+    )
+
+    args = parser.parse_args()
+
+    if not args.run_tests:
+        if args.test_executables and not args.build_dir:
+            parser.error("--build-dir is required when using --test-executables")
+
+        if not args.ctest_json and not args.test_executables:
+            parser.error(
+                "At least one of --ctest-json or --test-executables must be provided"
+            )
+
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.run_tests:
+        unittest.main(argv=[sys.argv[0]], exit=True)
+
+    validator = TestNameValidator()
+    test_names = []
+
+    if args.test_executables and args.build_dir:
+        test_names.extend(
+            validator.extract_test_names_from_executables(
+                args.test_executables, args.build_dir, args.verbose
+            )
+        )
+
+    if args.ctest_json:
+        test_names.extend(validator.extract_test_names_from_ctest_json(args.ctest_json))
+
+    if not test_names:
+        print("Warning: No test names found to validate", file=sys.stderr)
+        return 0
+
+    invalid_count = 0
+    results: Dict[str, List[str]] = {}
+
+    for test_name in test_names:
+        issues = validator.validate_test_name(test_name)
+        results[test_name] = issues
+        if issues:
+            invalid_count += 1
+
+    print(f"\nTest Name Validation Report")
+    print(f"{'=' * 60}")
+    print(f"Total tests found: {len(test_names)}")
+    print(f"Valid test names: {len(test_names) - invalid_count}")
+    print(f"Invalid test names: {invalid_count}\n")
+
+    if invalid_count == 0:
+        return 0
+
+    print(f"{'Test Name':<50} {'Status':<10}")
+    print(f"{'-' * 60}")
+
+    for test_name, issues in sorted(results.items()):
+        is_valid = len(issues) == 0
+        if not is_valid or args.verbose:
+            status = "[PASS]" if is_valid else "[FAIL]"
+            print(f"{test_name:<50} {status:<10}")
+            if issues:
+                for issue in issues:
+                    print(f"  → {issue}")
+
+    print(f"\nWarning: {invalid_count} test(s) have non-conforming names")
+    print(
+        " - For detailed hipDNN test naming rules, see: docs/CodingStyleAndNamingGuidelines.md\n"
+    )
+
+    return 1 if args.strict else 0
+
+
+class TestTestNameValidator(unittest.TestCase):
+    def setUp(self) -> None:
+        self.validator = TestNameValidator()
+
+    def test_valid_test_names_basic(self) -> None:
+        """Test basic valid test names in PascalCase"""
+        valid_names = [
+            "TestMyClass.Something",
+            "IntegrationConvolution.Forward",
+            "TestBatchNorm.Backward",
+            "TestExecutionPlanBuilder.Build",
+        ]
+
+        for name in valid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertEqual(
+                    issues, [], f"Expected {name} to be valid, but got issues: {issues}"
+                )
+
+    def test_valid_test_names_with_gpu(self) -> None:
+        """Test valid test names with Gpu keyword"""
+        valid_names = [
+            "TestGpuConvolution.Forward",
+            "IntegrationGpuBatchNorm.Backward",
+            "TestGpuExecutionPlanBuilder.Build",
+        ]
+
+        for name in valid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertEqual(
+                    issues, [], f"Expected {name} to be valid, but got issues: {issues}"
+                )
+
+    def test_valid_test_names_with_datatypes(self) -> None:
+        """Test valid test names with datatype suffixes"""
+        valid_names = [
+            "TestConvolutionFp32.Forward",
+            "TestBatchNormFp16.Backward",
+            "IntegrationConvolutionBfp16.Wrw",
+            "TestGpuConvolutionFp64.Performance",
+            "IntegrationGpuBatchNormFp32.Convergence",
+        ]
+
+        for name in valid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertEqual(
+                    issues, [], f"Expected {name} to be valid, but got issues: {issues}"
+                )
+
+    def test_valid_test_names_with_instance(self) -> None:
+        """Test valid parameterized test names with instance"""
+        valid_names = [
+            "Temp/TestConvolution.Forward",
+            "Group/IntegrationGpuBatchNormFp32.Accuracy",
+            "Config/TestMyClass.Method",
+        ]
+
+        for name in valid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertEqual(
+                    issues, [], f"Expected {name} to be valid, but got issues: {issues}"
+                )
+
+    def test_valid_disabled_test_names(self) -> None:
+        """Test valid disabled test names"""
+        valid_names = [
+            "TestMyClass.DISABLED_Something",
+            "IntegrationGpuConvolutionFp32.DISABLED_Forward",
+        ]
+
+        for name in valid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertEqual(
+                    issues, [], f"Expected {name} to be valid, but got issues: {issues}"
+                )
+
+    def test_invalid_format(self) -> None:
+        """Test names with invalid format"""
+        invalid_names = [
+            "test_my_class.test_something",  # lowercase
+            "TestMyClass_Something",  # underscore instead of dot
+            "TestMyClass.test_something",  # lowercase test case
+            "testMyClass.Something",  # lowercase suite
+            "Test-MyClass.Something",  # hyphens
+            "Test My Class.Something",  # spaces
+        ]
+
+        for name in invalid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertTrue(len(issues) > 0, f"Expected format error for {name}")
+
+    def test_keywords_in_test_case(self) -> None:
+        """Test that positional keywords are not allowed in test case names"""
+        invalid_names = [
+            "TestMyClass.TestGpuFunction",  # Gpu in test case
+            "TestMyClass.TestFp32Precision",  # Fp32 in test case
+            "TestMyClass.IntegrationTest",  # Integration in test case
+            "TestMyClass.TestBfp16Type",  # Bfp16 in test case
+        ]
+
+        for name in invalid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertTrue(
+                    any("should not contain keywords" in issue for issue in issues),
+                    f"Expected keyword error in test case for {name}",
+                )
+
+    def test_invalid_suite_structure(self) -> None:
+        """Test suite names that don't follow the required structure"""
+        invalid_names = [
+            "MyClass.Something",  # Missing Test/Integration prefix
+            "GpuTestConvolution.Forward",  # Gpu must come after Test/Integration
+            "TestConvolutionGpu.Forward",  # Gpu must come before feature name
+            "ConvolutionTest.Forward",  # Test must be at the beginning
+            "TestFp32Convolution.Forward",  # Datatype must be at the end
+        ]
+
+        for name in invalid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertTrue(len(issues) > 0, f"Expected structure error for {name}")
+
+    def test_keyword_misplacement(self) -> None:
+        """Test keywords misplaced in the feature name"""
+        invalid_names = [
+            "TestConvolutionGpuPlannerFp32.Forward",  # Gpu in middle
+            "TestConvolutionTestPlannerFp32.Forward",  # Test in middle
+            "IntegrationConvolutionFp32Planner.Forward",  # Fp32 in middle
+        ]
+
+        for name in invalid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertTrue(
+                    any("misplaced" in issue for issue in issues),
+                    f"Expected misplacement error for {name}",
+                )
+
+    def test_keyword_capitalization(self) -> None:
+        """Test incorrect keyword capitalization"""
+        invalid_names = [
+            "TestGPUConvolution.Forward",  # GPU instead of Gpu
+            "TestConvolutionFP32.Forward",  # FP32 instead of Fp32
+            "testConvolution.Forward",  # test instead of Test
+            "INTEGRATIONConvolution.Forward",  # INTEGRATION instead of Integration
+        ]
+
+        for name in invalid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertTrue(
+                    len(issues) > 0, f"Expected capitalization issues for {name}"
+                )
+
+    def test_keyword_duplicates(self) -> None:
+        """Test duplicate keywords"""
+        invalid_names = [
+            "TestTestConvolution.Forward",  # Duplicate Test
+            "TestGpuConvolutionGpu.Forward",  # Duplicate Gpu
+        ]
+
+        for name in invalid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertTrue(
+                    len(issues) > 0, f"Expected issues for duplicate keywords in {name}"
+                )
+
+    def test_complex_valid_names(self) -> None:
+        """Test more complex but valid test names"""
+        valid_names = [
+            "IntegrationGpuConvolutionPlannerNchwFp32.Forward",
+            "TestActivationKernelNchwFp32.Relu",
+            "TestExecutionPlanBuilderFp32.Optimization",
+            "IntegrationGraphFusion.MultipleOps",
+            "TestConvolutionHeuristicsFp32.Performance",
+            "TestConvolutionHeuristics.Accuracy",
+        ]
+
+        for name in valid_names:
+            with self.subTest(name=name):
+                issues = self.validator.validate_test_name(name)
+                self.assertEqual(
+                    issues, [], f"Expected {name} to be valid, but got issues: {issues}"
+                )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dnn-providers/hip-kernel-provider/engines/HipKernelEngine.cpp
+++ b/dnn-providers/hip-kernel-provider/engines/HipKernelEngine.cpp
@@ -117,15 +117,15 @@ void HipKernelEngine::initializeExecutionContext(
             }
             else
             {
-                HIPDNN_LOG_WARN(
-                    "Benchmarking knob setting value is not an integer. Type: {}",
-                    hipdnn_data_sdk::data_objects::EnumNameKnobValue(knobSetting.valueType()));
+                HIPDNN_PLUGIN_LOG_WARN(
+                    "Benchmarking knob setting value is not an integer. Type: "
+                    << hipdnn_data_sdk::data_objects::EnumNameKnobValue(knobSetting.valueType()));
             }
         }
     }
     else
     {
-        HIPDNN_LOG_WARN("Engine config is invalid");
+        HIPDNN_PLUGIN_LOG_WARN("Engine config is invalid");
     }
 
     for(const auto& planBuilder : _planBuilders)

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormApplicabilityChecks.cpp
@@ -303,7 +303,7 @@ void checkTensorLayoutsAndDimsSupported(
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
-    // Skip scalars (epsilon, momentum) - their type is validated by MIOpen
+    // Skip tensors with embedded scalar values (epsilon, momentum) - they don't have layouts or dimensions to validate
     std::vector<BatchnormTensorDescriptor> tensors;
     tensors.reserve(tensorMap.size());
 
@@ -649,7 +649,7 @@ namespace
 void checkBatchnormActivationModeSupported(
     const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr, bool isBwd)
 {
-    // MIOpen supports: PASSTHRU, RELU, CLIPPEDREU, CLAMP (no Leaky ReLU)
+    // hip-kernel-provider batchnorm supports: PASSTHRU, RELU, CLIPPEDREU, CLAMP (no Leaky ReLU)
 
     if(activAttr.operation() == hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY)
     {

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormApplicabilityChecks.cpp
@@ -1,0 +1,690 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <numeric>
+#include <vector>
+
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+
+#include "BatchnormApplicabilityChecks.hpp"
+#include "HipKernelUtils.hpp"
+
+namespace hip_kernel_plugin
+{
+
+// --- Type Configuration Helpers ---
+
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedIoTypes()
+{
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    for(const auto& config : VALID)
+    {
+        types.insert(config.io);
+    }
+    return types;
+}
+
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedAffineTypes()
+{
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    for(const auto& config : VALID)
+    {
+        types.insert(config.affine);
+    }
+    return types;
+}
+
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> bn_type_configs::getAllowedStatTypes()
+{
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    for(const auto& config : VALID)
+    {
+        types.insert(config.stat);
+    }
+    return types;
+}
+
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType>
+    bn_type_configs::getAllowedIntermediateTypes()
+{
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> types;
+    for(const auto& config : VALID)
+    {
+        types.insert(config.intermediate);
+    }
+    return types;
+}
+
+// --- Tensor Descriptor Implementation ---
+
+BatchnormTensorDescriptor::BatchnormTensorDescriptor(
+    const hipdnn_data_sdk::data_objects::TensorAttributes* attr)
+    : dims(attr->dims()->begin(), attr->dims()->end())
+    , strides(attr->strides()->begin(), attr->strides()->end())
+    , strideOrder(hipdnn_data_sdk::utilities::extractStrideOrder(strides))
+{
+}
+
+bool BatchnormTensorDescriptor::isPacked() const
+{
+    return hipdnn_data_sdk::utilities::isTensorPacked(dims, strides);
+}
+
+// --- Validation Utilities ---
+
+namespace validators
+{
+
+void validateDimensionCount(size_t numDims)
+{
+    constexpr size_t MIN_SUPPORTED_DIMS = 4;
+    constexpr size_t MAX_SUPPORTED_DIMS = 5;
+
+    if(numDims < MIN_SUPPORTED_DIMS || numDims > MAX_SUPPORTED_DIMS)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Batchnorm implementation supports only 4D or 5D tensors.");
+    }
+}
+
+void validateConsistentDimensions(const std::vector<BatchnormTensorDescriptor>& tensors)
+{
+    if(tensors.empty())
+    {
+        return;
+    }
+
+    const size_t expectedDims = tensors[0].numDims();
+    validateDimensionCount(expectedDims);
+
+    for(size_t i = 1; i < tensors.size(); ++i)
+    {
+        if(tensors[i].numDims() != expectedDims)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "All tensors for batchnorm must have the same number of dimensions.");
+        }
+    }
+}
+
+void validatePackedTensors(const std::vector<BatchnormTensorDescriptor>& tensors)
+{
+    for(const auto& tensor : tensors)
+    {
+        if(!tensor.isPacked())
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Batchnorm implementation supports only packed tensors.");
+        }
+    }
+}
+
+void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims)
+{
+    if(numDims == 4)
+    {
+        const auto layoutNchw = hipdnn_data_sdk::utilities::TensorLayout::NCHW;
+        const auto layoutNhwc = hipdnn_data_sdk::utilities::TensorLayout::NHWC;
+
+        if(strideOrder != layoutNchw.strideOrder && strideOrder != layoutNhwc.strideOrder)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Batchnorm implementation supports only NCHW and NHWC layouts for 4D tensors.");
+        }
+    }
+    else
+    {
+        const auto layoutNcdhw = hipdnn_data_sdk::utilities::TensorLayout::NCDHW;
+        const auto layoutNdhwc = hipdnn_data_sdk::utilities::TensorLayout::NDHWC;
+
+        if(strideOrder != layoutNcdhw.strideOrder && strideOrder != layoutNdhwc.strideOrder)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(
+                HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                "Batchnorm implementation supports only NCDHW and NDHWC layouts for 5D tensors.");
+        }
+    }
+}
+
+void validateConsistentLayouts(const std::vector<BatchnormTensorDescriptor>& tensors)
+{
+    if(tensors.empty())
+    {
+        return;
+    }
+
+    // Use first tensor with meaningful layout as reference
+    int64_t referenceIndex = -1;
+    for(size_t i = 0; i < tensors.size(); ++i)
+    {
+        if(hipdnn_data_sdk::utilities::isLayoutAgnostic(tensors[i].dims))
+        {
+            continue;
+        }
+
+        if(referenceIndex == -1)
+        {
+            referenceIndex = static_cast<int64_t>(i);
+            validateSupportedLayout(tensors[static_cast<size_t>(referenceIndex)].strideOrder,
+                                    tensors[static_cast<size_t>(referenceIndex)].numDims());
+        }
+        else
+        {
+            if(tensors[i].strideOrder != tensors[static_cast<size_t>(referenceIndex)].strideOrder)
+            {
+                throw hipdnn_plugin_sdk::HipdnnPluginException(
+                    HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                    "All tensors for batchnorm must have the same layout.");
+            }
+        }
+    }
+}
+
+void validateDataTypeIsSupported(
+    hipdnn_data_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& errorMessage)
+{
+    if(allowedTypes.count(dataType) > 0)
+    {
+        return;
+    }
+    throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM, errorMessage);
+}
+
+void validateConsistentDataTypes(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& typeErrorMessage,
+    const std::string& consistencyErrorMessage)
+{
+    if(tensorIds.empty())
+    {
+        return;
+    }
+
+    const auto& firstTensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[0]);
+    const auto referenceType = firstTensor.data_type();
+
+    validateDataTypeIsSupported(referenceType, allowedTypes, typeErrorMessage);
+
+    for(size_t i = 1; i < tensorIds.size(); ++i)
+    {
+        const auto& tensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorIds[i]);
+        if(tensor.data_type() != referenceType)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           consistencyErrorMessage);
+        }
+    }
+}
+
+void validateFixedDataType(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    hipdnn_data_sdk::data_objects::DataType expectedType,
+    const std::string& errorMessage)
+{
+    for(const auto tensorId : tensorIds)
+    {
+        const auto& tensor = hip_kernel_utils::findTensorAttributes(tensorMap, tensorId);
+        if(tensor.data_type() != expectedType)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           errorMessage);
+        }
+    }
+}
+
+void validateConsistentShapes(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::vector<int64_t>& referenceShape,
+    const std::string& errorMessage)
+{
+    for(const auto tensorId : tensorIds)
+    {
+        const auto& tensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, tensorId);
+        const std::vector<int64_t> dims(tensorAttr.dims()->begin(), tensorAttr.dims()->end());
+        if(dims != referenceShape)
+        {
+            throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                           errorMessage);
+        }
+    }
+}
+
+void validateSpatialDimensions(const std::vector<int64_t>& ioDims)
+{
+    if(ioDims.size() < 3)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+            "IO tensor must have at least 3 dimensions for batchnorm.");
+    }
+
+    const auto spatialSize
+        = std::accumulate(ioDims.begin() + 2, ioDims.end(), int64_t{1}, std::multiplies<>());
+
+    if(ioDims[0] * spatialSize <= 1)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "The product of the batch size and spatial dimensions must be greater than 1 for "
+            "batchnorm.");
+    }
+}
+
+void validatePeerStatsNotPopulated(const flatbuffers::Vector<int64_t>* peerStatsTensorUid,
+                                   const std::string& errorMessage)
+{
+    if(peerStatsTensorUid != nullptr && !peerStatsTensorUid->empty())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+                                                       errorMessage);
+    }
+}
+
+} // namespace validators
+
+// --- Component Validators ---
+
+void checkTensorLayoutsAndDimsSupported(
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    // Skip scalars (epsilon, momentum) - their type is validated by MIOpen
+    std::vector<BatchnormTensorDescriptor> tensors;
+    tensors.reserve(tensorMap.size());
+
+    for(const auto& [id, attr] : tensorMap)
+    {
+        if(attr->value_type() != hipdnn_data_sdk::data_objects::TensorValue::NONE)
+        {
+            continue;
+        }
+        tensors.emplace_back(attr);
+    }
+
+    validators::validateConsistentDimensions(tensors);
+    validators::validatePackedTensors(tensors);
+    validators::validateConsistentLayouts(tensors);
+}
+
+void checkTensorDataTypesSupported(
+    const std::vector<int64_t>& ioTensorIds,
+    const std::vector<int64_t>& affineTensorIds,
+    const std::vector<int64_t>& statTensorIds,
+    const std::vector<int64_t>& intermediateTensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    validators::validateConsistentDataTypes(
+        ioTensorIds,
+        tensorMap,
+        bn_type_configs::getAllowedIoTypes(),
+        "Batchnorm implementation supports only FLOAT, HALF, and BFLOAT16 data types for x, y, "
+        "dy, and dx tensors.",
+        "All IO tensors for batchnorm must have the same data type.");
+
+    const auto allowedAffineTypes = bn_type_configs::getAllowedAffineTypes();
+    if(allowedAffineTypes.size() == 1)
+    {
+        validators::validateFixedDataType(affineTensorIds,
+                                          tensorMap,
+                                          *allowedAffineTypes.begin(),
+                                          "Batchnorm implementation supports only FLOAT data type "
+                                          "for scale and bias tensors.");
+    }
+    else
+    {
+        validators::validateConsistentDataTypes(
+            affineTensorIds,
+            tensorMap,
+            allowedAffineTypes,
+            "Batchnorm affine tensors use unsupported data type.",
+            "All affine tensors for batchnorm must have the same data type.");
+    }
+
+    const auto allowedStatTypes = bn_type_configs::getAllowedStatTypes();
+    if(allowedStatTypes.size() == 1)
+    {
+        validators::validateFixedDataType(statTensorIds,
+                                          tensorMap,
+                                          *allowedStatTypes.begin(),
+                                          "Batchnorm implementation supports only FLOAT data type "
+                                          "for mean and variance tensors.");
+    }
+    else
+    {
+        validators::validateConsistentDataTypes(
+            statTensorIds,
+            tensorMap,
+            allowedStatTypes,
+            "Batchnorm stat tensors use unsupported data type.",
+            "All stat tensors for batchnorm must have the same data type.");
+    }
+
+    const auto allowedIntermediateTypes = bn_type_configs::getAllowedIntermediateTypes();
+    if(allowedIntermediateTypes.size() == 1)
+    {
+        validators::validateFixedDataType(
+            intermediateTensorIds,
+            tensorMap,
+            *allowedIntermediateTypes.begin(),
+            "Batchnorm implementation supports only FLOAT data type for intermediate tensors.");
+    }
+    else
+    {
+        validators::validateConsistentDataTypes(
+            intermediateTensorIds,
+            tensorMap,
+            allowedIntermediateTypes,
+            "Batchnorm intermediate tensors use unsupported data type.",
+            "All intermediate tensors for batchnorm must have the same data type.");
+    }
+}
+
+void checkTensorShapesSupported(
+    const std::vector<int64_t>& ioTensorIds,
+    const std::vector<int64_t>& affineTensorIds,
+    const std::vector<int64_t>& statTensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    bool isTraining)
+{
+    if(ioTensorIds.empty())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+            "At least one IO tensor must be provided for batchnorm.");
+    }
+
+    const auto& ioTensorAttr = hip_kernel_utils::findTensorAttributes(tensorMap, ioTensorIds[0]);
+    const std::vector<int64_t> ioDims(ioTensorAttr.dims()->begin(), ioTensorAttr.dims()->end());
+
+    validators::validateConsistentShapes(
+        ioTensorIds, tensorMap, ioDims, "All IO tensors for batchnorm must have the same shape.");
+
+    const auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(ioDims);
+    validators::validateConsistentShapes(affineTensorIds,
+                                         tensorMap,
+                                         derivedDims,
+                                         "Scale and bias tensors for batchnorm must have shape "
+                                         "derived from IO tensor shape.");
+    validators::validateConsistentShapes(statTensorIds,
+                                         tensorMap,
+                                         derivedDims,
+                                         "Mean and variance tensors for batchnorm must have shape "
+                                         "derived from IO tensor shape.");
+
+    if(isTraining)
+    {
+        validators::validateSpatialDimensions(ioDims);
+    }
+}
+
+// --- High-Level Configuration Validators ---
+
+namespace
+{
+
+void checkBatchnormTensorConfigSupported(
+    const std::vector<int64_t>& ioTensorIds,
+    const std::vector<int64_t>& affineTensorIds,
+    const std::vector<int64_t>& statTensorIds,
+    const std::vector<int64_t>& intermediateTensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    bool isTraining)
+{
+    checkTensorLayoutsAndDimsSupported(tensorMap);
+    checkTensorDataTypesSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, tensorMap);
+    checkTensorShapesSupported(ioTensorIds, affineTensorIds, statTensorIds, tensorMap, isTraining);
+}
+
+} // namespace
+
+void checkBatchnormInferenceTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), bnInfAttr.y_tensor_uid()};
+    std::vector<int64_t> affineTensorIds
+        = {bnInfAttr.scale_tensor_uid(), bnInfAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds
+        = {bnInfAttr.mean_tensor_uid(), bnInfAttr.inv_variance_tensor_uid()};
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, {}, tensorMap, false);
+}
+
+void checkBatchnormInferenceVarianceExtTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), bnInfAttr.y_tensor_uid()};
+    std::vector<int64_t> affineTensorIds
+        = {bnInfAttr.scale_tensor_uid(), bnInfAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds
+        = {bnInfAttr.mean_tensor_uid(), bnInfAttr.variance_tensor_uid()};
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, {}, tensorMap, false);
+}
+
+void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    checkBatchnormFwdActivationModeSupported(actAttr);
+
+    std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), actAttr.out_0_tensor_uid()};
+    std::vector<int64_t> affineTensorIds
+        = {bnInfAttr.scale_tensor_uid(), bnInfAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds
+        = {bnInfAttr.mean_tensor_uid(), bnInfAttr.variance_tensor_uid()};
+    std::vector<int64_t> intermediateTensorIds
+        = {bnInfAttr.y_tensor_uid(), actAttr.in_0_tensor_uid()};
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, tensorMap, false);
+}
+
+void checkBatchnormInferenceActivationTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    checkBatchnormFwdActivationModeSupported(actAttr);
+
+    std::vector<int64_t> ioTensorIds = {bnInfAttr.x_tensor_uid(), actAttr.out_0_tensor_uid()};
+    std::vector<int64_t> affineTensorIds
+        = {bnInfAttr.scale_tensor_uid(), bnInfAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds
+        = {bnInfAttr.mean_tensor_uid(), bnInfAttr.inv_variance_tensor_uid()};
+    std::vector<int64_t> intermediateTensorIds
+        = {bnInfAttr.y_tensor_uid(), actAttr.in_0_tensor_uid()};
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, tensorMap, false);
+}
+
+void checkBatchnormFwdTrainingTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    validators::validatePeerStatsNotPopulated(
+        bnAttr.peer_stats_tensor_uid(),
+        "Batchnorm forward training does not support peer statistics");
+
+    std::vector<int64_t> ioTensorIds = {bnAttr.x_tensor_uid(), bnAttr.y_tensor_uid()};
+    std::vector<int64_t> affineTensorIds = {bnAttr.scale_tensor_uid(), bnAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds;
+    if(bnAttr.mean_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnAttr.mean_tensor_uid().value());
+    }
+    if(bnAttr.inv_variance_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnAttr.inv_variance_tensor_uid().value());
+    }
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, {}, tensorMap, true);
+}
+
+void checkBatchnormFwdTrainingActivationTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    validators::validatePeerStatsNotPopulated(
+        bnAttr.peer_stats_tensor_uid(),
+        "Batchnorm forward training activation does not support peer statistics");
+
+    std::vector<int64_t> ioTensorIds = {bnAttr.x_tensor_uid(), actAttr.out_0_tensor_uid()};
+    std::vector<int64_t> affineTensorIds = {bnAttr.scale_tensor_uid(), bnAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds;
+    if(bnAttr.mean_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnAttr.mean_tensor_uid().value());
+    }
+    if(bnAttr.inv_variance_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnAttr.inv_variance_tensor_uid().value());
+    }
+    std::vector<int64_t> intermediateTensorIds = {bnAttr.y_tensor_uid(), actAttr.in_0_tensor_uid()};
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, tensorMap, true);
+}
+
+void checkBatchnormBackwardTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    validators::validatePeerStatsNotPopulated(
+        bnBwdAttr.peer_stats_tensor_uid(), "Batchnorm backward does not support peer statistics");
+
+    std::vector<int64_t> ioTensorIds
+        = {bnBwdAttr.x_tensor_uid(), bnBwdAttr.dy_tensor_uid(), bnBwdAttr.dx_tensor_uid()};
+    std::vector<int64_t> affineTensorIds = {
+        bnBwdAttr.scale_tensor_uid(), bnBwdAttr.dscale_tensor_uid(), bnBwdAttr.dbias_tensor_uid()};
+    std::vector<int64_t> statTensorIds;
+    if(bnBwdAttr.mean_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnBwdAttr.mean_tensor_uid().value());
+    }
+    if(bnBwdAttr.inv_variance_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnBwdAttr.inv_variance_tensor_uid().value());
+    }
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, {}, tensorMap, true);
+}
+
+void checkBatchnormInferenceActivationBackwardTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    checkBatchnormBwdActivationModeSupported(actAttr);
+
+    validators::validatePeerStatsNotPopulated(
+        bnBwdAttr.peer_stats_tensor_uid(),
+        "Batchnorm backward fusion does not support peer statistics");
+
+    std::vector<int64_t> ioTensorIds
+        = {bnBwdAttr.x_tensor_uid(), actAttr.in_1_tensor_uid().value(), bnBwdAttr.dx_tensor_uid()};
+    std::vector<int64_t> affineTensorIds = {bnBwdAttr.scale_tensor_uid(),
+                                            bnBwdAttr.dscale_tensor_uid(),
+                                            bnBwdAttr.dbias_tensor_uid(),
+                                            bnInfAttr.bias_tensor_uid()};
+    std::vector<int64_t> statTensorIds;
+    if(bnBwdAttr.mean_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnBwdAttr.mean_tensor_uid().value());
+    }
+    if(bnBwdAttr.inv_variance_tensor_uid().has_value())
+    {
+        statTensorIds.push_back(bnBwdAttr.inv_variance_tensor_uid().value());
+    }
+    std::vector<int64_t> intermediateTensorIds = {bnInfAttr.y_tensor_uid(),
+                                                  actAttr.in_0_tensor_uid(),
+                                                  actAttr.out_0_tensor_uid(),
+                                                  bnBwdAttr.dy_tensor_uid()};
+
+    checkBatchnormTensorConfigSupported(
+        ioTensorIds, affineTensorIds, statTensorIds, intermediateTensorIds, tensorMap, true);
+}
+
+// --- Activation Mode Validators ---
+
+namespace
+{
+
+void checkBatchnormActivationModeSupported(
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr, bool isBwd)
+{
+    // MIOpen supports: PASSTHRU, RELU, CLIPPEDREU, CLAMP (no Leaky ReLU)
+
+    if(activAttr.operation() == hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY)
+    {
+        return;
+    }
+
+    if(activAttr.operation()
+       == (isBwd ? hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD
+                 : hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD))
+    {
+        if(!activAttr.relu_lower_clip_slope())
+        {
+            return;
+        }
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Batchnorm fused activation does not support Leaky ReLU.");
+    }
+
+    throw hipdnn_plugin_sdk::HipdnnPluginException(
+        HIPDNN_PLUGIN_STATUS_BAD_PARAM, "Unsupported activation mode for batchnorm fusion.");
+}
+
+} // namespace
+
+void checkBatchnormFwdActivationModeSupported(
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr)
+{
+    checkBatchnormActivationModeSupported(activAttr, false);
+}
+
+void checkBatchnormBwdActivationModeSupported(
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr)
+{
+    checkBatchnormActivationModeSupported(activAttr, true);
+}
+
+} // namespace hip_kernel_plugin

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormApplicabilityChecks.hpp
@@ -157,7 +157,7 @@ void checkBatchnormBwdActivationModeSupported(
 
 // --- Batchnorm Type Configuration ---
 
-// MIOpen v6.x requirements:
+// hip-kernel-provider batchnorm requirements (based on underlying kernel constraints):
 // - IO tensors: same type (FLOAT, HALF, or BFLOAT16)
 // - Affine/Stat/Intermediate tensors: FLOAT only
 struct BnTensorTypes

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormApplicabilityChecks.hpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormApplicabilityChecks.hpp
@@ -1,0 +1,188 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <hipdnn_data_sdk/data_objects/batchnorm_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/batchnorm_backward_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/batchnorm_inference_attributes_variance_ext_generated.h>
+#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+
+namespace hip_kernel_plugin
+{
+
+// --- Tensor Descriptor Value Object ---
+
+struct BatchnormTensorDescriptor
+{
+    std::vector<int64_t> dims;
+    std::vector<int64_t> strides;
+    std::vector<int64_t> strideOrder;
+
+    explicit BatchnormTensorDescriptor(const hipdnn_data_sdk::data_objects::TensorAttributes* attr);
+
+    size_t numDims() const
+    {
+        return dims.size();
+    }
+    bool isPacked() const;
+};
+
+// --- Validation Utilities ---
+
+namespace validators
+{
+void validateDimensionCount(size_t numDims);
+
+void validateConsistentDimensions(const std::vector<BatchnormTensorDescriptor>& tensors);
+
+void validatePackedTensors(const std::vector<BatchnormTensorDescriptor>& tensors);
+
+void validateSupportedLayout(const std::vector<int64_t>& strideOrder, size_t numDims);
+
+void validateConsistentLayouts(const std::vector<BatchnormTensorDescriptor>& tensors);
+
+void validateDataTypeIsSupported(
+    hipdnn_data_sdk::data_objects::DataType dataType,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& errorMessage);
+
+void validateConsistentDataTypes(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::unordered_set<hipdnn_data_sdk::data_objects::DataType>& allowedTypes,
+    const std::string& typeErrorMessage,
+    const std::string& consistencyErrorMessage);
+
+void validateFixedDataType(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    hipdnn_data_sdk::data_objects::DataType expectedType,
+    const std::string& errorMessage);
+
+void validateConsistentShapes(
+    const std::vector<int64_t>& tensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    const std::vector<int64_t>& referenceShape,
+    const std::string& errorMessage);
+
+void validateSpatialDimensions(const std::vector<int64_t>& ioDims);
+
+} // namespace validators
+
+// --- Component Validators ---
+
+void checkTensorLayoutsAndDimsSupported(
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkTensorDataTypesSupported(
+    const std::vector<int64_t>& ioTensorIds,
+    const std::vector<int64_t>& affineTensorIds,
+    const std::vector<int64_t>& statTensorIds,
+    const std::vector<int64_t>& intermediateTensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkTensorShapesSupported(
+    const std::vector<int64_t>& ioTensorIds,
+    const std::vector<int64_t>& affineTensorIds,
+    const std::vector<int64_t>& statTensorIds,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap,
+    bool isTraining);
+
+// --- High-Level Configuration Validators ---
+
+void checkBatchnormInferenceTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormInferenceVarianceExtTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributesVarianceExt& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormInferenceActivationTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormFwdTrainingTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormFwdTrainingActivationTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormAttributes& bnAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormBackwardTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormInferenceActivationBackwardTensorConfigSupported(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const hipdnn_data_sdk::data_objects::BatchnormBackwardAttributes& bnBwdAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap);
+
+void checkBatchnormFwdActivationModeSupported(
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
+
+void checkBatchnormBwdActivationModeSupported(
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& activAttr);
+
+// --- Batchnorm Type Configuration ---
+
+// MIOpen v6.x requirements:
+// - IO tensors: same type (FLOAT, HALF, or BFLOAT16)
+// - Affine/Stat/Intermediate tensors: FLOAT only
+struct BnTensorTypes
+{
+    hipdnn_data_sdk::data_objects::DataType io;
+    hipdnn_data_sdk::data_objects::DataType affine;
+    hipdnn_data_sdk::data_objects::DataType stat;
+    hipdnn_data_sdk::data_objects::DataType intermediate;
+};
+
+namespace bn_type_configs
+{
+using DT = hipdnn_data_sdk::data_objects::DataType;
+
+inline constexpr BnTensorTypes ALL_FLOAT = {DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::FLOAT};
+inline constexpr BnTensorTypes HALF_IO = {DT::HALF, DT::FLOAT, DT::FLOAT, DT::FLOAT};
+inline constexpr BnTensorTypes BFLOAT16_IO = {DT::BFLOAT16, DT::FLOAT, DT::FLOAT, DT::FLOAT};
+
+inline constexpr std::array<BnTensorTypes, 3> VALID = {ALL_FLOAT, HALF_IO, BFLOAT16_IO};
+
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIoTypes();
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedAffineTypes();
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedStatTypes();
+std::unordered_set<hipdnn_data_sdk::data_objects::DataType> getAllowedIntermediateTypes();
+
+} // namespace bn_type_configs
+
+} // namespace hip_kernel_plugin

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormFwdInferencePlan.cpp
@@ -108,16 +108,13 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
                                         uint32_t numDeviceBuffers,
                                         [[maybe_unused]] void* workspace) const
 {
-    // TODO: This is an initial implementation to get batchnorm working. It needs to be enhanced
-    // to match the full MIOpen solver capabilities.
-
     // Get device and properties
     int device;
     HIP_CHECK(hipGetDevice(&device));
     hipDeviceProp_t props;
     HIP_CHECK(hipGetDeviceProperties(&props, device));
 
-    // Determine data type configuration (matching MIOpen solver logic)
+    // Determine data type configuration
     auto xDataType = _inferenceParams.x()->data_type();
     auto scaleDataType = _inferenceParams.scale()->data_type();
 
@@ -131,22 +128,16 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
     const auto* xDims = _inferenceParams.x()->dims();
     const auto* xStrides = _inferenceParams.x()->strides();
 
-    int n;
-    int c;
-    int hw;
-    int nStride;
-    int cStride;
-    int wStride;
+    int n, c, h, w;
+    int nStride, cStride, wStride;
 
     // Check if 4D (NCHW/NHWC) or 5D (NCDHW/NDHWC)
     if(xDims->size() == 4)
     {
-        // 4D tensor: N, C, H, W
         n = static_cast<int>(xDims->Get(0));
         c = static_cast<int>(xDims->Get(1));
-        int h = static_cast<int>(xDims->Get(2));
-        int w = static_cast<int>(xDims->Get(3));
-        hw = h * w;
+        h = static_cast<int>(xDims->Get(2));
+        w = static_cast<int>(xDims->Get(3));
 
         nStride = static_cast<int>(xStrides->Get(0));
         cStride = static_cast<int>(xStrides->Get(1));
@@ -154,13 +145,13 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
     }
     else if(xDims->size() == 5)
     {
-        // 5D tensor: N, C, D, H, W
         n = static_cast<int>(xDims->Get(0));
         c = static_cast<int>(xDims->Get(1));
         int d = static_cast<int>(xDims->Get(2));
-        int h = static_cast<int>(xDims->Get(3));
-        int w = static_cast<int>(xDims->Get(4));
-        hw = d * h * w; // For 5D, spatial volume is D*H*W
+        h = static_cast<int>(xDims->Get(3));
+        w = static_cast<int>(xDims->Get(4));
+        // For 5D, combine D*H*W into spatial dimension
+        h = d * h;
 
         nStride = static_cast<int>(xStrides->Get(0));
         cStride = static_cast<int>(xStrides->Get(1));
@@ -171,24 +162,60 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
         throw std::runtime_error("Unsupported tensor dimension: " + std::to_string(xDims->size()));
     }
 
-    // Prepare options for compilation
-    // For NCHW spatial mode: GRP0=1 (xlocalsize), GRP1=256 (ylocalsize), GRP2=1 (zlocalsize)
-    std::vector<std::string> options;
-    options.emplace_back("-I/opt/rocm/include");
-    // Only ONE of these can be 1 (FP32, FP16Mix, or BFP16Mix)
-    options.emplace_back(std::string("-DHIP_PLUGIN_USE_FP32=") + (useFp32 ? "1" : "0"));
-    options.emplace_back(std::string("-DHIP_PLUGIN_USE_FP16=")
-                         + "0"); // Not used for mixed precision
-    options.emplace_back(std::string("-DHIP_PLUGIN_USE_BFP16=")
-                         + "0"); // Not used for mixed precision
-    options.emplace_back(std::string("-DHIP_PLUGIN_USE_FPMIX=") + (useFp16Mix ? "1" : "0"));
-    options.emplace_back(std::string("-DHIP_PLUGIN_USE_BFPMIX=") + (useBfp16Mix ? "1" : "0"));
-    options.emplace_back("-DMIO_BN_GRP0=1");
-    options.emplace_back("-DMIO_BN_GRP1=256");
-    options.emplace_back("-DMIO_BN_GRP2=1");
-    options.emplace_back("-DMIO_BN_VEC_SIZE=1");
-    options.emplace_back("-DMIO_LAYOUT_NHWC=0");
+    unsigned int in_cstride = static_cast<unsigned int>(h * w);
 
+    // Detect layout: NHWC has C dimension (index 1) with stride 1, NCHW has stride H*W
+    bool isLayoutNHWC = (xStrides->Get(1) == 1);
+
+    // Calculate vector size based on layout
+    size_t vectorsize = isLayoutNHWC ? (c % 4 == 0 ? 4 : (c % 2 == 0 ? 2 : 1))
+                                     : (in_cstride % 4 == 0 ? 4 : (in_cstride % 2 == 0 ? 2 : 1));
+
+    // Calculate block and grid dimensions
+    size_t xlocalsize, xgridsize, ylocalsize, ygridsize, zlocalsize, zgridsize;
+    size_t max_localsize = 256;
+
+    if(isLayoutNHWC)
+    {
+        xlocalsize = std::min(static_cast<size_t>(c) / vectorsize, max_localsize);
+        xgridsize
+            = ((static_cast<size_t>(c) / vectorsize) + xlocalsize - 1) / xlocalsize * xlocalsize;
+
+        ylocalsize = max_localsize / xlocalsize;
+        ygridsize = (in_cstride + ylocalsize - 1) / ylocalsize * ylocalsize;
+    }
+    else
+    {
+        xlocalsize = 1;
+        xgridsize = ((static_cast<size_t>(c) + xlocalsize - 1) / xlocalsize) * xlocalsize;
+
+        ylocalsize = max_localsize;
+        ygridsize = ((in_cstride / vectorsize + ylocalsize - 1) / ylocalsize) * ylocalsize;
+    }
+
+    zlocalsize = 1;
+    size_t active_threads_xy = xgridsize * ygridsize;
+    size_t max_active_threads
+        = static_cast<size_t>(props.multiProcessorCount) * 32 * static_cast<size_t>(props.warpSize);
+
+    if(active_threads_xy < max_active_threads)
+    {
+        zgridsize
+            = std::min(size_t{max_active_threads / active_threads_xy}, static_cast<size_t>(n));
+    }
+    else
+    {
+        zgridsize = 1;
+    }
+
+    // Detect GPU architecture
+    std::string archName(props.gcnArchName);
+    bool isGfx103X = (archName.find("gfx103") == 0);
+    bool isGfx110X = (archName.find("gfx110") == 0);
+    bool isGfx120X = (archName.find("gfx120") == 0);
+    bool isGfx115X = (archName.find("gfx115") == 0);
+
+    // Get activation parameters
     int nrnOpId = 0;
     float alpha = 0.0f;
     float beta = 0.0f;
@@ -200,16 +227,38 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
         alpha = static_cast<float>(activation.alpha);
         beta = static_cast<float>(activation.beta);
     }
+
+    // Prepare compilation options
+    std::vector<std::string> options;
+    options.emplace_back("-I/opt/rocm/include");
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_FP32=") + (useFp32 ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_FP16=") + (useFp16Mix ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_BFP16=") + (useBfp16Mix ? "1" : "0"));
+    options.emplace_back("-DHIP_PLUGIN_USE_RNE_BFLOAT16=1");
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_FPMIX=") + (useFp16Mix ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_BFPMIX=") + (useBfp16Mix ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_BN_GRP0=") + std::to_string(xlocalsize));
+    options.emplace_back(std::string("-DHIP_PLUGIN_BN_GRP1=") + std::to_string(ylocalsize));
+    options.emplace_back(std::string("-DHIP_PLUGIN_BN_GRP2=") + std::to_string(zlocalsize));
+    options.emplace_back(std::string("-DHIP_PLUGIN_BN_VEC_SIZE=") + std::to_string(vectorsize));
+    options.emplace_back(std::string("-DHIP_PLUGIN_LAYOUT_NHWC=") + (isLayoutNHWC ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_BN_GFX103X=") + (isGfx103X ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_BN_GFX110X=") + (isGfx110X ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_BN_GFX120X=") + (isGfx120X ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_BN_GFX115X=") + (isGfx115X ? "1" : "0"));
     options.emplace_back(std::string("-DHIP_PLUGIN_NRN_OP_ID=") + std::to_string(nrnOpId));
     options.emplace_back(std::string("--offload-arch=") + props.gcnArchName);
 
+    // Create and configure kernel
     auto hipProgram = HipProgram("BatchNormFwdInferSpatial.cpp", options);
     auto hipKernel = HipKernel(hipProgram, "BatchNormFwdInferSpatialEstInvVar");
 
-    // Use tensor dimensions extracted earlier
-    auto batchSize = static_cast<unsigned int>(n);
-    auto channels = static_cast<unsigned int>(c);
-    auto hwVolume = static_cast<unsigned int>(hw);
+    hipKernel.SetBlockSize(static_cast<unsigned int>(xlocalsize),
+                           static_cast<unsigned int>(ylocalsize),
+                           static_cast<unsigned int>(zlocalsize));
+    hipKernel.SetGridSize(static_cast<unsigned int>(xgridsize / xlocalsize),
+                          static_cast<unsigned int>(ygridsize / ylocalsize),
+                          static_cast<unsigned int>(zgridsize / zlocalsize));
 
     // Get device buffer pointers
     auto xBuffer = hip_kernel_utils::findDeviceBuffer(
@@ -223,31 +272,10 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
     auto invVarianceBuffer = hip_kernel_utils::findDeviceBuffer(
         _inferenceParams.invVariance()->uid(), deviceBuffers, numDeviceBuffers);
 
-    // Calculate grid/block dimensions based on MIOpen solver logic
-    // For NCHW spatial mode:
-    // - x-dimension spans channels (c)
-    // - y-dimension spans spatial elements (h*w)
-    // - z-dimension spans batches (n)
-
-    // Block dimensions (MIO_BN_GRP0, GRP1, GRP2)
-    const unsigned int xlocalsize = 1; // For NCHW spatial
-    const unsigned int ylocalsize = 256; // max_localsize
-    const unsigned int zlocalsize = 1;
-    hipKernel.SetBlockSize(xlocalsize, ylocalsize, zlocalsize);
-
-    // Grid dimensions - must cover all channels, spatial elements, and batches
-    const unsigned int vectorsize
-        = 1; // TODO: Support vectorization (hwVolume % 4 == 0 ? 4 : hwVolume % 2 == 0 ? 2 : 1)
-    unsigned int xgridsize = ((channels + xlocalsize - 1) / xlocalsize) * xlocalsize;
-    unsigned int ygridsize = ((hwVolume / vectorsize + ylocalsize - 1) / ylocalsize) * ylocalsize;
-    unsigned int zgridsize = batchSize; // TODO: Optimize based on GPU compute units
-
-    // Convert to grid dimensions (in blocks, not threads)
-    hipKernel.SetGridSize(xgridsize / xlocalsize, ygridsize / ylocalsize, zgridsize / zlocalsize);
-
     unsigned int hwStride = static_cast<unsigned int>(wStride);
     unsigned int batchStride = static_cast<unsigned int>(nStride);
 
+    // Launch kernel with appropriate output buffer
     if(_inferenceParams.optActivation().has_value() && _inferenceParams.activationOut() != nullptr)
     {
         auto activationOutBuffer = hip_kernel_utils::findDeviceBuffer(
@@ -260,10 +288,10 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
                          invVarianceBuffer.ptr,
                          scaleBuffer.ptr,
                          biasBuffer.ptr,
-                         channels,
-                         hwVolume,
-                         batchSize,
-                         cStride,
+                         static_cast<unsigned int>(c),
+                         static_cast<unsigned int>(in_cstride),
+                         static_cast<unsigned int>(n),
+                         static_cast<unsigned int>(cStride),
                          hwStride,
                          batchStride,
                          alpha,
@@ -281,10 +309,10 @@ void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
                          invVarianceBuffer.ptr,
                          scaleBuffer.ptr,
                          biasBuffer.ptr,
-                         channels,
-                         hwVolume,
-                         batchSize,
-                         cStride,
+                         static_cast<unsigned int>(c),
+                         static_cast<unsigned int>(in_cstride),
+                         static_cast<unsigned int>(n),
+                         static_cast<unsigned int>(cStride),
                          hwStride,
                          batchStride,
                          alpha,

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormFwdInferencePlan.cpp
@@ -1,0 +1,295 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "BatchnormFwdInferencePlan.hpp"
+#include "HipdnnEnginePluginHandle.hpp"
+#include "hip/HipKernel.hpp"
+#include "hip/HipProgram.hpp"
+#include "hip/HipUtils.hpp"
+
+#include <hip/hip_runtime_api.h>
+#include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_data_sdk/utilities/Constants.hpp>
+#include <sstream>
+#include <stdexcept>
+
+namespace hip_kernel_plugin
+{
+
+BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& attributes,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+    : _x(tensorMap.at(attributes.x_tensor_uid()))
+    , _y(tensorMap.at(attributes.y_tensor_uid()))
+    , _scale(tensorMap.at(attributes.scale_tensor_uid()))
+    , _bias(tensorMap.at(attributes.bias_tensor_uid()))
+    , _estMean(tensorMap.at(attributes.mean_tensor_uid()))
+    , _invVariance(tensorMap.at(attributes.inv_variance_tensor_uid()))
+    , _activationOut(nullptr)
+{
+}
+
+BatchnormFwdInferenceParams::BatchnormFwdInferenceParams(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& inferenceAttributes,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+    : _x(tensorMap.at(inferenceAttributes.x_tensor_uid()))
+    , _y(tensorMap.at(inferenceAttributes.y_tensor_uid()))
+    , _scale(tensorMap.at(inferenceAttributes.scale_tensor_uid()))
+    , _bias(tensorMap.at(inferenceAttributes.bias_tensor_uid()))
+    , _estMean(tensorMap.at(inferenceAttributes.mean_tensor_uid()))
+    , _invVariance(tensorMap.at(inferenceAttributes.inv_variance_tensor_uid()))
+    , _optActivation(hip_kernel_utils::parseActivation(pointwiseAttributes))
+    , _activationOut(tensorMap.at(pointwiseAttributes.out_0_tensor_uid()))
+{
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::x() const
+{
+    return _x;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::y() const
+{
+    return _y;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::scale() const
+{
+    return _scale;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::bias() const
+{
+    return _bias;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes* BatchnormFwdInferenceParams::estMean() const
+{
+    return _estMean;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes*
+    BatchnormFwdInferenceParams::invVariance() const
+{
+    return _invVariance;
+}
+
+const std::optional<hip_kernel_utils::ActivationParams>&
+    BatchnormFwdInferenceParams::optActivation() const
+{
+    return _optActivation;
+}
+
+const hipdnn_data_sdk::data_objects::TensorAttributes*
+    BatchnormFwdInferenceParams::activationOut() const
+{
+    return _activationOut;
+}
+
+BatchnormFwdInferencePlan::BatchnormFwdInferencePlan(BatchnormFwdInferenceParams&& inferenceParams,
+                                                     bool benchmarkingEnabled)
+    : _inferenceParams(std::move(inferenceParams))
+    , _benchmarkingEnabled(benchmarkingEnabled)
+{
+}
+
+size_t BatchnormFwdInferencePlan::getWorkspaceSize(
+    [[maybe_unused]] const HipdnnEnginePluginHandle& handle) const
+{
+    // No workspace needed for batchnorm inference
+    return 0;
+}
+
+void BatchnormFwdInferencePlan::execute(const HipdnnEnginePluginHandle& handle,
+                                        const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                                        uint32_t numDeviceBuffers,
+                                        [[maybe_unused]] void* workspace) const
+{
+    // TODO: This is an initial implementation to get batchnorm working. It needs to be enhanced
+    // to match the full MIOpen solver capabilities.
+
+    // Get device and properties
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props;
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
+
+    // Determine data type configuration (matching MIOpen solver logic)
+    auto xDataType = _inferenceParams.x()->data_type();
+    auto scaleDataType = _inferenceParams.scale()->data_type();
+
+    bool useFp16Mix = (xDataType == hipdnn_data_sdk::data_objects::DataType::HALF
+                       && scaleDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT);
+    bool useBfp16Mix = (xDataType == hipdnn_data_sdk::data_objects::DataType::BFLOAT16
+                        && scaleDataType == hipdnn_data_sdk::data_objects::DataType::FLOAT);
+    bool useFp32 = !useFp16Mix && !useBfp16Mix;
+
+    // Extract dimensions from x tensor
+    const auto* xDims = _inferenceParams.x()->dims();
+    const auto* xStrides = _inferenceParams.x()->strides();
+
+    int n;
+    int c;
+    int hw;
+    int nStride;
+    int cStride;
+    int wStride;
+
+    // Check if 4D (NCHW/NHWC) or 5D (NCDHW/NDHWC)
+    if(xDims->size() == 4)
+    {
+        // 4D tensor: N, C, H, W
+        n = static_cast<int>(xDims->Get(0));
+        c = static_cast<int>(xDims->Get(1));
+        int h = static_cast<int>(xDims->Get(2));
+        int w = static_cast<int>(xDims->Get(3));
+        hw = h * w;
+
+        nStride = static_cast<int>(xStrides->Get(0));
+        cStride = static_cast<int>(xStrides->Get(1));
+        wStride = static_cast<int>(xStrides->Get(3));
+    }
+    else if(xDims->size() == 5)
+    {
+        // 5D tensor: N, C, D, H, W
+        n = static_cast<int>(xDims->Get(0));
+        c = static_cast<int>(xDims->Get(1));
+        int d = static_cast<int>(xDims->Get(2));
+        int h = static_cast<int>(xDims->Get(3));
+        int w = static_cast<int>(xDims->Get(4));
+        hw = d * h * w; // For 5D, spatial volume is D*H*W
+
+        nStride = static_cast<int>(xStrides->Get(0));
+        cStride = static_cast<int>(xStrides->Get(1));
+        wStride = static_cast<int>(xStrides->Get(4));
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported tensor dimension: " + std::to_string(xDims->size()));
+    }
+
+    // Prepare options for compilation
+    // For NCHW spatial mode: GRP0=1 (xlocalsize), GRP1=256 (ylocalsize), GRP2=1 (zlocalsize)
+    std::vector<std::string> options;
+    options.emplace_back("-I/opt/rocm/include");
+    // Only ONE of these can be 1 (FP32, FP16Mix, or BFP16Mix)
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_FP32=") + (useFp32 ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_FP16=")
+                         + "0"); // Not used for mixed precision
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_BFP16=")
+                         + "0"); // Not used for mixed precision
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_FPMIX=") + (useFp16Mix ? "1" : "0"));
+    options.emplace_back(std::string("-DHIP_PLUGIN_USE_BFPMIX=") + (useBfp16Mix ? "1" : "0"));
+    options.emplace_back("-DMIO_BN_GRP0=1");
+    options.emplace_back("-DMIO_BN_GRP1=256");
+    options.emplace_back("-DMIO_BN_GRP2=1");
+    options.emplace_back("-DMIO_BN_VEC_SIZE=1");
+    options.emplace_back("-DMIO_LAYOUT_NHWC=0");
+
+    int nrnOpId = 0;
+    float alpha = 0.0f;
+    float beta = 0.0f;
+
+    if(_inferenceParams.optActivation().has_value() && _inferenceParams.activationOut() != nullptr)
+    {
+        const auto& activation = *_inferenceParams.optActivation();
+        nrnOpId = static_cast<int>(activation.mode);
+        alpha = static_cast<float>(activation.alpha);
+        beta = static_cast<float>(activation.beta);
+    }
+    options.emplace_back(std::string("-DHIP_PLUGIN_NRN_OP_ID=") + std::to_string(nrnOpId));
+    options.emplace_back(std::string("--offload-arch=") + props.gcnArchName);
+
+    auto hipProgram = HipProgram("BatchNormFwdInferSpatial.cpp", options);
+    auto hipKernel = HipKernel(hipProgram, "BatchNormFwdInferSpatialEstInvVar");
+
+    // Use tensor dimensions extracted earlier
+    auto batchSize = static_cast<unsigned int>(n);
+    auto channels = static_cast<unsigned int>(c);
+    auto hwVolume = static_cast<unsigned int>(hw);
+
+    // Get device buffer pointers
+    auto xBuffer = hip_kernel_utils::findDeviceBuffer(
+        _inferenceParams.x()->uid(), deviceBuffers, numDeviceBuffers);
+    auto scaleBuffer = hip_kernel_utils::findDeviceBuffer(
+        _inferenceParams.scale()->uid(), deviceBuffers, numDeviceBuffers);
+    auto biasBuffer = hip_kernel_utils::findDeviceBuffer(
+        _inferenceParams.bias()->uid(), deviceBuffers, numDeviceBuffers);
+    auto estMeanBuffer = hip_kernel_utils::findDeviceBuffer(
+        _inferenceParams.estMean()->uid(), deviceBuffers, numDeviceBuffers);
+    auto invVarianceBuffer = hip_kernel_utils::findDeviceBuffer(
+        _inferenceParams.invVariance()->uid(), deviceBuffers, numDeviceBuffers);
+
+    // Calculate grid/block dimensions based on MIOpen solver logic
+    // For NCHW spatial mode:
+    // - x-dimension spans channels (c)
+    // - y-dimension spans spatial elements (h*w)
+    // - z-dimension spans batches (n)
+
+    // Block dimensions (MIO_BN_GRP0, GRP1, GRP2)
+    const unsigned int xlocalsize = 1; // For NCHW spatial
+    const unsigned int ylocalsize = 256; // max_localsize
+    const unsigned int zlocalsize = 1;
+    hipKernel.SetBlockSize(xlocalsize, ylocalsize, zlocalsize);
+
+    // Grid dimensions - must cover all channels, spatial elements, and batches
+    const unsigned int vectorsize
+        = 1; // TODO: Support vectorization (hwVolume % 4 == 0 ? 4 : hwVolume % 2 == 0 ? 2 : 1)
+    unsigned int xgridsize = ((channels + xlocalsize - 1) / xlocalsize) * xlocalsize;
+    unsigned int ygridsize = ((hwVolume / vectorsize + ylocalsize - 1) / ylocalsize) * ylocalsize;
+    unsigned int zgridsize = batchSize; // TODO: Optimize based on GPU compute units
+
+    // Convert to grid dimensions (in blocks, not threads)
+    hipKernel.SetGridSize(xgridsize / xlocalsize, ygridsize / ylocalsize, zgridsize / zlocalsize);
+
+    unsigned int hwStride = static_cast<unsigned int>(wStride);
+    unsigned int batchStride = static_cast<unsigned int>(nStride);
+
+    if(_inferenceParams.optActivation().has_value() && _inferenceParams.activationOut() != nullptr)
+    {
+        auto activationOutBuffer = hip_kernel_utils::findDeviceBuffer(
+            _inferenceParams.activationOut()->uid(), deviceBuffers, numDeviceBuffers);
+
+        hipKernel.Launch(handle.getStream(),
+                         xBuffer.ptr,
+                         activationOutBuffer.ptr,
+                         estMeanBuffer.ptr,
+                         invVarianceBuffer.ptr,
+                         scaleBuffer.ptr,
+                         biasBuffer.ptr,
+                         channels,
+                         hwVolume,
+                         batchSize,
+                         cStride,
+                         hwStride,
+                         batchStride,
+                         alpha,
+                         beta);
+    }
+    else
+    {
+        auto yBuffer = hip_kernel_utils::findDeviceBuffer(
+            _inferenceParams.y()->uid(), deviceBuffers, numDeviceBuffers);
+
+        hipKernel.Launch(handle.getStream(),
+                         xBuffer.ptr,
+                         yBuffer.ptr,
+                         estMeanBuffer.ptr,
+                         invVarianceBuffer.ptr,
+                         scaleBuffer.ptr,
+                         biasBuffer.ptr,
+                         channels,
+                         hwVolume,
+                         batchSize,
+                         cStride,
+                         hwStride,
+                         batchStride,
+                         alpha,
+                         beta);
+    }
+}
+
+}

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormFwdInferencePlan.hpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormFwdInferencePlan.hpp
@@ -1,0 +1,80 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+#include "HipKernelUtils.hpp"
+#include "PlanInterface.hpp"
+
+namespace hip_kernel_plugin
+{
+
+class BatchnormFwdInferenceParams
+{
+public:
+    BatchnormFwdInferenceParams(
+        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& attributes,
+        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+            tensorMap);
+
+    BatchnormFwdInferenceParams(
+        const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& inferenceAttributes,
+        const hipdnn_data_sdk::data_objects::PointwiseAttributes& pointwiseAttributes,
+        const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+            tensorMap);
+
+    BatchnormFwdInferenceParams(const BatchnormFwdInferenceParams&) = delete;
+    BatchnormFwdInferenceParams& operator=(const BatchnormFwdInferenceParams&) = delete;
+
+    BatchnormFwdInferenceParams(BatchnormFwdInferenceParams&&) = default;
+    BatchnormFwdInferenceParams& operator=(BatchnormFwdInferenceParams&&) = default;
+
+    const hipdnn_data_sdk::data_objects::TensorAttributes* x() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* y() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* scale() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* bias() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* estMean() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* invVariance() const;
+
+    const std::optional<hip_kernel_utils::ActivationParams>& optActivation() const;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* activationOut() const;
+
+private:
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _x;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _y;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _scale;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _bias;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _estMean;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _invVariance;
+
+    std::optional<hip_kernel_utils::ActivationParams> _optActivation;
+    const hipdnn_data_sdk::data_objects::TensorAttributes* _activationOut;
+};
+
+class BatchnormFwdInferencePlan : public IPlan
+{
+public:
+    BatchnormFwdInferencePlan(BatchnormFwdInferenceParams&& inferenceParams,
+                              bool benchmarkingEnabled = false);
+
+    BatchnormFwdInferencePlan(const BatchnormFwdInferencePlan&) = delete;
+    BatchnormFwdInferencePlan& operator=(const BatchnormFwdInferencePlan&) = delete;
+
+    BatchnormFwdInferencePlan(BatchnormFwdInferencePlan&&) = default;
+    BatchnormFwdInferencePlan& operator=(BatchnormFwdInferencePlan&&) = default;
+
+    size_t getWorkspaceSize(const HipdnnEnginePluginHandle& handle) const override;
+
+    void execute(const HipdnnEnginePluginHandle& handle,
+                 const hipdnnPluginDeviceBuffer_t* deviceBuffers,
+                 uint32_t numDeviceBuffers,
+                 void* workspace = nullptr) const override;
+
+private:
+    BatchnormFwdInferenceParams _inferenceParams;
+    [[maybe_unused]] bool _benchmarkingEnabled;
+};
+
+}

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormPlanBuilder.cpp
@@ -174,8 +174,8 @@ bool BatchnormPlanBuilder::isApplicable(
                 return false;
             }
 
-            // Since MIOpen does not provide an API to validate batchnorm applicability, we perform
-            // the checks manually.
+            // Validate applicability before kernel dispatch by checking tensor configurations
+            // and operation parameters manually.
             try
             {
                 checkBatchnormInferenceActivationTensorConfigSupported(

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormPlanBuilder.cpp
@@ -23,16 +23,6 @@ void batchnormFwdFusionCheckTensors(
     const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
         tensorMap)
 {
-    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
-    static const std::unordered_set<PM> s_supportedActivations = {PM::RELU_FWD};
-
-    if(s_supportedActivations.count(actAttr.operation()) == 0)
-    {
-        throw hipdnn_plugin_sdk::HipdnnPluginException(
-            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
-            "Batchnorm fusion currently only supports RELU_FWD activation");
-    }
-
     // in_0 must be the batchnorm inference output (forward path)
     if(actAttr.in_0_tensor_uid() != bnInfAttr.y_tensor_uid())
     {

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormPlanBuilder.cpp
@@ -1,0 +1,305 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
+#include <string>
+#include <unordered_set>
+
+#include "BatchnormPlanBuilder.hpp"
+#include "HipKernelUtils.hpp"
+#include "engines/plans/BatchnormApplicabilityChecks.hpp"
+#include "engines/plans/BatchnormFwdInferencePlan.hpp"
+
+namespace hip_kernel_plugin
+{
+
+namespace
+{
+void batchnormFwdFusionCheckTensors(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    static const std::unordered_set<PM> s_supportedActivations = {PM::RELU_FWD};
+
+    if(s_supportedActivations.count(actAttr.operation()) == 0)
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Batchnorm fusion currently only supports RELU_FWD activation");
+    }
+
+    // in_0 must be the batchnorm inference output (forward path)
+    if(actAttr.in_0_tensor_uid() != bnInfAttr.y_tensor_uid())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Activation in_0 must be the batchnorm inference output tensor (y)");
+    }
+
+    // Check for virtual tensors
+    const auto& bnInfTensorX
+        = hip_kernel_utils::findTensorAttributes(tensorMap, bnInfAttr.x_tensor_uid());
+    const auto& bnInfTensorMean
+        = hip_kernel_utils::findTensorAttributes(tensorMap, bnInfAttr.mean_tensor_uid());
+    const auto& bnInfTensorInvVar
+        = hip_kernel_utils::findTensorAttributes(tensorMap, bnInfAttr.inv_variance_tensor_uid());
+    const auto& bnInfTensorScale
+        = hip_kernel_utils::findTensorAttributes(tensorMap, bnInfAttr.scale_tensor_uid());
+    const auto& bnInfTensorBias
+        = hip_kernel_utils::findTensorAttributes(tensorMap, bnInfAttr.bias_tensor_uid());
+    const auto& bnInfTensorY
+        = hip_kernel_utils::findTensorAttributes(tensorMap, bnInfAttr.y_tensor_uid());
+
+    if(bnInfTensorX.virtual_() || bnInfTensorMean.virtual_() || bnInfTensorInvVar.virtual_()
+       || bnInfTensorScale.virtual_() || bnInfTensorBias.virtual_() || !bnInfTensorY.virtual_())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Batchnorm inference input tensors must be non-virtual, output tensor must be virtual");
+    }
+
+    const auto& actTensorIn0
+        = hip_kernel_utils::findTensorAttributes(tensorMap, actAttr.in_0_tensor_uid());
+    const auto& actTensorOut
+        = hip_kernel_utils::findTensorAttributes(tensorMap, actAttr.out_0_tensor_uid());
+
+    if(!actTensorIn0.virtual_() || actTensorOut.virtual_())
+    {
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Activation input from batchnorm must be virtual, output must be non virtual");
+    }
+}
+bool batchnormFwdFusionCheckTensorsLogErrors(
+    const hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes& bnInfAttr,
+    const hipdnn_data_sdk::data_objects::PointwiseAttributes& actAttr,
+    const std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*>&
+        tensorMap)
+{
+    try
+    {
+        batchnormFwdFusionCheckTensors(bnInfAttr, actAttr, tensorMap);
+        return true;
+    }
+    catch(const std::exception& e)
+    {
+        HIPDNN_PLUGIN_LOG_INFO(e.what());
+        return false;
+    }
+}
+} // namespace
+
+bool BatchnormPlanBuilder::isApplicable(
+    [[maybe_unused]] const HipdnnEnginePluginHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+{
+    auto anyNodeIsNotF32Compute = [&]() {
+        return !std::all_of(
+            opGraph.nodeWrappers().begin(), opGraph.nodeWrappers().end(), [](const auto& node) {
+                return node->computeDataType() == hipdnn_data_sdk::data_objects::DataType::FLOAT;
+            });
+    };
+
+    switch(opGraph.nodeCount())
+    {
+    case 1:
+    {
+        if(anyNodeIsNotF32Compute())
+        {
+            HIPDNN_PLUGIN_LOG_ERROR("Batchnorm plan builder only supports nodes with an fp32 "
+                                    "compute_data_type");
+            return false;
+        }
+
+        if(!opGraph.hasOnlySupportedAttributes(
+               std::set<hipdnn_data_sdk::data_objects::NodeAttributes>{
+                   hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes}))
+        {
+            HIPDNN_PLUGIN_LOG_INFO("Batchnorm plan builder is not applicable for this graph");
+            return false;
+        }
+
+        const auto& node = opGraph.getNode(0);
+
+        try
+        {
+            switch(node.attributes_type())
+            {
+            case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
+                checkBatchnormInferenceTensorConfigSupported(
+                    *node.attributes_as_BatchnormInferenceAttributes(), opGraph.getTensorMap());
+                break;
+            default:
+                throw hipdnn_plugin_sdk::HipdnnPluginException(HIPDNN_PLUGIN_STATUS_INTERNAL_ERROR,
+                                                               "Unexpected node attribute type");
+            }
+        }
+        catch(const std::exception& e)
+        {
+            HIPDNN_PLUGIN_LOG_INFO(e.what());
+            return false;
+        }
+
+        return true;
+    }
+    case 2:
+    {
+        if(anyNodeIsNotF32Compute())
+        {
+            HIPDNN_PLUGIN_LOG_ERROR("Batchnorm plan builder only supports nodes with an fp32 "
+                                    "compute_data_type");
+            return false;
+        }
+
+        const auto& node0 = opGraph.getNodeWrapper(0);
+        const auto& node1 = opGraph.getNodeWrapper(1);
+
+        bool isFwdInferenceFirst
+            = node0.attributesType()
+              == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes;
+        bool isPointwiseSecond
+            = node1.attributesType()
+              == hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes;
+
+        if(!((isFwdInferenceFirst) && isPointwiseSecond))
+        {
+            HIPDNN_PLUGIN_LOG_INFO(
+                "Batchnorm plan builder is not applicable for this graph node order and types");
+            return false;
+        }
+
+        if(isFwdInferenceFirst)
+        {
+            const auto& bnInfAttr
+                = node0.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+            const auto& actAttr
+                = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+            if(!batchnormFwdFusionCheckTensorsLogErrors(bnInfAttr, actAttr, opGraph.getTensorMap()))
+            {
+                return false;
+            }
+
+            // Since MIOpen does not provide an API to validate batchnorm applicability, we perform
+            // the checks manually.
+            try
+            {
+                checkBatchnormInferenceActivationTensorConfigSupported(
+                    bnInfAttr, actAttr, opGraph.getTensorMap());
+            }
+            catch(const std::exception& e)
+            {
+                HIPDNN_PLUGIN_LOG_INFO(e.what());
+                return false;
+            }
+        }
+
+        HIPDNN_PLUGIN_LOG_INFO("Batchnorm plan builder applicable for batchnorm inference + "
+                               "activation fusion");
+        return true;
+    }
+    default:
+    {
+        HIPDNN_PLUGIN_LOG_INFO("Batchnorm plan builder is applicable only for 1 or 2 node graphs. "
+                               "Graph has "
+                               << opGraph.nodeCount() << " nodes");
+        return false;
+    }
+    }
+}
+
+size_t BatchnormPlanBuilder::getWorkspaceSize(
+    [[maybe_unused]] const HipdnnEnginePluginHandle& handle,
+    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+{
+    //batchnorm plan builder does not require workspace size
+    return 0u;
+}
+
+namespace
+{
+
+void buildPlanInferenceSingleNode(
+    [[maybe_unused]] const HipdnnEnginePluginHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    const hipdnn_data_sdk::flatbuffer_utilities::INodeWrapper& nodeWrapper,
+    HipdnnEnginePluginExecutionContext& executionContext)
+{
+    const auto& attr
+        = nodeWrapper.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+
+    BatchnormFwdInferenceParams params(attr, opGraph.getTensorMap());
+    auto plan = std::make_unique<BatchnormFwdInferencePlan>(std::move(params),
+                                                            executionContext.benchmarkingEnabled());
+    executionContext.setPlan(std::move(plan));
+}
+
+void buildPlanFusedFwdInferenceActivation(
+    [[maybe_unused]] const HipdnnEnginePluginHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    HipdnnEnginePluginExecutionContext& executionContext)
+{
+    const auto& node0 = opGraph.getNodeWrapper(0);
+    const auto& node1 = opGraph.getNodeWrapper(1);
+
+    const auto& fwdInference
+        = node0.attributesAs<hipdnn_data_sdk::data_objects::BatchnormInferenceAttributes>();
+    const auto& activation
+        = node1.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
+
+    BatchnormFwdInferenceParams params(fwdInference, activation, opGraph.getTensorMap());
+    auto plan = std::make_unique<BatchnormFwdInferencePlan>(std::move(params),
+                                                            executionContext.benchmarkingEnabled());
+    executionContext.setPlan(std::move(plan));
+}
+
+} // namespace
+
+void BatchnormPlanBuilder::buildPlan(
+    const HipdnnEnginePluginHandle& handle,
+    const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+    HipdnnEnginePluginExecutionContext& executionContext) const
+{
+    if(opGraph.nodeCount() == 2)
+    {
+        const auto& node0 = opGraph.getNodeWrapper(0);
+        if(node0.attributesType()
+           == hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes)
+        {
+            HIPDNN_PLUGIN_LOG_INFO("Building batchnorm inference + activation fusion plan");
+            buildPlanFusedFwdInferenceActivation(handle, opGraph, executionContext);
+        }
+        return;
+    }
+
+    const auto& nodeWrapper = opGraph.getNodeWrapper(0);
+    const auto nodeName = nodeWrapper.name();
+
+    switch(nodeWrapper.attributesType())
+    {
+    case hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes:
+        HIPDNN_PLUGIN_LOG_INFO("Building batchnorm fwd inference plan for node: " << nodeName);
+        buildPlanInferenceSingleNode(handle, opGraph, nodeWrapper, executionContext);
+        break;
+    default:
+        throw hipdnn_plugin_sdk::HipdnnPluginException(
+            HIPDNN_PLUGIN_STATUS_BAD_PARAM,
+            "Unsupported node type for batchnorm plan builder: "
+                + std::string(
+                    hipdnn_data_sdk::data_objects::toString(nodeWrapper.attributesType())));
+    }
+}
+
+std::vector<hipdnn_data_sdk::data_objects::KnobT> BatchnormPlanBuilder::getCustomKnobs(
+    [[maybe_unused]] const HipdnnEnginePluginHandle& handle,
+    [[maybe_unused]] const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const
+{
+    return {};
+}
+
+} // namespace hip_kernel_plugin

--- a/dnn-providers/hip-kernel-provider/engines/plans/BatchnormPlanBuilder.hpp
+++ b/dnn-providers/hip-kernel-provider/engines/plans/BatchnormPlanBuilder.hpp
@@ -1,0 +1,38 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include "PlanBuilderInterface.hpp"
+#include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
+
+namespace hip_kernel_plugin
+{
+
+class BatchnormPlanBuilder : public IPlanBuilder
+{
+public:
+    BatchnormPlanBuilder() = default;
+    ~BatchnormPlanBuilder() override = default;
+
+    // Disallow copy and assignment
+    BatchnormPlanBuilder(const BatchnormPlanBuilder&) = delete;
+    BatchnormPlanBuilder& operator=(const BatchnormPlanBuilder&) = delete;
+
+    bool isApplicable(const HipdnnEnginePluginHandle& handle,
+                      const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+    size_t getWorkspaceSize(
+        const HipdnnEnginePluginHandle& handle,
+        const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+
+    void buildPlan(const HipdnnEnginePluginHandle& handle,
+                   const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph,
+                   const hipdnn_data_sdk::flatbuffer_utilities::IEngineConfig& engineConfig,
+                   HipdnnEnginePluginExecutionContext& executionContext) const override;
+
+    std::vector<hipdnn_data_sdk::data_objects::KnobT>
+        getCustomKnobs(const HipdnnEnginePluginHandle& handle,
+                       const hipdnn_data_sdk::flatbuffer_utilities::IGraph& opGraph) const override;
+};
+
+}

--- a/dnn-providers/hip-kernel-provider/hip/HipKernel.cpp
+++ b/dnn-providers/hip-kernel-provider/hip/HipKernel.cpp
@@ -1,0 +1,30 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipKernel.hpp"
+#include "HipProgram.hpp"
+
+HipKernel::HipKernel(const HipProgram& program, const std::string& kernelName)
+    : kernelName_(kernelName)
+    , kernel_(program.GetKernel(kernelName))
+{
+}
+
+void HipKernel::SetBlockSize(unsigned int x, unsigned int y, unsigned int z)
+{
+    blockX_ = x;
+    blockY_ = y;
+    blockZ_ = z;
+}
+
+void HipKernel::SetGridSize(unsigned int x, unsigned int y, unsigned int z)
+{
+    gridX_ = x;
+    gridY_ = y;
+    gridZ_ = z;
+}
+
+void HipKernel::SetSharedMemBytes(unsigned int bytes)
+{
+    sharedMemBytes_ = bytes;
+}

--- a/dnn-providers/hip-kernel-provider/hip/HipKernel.hpp
+++ b/dnn-providers/hip-kernel-provider/hip/HipKernel.hpp
@@ -1,0 +1,51 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include "HipUtils.hpp"
+#include <array>
+#include <hip/hip_runtime_api.h>
+#include <string>
+#include <vector>
+
+class HipProgram;
+
+class HipKernel
+{
+public:
+    HipKernel(const HipProgram& program, const std::string& kernelName);
+
+    void SetBlockSize(unsigned int x, unsigned int y = 1, unsigned int z = 1);
+    void SetGridSize(unsigned int x, unsigned int y = 1, unsigned int z = 1);
+    void SetSharedMemBytes(unsigned int bytes);
+
+    template <typename... Args>
+    void Launch(hipStream_t stream, Args&&... args)
+    {
+        // Pack arguments into void* array
+        std::array<void*, sizeof...(Args)> kernelParams
+            = {const_cast<void*>(static_cast<const void*>(&args))...};
+
+        HIP_CHECK(hipModuleLaunchKernel(kernel_,
+                                        gridX_,
+                                        gridY_,
+                                        gridZ_,
+                                        blockX_,
+                                        blockY_,
+                                        blockZ_,
+                                        sharedMemBytes_,
+                                        stream,
+                                        kernelParams.data(),
+                                        nullptr));
+    }
+
+    ~HipKernel() = default;
+
+private:
+    std::string kernelName_;
+    hipFunction_t kernel_;
+    unsigned int blockX_ = 1, blockY_ = 1, blockZ_ = 1;
+    unsigned int gridX_ = 1, gridY_ = 1, gridZ_ = 1;
+    unsigned int sharedMemBytes_ = 0;
+};

--- a/dnn-providers/hip-kernel-provider/hip/HipProgram.cpp
+++ b/dnn-providers/hip-kernel-provider/hip/HipProgram.cpp
@@ -1,0 +1,83 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "HipProgram.hpp"
+#include "HipUtils.hpp"
+
+#include "kernel_includes.hpp"
+#include "kernel_sources.hpp"
+#include <hip/hiprtc.h>
+
+HipProgram::HipProgram(std::string kernelFileName, std::vector<std::string> options)
+    : programName_(kernelFileName)
+{
+    // Load source/includes
+    auto kernelSrc = hip_plugin::getKernelSrc(kernelFileName.c_str());
+    std::vector<std::string_view> includeTexts;
+    std::vector<const char*> includeNames;
+    hip_plugin::getKernelIncList(includeTexts, includeNames);
+
+    // Convert includes
+    std::vector<const char*> headersData;
+    headersData.reserve(includeTexts.size());
+    for(const auto& h : includeTexts)
+        headersData.emplace_back(h.data());
+
+    // Create program
+    hiprtcProgram prog;
+    HIPRTC_CHECK(hiprtcCreateProgram(&prog,
+                                     kernelSrc.data(),
+                                     kernelFileName.c_str(),
+                                     static_cast<int>(headersData.size()),
+                                     headersData.data(),
+                                     includeNames.data()));
+
+    // Compile
+    std::vector<const char*> optPtrs;
+    for(const auto& opt : options)
+        optPtrs.push_back(opt.c_str());
+
+    auto result = hiprtcCompileProgram(prog, static_cast<int>(optPtrs.size()), optPtrs.data());
+    if(result != HIPRTC_SUCCESS)
+    {
+        // Get compilation log
+        size_t logSize = 0;
+        hiprtcGetProgramLogSize(prog, &logSize);
+        std::string log;
+        if(logSize > 1)
+        {
+            log.resize(logSize);
+            hiprtcGetProgramLog(prog, log.data());
+        }
+        hiprtcDestroyProgram(&prog);
+        throw std::runtime_error("hiprtcCompileProgram failed for " + programName_ + ": "
+                                 + hiprtcGetErrorString(result) + "\nCompilation log:\n" + log);
+    }
+
+    // Extract binary
+    size_t codeSize;
+    HIPRTC_CHECK(hiprtcGetCodeSize(prog, &codeSize));
+    binary_.resize(codeSize);
+    HIPRTC_CHECK(hiprtcGetCode(prog, binary_.data()));
+
+    // Cleanup rtc program (no longer needed)
+    hiprtcDestroyProgram(&prog);
+
+    // Load module
+    HIP_CHECK(hipModuleLoadData(&module_, binary_.data()));
+}
+
+hipFunction_t HipProgram::GetKernel(const std::string& kernelName) const
+{
+    hipFunction_t kernel = nullptr;
+    HIP_CHECK(hipModuleGetFunction(&kernel, module_, kernelName.c_str()));
+    return kernel;
+}
+
+HipProgram::~HipProgram()
+{
+    if(module_)
+    {
+        [[maybe_unused]] auto result = hipModuleUnload(module_);
+    }
+}

--- a/dnn-providers/hip-kernel-provider/hip/HipProgram.hpp
+++ b/dnn-providers/hip-kernel-provider/hip/HipProgram.hpp
@@ -1,0 +1,22 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hip/hip_runtime_api.h>
+#include <string>
+#include <vector>
+
+class HipProgram
+{
+public:
+    HipProgram(std::string kernelFileName, std::vector<std::string> options);
+    hipFunction_t GetKernel(const std::string& kernelName) const;
+
+    ~HipProgram();
+
+private:
+    std::string programName_;
+    hipModule_t module_ = nullptr;
+    std::vector<char> binary_;
+};

--- a/dnn-providers/hip-kernel-provider/hip/HipUtils.hpp
+++ b/dnn-providers/hip-kernel-provider/hip/HipUtils.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <hip/hip_runtime.h>
+#include <hip/hiprtc.h>
+#include <stdexcept>
+#include <string>
+
+namespace hip_plugin
+{
+
+// For HIP runtime API calls
+#define HIP_CHECK(call)                                                          \
+    do                                                                           \
+    {                                                                            \
+        hipError_t status = (call);                                              \
+        if(status != hipSuccess)                                                 \
+        {                                                                        \
+            throw std::runtime_error(std::string(#call)                          \
+                                     + " failed: " + hipGetErrorString(status)); \
+        }                                                                        \
+    } while(0)
+
+// For hipRTC API calls
+#define HIPRTC_CHECK(call)                                                          \
+    do                                                                              \
+    {                                                                               \
+        hiprtcResult status = (call);                                               \
+        if(status != HIPRTC_SUCCESS)                                                \
+        {                                                                           \
+            throw std::runtime_error(std::string(#call)                             \
+                                     + " failed: " + hiprtcGetErrorString(status)); \
+        }                                                                           \
+    } while(0)
+
+} // namespace hip_plugin

--- a/dnn-providers/hip-kernel-provider/hip/HipUtils.hpp
+++ b/dnn-providers/hip-kernel-provider/hip/HipUtils.hpp
@@ -1,34 +1,36 @@
 #pragma once
-#include <hip/hip_runtime.h>
 #include <hip/hiprtc.h>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
 #include <stdexcept>
 #include <string>
 
-namespace hip_plugin
+namespace hip_kernel_plugin
 {
 
 // For HIP runtime API calls
-#define HIP_CHECK(call)                                                          \
-    do                                                                           \
-    {                                                                            \
-        hipError_t status = (call);                                              \
-        if(status != hipSuccess)                                                 \
-        {                                                                        \
-            throw std::runtime_error(std::string(#call)                          \
-                                     + " failed: " + hipGetErrorString(status)); \
-        }                                                                        \
+#define HIP_CHECK(call)                                                        \
+    do                                                                         \
+    {                                                                          \
+        hipError_t status = (call);                                            \
+        if(status != hipSuccess)                                               \
+        {                                                                      \
+            throw hipdnn_plugin_sdk::HipdnnPluginException(                    \
+                HIPDNN_PLUGIN_STATUS_ALLOC_FAILED,                             \
+                std::string(#call) + " failed: " + hipGetErrorString(status)); \
+        }                                                                      \
     } while(0)
 
 // For hipRTC API calls
-#define HIPRTC_CHECK(call)                                                          \
-    do                                                                              \
-    {                                                                               \
-        hiprtcResult status = (call);                                               \
-        if(status != HIPRTC_SUCCESS)                                                \
-        {                                                                           \
-            throw std::runtime_error(std::string(#call)                             \
-                                     + " failed: " + hiprtcGetErrorString(status)); \
-        }                                                                           \
+#define HIPRTC_CHECK(call)                                                        \
+    do                                                                            \
+    {                                                                             \
+        hiprtcResult status = (call);                                             \
+        if(status != HIPRTC_SUCCESS)                                              \
+        {                                                                         \
+            throw hipdnn_plugin_sdk::HipdnnPluginException(                       \
+                HIPDNN_PLUGIN_STATUS_ALLOC_FAILED,                                \
+                std::string(#call) + " failed: " + hiprtcGetErrorString(status)); \
+        }                                                                         \
     } while(0)
 
 } // namespace hip_plugin

--- a/dnn-providers/hip-kernel-provider/integration_tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/integration_tests/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
 add_executable(
     hip_kernel_plugin_integration_tests
     main.cpp
+    IntegrationGpuBatchnormForwardInference.cpp
 )
 
 target_compile_options(hip_kernel_plugin_integration_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})

--- a/dnn-providers/hip-kernel-provider/integration_tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/integration_tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
     hip_kernel_plugin_integration_tests
     main.cpp
     IntegrationGpuBatchnormForwardInference.cpp
+    IntegrationGpuBatchnormForwardInferenceAndActivation.cpp
 )
 
 target_compile_options(hip_kernel_plugin_integration_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})

--- a/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -1,0 +1,246 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <filesystem>
+#include <random>
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "../tests/common/BatchnormCommon.hpp"
+#include "IntegrationGraphVerificationHarness.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities;
+using namespace hip_kernel_plugin::test_utilities;
+using namespace test_bn_common;
+
+namespace
+{
+
+template <typename DataType, typename IntermediateType>
+class BatchnormForwardInference
+    : public IntegrationGraphVerificationHarness<DataType, BatchnormTestCase>
+{
+protected:
+    void runGraphTest(DataType tolerance, const TensorLayout& layout = TensorLayout::NCHW) override
+    {
+        const BatchnormTestCase& testCase = this->GetParam();
+
+        auto derivedDims = getDerivedShape(testCase.dims);
+
+        hipdnn_frontend::graph::Graph graphObj;
+
+        graphObj.set_name("BatchnormInferenceTest");
+
+        auto dataType = getDataTypeEnumFromType<DataType>();
+        auto intermediateDataType = getDataTypeEnumFromType<IntermediateType>();
+        graphObj.set_intermediate_data_type(intermediateDataType)
+            .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+            .set_io_data_type(dataType);
+
+        auto xAttr = graph::makeTensorAttributes(
+            "X", testCase.dims, generateStrides(testCase.dims, layout.strideOrder));
+        auto xTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(xAttr));
+
+        // Channel-only tensors are layout-agnostic, specifying stride order is unnecessary
+        auto meanAttr = graph::makeTensorAttributes(
+            "mean", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto meanTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(meanAttr));
+
+        auto invVarianceAttr = graph::makeTensorAttributes(
+            "inv_variance", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto invVarianceTensorAttr
+            = std::make_shared<graph::TensorAttributes>(std::move(invVarianceAttr));
+
+        auto scaleAttr = graph::makeTensorAttributes(
+            "scale", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto scaleTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(scaleAttr));
+
+        auto biasAttr = graph::makeTensorAttributes(
+            "bias", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto biasTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(biasAttr));
+
+        graph::BatchnormInferenceAttributes bnAttrs;
+
+        auto yTensorAttr = graphObj.batchnorm_inference(xTensorAttr,
+                                                        meanTensorAttr,
+                                                        invVarianceTensorAttr,
+                                                        scaleTensorAttr,
+                                                        biasTensorAttr,
+                                                        bnAttrs);
+
+        yTensorAttr->set_output(true);
+
+        this->registerValidator(yTensorAttr, tolerance);
+
+        this->verifyGraph(graphObj, testCase.seed);
+    }
+};
+
+using IntegrationGpuBatchnormForwardInferenceNchwFp32 = BatchnormForwardInference<float, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNchwBfp16
+    = BatchnormForwardInference<hip_bfloat16, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNchwFp16 = BatchnormForwardInference<half, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNhwcFp32 = BatchnormForwardInference<float, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNhwcBfp16
+    = BatchnormForwardInference<hip_bfloat16, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNhwcFp16 = BatchnormForwardInference<half, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNcdhwFp32 = BatchnormForwardInference<float, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNcdhwBfp16
+    = BatchnormForwardInference<hip_bfloat16, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNcdhwFp16 = BatchnormForwardInference<half, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNdhwcFp32 = BatchnormForwardInference<float, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNdhwcBfp16
+    = BatchnormForwardInference<hip_bfloat16, float>;
+
+using IntegrationGpuBatchnormForwardInferenceNdhwcFp16 = BatchnormForwardInference<half, float>;
+
+} // namespace
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNchwFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNchwFp32,
+                         testing::ValuesIn(getBnFwdInferenceTestCases()));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuBatchnormForwardInferenceNchwFp32,
+                         testing::ValuesIn(getBnFwdInferenceFullTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNchwBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNchwBfp16,
+                         testing::ValuesIn(getBnFwdInferenceTestCases()));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuBatchnormForwardInferenceNchwBfp16,
+                         testing::ValuesIn(getBnFwdInferenceFullTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNchwFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNchwFp16,
+                         testing::ValuesIn(getBnFwdInferenceTestCases()));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuBatchnormForwardInferenceNchwFp16,
+                         testing::ValuesIn(getBnFwdInferenceFullTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNhwcFp32,
+                         testing::ValuesIn(getBnFwdInferenceTestCases()));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuBatchnormForwardInferenceNhwcFp32,
+                         testing::ValuesIn(getBnFwdInferenceFullTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNhwcBfp16,
+                         testing::ValuesIn(getBnFwdInferenceTestCases()));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuBatchnormForwardInferenceNhwcBfp16,
+                         testing::ValuesIn(getBnFwdInferenceFullTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNhwcFp16,
+                         testing::ValuesIn(getBnFwdInferenceTestCases()));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         IntegrationGpuBatchnormForwardInferenceNhwcFp16,
+                         testing::ValuesIn(getBnFwdInferenceFullTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCDHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNcdhwFp32,
+                         testing::ValuesIn(getBnFwdInference3dTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCDHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNcdhwBfp16,
+                         testing::ValuesIn(getBnFwdInference3dTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCDHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNcdhwFp16,
+                         testing::ValuesIn(getBnFwdInference3dTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NDHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNdhwcFp32,
+                         testing::ValuesIn(getBnFwdInference3dTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NDHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNdhwcBfp16,
+                         testing::ValuesIn(getBnFwdInference3dTestCases()));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NDHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         IntegrationGpuBatchnormForwardInferenceNdhwcFp16,
+                         testing::ValuesIn(getBnFwdInference3dTestCases()));

--- a/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGpuBatchnormForwardInferenceAndActivation.cpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGpuBatchnormForwardInferenceAndActivation.cpp
@@ -1,0 +1,357 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <filesystem>
+#include <random>
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include "../tests/common/ActivationCommon.hpp"
+#include "../tests/common/BatchnormCommon.hpp"
+#include "IntegrationGraphVerificationHarness.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities;
+using namespace hip_kernel_plugin::test_utilities;
+using namespace test_bn_common;
+
+namespace
+{
+
+template <typename DataType, typename IntermediateType, typename TestCaseType>
+class BatchnormForwardInferenceAndActivation
+    : public IntegrationGraphVerificationHarness<DataType, TestCaseType>
+{
+protected:
+    void runGraphTest(DataType tolerance, const TensorLayout& layout = TensorLayout::NCHW) override
+    {
+        const auto& [testCase, activeCase] = this->GetParam();
+
+        auto derivedDims = getDerivedShape(testCase.dims);
+
+        hipdnn_frontend::graph::Graph graphObj;
+
+        graphObj.set_name("BatchnormInferenceAndActivationTest");
+
+        auto dataType = getDataTypeEnumFromType<DataType>();
+        auto intermediateDataType = getDataTypeEnumFromType<IntermediateType>();
+        graphObj.set_intermediate_data_type(intermediateDataType)
+            .set_compute_data_type(hipdnn_frontend::DataType::FLOAT)
+            .set_io_data_type(dataType);
+
+        auto xAttr = graph::makeTensorAttributes(
+            "X", testCase.dims, generateStrides(testCase.dims, layout.strideOrder));
+        auto xTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(xAttr));
+
+        // Channel-only tensors are layout-agnostic, specifying stride order is unnecessary
+        auto meanAttr = graph::makeTensorAttributes(
+            "mean", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto meanTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(meanAttr));
+
+        auto invVarianceAttr = graph::makeTensorAttributes(
+            "inv_variance", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto invVarianceTensorAttr
+            = std::make_shared<graph::TensorAttributes>(std::move(invVarianceAttr));
+
+        auto scaleAttr = graph::makeTensorAttributes(
+            "scale", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto scaleTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(scaleAttr));
+
+        auto biasAttr = graph::makeTensorAttributes(
+            "bias", intermediateDataType, derivedDims, generateStrides(derivedDims));
+        auto biasTensorAttr = std::make_shared<graph::TensorAttributes>(std::move(biasAttr));
+
+        graph::BatchnormInferenceAttributes bnAttrs;
+
+        auto yTensorAttr = graphObj.batchnorm_inference(xTensorAttr,
+                                                        meanTensorAttr,
+                                                        invVarianceTensorAttr,
+                                                        scaleTensorAttr,
+                                                        biasTensorAttr,
+                                                        bnAttrs);
+
+        yTensorAttr->set_data_type(intermediateDataType);
+
+        graph::PointwiseAttributes pointwiseAttrs;
+        pointwiseAttrs.set_mode(static_cast<hipdnn_frontend::PointwiseMode>(activeCase.mode));
+        if(activeCase.reluLowerClip.has_value())
+        {
+            pointwiseAttrs.set_relu_lower_clip(activeCase.reluLowerClip.value());
+        }
+        if(activeCase.reluUpperClip.has_value())
+        {
+            pointwiseAttrs.set_relu_upper_clip(activeCase.reluUpperClip.value());
+        }
+        if(activeCase.reluLowerClipSlope.has_value())
+        {
+            pointwiseAttrs.set_relu_lower_clip_slope(activeCase.reluLowerClipSlope.value());
+        }
+        if(activeCase.swishBeta.has_value())
+        {
+            pointwiseAttrs.set_swish_beta(activeCase.swishBeta.value());
+        }
+        if(activeCase.eluAlpha.has_value())
+        {
+            pointwiseAttrs.set_elu_alpha(activeCase.eluAlpha.value());
+        }
+        if(activeCase.softplusBeta.has_value())
+        {
+            pointwiseAttrs.set_softplus_beta(activeCase.softplusBeta.value());
+        }
+
+        auto outTensorAttr = graphObj.pointwise(yTensorAttr, pointwiseAttrs);
+        outTensorAttr->set_output(true);
+
+        this->registerValidator(outTensorAttr, tolerance);
+
+        this->verifyGraph(graphObj, testCase.seed);
+    }
+};
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp32
+    = BatchnormForwardInferenceAndActivation<
+        float,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNchwBfp16
+    = BatchnormForwardInferenceAndActivation<
+        hip_bfloat16,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp16
+    = BatchnormForwardInferenceAndActivation<
+        half,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp32
+    = BatchnormForwardInferenceAndActivation<
+        float,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNhwcBfp16
+    = BatchnormForwardInferenceAndActivation<
+        hip_bfloat16,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp16
+    = BatchnormForwardInferenceAndActivation<
+        half,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwFp32
+    = BatchnormForwardInferenceAndActivation<
+        float,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwBfp16
+    = BatchnormForwardInferenceAndActivation<
+        hip_bfloat16,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwFp16
+    = BatchnormForwardInferenceAndActivation<
+        half,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp32
+    = BatchnormForwardInferenceAndActivation<
+        float,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcBfp16
+    = BatchnormForwardInferenceAndActivation<
+        hip_bfloat16,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+using IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp16
+    = BatchnormForwardInferenceAndActivation<
+        half,
+        float,
+        std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
+
+} // namespace
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNchwBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNchwBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNchwBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNhwcBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNhwcBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNhwcBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInferenceFullTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationFullCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NCDHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCDHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NCDHW);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp32, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<float>(), TensorLayout::NDHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp32,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcBfp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NDHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcBfp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));
+
+TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp16, Correctness)
+{
+    runGraphTest(batchnorm::getToleranceInference<half>(), TensorLayout::NDHWC);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp16,
+    testing::Combine(testing::ValuesIn(getBnFwdInference3dTestCases()),
+                     testing::ValuesIn(test_activation_common::createFwdActivationSmokeCases())));

--- a/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -1,0 +1,234 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/utilities/Workspace.hpp>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/Utilities.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+#include <hipdnn_frontend/node/Node.hpp>
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/VectorLoggingUtils.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp>
+
+#include <functional>
+
+namespace hip_kernel_plugin::test_utilities
+{
+
+// NOLINTBEGIN (portability-template-virtual-member-function)
+template <typename DataType, typename TestCaseType>
+class IntegrationGraphVerificationHarness : public ::testing::TestWithParam<TestCaseType>
+{
+protected:
+    static constexpr float DEFAULT_MIN = -1.0f;
+    static constexpr float DEFAULT_MAX = 1.0f;
+
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+
+        // Initialize HIP
+        ASSERT_EQ(hipInit(0), hipSuccess);
+        ASSERT_EQ(hipGetDevice(&_deviceId), hipSuccess);
+
+        // Note: The plugin paths has to be set before we create the hipdnn handle.
+        auto pluginPath = std::filesystem::weakly_canonical(
+            hipdnn_data_sdk::utilities::getCurrentExecutableDirectory() / PLUGIN_PATH);
+        const std::string pluginPathStr = pluginPath.string();
+        const std::array<const char*, 1> paths = {pluginPathStr.c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+
+        // Create handle and stream
+        ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
+        ASSERT_EQ(hipStreamCreate(&_stream), hipSuccess);
+        ASSERT_EQ(hipdnnSetStream(_handle, _stream), HIPDNN_STATUS_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        if(_handle != nullptr)
+        {
+            ASSERT_EQ(hipdnnDestroy(_handle), HIPDNN_STATUS_SUCCESS);
+        }
+        if(_stream != nullptr)
+        {
+            ASSERT_EQ(hipStreamDestroy(_stream), hipSuccess);
+        }
+    }
+
+    virtual void runGraphTest(DataType tolerance,
+                              const hipdnn_data_sdk::utilities::TensorLayout& layout
+                              = hipdnn_data_sdk::utilities::TensorLayout::NCHW)
+        = 0;
+
+    void verifyGraph(hipdnn_frontend::graph::Graph& graph, unsigned int seed)
+    {
+        hipdnn_test_sdk::utilities::GraphTensorBundle gpuBundle, cpuBundle;
+        std::vector<int64_t> outputTensorIds;
+
+        auto result = graph.build(_handle);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        generateBundles(graph, cpuBundle, gpuBundle, outputTensorIds);
+
+        initializeBundle(graph, gpuBundle, seed);
+        initializeBundle(graph, cpuBundle, seed);
+
+        ASSERT_NO_FATAL_FAILURE(executeGpuGraph(_handle, graph, gpuBundle));
+        executeCpuGraph(graph, cpuBundle);
+
+        ASSERT_GE(outputTensorIds.size(), 1)
+            << "At least one output tensor id must be specified for "
+               "validation.";
+
+        HIPDNN_PLUGIN_LOG_INFO("Validating " << outputTensorIds.size() << " output tensors");
+
+        // Lazily register validators after graph execution since tensor Ids and types may be inferred during graph finalization
+        for(const auto& registerValidator : _deferredValidators)
+        {
+            registerValidator();
+        }
+
+        for(const auto& tensorId : outputTensorIds)
+        {
+            auto& cpuTensor = cpuBundle.tensors.at(tensorId);
+            auto& gpuTensor = gpuBundle.tensors.at(tensorId);
+
+            // This tells the tensor that its data has been modified on the device side
+            // All frontend graph knows is a (void*) pointer to device memory, so we need to inform the tensor
+            // that the data there is now valid so that it knows to copy from device to host when requested
+            // by the validation step.
+            gpuTensor->markDeviceModified();
+
+            if(_tensorIdToValidatorMap.find(tensorId) == _tensorIdToValidatorMap.end())
+            {
+                FAIL() << "No validator registered for tensor with id: " << tensorId
+                       << ", name: " << getOutputTensorName(tensorId);
+            }
+
+            bool valid = _tensorIdToValidatorMap.at(tensorId)->allClose(*cpuTensor, *gpuTensor);
+            ASSERT_TRUE(valid) << "Mismatch found in tensor with id: " << tensorId
+                               << ", name: " << _tensorIdToNameMap.at(tensorId);
+        }
+    }
+
+    void registerValidator(const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes> attr,
+                           float tolerance)
+    {
+        registerValidator(attr, tolerance, tolerance);
+    }
+
+    void registerValidator(const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes> attr,
+                           float absoluteTolerance,
+                           float relativeTolerance)
+    {
+        // Since the graph can infer properties + Ids, we defer validator registration until right before validation in verifyGraph
+        _deferredValidators.emplace_back([=]() {
+            _tensorIdToValidatorMap.insert(
+                {attr->get_uid(),
+                 hipdnn_test_sdk::utilities::createAllCloseValidator(
+                     toSdkType(attr->get_data_type()), absoluteTolerance, relativeTolerance)});
+            _tensorIdToNameMap.insert({attr->get_uid(), attr->get_name()});
+        });
+    }
+
+    virtual void generateBundles(hipdnn_frontend::graph::Graph& graph,
+                                 hipdnn_test_sdk::utilities::GraphTensorBundle& cpuBundle,
+                                 hipdnn_test_sdk::utilities::GraphTensorBundle& gpuBundle,
+                                 std::vector<int64_t>& outputTensorIds)
+    {
+        graph.visit([&](const hipdnn_frontend::graph::INode& node) {
+            for(const auto& tensorAttr : node.getNodeOutputTensorAttributes())
+            {
+                if(tryAddTensorToBundles(tensorAttr, cpuBundle, gpuBundle))
+                {
+                    outputTensorIds.push_back(tensorAttr->get_uid());
+                }
+            }
+            for(const auto& tensorAttr : node.getNodeInputTensorAttributes())
+            {
+                tryAddTensorToBundles(tensorAttr, cpuBundle, gpuBundle);
+            }
+        });
+    }
+
+    virtual void initializeBundle([[maybe_unused]] const hipdnn_frontend::graph::Graph& graph,
+                                  hipdnn_test_sdk::utilities::GraphTensorBundle& bundle,
+                                  unsigned int seed)
+    {
+        for(auto& tensorPair : bundle.tensors)
+        {
+            bundle.randomizeTensor(tensorPair.first, DEFAULT_MIN, DEFAULT_MAX, seed);
+        }
+    }
+
+private:
+    void executeGpuGraph(hipdnnHandle_t handle,
+                         hipdnn_frontend::graph::Graph& graph,
+                         hipdnn_test_sdk::utilities::GraphTensorBundle& bundle)
+    {
+        int64_t workspaceSize;
+        auto result = graph.get_workspace_size(workspaceSize);
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+        ASSERT_GE(workspaceSize, 0) << result.err_msg;
+        hipdnn_data_sdk::utilities::Workspace workspace(static_cast<size_t>(workspaceSize));
+
+        auto variantPack = bundle.toDeviceVariantPack();
+        result = graph.execute(handle, variantPack, workspace.get());
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+    }
+
+    void executeCpuGraph(hipdnn_frontend::graph::Graph& graph,
+                         hipdnn_test_sdk::utilities::GraphTensorBundle& bundle)
+    {
+        auto flatbufferGraph = graph.buildFlatbufferOperationGraph();
+
+        hipdnn_test_sdk::utilities::CpuReferenceGraphExecutor().execute(
+            flatbufferGraph.data(), flatbufferGraph.size(), bundle.toHostVariantPack());
+    }
+
+    std::string getOutputTensorName(int64_t tensorId)
+    {
+        return _tensorIdToNameMap.at(tensorId);
+    }
+
+    bool tryAddTensorToBundles(
+        const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes>& tensorAttr,
+        hipdnn_test_sdk::utilities::GraphTensorBundle& cpuBundle,
+        hipdnn_test_sdk::utilities::GraphTensorBundle& gpuBundle)
+    {
+        int64_t tensorId = tensorAttr->get_uid();
+
+        if(tensorAttr->get_is_virtual()
+           || cpuBundle.tensors.find(tensorId) != cpuBundle.tensors.end())
+        {
+            return false;
+        }
+
+        cpuBundle.tensors.insert({tensorId, createTensorFromAttribute(*tensorAttr)});
+        gpuBundle.tensors.insert({tensorId, createTensorFromAttribute(*tensorAttr)});
+        _tensorIdToNameMap.insert({tensorId, tensorAttr->get_name()});
+
+        return true;
+    }
+
+    hipdnnHandle_t _handle = nullptr;
+    hipStream_t _stream = nullptr;
+    int _deviceId = 0;
+    std::unordered_map<int64_t, std::string> _tensorIdToNameMap;
+    std::unordered_map<int64_t, std::unique_ptr<hipdnn_test_sdk::utilities::IReferenceValidation>>
+        _tensorIdToValidatorMap;
+    std::vector<std::function<void()>> _deferredValidators;
+};
+
+// NOLINTEND (portability-template-virtual-member-function)
+
+} // namespace hipdnn_test_sdk::utilities

--- a/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -11,6 +11,7 @@
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 #include <hipdnn_frontend/node/Node.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceMiopenRmsValidation.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/VectorLoggingUtils.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp>
@@ -136,6 +137,18 @@ protected:
                 {attr->get_uid(),
                  hipdnn_test_sdk::utilities::createAllCloseValidator(
                      toSdkType(attr->get_data_type()), absoluteTolerance, relativeTolerance)});
+            _tensorIdToNameMap.insert({attr->get_uid(), attr->get_name()});
+        });
+    }
+
+    void registerRmsValidator(const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes> attr,
+                              float rmsThreshold)
+    {
+        // Since the graph can infer properties + Ids, we defer validator registration until right before validation in verifyGraph
+        _deferredValidators.emplace_back([=]() {
+            _tensorIdToValidatorMap.insert({attr->get_uid(),
+                                            hipdnn_test_sdk::utilities::createRmsValidator(
+                                                toSdkType(attr->get_data_type()), rmsThreshold)});
             _tensorIdToNameMap.insert({attr->get_uid(), attr->get_name()});
         });
     }

--- a/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -11,7 +11,6 @@
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 #include <hipdnn_frontend/node/Node.hpp>
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
-#include <hipdnn_test_sdk/utilities/CpuFpReferenceMiopenRmsValidation.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/VectorLoggingUtils.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp>
@@ -137,18 +136,6 @@ protected:
                 {attr->get_uid(),
                  hipdnn_test_sdk::utilities::createAllCloseValidator(
                      toSdkType(attr->get_data_type()), absoluteTolerance, relativeTolerance)});
-            _tensorIdToNameMap.insert({attr->get_uid(), attr->get_name()});
-        });
-    }
-
-    void registerRmsValidator(const std::shared_ptr<hipdnn_frontend::graph::TensorAttributes> attr,
-                              float rmsThreshold)
-    {
-        // Since the graph can infer properties + Ids, we defer validator registration until right before validation in verifyGraph
-        _deferredValidators.emplace_back([=]() {
-            _tensorIdToValidatorMap.insert({attr->get_uid(),
-                                            hipdnn_test_sdk::utilities::createRmsValidator(
-                                                toSdkType(attr->get_data_type()), rmsThreshold)});
             _tensorIdToNameMap.insert({attr->get_uid(), attr->get_name()});
         });
     }

--- a/dnn-providers/hip-kernel-provider/integration_tests/main.cpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/main.cpp
@@ -4,7 +4,6 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
-#include <spdlog/spdlog.h>
 
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
@@ -19,7 +18,5 @@ int main(int argc, char** argv)
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    auto result = RUN_ALL_TESTS();
-    spdlog::shutdown();
-    return result;
+    return RUN_ALL_TESTS();
 }

--- a/dnn-providers/hip-kernel-provider/kernels/BatchNormFwdInferSpatial.cpp
+++ b/dnn-providers/hip-kernel-provider/kernels/BatchNormFwdInferSpatial.cpp
@@ -1,0 +1,235 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "bnorm_spatial_activation_functions.hpp"
+#include "float_types.h"
+#include "vector_types.hpp"
+#include <hip/hip_runtime.h>
+
+// determine block size using parameters passed from the host
+constexpr int blockSize = MIO_BN_GRP0 * MIO_BN_GRP1 * MIO_BN_GRP2;
+
+// define types for vectorized loads/stores
+using FLOAT_VEC_TYPE = typename miopen::mapped_vector_type<FLOAT, MIO_BN_VEC_SIZE>::type;
+using FLOAT_ACCUM_VEC_TYPE =
+    typename miopen::mapped_vector_type<FLOAT_ACCUM, MIO_BN_VEC_SIZE>::type;
+
+template <unsigned int vecSizeX, unsigned int vecSizeY>
+__device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
+                                                      unsigned int tidy,
+                                                      const FLOAT* in,
+                                                      FLOAT* out,
+                                                      const FLOAT_ACCUM* mean,
+                                                      const FLOAT_ACCUM* invVariance,
+                                                      const FLOAT_ACCUM* scale,
+                                                      const FLOAT_ACCUM* bias,
+                                                      unsigned int batchSize,
+                                                      unsigned int cStride,
+                                                      unsigned int hwStride,
+                                                      unsigned int batchStride,
+                                                      FLOAT_ACCUM alpha,
+                                                      FLOAT_ACCUM beta)
+{
+    FLOAT_ACCUM inhat[MIO_BN_VEC_SIZE];
+    FLOAT value[MIO_BN_VEC_SIZE];
+
+    // loop over the batches
+    // NOTE: We use zlocalsize = 1 and zgridsize = min(batchSize, maxGridSizeToFillTheGPU). So the
+    // idea here is to use the blocks in z-dimension to cover the batch dimension first, and then
+    // each block will loop over the remaining batches with stride of gridDim.z if necessary.
+    for(unsigned int n = blockIdx.z; n < batchSize; n += gridDim.z)
+    {
+        // load input value
+        const unsigned int batchIndex
+            = (n * batchStride) + (tidx * cStride * vecSizeX) + (tidy * hwStride * vecSizeY);
+        *(reinterpret_cast<FLOAT_VEC_TYPE*>(value))
+            = *(reinterpret_cast<const FLOAT_VEC_TYPE*>(in + batchIndex));
+
+        // perform batchnorm and activation
+#pragma unroll
+        for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+        {
+            inhat[i] = (CVT_FLOAT2ACCUM(value[i]) - mean[i]) * invVariance[i];
+            inhat[i] = scale[i] * inhat[i] + bias[i];
+            inhat[i] = miopen::batchnorm::activation_op<FLOAT_ACCUM,
+                                                        miopen::neuron_op_type{MIOPEN_NRN_OP_ID}>(
+                inhat[i], alpha, beta);
+            value[i] = CVT_ACCUM2FLOAT(inhat[i]);
+        }
+
+        // write output value
+        *(reinterpret_cast<FLOAT_VEC_TYPE*>(out + batchIndex))
+            = *(reinterpret_cast<const FLOAT_VEC_TYPE*>(value));
+    }
+}
+
+extern "C" __global__ void __launch_bounds__(blockSize)
+    MIOpenBatchNormFwdInferSpatialEst(const FLOAT* __restrict in,
+                                      FLOAT* __restrict out,
+                                      const FLOAT_ACCUM* __restrict estimatedMean,
+                                      const FLOAT_ACCUM* __restrict estimatedVariance,
+                                      const FLOAT_ACCUM* __restrict scale,
+                                      const FLOAT_ACCUM* __restrict bias,
+                                      double epsilon,
+                                      unsigned int c,
+                                      unsigned int hw,
+                                      unsigned int batchSize,
+                                      unsigned int cStride,
+                                      unsigned int hwStride,
+                                      unsigned int batchStride,
+                                      FLOAT_ACCUM alpha,
+                                      FLOAT_ACCUM beta)
+{
+    unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
+    unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+    unsigned int tidz = blockIdx.z;
+
+    // decide vector sizes based on problem layout
+    constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
+    constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
+
+    // skip execution for out-of-bound threads
+    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw || tidz >= batchSize)
+    {
+        return;
+    }
+
+    // indices for current thread
+    unsigned int adjIndex = tidx * vecSizeX;
+
+    // batch parameters and values for current thread
+    FLOAT_ACCUM mean[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM variance[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM pscale[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM pbias[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM invVariance[MIO_BN_VEC_SIZE];
+    if constexpr(MIO_LAYOUT_NHWC)
+    {
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(mean))
+            = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedMean + adjIndex));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(variance))
+            = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedVariance + adjIndex));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pscale))
+            = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(scale + adjIndex));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pbias))
+            = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(bias + adjIndex));
+    }
+    else // NCHW layout
+    {
+        const auto mean_val = estimatedMean[adjIndex];
+        const auto variance_val = estimatedVariance[adjIndex];
+        const auto pscale_val = scale[adjIndex];
+        const auto pbias_val = bias[adjIndex];
+#pragma unroll
+        for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+        {
+            mean[i] = mean_val;
+            variance[i] = variance_val;
+            pscale[i] = pscale_val;
+            pbias[i] = pbias_val;
+        }
+    }
+#pragma unroll
+    for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+    {
+        invVariance[i] = rsqrt(fabs(variance[i] + static_cast<FLOAT_ACCUM>(epsilon)));
+    }
+
+    BNFwdInferSpatialImpl<vecSizeX, vecSizeY>(tidx,
+                                              tidy,
+                                              in,
+                                              out,
+                                              mean,
+                                              invVariance,
+                                              pscale,
+                                              pbias,
+                                              batchSize,
+                                              cStride,
+                                              hwStride,
+                                              batchStride,
+                                              alpha,
+                                              beta);
+}
+
+// Uses estimated inverse variance rather than inverse variance, which avoids need for an
+// epsilon parameter and rsqrt() operations.
+extern "C" __global__ void __launch_bounds__(blockSize)
+    MIOpenBatchNormFwdInferSpatialEstInvVar(const FLOAT* __restrict in,
+                                            FLOAT* __restrict out,
+                                            const FLOAT_ACCUM* __restrict estimatedMean,
+                                            const FLOAT_ACCUM* __restrict estimatedInvVariance,
+                                            const FLOAT_ACCUM* __restrict scale,
+                                            const FLOAT_ACCUM* __restrict bias,
+                                            unsigned int c,
+                                            unsigned int hw,
+                                            unsigned int batchSize,
+                                            unsigned int cStride,
+                                            unsigned int hwStride,
+                                            unsigned int batchStride,
+                                            FLOAT_ACCUM alpha,
+                                            FLOAT_ACCUM beta)
+{
+    unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
+    unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+    unsigned int tidz = blockIdx.z;
+
+    // decide vector sizes based on problem layout
+    constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
+    constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
+
+    // skip execution for out-of-bound threads
+    if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw || tidz >= batchSize)
+    {
+        return;
+    }
+
+    // indices for current thread
+    unsigned int adjIndex = tidx * vecSizeX;
+
+    // batch parameters and values for current thread
+    FLOAT_ACCUM mean[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM pscale[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM pbias[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM invVariance[MIO_BN_VEC_SIZE];
+    if constexpr(MIO_LAYOUT_NHWC)
+    {
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(mean))
+            = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedMean + adjIndex));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(invVariance))
+            = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedInvVariance + adjIndex));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pscale))
+            = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(scale + adjIndex));
+        *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(pbias))
+            = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(bias + adjIndex));
+    }
+    else // NCHW layout
+    {
+        const auto mean_val = estimatedMean[adjIndex];
+        const auto invVariance_val = estimatedInvVariance[adjIndex];
+        const auto pscale_val = scale[adjIndex];
+        const auto pbias_val = bias[adjIndex];
+#pragma unroll
+        for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+        {
+            mean[i] = mean_val;
+            invVariance[i] = invVariance_val;
+            pscale[i] = pscale_val;
+            pbias[i] = pbias_val;
+        }
+    }
+
+    BNFwdInferSpatialImpl<vecSizeX, vecSizeY>(tidx,
+                                              tidy,
+                                              in,
+                                              out,
+                                              mean,
+                                              invVariance,
+                                              pscale,
+                                              pbias,
+                                              batchSize,
+                                              cStride,
+                                              hwStride,
+                                              batchStride,
+                                              alpha,
+                                              beta);
+}

--- a/dnn-providers/hip-kernel-provider/kernels/BatchNormFwdInferSpatial.cpp
+++ b/dnn-providers/hip-kernel-provider/kernels/BatchNormFwdInferSpatial.cpp
@@ -6,12 +6,13 @@
 #include "VectorTypes.hpp"
 
 // determine block size using parameters passed from the host
-constexpr int blockSize = MIO_BN_GRP0 * MIO_BN_GRP1 * MIO_BN_GRP2;
+constexpr int blockSize = HIP_PLUGIN_BN_GRP0 * HIP_PLUGIN_BN_GRP1 * HIP_PLUGIN_BN_GRP2;
 
 // define types for vectorized loads/stores
-using FLOAT_VEC_TYPE = typename hip_kernel_plugin::mapped_vector_type<FLOAT, MIO_BN_VEC_SIZE>::type;
+using FLOAT_VEC_TYPE =
+    typename hip_kernel_plugin::mapped_vector_type<FLOAT, HIP_PLUGIN_BN_VEC_SIZE>::type;
 using FLOAT_ACCUM_VEC_TYPE =
-    typename hip_kernel_plugin::mapped_vector_type<FLOAT_ACCUM, MIO_BN_VEC_SIZE>::type;
+    typename hip_kernel_plugin::mapped_vector_type<FLOAT_ACCUM, HIP_PLUGIN_BN_VEC_SIZE>::type;
 
 template <unsigned int vecSizeX, unsigned int vecSizeY>
 __device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
@@ -29,8 +30,8 @@ __device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
                                                       FLOAT_ACCUM alpha,
                                                       FLOAT_ACCUM beta)
 {
-    FLOAT_ACCUM inhat[MIO_BN_VEC_SIZE];
-    FLOAT value[MIO_BN_VEC_SIZE];
+    FLOAT_ACCUM inhat[HIP_PLUGIN_BN_VEC_SIZE];
+    FLOAT value[HIP_PLUGIN_BN_VEC_SIZE];
 
     // loop over the batches
     // NOTE: We use zlocalsize = 1 and zgridsize = min(batchSize, maxGridSizeToFillTheGPU). So the
@@ -46,7 +47,7 @@ __device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
 
         // perform batchnorm and activation
 #pragma unroll
-        for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+        for(unsigned int i = 0; i < HIP_PLUGIN_BN_VEC_SIZE; ++i)
         {
             inhat[i] = (CVT_FLOAT2ACCUM(value[i]) - mean[i]) * invVariance[i];
             inhat[i] = scale[i] * inhat[i] + bias[i];
@@ -80,13 +81,13 @@ extern "C" __global__ void __launch_bounds__(blockSize)
                                 FLOAT_ACCUM alpha,
                                 FLOAT_ACCUM beta)
 {
-    unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
-    unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+    unsigned int tidx = blockIdx.x * HIP_PLUGIN_BN_GRP0 + threadIdx.x;
+    unsigned int tidy = blockIdx.y * HIP_PLUGIN_BN_GRP1 + threadIdx.y;
     unsigned int tidz = blockIdx.z;
 
     // decide vector sizes based on problem layout
-    constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
-    constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
+    constexpr unsigned int vecSizeX = HIP_PLUGIN_LAYOUT_NHWC ? HIP_PLUGIN_BN_VEC_SIZE : 1;
+    constexpr unsigned int vecSizeY = HIP_PLUGIN_LAYOUT_NHWC ? 1 : HIP_PLUGIN_BN_VEC_SIZE;
 
     // skip execution for out-of-bound threads
     if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw || tidz >= batchSize)
@@ -98,12 +99,12 @@ extern "C" __global__ void __launch_bounds__(blockSize)
     unsigned int adjIndex = tidx * vecSizeX;
 
     // batch parameters and values for current thread
-    FLOAT_ACCUM mean[MIO_BN_VEC_SIZE];
-    FLOAT_ACCUM variance[MIO_BN_VEC_SIZE];
-    FLOAT_ACCUM pscale[MIO_BN_VEC_SIZE];
-    FLOAT_ACCUM pbias[MIO_BN_VEC_SIZE];
-    FLOAT_ACCUM invVariance[MIO_BN_VEC_SIZE];
-    if constexpr(MIO_LAYOUT_NHWC)
+    FLOAT_ACCUM mean[HIP_PLUGIN_BN_VEC_SIZE];
+    FLOAT_ACCUM variance[HIP_PLUGIN_BN_VEC_SIZE];
+    FLOAT_ACCUM pscale[HIP_PLUGIN_BN_VEC_SIZE];
+    FLOAT_ACCUM pbias[HIP_PLUGIN_BN_VEC_SIZE];
+    FLOAT_ACCUM invVariance[HIP_PLUGIN_BN_VEC_SIZE];
+    if constexpr(HIP_PLUGIN_LAYOUT_NHWC)
     {
         *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(mean))
             = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedMean + adjIndex));
@@ -121,7 +122,7 @@ extern "C" __global__ void __launch_bounds__(blockSize)
         const auto pscale_val = scale[adjIndex];
         const auto pbias_val = bias[adjIndex];
 #pragma unroll
-        for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+        for(unsigned int i = 0; i < HIP_PLUGIN_BN_VEC_SIZE; ++i)
         {
             mean[i] = mean_val;
             variance[i] = variance_val;
@@ -130,7 +131,7 @@ extern "C" __global__ void __launch_bounds__(blockSize)
         }
     }
 #pragma unroll
-    for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+    for(unsigned int i = 0; i < HIP_PLUGIN_BN_VEC_SIZE; ++i)
     {
         invVariance[i] = rsqrt(fabs(variance[i] + static_cast<FLOAT_ACCUM>(epsilon)));
     }
@@ -169,13 +170,13 @@ extern "C" __global__ void __launch_bounds__(blockSize)
                                       FLOAT_ACCUM alpha,
                                       FLOAT_ACCUM beta)
 {
-    unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
-    unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
+    unsigned int tidx = blockIdx.x * HIP_PLUGIN_BN_GRP0 + threadIdx.x;
+    unsigned int tidy = blockIdx.y * HIP_PLUGIN_BN_GRP1 + threadIdx.y;
     unsigned int tidz = blockIdx.z;
 
     // decide vector sizes based on problem layout
-    constexpr unsigned int vecSizeX = MIO_LAYOUT_NHWC ? MIO_BN_VEC_SIZE : 1;
-    constexpr unsigned int vecSizeY = MIO_LAYOUT_NHWC ? 1 : MIO_BN_VEC_SIZE;
+    constexpr unsigned int vecSizeX = HIP_PLUGIN_LAYOUT_NHWC ? HIP_PLUGIN_BN_VEC_SIZE : 1;
+    constexpr unsigned int vecSizeY = HIP_PLUGIN_LAYOUT_NHWC ? 1 : HIP_PLUGIN_BN_VEC_SIZE;
 
     // skip execution for out-of-bound threads
     if(tidx * vecSizeX >= c || tidy * vecSizeY >= hw || tidz >= batchSize)
@@ -187,11 +188,11 @@ extern "C" __global__ void __launch_bounds__(blockSize)
     unsigned int adjIndex = tidx * vecSizeX;
 
     // batch parameters and values for current thread
-    FLOAT_ACCUM mean[MIO_BN_VEC_SIZE];
-    FLOAT_ACCUM pscale[MIO_BN_VEC_SIZE];
-    FLOAT_ACCUM pbias[MIO_BN_VEC_SIZE];
-    FLOAT_ACCUM invVariance[MIO_BN_VEC_SIZE];
-    if constexpr(MIO_LAYOUT_NHWC)
+    FLOAT_ACCUM mean[HIP_PLUGIN_BN_VEC_SIZE];
+    FLOAT_ACCUM pscale[HIP_PLUGIN_BN_VEC_SIZE];
+    FLOAT_ACCUM pbias[HIP_PLUGIN_BN_VEC_SIZE];
+    FLOAT_ACCUM invVariance[HIP_PLUGIN_BN_VEC_SIZE];
+    if constexpr(HIP_PLUGIN_LAYOUT_NHWC)
     {
         *(reinterpret_cast<FLOAT_ACCUM_VEC_TYPE*>(mean))
             = *(reinterpret_cast<const FLOAT_ACCUM_VEC_TYPE*>(estimatedMean + adjIndex));
@@ -209,7 +210,7 @@ extern "C" __global__ void __launch_bounds__(blockSize)
         const auto pscale_val = scale[adjIndex];
         const auto pbias_val = bias[adjIndex];
 #pragma unroll
-        for(unsigned int i = 0; i < MIO_BN_VEC_SIZE; ++i)
+        for(unsigned int i = 0; i < HIP_PLUGIN_BN_VEC_SIZE; ++i)
         {
             mean[i] = mean_val;
             invVariance[i] = invVariance_val;

--- a/dnn-providers/hip-kernel-provider/kernels/BatchNormFwdInferSpatial.cpp
+++ b/dnn-providers/hip-kernel-provider/kernels/BatchNormFwdInferSpatial.cpp
@@ -1,18 +1,17 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include "bnorm_spatial_activation_functions.hpp"
-#include "float_types.h"
-#include "vector_types.hpp"
-#include <hip/hip_runtime.h>
+#include "BatchnormActivation.hpp"
+#include "FloatTypes.h"
+#include "VectorTypes.hpp"
 
 // determine block size using parameters passed from the host
 constexpr int blockSize = MIO_BN_GRP0 * MIO_BN_GRP1 * MIO_BN_GRP2;
 
 // define types for vectorized loads/stores
-using FLOAT_VEC_TYPE = typename miopen::mapped_vector_type<FLOAT, MIO_BN_VEC_SIZE>::type;
+using FLOAT_VEC_TYPE = typename hip_kernel_plugin::mapped_vector_type<FLOAT, MIO_BN_VEC_SIZE>::type;
 using FLOAT_ACCUM_VEC_TYPE =
-    typename miopen::mapped_vector_type<FLOAT_ACCUM, MIO_BN_VEC_SIZE>::type;
+    typename hip_kernel_plugin::mapped_vector_type<FLOAT_ACCUM, MIO_BN_VEC_SIZE>::type;
 
 template <unsigned int vecSizeX, unsigned int vecSizeY>
 __device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
@@ -51,8 +50,9 @@ __device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
         {
             inhat[i] = (CVT_FLOAT2ACCUM(value[i]) - mean[i]) * invVariance[i];
             inhat[i] = scale[i] * inhat[i] + bias[i];
-            inhat[i] = miopen::batchnorm::activation_op<FLOAT_ACCUM,
-                                                        miopen::neuron_op_type{MIOPEN_NRN_OP_ID}>(
+            inhat[i] = hip_kernel_plugin::batchnorm::applyActivation<
+                FLOAT_ACCUM,
+                hip_kernel_plugin::batchnorm::ActivationMode{HIP_PLUGIN_NRN_OP_ID}>(
                 inhat[i], alpha, beta);
             value[i] = CVT_ACCUM2FLOAT(inhat[i]);
         }
@@ -64,21 +64,21 @@ __device__ __forceinline__ void BNFwdInferSpatialImpl(unsigned int tidx,
 }
 
 extern "C" __global__ void __launch_bounds__(blockSize)
-    MIOpenBatchNormFwdInferSpatialEst(const FLOAT* __restrict in,
-                                      FLOAT* __restrict out,
-                                      const FLOAT_ACCUM* __restrict estimatedMean,
-                                      const FLOAT_ACCUM* __restrict estimatedVariance,
-                                      const FLOAT_ACCUM* __restrict scale,
-                                      const FLOAT_ACCUM* __restrict bias,
-                                      double epsilon,
-                                      unsigned int c,
-                                      unsigned int hw,
-                                      unsigned int batchSize,
-                                      unsigned int cStride,
-                                      unsigned int hwStride,
-                                      unsigned int batchStride,
-                                      FLOAT_ACCUM alpha,
-                                      FLOAT_ACCUM beta)
+    BatchNormFwdInferSpatialEst(const FLOAT* __restrict in,
+                                FLOAT* __restrict out,
+                                const FLOAT_ACCUM* __restrict estimatedMean,
+                                const FLOAT_ACCUM* __restrict estimatedVariance,
+                                const FLOAT_ACCUM* __restrict scale,
+                                const FLOAT_ACCUM* __restrict bias,
+                                double epsilon,
+                                unsigned int c,
+                                unsigned int hw,
+                                unsigned int batchSize,
+                                unsigned int cStride,
+                                unsigned int hwStride,
+                                unsigned int batchStride,
+                                FLOAT_ACCUM alpha,
+                                FLOAT_ACCUM beta)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;
@@ -154,20 +154,20 @@ extern "C" __global__ void __launch_bounds__(blockSize)
 // Uses estimated inverse variance rather than inverse variance, which avoids need for an
 // epsilon parameter and rsqrt() operations.
 extern "C" __global__ void __launch_bounds__(blockSize)
-    MIOpenBatchNormFwdInferSpatialEstInvVar(const FLOAT* __restrict in,
-                                            FLOAT* __restrict out,
-                                            const FLOAT_ACCUM* __restrict estimatedMean,
-                                            const FLOAT_ACCUM* __restrict estimatedInvVariance,
-                                            const FLOAT_ACCUM* __restrict scale,
-                                            const FLOAT_ACCUM* __restrict bias,
-                                            unsigned int c,
-                                            unsigned int hw,
-                                            unsigned int batchSize,
-                                            unsigned int cStride,
-                                            unsigned int hwStride,
-                                            unsigned int batchStride,
-                                            FLOAT_ACCUM alpha,
-                                            FLOAT_ACCUM beta)
+    BatchNormFwdInferSpatialEstInvVar(const FLOAT* __restrict in,
+                                      FLOAT* __restrict out,
+                                      const FLOAT_ACCUM* __restrict estimatedMean,
+                                      const FLOAT_ACCUM* __restrict estimatedInvVariance,
+                                      const FLOAT_ACCUM* __restrict scale,
+                                      const FLOAT_ACCUM* __restrict bias,
+                                      unsigned int c,
+                                      unsigned int hw,
+                                      unsigned int batchSize,
+                                      unsigned int cStride,
+                                      unsigned int hwStride,
+                                      unsigned int batchStride,
+                                      FLOAT_ACCUM alpha,
+                                      FLOAT_ACCUM beta)
 {
     unsigned int tidx = blockIdx.x * MIO_BN_GRP0 + threadIdx.x;
     unsigned int tidy = blockIdx.y * MIO_BN_GRP1 + threadIdx.y;

--- a/dnn-providers/hip-kernel-provider/kernels/BatchnormActivation.hpp
+++ b/dnn-providers/hip-kernel-provider/kernels/BatchnormActivation.hpp
@@ -1,0 +1,101 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include "HipKernelMath.hpp"
+
+namespace hip_kernel_plugin
+{
+namespace batchnorm
+{
+
+/// Note: Values match hip_kernel_utils::ActivationMode in HipKernelUtils.hpp
+enum class ActivationMode : int
+{
+    PASTHRU = 0,
+    LOGISTIC = 1,
+    TANH = 2,
+    RELU = 3,
+    SOFTRELU = 4,
+    ABS = 5,
+    POWER = 6,
+    CLIPPED_RELU = 7,
+    LEAKY_RELU = 8,
+    ELU = 9,
+    CLAMP = 10
+};
+
+/// @brief Apply activation function to a single scalar value
+/// @tparam T Floating point type (float, _Float16, etc.)
+/// @tparam Mode Activation mode to apply
+/// @param value Input value to apply activation to
+/// @param alpha First activation parameter
+/// @param beta Second activation parameter
+/// @return Activated value
+template <typename T, ActivationMode Mode>
+__forceinline__ __device__ T applyActivation(T const& value, T const& alpha, T const& beta)
+{
+    static_assert(Mode == ActivationMode::PASTHRU || Mode == ActivationMode::RELU
+                      || Mode == ActivationMode::CLIPPED_RELU || Mode == ActivationMode::CLAMP,
+                  "Unsupported activation mode for batchnorm fusion");
+
+    if constexpr(Mode == ActivationMode::PASTHRU)
+    {
+        return value;
+    }
+    else if constexpr(Mode == ActivationMode::RELU)
+    {
+        return max(value, T(0));
+    }
+    else if constexpr(Mode == ActivationMode::CLIPPED_RELU)
+    {
+        return min(alpha, max(value, T(0)));
+    }
+    else if constexpr(Mode == ActivationMode::CLAMP)
+    {
+        return max(alpha, min(beta, value));
+    }
+}
+
+/// @brief Apply activation gradient for backward pass
+/// @tparam T Floating point type (float, _Float16, etc.)
+/// @tparam Mode Activation mode
+/// @param dy Gradient from next layer
+/// @param xnorm Normalized input value
+/// @param scale Scale parameter from batchnorm
+/// @param bias Bias parameter from batchnorm
+/// @param alpha First activation parameter
+/// @param beta Second activation parameter
+/// @return Gradient with respect to input
+template <typename T, ActivationMode Mode>
+__forceinline__ __device__ T applyActivationGradient(
+    T const& dy, T const& xnorm, T const& scale, T const& bias, T const& alpha, T const& beta)
+{
+    static_assert(Mode == ActivationMode::PASTHRU || Mode == ActivationMode::RELU
+                      || Mode == ActivationMode::CLIPPED_RELU || Mode == ActivationMode::CLAMP,
+                  "Unsupported activation mode for batchnorm fusion");
+
+    if constexpr(Mode == ActivationMode::PASTHRU)
+    {
+        return dy;
+    }
+    else if constexpr(Mode == ActivationMode::RELU)
+    {
+        T activated = scale * xnorm + bias;
+        return (activated > T(0)) ? dy : T(0);
+    }
+    else if constexpr(Mode == ActivationMode::CLIPPED_RELU)
+    {
+        T activated = scale * xnorm + bias;
+        return (activated > T(0) && activated <= alpha) ? dy : T(0);
+    }
+    else if constexpr(Mode == ActivationMode::CLAMP)
+    {
+        T activated = scale * xnorm + bias;
+        return (activated > alpha && activated <= beta) ? dy : T(0);
+    }
+}
+
+} // namespace batchnorm
+} // namespace hip_kernel_plugin

--- a/dnn-providers/hip-kernel-provider/kernels/Bfloat16Dev.hpp
+++ b/dnn-providers/hip-kernel-provider/kernels/Bfloat16Dev.hpp
@@ -1,8 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-#ifndef BFLOAT16_DEVICE_HPP
-#define BFLOAT16_DEVICE_HPP
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -79,5 +78,3 @@ EXECUTION_SPECIFIER ushort float_to_bfloat16(float src_val)
 #ifdef __cplusplus
 }
 #endif
-
-#endif // BFLOAT16_DEVICE_HPP

--- a/dnn-providers/hip-kernel-provider/kernels/Bfloat16Dev.hpp
+++ b/dnn-providers/hip-kernel-provider/kernels/Bfloat16Dev.hpp
@@ -1,0 +1,288 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#ifndef BFLOAT16_DEVICE_HPP
+#define BFLOAT16_DEVICE_HPP
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __HIP_PLATFORM_AMD__
+#define EXECUTION_SPECIFIER __device__
+#else
+#define EXECUTION_SPECIFIER
+#endif // HIP_PLUGIN_BACKEND_HIP
+
+typedef union cvt_bf16_fp32
+{
+    uint u32;
+    ushort2 ushortx2;
+
+// Composable kernels are written in HIP language. The language doesnt support
+// ushort2.hi or ushort2.low.
+#ifdef __HIP_PLATFORM_AMD__
+    ushort ushortvec[2];
+#endif // HIP_PLUGIN_BACKEND_HIP
+    float f32;
+} cvt_bf16_fp32_t;
+
+EXECUTION_SPECIFIER float bfloat16_to_float(ushort src_val)
+{
+    cvt_bf16_fp32_t target_val;
+
+#ifdef __HIP_PLATFORM_AMD__
+    target_val.ushortx2 = make_ushort2(0, src_val);
+#else
+    target_val.ushortx2 = (ushort2)(0, src_val);
+#endif
+
+    return target_val.f32;
+}
+
+EXECUTION_SPECIFIER ushort float_to_bfloat16(float src_val)
+{
+    cvt_bf16_fp32_t target_val;
+    target_val.f32 = src_val;
+    // BF16 round and NaN preservation code matches
+    // https://github.com/ROCm/rocBLAS/blob/develop/library/include/rocblas_bfloat16.h
+    if((~target_val.u32 & 0x7f800000) == 0) // Inf or NaN
+    {
+        // When all of the exponent bits are 1, the value is Inf or NaN.
+        // Inf is indicated by a zero mantissa. NaN is indicated by any nonzero
+        // mantissa bit. Quiet NaN is indicated by the most significant mantissa
+        // bit being 1. Signaling NaN is indicated by the most significant
+        // mantissa bit being 0 but some other bit(s) being 1. If any of the
+        // lower 16 bits of the mantissa are 1, we set the least significant bit
+        // of the bfloat16 mantissa, in order to preserve signaling NaN in case
+        // the bloat16's mantissa bits are all 0.
+        if((target_val.u32 & 0xffff) != 0)
+        {
+            target_val.u32 |= 0x10000; // Preserve signaling NaN
+        }
+    }
+    else
+    {
+#ifdef HIP_PLUGIN_USE_RNE_BFLOAT16
+// When the exponent bits are not all 1s, then the value is zero, normal,
+// or subnormal. We round the bfloat16 mantissa up by adding 0x7FFF, plus
+// 1 if the least significant bit of the bfloat16 mantissa is 1 (odd).
+// This causes the bfloat16's mantissa to be incremented by 1 if the 16
+// least significant bits of the float mantissa are greater than 0x8000,
+// or if they are equal to 0x8000 and the least significant bit of the
+// bfloat16 mantissa is 1 (odd). This causes it to be rounded to even when
+// the lower 16 bits are exactly 0x8000. If the bfloat16 mantissa already
+// has the value 0x7f, then incrementing it causes it to become 0x00 and
+// the exponent is incremented by one, which is the next higher FP value
+// to the unrounded bfloat16 value. When the bfloat16 value is subnormal
+// with an exponent of 0x00 and a mantissa of 0x7F, it may be rounded up
+// to a normal value with an exponent of 0x01 and a mantissa of 0x00.
+// When the bfloat16 value has an exponent of 0xFE and a mantissa of 0x7F,
+// incrementing it causes it to become an exponent of 0xFF and a mantissa
+// of 0x00, which is Inf, the next higher value to the unrounded value.
+#ifdef __HIP_PLATFORM_AMD__
+        target_val.u32 += (0x7fff + (target_val.ushortvec[1] & 1));
+#else
+        target_val.u32
+            += (0x7fff + (target_val.ushortx2.hi & 1)); // Round to nearest, round to even
+#endif // HIP_PLUGIN_BACKEND_HIP
+#endif // HIP_PLUGIN_USE_RNE_BFLOAT16
+    }
+
+#ifdef __HIP_PLATFORM_AMD__
+    return target_val.ushortvec[1];
+#else
+    return target_val.ushortx2.hi;
+#endif // HIP_PLUGIN_BACKEND_HIP
+}
+
+#ifndef HIP_PLUGIN_USE_FP8
+#define HIP_PLUGIN_USE_FP8 0
+#endif
+
+#ifndef HIP_PLUGIN_USE_BFP8
+#define HIP_PLUGIN_USE_BFP8 0
+#endif
+
+#if HIP_PLUGIN_USE_FP8 || HIP_PLUGIN_USE_BFP8
+// TODO: Convert the Col2Im kernels from OpenCL to HIP and remove the following
+// functions which are rewrites of the f8 header impl functions
+EXECUTION_SPECIFIER float fp8_to_float_impl(uchar x, const int wm, const int we)
+{
+    bool negative_zero_nan = HIP_PLUGIN_FP8_IEEE_EXPONENT_BIAS ? false : true;
+
+    const int weo = 8;
+    const int wmo = 23;
+
+    float fInf, fNegInf, fNaN, fNeg0;
+    const uint ifInf = 0x7F800000;
+    const uint ifNegInf = 0xFF800000;
+    const uint ifNaN = 0x7F800001;
+    const uint ifNeg0 = 0x80000000;
+    fInf = *((const float*)(&ifInf));
+    fNegInf = *((const float*)(&ifNegInf));
+    fNaN = *((const float*)(&ifNaN));
+    fNeg0 = *((const float*)(&ifNeg0));
+
+    if(x == 0)
+        return (float)(0);
+
+    uint sign = x >> 7;
+    uint mantissa = x & ((1 << wm) - 1);
+    int exponent = (x & 0x7F) >> wm;
+    if(negative_zero_nan)
+    {
+        if(x == 0x80)
+            return fNaN;
+    }
+    else
+    {
+        if(x == 0x80)
+            return fNeg0;
+        if(exponent == ((1 << we) - 1))
+            return (mantissa == 0) ? (sign ? fNegInf : fInf) : fNaN;
+    }
+    uint retval;
+    const int exp_low_cutoff = (1 << (weo - 1)) - (1 << (we - 1)) + 1 - (negative_zero_nan ? 1 : 0);
+
+    // subnormal input
+    if(exponent == 0)
+    {
+        // guaranteed mantissa!=0 since cases 0x0 and 0x80 are handled above
+        // TODO: verify __builtin_clz and OpenCL's clz do the same thing
+        int sh = 1 + clz(mantissa) - (32 - wm);
+        mantissa <<= sh;
+        exponent += 1 - sh;
+        /*
+        exponent++;
+        while(mantissa<(1<<wm)) {
+          mantissa <<= 1;
+          exponent--;
+        }
+        */
+        mantissa &= ((1 << wm) - 1);
+    }
+    exponent += exp_low_cutoff - 1;
+    mantissa <<= wmo - wm;
+
+    // subnormal output (occurs when T=half, we=5, negative_zero_nan=true)
+    if(exponent <= 0)
+    {
+        mantissa |= 1 << wmo;
+        mantissa >>= 1 - exponent;
+        exponent = 0;
+    }
+
+    retval = (sign << 31) | (exponent << 23) | mantissa;
+    return *((const float*)(&retval));
+}
+
+EXECUTION_SPECIFIER float fp8_to_float(uchar x)
+{
+    return fp8_to_float_impl(x, 3, 4);
+}
+
+EXECUTION_SPECIFIER float bfp8_to_float(uchar x)
+{
+    return fp8_to_float_impl(x, 2, 5);
+}
+
+inline uchar float_to_fp8_impl(float _x, const int wm, const int we) // bool stoch, uint rng)
+{
+    bool negative_zero_nan = HIP_PLUGIN_FP8_IEEE_EXPONENT_BIAS ? false : true;
+    bool clip = HIP_PLUGIN_FP8_CLIPPING;
+
+    // Conserve the logic for stochastic rounding:
+    bool stoch = false;
+    uint rng = 0;
+    const int mfmt = 23;
+    uint x;
+    x = *((uint*)(&_x));
+
+    uint head, mantissa;
+    int exponent;
+    uint sign;
+
+    head = x & 0xFF800000;
+    mantissa = x & 0x7FFFFF;
+    exponent = (head >> 23) & 0xFF;
+    sign = head >> 31;
+
+    uint signed_inf = (sign << 7) + (((1 << we) - 1) << wm);
+
+    if(negative_zero_nan)
+    {
+        if((x & 0x7F800000) == 0x7F800000)
+            return 0x80;
+    }
+    else
+    {
+        if((x & 0x7F800000) == 0x7F800000)
+            return signed_inf + (mantissa != 0 ? 1 : 0);
+    }
+    if(x == 0)
+        return 0;
+
+    uint drop_mask = (1 << (mfmt - wm)) - 1;
+    const int max_exp = (1 << we) - (negative_zero_nan ? 1 : 2);
+    const int exp_low_cutoff = (128) - (1 << (we - 1)) + 1 - (negative_zero_nan ? 1 : 0);
+
+    exponent -= exp_low_cutoff - 1;
+    if(exponent <= 0)
+        drop_mask = (1 << (mfmt - wm + 1 - exponent)) - 1;
+    mantissa += 1 << mfmt;
+    mantissa += (stoch ? rng : mantissa) & drop_mask;
+    if(mantissa >= (2 << mfmt))
+    {
+        mantissa >>= 1;
+        exponent++;
+    }
+    mantissa >>= (mfmt - wm);
+
+    if(exponent <= 0)
+    {
+        if(x == 0) // cppcheck-suppress identicalConditionAfterEarlyExit
+            return 0;
+        else
+        {
+            // subnormal range; represented by a subnormal float8 (exponent 0)
+            // and involves loss of accuracy
+            mantissa >>= 1 - exponent;
+            exponent = 0;
+        }
+    }
+    // above range: quantize to maximum possible float of the same sign
+    else if(exponent > max_exp)
+    {
+        if(clip)
+        {
+            mantissa = (1 << wm) - 1;
+            exponent = max_exp;
+        }
+        else
+        {
+            return signed_inf;
+        }
+    }
+    if(exponent == 0 && mantissa == 0)
+        return negative_zero_nan ? 0 : (sign << 7);
+    mantissa &= (1 << wm) - 1;
+    return (sign << 7) | (exponent << wm) | mantissa;
+}
+
+EXECUTION_SPECIFIER uchar float_to_fp8(float _x) // bool stoch, uint rng)
+{
+    return float_to_fp8_impl(_x, 3, 4);
+}
+
+EXECUTION_SPECIFIER uchar float_to_bfp8(float _x) // bool stoch, uint rng)
+{
+    return float_to_fp8_impl(_x, 2, 5);
+}
+#endif // HIP_PLUGIN_USE_FP8 || HIP_PLUGIN_USE_BFP8
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BFLOAT16_DEVICE_HPP

--- a/dnn-providers/hip-kernel-provider/kernels/Bfloat16Dev.hpp
+++ b/dnn-providers/hip-kernel-provider/kernels/Bfloat16Dev.hpp
@@ -8,22 +8,14 @@
 extern "C" {
 #endif
 
-#ifdef __HIP_PLATFORM_AMD__
 #define EXECUTION_SPECIFIER __device__
-#else
-#define EXECUTION_SPECIFIER
-#endif // HIP_PLUGIN_BACKEND_HIP
 
 typedef union cvt_bf16_fp32
 {
     uint u32;
     ushort2 ushortx2;
 
-// Composable kernels are written in HIP language. The language doesnt support
-// ushort2.hi or ushort2.low.
-#ifdef __HIP_PLATFORM_AMD__
     ushort ushortvec[2];
-#endif // HIP_PLUGIN_BACKEND_HIP
     float f32;
 } cvt_bf16_fp32_t;
 
@@ -31,11 +23,7 @@ EXECUTION_SPECIFIER float bfloat16_to_float(ushort src_val)
 {
     cvt_bf16_fp32_t target_val;
 
-#ifdef __HIP_PLATFORM_AMD__
     target_val.ushortx2 = make_ushort2(0, src_val);
-#else
-    target_val.ushortx2 = (ushort2)(0, src_val);
-#endif
 
     return target_val.f32;
 }
@@ -64,222 +52,29 @@ EXECUTION_SPECIFIER ushort float_to_bfloat16(float src_val)
     else
     {
 #ifdef HIP_PLUGIN_USE_RNE_BFLOAT16
-// When the exponent bits are not all 1s, then the value is zero, normal,
-// or subnormal. We round the bfloat16 mantissa up by adding 0x7FFF, plus
-// 1 if the least significant bit of the bfloat16 mantissa is 1 (odd).
-// This causes the bfloat16's mantissa to be incremented by 1 if the 16
-// least significant bits of the float mantissa are greater than 0x8000,
-// or if they are equal to 0x8000 and the least significant bit of the
-// bfloat16 mantissa is 1 (odd). This causes it to be rounded to even when
-// the lower 16 bits are exactly 0x8000. If the bfloat16 mantissa already
-// has the value 0x7f, then incrementing it causes it to become 0x00 and
-// the exponent is incremented by one, which is the next higher FP value
-// to the unrounded bfloat16 value. When the bfloat16 value is subnormal
-// with an exponent of 0x00 and a mantissa of 0x7F, it may be rounded up
-// to a normal value with an exponent of 0x01 and a mantissa of 0x00.
-// When the bfloat16 value has an exponent of 0xFE and a mantissa of 0x7F,
-// incrementing it causes it to become an exponent of 0xFF and a mantissa
-// of 0x00, which is Inf, the next higher value to the unrounded value.
-#ifdef __HIP_PLATFORM_AMD__
+        // When the exponent bits are not all 1s, then the value is zero, normal,
+        // or subnormal. We round the bfloat16 mantissa up by adding 0x7FFF, plus
+        // 1 if the least significant bit of the bfloat16 mantissa is 1 (odd).
+        // This causes the bfloat16's mantissa to be incremented by 1 if the 16
+        // least significant bits of the float mantissa are greater than 0x8000,
+        // or if they are equal to 0x8000 and the least significant bit of the
+        // bfloat16 mantissa is 1 (odd). This causes it to be rounded to even when
+        // the lower 16 bits are exactly 0x8000. If the bfloat16 mantissa already
+        // has the value 0x7f, then incrementing it causes it to become 0x00 and
+        // the exponent is incremented by one, which is the next higher FP value
+        // to the unrounded bfloat16 value. When the bfloat16 value is subnormal
+        // with an exponent of 0x00 and a mantissa of 0x7F, it may be rounded up
+        // to a normal value with an exponent of 0x01 and a mantissa of 0x00.
+        // When the bfloat16 value has an exponent of 0xFE and a mantissa of 0x7F,
+        // incrementing it causes it to become an exponent of 0xFF and a mantissa
+        // of 0x00, which is Inf, the next higher value to the unrounded value.
         target_val.u32 += (0x7fff + (target_val.ushortvec[1] & 1));
-#else
-        target_val.u32
-            += (0x7fff + (target_val.ushortx2.hi & 1)); // Round to nearest, round to even
-#endif // HIP_PLUGIN_BACKEND_HIP
+
 #endif // HIP_PLUGIN_USE_RNE_BFLOAT16
     }
 
-#ifdef __HIP_PLATFORM_AMD__
     return target_val.ushortvec[1];
-#else
-    return target_val.ushortx2.hi;
-#endif // HIP_PLUGIN_BACKEND_HIP
 }
-
-#ifndef HIP_PLUGIN_USE_FP8
-#define HIP_PLUGIN_USE_FP8 0
-#endif
-
-#ifndef HIP_PLUGIN_USE_BFP8
-#define HIP_PLUGIN_USE_BFP8 0
-#endif
-
-#if HIP_PLUGIN_USE_FP8 || HIP_PLUGIN_USE_BFP8
-// TODO: Convert the Col2Im kernels from OpenCL to HIP and remove the following
-// functions which are rewrites of the f8 header impl functions
-EXECUTION_SPECIFIER float fp8_to_float_impl(uchar x, const int wm, const int we)
-{
-    bool negative_zero_nan = HIP_PLUGIN_FP8_IEEE_EXPONENT_BIAS ? false : true;
-
-    const int weo = 8;
-    const int wmo = 23;
-
-    float fInf, fNegInf, fNaN, fNeg0;
-    const uint ifInf = 0x7F800000;
-    const uint ifNegInf = 0xFF800000;
-    const uint ifNaN = 0x7F800001;
-    const uint ifNeg0 = 0x80000000;
-    fInf = *((const float*)(&ifInf));
-    fNegInf = *((const float*)(&ifNegInf));
-    fNaN = *((const float*)(&ifNaN));
-    fNeg0 = *((const float*)(&ifNeg0));
-
-    if(x == 0)
-        return (float)(0);
-
-    uint sign = x >> 7;
-    uint mantissa = x & ((1 << wm) - 1);
-    int exponent = (x & 0x7F) >> wm;
-    if(negative_zero_nan)
-    {
-        if(x == 0x80)
-            return fNaN;
-    }
-    else
-    {
-        if(x == 0x80)
-            return fNeg0;
-        if(exponent == ((1 << we) - 1))
-            return (mantissa == 0) ? (sign ? fNegInf : fInf) : fNaN;
-    }
-    uint retval;
-    const int exp_low_cutoff = (1 << (weo - 1)) - (1 << (we - 1)) + 1 - (negative_zero_nan ? 1 : 0);
-
-    // subnormal input
-    if(exponent == 0)
-    {
-        // guaranteed mantissa!=0 since cases 0x0 and 0x80 are handled above
-        // TODO: verify __builtin_clz and OpenCL's clz do the same thing
-        int sh = 1 + clz(mantissa) - (32 - wm);
-        mantissa <<= sh;
-        exponent += 1 - sh;
-        /*
-        exponent++;
-        while(mantissa<(1<<wm)) {
-          mantissa <<= 1;
-          exponent--;
-        }
-        */
-        mantissa &= ((1 << wm) - 1);
-    }
-    exponent += exp_low_cutoff - 1;
-    mantissa <<= wmo - wm;
-
-    // subnormal output (occurs when T=half, we=5, negative_zero_nan=true)
-    if(exponent <= 0)
-    {
-        mantissa |= 1 << wmo;
-        mantissa >>= 1 - exponent;
-        exponent = 0;
-    }
-
-    retval = (sign << 31) | (exponent << 23) | mantissa;
-    return *((const float*)(&retval));
-}
-
-EXECUTION_SPECIFIER float fp8_to_float(uchar x)
-{
-    return fp8_to_float_impl(x, 3, 4);
-}
-
-EXECUTION_SPECIFIER float bfp8_to_float(uchar x)
-{
-    return fp8_to_float_impl(x, 2, 5);
-}
-
-inline uchar float_to_fp8_impl(float _x, const int wm, const int we) // bool stoch, uint rng)
-{
-    bool negative_zero_nan = HIP_PLUGIN_FP8_IEEE_EXPONENT_BIAS ? false : true;
-    bool clip = HIP_PLUGIN_FP8_CLIPPING;
-
-    // Conserve the logic for stochastic rounding:
-    bool stoch = false;
-    uint rng = 0;
-    const int mfmt = 23;
-    uint x;
-    x = *((uint*)(&_x));
-
-    uint head, mantissa;
-    int exponent;
-    uint sign;
-
-    head = x & 0xFF800000;
-    mantissa = x & 0x7FFFFF;
-    exponent = (head >> 23) & 0xFF;
-    sign = head >> 31;
-
-    uint signed_inf = (sign << 7) + (((1 << we) - 1) << wm);
-
-    if(negative_zero_nan)
-    {
-        if((x & 0x7F800000) == 0x7F800000)
-            return 0x80;
-    }
-    else
-    {
-        if((x & 0x7F800000) == 0x7F800000)
-            return signed_inf + (mantissa != 0 ? 1 : 0);
-    }
-    if(x == 0)
-        return 0;
-
-    uint drop_mask = (1 << (mfmt - wm)) - 1;
-    const int max_exp = (1 << we) - (negative_zero_nan ? 1 : 2);
-    const int exp_low_cutoff = (128) - (1 << (we - 1)) + 1 - (negative_zero_nan ? 1 : 0);
-
-    exponent -= exp_low_cutoff - 1;
-    if(exponent <= 0)
-        drop_mask = (1 << (mfmt - wm + 1 - exponent)) - 1;
-    mantissa += 1 << mfmt;
-    mantissa += (stoch ? rng : mantissa) & drop_mask;
-    if(mantissa >= (2 << mfmt))
-    {
-        mantissa >>= 1;
-        exponent++;
-    }
-    mantissa >>= (mfmt - wm);
-
-    if(exponent <= 0)
-    {
-        if(x == 0) // cppcheck-suppress identicalConditionAfterEarlyExit
-            return 0;
-        else
-        {
-            // subnormal range; represented by a subnormal float8 (exponent 0)
-            // and involves loss of accuracy
-            mantissa >>= 1 - exponent;
-            exponent = 0;
-        }
-    }
-    // above range: quantize to maximum possible float of the same sign
-    else if(exponent > max_exp)
-    {
-        if(clip)
-        {
-            mantissa = (1 << wm) - 1;
-            exponent = max_exp;
-        }
-        else
-        {
-            return signed_inf;
-        }
-    }
-    if(exponent == 0 && mantissa == 0)
-        return negative_zero_nan ? 0 : (sign << 7);
-    mantissa &= (1 << wm) - 1;
-    return (sign << 7) | (exponent << wm) | mantissa;
-}
-
-EXECUTION_SPECIFIER uchar float_to_fp8(float _x) // bool stoch, uint rng)
-{
-    return float_to_fp8_impl(_x, 3, 4);
-}
-
-EXECUTION_SPECIFIER uchar float_to_bfp8(float _x) // bool stoch, uint rng)
-{
-    return float_to_fp8_impl(_x, 2, 5);
-}
-#endif // HIP_PLUGIN_USE_FP8 || HIP_PLUGIN_USE_BFP8
 
 #ifdef __cplusplus
 }

--- a/dnn-providers/hip-kernel-provider/kernels/FloatTypes.h
+++ b/dnn-providers/hip-kernel-provider/kernels/FloatTypes.h
@@ -1,8 +1,7 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#ifndef GUARD_FLOAT_TYPES_H
-#define GUARD_FLOAT_TYPES_H
+#pragma once
 
 #include "Bfloat16Dev.hpp"
 
@@ -11,35 +10,6 @@
 #define TWO 2
 #define FOUR 4
 #define EIGHT 8
-#if HIP_PLUGIN_USE_FP8 == 1
-#define FLOAT hip_f8<miopen_f8::hip_f8_type::fp8>
-#define FLOAT_ACCUM float
-// HIP implements the correct operators for conversion
-#define SIZEOF_FLOAT 1
-// Max value for the main datatype
-#define MAX_VAL 0x7F
-// Max value for accumulator
-// #ifndef FLT_MAX
-// #define MAX_VAL_ACCUM 3.402823466e+38F
-// #else
-// #define MAX_VAL_ACCUM FLT_MAX
-// #endif
-#endif // HIP_PLUGIN_USE_FP8
-
-#if HIP_PLUGIN_USE_BFP8 == 1
-#define FLOAT hip_f8<miopen_f8::hip_f8_type::bf8>
-#define FLOAT_ACCUM float
-// HIP implements the correct operators for conversion
-#define SIZEOF_FLOAT 1
-// Max value for the main datatype
-#define MAX_VAL 0x7F
-// Max value for accumulator
-// #ifndef FLT_MAX
-// #define MAX_VAL_ACCUM 3.402823466e+38F
-// #else
-// #define MAX_VAL_ACCUM FLT_MAX
-// #endif
-#endif // HIP_PLUGIN_USE_BFP8
 
 /// If HIP_PLUGIN_USE_DOUBLE_ACCUM is defined as 1 when "float_types.h" is included,
 /// then all the ACCUM macros (the represent operations and types) will use FP64
@@ -177,5 +147,3 @@
 #endif
 
 #endif // HIP_PLUGIN_USE_NATIVE_DATATYPE_ACCUM
-
-#endif // GUARD_FLOAT_TYPES_H

--- a/dnn-providers/hip-kernel-provider/kernels/FloatTypes.h
+++ b/dnn-providers/hip-kernel-provider/kernels/FloatTypes.h
@@ -1,0 +1,181 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#ifndef GUARD_FLOAT_TYPES_H
+#define GUARD_FLOAT_TYPES_H
+
+#include "Bfloat16Dev.hpp"
+
+#define PPCAT_NX(A, B) A##B
+#define PPCAT(A, B) PPCAT_NX(A, B)
+#define TWO 2
+#define FOUR 4
+#define EIGHT 8
+#if HIP_PLUGIN_USE_FP8 == 1
+#define FLOAT hip_f8<miopen_f8::hip_f8_type::fp8>
+#define FLOAT_ACCUM float
+// HIP implements the correct operators for conversion
+#define SIZEOF_FLOAT 1
+// Max value for the main datatype
+#define MAX_VAL 0x7F
+// Max value for accumulator
+// #ifndef FLT_MAX
+// #define MAX_VAL_ACCUM 3.402823466e+38F
+// #else
+// #define MAX_VAL_ACCUM FLT_MAX
+// #endif
+#endif // HIP_PLUGIN_USE_FP8
+
+#if HIP_PLUGIN_USE_BFP8 == 1
+#define FLOAT hip_f8<miopen_f8::hip_f8_type::bf8>
+#define FLOAT_ACCUM float
+// HIP implements the correct operators for conversion
+#define SIZEOF_FLOAT 1
+// Max value for the main datatype
+#define MAX_VAL 0x7F
+// Max value for accumulator
+// #ifndef FLT_MAX
+// #define MAX_VAL_ACCUM 3.402823466e+38F
+// #else
+// #define MAX_VAL_ACCUM FLT_MAX
+// #endif
+#endif // HIP_PLUGIN_USE_BFP8
+
+/// If HIP_PLUGIN_USE_DOUBLE_ACCUM is defined as 1 when "float_types.h" is included,
+/// then all the ACCUM macros (the represent operations and types) will use FP64
+/// instead of FP32. In other words, the computations will be
+/// performed using the native datatype even if ACCUM macros are used.
+/// This functionality is indended mostly for debugging.
+#ifdef HIP_PLUGIN_USE_DOUBLE_ACCUM
+#if !(HIP_PLUGIN_USE_DOUBLE_ACCUM == 0 || HIP_PLUGIN_USE_DOUBLE_ACCUM == 1)
+#error "Invalid value of HIP_PLUGIN_USE_DOUBLE_ACCUM"
+#endif
+#else
+#define HIP_PLUGIN_USE_DOUBLE_ACCUM 0
+#endif
+
+#if HIP_PLUGIN_USE_DOUBLE_ACCUM
+#define FLOAT_ACCUM double
+#define MAX_VAL_ACCUM DBL_MAX
+#else // HIP_PLUGIN_USE_DOUBLE_ACCUM
+#define FLOAT_ACCUM float
+#ifndef FLT_MAX
+#define MAX_VAL_ACCUM 3.402823466e+38F
+#else
+#define MAX_VAL_ACCUM FLT_MAX
+#endif
+#endif // HIP_PLUGIN_USE_DOUBLE_ACCUM
+
+#if(HIP_PLUGIN_USE_FP16 == 1) || (HIP_PLUGIN_USE_FPMIX == 1)
+#define FLOAT _Float16
+#define SIZEOF_FLOAT 2
+// Max value for the main datatype
+#ifndef HALF_MAX
+#define MAX_VAL 65504
+#else
+#define MAX_VAL HALF_MAX
+#endif
+#endif // HIP_PLUGIN_USE_FP16 || HIP_PLUGIN_USE_FPMIX
+
+#if HIP_PLUGIN_USE_FP32 == 1
+#define FLOAT float
+#define SIZEOF_FLOAT 4
+// Max value for the main datatype
+#ifndef FLT_MAX
+#define MAX_VAL 3.402823466e+38F
+#else
+#define MAX_VAL FLT_MAX
+#endif
+#endif // HIP_PLUGIN_USE_FP32
+
+#if(HIP_PLUGIN_USE_BFP16 == 1) || (HIP_PLUGIN_USE_BFPMIX == 1)
+#define FLOAT ushort
+#define SIZEOF_FLOAT 2
+// Max value for the main datatype
+#define MAX_VAL 0x7F7F
+#endif // HIP_PLUGIN_USE_BFP16 || HIP_PLUGIN_USE_BFPMIX
+
+#if(HIP_PLUGIN_USE_FP16 == 1) || (HIP_PLUGIN_USE_FPMIX == 1)
+#define CVT_FLOAT2ACCUM(x) (static_cast<FLOAT_ACCUM>(x))
+#define CVT_ACCUM2FLOAT(x) (static_cast<FLOAT>(x))
+#define CVT_INTEGRAL2ACCUM(x) (static_cast<FLOAT_ACCUM>(x))
+// These two are required to uniformly initialize
+// variables with non-zero literal constants of FP32 type
+// regardless of the actual type of the variable.
+// This is especially complicated for BF16, because
+// the compiler lacks the support of BF16 literals.
+#define CVT_FP32_2FLOAT(x) (CVT_ACCUM2FLOAT(x))
+#define CVT_FP32_2ACCUM(x) (x)
+#define CVT_FLOAT2FP32(x) (CVT_FLOAT2ACCUM(x))
+#define CVT_ACCUM2FP32(x) (x)
+#endif // HIP_PLUGIN_USE_FP16 || HIP_PLUGIN_USE_FPMIX
+
+#if HIP_PLUGIN_USE_FP32 == 1
+/// \todo Basically, conversions from float to accum and vice versa
+/// should be removed because FLOAT_ACCUM and FLOAT are identical.
+/// However this may lead to problems if these macros are used in
+/// inappropriate contexts (e.g. with integral types), so this
+/// refactoring should be considered as nontrivial and requires
+/// a separate PR. Let's keep this historical stuff for now.
+/// --atamazov 30.08.2023
+#define CVT_FLOAT2ACCUM(x) (static_cast<FLOAT_ACCUM>(x))
+#define CVT_ACCUM2FLOAT(x) (static_cast<FLOAT>(x))
+#define CVT_INTEGRAL2ACCUM(x) (static_cast<FLOAT_ACCUM>(x))
+#define CVT_FP32_2FLOAT(x) (CVT_ACCUM2FLOAT(x))
+#define CVT_FP32_2ACCUM(x) (x)
+#define CVT_FLOAT2FP32(x) (CVT_FLOAT2ACCUM(x))
+#define CVT_ACCUM2FP32(x) (x)
+#endif // HIP_PLUGIN_USE_FP32
+
+#if(HIP_PLUGIN_USE_BFP16 == 1) || (HIP_PLUGIN_USE_BFPMIX == 1)
+#define CVT_FLOAT2ACCUM(x) (bfloat16_to_float(x))
+#define CVT_ACCUM2FLOAT(x) (float_to_bfloat16(x))
+#define CVT_INTEGRAL2ACCUM(x) (static_cast<FLOAT_ACCUM>(x))
+#define CVT_FP32_2FLOAT(x) (CVT_ACCUM2FLOAT(x))
+#define CVT_FP32_2ACCUM(x) (x)
+#define CVT_FLOAT2FP32(x) (CVT_FLOAT2ACCUM(x))
+#define CVT_ACCUM2FP32(x) (x)
+#endif
+
+/// If HIP_PLUGIN_USE_NATIVE_DATATYPE_ACCUM is defined as 1 when "float_types.h" is included,
+/// then all the ACCUM macros (the represent operations and types) will use the native
+/// datatype (BF16 or FP16) instead of FP32. In other words, the computations will be
+/// performed using the native datatype even if ACCUM macros are used. This allows for
+/// building both mixed-precision and "pure" kernels from the single source.
+/// Note: This macro has higher priority than HIP_PLUGIN_USE_DOUBLE_ACCUM.
+#ifdef HIP_PLUGIN_USE_NATIVE_DATATYPE_ACCUM
+#if !(HIP_PLUGIN_USE_NATIVE_DATATYPE_ACCUM == 0 || HIP_PLUGIN_USE_NATIVE_DATATYPE_ACCUM == 1)
+#error "Invalid value of HIP_PLUGIN_USE_NATIVE_DATATYPE_ACCUM"
+#endif
+#else
+#define HIP_PLUGIN_USE_NATIVE_DATATYPE_ACCUM 0
+#endif
+
+#if HIP_PLUGIN_USE_NATIVE_DATATYPE_ACCUM
+
+#undef FLOAT_ACCUM
+#define FLOAT_ACCUM FLOAT
+
+#undef MAX_VAL_ACCUM
+#define MAX_VAL_ACCUM MAX_VAL
+#undef CVT_FLOAT2ACCUM
+#define CVT_FLOAT2ACCUM(x) (x)
+#undef CVT_ACCUM2FLOAT
+#define CVT_ACCUM2FLOAT(x) (x)
+#undef CVT_FP32_2ACCUM
+#define CVT_FP32_2ACCUM(x) (CVT_FP32_2FLOAT(x))
+#undef CVT_ACCUM2FP32
+#define CVT_ACCUM2FP32(x) (CVT_FLOAT2FP32(x))
+
+#undef CVT_INTEGRAL2ACCUM
+#if(HIP_PLUGIN_USE_BFP16 == 1) || (HIP_PLUGIN_USE_BFPMIX == 1)
+// No direct conversion from integral types to BF16 is available.
+// WARNING: Precision loss when integral type is wider than 16 bits.
+#define CVT_INTEGRAL2ACCUM(x) (float_to_bfloat16(static_cast<float>(x)))
+#else
+#define CVT_INTEGRAL2ACCUM(x) (static_cast<FLOAT>(x))
+#endif
+
+#endif // HIP_PLUGIN_USE_NATIVE_DATATYPE_ACCUM
+
+#endif // GUARD_FLOAT_TYPES_H

--- a/dnn-providers/hip-kernel-provider/kernels/HipKernelMath.hpp
+++ b/dnn-providers/hip-kernel-provider/kernels/HipKernelMath.hpp
@@ -1,0 +1,643 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "Bfloat16Dev.hpp"
+#include "FloatTypes.h"
+#include "VectorTypes.hpp"
+
+namespace hip_kernel_plugin
+{
+namespace detail
+{
+
+//=============================================================================
+// Float overloads
+//=============================================================================
+
+__forceinline__ __device__ float exp(float x)
+{
+    return expf(x);
+}
+__forceinline__ __device__ float log(float x)
+{
+    return logf(x);
+}
+__forceinline__ __device__ float sqrt(float x)
+{
+    return sqrtf(x);
+}
+__forceinline__ __device__ float rsqrt(float x)
+{
+    return rsqrtf(x);
+}
+__forceinline__ __device__ float sin(float x)
+{
+    return sinf(x);
+}
+__forceinline__ __device__ float cos(float x)
+{
+    return cosf(x);
+}
+__forceinline__ __device__ float tan(float x)
+{
+    return tanf(x);
+}
+__forceinline__ __device__ float tanh(float x)
+{
+    return tanhf(x);
+}
+__forceinline__ __device__ float pow(float x, float y)
+{
+    return powf(x, y);
+}
+__forceinline__ __device__ float fabs(float x)
+{
+    return fabsf(x);
+}
+__forceinline__ __device__ float fmax(float x, float y)
+{
+    return fmaxf(x, y);
+}
+__forceinline__ __device__ float fmin(float x, float y)
+{
+    return fminf(x, y);
+}
+__forceinline__ __device__ float fma(float a, float b, float c)
+{
+    return ::fma(a, b, c);
+}
+
+//=============================================================================
+// Half precision overloads
+//=============================================================================
+
+__forceinline__ __device__ _Float16 exp(_Float16 x)
+{
+    return __ocml_exp_f16(x);
+}
+__forceinline__ __device__ _Float16 log(_Float16 x)
+{
+    return __ocml_log_f16(x);
+}
+__forceinline__ __device__ _Float16 sqrt(_Float16 x)
+{
+    return __ocml_sqrt_f16(x);
+}
+__forceinline__ __device__ _Float16 rsqrt(_Float16 x)
+{
+    return __ocml_rsqrt_f16(x);
+}
+__forceinline__ __device__ _Float16 sin(_Float16 x)
+{
+    return hsin(__half(x));
+}
+__forceinline__ __device__ _Float16 cos(_Float16 x)
+{
+    return hcos(__half(x));
+}
+__forceinline__ __device__ _Float16 fabs(_Float16 x)
+{
+    return __ocml_fabs_f16(x);
+}
+__forceinline__ __device__ _Float16 fmin(_Float16 x, _Float16 y)
+{
+    return __ocml_fmin_f16(x, y);
+}
+__forceinline__ __device__ _Float16 fmax(_Float16 x, _Float16 y)
+{
+    return __ocml_fmax_f16(x, y);
+}
+__forceinline__ __device__ _Float16 pow(_Float16 x, _Float16 y)
+{
+    return __ocml_exp_f16(y * __ocml_log_f16(x));
+}
+__forceinline__ __device__ _Float16 tanh(_Float16 x)
+{
+    float x_scaled = static_cast<float>(x) * 1.4426950408889634f; // 0x1.715476p+0f = log2(e)
+    float a = __builtin_amdgcn_exp2f(x_scaled);
+    float b = __builtin_amdgcn_exp2f(-x_scaled);
+
+    _Float16 ret = static_cast<_Float16>((a - b) * __builtin_amdgcn_rcpf(a + b));
+    _Float16 one = __builtin_copysignf(1.0f, x);
+
+    return __ocml_fabs_f16(x) > 4.5f ? one : ret;
+}
+
+__forceinline__ __device__ _Float16 fma(_Float16 a, _Float16 b, _Float16 c)
+{
+    return __hfma(__half(a), __half(b), __half(c));
+}
+
+// The following overloads with __half are needed due to a regression
+// in the current implementation of the RNNHiddenStateUpdate kernel
+
+__forceinline__ __device__ __half exp(__half x)
+{
+    return static_cast<__half>(exp(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half log(__half x)
+{
+    return static_cast<__half>(log(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half sqrt(__half x)
+{
+    return static_cast<__half>(sqrt(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half rsqrt(__half x)
+{
+    return static_cast<__half>(rsqrt(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half sin(__half x)
+{
+    return static_cast<__half>(sin(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half cos(__half x)
+{
+    return static_cast<__half>(cos(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half fabs(__half x)
+{
+    return static_cast<__half>(fabs(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half fmin(__half x)
+{
+    return static_cast<__half>(fmin(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half fmax(__half x)
+{
+    return static_cast<__half>(fmax(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half pow(__half x)
+{
+    return static_cast<__half>(pow(static_cast<_Float16>(x)));
+}
+__forceinline__ __device__ __half tanh(__half x)
+{
+    return static_cast<__half>(tanh(static_cast<_Float16>(x)));
+}
+
+//=============================================================================
+// BFloat16 overloads
+//=============================================================================
+
+using bf16_ushort_conversion_t = union
+{
+    unsigned short int usi;
+    __bf16 bf16;
+};
+
+__forceinline__ __device__ ushort exp(ushort x)
+{
+    return float_to_bfloat16(exp(bfloat16_to_float(x)));
+}
+
+__forceinline__ __device__ ushort log(ushort x)
+{
+    return float_to_bfloat16(log(bfloat16_to_float(x)));
+}
+__forceinline__ __device__ ushort sqrt(ushort x)
+{
+    return float_to_bfloat16(sqrt(bfloat16_to_float(x)));
+}
+__forceinline__ __device__ ushort rsqrt(ushort x)
+{
+    return float_to_bfloat16(rsqrt(bfloat16_to_float(x)));
+}
+__forceinline__ __device__ ushort sin(ushort x)
+{
+    return float_to_bfloat16(sin(bfloat16_to_float(x)));
+}
+__forceinline__ __device__ ushort cos(ushort x)
+{
+    return float_to_bfloat16(cos(bfloat16_to_float(x)));
+}
+__forceinline__ __device__ ushort fabs(ushort x)
+{
+    return float_to_bfloat16(__habs(bfloat16_to_float(x)));
+}
+__forceinline__ __device__ ushort fmax(ushort x, ushort y)
+{
+    return float_to_bfloat16(fmax(bfloat16_to_float(x), bfloat16_to_float(y)));
+}
+__forceinline__ __device__ ushort fmin(ushort x, ushort y)
+{
+    return float_to_bfloat16(fmin(bfloat16_to_float(x), bfloat16_to_float(y)));
+}
+
+__forceinline__ __device__ ushort pow(ushort x, ushort y)
+{
+    bf16_ushort_conversion_t bf_x{x};
+    bf16_ushort_conversion_t bf_y{y};
+
+    bf16_ushort_conversion_t bf_mul{.bf16 = bf_x.bf16 * bf_y.bf16};
+
+    return float_to_bfloat16(exp(bfloat16_to_float(bf_mul.usi)));
+}
+__forceinline__ __device__ ushort tan(ushort x)
+{
+    bf16_ushort_conversion_t bf_x{x};
+    bf16_ushort_conversion_t sinVal{float_to_bfloat16(sin(bfloat16_to_float(bf_x.usi)))};
+    bf16_ushort_conversion_t cosVal{float_to_bfloat16(cos(bfloat16_to_float(bf_x.usi)))};
+
+    return bf16_ushort_conversion_t{.bf16 = sinVal.bf16 / cosVal.bf16}.usi;
+}
+__forceinline__ __device__ ushort tanh(ushort x)
+{
+    bf16_ushort_conversion_t bf_x{x};
+    bf16_ushort_conversion_t two{.usi = float_to_bfloat16(2.0f)};
+    bf16_ushort_conversion_t one{.usi = float_to_bfloat16(1.0f)};
+    bf16_ushort_conversion_t exp2x{exp(float_to_bfloat16(two.bf16 * bf_x.bf16))};
+    bf16_ushort_conversion_t numerator{.bf16 = exp2x.bf16 - one.bf16};
+    bf16_ushort_conversion_t denominator{.bf16 = exp2x.bf16 + one.bf16};
+    return bf16_ushort_conversion_t{.bf16 = numerator.bf16 / denominator.bf16}.usi;
+}
+
+__forceinline__ __device__ ushort fma(ushort a, ushort b, ushort c)
+{
+    bf16_ushort_conversion_t bf_a{a};
+    bf16_ushort_conversion_t bf_b{b};
+    bf16_ushort_conversion_t bf_c{c};
+
+    return bf16_ushort_conversion_t{.bf16
+                                    = __builtin_elementwise_fma(bf_a.bf16, bf_b.bf16, bf_c.bf16)}
+        .usi;
+}
+
+//=============================================================================
+// Double precision overloads
+//=============================================================================
+
+__forceinline__ __device__ double exp(double x)
+{
+    return ::exp(x);
+}
+__forceinline__ __device__ double log(double x)
+{
+    return ::log(x);
+}
+__forceinline__ __device__ double sqrt(double x)
+{
+    return ::sqrt(x);
+}
+__forceinline__ __device__ double rsqrt(double x)
+{
+    return ::rsqrt(x);
+}
+__forceinline__ __device__ double sin(double x)
+{
+    return ::sin(x);
+}
+__forceinline__ __device__ double cos(double x)
+{
+    return ::cos(x);
+}
+__forceinline__ __device__ double tan(double x)
+{
+    return ::tan(x);
+}
+__forceinline__ __device__ double tanh(double x)
+{
+    return ::tanh(x);
+}
+__forceinline__ __device__ double pow(double x, double y)
+{
+    return ::pow(x, y);
+}
+__forceinline__ __device__ double fabs(double x)
+{
+    return ::fabs(x);
+}
+__forceinline__ __device__ double fmax(double x, double y)
+{
+    return ::fmax(x, y);
+}
+__forceinline__ __device__ double fmin(double x, double y)
+{
+    return ::fmin(x, y);
+}
+__forceinline__ __device__ double fma(double a, double b, double c)
+{
+    return ::fma(a, b, c);
+}
+
+} // namespace detail
+
+//=============================================================================
+// 4-element vector overloads
+//=============================================================================
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType exp(FpVecType x)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::exp(x.x);
+        out.y = detail::exp(x.y);
+        out.z = detail::exp(x.z);
+        out.w = detail::exp(x.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::exp(x.x);
+        out.y = detail::exp(x.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::exp(x);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType log(FpVecType x)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::log(x.x);
+        out.y = detail::log(x.y);
+        out.z = detail::log(x.z);
+        out.w = detail::log(x.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::log(x.x);
+        out.y = detail::log(x.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::log(x);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType sqrt(FpVecType x)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::sqrt(x.x);
+        out.y = detail::sqrt(x.y);
+        out.z = detail::sqrt(x.z);
+        out.w = detail::sqrt(x.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::sqrt(x.x);
+        out.y = detail::sqrt(x.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::sqrt(x);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType rsqrt(FpVecType x)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::rsqrt(x.x);
+        out.y = detail::rsqrt(x.y);
+        out.z = detail::rsqrt(x.z);
+        out.w = detail::rsqrt(x.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::rsqrt(x.x);
+        out.y = detail::rsqrt(x.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::rsqrt(x);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType fma(FpVecType a, FpVecType b, FpVecType c)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::fma(a.x, b.x, c.x);
+        out.y = detail::fma(a.y, b.y, c.y);
+        out.z = detail::fma(a.z, b.z, c.z);
+        out.w = detail::fma(a.w, b.w, c.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::fma(a.x, b.x, c.x);
+        out.y = detail::fma(a.y, b.y, c.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::fma(a, b, c);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType fmax(FpVecType x, FpVecType y)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::fmax(x.x, y.x);
+        out.y = detail::fmax(x.y, y.y);
+        out.z = detail::fmax(x.z, y.z);
+        out.w = detail::fmax(x.w, y.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::fmax(x.x, y.x);
+        out.y = detail::fmax(x.y, y.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::fmax(x, y);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType fmin(FpVecType x, FpVecType y)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::fmin(x.x, y.x);
+        out.y = detail::fmin(x.y, y.y);
+        out.z = detail::fmin(x.z, y.z);
+        out.w = detail::fmin(x.w, y.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::fmin(x.x, y.x);
+        out.y = detail::fmin(x.y, y.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::fmin(x, y);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType min(FpVecType x, FpVecType y)
+{
+    return fmin(x, y);
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType max(FpVecType x, FpVecType y)
+{
+    return fmax(x, y);
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType tanh(FpVecType x)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::tanh(x.x);
+        out.y = detail::tanh(x.y);
+        out.z = detail::tanh(x.z);
+        out.w = detail::tanh(x.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::tanh(x.x);
+        out.y = detail::tanh(x.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::tanh(x);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType pow(FpVecType x, FpVecType y)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::pow(x.x, y.x);
+        out.y = detail::pow(x.y, y.y);
+        out.z = detail::pow(x.z, y.z);
+        out.w = detail::pow(x.w, y.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::pow(x.x, y.x);
+        out.y = detail::pow(x.y, y.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::pow(x, y);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+template <typename FpVecType>
+__forceinline__ __device__ FpVecType fabs(FpVecType x)
+{
+    constexpr auto VecSize = mapped_vector_info<FpVecType>::size;
+    if constexpr(VecSize == 4)
+    {
+        FpVecType out;
+        out.x = detail::fabs(x.x);
+        out.y = detail::fabs(x.y);
+        out.z = detail::fabs(x.z);
+        out.w = detail::fabs(x.w);
+        return out;
+    }
+    else if constexpr(VecSize == 2)
+    {
+        FpVecType out;
+        out.x = detail::fabs(x.x);
+        out.y = detail::fabs(x.y);
+        return out;
+    }
+    else if constexpr(VecSize == 1)
+    {
+        return detail::fabs(x);
+    }
+    else
+    {
+        static_assert(false, "Unsupported miopen vector operation.");
+    }
+}
+
+} // namespace miopen

--- a/dnn-providers/hip-kernel-provider/kernels/HipKernelMath.hpp
+++ b/dnn-providers/hip-kernel-provider/kernels/HipKernelMath.hpp
@@ -354,7 +354,7 @@ __forceinline__ __device__ FpVecType exp(FpVecType x)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
@@ -384,7 +384,7 @@ __forceinline__ __device__ FpVecType log(FpVecType x)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
@@ -414,7 +414,7 @@ __forceinline__ __device__ FpVecType sqrt(FpVecType x)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
@@ -444,7 +444,7 @@ __forceinline__ __device__ FpVecType rsqrt(FpVecType x)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
@@ -474,7 +474,7 @@ __forceinline__ __device__ FpVecType fma(FpVecType a, FpVecType b, FpVecType c)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
@@ -504,7 +504,7 @@ __forceinline__ __device__ FpVecType fmax(FpVecType x, FpVecType y)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
@@ -534,7 +534,7 @@ __forceinline__ __device__ FpVecType fmin(FpVecType x, FpVecType y)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
@@ -576,7 +576,7 @@ __forceinline__ __device__ FpVecType tanh(FpVecType x)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
@@ -606,7 +606,7 @@ __forceinline__ __device__ FpVecType pow(FpVecType x, FpVecType y)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
@@ -636,8 +636,8 @@ __forceinline__ __device__ FpVecType fabs(FpVecType x)
     }
     else
     {
-        static_assert(false, "Unsupported miopen vector operation.");
+        static_assert(false, "Unsupported hip kernel provider vector operation.");
     }
 }
 
-} // namespace miopen
+} // namespace hip_kernel_plugin

--- a/dnn-providers/hip-kernel-provider/kernels/VectorTypes.hpp
+++ b/dnn-providers/hip-kernel-provider/kernels/VectorTypes.hpp
@@ -1,0 +1,180 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#ifndef VECTOR_TYPES_HPP
+#define VECTOR_TYPES_HPP
+
+#include "Bfloat16Dev.hpp"
+#include <hip/hip_fp16.h>
+#include <type_traits>
+
+namespace hip_kernel_plugin
+{
+
+// used by batch norm functions.
+template <typename T, int N>
+struct mapped_vector_type
+{
+    static_assert(false, "there is no specialization for this T & N combination.");
+};
+
+template <typename Vec>
+struct mapped_vector_info;
+
+#define DEFINE_VECTOR_MAPPING(ScalarType, N)                                  \
+    template <>                                                               \
+    struct mapped_vector_type<ScalarType, N>                                  \
+    {                                                                         \
+        using type = ScalarType __attribute__((ext_vector_type(N)));          \
+    };                                                                        \
+    template <>                                                               \
+    struct mapped_vector_info<ScalarType __attribute__((ext_vector_type(N)))> \
+    {                                                                         \
+        using UnderlyingType = ScalarType;                                    \
+        static constexpr size_t size = N;                                     \
+    };
+
+#define DEFINE_SCALAR_MAPPING(ScalarType)    \
+    template <>                              \
+    struct mapped_vector_type<ScalarType, 1> \
+    {                                        \
+        using type = ScalarType;             \
+    };                                       \
+    template <>                              \
+    struct mapped_vector_info<ScalarType>    \
+    {                                        \
+        using UnderlyingType = ScalarType;   \
+        static constexpr size_t size = 1;    \
+    };
+
+DEFINE_SCALAR_MAPPING(double)
+DEFINE_SCALAR_MAPPING(float)
+DEFINE_SCALAR_MAPPING(_Float16)
+DEFINE_SCALAR_MAPPING(ushort)
+DEFINE_SCALAR_MAPPING(int)
+DEFINE_SCALAR_MAPPING(unsigned int)
+
+DEFINE_VECTOR_MAPPING(float, 2)
+DEFINE_VECTOR_MAPPING(float, 4)
+
+DEFINE_VECTOR_MAPPING(_Float16, 2)
+DEFINE_VECTOR_MAPPING(_Float16, 4)
+DEFINE_VECTOR_MAPPING(_Float16, 8)
+
+DEFINE_VECTOR_MAPPING(ushort, 2)
+DEFINE_VECTOR_MAPPING(ushort, 4)
+DEFINE_VECTOR_MAPPING(ushort, 8)
+
+DEFINE_VECTOR_MAPPING(int, 2)
+DEFINE_VECTOR_MAPPING(int, 4)
+
+DEFINE_VECTOR_MAPPING(unsigned int, 2)
+DEFINE_VECTOR_MAPPING(unsigned int, 4)
+
+// The following overloads with __half are needed due to a regression
+// in the current implementation of the RNNHiddenStateUpdate kernel
+// Moreover, __half is defined as a struct, thus the attribute
+// ext_vector_type, which is used here extensively, will fail
+
+template <>
+struct mapped_vector_type<__half, 1>
+{
+    using type = _Float16;
+};
+
+template <>
+struct mapped_vector_info<__half>
+{
+    using UnderlyingType = _Float16;
+    static constexpr size_t size = 1;
+};
+
+template <>
+struct mapped_vector_type<__half, 2>
+{
+    using type = _Float16 __attribute__((ext_vector_type(2)));
+};
+
+template <>
+struct mapped_vector_type<__half, 4>
+{
+    using type = _Float16 __attribute__((ext_vector_type(4)));
+};
+
+namespace detail
+{
+
+template <typename OutType, typename InType>
+__forceinline__ __device__ __host__ OutType scalarcast(InType in)
+{
+    if constexpr(std::is_same<OutType, InType>::value)
+    {
+        return in;
+    }
+    else if constexpr(std::is_same<OutType, ushort>::value && std::is_same<InType, float>::value)
+    {
+        return float_to_bfloat16(in);
+    }
+    else if constexpr(std::is_same<InType, ushort>::value && std::is_same<OutType, float>::value)
+    {
+        return bfloat16_to_float(in);
+    }
+    else
+    {
+        return static_cast<OutType>(in);
+    }
+}
+
+template <typename MappedVectorType, typename T>
+__forceinline__ __device__ __host__ MappedVectorType broadcast(const T val)
+{
+    using VectorInfo = mapped_vector_info<MappedVectorType>;
+    MappedVectorType retval;
+    auto* retvalPtr = reinterpret_cast<typename VectorInfo::UnderlyingType*>(&retval);
+    for(auto i = 0; i < VectorInfo::size; ++i)
+    {
+        retvalPtr[i] = detail::scalarcast<typename VectorInfo::UnderlyingType>(val);
+    }
+    return retval;
+};
+
+} // namespace detail
+
+template <typename OutType, typename InType>
+__forceinline__ __device__ __host__ OutType cast(InType input)
+{
+    using InTypeInfo = mapped_vector_info<InType>;
+    using OutTypeInfo = mapped_vector_info<OutType>;
+
+    constexpr auto inSize = InTypeInfo::size;
+    constexpr auto outSize = OutTypeInfo::size;
+
+    if constexpr(inSize == outSize && outSize == 4)
+    {
+        return OutType{detail::scalarcast<typename OutTypeInfo::UnderlyingType>(input.x),
+                       detail::scalarcast<typename OutTypeInfo::UnderlyingType>(input.y),
+                       detail::scalarcast<typename OutTypeInfo::UnderlyingType>(input.z),
+                       detail::scalarcast<typename OutTypeInfo::UnderlyingType>(input.w)};
+    }
+    else if constexpr(inSize == outSize && outSize == 2)
+    {
+        return OutType{detail::scalarcast<typename OutTypeInfo::UnderlyingType>(input.x),
+                       detail::scalarcast<typename OutTypeInfo::UnderlyingType>(input.y)};
+    }
+    else if constexpr(inSize == outSize && outSize == 1)
+    {
+        return detail::scalarcast<typename OutTypeInfo::UnderlyingType>(input);
+    }
+    else if constexpr(inSize == 1 && outSize > 1)
+    {
+        return detail::broadcast<OutType>(input);
+    }
+    else
+    {
+        static_assert(false, "Unsupported type cast.");
+    }
+}
+
+} // namespace hip_kernel_plugin
+
+#endif

--- a/dnn-providers/hip-kernel-provider/kernels/VectorTypes.hpp
+++ b/dnn-providers/hip-kernel-provider/kernels/VectorTypes.hpp
@@ -1,8 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
-#ifndef VECTOR_TYPES_HPP
-#define VECTOR_TYPES_HPP
+#pragma once
 
 #include "Bfloat16Dev.hpp"
 #include <hip/hip_fp16.h>
@@ -176,5 +175,3 @@ __forceinline__ __device__ __host__ OutType cast(InType input)
 }
 
 } // namespace hip_kernel_plugin
-
-#endif

--- a/dnn-providers/hip-kernel-provider/kernels/kernel_includes.cpp.in
+++ b/dnn-providers/hip-kernel-provider/kernels/kernel_includes.cpp.in
@@ -1,0 +1,44 @@
+// Auto-generated kernel includes - DO NOT EDIT
+#include "kernel_includes.hpp"
+#include <cstddef>
+#include <unordered_map>
+#include <stdexcept>
+
+@HEADER_DEFINITIONS@
+
+namespace hip_plugin {
+
+static const std::unordered_map<std::string_view, std::string_view>& getKernelIncludes()
+{
+    static const std::unordered_map<std::string_view, std::string_view> s_data{
+@HEADER_MAP_ENTRIES@
+    };
+    return s_data;
+}
+
+std::string_view getKernelInc(const char* name)
+{
+    const auto& map = getKernelIncludes();
+    auto it = map.find(name);
+    if(it == map.end())
+    {
+        throw std::runtime_error(std::string("Failed to load kernel include: ") + name);
+    }
+    return it->second;
+}
+
+void getKernelIncList(std::vector<std::string_view>& includeTexts,
+                      std::vector<const char*>& includeNames)
+{
+    static const std::vector<const char*> s_allIncludes = {
+@HEADER_FILENAMES@
+    };
+
+    for(const char* filename : s_allIncludes)
+    {
+        includeTexts.push_back(getKernelInc(filename));
+        includeNames.push_back(filename);
+    }
+}
+
+} // namespace hip_plugin

--- a/dnn-providers/hip-kernel-provider/kernels/kernel_includes.cpp.in
+++ b/dnn-providers/hip-kernel-provider/kernels/kernel_includes.cpp.in
@@ -1,3 +1,6 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 // Auto-generated kernel includes - DO NOT EDIT
 #include "kernel_includes.hpp"
 #include <cstddef>

--- a/dnn-providers/hip-kernel-provider/kernels/kernel_includes.hpp.in
+++ b/dnn-providers/hip-kernel-provider/kernels/kernel_includes.hpp.in
@@ -1,0 +1,16 @@
+// Auto-generated kernel includes - DO NOT EDIT
+#pragma once
+
+#include <string_view>
+#include <vector>
+
+@HEADER_DECLARATIONS@
+
+namespace hip_plugin {
+
+std::string_view getKernelInc(const char* name);
+
+void getKernelIncList(std::vector<std::string_view>& includeTexts,
+                      std::vector<const char*>& includeNames);
+
+} // namespace hip_plugin

--- a/dnn-providers/hip-kernel-provider/kernels/kernel_includes.hpp.in
+++ b/dnn-providers/hip-kernel-provider/kernels/kernel_includes.hpp.in
@@ -1,3 +1,6 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 // Auto-generated kernel includes - DO NOT EDIT
 #pragma once
 

--- a/dnn-providers/hip-kernel-provider/kernels/kernel_sources.cpp.in
+++ b/dnn-providers/hip-kernel-provider/kernels/kernel_sources.cpp.in
@@ -1,0 +1,30 @@
+// Auto-generated kernel sources - DO NOT EDIT
+#include "kernel_sources.hpp"
+#include <cstddef>
+#include <unordered_map>
+#include <stdexcept>
+
+@KERNEL_DEFINITIONS@
+
+namespace hip_plugin {
+
+static const std::unordered_map<std::string_view, std::string_view>& getKernelMap()
+{
+    static const std::unordered_map<std::string_view, std::string_view> s_kernelMap{
+@KERNEL_MAP_ENTRIES@
+    };
+    return s_kernelMap;
+}
+
+std::string_view getKernelSrc(const char* name)
+{
+    const auto& map = getKernelMap();
+    auto it = map.find(name);
+    if(it == map.end())
+    {
+        throw std::runtime_error(std::string("Failed to load kernel source: ") + name);
+    }
+    return it->second;
+}
+
+} // namespace hip_plugin

--- a/dnn-providers/hip-kernel-provider/kernels/kernel_sources.cpp.in
+++ b/dnn-providers/hip-kernel-provider/kernels/kernel_sources.cpp.in
@@ -1,3 +1,6 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 // Auto-generated kernel sources - DO NOT EDIT
 #include "kernel_sources.hpp"
 #include <cstddef>

--- a/dnn-providers/hip-kernel-provider/kernels/kernel_sources.hpp.in
+++ b/dnn-providers/hip-kernel-provider/kernels/kernel_sources.hpp.in
@@ -1,0 +1,12 @@
+// Auto-generated kernel sources - DO NOT EDIT
+#pragma once
+
+#include <string_view>
+
+@KERNEL_DECLARATIONS@
+
+namespace hip_plugin {
+
+std::string_view getKernelSrc(const char* name);
+
+} // namespace hip_plugin

--- a/dnn-providers/hip-kernel-provider/kernels/kernel_sources.hpp.in
+++ b/dnn-providers/hip-kernel-provider/kernels/kernel_sources.hpp.in
@@ -1,3 +1,6 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
 // Auto-generated kernel sources - DO NOT EDIT
 #pragma once
 

--- a/dnn-providers/hip-kernel-provider/kernels/vector_add.cpp
+++ b/dnn-providers/hip-kernel-provider/kernels/vector_add.cpp
@@ -1,0 +1,11 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+extern "C" __global__ void vector_add(const float* a, const float* b, float* c, int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if(idx < n)
+    {
+        c[idx] = a[idx] + b[idx];
+    }
+}

--- a/dnn-providers/hip-kernel-provider/kernels/vector_add.cpp
+++ b/dnn-providers/hip-kernel-provider/kernels/vector_add.cpp
@@ -1,5 +1,7 @@
-// Copyright © Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier:  MIT
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+// This kernel is used for testing in TestHipProgramAndKernel.cpp
 
 extern "C" __global__ void vector_add(const float* a, const float* b, float* c, int n)
 {

--- a/dnn-providers/hip-kernel-provider/tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
     TestHipKernelHipdnnEnginePluginHandle.cpp
     TestHipKernelHipdnnPluginExecutionContext.cpp
     TestHipKernelPluginApi.cpp
+    TestHipProgramAndKernel.cpp
 )
 
 target_compile_options(hip_kernel_plugin_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})

--- a/dnn-providers/hip-kernel-provider/tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/tests/CMakeLists.txt
@@ -11,6 +11,9 @@ find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
 add_executable(
     hip_kernel_plugin_tests
     engines/TestHipKernelEngine.cpp
+    engines/plans/TestBatchnormApplicabilityChecks.cpp
+    engines/plans/TestBatchnormFwdInferencePlan.cpp
+    engines/plans/TestBatchnormPlanBuilder.cpp
     main.cpp
     TestHipKernelEngineManager.cpp
     TestHipKernelEnginePluginApi.cpp

--- a/dnn-providers/hip-kernel-provider/tests/TestHipProgramAndKernel.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/TestHipProgramAndKernel.cpp
@@ -1,0 +1,53 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+
+#include "hip/HipKernel.hpp"
+#include "hip/HipProgram.hpp"
+
+#include <vector>
+
+TEST(HipProgram, CompilesAndGetsKernel)
+{
+    HipProgram program("vector_add.cpp", {"-O3"});
+    hipFunction_t kernel = program.GetKernel("vector_add");
+    EXPECT_NE(nullptr, kernel);
+}
+
+TEST(HipKernel, LaunchesVectorAdd)
+{
+    constexpr int N = 256;
+
+    // Allocate and initialize
+    float *d_a, *d_b, *d_c;
+    ASSERT_EQ(hipSuccess, hipMalloc(&d_a, N * sizeof(float)));
+    ASSERT_EQ(hipSuccess, hipMalloc(&d_b, N * sizeof(float)));
+    ASSERT_EQ(hipSuccess, hipMalloc(&d_c, N * sizeof(float)));
+
+    std::vector<float> h_a(N, 1.0f);
+    std::vector<float> h_b(N, 2.0f);
+    std::vector<float> h_c(N);
+
+    ASSERT_EQ(hipSuccess, hipMemcpy(d_a, h_a.data(), N * sizeof(float), hipMemcpyHostToDevice));
+    ASSERT_EQ(hipSuccess, hipMemcpy(d_b, h_b.data(), N * sizeof(float), hipMemcpyHostToDevice));
+
+    // Launch kernel
+    HipProgram program("vector_add.cpp", {"-O3"});
+    HipKernel kernel(program, "vector_add");
+    kernel.SetBlockSize(256);
+    kernel.SetGridSize(1);
+    kernel.Launch(nullptr, d_a, d_b, d_c, N);
+
+    ASSERT_EQ(hipSuccess, hipDeviceSynchronize());
+    ASSERT_EQ(hipSuccess, hipMemcpy(h_c.data(), d_c, N * sizeof(float), hipMemcpyDeviceToHost));
+
+    // Verify
+    EXPECT_FLOAT_EQ(3.0f, h_c[0]);
+    EXPECT_FLOAT_EQ(3.0f, h_c[N - 1]);
+
+    ASSERT_EQ(hipSuccess, hipFree(d_a));
+    ASSERT_EQ(hipSuccess, hipFree(d_b));
+    ASSERT_EQ(hipSuccess, hipFree(d_c));
+}

--- a/dnn-providers/hip-kernel-provider/tests/TestHipProgramAndKernel.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/TestHipProgramAndKernel.cpp
@@ -9,14 +9,14 @@
 
 #include <vector>
 
-TEST(HipProgram, CompilesAndGetsKernel)
+TEST(TestHipProgram, CompilesAndGetsKernel)
 {
     HipProgram program("vector_add.cpp", {"-O3"});
     hipFunction_t kernel = program.GetKernel("vector_add");
     EXPECT_NE(nullptr, kernel);
 }
 
-TEST(HipKernel, LaunchesVectorAdd)
+TEST(TestHipKernel, LaunchesVectorAdd)
 {
     constexpr int N = 256;
 

--- a/dnn-providers/hip-kernel-provider/tests/common/ActivationCommon.hpp
+++ b/dnn-providers/hip-kernel-provider/tests/common/ActivationCommon.hpp
@@ -1,0 +1,204 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <exception>
+#include <optional>
+
+#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+
+namespace test_activation_common
+{
+
+struct ActivTestCase
+{
+    hipdnn_data_sdk::data_objects::PointwiseMode mode;
+    std::optional<float> reluLowerClip;
+    std::optional<float> reluUpperClip;
+    std::optional<float> reluLowerClipSlope;
+    std::optional<float> swishBeta;
+    std::optional<float> eluAlpha;
+    std::optional<float> softplusBeta;
+
+    ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode modeLocal,
+                  std::optional<float> reluLowerClipLocal = std::nullopt,
+                  std::optional<float> reluUpperClipLocal = std::nullopt,
+                  std::optional<float> reluLowerClipSlopeLocal = std::nullopt,
+                  std::optional<float> swishBetaLocal = std::nullopt,
+                  std::optional<float> eluAlphaLocal = std::nullopt,
+                  std::optional<float> softplusBetaLocal = std::nullopt)
+        : mode(modeLocal)
+        , reluLowerClip(reluLowerClipLocal)
+        , reluUpperClip(reluUpperClipLocal)
+        , reluLowerClipSlope(reluLowerClipSlopeLocal)
+        , swishBeta(swishBetaLocal)
+        , eluAlpha(eluAlphaLocal)
+        , softplusBeta(softplusBetaLocal)
+    {
+        using PointwiseMode = hipdnn_data_sdk::data_objects::PointwiseMode;
+
+        switch(mode)
+        {
+        case PointwiseMode::RELU_FWD:
+        case PointwiseMode::RELU_BWD:
+        case PointwiseMode::SIGMOID_FWD:
+        case PointwiseMode::SIGMOID_BWD:
+        case PointwiseMode::TANH_FWD:
+        case PointwiseMode::TANH_BWD:
+        case PointwiseMode::ELU_FWD:
+        case PointwiseMode::ELU_BWD:
+        case PointwiseMode::SOFTPLUS_FWD:
+        case PointwiseMode::SOFTPLUS_BWD:
+        case PointwiseMode::ABS:
+        case PointwiseMode::IDENTITY:
+            break;
+        default:
+            throw std::invalid_argument("Unknown activation mode");
+        }
+    }
+
+    friend std::ostream& operator<<(std::ostream& ss, const ActivTestCase& tc)
+    {
+        using namespace hipdnn_data_sdk::utilities;
+
+        ss << "(mode:" << tc.mode;
+        if(tc.reluLowerClip)
+        {
+            ss << " reluLowerClip:" << tc.reluLowerClip.value();
+        }
+        if(tc.reluUpperClip)
+        {
+            ss << " reluUpperClip:" << tc.reluUpperClip.value();
+        }
+        if(tc.reluLowerClipSlope)
+        {
+            ss << " reluLowerClipSlope:" << tc.reluLowerClipSlope.value();
+        }
+        if(tc.swishBeta)
+        {
+            ss << " swishBeta:" << tc.swishBeta.value();
+        }
+        if(tc.eluAlpha)
+        {
+            ss << " eluAlpha:" << tc.eluAlpha.value();
+        }
+        if(tc.softplusBeta)
+        {
+            ss << " softplusBeta:" << tc.softplusBeta.value();
+        }
+        ss << ")";
+
+        return ss;
+    }
+};
+
+inline std::vector<ActivTestCase> createFwdActivationSmokeCases()
+{
+    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+
+    std::vector<ActivTestCase> cases;
+
+    // RELU_FWD (standard ReLU) - Only activation supported by MIOpen fusion
+    cases.emplace_back(PM::RELU_FWD,
+                       std::nullopt, // reluLowerClip
+                       std::nullopt, // reluUpperClip
+                       std::nullopt, // reluLowerClipSlope
+                       std::nullopt, // swishBeta
+                       std::nullopt, // eluAlpha
+                       std::nullopt // softplusBeta
+    );
+
+    return cases;
+}
+
+inline std::vector<ActivTestCase> createFwdActivationFullCases()
+{
+    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+
+    std::vector<ActivTestCase> cases;
+
+    // RELU_FWD (standard ReLU)
+    cases.emplace_back(PM::RELU_FWD,
+                       0.0f, // reluLowerClip
+                       std::nullopt, // reluUpperClip
+                       std::nullopt, // reluLowerClipSlope
+                       std::nullopt, // swishBeta
+                       std::nullopt, // eluAlpha
+                       std::nullopt // softplusBeta
+    );
+
+    // ReLU6: upper clip at 6.0 (Clipped ReLU)
+    cases.emplace_back(PM::RELU_FWD,
+                       std::nullopt, // reluLowerClip
+                       0.5f, // reluUpperClip
+                       std::nullopt, // reluLowerClipSlope
+                       std::nullopt, // swishBeta
+                       std::nullopt, // eluAlpha
+                       std::nullopt // softplusBeta
+    );
+
+    // CLAMP: both lower and upper clips (e.g., clip to range [0.0, 6.0])
+    cases.emplace_back(PM::RELU_FWD,
+                       0.1f, // reluLowerClip
+                       0.5f, // reluUpperClip
+                       std::nullopt, // reluLowerClipSlope
+                       std::nullopt, // swishBeta
+                       std::nullopt, // eluAlpha
+                       std::nullopt // softplusBeta
+    );
+
+    // Leaky ReLU: NOT supported by batchnorm activation fusion
+    // Supported activation modes for batchnorm fusion:
+    //   - PASSTHRU (identity/no activation)
+    //   - RELU (standard ReLU)
+    //   - CLIPPED_RELU (ReLU with upper clip)
+    //   - CLAMP (ReLU with both upper and lower clips)
+    // Unsupported:
+    //   - LEAKY_RELU (ReLU with lower clip slope)
+    // This applies to both forward inference and forward training operations.
+    // See: kernels/BatchnormActivation.hpp for implementation details.
+#if 0
+    cases.emplace_back(PM::RELU_FWD,
+                       std::nullopt, // reluLowerClip
+                       std::nullopt, // reluUpperClip
+                       0.01f, // reluLowerClipSlope
+                       std::nullopt, // swishBeta
+                       std::nullopt, // eluAlpha
+                       std::nullopt // softplusBeta
+    );
+#endif
+
+    return cases;
+}
+
+inline std::vector<ActivTestCase> createBatchnormBwdActivationTestCases()
+{
+    return {// ReLU Backward: d/dx Max(0, x) = 1 * (x > 0)
+            ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+                          0.0f,
+                          std::nullopt,
+                          std::nullopt,
+                          std::nullopt,
+                          std::nullopt,
+                          std::nullopt),
+            // Clipped ReLU Backward: d/dx Clamp(x, -inf, upper)
+            ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+                          std::nullopt,
+                          0.5f,
+                          std::nullopt,
+                          std::nullopt,
+                          std::nullopt,
+                          std::nullopt),
+            // CLAMP Backward: d/dx Clamp(x, lower, upper)
+            ActivTestCase(hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+                          0.1f,
+                          0.5f,
+                          std::nullopt,
+                          std::nullopt,
+                          std::nullopt,
+                          std::nullopt)};
+}
+
+} // namespace test_activation_common

--- a/dnn-providers/hip-kernel-provider/tests/common/BatchnormCommon.hpp
+++ b/dnn-providers/hip-kernel-provider/tests/common/BatchnormCommon.hpp
@@ -1,0 +1,165 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <cstdint>
+#include <ostream>
+#include <random>
+#include <vector>
+
+#include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+#include <hipdnn_test_sdk/utilities/Seeds.hpp>
+
+namespace test_bn_common
+{
+
+struct BatchnormTestCase
+{
+    std::vector<int64_t> dims;
+    unsigned int seed;
+
+    BatchnormTestCase(std::vector<int64_t>&& dimsLocal, unsigned int seedLocal)
+        : dims(std::move(dimsLocal))
+        , seed(seedLocal)
+    {
+        if(dims.size() != 4 && dims.size() != 5)
+        {
+            throw std::invalid_argument(
+                "dims must be either 4D (N, C, H, W) or 5D (N, C, D, H, W)");
+        }
+    }
+
+    friend std::ostream& operator<<(std::ostream& ss, const BatchnormTestCase& tc)
+    {
+        ss << "(dims:";
+        hipdnn_data_sdk::utilities::vecToStream(ss, tc.dims);
+        ss << " seed:" << tc.seed;
+        ss << ")";
+
+        return ss;
+    }
+};
+
+// This is used for operation tests
+inline std::vector<BatchnormTestCase> getBatchnorm2dTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{1, 3, 14, 14}, seed},
+        {{2, 3, 14, 14}, seed},
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnFwdInferenceTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{1, 3, 14, 14}, seed},
+        {{1, 256, 1, 1}, seed},
+        {{2, 3, 1, 1}, seed},
+        {{32, 1, 14, 14}, seed},
+        {{32, 3, 1, 14}, seed},
+        {{32, 3, 14, 1}, seed},
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnFwdInferenceFullTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{1, 16, 112, 112}, seed},
+        {{5, 256, 14, 14}, seed},
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnFwdInference3dTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{2, 3, 3, 1, 1}, seed},
+        {{16, 3, 8, 14, 14}, seed},
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnBwdTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{1, 3, 14, 14}, seed},
+        {{2, 3, 1, 1}, seed},
+        {{32, 1, 14, 14}, seed},
+        {{32, 3, 1, 14}, seed},
+        {{32, 3, 14, 1}, seed},
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnBwdFullTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{1, 16, 112, 112}, seed},
+        {{5, 256, 14, 14}, seed},
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnBwd3dTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{2, 3, 3, 1, 1}, seed},
+        {{16, 3, 8, 14, 14}, seed},
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnFwdTrainingSmoke2dTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{2, 3, 1, 1}, seed}, // Minimal case
+        {{32, 3, 1, 14}, seed}, // Typical small training case
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnFwdTrainingFull2dTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{1, 3, 14, 14}, seed}, // Small batch
+        {{2, 3, 1, 1}, seed}, // Edge case: 1x1 spatial
+        {{8, 16, 28, 28}, seed}, // Medium size
+        {{4, 64, 7, 7}, seed}, // Many channels, smaller spatial
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnFwdTrainingSmoke3dTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{2, 3, 3, 1, 1}, seed}, // Minimal 3D case
+        {{2, 3, 2, 4, 4}, seed}, // Small case with non-1 spatial dims
+    };
+}
+
+inline std::vector<BatchnormTestCase> getBnFwdTrainingFull3dTestCases()
+{
+    unsigned seed = hipdnn_test_sdk::utilities::getGlobalTestSeed();
+
+    return {
+        {{2, 3, 3, 1, 1}, seed}, // Minimal case
+        {{2, 3, 2, 4, 4}, seed}, // Small case
+        {{16, 3, 8, 14, 14}, seed}, // Larger regression case
+    };
+}
+
+} // namespace test_bn_common

--- a/dnn-providers/hip-kernel-provider/tests/engines/plans/TestBatchnormApplicabilityChecks.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/engines/plans/TestBatchnormApplicabilityChecks.cpp
@@ -1,0 +1,3896 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_plugin_sdk/PluginException.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+
+#include "engines/plans/BatchnormApplicabilityChecks.hpp"
+
+using namespace hip_kernel_plugin;
+
+namespace
+{
+
+// --- Configuration Data Structs ---
+
+struct TensorConfig
+{
+    int64_t uid;
+    std::string name;
+    hipdnn_data_sdk::data_objects::DataType dataType;
+    std::vector<int64_t> dims;
+    std::vector<int64_t> strides;
+    std::string description;
+    bool isVirtual = false;
+    bool isPassByValue = false;
+    double passedValue = 0.0;
+};
+
+// --- Tensor UID Constants ---
+
+// Common UIDs for all batchnorm operations
+struct BnCommonTensorIds
+{
+    [[maybe_unused]] static constexpr int64_t X = 1;
+    [[maybe_unused]] static constexpr int64_t Y = 2;
+    [[maybe_unused]] static constexpr int64_t SCALE = 3;
+    [[maybe_unused]] static constexpr int64_t BIAS = 4;
+    [[maybe_unused]] static constexpr int64_t EPSILON = 5;
+    [[maybe_unused]] static constexpr int64_t MEAN = 6;
+    [[maybe_unused]] static constexpr int64_t INV_VARIANCE = 7;
+};
+
+// Backward-specific
+struct BnBackwardTensorIds : BnCommonTensorIds
+{
+    [[maybe_unused]] static constexpr int64_t DY = 8;
+    [[maybe_unused]] static constexpr int64_t DX = 9;
+    [[maybe_unused]] static constexpr int64_t DSCALE = 10;
+    [[maybe_unused]] static constexpr int64_t DBIAS = 11;
+};
+
+// Fused operations (virtual tensors)
+struct BnFusedTensorIds : BnBackwardTensorIds
+{
+    [[maybe_unused]] static constexpr int64_t BN_Y_VIRTUAL = 12;
+    [[maybe_unused]] static constexpr int64_t DX_DRELU_VIRTUAL = 13;
+};
+
+// Training-specific
+struct BnTrainingTensorIds : BnCommonTensorIds
+{
+    [[maybe_unused]] static constexpr int64_t PREV_RUNNING_MEAN = 8;
+    [[maybe_unused]] static constexpr int64_t PREV_RUNNING_VARIANCE = 9;
+    [[maybe_unused]] static constexpr int64_t MOMENTUM = 10;
+    [[maybe_unused]] static constexpr int64_t NEXT_RUNNING_MEAN = 11;
+    [[maybe_unused]] static constexpr int64_t NEXT_RUNNING_VARIANCE = 12;
+};
+
+// Inference with variance extension (standalone - uses variance instead of inv_variance, plus epsilon)
+struct BnInferenceVarianceExtTensorIds
+{
+    [[maybe_unused]] static constexpr int64_t X = 1;
+    [[maybe_unused]] static constexpr int64_t Y = 2;
+    [[maybe_unused]] static constexpr int64_t SCALE = 3;
+    [[maybe_unused]] static constexpr int64_t BIAS = 4;
+    [[maybe_unused]] static constexpr int64_t EPSILON = 5;
+    [[maybe_unused]] static constexpr int64_t MEAN = 6;
+    [[maybe_unused]] static constexpr int64_t VARIANCE = 7;
+};
+
+// --- Tensor Role Classification ---
+enum class TensorRole
+{
+    IO, // Input/output tensors (x, y, dx, dy)
+    AFFINE, // Scale/bias parameters
+    STAT, // Mean/variance statistics
+    SCALAR // Pass-by-value scalars (epsilon, momentum)
+};
+
+// --- Canonical Tensor Layout Database ---
+using hipdnn_data_sdk::utilities::TensorLayout;
+
+namespace canonical_layouts
+{
+
+// Test-specific: naming helper (uses TensorLayout.name!)
+inline std::string generateName(const std::vector<int64_t>& dims, const TensorLayout& layout)
+{
+    std::string name = layout.name; // Reuse production name!
+    for(auto dim : dims)
+    {
+        name += "_" + std::to_string(dim);
+    }
+    return name;
+}
+
+// Shape collections (layout-independent)
+namespace shapes
+{
+// 4D shapes for inference/backward (larger spatial dimensions)
+inline const std::vector<std::vector<int64_t>> INFERENCE_4D = {
+    {1, 3, 56, 56},
+    {1, 3, 112, 112},
+    {1, 3, 224, 224},
+    {2, 3, 224, 224},
+    {1, 16, 224, 224},
+};
+
+// 4D shapes for training (sufficient spatial: B×S > 1)
+inline const std::vector<std::vector<int64_t>> TRAINING_4D = {
+    {1, 3, 14, 14},
+    {2, 3, 14, 14},
+    {1, 3, 28, 28},
+};
+
+// 5D shapes for inference/backward
+inline const std::vector<std::vector<int64_t>> INFERENCE_5D = {
+    {1, 3, 16, 224, 224},
+    {1, 4, 16, 224, 224},
+    {1, 3, 8, 112, 112},
+};
+
+// 5D shapes for training (sufficient spatial: B×S > 1)
+inline const std::vector<std::vector<int64_t>> TRAINING_5D = {
+    {1, 4, 16, 14, 14},
+    {1, 3, 16, 14, 14},
+};
+
+// Edge case shapes for specific test scenarios
+inline const std::vector<int64_t> DEGENERATE_4D = {1, 1, 1, 1};
+inline const std::vector<int64_t> INSUFFICIENT_SPATIAL_4D = {1, 3, 1, 1};
+inline const std::vector<int64_t> DIFFERENT_CHANNELS_4D = {1, 5, 224, 224};
+} // namespace shapes
+
+// Test-specific: iteration arrays (use struct pointers or references)
+inline const std::vector<const TensorLayout*> LAYOUTS_4D
+    = {&TensorLayout::NCHW, &TensorLayout::NHWC};
+
+inline const std::vector<const TensorLayout*> LAYOUTS_5D
+    = {&TensorLayout::NCDHW, &TensorLayout::NDHWC};
+
+namespace type_configs
+{
+using DT = hipdnn_data_sdk::data_objects::DataType;
+
+// All invalid type configurations that should be REJECTED
+// Documents what type combinations are NOT supported
+inline const std::vector<BnTensorTypes> INVALID_ALL = {
+    // Invalid IO type (IO must be FLOAT/HALF/BFLOAT16)
+    {DT::UINT8, DT::FLOAT, DT::FLOAT, DT::FLOAT}, // IO=UINT8 (unsupported)
+
+    // Invalid affine types (scale/bias must be FLOAT)
+    {DT::HALF, DT::HALF, DT::FLOAT, DT::FLOAT}, // IO=HALF, Affine=HALF
+    {DT::BFLOAT16, DT::HALF, DT::FLOAT, DT::FLOAT}, // IO=BFLOAT16, Affine=HALF
+    {DT::BFLOAT16, DT::BFLOAT16, DT::FLOAT, DT::FLOAT}, // IO=BFLOAT16, Affine=BFLOAT16
+
+    // Invalid stat types (mean/variance must be FLOAT)
+    {DT::HALF, DT::FLOAT, DT::HALF, DT::FLOAT}, // IO=HALF, Stat=HALF
+    {DT::BFLOAT16, DT::FLOAT, DT::HALF, DT::FLOAT}, // IO=BFLOAT16, Stat=HALF
+    {DT::BFLOAT16, DT::FLOAT, DT::BFLOAT16, DT::FLOAT}, // IO=BFLOAT16, Stat=BFLOAT16
+
+    // Both affine and stat invalid (must be FLOAT)
+    {DT::HALF, DT::HALF, DT::HALF, DT::FLOAT}, // All HALF
+    {DT::BFLOAT16, DT::BFLOAT16, DT::BFLOAT16, DT::FLOAT}, // All BFLOAT16
+    {DT::BFLOAT16, DT::HALF, DT::HALF, DT::FLOAT}, // Mixed invalid
+};
+
+// Invalid configs for fused operations (intermediate tensor data type errors)
+inline const std::vector<BnTensorTypes> INVALID_FUSED_ALL = []() {
+    auto configs = INVALID_ALL;
+    configs.push_back({DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::HALF});
+    configs.push_back({DT::HALF, DT::FLOAT, DT::FLOAT, DT::HALF});
+    configs.push_back({DT::FLOAT, DT::FLOAT, DT::FLOAT, DT::BFLOAT16});
+    return configs;
+}();
+
+} // namespace type_configs
+
+} // namespace canonical_layouts
+
+class TensorConfigBuilder
+{
+public:
+    TensorConfigBuilder(int64_t uid, const std::string& name, TensorRole role)
+        : _config{uid,
+                  name,
+                  hipdnn_data_sdk::data_objects::DataType::FLOAT,
+                  {},
+                  {},
+                  "",
+                  false,
+                  false,
+                  0.0}
+        , _role(role)
+    {
+    }
+
+    TensorConfigBuilder& withDataType(hipdnn_data_sdk::data_objects::DataType dt)
+    {
+        _config.dataType = dt;
+        return *this;
+    }
+
+    TensorConfigBuilder& withDims(std::vector<int64_t> dims)
+    {
+        _config.dims = std::move(dims);
+        return *this;
+    }
+
+    TensorConfigBuilder& withStrides(std::vector<int64_t> strides)
+    {
+        _config.strides = std::move(strides);
+        return *this;
+    }
+
+    TensorConfigBuilder& withDescription(const std::string& desc)
+    {
+        _config.description = desc;
+        return *this;
+    }
+
+    TensorConfigBuilder& asVirtual()
+    {
+        _config.isVirtual = true;
+        return *this;
+    }
+
+    TensorConfigBuilder& asScalar(double value)
+    {
+        _config.isPassByValue = true;
+        _config.passedValue = value;
+        _config.dims = {1};
+        _config.strides = {1};
+        return *this;
+    }
+
+    TensorConfig build() const
+    {
+        return _config;
+    }
+
+private:
+    TensorConfig _config;
+    [[maybe_unused]] TensorRole _role;
+};
+
+// --- Factory Helpers ---
+
+inline TensorConfig createIoTensor(int64_t uid,
+                                   const std::string& name,
+                                   hipdnn_data_sdk::data_objects::DataType dt,
+                                   const std::vector<int64_t>& dims,
+                                   const std::vector<int64_t>& strides,
+                                   bool isVirtual = false)
+{
+    auto builder = TensorConfigBuilder(uid, name, TensorRole::IO)
+                       .withDataType(dt)
+                       .withDims(dims)
+                       .withStrides(strides);
+
+    if(isVirtual)
+    {
+        builder.asVirtual();
+    }
+    return builder.build();
+}
+
+[[maybe_unused]] inline TensorConfig createAffineTensor(int64_t uid,
+                                                        const std::string& name,
+                                                        hipdnn_data_sdk::data_objects::DataType dt,
+                                                        const std::vector<int64_t>& derivedDims,
+                                                        const std::vector<int64_t>& derivedStrides)
+{
+    return TensorConfigBuilder(uid, name, TensorRole::AFFINE)
+        .withDataType(dt)
+        .withDims(derivedDims)
+        .withStrides(derivedStrides)
+        .build();
+}
+
+[[maybe_unused]] inline TensorConfig createStatTensor(int64_t uid,
+                                                      const std::string& name,
+                                                      hipdnn_data_sdk::data_objects::DataType dt,
+                                                      const std::vector<int64_t>& derivedDims,
+                                                      const std::vector<int64_t>& derivedStrides)
+{
+    return TensorConfigBuilder(uid, name, TensorRole::STAT)
+        .withDataType(dt)
+        .withDims(derivedDims)
+        .withStrides(derivedStrides)
+        .build();
+}
+
+[[maybe_unused]] inline TensorConfig
+    createScalarTensor(int64_t uid, const std::string& name, double value)
+{
+    return TensorConfigBuilder(uid, name, TensorRole::SCALAR).asScalar(value).build();
+}
+
+// --- Reusable Tensor Set Factories ---
+
+inline std::vector<TensorConfig> createIoTensorPair(const BnTensorTypes& types,
+                                                    const std::vector<int64_t>& dims,
+                                                    const TensorLayout& layout,
+                                                    int64_t xUid = BnCommonTensorIds::X,
+                                                    int64_t yUid = BnCommonTensorIds::Y)
+{
+    auto strides = hipdnn_data_sdk::utilities::generateStrides(dims, layout.strideOrder);
+    return {createIoTensor(xUid, "x", types.io, dims, strides),
+            createIoTensor(yUid, "y", types.io, dims, strides)};
+}
+
+inline std::vector<TensorConfig> createAffineTensorPair(const BnTensorTypes& types,
+                                                        const std::vector<int64_t>& baseDims,
+                                                        const TensorLayout& layout,
+                                                        int64_t scaleUid = BnCommonTensorIds::SCALE,
+                                                        int64_t biasUid = BnCommonTensorIds::BIAS)
+{
+    auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(baseDims);
+    auto derivedStrides
+        = hipdnn_data_sdk::utilities::generateStrides(derivedDims, layout.strideOrder);
+    return {createAffineTensor(scaleUid, "scale", types.affine, derivedDims, derivedStrides),
+            createAffineTensor(biasUid, "bias", types.affine, derivedDims, derivedStrides)};
+}
+
+inline std::vector<TensorConfig> createStatTensorPair(const BnTensorTypes& types,
+                                                      const std::vector<int64_t>& baseDims,
+                                                      const TensorLayout& layout,
+                                                      int64_t meanUid = BnCommonTensorIds::MEAN,
+                                                      int64_t invVarianceUid
+                                                      = BnCommonTensorIds::INV_VARIANCE)
+{
+    auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(baseDims);
+    auto derivedStrides
+        = hipdnn_data_sdk::utilities::generateStrides(derivedDims, layout.strideOrder);
+    return {
+        createStatTensor(meanUid, "mean", types.stat, derivedDims, derivedStrides),
+        createStatTensor(invVarianceUid, "inv_variance", types.stat, derivedDims, derivedStrides)};
+}
+
+inline std::vector<TensorConfig> createBatchnormInferenceTensors(const BnTensorTypes& types,
+                                                                 const std::vector<int64_t>& dims,
+                                                                 const TensorLayout& layout)
+{
+    using UIDs = BnCommonTensorIds;
+    std::vector<TensorConfig> configs;
+
+    auto io = createIoTensorPair(types, dims, layout, UIDs::X, UIDs::Y);
+    configs.insert(configs.end(), io.begin(), io.end());
+
+    auto affine = createAffineTensorPair(types, dims, layout, UIDs::SCALE, UIDs::BIAS);
+    configs.insert(configs.end(), affine.begin(), affine.end());
+
+    auto stat = createStatTensorPair(types, dims, layout, UIDs::MEAN, UIDs::INV_VARIANCE);
+    configs.insert(configs.end(), stat.begin(), stat.end());
+
+    return configs;
+}
+
+inline std::vector<TensorConfig> createBatchnormTrainingTensors(const BnTensorTypes& types,
+                                                                const std::vector<int64_t>& dims,
+                                                                const TensorLayout& layout,
+                                                                bool includeMeanOutput = false,
+                                                                bool includeInvVarianceOutput
+                                                                = false)
+{
+    using UIDs = BnTrainingTensorIds;
+    std::vector<TensorConfig> configs;
+
+    auto io = createIoTensorPair(types, dims, layout, UIDs::X, UIDs::Y);
+    configs.insert(configs.end(), io.begin(), io.end());
+
+    auto affine = createAffineTensorPair(types, dims, layout, UIDs::SCALE, UIDs::BIAS);
+    configs.insert(configs.end(), affine.begin(), affine.end());
+
+    configs.push_back(createScalarTensor(UIDs::EPSILON, "epsilon", 1e-5));
+
+    if(includeMeanOutput || includeInvVarianceOutput)
+    {
+        auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+        auto derivedStrides
+            = hipdnn_data_sdk::utilities::generateStrides(derivedDims, layout.strideOrder);
+
+        if(includeMeanOutput)
+        {
+            configs.push_back(
+                createStatTensor(UIDs::MEAN, "mean", types.stat, derivedDims, derivedStrides));
+        }
+        if(includeInvVarianceOutput)
+        {
+            configs.push_back(createStatTensor(
+                UIDs::INV_VARIANCE, "inv_variance", types.stat, derivedDims, derivedStrides));
+        }
+    }
+
+    return configs;
+}
+
+inline std::vector<TensorConfig> createBatchnormBackwardTensors(const BnTensorTypes& types,
+                                                                const std::vector<int64_t>& dims,
+                                                                const TensorLayout& layout,
+                                                                bool includeMeanInput = false,
+                                                                bool includeInvVarianceInput
+                                                                = false)
+{
+    using UIDs = BnBackwardTensorIds;
+    std::vector<TensorConfig> configs;
+    auto strides = hipdnn_data_sdk::utilities::generateStrides(dims, layout.strideOrder);
+
+    configs.push_back(createIoTensor(UIDs::X, "x", types.io, dims, strides));
+    configs.push_back(createIoTensor(UIDs::DY, "dy", types.io, dims, strides));
+    configs.push_back(createIoTensor(UIDs::DX, "dx", types.io, dims, strides));
+
+    auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    auto derivedStrides
+        = hipdnn_data_sdk::utilities::generateStrides(derivedDims, layout.strideOrder);
+    configs.push_back(
+        createAffineTensor(UIDs::SCALE, "scale", types.affine, derivedDims, derivedStrides));
+    configs.push_back(
+        createAffineTensor(UIDs::DSCALE, "dscale", types.affine, derivedDims, derivedStrides));
+    configs.push_back(
+        createAffineTensor(UIDs::DBIAS, "dbias", types.affine, derivedDims, derivedStrides));
+
+    if(includeMeanInput)
+    {
+        configs.push_back(
+            createStatTensor(UIDs::MEAN, "mean", types.stat, derivedDims, derivedStrides));
+    }
+    if(includeInvVarianceInput)
+    {
+        configs.push_back(createStatTensor(
+            UIDs::INV_VARIANCE, "inv_variance", types.stat, derivedDims, derivedStrides));
+    }
+
+    return configs;
+}
+
+inline std::vector<TensorConfig> createBatchnormFusedBackwardTensors(
+    const BnTensorTypes& types, const std::vector<int64_t>& dims, const TensorLayout& layout)
+{
+    using UIDs = BnFusedTensorIds;
+    std::vector<TensorConfig> configs;
+    auto strides = hipdnn_data_sdk::utilities::generateStrides(dims, layout.strideOrder);
+    auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    auto derivedStrides
+        = hipdnn_data_sdk::utilities::generateStrides(derivedDims, layout.strideOrder);
+
+    // Forward inputs (x, scale, bias, mean, invVariance)
+    configs.push_back(createIoTensor(UIDs::X, "x", types.io, dims, strides));
+    configs.push_back(
+        createAffineTensor(UIDs::SCALE, "scale", types.affine, derivedDims, derivedStrides));
+    configs.push_back(
+        createAffineTensor(UIDs::BIAS, "bias", types.affine, derivedDims, derivedStrides));
+    configs.push_back(
+        createStatTensor(UIDs::MEAN, "mean", types.stat, derivedDims, derivedStrides));
+    configs.push_back(createStatTensor(
+        UIDs::INV_VARIANCE, "inv_variance", types.stat, derivedDims, derivedStrides));
+
+    // Backward inputs (dy)
+    configs.push_back(createIoTensor(UIDs::DY, "dy", types.io, dims, strides));
+
+    // Backward outputs (dx, dscale, dbias)
+    configs.push_back(createIoTensor(UIDs::DX, "dx", types.io, dims, strides));
+    configs.push_back(
+        createAffineTensor(UIDs::DSCALE, "dscale", types.affine, derivedDims, derivedStrides));
+    configs.push_back(
+        createAffineTensor(UIDs::DBIAS, "dbias", types.affine, derivedDims, derivedStrides));
+
+    // Virtual tensors (BN_Y, DX_drelu)
+    configs.push_back(
+        createIoTensor(UIDs::BN_Y_VIRTUAL, "BN_Y", types.intermediate, dims, strides, true));
+    configs.push_back(createIoTensor(
+        UIDs::DX_DRELU_VIRTUAL, "DX_drelu", types.intermediate, dims, strides, true));
+
+    return configs;
+}
+
+// --- BnTensorTypes Helpers ---
+
+inline std::string dataTypeToString(hipdnn_data_sdk::data_objects::DataType dt)
+{
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    switch(dt)
+    {
+    case DT::FLOAT:
+        return "Float";
+    case DT::HALF:
+        return "Half";
+    case DT::BFLOAT16:
+        return "Bfloat16";
+    default:
+        return "Unknown";
+    }
+}
+
+inline std::string toString(const BnTensorTypes& types)
+{
+    return "IO_" + dataTypeToString(types.io) + "_Affine_" + dataTypeToString(types.affine)
+           + "_Stat_" + dataTypeToString(types.stat);
+}
+
+inline std::string activationModeToString(hipdnn_data_sdk::data_objects::PointwiseMode mode)
+{
+    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    switch(mode)
+    {
+    case PM::IDENTITY:
+        return "Identity";
+    case PM::RELU_BWD:
+        return "ReluBwd";
+    case PM::SIGMOID_BWD:
+        return "SigmoidBwd";
+    case PM::TANH_BWD:
+        return "TanhBwd";
+    case PM::RELU_FWD:
+        return "ReluFwd";
+    default:
+        return "Unknown";
+    }
+}
+
+// --- Test Case Structs: Layer 1 (Atomic Validators) ---
+
+struct DimensionCountTestCase
+{
+    std::string name;
+    bool shouldPass;
+    size_t numDims;
+
+    friend std::ostream& operator<<(std::ostream& os, const DimensionCountTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct SupportedLayoutTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<int64_t> strideOrder;
+    size_t numDims;
+
+    friend std::ostream& operator<<(std::ostream& os, const SupportedLayoutTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct TensorDescriptorListTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<std::vector<int64_t>> tensorDims;
+    std::vector<std::vector<int64_t>> tensorStrides;
+
+    friend std::ostream& operator<<(std::ostream& os, const TensorDescriptorListTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct DataTypeIsSupportedTestCase
+{
+    std::string name;
+    bool shouldPass;
+    hipdnn_data_sdk::data_objects::DataType dataType;
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allowedTypes;
+
+    friend std::ostream& operator<<(std::ostream& os, const DataTypeIsSupportedTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct ConsistentDataTypesTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    std::vector<int64_t> tensorIds;
+    std::unordered_set<hipdnn_data_sdk::data_objects::DataType> allowedTypes;
+
+    friend std::ostream& operator<<(std::ostream& os, const ConsistentDataTypesTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct FixedDataTypeTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    std::vector<int64_t> tensorIds;
+    hipdnn_data_sdk::data_objects::DataType expectedType;
+
+    friend std::ostream& operator<<(std::ostream& os, const FixedDataTypeTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct ConsistentShapesTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    std::vector<int64_t> tensorIds;
+    std::vector<int64_t> referenceShape;
+
+    friend std::ostream& operator<<(std::ostream& os, const ConsistentShapesTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct SpatialDimensionsTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<int64_t> ioDims;
+
+    friend std::ostream& operator<<(std::ostream& os, const SpatialDimensionsTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+// --- Test Case Structs: Layer 2 (Component Validators) ---
+
+struct TensorLayoutsAndDimsTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+
+    friend std::ostream& operator<<(std::ostream& os, const TensorLayoutsAndDimsTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct TensorDataTypesComponentTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    std::vector<int64_t> ioTensorIds;
+    std::vector<int64_t> affineTensorIds;
+    std::vector<int64_t> statTensorIds;
+    std::vector<int64_t> intermediateTensorIds;
+
+    friend std::ostream& operator<<(std::ostream& os, const TensorDataTypesComponentTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct TensorShapesComponentTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    std::vector<int64_t> ioTensorIds;
+    std::vector<int64_t> affineTensorIds;
+    std::vector<int64_t> statTensorIds;
+    bool isTraining;
+
+    friend std::ostream& operator<<(std::ostream& os, const TensorShapesComponentTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+// --- Test Case Structs: Layer 3 (High-Level Validators) ---
+
+struct BatchnormInferenceConfigTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    int64_t xUid;
+    int64_t yUid;
+    int64_t scaleUid;
+    int64_t biasUid;
+    int64_t meanUid;
+    int64_t invVarianceUid;
+
+    friend std::ostream& operator<<(std::ostream& os, const BatchnormInferenceConfigTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct BatchnormTrainingConfigTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    int64_t xUid;
+    int64_t yUid;
+    int64_t scaleUid;
+    int64_t biasUid;
+    int64_t epsilonUid;
+    flatbuffers::Optional<int64_t> meanUid;
+    flatbuffers::Optional<int64_t> invVarianceUid;
+
+    friend std::ostream& operator<<(std::ostream& os, const BatchnormTrainingConfigTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct BatchnormBackwardConfigTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    int64_t xUid;
+    int64_t dyUid;
+    int64_t dxUid;
+    int64_t scaleUid;
+    int64_t dscaleUid;
+    int64_t dbiasUid;
+    flatbuffers::Optional<int64_t> meanUid;
+    flatbuffers::Optional<int64_t> invVarianceUid;
+
+    friend std::ostream& operator<<(std::ostream& os, const BatchnormBackwardConfigTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct BatchnormFusedBackwardConfigTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    int64_t xUid;
+    int64_t scaleUid;
+    int64_t biasUid;
+    int64_t meanUid;
+    int64_t invVarianceUid;
+    int64_t dyUid;
+    int64_t dxUid;
+    int64_t dscaleUid;
+    int64_t dbiasUid;
+    int64_t bnYVirtualUid;
+    int64_t dxDreluVirtualUid;
+    hipdnn_data_sdk::data_objects::PointwiseMode activationMode;
+
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const BatchnormFusedBackwardConfigTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct BatchnormInferenceVarianceExtFusedConfigTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    int64_t xUid;
+    int64_t yUid;
+    int64_t scaleUid;
+    int64_t biasUid;
+    int64_t epsilonUid;
+    int64_t meanUid;
+    int64_t varianceUid;
+    hipdnn_data_sdk::data_objects::PointwiseMode activationMode;
+
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const BatchnormInferenceVarianceExtFusedConfigTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+struct ActivationModeTestCase
+{
+    std::string name;
+    bool shouldPass;
+    hipdnn_data_sdk::data_objects::PointwiseMode mode;
+    flatbuffers::Optional<double> reluLowerClip;
+    flatbuffers::Optional<double> reluUpperClip;
+    flatbuffers::Optional<double> reluLowerClipSlope;
+
+    friend std::ostream& operator<<(std::ostream& os, const ActivationModeTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+// --- Helper Functions ---
+
+std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*> buildTensorMap(
+    flatbuffers::FlatBufferBuilder& builder,
+    const std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>&
+        tensorOffsets)
+{
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test_graph",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorOffsets,
+        nullptr);
+
+    builder.Finish(graphOffset);
+
+    const auto* graph = hipdnn_data_sdk::data_objects::GetGraph(builder.GetBufferPointer());
+    std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributes*> tensorMap;
+
+    if(graph->tensors() != nullptr)
+    {
+        for(const auto* tensorAttr : *graph->tensors())
+        {
+            tensorMap[tensorAttr->uid()] = tensorAttr;
+        }
+    }
+
+    return tensorMap;
+}
+
+auto buildTensorMapFromConfigs(const std::vector<TensorConfig>& configs)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    tensorOffsets.reserve(configs.size());
+
+    for(const auto& config : configs)
+    {
+        if(config.isPassByValue)
+        {
+            // Create a pass-by-value tensor with embedded scalar value
+            hipdnn_data_sdk::data_objects::Float64Value floatValue(config.passedValue);
+            auto valueOffset = builder.CreateStruct(floatValue).Union();
+            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                config.uid,
+                config.name.c_str(),
+                config.dataType,
+                &config.strides,
+                &config.dims,
+                config.isVirtual,
+                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
+                valueOffset));
+        }
+        else
+        {
+            tensorOffsets.push_back(
+                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                            config.uid,
+                                                                            config.name.c_str(),
+                                                                            config.dataType,
+                                                                            &config.strides,
+                                                                            &config.dims,
+                                                                            config.isVirtual));
+        }
+    }
+
+    auto tensorMap = buildTensorMap(builder, tensorOffsets);
+    return std::make_pair(std::move(builder), std::move(tensorMap));
+}
+
+// --- Graph Builders ---
+
+inline flatbuffers::FlatBufferBuilder
+    buildBatchnormInferenceGraph(const std::vector<TensorConfig>& configs,
+                                 int64_t xUid,
+                                 int64_t yUid,
+                                 int64_t scaleUid,
+                                 int64_t biasUid,
+                                 int64_t meanUid,
+                                 int64_t invVarianceUid)
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    // Build tensor attribute offsets from configs
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    tensorOffsets.reserve(configs.size());
+    for(const auto& cfg : configs)
+    {
+        tensorOffsets.push_back(
+            hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                        cfg.uid,
+                                                                        cfg.name.c_str(),
+                                                                        cfg.dataType,
+                                                                        &cfg.strides,
+                                                                        &cfg.dims,
+                                                                        cfg.isVirtual));
+    }
+
+    // Create BatchnormInferenceAttributes with specified UIDs
+    auto bnInfAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, xUid, meanUid, invVarianceUid, scaleUid, biasUid, yUid);
+
+    // Create node
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_inference",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttrs.Union()));
+
+    // Build graph
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test_graph",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorOffsets,
+        &nodes);
+
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+inline flatbuffers::FlatBufferBuilder
+    buildBatchnormTrainingGraph(const std::vector<TensorConfig>& configs,
+                                int64_t xUid,
+                                int64_t yUid,
+                                int64_t scaleUid,
+                                int64_t biasUid,
+                                int64_t epsilonUid,
+                                flatbuffers::Optional<int64_t> meanUid = flatbuffers::nullopt,
+                                flatbuffers::Optional<int64_t> invVarianceUid
+                                = flatbuffers::nullopt)
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    // Build tensor attribute offsets
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    tensorOffsets.reserve(configs.size());
+    for(const auto& cfg : configs)
+    {
+        if(cfg.isPassByValue)
+        {
+            // Create a pass-by-value tensor with embedded scalar value
+            hipdnn_data_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
+            auto valueOffset = builder.CreateStruct(floatValue).Union();
+            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                cfg.uid,
+                cfg.name.c_str(),
+                cfg.dataType,
+                &cfg.strides,
+                &cfg.dims,
+                cfg.isVirtual,
+                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
+                valueOffset));
+        }
+        else
+        {
+            tensorOffsets.push_back(
+                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                            cfg.uid,
+                                                                            cfg.name.c_str(),
+                                                                            cfg.dataType,
+                                                                            &cfg.strides,
+                                                                            &cfg.dims,
+                                                                            cfg.isVirtual));
+        }
+    }
+
+    // Create BatchnormAttributes (training mode) with specified UIDs
+    auto bnAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(
+        builder,
+        xUid,
+        scaleUid,
+        biasUid,
+        epsilonUid,
+        0, // peer_stats_tensor_uid
+        flatbuffers::nullopt, // prev_running_mean_tensor_uid
+        flatbuffers::nullopt, // prev_running_variance_tensor_uid
+        flatbuffers::nullopt, // momentum_tensor_uid
+        yUid,
+        meanUid,
+        invVarianceUid,
+        flatbuffers::nullopt, // next_running_mean_tensor_uid
+        flatbuffers::nullopt // next_running_variance_tensor_uid
+    );
+
+    // Create node
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_training",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        bnAttrs.Union()));
+
+    // Build graph
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test_graph",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorOffsets,
+        &nodes);
+
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+inline flatbuffers::FlatBufferBuilder
+    buildBatchnormBackwardGraph(const std::vector<TensorConfig>& configs,
+                                int64_t xUid,
+                                int64_t dyUid,
+                                int64_t dxUid,
+                                int64_t scaleUid,
+                                int64_t dscaleUid,
+                                int64_t dbiasUid,
+                                flatbuffers::Optional<int64_t> meanUid = flatbuffers::nullopt,
+                                flatbuffers::Optional<int64_t> invVarianceUid
+                                = flatbuffers::nullopt)
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    // Build tensor attribute offsets
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    tensorOffsets.reserve(configs.size());
+    for(const auto& cfg : configs)
+    {
+        tensorOffsets.push_back(
+            hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                        cfg.uid,
+                                                                        cfg.name.c_str(),
+                                                                        cfg.dataType,
+                                                                        &cfg.strides,
+                                                                        &cfg.dims,
+                                                                        cfg.isVirtual));
+    }
+
+    // Create BatchnormBackwardAttributes with specified UIDs
+    auto bnBwdAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        dyUid,
+        xUid,
+        meanUid,
+        invVarianceUid,
+        scaleUid,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(), // peer_stats_tensor_uid
+        dxUid,
+        dscaleUid,
+        dbiasUid);
+
+    // Create node
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_backward",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttrs.Union()));
+
+    // Build graph
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test_graph",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorOffsets,
+        &nodes);
+
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+inline flatbuffers::FlatBufferBuilder
+    buildBatchnormFusedBackwardGraph(const std::vector<TensorConfig>& configs,
+                                     int64_t xUid,
+                                     int64_t scaleUid,
+                                     int64_t biasUid,
+                                     int64_t meanUid,
+                                     int64_t invVarianceUid,
+                                     int64_t dyUid,
+                                     int64_t dxUid,
+                                     int64_t dscaleUid,
+                                     int64_t dbiasUid,
+                                     int64_t bnYVirtualUid,
+                                     int64_t dxDreluVirtualUid,
+                                     hipdnn_data_sdk::data_objects::PointwiseMode activationMode
+                                     = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD)
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    // Build tensor attribute offsets
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    tensorOffsets.reserve(configs.size());
+    for(const auto& cfg : configs)
+    {
+        tensorOffsets.push_back(
+            hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                        cfg.uid,
+                                                                        cfg.name.c_str(),
+                                                                        cfg.dataType,
+                                                                        &cfg.strides,
+                                                                        &cfg.dims,
+                                                                        cfg.isVirtual));
+    }
+
+    // Create 3 nodes for the fusion
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Node 0: Batchnorm Inference
+    auto bnInfAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, xUid, meanUid, invVarianceUid, scaleUid, biasUid, bnYVirtualUid);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_inference",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttrs.Union()));
+
+    // Node 1: Activation (Backward mode, e.g., RELU_BWD)
+    auto actAttrs = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        activationMode,
+        flatbuffers::nullopt, // relu_lower_clip
+        flatbuffers::nullopt, // relu_upper_clip
+        flatbuffers::nullopt, // relu_lower_clip_slope
+        flatbuffers::nullopt, // axis_tensor_uid
+        bnYVirtualUid,
+        flatbuffers::Optional<int64_t>(dyUid),
+        flatbuffers::nullopt, // in_2_tensor_uid
+        dxDreluVirtualUid);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "activation_bwd",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttrs.Union()));
+
+    // Node 2: Batchnorm Backward
+    auto bnBwdAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        dxDreluVirtualUid,
+        xUid,
+        flatbuffers::Optional<int64_t>(meanUid),
+        flatbuffers::Optional<int64_t>(invVarianceUid),
+        scaleUid,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(), // peer_stats_tensor_uid
+        dxUid,
+        dscaleUid,
+        dbiasUid);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_backward",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttrs.Union()));
+
+    // Build graph
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test_graph",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorOffsets,
+        &nodes);
+
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+inline flatbuffers::FlatBufferBuilder buildBatchnormInferenceWithVarianceFusedGraph(
+    const std::vector<TensorConfig>& configs,
+    int64_t xUid,
+    int64_t yUid,
+    int64_t scaleUid,
+    int64_t biasUid,
+    int64_t epsilonUid,
+    int64_t meanUid,
+    int64_t varianceUid,
+    int64_t bnYVirtualUid,
+    hipdnn_data_sdk::data_objects::PointwiseMode activationMode
+    = hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD)
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    tensorOffsets.reserve(configs.size());
+    for(const auto& cfg : configs)
+    {
+        if(cfg.isPassByValue)
+        {
+            hipdnn_data_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
+            auto valueOffset = builder.CreateStruct(floatValue).Union();
+            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                cfg.uid,
+                cfg.name.c_str(),
+                cfg.dataType,
+                &cfg.strides,
+                &cfg.dims,
+                cfg.isVirtual,
+                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
+                valueOffset));
+        }
+        else
+        {
+            tensorOffsets.push_back(
+                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                            cfg.uid,
+                                                                            cfg.name.c_str(),
+                                                                            cfg.dataType,
+                                                                            &cfg.strides,
+                                                                            &cfg.dims,
+                                                                            cfg.isVirtual));
+        }
+    }
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Node 0: Batchnorm Inference with Variance
+    auto bnAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, xUid, meanUid, varianceUid, scaleUid, biasUid, bnYVirtualUid, epsilonUid);
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_inference_variance_ext",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnAttrs.Union()));
+
+    // Node 1: Activation
+    auto actAttrs = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        activationMode,
+        flatbuffers::nullopt, // relu_lower_clip
+        flatbuffers::nullopt, // relu_upper_clip
+        flatbuffers::nullopt, // relu_lower_clip_slope
+        flatbuffers::nullopt, // axis_tensor_uid
+        bnYVirtualUid, // in_0_tensor_uid
+        flatbuffers::nullopt, // in_1_tensor_uid
+        flatbuffers::nullopt, // in_2_tensor_uid
+        yUid); // out_0_tensor_uid
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "activation",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttrs.Union()));
+
+    // Build graph
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test_graph",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorOffsets,
+        &nodes);
+
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+// --- Test Data Providers: Layer 1 (Atomic Validators) ---
+
+// Only 4D and 5D tensors work with batchnorm
+inline std::vector<DimensionCountTestCase> getValidateDimensionCountTestCases()
+{
+    return {
+        // Happy paths - supported dimensions
+        {"Accepts4D", true, 4},
+        {"Accepts5D", true, 5},
+
+        // Unhappy paths - unsupported dimensions
+        {"Rejects3D", false, 3},
+        {"Rejects6D", false, 6},
+        {"Rejects2D", false, 2},
+        {"Rejects1D", false, 1},
+    };
+}
+
+// Only NCHW/NHWC (4D) and NCDHW/NDHWC (5D) layouts are supported
+inline std::vector<SupportedLayoutTestCase> getValidateSupportedLayoutTestCases()
+{
+    return {
+        // Happy paths - 4D supported layouts
+        {"AcceptsNchw4D", true, {3, 2, 1, 0}, 4}, // NCHW stride order
+        {"AcceptsNhwc4D", true, {3, 0, 2, 1}, 4}, // NHWC stride order
+
+        // Happy paths - 5D supported layouts
+        {"AcceptsNcdhw5D", true, {4, 3, 2, 1, 0}, 5}, // NCDHW stride order
+        {"AcceptsNdhwc5D", true, {4, 0, 3, 2, 1}, 5}, // NDHWC stride order
+
+        // Unhappy paths - unsupported 4D layouts
+        {"RejectsInvalid4D_AllReversed", false, {0, 1, 2, 3}, 4},
+        {"RejectsInvalid4D_Random", false, {2, 1, 0, 3}, 4},
+
+        // Unhappy paths - unsupported 5D layouts
+        {"RejectsInvalid5D_AllReversed", false, {0, 1, 2, 3, 4}, 5},
+        {"RejectsInvalid5D_Random", false, {1, 2, 3, 4, 0}, 5},
+    };
+}
+
+// All tensors must have the same number of dimensions
+inline std::vector<TensorDescriptorListTestCase> getValidateConsistentDimensionsTestCases()
+{
+    using namespace canonical_layouts;
+
+    auto dims4D = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
+    auto dims5D = shapes::INFERENCE_5D[0]; // {1, 3, 16, 224, 224}
+    auto strides4D
+        = hipdnn_data_sdk::utilities::generateStrides(dims4D, TensorLayout::NCHW.strideOrder);
+    auto strides5D
+        = hipdnn_data_sdk::utilities::generateStrides(dims5D, TensorLayout::NCDHW.strideOrder);
+
+    return {
+        // Happy paths - consistent dimensions
+        {"AcceptsSame4D_TwoTensors", true, {dims4D, dims4D}, {strides4D, strides4D}},
+        {"AcceptsSame5D_ThreeTensors",
+         true,
+         {dims5D, dims5D, dims5D},
+         {strides5D, strides5D, strides5D}},
+        {"AcceptsEmpty", true, {}, {}},
+        {"AcceptsSingleTensor", true, {dims4D}, {strides4D}},
+
+        // Unhappy paths - inconsistent dimensions
+        {"RejectsMixed4D5D", false, {dims4D, dims5D}, {strides4D, strides5D}},
+        {"RejectsMixed5D4D", false, {dims5D, dims4D}, {strides5D, strides4D}},
+    };
+}
+
+// All tensors must be packed (contiguous in memory)
+inline std::vector<TensorDescriptorListTestCase> getValidatePackedTensorsTestCases()
+{
+    using namespace canonical_layouts;
+
+    auto dims4D = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
+    auto dims5D = shapes::INFERENCE_5D[0]; // {1, 3, 16, 224, 224}
+    auto nchwStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims4D, TensorLayout::NCHW.strideOrder);
+    auto nhwcStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims4D, TensorLayout::NHWC.strideOrder);
+    auto ncdhwStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims5D, TensorLayout::NCDHW.strideOrder);
+
+    return {
+        // Happy paths - packed tensors
+        {"AcceptsPacked4D_NCHW", true, {dims4D}, {nchwStrides}},
+        {"AcceptsPacked4D_NHWC", true, {dims4D}, {nhwcStrides}},
+        {"AcceptsPacked5D_NCDHW", true, {dims5D}, {ncdhwStrides}},
+        {"AcceptsMultiplePacked", true, {dims4D, dims4D}, {nchwStrides, nhwcStrides}},
+
+        // Unhappy paths - non-packed tensors
+        {"RejectsNonPacked_ExtraStride", false, {dims4D}, {{200000, 60000, 250, 1}}},
+        {"RejectsNonPacked_Gaps", false, {dims4D}, {{151000, 50200, 225, 1}}},
+        {"RejectsOneNonPacked", false, {dims4D, dims4D}, {nchwStrides, {200000, 60000, 250, 1}}},
+    };
+}
+
+// All tensors must have the same layout
+inline std::vector<TensorDescriptorListTestCase> getValidateConsistentLayoutsTestCases()
+{
+    using namespace canonical_layouts;
+
+    auto dims4D = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
+    auto dims5D = shapes::INFERENCE_5D[0]; // {1, 3, 16, 224, 224}
+    auto nchwStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims4D, TensorLayout::NCHW.strideOrder);
+    auto nhwcStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims4D, TensorLayout::NHWC.strideOrder);
+    auto ncdhwStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims5D, TensorLayout::NCDHW.strideOrder);
+    auto ndhwcStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims5D, TensorLayout::NDHWC.strideOrder);
+    auto degenerateStrides = hipdnn_data_sdk::utilities::generateStrides(
+        shapes::DEGENERATE_4D, TensorLayout::NCHW.strideOrder);
+
+    return {
+        // Happy paths - consistent layouts
+        {"AcceptsSameNchw", true, {dims4D, dims4D}, {nchwStrides, nchwStrides}},
+        {"AcceptsSameNhwc", true, {dims4D, dims4D}, {nhwcStrides, nhwcStrides}},
+        {"AcceptsSameNcdhw", true, {dims5D, dims5D}, {ncdhwStrides, ncdhwStrides}},
+        {"AcceptsWithDegenerate",
+         true, // Degenerate tensors (all dims=1) are layout-agnostic
+         {dims4D, shapes::DEGENERATE_4D},
+         {nchwStrides, degenerateStrides}},
+
+        // Unhappy paths - inconsistent layouts
+        {"RejectsMixedNchwNhwc", false, {dims4D, dims4D}, {nchwStrides, nhwcStrides}},
+        {"RejectsMixedNcdhwNdhwc", false, {dims5D, dims5D}, {ncdhwStrides, ndhwcStrides}},
+    };
+}
+
+inline std::vector<DataTypeIsSupportedTestCase> getValidateDataTypeIsSupportedTestCases()
+{
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    std::unordered_set<DT> ioTypes = {DT::FLOAT, DT::HALF, DT::BFLOAT16};
+
+    return {
+        // Happy paths - supported types
+        {"AcceptsFloat", true, DT::FLOAT, ioTypes},
+        {"AcceptsHalf", true, DT::HALF, ioTypes},
+        {"AcceptsBfloat16", true, DT::BFLOAT16, ioTypes},
+
+        // Unhappy paths - unsupported types
+        {"RejectsUint8", false, DT::UINT8, ioTypes},
+        {"RejectsWithEmptyAllowedList", false, DT::FLOAT, {}}, // Edge case
+    };
+}
+
+// Training requires B × S > 1 (batch × spatial product)
+inline std::vector<SpatialDimensionsTestCase> getValidateSpatialDimensionsTestCases()
+{
+    using namespace canonical_layouts;
+
+    return {
+        // Happy paths - sufficient spatial dimensions (B × S > 1)
+        {"AcceptsSufficientSpatial4D_LargeBatch",
+         true,
+         shapes::INFERENCE_4D[3]}, // {2, 3, 224, 224}
+        {"AcceptsSufficientSpatial5D", true, shapes::INFERENCE_5D[0]}, // {1, 3, 16, 224, 224}
+        {"AcceptsBatch2Spatial1", true, {2, 3, 1, 1}}, // B=2, S=1 → B×S=2 > 1
+        {"AcceptsBatch1Spatial2", true, {1, 3, 2, 1}}, // B=1, S=2 → B×S=2 > 1
+        {"AcceptsLargeSpatial", true, {1, 3, 512, 512}},
+
+        // Unhappy paths - insufficient spatial dimensions (B × S ≤ 1)
+        {"RejectsBatch1Spatial1_4D", false, shapes::INSUFFICIENT_SPATIAL_4D}, // {1, 3, 1, 1}
+        {"RejectsBatch1Spatial1_5D", false, {1, 3, 1, 1, 1}}, // B=1, S=1 → B×S=1 ≤ 1
+        {"RejectsZeroBatch", false, {0, 3, 224, 224}}, // B=0 → B×S=0 ≤ 1
+        {"RejectsZeroSpatial", false, {2, 3, 0, 0}}, // S=0 → B×S=0 ≤ 1
+    };
+}
+
+// Validates a group of tensors all have the same data type from allowed list
+inline std::vector<ConsistentDataTypesTestCase> getValidateConsistentDataTypesTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+
+    const auto& testDims = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
+    auto testStrides
+        = hipdnn_data_sdk::utilities::generateStrides(testDims, TensorLayout::NCHW.strideOrder);
+
+    return {
+        // Happy paths - consistent types
+        {"AcceptsConsistentFloat",
+         true,
+         {createIoTensor(1, "float_tensor_a", DT::FLOAT, testDims, testStrides),
+          createIoTensor(2, "float_tensor_b", DT::FLOAT, testDims, testStrides)},
+         {1, 2},
+         bn_type_configs::getAllowedIoTypes()},
+        {"AcceptsConsistentHalf",
+         true,
+         {createIoTensor(1, "half_tensor_a", DT::HALF, testDims, testStrides),
+          createIoTensor(2, "half_tensor_b", DT::HALF, testDims, testStrides)},
+         {1, 2},
+         bn_type_configs::getAllowedIoTypes()},
+        {"AcceptsSingleTensor",
+         true,
+         {createIoTensor(1, "single_tensor", DT::FLOAT, testDims, testStrides)},
+         {1},
+         bn_type_configs::getAllowedIoTypes()},
+        {"AcceptsEmptyTensorList", true, {}, {}, bn_type_configs::getAllowedIoTypes()},
+
+        // Unhappy paths - inconsistent types or unsupported types
+        {"RejectsInconsistentTypes_FloatHalf",
+         false,
+         {createIoTensor(1, "float_tensor", DT::FLOAT, testDims, testStrides),
+          createIoTensor(2, "half_tensor", DT::HALF, testDims, testStrides)},
+         {1, 2},
+         bn_type_configs::getAllowedIoTypes()},
+        {"RejectsUnsupportedType",
+         false,
+         {createIoTensor(1, "unsupported_uint8_tensor", DT::UINT8, testDims, testStrides)},
+         {1},
+         bn_type_configs::getAllowedIoTypes()},
+    };
+}
+
+// Validates all specified tensors have a specific required data type
+inline std::vector<FixedDataTypeTestCase> getValidateFixedDataTypeTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+
+    auto derivedDims
+        = hipdnn_data_sdk::utilities::getDerivedShape(shapes::INFERENCE_4D[2]); // {1, 3, 1, 1}
+    auto derivedStrides
+        = hipdnn_data_sdk::utilities::generateStrides(derivedDims, TensorLayout::NCHW.strideOrder);
+
+    return {
+        // Happy paths - matching types
+        {"AcceptsMatchingFloat",
+         true,
+         {{1, "t1", DT::FLOAT, derivedDims, derivedStrides, ""}},
+         {1},
+         DT::FLOAT},
+        {"AcceptsMultipleMatchingFloat",
+         true,
+         {{1, "t1", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {2, "t2", DT::FLOAT, derivedDims, derivedStrides, ""}},
+         {1, 2},
+         DT::FLOAT},
+        {"AcceptsMatchingHalf",
+         true,
+         {{1, "t1", DT::HALF, derivedDims, derivedStrides, ""}},
+         {1},
+         DT::HALF},
+
+        // Unhappy paths - mismatched types
+        {"RejectsMismatchedType_HalfExpectFloat",
+         false,
+         {{1, "t1", DT::HALF, derivedDims, derivedStrides, ""}},
+         {1},
+         DT::FLOAT},
+        {"RejectsMismatchedType_FloatExpectHalf",
+         false,
+         {{1, "t1", DT::FLOAT, derivedDims, derivedStrides, ""}},
+         {1},
+         DT::HALF},
+        {"RejectsOneMismatch",
+         false,
+         {{1, "t1", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {2, "t2", DT::HALF, derivedDims, derivedStrides, ""}},
+         {1, 2},
+         DT::FLOAT},
+    };
+}
+
+// Validates all tensors have the same shape
+inline std::vector<ConsistentShapesTestCase> getValidateConsistentShapesTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+
+    auto canonicalDims = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
+    auto canonicalStrides = hipdnn_data_sdk::utilities::generateStrides(
+        canonicalDims, TensorLayout::NCHW.strideOrder);
+    auto mediumDims = shapes::INFERENCE_4D[1]; // {1, 3, 112, 112}
+    auto mediumStrides
+        = hipdnn_data_sdk::utilities::generateStrides(mediumDims, TensorLayout::NCHW.strideOrder);
+    auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(canonicalDims); // {1, 3, 1, 1}
+    auto derivedStrides
+        = hipdnn_data_sdk::utilities::generateStrides(derivedDims, TensorLayout::NCHW.strideOrder);
+    auto differentChannelsDims = shapes::DIFFERENT_CHANNELS_4D; // {1, 5, 224, 224}
+    auto differentChannelsStrides = hipdnn_data_sdk::utilities::generateStrides(
+        differentChannelsDims, TensorLayout::NCHW.strideOrder);
+
+    return {
+        // Happy paths - matching shapes
+        {"AcceptsMatchingShape",
+         true,
+         {{1, "t1", DT::FLOAT, canonicalDims, canonicalStrides, ""}},
+         {1},
+         canonicalDims},
+        {"AcceptsMultipleMatchingShapes",
+         true,
+         {{1, "t1", DT::FLOAT, canonicalDims, canonicalStrides, ""},
+          {2, "t2", DT::FLOAT, canonicalDims, canonicalStrides, ""}},
+         {1, 2},
+         canonicalDims},
+        {"AcceptsDerivedShape",
+         true,
+         {{1, "t1", DT::FLOAT, derivedDims, derivedStrides, ""}},
+         {1},
+         derivedDims},
+
+        // Unhappy paths - mismatched shapes
+        {"RejectsMismatchedShape_DifferentSpatial",
+         false,
+         {{1, "t1", DT::FLOAT, mediumDims, mediumStrides, ""}},
+         {1},
+         canonicalDims},
+        {"RejectsMismatchedShape_DifferentChannels",
+         false,
+         {{1, "t1", DT::FLOAT, differentChannelsDims, differentChannelsStrides, ""}},
+         {1},
+         canonicalDims},
+        {"RejectsOneMismatch",
+         false,
+         {{1, "t1", DT::FLOAT, canonicalDims, canonicalStrides, ""},
+          {2, "t2", DT::FLOAT, mediumDims, mediumStrides, ""}},
+         {1, 2},
+         canonicalDims},
+    };
+}
+
+// --- Test Data Providers: Layer 2 (Component Validators) ---
+
+inline std::vector<TensorLayoutsAndDimsTestCase> getCheckTensorLayoutsAndDimsSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+
+    auto dims4D = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
+    auto dims5D = shapes::INFERENCE_5D[0]; // {1, 3, 16, 224, 224}
+    auto nchwStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims4D, TensorLayout::NCHW.strideOrder);
+    auto nhwcStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims4D, TensorLayout::NHWC.strideOrder);
+    auto ncdhwStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims5D, TensorLayout::NCDHW.strideOrder);
+    auto ndhwcStrides
+        = hipdnn_data_sdk::utilities::generateStrides(dims5D, TensorLayout::NDHWC.strideOrder);
+
+    return {
+        // Happy paths - valid layouts and dimensions
+        {"AcceptsNchw4D", true, {{1, "x", DT::FLOAT, dims4D, nchwStrides, ""}}},
+        {"AcceptsNhwc4D", true, {{1, "x", DT::FLOAT, dims4D, nhwcStrides, ""}}},
+        {"AcceptsNcdhw5D", true, {{1, "x", DT::FLOAT, dims5D, ncdhwStrides, ""}}},
+        {"AcceptsNdhwc5D", true, {{1, "x", DT::FLOAT, dims5D, ndhwcStrides, ""}}},
+
+        // Unhappy paths - mixed layouts
+        {"RejectsMixedNchwNhwc",
+         false,
+         {{1, "x1", DT::FLOAT, dims4D, nchwStrides, ""},
+          {2, "x2", DT::FLOAT, dims4D, nhwcStrides, ""}}},
+
+        // Unhappy paths - mixed dimensions
+        {"RejectsMixed4D5D",
+         false,
+         {{1, "x1", DT::FLOAT, dims4D, nchwStrides, ""},
+          {2, "x2", DT::FLOAT, dims5D, ncdhwStrides, ""}}},
+
+        // Unhappy paths - non-packed tensors
+        {"RejectsNonPacked", false, {{1, "x", DT::FLOAT, dims4D, {200000, 60000, 250, 1}, ""}}},
+    };
+}
+
+// IO: FLOAT/HALF/BFLOAT16, Affine: FLOAT, Stat: FLOAT
+inline std::vector<TensorDataTypesComponentTestCase> getCheckTensorDataTypesSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+
+    auto ioDims = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
+    auto ioStrides
+        = hipdnn_data_sdk::utilities::generateStrides(ioDims, TensorLayout::NCHW.strideOrder);
+    auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(ioDims); // {1, 3, 1, 1}
+    auto derivedStrides
+        = hipdnn_data_sdk::utilities::generateStrides(derivedDims, TensorLayout::NCHW.strideOrder);
+
+    return {
+        // Happy paths - valid IO data types (FLOAT, HALF, BFLOAT16) with FLOAT affine/stat
+        {"AcceptsFloat_IO",
+         true,
+         {{1, "x", DT::FLOAT, ioDims, ioStrides, ""},
+          {2, "y", DT::FLOAT, ioDims, ioStrides, ""},
+          {3, "scale", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {4, "bias", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {5, "activ_out", DT::FLOAT, ioDims, ioStrides, ""}},
+         {1, 5},
+         {3, 4},
+         {},
+         {2}},
+        {"AcceptsHalf_IO",
+         true,
+         {{1, "x", DT::HALF, ioDims, ioStrides, ""},
+          {2, "y", DT::FLOAT, ioDims, ioStrides, ""},
+          {3, "scale", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {4, "bias", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {5, "activ_out", DT::HALF, ioDims, ioStrides, ""}},
+         {1, 5},
+         {3, 4},
+         {},
+         {2}},
+        {"AcceptsBfloat16_IO",
+         true,
+         {{1, "x", DT::BFLOAT16, ioDims, ioStrides, ""},
+          {2, "y", DT::FLOAT, ioDims, ioStrides, ""},
+          {3, "scale", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {4, "bias", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {5, "activ_out", DT::BFLOAT16, ioDims, ioStrides, ""}},
+         {1, 5},
+         {3, 4},
+         {},
+         {2}},
+
+        // Unhappy paths - invalid data types
+        {"RejectsInvalidInputDataType",
+         false,
+         {{1, "x", DT::UINT8, ioDims, ioStrides, ""}, // Invalid
+          {2, "y", DT::FLOAT, ioDims, ioStrides, ""},
+          {3, "scale", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {4, "bias", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {5, "activ_out", DT::HALF, ioDims, ioStrides, ""}},
+         {1, 5},
+         {3, 4},
+         {},
+         {2}},
+
+        {"RejectsInvalidAffineType",
+         false,
+         {{1, "x", DT::HALF, ioDims, ioStrides, ""},
+          {2, "y", DT::FLOAT, ioDims, ioStrides, ""},
+          {3, "scale", DT::HALF, derivedDims, derivedStrides, ""}, // Invalid
+          {4, "bias", DT::HALF, derivedDims, derivedStrides, ""}, // Invalid
+          {5, "activ_out", DT::HALF, ioDims, ioStrides, ""}},
+         {1, 5},
+         {3, 4},
+         {},
+         {2}},
+        {"RejectsInvalidIntermediateDataType",
+         false,
+         {{1, "x", DT::HALF, ioDims, ioStrides, ""},
+          {2, "y", DT::HALF, ioDims, ioStrides, ""}, // Invalid
+          {3, "scale", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {4, "bias", DT::FLOAT, derivedDims, derivedStrides, ""},
+          {5, "activ_out", DT::HALF, ioDims, ioStrides, ""}},
+         {1, 5},
+         {3, 4},
+         {},
+         {2}},
+    };
+}
+
+// IO tensors match, affine/stat have derived shape
+inline std::vector<TensorShapesComponentTestCase> getCheckTensorShapesSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+
+    auto inferenceDims = shapes::INFERENCE_4D[2]; // {1, 3, 224, 224}
+    auto inferenceStrides = hipdnn_data_sdk::utilities::generateStrides(
+        inferenceDims, TensorLayout::NCHW.strideOrder);
+    auto trainingDims = shapes::INFERENCE_4D[3]; // {2, 3, 224, 224}
+    auto trainingStrides
+        = hipdnn_data_sdk::utilities::generateStrides(trainingDims, TensorLayout::NCHW.strideOrder);
+    auto mediumDims = shapes::INFERENCE_4D[1]; // {1, 3, 112, 112}
+    auto mediumStrides
+        = hipdnn_data_sdk::utilities::generateStrides(mediumDims, TensorLayout::NCHW.strideOrder);
+    auto insufficientDims = shapes::INSUFFICIENT_SPATIAL_4D; // {1, 3, 1, 1}
+    auto insufficientStrides = hipdnn_data_sdk::utilities::generateStrides(
+        insufficientDims, TensorLayout::NCHW.strideOrder);
+
+    auto derivedDimsInference
+        = hipdnn_data_sdk::utilities::getDerivedShape(inferenceDims); // {1, 3, 1, 1}
+    auto derivedStridesInference = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDimsInference, TensorLayout::NCHW.strideOrder);
+    auto derivedDimsTraining
+        = hipdnn_data_sdk::utilities::getDerivedShape(trainingDims); // {1, 3, 1, 1}
+    auto derivedStridesTraining = hipdnn_data_sdk::utilities::generateStrides(
+        derivedDimsTraining, TensorLayout::NCHW.strideOrder);
+
+    auto wrongChannelDerivedDims = hipdnn_data_sdk::utilities::getDerivedShape(
+        shapes::DIFFERENT_CHANNELS_4D); // {1, 5, 1, 1}
+    auto wrongChannelDerivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        wrongChannelDerivedDims, TensorLayout::NCHW.strideOrder);
+
+    return {
+        // Happy paths - valid shapes for inference
+        {"AcceptsValidInferenceShapes",
+         true,
+         {{1, "x", DT::FLOAT, inferenceDims, inferenceStrides, ""},
+          {2, "y", DT::FLOAT, inferenceDims, inferenceStrides, ""},
+          {3, "scale", DT::FLOAT, derivedDimsInference, derivedStridesInference, ""},
+          {4, "bias", DT::FLOAT, derivedDimsInference, derivedStridesInference, ""}},
+         {1, 2},
+         {3, 4},
+         {},
+         false},
+
+        // Happy paths - valid shapes for training with sufficient spatial
+        {"AcceptsValidTrainingShapes",
+         true,
+         {{1, "x", DT::FLOAT, trainingDims, trainingStrides, ""},
+          {2, "y", DT::FLOAT, trainingDims, trainingStrides, ""},
+          {3, "scale", DT::FLOAT, derivedDimsTraining, derivedStridesTraining, ""}},
+         {1, 2},
+         {3},
+         {},
+         true},
+
+        // Unhappy paths - inconsistent IO shapes
+        {"RejectsInconsistentIoShapes",
+         false,
+         {{1, "x", DT::FLOAT, inferenceDims, inferenceStrides, ""},
+          {2, "y", DT::FLOAT, mediumDims, mediumStrides, ""},
+          {3, "scale", DT::FLOAT, derivedDimsInference, derivedStridesInference, ""}},
+         {1, 2},
+         {3},
+         {},
+         false},
+
+        // Unhappy paths - wrong derived channel count
+        {"RejectsWrongDerivedChannels",
+         false,
+         {{1, "x", DT::FLOAT, inferenceDims, inferenceStrides, ""},
+          {3, "scale", DT::FLOAT, wrongChannelDerivedDims, wrongChannelDerivedStrides, ""}},
+         {1},
+         {3},
+         {},
+         false},
+
+        // Unhappy paths - insufficient spatial for training (B × S ≤ 1)
+        {"RejectsInsufficientSpatialForTraining",
+         false,
+         {{1, "x", DT::FLOAT, insufficientDims, insufficientStrides, ""},
+          {2, "y", DT::FLOAT, insufficientDims, insufficientStrides, ""}},
+         {1, 2},
+         {},
+         {},
+         true},
+    };
+}
+
+// --- Test Data Providers: Layer 3 (High-Level Validators) ---
+
+inline std::vector<BatchnormInferenceConfigTestCase>
+    getCheckBatchnormInferenceConfigSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using UIDs = BnCommonTensorIds;
+
+    std::vector<BatchnormInferenceConfigTestCase> cases;
+
+    // Happy paths - all shapes × all 4D layouts × all valid type configurations
+    for(const auto& dims : shapes::INFERENCE_4D)
+    {
+        for(const auto* layout : LAYOUTS_4D)
+        {
+            for(const auto& typeConfig : bn_type_configs::VALID)
+            {
+                cases.push_back(
+                    {"AcceptsInference_" + generateName(dims, *layout) + "_" + toString(typeConfig),
+                     true,
+                     createBatchnormInferenceTensors(typeConfig, dims, *layout),
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::MEAN,
+                     UIDs::INV_VARIANCE});
+            }
+        }
+    }
+
+    // Happy paths - 5D shapes × 5D layouts × all valid type configurations
+    for(const auto& dims : shapes::INFERENCE_5D)
+    {
+        for(const auto* layout : LAYOUTS_5D)
+        {
+            for(const auto& typeConfig : bn_type_configs::VALID)
+            {
+                cases.push_back(
+                    {"AcceptsInference_" + generateName(dims, *layout) + "_" + toString(typeConfig),
+                     true,
+                     createBatchnormInferenceTensors(typeConfig, dims, *layout),
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::MEAN,
+                     UIDs::INV_VARIANCE});
+            }
+        }
+    }
+
+    // Unhappy paths - all invalid type configurations
+    auto sampleDims = shapes::INFERENCE_4D[0];
+    for(const auto& invalidConfig : type_configs::INVALID_ALL)
+    {
+        cases.push_back(
+            {"RejectsInference_" + toString(invalidConfig),
+             false,
+             createBatchnormInferenceTensors(invalidConfig, sampleDims, TensorLayout::NCHW),
+             UIDs::X,
+             UIDs::Y,
+             UIDs::SCALE,
+             UIDs::BIAS,
+             UIDs::MEAN,
+             UIDs::INV_VARIANCE});
+    }
+
+    // Unhappy paths - mixed layouts (x is NCHW, y is NHWC)
+    auto nchwStrides
+        = hipdnn_data_sdk::utilities::generateStrides(sampleDims, TensorLayout::NCHW.strideOrder);
+    auto nhwcStrides
+        = hipdnn_data_sdk::utilities::generateStrides(sampleDims, TensorLayout::NHWC.strideOrder);
+    auto sampleDerivedDims = hipdnn_data_sdk::utilities::getDerivedShape(sampleDims);
+    auto sampleDerivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        sampleDerivedDims, TensorLayout::NCHW.strideOrder);
+
+    std::vector<TensorConfig> mixedLayoutConfigs
+        = {{UIDs::X, "x", DT::FLOAT, sampleDims, nchwStrides, ""},
+           {UIDs::Y, "y", DT::FLOAT, sampleDims, nhwcStrides, ""},
+           {UIDs::SCALE, "scale", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::BIAS, "bias", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::MEAN, "mean", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::INV_VARIANCE,
+            "inv_variance",
+            DT::FLOAT,
+            sampleDerivedDims,
+            sampleDerivedStrides,
+            ""}};
+    cases.push_back({"RejectsInference_MixedLayouts",
+                     false,
+                     mixedLayoutConfigs,
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::MEAN,
+                     UIDs::INV_VARIANCE});
+
+    return cases;
+}
+
+inline std::vector<BatchnormTrainingConfigTestCase>
+    getCheckBatchnormTrainingConfigSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using UIDs = BnTrainingTensorIds;
+
+    std::vector<BatchnormTrainingConfigTestCase> cases;
+
+    // ========================================================================
+    // Happy Paths: Valid Type Configurations from bn_type_configs::VALID
+    // ========================================================================
+
+    // All training shapes × all layouts × all valid type configs × 2 variants
+    for(const auto& typeConfig : bn_type_configs::VALID)
+    {
+        for(const auto& dims : shapes::TRAINING_4D)
+        {
+            for(const auto* layout : LAYOUTS_4D)
+            {
+                // With mean/variance
+                cases.push_back(
+                    {"AcceptsTraining_" + generateName(dims, *layout) + "_" + toString(typeConfig)
+                         + "_WithMeanVar",
+                     true,
+                     createBatchnormTrainingTensors(typeConfig, dims, *layout, true, true),
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     flatbuffers::Optional<int64_t>(UIDs::MEAN),
+                     flatbuffers::Optional<int64_t>(UIDs::INV_VARIANCE)});
+                // Without mean/variance
+                cases.push_back(
+                    {"AcceptsTraining_" + generateName(dims, *layout) + "_" + toString(typeConfig)
+                         + "_WithoutMeanVar",
+                     true,
+                     createBatchnormTrainingTensors(typeConfig, dims, *layout, false, false),
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     flatbuffers::nullopt,
+                     flatbuffers::nullopt});
+            }
+        }
+    }
+
+    // Happy paths - 5D training shapes × all valid type configs
+    for(const auto& typeConfig : bn_type_configs::VALID)
+    {
+        for(const auto& dims : shapes::TRAINING_5D)
+        {
+            for(const auto* layout : LAYOUTS_5D)
+            {
+                // With mean/variance
+                cases.push_back(
+                    {"AcceptsTraining_" + generateName(dims, *layout) + "_" + toString(typeConfig)
+                         + "_WithMeanVar",
+                     true,
+                     createBatchnormTrainingTensors(typeConfig, dims, *layout, true, true),
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     flatbuffers::Optional<int64_t>(UIDs::MEAN),
+                     flatbuffers::Optional<int64_t>(UIDs::INV_VARIANCE)});
+                // Without mean/variance
+                cases.push_back(
+                    {"AcceptsTraining_" + generateName(dims, *layout) + "_" + toString(typeConfig)
+                         + "_WithoutMeanVar",
+                     true,
+                     createBatchnormTrainingTensors(typeConfig, dims, *layout, false, false),
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     flatbuffers::nullopt,
+                     flatbuffers::nullopt});
+            }
+        }
+    }
+
+    // ========================================================================
+    // Unhappy Paths: Invalid Configurations
+    // ========================================================================
+
+    auto sampleTrainingDims = shapes::TRAINING_4D[0];
+
+    // Unhappy paths - insufficient spatial dimensions (B × S ≤ 1)
+    cases.push_back({"RejectsTraining_InsufficientSpatial_1x1",
+                     false,
+                     createBatchnormTrainingTensors(bn_type_configs::ALL_FLOAT,
+                                                    shapes::INSUFFICIENT_SPATIAL_4D,
+                                                    TensorLayout::NCHW,
+                                                    false,
+                                                    false),
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     flatbuffers::nullopt,
+                     flatbuffers::nullopt});
+
+    // Unhappy paths - invalid IO data type (UINT8 instead of FLOAT)
+    auto sampleTrainingStrides = hipdnn_data_sdk::utilities::generateStrides(
+        sampleTrainingDims, TensorLayout::NCHW.strideOrder);
+    auto derivedTrainingDims = hipdnn_data_sdk::utilities::getDerivedShape(sampleTrainingDims);
+    auto derivedTrainingStrides = hipdnn_data_sdk::utilities::generateStrides(
+        derivedTrainingDims, TensorLayout::NCHW.strideOrder);
+
+    std::vector<TensorConfig> invalidTypeConfigs = {
+        {UIDs::X, "x", DT::UINT8, sampleTrainingDims, sampleTrainingStrides, "", false, false, 0.0},
+        {UIDs::Y, "y", DT::UINT8, sampleTrainingDims, sampleTrainingStrides, "", false, false, 0.0},
+        {UIDs::SCALE,
+         "scale",
+         DT::FLOAT,
+         derivedTrainingDims,
+         derivedTrainingStrides,
+         "",
+         false,
+         false,
+         0.0},
+        {UIDs::BIAS,
+         "bias",
+         DT::FLOAT,
+         derivedTrainingDims,
+         derivedTrainingStrides,
+         "",
+         false,
+         false,
+         0.0},
+        {UIDs::EPSILON, "epsilon", DT::FLOAT, {1}, {1}, "", false, true, 1e-5}};
+    cases.push_back({"RejectsTraining_InvalidIoDataType",
+                     false,
+                     invalidTypeConfigs,
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     flatbuffers::nullopt,
+                     flatbuffers::nullopt});
+
+    // Unhappy paths - non-packed tensor (invalid strides)
+    std::vector<TensorConfig> nonPackedConfigs = {
+        {UIDs::X,
+         "x",
+         DT::FLOAT,
+         sampleTrainingDims,
+         {1000, 300, 20, 1},
+         "",
+         false,
+         false,
+         0.0}, // Non-packed! (intentionally invalid strides)
+        {UIDs::Y, "y", DT::FLOAT, sampleTrainingDims, sampleTrainingStrides, "", false, false, 0.0},
+        {UIDs::SCALE,
+         "scale",
+         DT::FLOAT,
+         derivedTrainingDims,
+         derivedTrainingStrides,
+         "",
+         false,
+         false,
+         0.0},
+        {UIDs::BIAS,
+         "bias",
+         DT::FLOAT,
+         derivedTrainingDims,
+         derivedTrainingStrides,
+         "",
+         false,
+         false,
+         0.0},
+        {UIDs::EPSILON, "epsilon", DT::FLOAT, {1}, {1}, "", false, true, 1e-5}};
+    cases.push_back({"RejectsTraining_NonPackedTensor",
+                     false,
+                     nonPackedConfigs,
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     flatbuffers::nullopt,
+                     flatbuffers::nullopt});
+
+    // Unhappy paths - all invalid type configurations
+    for(const auto& invalidConfig : type_configs::INVALID_ALL)
+    {
+        const bool hasInvalidStatType = (invalidConfig.stat != DT::FLOAT);
+
+        // Always test with mean/variance outputs (validates all types)
+        cases.push_back({"RejectsTraining_" + toString(invalidConfig) + "_WithMeanVar",
+                         false,
+                         createBatchnormTrainingTensors(
+                             invalidConfig, sampleTrainingDims, TensorLayout::NCHW, true, true),
+                         UIDs::X,
+                         UIDs::Y,
+                         UIDs::SCALE,
+                         UIDs::BIAS,
+                         UIDs::EPSILON,
+                         flatbuffers::Optional<int64_t>(UIDs::MEAN),
+                         flatbuffers::Optional<int64_t>(UIDs::INV_VARIANCE)});
+
+        // Only test without mean/variance if stat type is valid (FLOAT)
+        // (Can't validate stat type if no stat tensors exist)
+        if(!hasInvalidStatType)
+        {
+            cases.push_back(
+                {"RejectsTraining_" + toString(invalidConfig) + "_NoMeanVar",
+                 false,
+                 createBatchnormTrainingTensors(
+                     invalidConfig, sampleTrainingDims, TensorLayout::NCHW, false, false),
+                 UIDs::X,
+                 UIDs::Y,
+                 UIDs::SCALE,
+                 UIDs::BIAS,
+                 UIDs::EPSILON,
+                 flatbuffers::nullopt,
+                 flatbuffers::nullopt});
+        }
+    }
+
+    return cases;
+}
+
+inline std::vector<BatchnormBackwardConfigTestCase>
+    getCheckBatchnormBackwardConfigSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using UIDs = BnBackwardTensorIds;
+
+    std::vector<BatchnormBackwardConfigTestCase> cases;
+
+    // Happy paths - all inference shapes × all 4D layouts × all valid type configs × 2 variants
+    for(const auto& dims : shapes::INFERENCE_4D)
+    {
+        for(const auto* layout : LAYOUTS_4D)
+        {
+            for(const auto& typeConfig : bn_type_configs::VALID)
+            {
+                // With optionals
+                cases.push_back(
+                    {"AcceptsBackward_" + generateName(dims, *layout) + "_" + toString(typeConfig)
+                         + "_WithOptionals",
+                     true,
+                     createBatchnormBackwardTensors(typeConfig, dims, *layout, true, true),
+                     UIDs::X,
+                     UIDs::DY,
+                     UIDs::DX,
+                     UIDs::SCALE,
+                     UIDs::DSCALE,
+                     UIDs::DBIAS,
+                     flatbuffers::Optional<int64_t>(UIDs::MEAN),
+                     flatbuffers::Optional<int64_t>(UIDs::INV_VARIANCE)});
+                // Without optionals
+                cases.push_back(
+                    {"AcceptsBackward_" + generateName(dims, *layout) + "_" + toString(typeConfig)
+                         + "_WithoutOptionals",
+                     true,
+                     createBatchnormBackwardTensors(typeConfig, dims, *layout, false, false),
+                     UIDs::X,
+                     UIDs::DY,
+                     UIDs::DX,
+                     UIDs::SCALE,
+                     UIDs::DSCALE,
+                     UIDs::DBIAS,
+                     flatbuffers::nullopt,
+                     flatbuffers::nullopt});
+            }
+        }
+    }
+
+    // Happy paths - 5D inference shapes × 5D layouts × all valid type configs
+    for(const auto& dims : shapes::INFERENCE_5D)
+    {
+        for(const auto* layout : LAYOUTS_5D)
+        {
+            for(const auto& typeConfig : bn_type_configs::VALID)
+            {
+                // With optionals
+                cases.push_back(
+                    {"AcceptsBackward_" + generateName(dims, *layout) + "_" + toString(typeConfig)
+                         + "_WithOptionals",
+                     true,
+                     createBatchnormBackwardTensors(typeConfig, dims, *layout, true, true),
+                     UIDs::X,
+                     UIDs::DY,
+                     UIDs::DX,
+                     UIDs::SCALE,
+                     UIDs::DSCALE,
+                     UIDs::DBIAS,
+                     flatbuffers::Optional<int64_t>(UIDs::MEAN),
+                     flatbuffers::Optional<int64_t>(UIDs::INV_VARIANCE)});
+                // Without optionals
+                cases.push_back(
+                    {"AcceptsBackward_" + generateName(dims, *layout) + "_" + toString(typeConfig)
+                         + "_WithoutOptionals",
+                     true,
+                     createBatchnormBackwardTensors(typeConfig, dims, *layout, false, false),
+                     UIDs::X,
+                     UIDs::DY,
+                     UIDs::DX,
+                     UIDs::SCALE,
+                     UIDs::DSCALE,
+                     UIDs::DBIAS,
+                     flatbuffers::nullopt,
+                     flatbuffers::nullopt});
+            }
+        }
+    }
+
+    // Unhappy paths - all invalid type configurations
+    auto sampleDims = shapes::INFERENCE_4D[0];
+    for(const auto& invalidConfig : type_configs::INVALID_ALL)
+    {
+        const bool hasInvalidStatType = (invalidConfig.stat != DT::FLOAT);
+
+        // Always test with mean/variance inputs (validates all types)
+        cases.push_back({"RejectsBackward_" + toString(invalidConfig) + "_WithMeanVar",
+                         false,
+                         createBatchnormBackwardTensors(
+                             invalidConfig, sampleDims, TensorLayout::NCHW, true, true),
+                         UIDs::X,
+                         UIDs::DY,
+                         UIDs::DX,
+                         UIDs::SCALE,
+                         UIDs::DSCALE,
+                         UIDs::DBIAS,
+                         flatbuffers::Optional<int64_t>(UIDs::MEAN),
+                         flatbuffers::Optional<int64_t>(UIDs::INV_VARIANCE)});
+
+        // Only test without mean/variance if stat type is valid (FLOAT)
+        // (Can't validate stat type if no stat tensors exist)
+        if(!hasInvalidStatType)
+        {
+            cases.push_back({"RejectsBackward_" + toString(invalidConfig) + "_NoMeanVar",
+                             false,
+                             createBatchnormBackwardTensors(
+                                 invalidConfig, sampleDims, TensorLayout::NCHW, false, false),
+                             UIDs::X,
+                             UIDs::DY,
+                             UIDs::DX,
+                             UIDs::SCALE,
+                             UIDs::DSCALE,
+                             UIDs::DBIAS,
+                             flatbuffers::nullopt,
+                             flatbuffers::nullopt});
+        }
+    }
+
+    // Unhappy paths - inconsistent IO shapes
+    auto sampleStrides
+        = hipdnn_data_sdk::utilities::generateStrides(sampleDims, TensorLayout::NCHW.strideOrder);
+    auto sampleDerivedDims = hipdnn_data_sdk::utilities::getDerivedShape(sampleDims);
+    auto sampleDerivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        sampleDerivedDims, TensorLayout::NCHW.strideOrder);
+    auto mediumDims = shapes::INFERENCE_4D[1]; // {1, 3, 112, 112}
+    auto mediumStrides
+        = hipdnn_data_sdk::utilities::generateStrides(mediumDims, TensorLayout::NCHW.strideOrder);
+
+    std::vector<TensorConfig> inconsistentShapes
+        = {{UIDs::X, "x", DT::FLOAT, sampleDims, sampleStrides, ""},
+           {UIDs::DY, "dy", DT::FLOAT, mediumDims, mediumStrides, ""}, // Different!
+           {UIDs::DX, "dx", DT::FLOAT, sampleDims, sampleStrides, ""},
+           {UIDs::SCALE, "scale", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::DSCALE, "dscale", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::DBIAS, "dbias", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""}};
+    cases.push_back({"RejectsBackward_InconsistentShapes",
+                     false,
+                     inconsistentShapes,
+                     UIDs::X,
+                     UIDs::DY,
+                     UIDs::DX,
+                     UIDs::SCALE,
+                     UIDs::DSCALE,
+                     UIDs::DBIAS,
+                     flatbuffers::nullopt,
+                     flatbuffers::nullopt});
+
+    // Unhappy paths - non-packed tensor
+    std::vector<TensorConfig> nonPackedConfigs
+        = {{UIDs::X, "x", DT::FLOAT, sampleDims, sampleStrides, ""},
+           {UIDs::DY,
+            "dy",
+            DT::FLOAT,
+            sampleDims,
+            {200000, 60000, 250, 1},
+            ""}, // Non-packed! (intentionally invalid strides)
+           {UIDs::DX, "dx", DT::FLOAT, sampleDims, sampleStrides, ""},
+           {UIDs::SCALE, "scale", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::DSCALE, "dscale", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::DBIAS, "dbias", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""}};
+    cases.push_back({"RejectsBackward_NonPackedTensor",
+                     false,
+                     nonPackedConfigs,
+                     UIDs::X,
+                     UIDs::DY,
+                     UIDs::DX,
+                     UIDs::SCALE,
+                     UIDs::DSCALE,
+                     UIDs::DBIAS,
+                     flatbuffers::nullopt,
+                     flatbuffers::nullopt});
+
+    return cases;
+}
+
+inline std::vector<BatchnormFusedBackwardConfigTestCase>
+    getCheckBatchnormFusedBackwardConfigSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using UIDs = BnFusedTensorIds;
+
+    std::vector<BatchnormFusedBackwardConfigTestCase> cases;
+
+    // Supported backward activation modes (from atomic validation tests)
+    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+    const std::vector<PM> supportedBwdActivations = {PM::IDENTITY, PM::RELU_BWD};
+
+    // Happy paths - all inference shapes × all 4D layouts × all valid type configs × all supported activations
+    for(const auto& dims : shapes::INFERENCE_4D)
+    {
+        for(const auto* layout : LAYOUTS_4D)
+        {
+            for(const auto& typeConfig : bn_type_configs::VALID)
+            {
+                for(const auto& activMode : supportedBwdActivations)
+                {
+                    cases.push_back({"AcceptsFused_" + generateName(dims, *layout) + "_"
+                                         + toString(typeConfig) + "_"
+                                         + activationModeToString(activMode),
+                                     true,
+                                     createBatchnormFusedBackwardTensors(typeConfig, dims, *layout),
+                                     UIDs::X,
+                                     UIDs::SCALE,
+                                     UIDs::BIAS,
+                                     UIDs::MEAN,
+                                     UIDs::INV_VARIANCE,
+                                     UIDs::DY,
+                                     UIDs::DX,
+                                     UIDs::DSCALE,
+                                     UIDs::DBIAS,
+                                     UIDs::BN_Y_VIRTUAL,
+                                     UIDs::DX_DRELU_VIRTUAL,
+                                     activMode});
+                }
+            }
+        }
+    }
+
+    // Happy paths - 5D inference shapes × 5D layouts × all valid type configs × all supported activations
+    for(const auto& dims : shapes::INFERENCE_5D)
+    {
+        for(const auto* layout : LAYOUTS_5D)
+        {
+            for(const auto& typeConfig : bn_type_configs::VALID)
+            {
+                for(const auto& activMode : supportedBwdActivations)
+                {
+                    cases.push_back({"AcceptsFused_" + generateName(dims, *layout) + "_"
+                                         + toString(typeConfig) + "_"
+                                         + activationModeToString(activMode),
+                                     true,
+                                     createBatchnormFusedBackwardTensors(typeConfig, dims, *layout),
+                                     UIDs::X,
+                                     UIDs::SCALE,
+                                     UIDs::BIAS,
+                                     UIDs::MEAN,
+                                     UIDs::INV_VARIANCE,
+                                     UIDs::DY,
+                                     UIDs::DX,
+                                     UIDs::DSCALE,
+                                     UIDs::DBIAS,
+                                     UIDs::BN_Y_VIRTUAL,
+                                     UIDs::DX_DRELU_VIRTUAL,
+                                     activMode});
+                }
+            }
+        }
+    }
+
+    // Unhappy paths - all invalid type configurations
+    auto sampleDims = shapes::INFERENCE_4D[0];
+    for(const auto& invalidConfig : type_configs::INVALID_FUSED_ALL)
+    {
+        cases.push_back(
+            {"RejectsFused_" + toString(invalidConfig),
+             false,
+             createBatchnormFusedBackwardTensors(invalidConfig, sampleDims, TensorLayout::NCHW),
+             UIDs::X,
+             UIDs::SCALE,
+             UIDs::BIAS,
+             UIDs::MEAN,
+             UIDs::INV_VARIANCE,
+             UIDs::DY,
+             UIDs::DX,
+             UIDs::DSCALE,
+             UIDs::DBIAS,
+             UIDs::BN_Y_VIRTUAL,
+             UIDs::DX_DRELU_VIRTUAL,
+             PM::RELU_BWD});
+    }
+
+    // Unhappy paths - mixed layouts
+    auto sampleStrides
+        = hipdnn_data_sdk::utilities::generateStrides(sampleDims, TensorLayout::NCHW.strideOrder);
+    auto sampleDerivedDims = hipdnn_data_sdk::utilities::getDerivedShape(sampleDims);
+    auto sampleDerivedStrides = hipdnn_data_sdk::utilities::generateStrides(
+        sampleDerivedDims, TensorLayout::NCHW.strideOrder);
+    auto nhwcStrides
+        = hipdnn_data_sdk::utilities::generateStrides(sampleDims, TensorLayout::NHWC.strideOrder);
+
+    std::vector<TensorConfig> mixedLayoutConfigs
+        = {{UIDs::X, "x", DT::FLOAT, sampleDims, sampleStrides, ""},
+           {UIDs::SCALE, "scale", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::BIAS, "bias", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::MEAN, "mean", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::INV_VARIANCE,
+            "inv_variance",
+            DT::FLOAT,
+            sampleDerivedDims,
+            sampleDerivedStrides,
+            ""},
+           {UIDs::DY, "dy", DT::FLOAT, sampleDims, nhwcStrides, ""}, // NHWC - different!
+           {UIDs::DX, "dx", DT::FLOAT, sampleDims, sampleStrides, ""},
+           {UIDs::DSCALE, "dscale", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::DBIAS, "dbias", DT::FLOAT, sampleDerivedDims, sampleDerivedStrides, ""},
+           {UIDs::BN_Y_VIRTUAL, "BN_Y", DT::FLOAT, sampleDims, sampleStrides, "", true},
+           {UIDs::DX_DRELU_VIRTUAL, "DX_drelu", DT::FLOAT, sampleDims, sampleStrides, "", true}};
+    cases.push_back({"RejectsFused_MixedLayouts",
+                     false,
+                     mixedLayoutConfigs,
+                     BnFusedTensorIds::X,
+                     BnFusedTensorIds::SCALE,
+                     BnFusedTensorIds::BIAS,
+                     BnFusedTensorIds::MEAN,
+                     BnFusedTensorIds::INV_VARIANCE,
+                     BnFusedTensorIds::DY,
+                     BnFusedTensorIds::DX,
+                     BnFusedTensorIds::DSCALE,
+                     BnFusedTensorIds::DBIAS,
+                     BnFusedTensorIds::BN_Y_VIRTUAL,
+                     BnFusedTensorIds::DX_DRELU_VIRTUAL,
+                     PM::RELU_BWD});
+
+    // Unhappy paths - unsupported activation: SIGMOID_BWD
+    cases.push_back({"RejectsFused_UnsupportedActivation_SigmoidBwd",
+                     false,
+                     createBatchnormFusedBackwardTensors(
+                         bn_type_configs::ALL_FLOAT, sampleDims, TensorLayout::NCHW),
+                     BnFusedTensorIds::X,
+                     BnFusedTensorIds::SCALE,
+                     BnFusedTensorIds::BIAS,
+                     BnFusedTensorIds::MEAN,
+                     BnFusedTensorIds::INV_VARIANCE,
+                     BnFusedTensorIds::DY,
+                     BnFusedTensorIds::DX,
+                     BnFusedTensorIds::DSCALE,
+                     BnFusedTensorIds::DBIAS,
+                     BnFusedTensorIds::BN_Y_VIRTUAL,
+                     BnFusedTensorIds::DX_DRELU_VIRTUAL,
+                     PM::SIGMOID_BWD});
+
+    // Unhappy paths - unsupported activation: TANH_BWD
+    cases.push_back({"RejectsFused_UnsupportedActivation_TanhBwd",
+                     false,
+                     createBatchnormFusedBackwardTensors(
+                         bn_type_configs::ALL_FLOAT, sampleDims, TensorLayout::NCHW),
+                     BnFusedTensorIds::X,
+                     BnFusedTensorIds::SCALE,
+                     BnFusedTensorIds::BIAS,
+                     BnFusedTensorIds::MEAN,
+                     BnFusedTensorIds::INV_VARIANCE,
+                     BnFusedTensorIds::DY,
+                     BnFusedTensorIds::DX,
+                     BnFusedTensorIds::DSCALE,
+                     BnFusedTensorIds::DBIAS,
+                     BnFusedTensorIds::BN_Y_VIRTUAL,
+                     BnFusedTensorIds::DX_DRELU_VIRTUAL,
+                     PM::TANH_BWD});
+
+    // Unhappy paths - unsupported activation: RELU_FWD (wrong direction)
+    cases.push_back({"RejectsFused_UnsupportedActivation_ReluFwdInBwdContext",
+                     false,
+                     createBatchnormFusedBackwardTensors(
+                         bn_type_configs::ALL_FLOAT, sampleDims, TensorLayout::NCHW),
+                     BnFusedTensorIds::X,
+                     BnFusedTensorIds::SCALE,
+                     BnFusedTensorIds::BIAS,
+                     BnFusedTensorIds::MEAN,
+                     BnFusedTensorIds::INV_VARIANCE,
+                     BnFusedTensorIds::DY,
+                     BnFusedTensorIds::DX,
+                     BnFusedTensorIds::DSCALE,
+                     BnFusedTensorIds::DBIAS,
+                     BnFusedTensorIds::BN_Y_VIRTUAL,
+                     BnFusedTensorIds::DX_DRELU_VIRTUAL,
+                     PM::RELU_FWD});
+
+    return cases;
+}
+
+inline std::vector<ActivationModeTestCase> getCheckBatchnormFwdActivationModeSupportedTestCases()
+{
+    return {
+        // Happy paths - supported activation modes
+        {"AcceptsIdentity",
+         true,
+         hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+        {"AcceptsRelu",
+         true,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+        {"AcceptsClippedRelu",
+         true,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         flatbuffers::nullopt,
+         flatbuffers::Optional<double>(6.0),
+         flatbuffers::nullopt},
+        {"AcceptsClamp",
+         true,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         flatbuffers::Optional<double>(0.0),
+         flatbuffers::Optional<double>(6.0),
+         flatbuffers::nullopt},
+
+        // Unhappy paths - unsupported activation modes
+        {"RejectsLeakyRelu",
+         false,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::Optional<double>(0.01)},
+        {"RejectsSigmoid",
+         false,
+         hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_FWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+        {"RejectsTanh",
+         false,
+         hipdnn_data_sdk::data_objects::PointwiseMode::TANH_FWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+        {"RejectsReluBwdInFwdContext",
+         false,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+    };
+}
+
+inline std::vector<ActivationModeTestCase> getCheckBatchnormBwdActivationModeSupportedTestCases()
+{
+    return {
+        // Happy paths - supported activation modes
+        {"AcceptsIdentityBwd",
+         true,
+         hipdnn_data_sdk::data_objects::PointwiseMode::IDENTITY,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+        {"AcceptsReluBwd",
+         true,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+        {"AcceptsClippedReluBwd",
+         true,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         flatbuffers::nullopt,
+         flatbuffers::Optional<double>(6.0),
+         flatbuffers::nullopt},
+        {"AcceptsClampBwd",
+         true,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         flatbuffers::Optional<double>(0.0),
+         flatbuffers::Optional<double>(6.0),
+         flatbuffers::nullopt},
+
+        // Unhappy paths - unsupported activation modes
+        {"RejectsLeakyReluBwd",
+         false,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::Optional<double>(0.01)},
+        {"RejectsSigmoidBwd",
+         false,
+         hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_BWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+        {"RejectsTanhBwd",
+         false,
+         hipdnn_data_sdk::data_objects::PointwiseMode::TANH_BWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+        {"RejectsReluFwdInBwdContext",
+         false,
+         hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt,
+         flatbuffers::nullopt},
+    };
+}
+
+} // namespace
+
+// --- Test Classes: Layer 1 (Atomic Validators) ---
+
+class TestValidateDimensionCount : public ::testing::TestWithParam<DimensionCountTestCase>
+{
+};
+
+TEST_P(TestValidateDimensionCount, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ validators::validateDimensionCount(tc.numDims); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { validators::validateDimensionCount(tc.numDims); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidateDimensionCount,
+                         testing::ValuesIn(getValidateDimensionCountTestCases()));
+
+class TestValidateConsistentDimensions
+    : public ::testing::TestWithParam<TensorDescriptorListTestCase>
+{
+};
+
+TEST_P(TestValidateConsistentDimensions, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    std::vector<BatchnormTensorDescriptor> tensors;
+    tensors.reserve(tc.tensorDims.size());
+    for(size_t i = 0; i < tc.tensorDims.size(); ++i)
+    {
+        flatbuffers::FlatBufferBuilder builder;
+        auto tensorOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+            builder,
+            static_cast<int64_t>(i + 1),
+            ("tensor_" + std::to_string(i + 1)).c_str(),
+            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            &tc.tensorStrides[i],
+            &tc.tensorDims[i]);
+        builder.Finish(tensorOffset);
+
+        const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+            builder.GetBufferPointer());
+        tensors.emplace_back(attr);
+    }
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ validators::validateConsistentDimensions(tensors); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { validators::validateConsistentDimensions(tensors); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidateConsistentDimensions,
+                         testing::ValuesIn(getValidateConsistentDimensionsTestCases()));
+
+class TestValidatePackedTensors : public ::testing::TestWithParam<TensorDescriptorListTestCase>
+{
+};
+
+TEST_P(TestValidatePackedTensors, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    std::vector<BatchnormTensorDescriptor> tensors;
+    tensors.reserve(tc.tensorDims.size());
+    for(size_t i = 0; i < tc.tensorDims.size(); ++i)
+    {
+        flatbuffers::FlatBufferBuilder builder;
+        auto tensorOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+            builder,
+            static_cast<int64_t>(i + 1),
+            ("tensor_" + std::to_string(i + 1)).c_str(),
+            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            &tc.tensorStrides[i],
+            &tc.tensorDims[i]);
+        builder.Finish(tensorOffset);
+
+        const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+            builder.GetBufferPointer());
+        tensors.emplace_back(attr);
+    }
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ validators::validatePackedTensors(tensors); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { validators::validatePackedTensors(tensors); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidatePackedTensors,
+                         testing::ValuesIn(getValidatePackedTensorsTestCases()));
+
+class TestValidateSupportedLayout : public ::testing::TestWithParam<SupportedLayoutTestCase>
+{
+};
+
+TEST_P(TestValidateSupportedLayout, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ validators::validateSupportedLayout(tc.strideOrder, tc.numDims); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { validators::validateSupportedLayout(tc.strideOrder, tc.numDims); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidateSupportedLayout,
+                         testing::ValuesIn(getValidateSupportedLayoutTestCases()));
+class TestValidateConsistentLayouts : public ::testing::TestWithParam<TensorDescriptorListTestCase>
+{
+};
+
+TEST_P(TestValidateConsistentLayouts, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    std::vector<BatchnormTensorDescriptor> tensors;
+    tensors.reserve(tc.tensorDims.size());
+    for(size_t i = 0; i < tc.tensorDims.size(); ++i)
+    {
+        flatbuffers::FlatBufferBuilder builder;
+        auto tensorOffset = hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+            builder,
+            static_cast<int64_t>(i + 1),
+            ("tensor_" + std::to_string(i + 1)).c_str(),
+            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            &tc.tensorStrides[i],
+            &tc.tensorDims[i]);
+        builder.Finish(tensorOffset);
+
+        const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::TensorAttributes>(
+            builder.GetBufferPointer());
+        tensors.emplace_back(attr);
+    }
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ validators::validateConsistentLayouts(tensors); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { validators::validateConsistentLayouts(tensors); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidateConsistentLayouts,
+                         testing::ValuesIn(getValidateConsistentLayoutsTestCases()));
+
+class TestValidateDataTypeIsSupported : public ::testing::TestWithParam<DataTypeIsSupportedTestCase>
+{
+};
+
+TEST_P(TestValidateDataTypeIsSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({
+            validators::validateDataTypeIsSupported(
+                tc.dataType, tc.allowedTypes, "Test error message");
+        });
+    }
+    else
+    {
+        EXPECT_THROW(
+            {
+                validators::validateDataTypeIsSupported(
+                    tc.dataType, tc.allowedTypes, "Test error message");
+            },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidateDataTypeIsSupported,
+                         testing::ValuesIn(getValidateDataTypeIsSupportedTestCases()));
+
+class TestValidateConsistentDataTypes : public ::testing::TestWithParam<ConsistentDataTypesTestCase>
+{
+};
+
+TEST_P(TestValidateConsistentDataTypes, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+    auto [builder, tensorMap] = buildTensorMapFromConfigs(tc.tensorConfigs);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({
+            validators::validateConsistentDataTypes(
+                tc.tensorIds, tensorMap, tc.allowedTypes, "Type error", "Consistency error");
+        });
+    }
+    else
+    {
+        EXPECT_THROW(
+            {
+                validators::validateConsistentDataTypes(
+                    tc.tensorIds, tensorMap, tc.allowedTypes, "Type error", "Consistency error");
+            },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidateConsistentDataTypes,
+                         testing::ValuesIn(getValidateConsistentDataTypesTestCases()));
+
+class TestValidateFixedDataType : public ::testing::TestWithParam<FixedDataTypeTestCase>
+{
+};
+
+TEST_P(TestValidateFixedDataType, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+    auto [builder, tensorMap] = buildTensorMapFromConfigs(tc.tensorConfigs);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({
+            validators::validateFixedDataType(
+                tc.tensorIds, tensorMap, tc.expectedType, "Type mismatch error");
+        });
+    }
+    else
+    {
+        EXPECT_THROW(
+            {
+                validators::validateFixedDataType(
+                    tc.tensorIds, tensorMap, tc.expectedType, "Type mismatch error");
+            },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidateFixedDataType,
+                         testing::ValuesIn(getValidateFixedDataTypeTestCases()));
+
+class TestValidateConsistentShapes : public ::testing::TestWithParam<ConsistentShapesTestCase>
+{
+};
+
+TEST_P(TestValidateConsistentShapes, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+    auto [builder, tensorMap] = buildTensorMapFromConfigs(tc.tensorConfigs);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({
+            validators::validateConsistentShapes(
+                tc.tensorIds, tensorMap, tc.referenceShape, "Shape mismatch error");
+        });
+    }
+    else
+    {
+        EXPECT_THROW(
+            {
+                validators::validateConsistentShapes(
+                    tc.tensorIds, tensorMap, tc.referenceShape, "Shape mismatch error");
+            },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidateConsistentShapes,
+                         testing::ValuesIn(getValidateConsistentShapesTestCases()));
+
+class TestValidateSpatialDimensions : public ::testing::TestWithParam<SpatialDimensionsTestCase>
+{
+};
+
+TEST_P(TestValidateSpatialDimensions, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ validators::validateSpatialDimensions(tc.ioDims); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { validators::validateSpatialDimensions(tc.ioDims); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestValidateSpatialDimensions,
+                         testing::ValuesIn(getValidateSpatialDimensionsTestCases()));
+
+// Note: validatePeerStatsNotPopulated is tested through integration tests below
+// (RejectsBatchnormFwdTrainingWithPeerStats, RejectsBatchnormBackwardWithPeerStats)
+
+// --- Test Classes: Layer 2 (Component Validators) ---
+
+class TestCheckTensorLayoutsAndDimsSupported
+    : public ::testing::TestWithParam<TensorLayoutsAndDimsTestCase>
+{
+};
+
+TEST_P(TestCheckTensorLayoutsAndDimsSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+    auto [builder, tensorMap] = buildTensorMapFromConfigs(tc.tensorConfigs);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ checkTensorLayoutsAndDimsSupported(tensorMap); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { checkTensorLayoutsAndDimsSupported(tensorMap); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestCheckTensorLayoutsAndDimsSupported,
+                         testing::ValuesIn(getCheckTensorLayoutsAndDimsSupportedTestCases()));
+
+class TestCheckTensorDataTypesSupported
+    : public ::testing::TestWithParam<TensorDataTypesComponentTestCase>
+{
+};
+
+TEST_P(TestCheckTensorDataTypesSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+    auto [builder, tensorMap] = buildTensorMapFromConfigs(tc.tensorConfigs);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({
+            checkTensorDataTypesSupported(tc.ioTensorIds,
+                                          tc.affineTensorIds,
+                                          tc.statTensorIds,
+                                          tc.intermediateTensorIds,
+                                          tensorMap);
+        });
+    }
+    else
+    {
+        EXPECT_THROW(
+            {
+                checkTensorDataTypesSupported(tc.ioTensorIds,
+                                              tc.affineTensorIds,
+                                              tc.statTensorIds,
+                                              tc.intermediateTensorIds,
+                                              tensorMap);
+            },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestCheckTensorDataTypesSupported,
+                         testing::ValuesIn(getCheckTensorDataTypesSupportedTestCases()));
+
+class TestCheckTensorShapesSupported
+    : public ::testing::TestWithParam<TensorShapesComponentTestCase>
+{
+};
+
+TEST_P(TestCheckTensorShapesSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+    auto [builder, tensorMap] = buildTensorMapFromConfigs(tc.tensorConfigs);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({
+            checkTensorShapesSupported(
+                tc.ioTensorIds, tc.affineTensorIds, tc.statTensorIds, tensorMap, tc.isTraining);
+        });
+    }
+    else
+    {
+        EXPECT_THROW(
+            {
+                checkTensorShapesSupported(
+                    tc.ioTensorIds, tc.affineTensorIds, tc.statTensorIds, tensorMap, tc.isTraining);
+            },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestCheckTensorShapesSupported,
+                         testing::ValuesIn(getCheckTensorShapesSupportedTestCases()));
+
+// --- Test Classes: Layer 3 (High-Level Configuration Validators) ---
+
+class TestCheckBatchnormInferenceConfigSupported
+    : public ::testing::TestWithParam<BatchnormInferenceConfigTestCase>
+{
+};
+
+TEST_P(TestCheckBatchnormInferenceConfigSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    auto builder = buildBatchnormInferenceGraph(
+        tc.tensorConfigs, tc.xUid, tc.yUid, tc.scaleUid, tc.biasUid, tc.meanUid, tc.invVarianceUid);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_BatchnormInferenceAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW(
+            { checkBatchnormInferenceTensorConfigSupported(*attrs, graph.getTensorMap()); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { checkBatchnormInferenceTensorConfigSupported(*attrs, graph.getTensorMap()); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestCheckBatchnormInferenceConfigSupported,
+                         testing::ValuesIn(getCheckBatchnormInferenceConfigSupportedTestCases()));
+
+class TestCheckBatchnormTrainingConfigSupported
+    : public ::testing::TestWithParam<BatchnormTrainingConfigTestCase>
+{
+};
+
+TEST_P(TestCheckBatchnormTrainingConfigSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    auto builder = buildBatchnormTrainingGraph(tc.tensorConfigs,
+                                               tc.xUid,
+                                               tc.yUid,
+                                               tc.scaleUid,
+                                               tc.biasUid,
+                                               tc.epsilonUid,
+                                               tc.meanUid,
+                                               tc.invVarianceUid);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_BatchnormAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW(
+            { checkBatchnormFwdTrainingTensorConfigSupported(*attrs, graph.getTensorMap()); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { checkBatchnormFwdTrainingTensorConfigSupported(*attrs, graph.getTensorMap()); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestCheckBatchnormTrainingConfigSupported,
+                         testing::ValuesIn(getCheckBatchnormTrainingConfigSupportedTestCases()));
+
+class TestCheckBatchnormBackwardConfigSupported
+    : public ::testing::TestWithParam<BatchnormBackwardConfigTestCase>
+{
+};
+
+TEST_P(TestCheckBatchnormBackwardConfigSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    auto builder = buildBatchnormBackwardGraph(tc.tensorConfigs,
+                                               tc.xUid,
+                                               tc.dyUid,
+                                               tc.dxUid,
+                                               tc.scaleUid,
+                                               tc.dscaleUid,
+                                               tc.dbiasUid,
+                                               tc.meanUid,
+                                               tc.invVarianceUid);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_BatchnormBackwardAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW(
+            { checkBatchnormBackwardTensorConfigSupported(*attrs, graph.getTensorMap()); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { checkBatchnormBackwardTensorConfigSupported(*attrs, graph.getTensorMap()); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestCheckBatchnormBackwardConfigSupported,
+                         testing::ValuesIn(getCheckBatchnormBackwardConfigSupportedTestCases()));
+
+class TestCheckBatchnormFusedBackwardConfigSupported
+    : public ::testing::TestWithParam<BatchnormFusedBackwardConfigTestCase>
+{
+};
+
+TEST_P(TestCheckBatchnormFusedBackwardConfigSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    auto builder = buildBatchnormFusedBackwardGraph(tc.tensorConfigs,
+                                                    tc.xUid,
+                                                    tc.scaleUid,
+                                                    tc.biasUid,
+                                                    tc.meanUid,
+                                                    tc.invVarianceUid,
+                                                    tc.dyUid,
+                                                    tc.dxUid,
+                                                    tc.dscaleUid,
+                                                    tc.dbiasUid,
+                                                    tc.bnYVirtualUid,
+                                                    tc.dxDreluVirtualUid,
+                                                    tc.activationMode);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& bnInfNode = graph.getNode(0);
+    const auto& actNode = graph.getNode(1);
+    const auto& bnBwdNode = graph.getNode(2);
+
+    auto* bnInfAttrs = bnInfNode.attributes_as_BatchnormInferenceAttributes();
+    auto* actAttrs = actNode.attributes_as_PointwiseAttributes();
+    auto* bnBwdAttrs = bnBwdNode.attributes_as_BatchnormBackwardAttributes();
+
+    ASSERT_NE(bnInfAttrs, nullptr);
+    ASSERT_NE(actAttrs, nullptr);
+    ASSERT_NE(bnBwdAttrs, nullptr);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({
+            checkBatchnormInferenceActivationBackwardTensorConfigSupported(
+                *bnInfAttrs, *actAttrs, *bnBwdAttrs, graph.getTensorMap());
+        });
+    }
+    else
+    {
+        EXPECT_THROW(
+            {
+                checkBatchnormInferenceActivationBackwardTensorConfigSupported(
+                    *bnInfAttrs, *actAttrs, *bnBwdAttrs, graph.getTensorMap());
+            },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllCases,
+    TestCheckBatchnormFusedBackwardConfigSupported,
+    testing::ValuesIn(getCheckBatchnormFusedBackwardConfigSupportedTestCases()));
+
+class TestCheckBatchnormFwdActivationModeSupported
+    : public ::testing::TestWithParam<ActivationModeTestCase>
+{
+};
+
+TEST_P(TestCheckBatchnormFwdActivationModeSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(builder,
+                                                                            tc.mode,
+                                                                            tc.reluLowerClip,
+                                                                            tc.reluUpperClip,
+                                                                            tc.reluLowerClipSlope,
+                                                                            flatbuffers::nullopt,
+                                                                            1,
+                                                                            flatbuffers::nullopt,
+                                                                            flatbuffers::nullopt,
+                                                                            2);
+    builder.Finish(actAttr);
+
+    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ checkBatchnormFwdActivationModeSupported(*attr); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { checkBatchnormFwdActivationModeSupported(*attr); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestCheckBatchnormFwdActivationModeSupported,
+                         testing::ValuesIn(getCheckBatchnormFwdActivationModeSupportedTestCases()));
+
+class TestCheckBatchnormBwdActivationModeSupported
+    : public ::testing::TestWithParam<ActivationModeTestCase>
+{
+};
+
+TEST_P(TestCheckBatchnormBwdActivationModeSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    flatbuffers::FlatBufferBuilder builder;
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(builder,
+                                                                            tc.mode,
+                                                                            tc.reluLowerClip,
+                                                                            tc.reluUpperClip,
+                                                                            tc.reluLowerClipSlope,
+                                                                            flatbuffers::nullopt,
+                                                                            1,
+                                                                            flatbuffers::nullopt,
+                                                                            flatbuffers::nullopt,
+                                                                            2);
+    builder.Finish(actAttr);
+
+    const auto* attr = flatbuffers::GetRoot<hipdnn_data_sdk::data_objects::PointwiseAttributes>(
+        builder.GetBufferPointer());
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({ checkBatchnormBwdActivationModeSupported(*attr); });
+    }
+    else
+    {
+        EXPECT_THROW(
+            { checkBatchnormBwdActivationModeSupported(*attr); },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(AllCases,
+                         TestCheckBatchnormBwdActivationModeSupported,
+                         testing::ValuesIn(getCheckBatchnormBwdActivationModeSupportedTestCases()));
+
+// --- Integration Tests: Peer Stats Validation ---
+
+TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormFwdTrainingWithPeerStats)
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using UIDs = BnTrainingTensorIds;
+
+    // Create valid tensor configs
+    const auto& dims = shapes::TRAINING_4D[0];
+    auto configs = createBatchnormTrainingTensors(
+        bn_type_configs::ALL_FLOAT, dims, TensorLayout::NCHW, false, false);
+
+    flatbuffers::FlatBufferBuilder builder;
+
+    // Build tensor attributes
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    for(const auto& cfg : configs)
+    {
+        if(cfg.isPassByValue)
+        {
+            hipdnn_data_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
+            auto valueOffset = builder.CreateStruct(floatValue).Union();
+            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                cfg.uid,
+                cfg.name.c_str(),
+                cfg.dataType,
+                &cfg.strides,
+                &cfg.dims,
+                cfg.isVirtual,
+                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
+                valueOffset));
+        }
+        else
+        {
+            tensorOffsets.push_back(
+                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                            cfg.uid,
+                                                                            cfg.name.c_str(),
+                                                                            cfg.dataType,
+                                                                            &cfg.strides,
+                                                                            &cfg.dims,
+                                                                            cfg.isVirtual));
+        }
+    }
+
+    // Create peer_stats_tensor_uid with populated values (should be rejected)
+    std::vector<int64_t> peerStatsUids = {100, 101, 102};
+    auto peerStatsOffset = builder.CreateVector(peerStatsUids);
+
+    // Create BatchnormAttributes WITH peer_stats populated
+    auto bnAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormAttributes(
+        builder,
+        UIDs::X,
+        UIDs::SCALE,
+        UIDs::BIAS,
+        UIDs::EPSILON,
+        peerStatsOffset, // peer_stats populated - should be rejected
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        UIDs::Y,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt);
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_training",
+        DT::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormAttributes,
+        bnAttrs.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder, "test_graph", DT::FLOAT, DT::HALF, DT::BFLOAT16, &tensorOffsets, &nodes);
+
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_BatchnormAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should throw because peer_stats is populated
+    EXPECT_THROW(
+        { checkBatchnormFwdTrainingTensorConfigSupported(*attrs, graph.getTensorMap()); },
+        hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+// --- Variance Extension Support ---
+
+// Creates tensors for BatchnormInferenceAttributesVarianceExt
+inline std::vector<TensorConfig> createBatchnormInferenceWithVarianceTensors(
+    const BnTensorTypes& types, const std::vector<int64_t>& dims, const TensorLayout& layout)
+{
+    using UIDs = BnInferenceVarianceExtTensorIds;
+    std::vector<TensorConfig> configs;
+
+    auto strides = hipdnn_data_sdk::utilities::generateStrides(dims, layout.strideOrder);
+    configs.push_back(createIoTensor(UIDs::X, "x", types.io, dims, strides));
+    configs.push_back(createIoTensor(UIDs::Y, "y", types.io, dims, strides));
+
+    auto derivedDims = hipdnn_data_sdk::utilities::getDerivedShape(dims);
+    auto derivedStrides
+        = hipdnn_data_sdk::utilities::generateStrides(derivedDims, layout.strideOrder);
+    configs.push_back(
+        createAffineTensor(UIDs::SCALE, "scale", types.affine, derivedDims, derivedStrides));
+    configs.push_back(
+        createAffineTensor(UIDs::BIAS, "bias", types.affine, derivedDims, derivedStrides));
+
+    configs.push_back(createScalarTensor(UIDs::EPSILON, "epsilon", 1e-5));
+
+    configs.push_back(
+        createStatTensor(UIDs::MEAN, "mean", types.stat, derivedDims, derivedStrides));
+    configs.push_back(
+        createStatTensor(UIDs::VARIANCE, "variance", types.stat, derivedDims, derivedStrides));
+
+    return configs;
+}
+
+inline flatbuffers::FlatBufferBuilder
+    buildBatchnormInferenceWithVarianceGraph(const std::vector<TensorConfig>& configs,
+                                             int64_t xUid,
+                                             int64_t yUid,
+                                             int64_t scaleUid,
+                                             int64_t biasUid,
+                                             int64_t epsilonUid,
+                                             int64_t meanUid,
+                                             int64_t varianceUid)
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    tensorOffsets.reserve(configs.size());
+    for(const auto& cfg : configs)
+    {
+        if(cfg.isPassByValue)
+        {
+            hipdnn_data_sdk::data_objects::Float64Value floatValue(cfg.passedValue);
+            auto valueOffset = builder.CreateStruct(floatValue).Union();
+            tensorOffsets.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+                builder,
+                cfg.uid,
+                cfg.name.c_str(),
+                cfg.dataType,
+                &cfg.strides,
+                &cfg.dims,
+                cfg.isVirtual,
+                hipdnn_data_sdk::data_objects::TensorValue::Float64Value,
+                valueOffset));
+        }
+        else
+        {
+            tensorOffsets.push_back(
+                hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                            cfg.uid,
+                                                                            cfg.name.c_str(),
+                                                                            cfg.dataType,
+                                                                            &cfg.strides,
+                                                                            &cfg.dims,
+                                                                            cfg.isVirtual));
+        }
+    }
+
+    auto bnAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, xUid, meanUid, varianceUid, scaleUid, biasUid, yUid, epsilonUid);
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_inference_variance_ext",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnAttrs.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test_graph",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorOffsets,
+        &nodes);
+
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+struct BatchnormInferenceVarianceExtConfigTestCase
+{
+    std::string name;
+    bool shouldPass;
+    std::vector<TensorConfig> tensorConfigs;
+    int64_t xUid;
+    int64_t yUid;
+    int64_t scaleUid;
+    int64_t biasUid;
+    int64_t epsilonUid;
+    int64_t meanUid;
+    int64_t varianceUid;
+
+    friend std::ostream& operator<<(std::ostream& os,
+                                    const BatchnormInferenceVarianceExtConfigTestCase& tc)
+    {
+        return os << tc.name;
+    }
+};
+
+inline std::vector<BatchnormInferenceVarianceExtConfigTestCase>
+    getCheckBatchnormInferenceWithVarianceConfigSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using UIDs = BnInferenceVarianceExtTensorIds;
+
+    std::vector<BatchnormInferenceVarianceExtConfigTestCase> cases;
+
+    // Happy paths - all shapes × all 4D layouts × all valid type configurations
+    for(const auto& dims : shapes::INFERENCE_4D)
+    {
+        for(const auto* layout : LAYOUTS_4D)
+        {
+            for(const auto& typeConfig : bn_type_configs::VALID)
+            {
+                cases.push_back(
+                    {"AcceptsInferenceVarExt_" + generateName(dims, *layout) + "_"
+                         + toString(typeConfig),
+                     true,
+                     createBatchnormInferenceWithVarianceTensors(typeConfig, dims, *layout),
+                     UIDs::X,
+                     UIDs::Y,
+                     UIDs::SCALE,
+                     UIDs::BIAS,
+                     UIDs::EPSILON,
+                     UIDs::MEAN,
+                     UIDs::VARIANCE});
+            }
+        }
+    }
+
+    // Happy paths - 5D shapes
+    for(const auto& dims : shapes::INFERENCE_5D)
+    {
+        for(const auto* layout : LAYOUTS_5D)
+        {
+            cases.push_back({"AcceptsInferenceVarExt_" + generateName(dims, *layout) + "_AllFloat",
+                             true,
+                             createBatchnormInferenceWithVarianceTensors(
+                                 bn_type_configs::ALL_FLOAT, dims, *layout),
+                             UIDs::X,
+                             UIDs::Y,
+                             UIDs::SCALE,
+                             UIDs::BIAS,
+                             UIDs::EPSILON,
+                             UIDs::MEAN,
+                             UIDs::VARIANCE});
+        }
+    }
+
+    // Unhappy paths - invalid type configurations
+    const auto& sampleDims = shapes::INFERENCE_4D[0];
+    for(const auto& invalidConfig : type_configs::INVALID_ALL)
+    {
+        cases.push_back({"RejectsInferenceVarExt_" + toString(invalidConfig),
+                         false,
+                         createBatchnormInferenceWithVarianceTensors(
+                             invalidConfig, sampleDims, TensorLayout::NCHW),
+                         UIDs::X,
+                         UIDs::Y,
+                         UIDs::SCALE,
+                         UIDs::BIAS,
+                         UIDs::EPSILON,
+                         UIDs::MEAN,
+                         UIDs::VARIANCE});
+    }
+
+    return cases;
+}
+
+inline std::vector<BatchnormInferenceVarianceExtFusedConfigTestCase>
+    getCheckBatchnormInferenceWithVarianceFusedConfigSupportedTestCases()
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using UIDs = BnInferenceVarianceExtTensorIds;
+    using PM = hipdnn_data_sdk::data_objects::PointwiseMode;
+
+    std::vector<BatchnormInferenceVarianceExtFusedConfigTestCase> cases;
+    const int64_t bnYVirtualUid = 100;
+
+    // Happy paths - all shapes × all 4D layouts × all valid type configurations
+    for(const auto& dims : shapes::INFERENCE_4D)
+    {
+        for(const auto* layout : LAYOUTS_4D)
+        {
+            for(const auto& typeConfig : bn_type_configs::VALID)
+            {
+                auto configs
+                    = createBatchnormInferenceWithVarianceTensors(typeConfig, dims, *layout);
+                // Add virtual tensor for fusion
+                auto strides
+                    = hipdnn_data_sdk::utilities::generateStrides(dims, layout->strideOrder);
+                configs.push_back(createIoTensor(
+                    bnYVirtualUid, "bn_y", typeConfig.intermediate, dims, strides, true));
+
+                cases.push_back({"AcceptsInferenceVarExtFused_" + generateName(dims, *layout) + "_"
+                                     + toString(typeConfig),
+                                 true,
+                                 configs,
+                                 UIDs::X,
+                                 UIDs::Y,
+                                 UIDs::SCALE,
+                                 UIDs::BIAS,
+                                 UIDs::EPSILON,
+                                 UIDs::MEAN,
+                                 UIDs::VARIANCE,
+                                 PM::RELU_FWD});
+            }
+        }
+    }
+
+    // Unhappy paths - all invalid type configurations
+    for(const auto& invalidTypeConfig : type_configs::INVALID_FUSED_ALL)
+    {
+        const auto& dims = shapes::INFERENCE_4D[0];
+        auto layout = LAYOUTS_4D[0];
+        auto configs
+            = createBatchnormInferenceWithVarianceTensors(invalidTypeConfig, dims, *layout);
+        // Add virtual tensor for fusion
+        auto strides = hipdnn_data_sdk::utilities::generateStrides(dims, layout->strideOrder);
+        configs.push_back(createIoTensor(
+            bnYVirtualUid, "bn_y", invalidTypeConfig.intermediate, dims, strides, true));
+
+        cases.push_back({"RejectsInferenceVarExtFused_" + generateName(dims, *layout) + "_"
+                             + toString(invalidTypeConfig),
+                         false,
+                         configs,
+                         UIDs::X,
+                         UIDs::Y,
+                         UIDs::SCALE,
+                         UIDs::BIAS,
+                         UIDs::EPSILON,
+                         UIDs::MEAN,
+                         UIDs::VARIANCE,
+                         PM::RELU_FWD});
+    }
+
+    {
+        // Unhappy paths - unsupported activation mode
+        const auto& sampleDims = shapes::INFERENCE_4D[0];
+        auto configs = createBatchnormInferenceWithVarianceTensors(
+            bn_type_configs::ALL_FLOAT, sampleDims, TensorLayout::NCHW);
+        auto strides = hipdnn_data_sdk::utilities::generateStrides(sampleDims,
+                                                                   TensorLayout::NCHW.strideOrder);
+        configs.push_back(
+            createIoTensor(bnYVirtualUid, "bn_y", DT::FLOAT, sampleDims, strides, true));
+
+        cases.push_back({"RejectsInferenceVarExtFused_UnsupportedActivation",
+                         false,
+                         configs,
+                         UIDs::X,
+                         UIDs::Y,
+                         UIDs::SCALE,
+                         UIDs::BIAS,
+                         UIDs::EPSILON,
+                         UIDs::MEAN,
+                         UIDs::VARIANCE,
+                         PM::SIGMOID_FWD});
+    }
+
+    return cases;
+}
+
+class TestCheckBatchnormInferenceWithVarianceConfigSupported
+    : public ::testing::TestWithParam<BatchnormInferenceVarianceExtConfigTestCase>
+{
+};
+
+TEST_P(TestCheckBatchnormInferenceWithVarianceConfigSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+
+    auto builder = buildBatchnormInferenceWithVarianceGraph(tc.tensorConfigs,
+                                                            tc.xUid,
+                                                            tc.yUid,
+                                                            tc.scaleUid,
+                                                            tc.biasUid,
+                                                            tc.epsilonUid,
+                                                            tc.meanUid,
+                                                            tc.varianceUid);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_BatchnormInferenceAttributesVarianceExt();
+    ASSERT_NE(attrs, nullptr);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({
+            checkBatchnormInferenceVarianceExtTensorConfigSupported(*attrs, graph.getTensorMap());
+        });
+    }
+    else
+    {
+        EXPECT_THROW(
+            {
+                checkBatchnormInferenceVarianceExtTensorConfigSupported(*attrs,
+                                                                        graph.getTensorMap());
+            },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllCases,
+    TestCheckBatchnormInferenceWithVarianceConfigSupported,
+    testing::ValuesIn(getCheckBatchnormInferenceWithVarianceConfigSupportedTestCases()));
+
+class TestCheckBatchnormInferenceWithVarianceFusedConfigSupported
+    : public ::testing::TestWithParam<BatchnormInferenceVarianceExtFusedConfigTestCase>
+{
+};
+
+TEST_P(TestCheckBatchnormInferenceWithVarianceFusedConfigSupported, ValidatesCorrectly)
+{
+    const auto& tc = GetParam();
+    const int64_t bnYVirtualUid = 100;
+
+    auto builder = buildBatchnormInferenceWithVarianceFusedGraph(tc.tensorConfigs,
+                                                                 tc.xUid,
+                                                                 tc.yUid,
+                                                                 tc.scaleUid,
+                                                                 tc.biasUid,
+                                                                 tc.epsilonUid,
+                                                                 tc.meanUid,
+                                                                 tc.varianceUid,
+                                                                 bnYVirtualUid,
+                                                                 tc.activationMode);
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    const auto& bnNode = graph.getNode(0);
+    const auto& actNode = graph.getNode(1);
+
+    auto* bnAttrs = bnNode.attributes_as_BatchnormInferenceAttributesVarianceExt();
+    auto* actAttrs = actNode.attributes_as_PointwiseAttributes();
+
+    ASSERT_NE(bnAttrs, nullptr);
+    ASSERT_NE(actAttrs, nullptr);
+
+    if(tc.shouldPass)
+    {
+        EXPECT_NO_THROW({
+            checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
+                *bnAttrs, *actAttrs, graph.getTensorMap());
+        });
+    }
+    else
+    {
+        EXPECT_THROW(
+            {
+                checkBatchnormInferenceVarianceExtActivationTensorConfigSupported(
+                    *bnAttrs, *actAttrs, graph.getTensorMap());
+            },
+            hipdnn_plugin_sdk::HipdnnPluginException);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllCases,
+    TestCheckBatchnormInferenceWithVarianceFusedConfigSupported,
+    testing::ValuesIn(getCheckBatchnormInferenceWithVarianceFusedConfigSupportedTestCases()));
+
+// --- Integration Tests: Peer Stats Validation ---
+
+namespace
+{
+
+TEST(TestBatchnormApplicabilityChecks, RejectsBatchnormBackwardWithPeerStats)
+{
+    using namespace canonical_layouts;
+    using DT = hipdnn_data_sdk::data_objects::DataType;
+    using UIDs = BnBackwardTensorIds;
+
+    // Create valid tensor configs
+    const auto& dims = shapes::INFERENCE_4D[0];
+    auto configs = createBatchnormBackwardTensors(
+        bn_type_configs::ALL_FLOAT, dims, TensorLayout::NCHW, false, false);
+
+    flatbuffers::FlatBufferBuilder builder;
+
+    // Build tensor attributes
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>> tensorOffsets;
+    tensorOffsets.reserve(configs.size());
+    for(const auto& cfg : configs)
+    {
+        tensorOffsets.push_back(
+            hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(builder,
+                                                                        cfg.uid,
+                                                                        cfg.name.c_str(),
+                                                                        cfg.dataType,
+                                                                        &cfg.strides,
+                                                                        &cfg.dims,
+                                                                        cfg.isVirtual));
+    }
+
+    // Create peer_stats_tensor_uid with populated values (should be rejected)
+    std::vector<int64_t> peerStatsUids = {200, 201};
+    auto peerStatsOffset = builder.CreateVector(peerStatsUids);
+
+    // Create BatchnormBackwardAttributes WITH peer_stats populated
+    auto bnBwdAttrs = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        UIDs::DY,
+        UIDs::X,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        UIDs::SCALE,
+        peerStatsOffset, // peer_stats populated - should be rejected
+        UIDs::DX,
+        UIDs::DSCALE,
+        UIDs::DBIAS);
+
+    std::vector<flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "batchnorm_backward",
+        DT::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttrs.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder, "test_graph", DT::FLOAT, DT::HALF, DT::BFLOAT16, &tensorOffsets, &nodes);
+
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_BatchnormBackwardAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Should throw because peer_stats is populated
+    EXPECT_THROW(
+        { checkBatchnormBackwardTensorConfigSupported(*attrs, graph.getTensorMap()); },
+        hipdnn_plugin_sdk::HipdnnPluginException);
+}
+
+} // namespace

--- a/dnn-providers/hip-kernel-provider/tests/engines/plans/TestBatchnormFwdInferencePlan.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/engines/plans/TestBatchnormFwdInferencePlan.cpp
@@ -1,0 +1,63 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "engines/plans/BatchnormFwdInferencePlan.hpp"
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+
+using namespace hip_kernel_plugin;
+
+TEST(TestBatchnormFwdInferenceParams, InitializesAllTensorsFromValidGraph)
+{
+    // Create a valid batchnorm graph
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    // Get the batchnorm node and attributes
+    const auto& node = graph.getNode(0);
+    auto* attrs = node.attributes_as_BatchnormInferenceAttributes();
+    ASSERT_NE(attrs, nullptr);
+
+    // Expect that params construction doesn't throw
+    EXPECT_NO_THROW(BatchnormFwdInferenceParams(*attrs, graph.getTensorMap()));
+
+    BatchnormFwdInferenceParams params(*attrs, graph.getTensorMap());
+    // verify activation optional params are null when no activation is specified
+    EXPECT_EQ(params.optActivation(), std::nullopt);
+    EXPECT_EQ(params.activationOut(), nullptr);
+}
+
+TEST(TestBatchnormFwdInferenceParams, InitializesFusedActivationBiasWithAllTensors)
+{
+    // Create a fused batchnorm fwd + activation graph
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    // Get the two required nodes
+    const auto& batchnormInfNode = graph.getNode(0);
+    const auto& pointwiseNode = graph.getNode(1);
+
+    auto* batchnormInfAttrs = batchnormInfNode.attributes_as_BatchnormInferenceAttributes();
+    auto* pointwiseAttrs = pointwiseNode.attributes_as_PointwiseAttributes();
+
+    ASSERT_NE(batchnormInfAttrs, nullptr);
+    ASSERT_NE(pointwiseAttrs, nullptr);
+
+    // Construct fused params
+    BatchnormFwdInferenceParams params(*batchnormInfAttrs, *pointwiseAttrs, graph.getTensorMap());
+
+    // All required tensors should be initialized
+    EXPECT_NO_THROW(params.x());
+    EXPECT_NO_THROW(params.y());
+    EXPECT_NO_THROW(params.scale());
+    EXPECT_NO_THROW(params.bias());
+    EXPECT_NO_THROW(params.estMean());
+    EXPECT_NO_THROW(params.invVariance());
+
+    // Optional fusion-specific tensors should be present
+    EXPECT_TRUE(params.optActivation().has_value());
+    EXPECT_NE(params.activationOut(), nullptr);
+}

--- a/dnn-providers/hip-kernel-provider/tests/engines/plans/TestBatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/engines/plans/TestBatchnormPlanBuilder.cpp
@@ -22,7 +22,6 @@ using namespace hip_kernel_plugin;
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_data_sdk::flatbuffer_utilities;
 
-//tests in here
 namespace
 {
 

--- a/dnn-providers/hip-kernel-provider/tests/engines/plans/TestBatchnormPlanBuilder.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/engines/plans/TestBatchnormPlanBuilder.cpp
@@ -1,0 +1,2060 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <numeric>
+#include <unordered_set>
+
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_plugin_sdk/EnginePluginApi.h>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/MockGraph.hpp>
+#include <hipdnn_test_sdk/utilities/MockNode.hpp>
+
+#include <hipdnn_test_sdk/utilities/MockEngineConfig.hpp>
+
+#include "HipdnnEnginePluginHandle.hpp"
+#include "engines/plans/BatchnormPlanBuilder.hpp"
+
+#include "mocks/MockHipdnnEnginePluginExecutionContext.hpp"
+
+using namespace hip_kernel_plugin;
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_data_sdk::flatbuffer_utilities;
+
+//tests in here
+namespace
+{
+
+void createBatchnormFusionTensorAttributes(
+    flatbuffers::FlatBufferBuilder& builder,
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>&
+        tensorAttributes,
+    int64_t numTensors,
+    const std::unordered_set<int64_t>& virtualTensorIds)
+{
+    static const std::unordered_set<int64_t> s_derivedDimTensorIds = {2, 3, 4, 5, 8, 9, 12};
+
+    std::vector<int64_t> dims = {1, 3, 224, 224};
+    std::vector<int64_t> strides = {150528, 50176, 224, 1};
+    std::vector<int64_t> derivedDims = {1, 3, 1, 1};
+    std::vector<int64_t> derivedStrides = {3, 1, 1, 1};
+
+    for(int64_t i = 1; i <= numTensors; ++i)
+    {
+        const auto isDerived = s_derivedDimTensorIds.count(i) > 0;
+        const auto& tensorDims = isDerived ? derivedDims : dims;
+        const auto& tensorStrides = isDerived ? derivedStrides : strides;
+        const auto isVirtual = virtualTensorIds.count(i) > 0;
+
+        tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+            builder,
+            i,
+            ("tensor_" + std::to_string(i)).c_str(),
+            hipdnn_data_sdk::data_objects::DataType::FLOAT,
+            &tensorStrides,
+            &tensorDims,
+            isVirtual));
+    }
+}
+
+} // namespace
+
+class TestBatchnormPlanBuilder : public ::testing::Test
+{
+protected:
+    BatchnormPlanBuilder _planBuilder;
+    HipdnnEnginePluginHandle _dummyHandle;
+};
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForGraphWithUnsupportedNodeCount)
+{
+    MockGraph mockGraph;
+    EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(4));
+    // nodeWrappers is only used in an all_of check which will pass when it's empty
+    std::vector<std::unique_ptr<INodeWrapper>> nodeWrappers;
+    EXPECT_CALL(mockGraph, nodeWrappers()).WillRepeatedly(::testing::ReturnRef(nodeWrappers));
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+
+    EXPECT_FALSE(applicable);
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForUnsupportedAttributes)
+{
+    MockGraph mockGraph;
+    EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(1));
+    EXPECT_CALL(mockGraph, hasOnlySupportedAttributes(::testing::_))
+        .WillOnce(::testing::Return(false));
+    // nodeWrappers is only used in an all_of check which will pass when it's empty
+    std::vector<std::unique_ptr<INodeWrapper>> nodeWrappers;
+    EXPECT_CALL(mockGraph, nodeWrappers()).WillRepeatedly(::testing::ReturnRef(nodeWrappers));
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+
+    EXPECT_FALSE(applicable);
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsTrueForFusedTwoNodeGraph)
+{
+    // Use a real flatbuffer graph with valid fusion pattern
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+
+    EXPECT_TRUE(applicable);
+}
+
+TEST_F(TestBatchnormPlanBuilder, DISABLED_IsApplicableReturnsTrueForFusedThreeNodeGraph)
+{
+    // Use a real flatbuffer graph with valid fusion pattern
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+
+    EXPECT_TRUE(applicable);
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForIncorrectTwoNodeOrder)
+{
+    // Create a graph with 2 nodes but in wrong order
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Wrong order: activation -> batchnorm inference
+    auto node0 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "pointwise",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        0);
+    nodes.push_back(node0);
+
+    auto node1 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inference",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        0);
+    nodes.push_back(node1);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+
+    EXPECT_FALSE(applicable);
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForIncorrectThreeNodeOrder)
+{
+    // Create a graph with 3 nodes but in wrong order
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Wrong order: activation -> batchnorm inference -> batchnorm backward
+    auto node0 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "pointwise",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        0);
+    nodes.push_back(node0);
+
+    auto node1 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inference",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        0);
+    nodes.push_back(node1);
+
+    auto node2 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_backward",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        0);
+    nodes.push_back(node2);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+
+    EXPECT_FALSE(applicable);
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForTwoNodeFusionUnsupportedActivatio)
+{
+    // Fusion graph with unsupported activation (e.g., MUL instead of RELU_FWD)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Activation with unsupported MUL
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::MUL, // Unsupported!
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        6,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+// ============================================================================
+// Single-Node Backward Tests - Happy & Unhappy Paths
+// ============================================================================
+
+TEST_F(TestBatchnormPlanBuilder, DISABLED_IsApplicableReturnsTrueForValidSingleNodeBackward)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, graph);
+
+    EXPECT_TRUE(applicable);
+}
+
+TEST_F(TestBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvalidIoDataType)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph(
+        {150528, 50176, 224, 1},
+        {1, 3, 224, 224},
+        true,
+        hipdnn_data_sdk::data_objects::DataType::UINT8); // Invalid IO data type
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvalidScaleBiasDataType)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph(
+        {150528, 50176, 224, 1},
+        {1, 3, 224, 224},
+        true,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF); // Invalid scale/bias type
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvalidStatDataType)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph(
+        {150528, 50176, 224, 1},
+        {1, 3, 224, 224},
+        true,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF); // Invalid mean/variance type
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInvalidLayout)
+{
+    // Create backward graph with 3D tensors (invalid)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    std::vector<int64_t> strides3D = {42, 14, 1};
+    std::vector<int64_t> dims3D = {1, 3, 14};
+    std::vector<int64_t> derivedStrides = {3, 1, 1};
+    std::vector<int64_t> derivedDims = {1, 3, 1};
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "dy", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 3, "dx", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        4,
+        "scale",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        5,
+        "dscale",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        6,
+        "dbias",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        2,
+        1,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        4,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        3,
+        5,
+        6);
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union());
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, BackwardIsApplicableReturnsFalseForInsufficientSpatialDims)
+{
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph(
+        {3, 1, 1, 1}, {1, 3, 1, 1}); // Batch * spatial = 1 (invalid for training)
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+// ============================================================================
+// Validator Error Propagation Tests - Inference
+// ============================================================================
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForInvalidLayoutInference)
+{
+    // Create an inference graph with 3D tensors (invalid layout)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    std::vector<int64_t> strides3D = {42, 14, 1}; // 3D instead of 4D/5D
+    std::vector<int64_t> dims3D = {1, 3, 14};
+    std::vector<int64_t> derivedStrides = {3, 1, 1, 1};
+    std::vector<int64_t> derivedDims = {1, 3, 1, 1};
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "y", hipdnn_data_sdk::data_objects::DataType::FLOAT, &strides3D, &dims3D));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        3,
+        "scale",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        4,
+        "bias",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        5,
+        "mean",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        6,
+        "inv_variance",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+
+    auto bnormAttributes = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 5, 6, 3, 4, 2);
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnormAttributes.Union());
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+// ============================================================================
+// Validator Error Propagation Tests - Backward
+// ============================================================================
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForNonPackedTensorBackward)
+{
+    // Create a backward graph with non-packed tensors
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    std::vector<int64_t> nonPackedStrides = {1000, 300, 14, 1}; // Non-packed
+    std::vector<int64_t> dims = {1, 3, 14, 14};
+    std::vector<int64_t> derivedStrides = {3, 1, 1, 1};
+    std::vector<int64_t> derivedDims = {1, 3, 1, 1};
+
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", hipdnn_data_sdk::data_objects::DataType::FLOAT, &nonPackedStrides, &dims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        2,
+        "dy",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &nonPackedStrides,
+        &dims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        3,
+        "dx",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &nonPackedStrides,
+        &dims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        4,
+        "scale",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        5,
+        "dscale",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+    tensorAttributes.push_back(hipdnn_data_sdk::data_objects::CreateTensorAttributesDirect(
+        builder,
+        6,
+        "dbias",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        &derivedStrides,
+        &derivedDims));
+
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        2,
+        1,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        4,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        3,
+        5,
+        6);
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union());
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForThreeNodeUnsupportedActivation)
+{
+    // Fusion graph with unsupported activation (e.g., SIGMOID_BWD instead of RELU_BWD)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Activation with unsupported SIGMOID_BWD
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::SIGMOID_BWD, // Unsupported!
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        10,
+        flatbuffers::Optional<int64_t>(6),
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // BN backward
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        11,
+        1,
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        2,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationMissingIn1)
+{
+    // Fusion graph where activation doesn't have in_1 tensor (required for backward)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Activation without in_1 (missing dy gradient!)
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        10,
+        flatbuffers::nullopt, // Missing in_1!
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // BN backward
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        11,
+        1,
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        2,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForFourNodeGraph)
+{
+    MockGraph mockGraph;
+    EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(4));
+    // nodeWrappers is only used in an all_of check which will pass when it's empty
+    std::vector<std::unique_ptr<INodeWrapper>> nodeWrappers;
+    EXPECT_CALL(mockGraph, nodeWrappers()).WillRepeatedly(::testing::ReturnRef(nodeWrappers));
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+
+    EXPECT_FALSE(applicable);
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForUnsupportedComputeType)
+{
+    MockGraph mockGraph;
+    EXPECT_CALL(mockGraph, nodeCount()).WillRepeatedly(::testing::Return(2));
+    auto nodeA = std::make_unique<MockNode>();
+    auto nodeB = std::make_unique<MockNode>();
+    EXPECT_CALL(*nodeA, computeDataType())
+        .WillOnce(::testing::Return(hipdnn_data_sdk::data_objects::DataType::FLOAT));
+    EXPECT_CALL(*nodeB, computeDataType())
+        .WillOnce(::testing::Return(hipdnn_data_sdk::data_objects::DataType::BFLOAT16));
+
+    std::vector<std::unique_ptr<INodeWrapper>> nodeWrappers;
+    nodeWrappers.emplace_back(std::move(nodeA));
+    nodeWrappers.emplace_back(std::move(nodeB));
+    EXPECT_CALL(mockGraph, nodeWrappers()).WillRepeatedly(::testing::ReturnRef(nodeWrappers));
+
+    bool applicable = _planBuilder.isApplicable(_dummyHandle, mockGraph);
+
+    EXPECT_FALSE(applicable);
+}
+
+TEST_F(TestBatchnormPlanBuilder, GetWorkspaceSizeReturnsExpectedValue)
+{
+    MockGraph mockGraph;
+
+    size_t workspaceSize = _planBuilder.getWorkspaceSize(_dummyHandle, mockGraph);
+
+    EXPECT_EQ(workspaceSize, 0u);
+}
+
+TEST_F(TestBatchnormPlanBuilder, BuildPlanSetsPlanForSupportedInferenceNode)
+{
+    // Use a real flatbuffer graph with a valid batchnorm node
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferenceGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_TRUE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, DISABLED_BuildPlanSetsPlanForSupportedInferenceWithVarianceNode)
+{
+    // Use a real flatbuffer graph with a valid batchnorm variance node
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormWithVarianceInferenceGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_TRUE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, DISABLED_BuildPlanSetsPlanForSupportedBackwardNode)
+{
+    // Use a real flatbuffer graph with a valid batchnorm backward node
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormBwdGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_TRUE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, BuildPlanSetsPlanForFusedTwoNodeGraph)
+{
+    // Use a real flatbuffer graph with valid fusion pattern
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormFwdInferActGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_TRUE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, BuildPlanSetsPlanForFusedThreeNodeGraph)
+{
+    // Use a real flatbuffer graph with valid fusion pattern
+    auto builder = hipdnn_test_sdk::utilities::createValidBatchnormInferActBwdGraph();
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_NO_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx));
+    EXPECT_TRUE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, BuildPlanThrowsForUnsupportedNodeType)
+{
+    // Create a graph with a node of unsupported type
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Node with NONE attributes type
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "unsupported",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::NONE,
+        0);
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+                 hipdnn_plugin_sdk::HipdnnPluginException);
+    EXPECT_FALSE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, BuildPlanThrowsForMalformedInferenceAttributes)
+{
+    // Create a graph with batchnorm inference node but malformed attributes
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Node with BatchnormInferenceAttributes type but null attributes pointer
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "malformed_bn_inference",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        0);
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+                 std::invalid_argument);
+    EXPECT_FALSE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, DISABLED_BuildPlanThrowsForMalformedBackwardAttributes)
+{
+    // Create a graph with batchnorm backward node but malformed attributes
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Node with BatchnormBackwardAttributes type but null attributes pointer
+    auto node = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "malformed_bn_backward",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        0);
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+                 std::invalid_argument);
+    EXPECT_FALSE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, BuildPlanThrowsForMalformedTwoNodeFusedGraphFirstNode)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        0)); // Malformed!
+
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        6,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+                 std::invalid_argument);
+    EXPECT_FALSE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, BuildPlanThrowsForMalformedTwoNodeFusedGraphSecondNode)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        0)); //malformed!
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+                 std::invalid_argument);
+    EXPECT_FALSE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, BuildPlanThrowsForMalformedFusedGraphFirstNode)
+{
+    // Create a 3-node graph with malformed first node (batchnorm inference)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Malformed batchnorm inference (null attributes)
+    auto node0 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "malformed_bn_inference",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        0);
+    nodes.push_back(node0);
+
+    // Valid pointwise
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        10,
+        flatbuffers::Optional<int64_t>(6),
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "pointwise",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // Valid batchnorm backward
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        11,
+        1,
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        2,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_backward",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+                 std::invalid_argument);
+    EXPECT_FALSE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, DISABLED_BuildPlanThrowsForMalformedFusedGraphSecondNode)
+{
+    // Create a 3-node graph with malformed second node (pointwise)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Valid batchnorm inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inference",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Malformed pointwise (null attributes)
+    auto node1 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "malformed_pointwise",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        0);
+    nodes.push_back(node1);
+
+    // Valid batchnorm backward
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        11,
+        1,
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        2,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_backward",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+                 std::invalid_argument);
+    EXPECT_FALSE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder, DISABLED_BuildPlanThrowsForMalformedFusedGraphThirdNode)
+{
+    // Create a 3-node graph with malformed third node (batchnorm backward)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // Valid batchnorm inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inference",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Valid pointwise
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        10,
+        flatbuffers::Optional<int64_t>(6),
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "pointwise",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // Malformed batchnorm backward (null attributes)
+    auto node2 = hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "malformed_bn_backward",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        0);
+    nodes.push_back(node2);
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+    HipdnnEnginePluginExecutionContext ctx;
+    MockEngineConfig mockEngineConfig;
+
+    EXPECT_THROW(_planBuilder.buildPlan(_dummyHandle, graph, mockEngineConfig, ctx),
+                 std::invalid_argument);
+    EXPECT_FALSE(ctx.hasValidPlan());
+}
+
+TEST_F(TestBatchnormPlanBuilder,
+       IsApplicableReturnsFalseWhenBnInferenceOutputDoesNotMatchActivationInput)
+{
+    // Fusion graph where BN inference output doesn't connect to activation
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with output uid=10
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Activation with input uid=999
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        999, // Wrong input
+        flatbuffers::Optional<int64_t>(6),
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // BN backward
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        11,
+        1,
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        2,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder,
+       IsApplicableReturnsFalseWhenActivationOutputDoesNotMatchBnBackwardDy)
+{
+    // Fusion graph where activation output doesn't connect to BN backward dy
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10, 11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Activation with output uid=11
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        10,
+        flatbuffers::Optional<int64_t>(6),
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // BN backward with dy=999
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        999, // Wrong dy
+        1,
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        2,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnBackwardXDiffersFromInference)
+{
+    // Fusion graph where BN backward uses different X than BN inference
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 13, {10, 11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with x=1
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Activation
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        10,
+        flatbuffers::Optional<int64_t>(6),
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // BN backward with x=12 (wrong - should be 1 like BN inference)
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        11,
+        12, // Wrong X
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        2,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnBackwardScaleDiffersFromInference)
+{
+    // Fusion graph where BN backward uses different scale than BN inference
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 13, {10, 11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with scale=2
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Activation
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        10,
+        flatbuffers::Optional<int64_t>(6),
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // BN backward with scale=12 (wrong - should be 2 like BN inference)
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        11,
+        1,
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        12, // Wrong scale
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseWhenBnInferenceOutputIsNotVirtual)
+{
+    // Fusion graph where BN inference output tensor is non-virtual (should be virtual)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {11});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with output uid=10 (which is non-virtual - wrong!)
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Activation
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        10,
+        flatbuffers::Optional<int64_t>(6),
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // BN backward
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        11,
+        1,
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        2,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseWhenActivationOutputIsNotVirtual)
+{
+    // Fusion graph where activation output tensor is non-virtual (should be virtual)
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 12, {10});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 10);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    // Activation with output=11 (which is non-virtual - wrong!)
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        10,
+        flatbuffers::Optional<int64_t>(6),
+        flatbuffers::nullopt,
+        11);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    // BN backward
+    auto bnBwdAttr = hipdnn_data_sdk::data_objects::CreateBatchnormBackwardAttributes(
+        builder,
+        11,
+        1,
+        flatbuffers::Optional<int64_t>(4),
+        flatbuffers::Optional<int64_t>(5),
+        2,
+        flatbuffers::Offset<flatbuffers::Vector<int64_t>>(),
+        7,
+        8,
+        9);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_bwd",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormBackwardAttributes,
+        bnBwdAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder,
+       IsApplicableReturnsFalseForTwoNodeFusionWhenInfOutputNotMatchingActInput)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        5, //wrong input
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder, IsApplicableReturnsFalseForTwoNodeFusionWhenInfOutputIsNonVirtual)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {}); //node 6 not virtual
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributes(
+        builder, 1, 4, 5, 2, 3, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributes,
+        bnInfAttr.Union()));
+
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        6,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::UNSET,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+// ============================================================================
+// Variance Extension Fusion Tests
+// ============================================================================
+
+TEST_F(TestBatchnormPlanBuilder, DISABLED_IsApplicableReturnsTrueForFusedTwoNodeGraphWithVariance)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with variance
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf_var",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnInfAttr.Union()));
+
+    // Activation
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        6,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_TRUE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder,
+       IsApplicableReturnsFalseForFusedTwoNodeGraphWithVarianceAndBrokenConnectivity)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with variance
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf_var",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnInfAttr.Union()));
+
+    // Activation with wrong input
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        5, // Wrong input!
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder,
+       IsApplicableReturnsFalseForFusedTwoNodeGraphWithVarianceAndNonVirtualIntermediate)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {}); // No virtual tensors
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with variance
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf_var",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnInfAttr.Union()));
+
+    // Activation
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        6,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}
+
+TEST_F(TestBatchnormPlanBuilder,
+       IsApplicableReturnsFalseForFusedTwoNodeGraphWithVarianceAndUnsupportedActivation)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    createBatchnormFusionTensorAttributes(builder, tensorAttributes, 7, {6});
+
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+
+    // BN inference with variance
+    auto bnInfAttr = hipdnn_data_sdk::data_objects::CreateBatchnormInferenceAttributesVarianceExt(
+        builder, 1, 2, 3, 4, 5, 6);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "bn_inf_var",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::BatchnormInferenceAttributesVarianceExt,
+        bnInfAttr.Union()));
+
+    // Activation with unsupported MUL
+    auto actAttr = hipdnn_data_sdk::data_objects::CreatePointwiseAttributes(
+        builder,
+        hipdnn_data_sdk::data_objects::PointwiseMode::MUL, // Unsupported!
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        6,
+        flatbuffers::nullopt,
+        flatbuffers::nullopt,
+        7);
+    nodes.push_back(hipdnn_data_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "act",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes,
+        actAttr.Union()));
+
+    auto graphOffset = hipdnn_data_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_data_sdk::data_objects::DataType::FLOAT,
+        hipdnn_data_sdk::data_objects::DataType::HALF,
+        hipdnn_data_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+
+    hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper graph(builder.GetBufferPointer(),
+                                                              builder.GetSize());
+
+    EXPECT_FALSE(_planBuilder.isApplicable(_dummyHandle, graph));
+}

--- a/dnn-providers/hip-kernel-provider/tests/main.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/main.cpp
@@ -4,23 +4,21 @@ SPDX-License-Identifier: MIT
 */
 
 #include <gtest/gtest.h>
-#include <spdlog/spdlog.h>
 
 #include <hipdnn_data_sdk/logging/Logger.hpp>
+#include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
 #include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
 
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
-    hipdnn::logging::initializeCallbackLogging(COMPONENT_NAME,
+    hipdnn::logging::initializeCallbackLogging("hip_kernel_plugin",
                                                hipdnn_test_sdk::utilities::testLoggingCallback);
 
     // Register HipErrorHandler to check and clear HIP errors after each test
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();
     listeners.Append(new hipdnn_test_sdk::utilities::HipErrorHandler);
 
-    auto result = RUN_ALL_TESTS();
-    spdlog::shutdown();
-    return result;
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Motivation

This PR introduces the initial prototype and boilerplate for supporting batch normalization operations in the new HIP kernel provider. It implements BatchNorm forward inference only.

Although this is a large PR, the majority of the code is adapted from the MIOpen provider or MIOpen itself.

## Technical Details

Below is a summary of the main features included:

- **Test Infrastructure & Coverage**:  
  Added comprehensive tests for BatchNorm forward inference and BatchNorm forward inference with activation, covering all supported data types and tensor layouts.

- **Plan Builder & Plan**:  
  Implemented `BatchnormFwdInferencePlan` and its corresponding `PlanBuilder`.

- **HIP Runtime Support**:  
  Introduced a new `hip/` directory containing two classes to support HIP runtime compilation and execution. This is an initial prototype; a more robust HIP-based hipDNN SDK will be developed after the first MVP.

- **Kernel Porting**:  
  Ported the BatchNorm kernel and required utility functions from MIOpen. Only essential utilities were included; further refactoring and architectural improvements are needed.

### File-by-File Breakdown for Review

- `cmake/scripts/test_name_validator.py`  
  → Ported from MIOpen provider, no changes.

- `engines/plans/BatchnormApplicabilityChecks.cpp/hpp`  
  → Ported from MIOpen provider, minor changes: removed MIOpen-specific naming.

- `engines/plans/BatchnormFwdInferencePlan.cpp/hpp`  
  → Ported from MIOpen provider. Replaced MIOpen tensor utilities with Data SDK tensors. Implemented `execute()` method following MIOpen’s corresponding solver.

- `engines/plans/BatchnormPlanBuilder.cpp/hpp`  
  → Ported from MIOpen provider. Removed unimplemented BatchNorm variants; retained only forward inference.

- `hip/`  
  → All new code (HIP runtime/execution support).

- `integration_tests/IntegrationGpuBatchnormForwardInference.cpp`  
  → Ported from MIOpen provider, minor change: updated namespace.

- `integration_tests/IntegrationGpuBatchnormForwardInferenceAndActivation.cpp`  
  → Ported from MIOpen provider. Adapted from `IntegrationGpuBatchnormForwardInferenceWithVarianceAndActivation.cpp`.

- `integration_tests/IntegrationGraphVerificationHarness.hpp`  
  → Ported from MIOpen provider, minor change: updated namespace.

- `kernels/`  
  → All files ported from MIOpen. Changes: renamed, removed OpenCL-specific code.

- `tests/`  
  → All files ported from MIOpen provider, except `TestHipProgramAndKernel.cpp`, which tests the temporary HIP classes in `hip/`.

- `HipKernelUtils.cpp/hpp`  
  → Ported from MIOpen provider; removed MIOpen-specific code.

## Questions for the reviewer

- Should we create different sub directories in kernels/ to have files better organized? (MIOpen does not)
- Should we call the namespace hip_kernel_plugin or just hip_plugin? Currently its the later but the shorter version could be more readable for cleaner code.
- Probably not for this PR but how should we organize all the kernel utils? Want to avoid keeping the MIOpen mess in the hip-kernel-provider MVP.


## Test Plan

Tested locally on gfx90a

## Test Result

All tests pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
