### PR TITLE
[rocWMMA] Add regression test infra and fix issue with __half compute type MFMA compiles

### DIFF
--- a/projects/rocwmma/README.md
+++ b/projects/rocwmma/README.md
@@ -56,6 +56,7 @@ For more detailed information, please refer to the [rocWMMA installation guide](
 |ROCWMMA_BUILD_DOCS|Build doxygen documentation from code|OFF|
 |ROCWMMA_BUILD_ASSEMBLY|Generate assembly files|OFF|
 |ROCWMMA_BUILD_VALIDATION_TESTS|Build validation tests |ON (requires ROCWMMA_BUILD_TESTS=ON)|
+|ROCWMMA_BUILD_REGRESSION_TESTS|Build regression testing coverage |ON (requires ROCWMMA_BUILD_TESTS=ON)|
 |ROCWMMA_BUILD_BENCHMARK_TESTS|Build benchmark tests |OFF (requires ROCWMMA_BUILD_TESTS=ON)|
 |ROCWMMA_BUILD_EXTENDED_TESTS|Build extended testing coverage |OFF (requires ROCWMMA_BUILD_TESTS=ON)|
 |ROCWMMA_VALIDATE_WITH_ROCBLAS|Use rocBLAS for validation tests|ON (requires ROCWMMA_BUILD_VALIDATION_TESTS=ON)|

--- a/projects/rocwmma/docs/install/installation.rst
+++ b/projects/rocwmma/docs/install/installation.rst
@@ -205,6 +205,9 @@ Here are the available options to build the rocWMMA library, with or without cli
     *   -   ``ROCWMMA_BUILD_VALIDATION_TESTS``
         -   Build validation tests
         -   ``ON`` (requires ``ROCWMMA_BUILD_TESTS=ON``)
+    *   -   ``ROCWMMA_BUILD_REGRESSION_TESTS``
+        -   Build regression tests
+        -   ``ON`` (requires ``ROCWMMA_BUILD_TESTS=ON``)
     *   -   ``ROCWMMA_BUILD_BENCHMARK_TESTS``
         -   Build benchmark tests
         -   ``OFF`` (requires ``ROCWMMA_BUILD_TESTS=ON``)

--- a/projects/rocwmma/library/include/rocwmma/internal/mfma_impl.hpp
+++ b/projects/rocwmma/library/include/rocwmma/internal/mfma_impl.hpp
@@ -135,7 +135,10 @@ namespace rocwmma
                            BlockN,
                            BlockK,
                            GfxTargetId,
-                           enable_gfx9_t<GfxTargetId, (sizeof(ComputeT) < 4u)>>
+                           enable_gfx9_t<GfxTargetId,
+                                         (sizeof(ComputeT) < 4u) && !is_same_v<InputTA, hfloat16_t>
+                                             && !is_same_v<InputTB, hfloat16_t>
+                                             && !is_same_v<ComputeT, hfloat16_t>>>
             : public amdgcn_mfma<InputTA,
                                  InputTB,
                                  typename PackTraits<ComputeT>::PackedT,

--- a/projects/rocwmma/test/CMakeLists.txt
+++ b/projects/rocwmma/test/CMakeLists.txt
@@ -29,6 +29,7 @@ include( CMakeDependentOption )
 cmake_dependent_option( ROCWMMA_BUILD_VALIDATION_TESTS "Build validation tests" ON "ROCWMMA_BUILD_TESTS" OFF )
 cmake_dependent_option( ROCWMMA_BUILD_BENCHMARK_TESTS "Build benchmarking tests" OFF "ROCWMMA_BUILD_TESTS" OFF )
 cmake_dependent_option( ROCWMMA_BUILD_EXTENDED_TESTS "Build extended test parameter coverage" OFF "ROCWMMA_BUILD_TESTS" OFF )
+cmake_dependent_option( ROCWMMA_BUILD_REGRESSION_TESTS "Build regression tests" ON "ROCWMMA_BUILD_TESTS" OFF )
 cmake_dependent_option( ROCWMMA_USE_SYSTEM_GOOGLETEST "Use system Google Test library instead of downloading and building it" OFF "ROCWMMA_BUILD_TESTS" OFF )
 
 add_compile_options(-mcmodel=large)
@@ -191,6 +192,10 @@ endfunction()
 add_subdirectory(gemm)
 add_subdirectory(unit)
 add_subdirectory(dlrm)
+
+if(ROCWMMA_BUILD_REGRESSION_TESTS)
+    add_subdirectory(regression)
+endif()
 
 rocm_install(
     FILES "${INSTALL_TEST_FILE}"

--- a/projects/rocwmma/test/regression/CMakeLists.txt
+++ b/projects/rocwmma/test/regression/CMakeLists.txt
@@ -1,0 +1,113 @@
+###############################################################################
+ #
+ # MIT License
+ #
+ # Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
+ # of this software and associated documentation files (the "Software"), to deal
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
+ # furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included in
+ # all copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ #
+ ###############################################################################
+
+# Regression test category - simplified test infrastructure for bug reproducers
+#
+# Key differences from other test categories:
+# - Single executable containing all regression tests
+# - Uses standard GTest::gtest_main (not rocwmma_gtest_main.cpp)
+# - No emulation framework (no smoke/regression/extended variants)
+# - Validation-only (no benchmark mode)
+# - Minimal boilerplate per test
+# - Flat directory structure (no subdirectories)
+#
+# Adding a new test: Just create issue_<number>.cpp and rebuild - no CMake changes needed
+
+# Collect all regression test source files
+file(GLOB REGRESSION_TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+# Only build if we have test files
+if(REGRESSION_TEST_SOURCES)
+    # Create single executable from all test sources
+    set(TEST_TARGET rocwmma_regression_tests)
+
+    add_executable(${TEST_TARGET}
+        ${REGRESSION_TEST_SOURCES}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../hip_device.cpp)
+
+    # Link against rocWMMA and GTest
+    target_link_libraries(${TEST_TARGET} rocwmma GTest::gtest GTest::gtest_main)
+    target_link_libraries(${TEST_TARGET} OpenMP::OpenMP_CXX "-L${HIP_CLANG_ROOT}/lib")
+    if(UNIX)
+        set_target_properties(${TEST_TARGET} PROPERTIES INSTALL_RPATH "\$ORIGIN/../llvm/lib")
+        target_link_libraries(${TEST_TARGET} "-fno-rtlib-add-rpath")
+    endif()
+
+    # Include directories
+    target_include_directories(${TEST_TARGET} PRIVATE
+                               ${CMAKE_CURRENT_SOURCE_DIR}
+                               ${ROCWMMA_TEST_INCLUDE_DIRS})
+
+    # Use offload compress flag if supported
+    if(BUILD_OFFLOAD_COMPRESS AND CXX_COMPILER_SUPPORTS_OFFLOAD_COMPRESS)
+        target_compile_options(${TEST_TARGET} PRIVATE "--offload-compress")
+    endif()
+
+    # Add validation tests definition
+    target_compile_definitions(${TEST_TARGET} PRIVATE ROCWMMA_VALIDATION_TESTS)
+
+    # Add support to build the target's assembly files
+    if(ROCWMMA_BUILD_ASSEMBLY)
+        foreach(file_name ${REGRESSION_TEST_SOURCES})
+            # Replicate the current source tree in the build output/assembly folder
+            file(RELATIVE_PATH relative_file_path "${CMAKE_CURRENT_SOURCE_DIR}" "${file_name}")
+            string(REPLACE "../" "__/" relative_file_string "${relative_file_path}")
+            add_custom_command(TARGET ${TEST_TARGET}
+                               POST_BUILD
+                               COMMAND make ARGS ${relative_file_string}.s
+                               COMMAND ${CMAKE_COMMAND} -E copy
+                                 "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${TEST_TARGET}.dir/${relative_file_string}.s"
+                                 "${CMAKE_CURRENT_BINARY_DIR}/assembly/${relative_file_string}.s"
+                               WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        endforeach()
+    endif()
+
+    # Register single CTest test
+    add_test(NAME regression_tests COMMAND ${TEST_TARGET})
+    set_property(TEST regression_tests PROPERTY SKIP_REGULAR_EXPRESSION "no ROCm-capable device" "unsupported host device")
+
+    # Install the executable
+    rocm_install_targets(
+        TARGETS ${TEST_TARGET}
+        COMPONENT tests
+    )
+
+    # Add to install test file
+    get_target_property(EXE_NAME ${TEST_TARGET} RUNTIME_OUTPUT_NAME)
+    if(EXE_NAME STREQUAL "EXE_NAME-NOTFOUND")
+        get_target_property(EXE_NAME ${TEST_TARGET} OUTPUT_NAME)
+        if(EXE_NAME STREQUAL "EXE_NAME-NOTFOUND")
+            set(EXE_NAME "${TEST_TARGET}")
+        endif()
+    endif()
+
+    file(APPEND "${INSTALL_TEST_FILE}" "add_test(regression_tests \"../${EXE_NAME}\")\n")
+    file(APPEND "${INSTALL_TEST_FILE}" "set_tests_properties(regression_tests PROPERTIES SKIP_REGULAR_EXPRESSION \"no ROCm-capable device;unsupported host device\")\n")
+
+    message(STATUS "Regression tests: Enabled (${TEST_TARGET})")
+else()
+    message(STATUS "Regression tests: No test files found in ${CMAKE_CURRENT_SOURCE_DIR}")
+endif()

--- a/projects/rocwmma/test/regression/CMakeLists.txt
+++ b/projects/rocwmma/test/regression/CMakeLists.txt
@@ -113,7 +113,6 @@ if(REGRESSION_TEST_SOURCES)
 
   file(APPEND "${INSTALL_REGRESSION_TEST_FILE}" "add_test(\"regression_tests\" \"../../${EXE_NAME}\")\n")
   file(APPEND "${INSTALL_REGRESSION_TEST_FILE}" "set_tests_properties(\"regression_tests\" PROPERTIES SKIP_REGULAR_EXPRESSION \"no ROCm-capable device;unsupported host device\")\n")
-endfunction()
 
     message(STATUS "Regression tests: Enabled (${TEST_TARGET})")
 else()

--- a/projects/rocwmma/test/regression/CMakeLists.txt
+++ b/projects/rocwmma/test/regression/CMakeLists.txt
@@ -34,7 +34,8 @@
 # - Minimal boilerplate per test
 # - Flat directory structure (no subdirectories)
 #
-# Adding a new test: Just create issue_<number>.cpp and rebuild - no CMake changes needed
+# Adding a new test: Add a new <name>.cpp file in this directory and rebuild (no CMake changes needed).
+#                    Recommended naming convention: issue_<number>.cpp (for example, issue_4398.cpp).
 
 # Collect all regression test source files
 file(GLOB REGRESSION_TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
@@ -106,6 +107,13 @@ if(REGRESSION_TEST_SOURCES)
 
     file(APPEND "${INSTALL_TEST_FILE}" "add_test(regression_tests \"../${EXE_NAME}\")\n")
     file(APPEND "${INSTALL_TEST_FILE}" "set_tests_properties(regression_tests PROPERTIES SKIP_REGULAR_EXPRESSION \"no ROCm-capable device;unsupported host device\")\n")
+
+  file(APPEND "${INSTALL_SMOKE_TEST_FILE}" "add_test(\"regression_tests\" \"../../${EXE_NAME}\")\n")
+  file(APPEND "${INSTALL_SMOKE_TEST_FILE}" "set_tests_properties(\"regression_tests\" PROPERTIES SKIP_REGULAR_EXPRESSION \"no ROCm-capable device;unsupported host device\")\n")
+
+  file(APPEND "${INSTALL_REGRESSION_TEST_FILE}" "add_test(\"regression_tests\" \"../../${EXE_NAME}\")\n")
+  file(APPEND "${INSTALL_REGRESSION_TEST_FILE}" "set_tests_properties(\"regression_tests\" PROPERTIES SKIP_REGULAR_EXPRESSION \"no ROCm-capable device;unsupported host device\")\n")
+endfunction()
 
     message(STATUS "Regression tests: Enabled (${TEST_TARGET})")
 else()

--- a/projects/rocwmma/test/regression/issue_example.cpp
+++ b/projects/rocwmma/test/regression/issue_example.cpp
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+// Example regression test demonstrating the infrastructure
+//
+// This is a working example showing how to write a minimal regression test.
+// It can be used to verify the regression test infrastructure is working correctly.
+//
+// This file can be removed once real regression tests are added.
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <vector>
+#include "common.hpp"
+#include "hip_device.hpp"
+
+// Simple kernel that writes thread indices to output
+__global__ void example_kernel(int* output, int size)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if(idx < size)
+    {
+        output[idx] = idx;
+    }
+}
+
+// Example test that verifies basic device functionality
+TEST(RegressionIssue_Example, BasicDeviceOperation)
+{
+    // Check if a ROCm device is available
+    int deviceCount = 0;
+    CHECK_HIP_ERROR(hipGetDeviceCount(&deviceCount));
+
+    if(deviceCount == 0)
+    {
+        GTEST_SKIP() << "No ROCm-capable device available";
+    }
+
+    // Get device info using HipDevice singleton
+    auto& device = rocwmma::HipDevice::instance();
+    EXPECT_GT(device->warpSize(), 0);
+
+    // Allocate device memory
+    const int size = 256;
+    int*      d_output;
+    CHECK_HIP_ERROR(hipMalloc(&d_output, size * sizeof(int)));
+
+    // Launch kernel
+    dim3 blockDim(256);
+    dim3 gridDim(1);
+    hipLaunchKernelGGL(example_kernel, gridDim, blockDim, 0, 0, d_output, size);
+    CHECK_HIP_ERROR(hipDeviceSynchronize());
+
+    // Copy results back
+    std::vector<int> h_output(size);
+    CHECK_HIP_ERROR(
+        hipMemcpy(h_output.data(), d_output, size * sizeof(int), hipMemcpyDeviceToHost));
+
+    // Verify results
+    for(int i = 0; i < size; i++)
+    {
+        EXPECT_EQ(h_output[i], i) << "Mismatch at index " << i;
+    }
+
+    // Clean up
+    CHECK_HIP_ERROR(hipFree(d_output));
+}
+
+// Example test showing how to skip based on architecture
+TEST(RegressionIssue_Example, ArchitectureSpecificTest)
+{
+    auto& device = rocwmma::HipDevice::instance();
+
+    // This test only runs on specific architectures
+    auto arch = device->getGcnArch();
+    if(arch != rocwmma::HipDevice::GFX908 && arch != rocwmma::HipDevice::GFX90A
+       && arch != rocwmma::HipDevice::GFX942 && arch != rocwmma::HipDevice::GFX1100
+       && arch != rocwmma::HipDevice::GFX1200)
+    {
+        GTEST_SKIP() << "Test skipped for architecture: " << arch;
+    }
+
+    // Test would run here for supported architectures
+    EXPECT_TRUE(true);
+}
+
+// Example test showing minimal test structure
+TEST(RegressionIssue_Example, MinimalTest)
+{
+    // This is the simplest possible test
+    // Just verify we can run GTest tests
+    EXPECT_TRUE(true);
+}

--- a/projects/rocwmma/test/regression/rocm-libraries_issues_4398.cpp
+++ b/projects/rocwmma/test/regression/rocm-libraries_issues_4398.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+// Regression test for issue #4398
+// https://github.com/ROCm/rocm-libraries/issues/4398
+//
+// Bug: Compile failure due to multiple partial template specializations
+//      matching for half-precision fragment compute/accumulator type.
+// Fix: Explicitly excluded the catch-all partial specialization for the case of
+//      half-precision fragments with half-precision compute/accumulator type.
+//
+// This test verifies that the kernel compiles properly when targeting
+// half-precision fragments with half-precision compute/accumulator type, and
+// that it can be launched successfully on a ROCm-capable device.
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <vector>
+#include "common.hpp"
+#include "hip_device.hpp"
+
+static __global__ void kernel()
+{
+    constexpr int frag_m = 16;
+    constexpr int frag_n = 16;
+    constexpr int D = 128;
+    constexpr int VKQ_stride = 128;
+    constexpr int ncols = 32;
+    typedef rocwmma::fragment<rocwmma::matrix_a,    frag_m, frag_n, 16, half, rocwmma::col_major> frag_a_V;
+    typedef rocwmma::fragment<rocwmma::matrix_b,    frag_m, frag_n, 16, half, rocwmma::col_major> frag_b;
+    typedef rocwmma::fragment<rocwmma::accumulator, frag_m, frag_n, 16, half> frag_c_VKQ;
+    frag_c_VKQ VKQ_c;
+    frag_b KQ_b;
+    frag_a_V v_a;
+    rocwmma::mma_sync(VKQ_c, v_a, KQ_b, VKQ_c);
+}
+
+// Example test that verifies basic device functionality
+TEST(RegressionIssue_Example, HalfHalfHalfTest)
+{
+    // Check if a ROCm device is available
+    int deviceCount = 0;
+    CHECK_HIP_ERROR(hipGetDeviceCount(&deviceCount));
+
+    if(deviceCount == 0)
+    {
+        GTEST_SKIP() << "No ROCm-capable device available";
+    }
+
+    // Launch kernel
+    dim3 blockDim(256);
+    dim3 gridDim(1);
+    hipLaunchKernelGGL(kernel, gridDim, blockDim, 0, 0);
+    CHECK_HIP_ERROR(hipDeviceSynchronize());
+}
+

--- a/projects/rocwmma/test/regression/rocm-libraries_issues_4398.cpp
+++ b/projects/rocwmma/test/regression/rocm-libraries_issues_4398.cpp
@@ -59,7 +59,7 @@ static __global__ void kernel()
 }
 
 // Example test that verifies basic device functionality
-TEST(RegressionIssue_Example, HalfHalfHalfTest)
+TEST(RegressionIssue_4398, HalfHalfHalfTest)
 {
     // Check if a ROCm device is available
     int deviceCount = 0;


### PR DESCRIPTION
## Motivation

A change in the clang compiler has caused a regression for 7.2 due to differences in template partial specialization matching.  This would have been caught by the 'extended tests', but they aren't built or run regularly, so this ended up slipping through to the release.  Adding a regression test section with small reproducers should help catch issues early.

## Technical Details

Add a new directory to hold regression tests.
Add a regression test for issue #4398.
Fix #4398 by explicitly preventing the catch-all template specialization from creating a conflict.

## Test Plan

Manual testing.
CI.

## Test Result

Manual testing looks good.
Waiting on CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
