### PR TITLE
[Tensile] Fix data race in PlaceholderLibrary

### DIFF
--- a/shared/tensile/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
+++ b/shared/tensile/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
@@ -149,7 +149,7 @@ namespace Tensile
 
         PlaceholderLibrary() = default;
 
-        bool loadPlaceholderLibrary() const
+        bool loadPlaceholderLibrary(Hardware const* hardware = nullptr) const
         {
             std::lock_guard<std::mutex> lock(lazyLoadingGuard);
             // If condition in case two threads got into this function
@@ -161,7 +161,21 @@ namespace Tensile
                     = static_cast<MasterSolutionLibrary<MyProblem, MySolution>*>(newLibrary.get());
                 library = mLibrary->library;
                 std::lock_guard<std::mutex> lock(*solutionsGuard);
-                masterSolutions->insert(mLibrary->solutions.begin(), mLibrary->solutions.end());
+                if(hardware == nullptr)
+                {
+                    masterSolutions->insert(mLibrary->solutions.begin(), mLibrary->solutions.end());
+                }
+                else
+                {
+                    std::transform(std::begin(mLibrary->solutions),
+                                   std::end(mLibrary->solutions),
+                                   std::inserter(*masterSolutions, std::end(*masterSolutions)),
+                                   [this, hardware](auto& i) {
+                                       i.second->codeObjectFilename
+                                           = getCodeObjectFileName(*hardware, *i.second);
+                                       return i;
+                                   });
+                }
 
                 return mLibrary;
             }
@@ -199,7 +213,7 @@ namespace Tensile
                                                              = nullptr) const override
         {
             if(!library)
-                loadPlaceholderLibrary();
+                loadPlaceholderLibrary(&hardware);
 
             auto solution = library->findBestSolution(problem, hardware, fitness);
 
@@ -220,13 +234,14 @@ namespace Tensile
         {
             if(!library)
             {
-                loadPlaceholderLibrary();
+                loadPlaceholderLibrary(&hardware);
             }
 
             auto solutions = library->findAllSolutions(problem, hardware);
 
             for(auto& solution : solutions)
             {
+                // TODO(rocm): possibly redudant given codeObjectFilename assignment in loadPlaceholderLibrary
                 solution->codeObjectFilename = getCodeObjectFileName(hardware, *solution);
             }
 
@@ -239,7 +254,7 @@ namespace Tensile
         {
             if(!library)
             {
-                loadPlaceholderLibrary();
+                loadPlaceholderLibrary(&hardware);
             }
 
             auto solutions = library->findAllSolutionsMatchingType(problem, hardware);

--- a/shared/tensile/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
+++ b/shared/tensile/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
@@ -241,7 +241,6 @@ namespace Tensile
 
             for(auto& solution : solutions)
             {
-                // TODO(rocm): possibly redudant given codeObjectFilename assignment in loadPlaceholderLibrary
                 solution->codeObjectFilename = getCodeObjectFileName(hardware, *solution);
             }
 


### PR DESCRIPTION
Based on 020dd9f6e235e609ba004b85446ecd1dde7e215b

## Motivation

Data race in PlaceholderLibrary can transiently expose solutions w/o codeObjectFilename being set.

## Technical Details

Populate solution codeObjectFilename fields when doing lazy loading before exposing the via master library.

## Test Plan

CI

## Test Result

N\A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
