### PR TITLE
[rocroller] Update CDNA 3.5 references to CDNA 4

### DIFF
--- a/shared/rocroller/GPUArchitectureGenerator/include/GPUArchitectureGenerator/GPUArchitectureGenerator_defs.hpp
+++ b/shared/rocroller/GPUArchitectureGenerator/include/GPUArchitectureGenerator/GPUArchitectureGenerator_defs.hpp
@@ -340,7 +340,7 @@ namespace GPUArchitectureGenerator
                      std::back_inserter(retval),
                      [](rocRoller::GPUArchitectureTarget const& x) -> bool {
                          return x.isCDNA1GPU() || x.isCDNA2GPU() || x.isCDNA3GPU()
-                                || x.isCDNA35GPU();
+                                || x.isCDNA4GPU();
                      });
         return retval;
     }
@@ -398,7 +398,7 @@ namespace GPUArchitectureGenerator
             rocRoller::SupportedArchitectures.begin(),
             rocRoller::SupportedArchitectures.end(),
             std::back_inserter(retval),
-            [](rocRoller::GPUArchitectureTarget const& x) -> bool { return x.isCDNA35GPU(); });
+            [](rocRoller::GPUArchitectureTarget const& x) -> bool { return x.isCDNA4GPU(); });
         return retval;
     }
 
@@ -418,7 +418,7 @@ namespace GPUArchitectureGenerator
 
             {rocRoller::GPUCapability::PackedWorkitemIDs,
              [](rocRoller::GPUArchitectureTarget x) -> bool {
-                 return x.isCDNA2GPU() || x.isCDNA3GPU() || x.isCDNA35GPU() || x.isRDNA4GPU();
+                 return x.isCDNA2GPU() || x.isCDNA3GPU() || x.isCDNA4GPU() || x.isRDNA4GPU();
              }},
             {rocRoller::GPUCapability::WorkgroupIdxViaTTMP,
              [](rocRoller::GPUArchitectureTarget x) -> bool { return x.isGFX12GPU(); }},

--- a/shared/rocroller/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp
+++ b/shared/rocroller/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget.hpp
@@ -117,7 +117,7 @@ namespace rocRoller
             return gfx == GPUArchitectureGFX::GFX942;
         }
 
-        constexpr bool isCDNA35GPU() const
+        constexpr bool isCDNA4GPU() const
         {
             return gfx == GPUArchitectureGFX::GFX950;
         }
@@ -149,7 +149,7 @@ namespace rocRoller
 
         constexpr bool isCDNAGPU() const
         {
-            return isCDNA1GPU() || isCDNA2GPU() || isCDNA3GPU() || isCDNA35GPU();
+            return isCDNA1GPU() || isCDNA2GPU() || isCDNA3GPU() || isCDNA4GPU();
         }
 
         constexpr bool isGFX9GPU() const

--- a/shared/rocroller/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget_impl.hpp
+++ b/shared/rocroller/lib/include/rocRoller/GPUArchitecture/GPUArchitectureTarget_impl.hpp
@@ -88,7 +88,7 @@ namespace rocRoller
         case GPUArchitectureGFX::GFX942:
             return "AMD CDNA 3";
         case GPUArchitectureGFX::GFX950:
