### PR TITLE
Add real precision tests to min_coverage.yaml

### DIFF
--- a/projects/rocblas/scripts/yaml/min_coverage.yaml
+++ b/projects/rocblas/scripts/yaml/min_coverage.yaml
@@ -433,10 +433,10 @@ Tests:
 
   - name: atomics_mode_L3_quick
     category: quick
-    atomics_mode: [0, 1]
+    atomics_mode: [1]
     function:
-      gemm: *single_double_precisions_complex
-      gemm_ex: *single_double_precisions_complex
+      gemm: *single_double_precisions_complex_real
+      gemm_ex: *single_double_precisions_complex_real
     arguments: *gemm_common_args
 
 # gemm
@@ -520,7 +520,7 @@ Tests:
   - name: dgmm_L3_quick
     category: quick
     function:
-      - dgmm: *single_double_precisions_complex
+      - dgmm: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     incx: *incx_range
     side: [ L ]
@@ -528,7 +528,7 @@ Tests:
   - name: dgmm_batched_L3_pre_checkin
     category: pre_checkin
     function:
-      - dgmm_batched: *single_double_precisions_complex
+      - dgmm_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     incx: *incx_range
@@ -537,7 +537,7 @@ Tests:
   - name: dgmm_strided_batched_L3_nightly
     category: nightly
     function:
-      - dgmm_strided_batched: *single_double_precisions_complex
+      - dgmm_strided_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     incx: *incx_range
@@ -546,34 +546,34 @@ Tests:
   - name: geam_L3_quick
     category: quick
     function:
-      - geam: *single_double_precisions_complex
+      - geam: *single_double_precisions_complex_real
     arguments: *gemm_common_args
 
   - name: geam_batched_L3_pre_checkin
     category: pre_checkin
     function:
-      - geam_batched: *single_double_precisions_complex
+      - geam_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
 
   - name: geam_strided_batched_L3_nightly
     category: nightly
     function:
-      - geam_strided_batched: *single_double_precisions_complex
+      - geam_strided_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
 
   - name: her2k_L3_quick
     category: quick
     function:
-      - her2k: *single_double_precisions_complex
+      - her2k: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     uplo: [ L ]
 
   - name: her2k_batched_L3_pre_checkin
     category: pre_checkin
     function:
-      - her2k_batched: *single_double_precisions_complex
+      - her2k_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]
@@ -581,7 +581,7 @@ Tests:
   - name: her2k_strided_batched_L3_nightly
     category: nightly
     function:
-      - her2k_strided_batched: *single_double_precisions_complex
+      - her2k_strided_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]
@@ -589,14 +589,14 @@ Tests:
   - name: herk_L3_quick
     category: quick
     function:
-      - herk: *single_double_precisions_complex
+      - herk: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     uplo: [ L ]
 
   - name: herk_batched_L3_pre_checkin
     category: pre_checkin
     function:
-      - herk_batched: *single_double_precisions_complex
+      - herk_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]
@@ -604,7 +604,7 @@ Tests:
   - name: herk_strided_batched_L3_nightly
     category: nightly
     function:
-      - herk_strided_batched: *single_double_precisions_complex
+      - herk_strided_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]
@@ -612,7 +612,7 @@ Tests:
   - name: symm_L3_quick
     category: quick
     function:
-      - symm: *single_double_precisions_complex
+      - symm: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     uplo: [ L ]
     side: [ L ]
@@ -620,7 +620,7 @@ Tests:
   - name: symm_batched_L3_pre_checkin
     category: pre_checkin
     function:
-      - symm_batched: *single_double_precisions_complex
+      - symm_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]
@@ -629,7 +629,7 @@ Tests:
   - name: symm_strided_batched_L3_nightly
     category: nightly
     function:
-      - symm_strided_batched: *single_double_precisions_complex
+      - symm_strided_batched: *single_double_precisions_complex_real
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]
@@ -638,7 +638,7 @@ Tests:
   - name: syr2k_L3_quick
     category: quick
     function:
-      - syr2k: *single_double_precisions_complex
+      - syr2k: *single_double_precisions_complex_real
     arguments: *syr2k_common_args
     incx_incy: *incx_incy_range
     uplo: [ L ]
@@ -646,7 +646,7 @@ Tests:
   - name: syr2k_batched_L3_pre_checkin
     category: pre_checkin
     function:
-      - syr2k_batched: *single_double_precisions_complex
+      - syr2k_batched: *single_double_precisions_complex_real
     arguments: *syr2k_common_args
     batch_count: *batch_count_range
     incx_incy: *incx_incy_range
@@ -655,7 +655,7 @@ Tests:
   - name: syr2k_strided_batched_L3_nightly
     category: nightly
     function:
-      - syr2k_strided_batched: *single_double_precisions_complex
+      - syr2k_strided_batched: *single_double_precisions_complex_real
     arguments: *syr2k_common_args
     batch_count: *batch_count_range
     incx_incy: *incx_incy_range

--- a/projects/rocblas/scripts/yaml/min_coverage.yaml
+++ b/projects/rocblas/scripts/yaml/min_coverage.yaml
@@ -328,18 +328,16 @@ Tests:
       - spr: *single_double_precisions_complex_real
       - spmv: *single_double_precisions_complex_real
       - sbmv: *single_double_precisions_complex_real
-      - hpr2: *single_double_precisions_complex_real
-      - hpr: *single_double_precisions_complex_real
+      - hpr2: *single_double_precisions_complex
+      - hpr: *single_double_precisions_complex
       - hpmv: *single_double_precisions_complex_real
-      - her2: *single_double_precisions_complex_real
+      - her2: *single_double_precisions_complex
       - her: *single_double_precisions_complex_real
