### PR TITLE
Print formocast hardware constants

### DIFF
--- a/shared/origami/tests/test_formocast.cpp
+++ b/shared/origami/tests/test_formocast.cpp
@@ -500,6 +500,19 @@ TEST_CASE("Formocast: Intermediate metrics calculation", "[formocast]") {
     }
 }
 
+TEST_CASE("Formocast: Print hardware", "[formocast]") {
+  Formocast simulator;
+
+  for (int arch = 0; arch != static_cast<int>(hardware_t::architecture_t::Count); ++arch) {
+    try {
+      simulator.setHardware(static_cast<hardware_t::architecture_t>(arch));
+    } catch (const std::runtime_error&) {
+      continue;  // Skip unsupported architectures
+    }
+    simulator.hw_consts.print();
+  }
+}
+
 TEST_CASE("Formocast: FIFO queue operations", "[formocast]") {
     Formocast simulator;
     simulator.setHardware(hardware_t::architecture_t::gfx950);


### PR DESCRIPTION
Exists because hardware constants are included in source as magic char array.

Follow origami instructions to build tests
`tests/origami-tests "Formocast: Print hardware"`

```
HardwareConstants:
  architecture:         gfx942
  L1CacheCapacity:      32768
  L2CacheCapacity:      4.1943e+06
  L3CacheCapacity:      2.68435e+08
  L1CacheLineSize:      128
  L2CacheLineSize:      128
  L1BusWidthPerCU:      64
  L2BusWidthPerCU:      128
  L1WriteBusWidthPerCU: 64
  L2WriteBusWidthPerCU: 64
  maxBandWidthHBM:      3
  mem_frequency:        1300
  hbmBandWidth:         2307.69
  L3BandWidth:          4615.38
  math_frequency:       1100
  boost_frequency:      2.08643e-316
  initialCost:          2.7
  initialCostHit:       2.08643e-316
  flopsPerClk:          2048
  NumCUs:               304
  wavefrontSize:        64
  L2ReadArbEff:         0.9
  L2WriteArbEff:        0.58
  NumXCDs:              8
  LocalReadBaseLatencyB128: 10
  LocalReadBaseLatencyB64: 5
  LocalReadBaseLatencyB32: 2
  LocalReadConflictMultiplierB128: 6
  LocalReadConflictMultiplierB64: 3
  LocalReadConflictMultiplierB32: 3
HardwareConstants:
  architecture:         gfx950
  L1CacheCapacity:      32768
  L2CacheCapacity:      4.1943e+06
  L3CacheCapacity:      2.68435e+08
  L1CacheLineSize:      128
  L2CacheLineSize:      128
  L1BusWidthPerCU:      64
  L2BusWidthPerCU:      128
  L1WriteBusWidthPerCU: 64
  L2WriteBusWidthPerCU: 64
  maxBandWidthHBM:      3
  mem_frequency:        1900
  hbmBandWidth:         1578.95
  L3BandWidth:          3157.89
  math_frequency:       1800
  boost_frequency:      2350
  initialCost:          2.6
  initialCostHit:       2.1
  flopsPerClk:          4096
  NumCUs:               256
  wavefrontSize:        64
  L2ReadArbEff:         0.9
  L2WriteArbEff:        0.75
  NumXCDs:              8
  LocalReadBaseLatencyB128: 14
  LocalReadBaseLatencyB64: 10
  LocalReadBaseLatencyB32: 10
  LocalReadConflictMultiplierB128: 6
  LocalReadConflictMultiplierB64: 3
  LocalReadConflictMultiplierB32: 3
HardwareConstants:
  architecture:         gfx1201
  L1CacheCapacity:      32768
  L2CacheCapacity:      8.38861e+06
  L3CacheCapacity:      6.71089e+07
  L1CacheLineSize:      128
  L2CacheLineSize:      128
  L1BusWidthPerCU:      128
  L2BusWidthPerCU:      128
  L1WriteBusWidthPerCU: 64
  L2WriteBusWidthPerCU: 128
  maxBandWidthHBM:      0.625
  mem_frequency:        1258
  hbmBandWidth:         61.035
  L3BandWidth:          439.453
  math_frequency:       2350
  boost_frequency:      2500
  initialCost:          14.6
  initialCostHit:       14.4
  flopsPerClk:          2048
  NumCUs:               64
  wavefrontSize:        32
  L2ReadArbEff:         0.9
  L2WriteArbEff:        0.75
  NumXCDs:              1
  LocalReadBaseLatencyB128: 14
  LocalReadBaseLatencyB64: 10
  LocalReadBaseLatencyB32: 10
  LocalReadConflictMultiplierB128: 6
  LocalReadConflictMultiplierB64: 3
  LocalReadConflictMultiplierB32: 3
```