-            return "AMD CDNA 3.5";
+            return "AMD CDNA 4";
         case GPUArchitectureGFX::GFX1012:
             return "AMD RDNA 1";
         case GPUArchitectureGFX::GFX1030:

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DGEMM16x16x4Write.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DGEMM16x16x4Write.hpp
@@ -68,7 +68,7 @@ namespace rocRoller
 
             constexpr static bool required(GPUArchitectureTarget const& target)
             {
-                return target.isCDNA2GPU() || target.isCDNA3GPU() || target.isCDNA35GPU();
+                return target.isCDNA2GPU() || target.isCDNA3GPU() || target.isCDNA4GPU();
             }
 
             int                   getMaxNops(Instruction const& inst) const;

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DGEMM4x4x4Write.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DGEMM4x4x4Write.hpp
@@ -64,7 +64,7 @@ namespace rocRoller
 
             constexpr static bool required(GPUArchitectureTarget const& target)
             {
-                return target.isCDNA2GPU() || target.isCDNA3GPU() || target.isCDNA35GPU();
+                return target.isCDNA2GPU() || target.isCDNA3GPU() || target.isCDNA4GPU();
             }
 
             int                   getMaxNops(Instruction const& inst) const;

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DLWrite.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/DLWrite.hpp
@@ -54,7 +54,7 @@ namespace rocRoller
 
             constexpr static bool required(GPUArchitectureTarget const& target)
             {
-                return target.isCDNA2GPU() || target.isCDNA3GPU() || target.isCDNA35GPU();
+                return target.isCDNA2GPU() || target.isCDNA3GPU() || target.isCDNA4GPU();
             }
 
             /**

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLReadSrcC94x.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLReadSrcC94x.hpp
@@ -57,7 +57,7 @@ namespace rocRoller
 
             constexpr static bool required(GPUArchitectureTarget const& target)
             {
-                return target.isCDNA3GPU() || target.isCDNA35GPU();
+                return target.isCDNA3GPU() || target.isCDNA4GPU();
             }
 
             int                   getMaxNops(Instruction const& inst) const;

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLWrite94x.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/MFMA/XDLWrite94x.hpp
@@ -110,7 +110,7 @@ namespace rocRoller
 
             constexpr static bool required(GPUArchitectureTarget const& target)
             {
-                return target.isCDNA3GPU() || target.isCDNA35GPU();
+                return target.isCDNA3GPU() || target.isCDNA4GPU();
             }
 
             int                   getMaxNops(Instruction const& inst) const;

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/OPSEL94x.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/OPSEL94x.hpp
@@ -50,7 +50,7 @@ namespace rocRoller
 
             constexpr static bool required(GPUArchitectureTarget const& target)
             {
-                return target.isCDNA3GPU() || target.isCDNA35GPU();
+                return target.isCDNA3GPU() || target.isCDNA4GPU();
             }
 
             int                   getMaxNops(Instruction const& inst) const;

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUTransWrite94x.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUTransWrite94x.hpp
@@ -68,7 +68,7 @@ namespace rocRoller
 
             constexpr static bool required(GPUArchitectureTarget const& target)
             {
-                return target.isCDNA3GPU() || target.isCDNA35GPU();
+                return target.isCDNA3GPU() || target.isCDNA4GPU();
             }
 
             int                   getMaxNops(Instruction const& inst) const;

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteReadlane94x.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/VALUWriteReadlane94x.hpp
@@ -50,7 +50,7 @@ namespace rocRoller
 
             constexpr static bool required(GPUArchitectureTarget const& target)
             {
-                return target.isCDNA3GPU() || target.isCDNA35GPU();
+                return target.isCDNA3GPU() || target.isCDNA4GPU();
             }
 
             int                   getMaxNops(Instruction const& inst) const;

--- a/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/VCMPXWrite94x.hpp
+++ b/shared/rocroller/lib/include/rocRoller/Scheduling/Observers/WaitState/VCMPXWrite94x.hpp
@@ -54,7 +54,7 @@ namespace rocRoller
 
             constexpr static bool required(GPUArchitectureTarget const& target)
             {
-                return target.isCDNA3GPU() || target.isCDNA35GPU();
+                return target.isCDNA3GPU() || target.isCDNA4GPU();
             }
 
             /**

--- a/shared/rocroller/lib/source/Costs/LinearWeightedCost.cpp
+++ b/shared/rocroller/lib/source/Costs/LinearWeightedCost.cpp
@@ -270,7 +270,7 @@ namespace rocRoller
 
                 if(fn == CostFunction::LinearWeightedSimple)
                 {
-                    if(!arch.isCDNA35GPU())
+                    if(!arch.isCDNA4GPU())
                         Log::warn("Architecture {} not tested for simplifed weights.",
                                   arch.toString());
 
@@ -283,7 +283,7 @@ namespace rocRoller
                     return GFX90A_WEIGHTS;
                 else if(arch.isCDNA3GPU())
                     return GFX942_WEIGHTS;
-                else if(arch.isCDNA35GPU())
+                else if(arch.isCDNA4GPU())
                     return GFX950_WEIGHTS;
                 else
                 {

--- a/shared/rocroller/lib/source/Observers/XDLWrite94x.cpp
+++ b/shared/rocroller/lib/source/Observers/XDLWrite94x.cpp
@@ -35,7 +35,7 @@ namespace rocRoller
         {
             auto const& architecture = m_context.lock()->targetArchitecture();
             int         passes = architecture.GetInstructionInfo(inst.getOpCode()).getLatency();
-            bool        is950  = architecture.target().isCDNA35GPU();
+            bool        is950  = architecture.target().isCDNA4GPU();
 
             AssertFatal(m_latencyAndNops.contains(passes),
                         "Unexpected number of passes",
@@ -109,7 +109,7 @@ namespace rocRoller
                     {
                         auto const& architecture = m_context.lock()->targetArchitecture();
                         int passes = architecture.GetInstructionInfo(inst.getOpCode()).getLatency();
-                        bool is950 = architecture.target().isCDNA35GPU();
+                        bool is950 = architecture.target().isCDNA4GPU();
 
                         if(mismatched)
                         {

--- a/shared/rocroller/test/catch/HazardObserverTest.cpp
+++ b/shared/rocroller/test/catch/HazardObserverTest.cpp
@@ -332,7 +332,7 @@ namespace HazardObserverTest
                         "v_mul_f32", {v[0]}, {Register::Value::Literal(0x4f7ffffe), v[0]}, {}, ""),
                     Instruction("s_endpgm", {}, {}, {}, "")};
 
-                if(arch.isCDNA3GPU() || arch.isCDNA35GPU())
+                if(arch.isCDNA3GPU() || arch.isCDNA4GPU())
                 {
                     peekAndSchedule(context, insts[0]);
                     peekAndSchedule(context, insts[1], 1);
@@ -424,7 +424,7 @@ namespace HazardObserverTest
                            "v_readlane_b32", {s[1]}, {v[0], Register::Value::Literal(0)}, {}, ""),
                        Instruction("s_endpgm", {}, {}, {}, "")};
 
-                if(arch.isCDNA3GPU() || arch.isCDNA35GPU())
+                if(arch.isCDNA3GPU() || arch.isCDNA4GPU())
                 {
                     peekAndSchedule(context, insts[0]);
                     peekAndSchedule(context, insts[1], 1);
@@ -639,7 +639,7 @@ namespace HazardObserverTest
                    Instruction("v_mov_b32", {v[0]}, {v[1]}, {}, ""),
                    Instruction("s_endpgm", {}, {}, {}, "")};
 
-            if(arch.isCDNA3GPU() || arch.isCDNA35GPU())
+            if(arch.isCDNA3GPU() || arch.isCDNA4GPU())
             {
                 peekAndSchedule(context, insts[0]);
                 peekAndSchedule(context, insts[1], 1);

--- a/shared/rocroller/test/rocprofiler/BankConflictTest.cpp
+++ b/shared/rocroller/test/rocprofiler/BankConflictTest.cpp
@@ -228,9 +228,9 @@ namespace rocRollerTest
 
                         auto context = TestContext::ForTestDevice({}, name);
 
-                        if(not context->targetArchitecture().target().isCDNA35GPU())
+                        if(not context->targetArchitecture().target().isCDNA4GPU())
                         {
-                            SKIP("LDS Bank Model only implemented for CDNA 3.5 GPUs");
+                            SKIP("LDS Bank Model only implemented for CDNA 4 GPUs");
                         }
 
                         LDSBankConflictTestKernel kernel(


### PR DESCRIPTION
## Motivation

RocRoller/GPUArchitectureGenerator currently ties GFX950 to CDNA 3.5, but the MRISA files for GFX950 are CDNA 4. This discrepancy causes incorrect/incomplete regeneration/updating of the architecture files for GFX950.
 
## Technical Details

- Update all references to CDNA 3.5 to CDNA 4

## Test Plan

Test architecture file generation

## Test Result

Proper architecture file generation

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

For AIROCROLL-1532