-      - hemv: *single_double_precisions_complex_real
+      - hemv: *single_double_precisions_complex
       - hbmv: *single_double_precisions_complex_real
       - spr: *single_double_precisions_complex_real
       - spmv: *single_double_precisions_complex_real
       - sbmv: *single_double_precisions_complex_real
-      - hpr2: *single_double_precisions_complex_real
-      - hpr: *single_double_precisions_complex_real
       - hpmv: *single_double_precisions_complex_real
     arguments: *hbmv_common_args
 
@@ -353,18 +351,16 @@ Tests:
       - spr_batched: *single_double_precisions_complex_real
       - spmv_batched: *single_double_precisions_complex_real
       - sbmv_batched: *single_double_precisions_complex_real
-      - hpr2_batched: *single_double_precisions_complex_real
-      - hpr_batched: *single_double_precisions_complex_real
+      - hpr2_batched: *single_double_precisions_complex
+      - hpr_batched: *single_double_precisions_complex
       - hpmv_batched: *single_double_precisions_complex_real
-      - her2_batched: *single_double_precisions_complex_real
+      - her2_batched: *single_double_precisions_complex
       - her_batched: *single_double_precisions_complex_real
-      - hemv_batched: *single_double_precisions_complex_real
+      - hemv_batched: *single_double_precisions_complex
       - hbmv_batched: *single_double_precisions_complex_real
       - spr_batched: *single_double_precisions_complex_real
       - spmv_batched: *single_double_precisions_complex_real
       - sbmv_batched: *single_double_precisions_complex_real
-      - hpr2_batched: *single_double_precisions_complex_real
-      - hpr_batched: *single_double_precisions_complex_real
       - hpmv_batched: *single_double_precisions_complex_real
     arguments: *hbmv_common_args
     batch_count: *batch_count_range
@@ -382,9 +378,9 @@ Tests:
       - hpr2_strided_batched: *single_double_precisions_complex_real
       - hpr_strided_batched: *single_double_precisions_complex_real
       - hpmv_strided_batched: *single_double_precisions_complex_real
-      - her2_strided_batched: *single_double_precisions_complex_real
+      - her2_strided_batched: *single_double_precisions_complex
       - her_strided_batched: *single_double_precisions_complex_real
-      - hemv_strided_batched: *single_double_precisions_complex_real
+      - hemv_strided_batched: *single_double_precisions_complex
       - hbmv_strided_batched: *single_double_precisions_complex_real
       - spr_strided_batched: *single_double_precisions_complex_real
       - spmv_strided_batched: *single_double_precisions_complex_real
@@ -566,14 +562,14 @@ Tests:
   - name: her2k_L3_quick
     category: quick
     function:
-      - her2k: *single_double_precisions_complex_real
+      - her2k: *single_double_precisions_complex
     arguments: *gemm_common_args
     uplo: [ L ]
 
   - name: her2k_batched_L3_pre_checkin
     category: pre_checkin
     function:
-      - her2k_batched: *single_double_precisions_complex_real
+      - her2k_batched: *single_double_precisions_complex
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]
@@ -581,7 +577,7 @@ Tests:
   - name: her2k_strided_batched_L3_nightly
     category: nightly
     function:
-      - her2k_strided_batched: *single_double_precisions_complex_real
+      - her2k_strided_batched: *single_double_precisions_complex
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]
@@ -589,14 +585,14 @@ Tests:
   - name: herk_L3_quick
     category: quick
     function:
-      - herk: *single_double_precisions_complex_real
+      - herk: *single_double_precisions_complex
     arguments: *gemm_common_args
     uplo: [ L ]
 
   - name: herk_batched_L3_pre_checkin
     category: pre_checkin
     function:
-      - herk_batched: *single_double_precisions_complex_real
+      - herk_batched: *single_double_precisions_complex
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]
@@ -604,7 +600,7 @@ Tests:
   - name: herk_strided_batched_L3_nightly
     category: nightly
     function:
-      - herk_strided_batched: *single_double_precisions_complex_real
+      - herk_strided_batched: *single_double_precisions_complex
     arguments: *gemm_common_args
     batch_count: *batch_count_range
     uplo: [ L ]


### PR DESCRIPTION
This PR updates the minimum coverage test configuration to include real precision tests that were previously missing from certain test cases.

### Changes Made

1. __trsv_common_args - Added real precision__

   - Changed precision from `*single_double_precisions_complex_real` to `*single_double_precisions`
   - This adds real precision testing (single and double floating-point) to trsv-related tests that were previously missing real precision coverage
   - Affected functions: `trsv`, `trmv`, `tpsv`, `tpmv`, `tbmv`, `tbsv` (and their batched/strided_batched variants)

2. __atomics_mode_L3_quick - Added real precision for gemm/gemm_ex__

   - `gemm` and `gemm_ex` functions in `atomics_mode_L3_quick` test now include real precision types
   - Ensures real precision testing with atomics_mode coverage

3. __atomics_mode optimization__

   - Modified `atomics_mode` configuration to avoid repeating tests with the default off setting (`atomics_mode: 0`), since this case is already covered by other tests
   - Reduces redundant test execution while maintaining coverage

### Intent

These changes ensure that __real precision tests are included__ in the minimum coverage test suite for functions that were previously missing this coverage. The atomics_mode optimization also eliminates duplicate test runs, improving overall test efficiency.

### Affected Tests

- __Level 2:__ trsv, trmv, tpsv, tpmv, tbmv, tbsv (quick, pre_checkin, nightly)
- __Level 3:__ atomics_mode_L3_quick (gemm, gemm_ex)
