### PR TITLE
[MIOpen] Reduce boost usage by replacing calls to boost::core::demangle

### DIFF
--- a/projects/miopen/driver/rocrand_wrapper.hpp
+++ b/projects/miopen/driver/rocrand_wrapper.hpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2024 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #pragma once
 #ifndef GUARD_ROCRAND_WRAPPER_HPP
 #define GUARD_ROCRAND_WRAPPER_HPP
@@ -33,7 +11,7 @@
 // half from half.hpp, while rocrand uses definition of half type from HIP headers, i.e. the
 // definitions are different.
 
-#include <boost/core/demangle.hpp>
+#include <miopen/demangle.hpp>
 #include <half/half.hpp>
 
 #include <iostream>
@@ -50,9 +28,8 @@ int gen_0_1(T* buf, size_t sz)
 {
     std::cout << "Warning: gpumemrand functions are supported only for double, float and half. GPU "
                  "buffer { "
-              << static_cast<void*>(buf) << ", " << sz << ", "
-              << boost::core::demangle(typeid(T).name()) << " } remains uninitialized."
-              << std::endl;
+              << static_cast<void*>(buf) << ", " << sz << ", " << miopen::demangle(typeid(T).name())
+              << " } remains uninitialized." << std::endl;
     return 0;
 }
 

--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -1,28 +1,5 @@
-################################################################################
-#
-# MIT License
-#
-# Copyright (c) 2017 Advanced Micro Devices, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-################################################################################
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
 
 cmake_policy(SET CMP0057 NEW)
 
@@ -107,6 +84,7 @@ set( MIOpen_Source
     ctc_api.cpp
     db.cpp
     db_record.cpp
+    demangle.cpp
     driver_arguments.cpp
     dropout.cpp
     dropout_api.cpp

--- a/projects/miopen/src/demangle.cpp
+++ b/projects/miopen/src/demangle.cpp
@@ -11,21 +11,24 @@
 #include <cxxabi.h>
 #endif
 
+#include <memory>
+
 #include <miopen/demangle.hpp>
 
 namespace miopen {
 
 #if defined(MIOPEN_HAS_CXXABI_H)
 
+using DemangledNamePtr = std::unique_ptr<char, decltype(&free)>;
+
 std::string demangle(const char* name)
 {
     std::string s;
-    char* demangled_name = abi::__cxa_demangle(name, nullptr, nullptr, nullptr);
+    DemangledNamePtr demangled_name(abi::__cxa_demangle(name, nullptr, nullptr, nullptr), free);
 
-    if(demangled_name != nullptr)
+    if(demangled_name)
     {
-        s = demangled_name;
-        free(demangled_name);
+        s = demangled_name.get();
     }
     else
     {

--- a/projects/miopen/src/demangle.cpp
+++ b/projects/miopen/src/demangle.cpp
@@ -1,0 +1,44 @@
+#if defined(__has_include)
+#if __has_include(<cxxabi.h>)
+#define MIOPEN_HAS_CXXABI_H
+#endif
+#elif defined(__GLIBCXX__) || defined(__GLIBCPP__)
+#define MIOPEN_HAS_CXXABI_H
+#endif
+
+#if defined(MIOPEN_HAS_CXXABI_H)
+#include <cstdlib>
+#include <cxxabi.h>
+#endif
+
+#include <miopen/demangle.hpp>
+
+namespace miopen {
+
+#if defined(MIOPEN_HAS_CXXABI_H)
+
+std::string demangle(const char* name)
+{
+    std::string s;
+    char* demangled_name = abi::__cxa_demangle(name, nullptr, nullptr, nullptr);
+
+    if(demangled_name != nullptr)
+    {
+        s = demangled_name;
+        free(demangled_name);
+    }
+    else
+    {
+        s = name;
+    }
+
+    return s;
+}
+
+#else
+
+std::string demangle(const char* name) { return name; }
+
+#endif
+
+} // namespace miopen

--- a/projects/miopen/src/include/miopen/demangle.hpp
+++ b/projects/miopen/src/include/miopen/demangle.hpp
@@ -1,0 +1,12 @@
+#ifndef DEMANGLE_HPP
+#define DEMANGLE_HPP
+
+#include <string>
+
+namespace miopen {
+
+std::string demangle(const char* name);
+
+} // namespace miopen
+
+#endif // DEMANGLE_HPP

--- a/projects/miopen/src/include/miopen/demangle.hpp
+++ b/projects/miopen/src/include/miopen/demangle.hpp
@@ -3,9 +3,11 @@
 
 #include <string>
 
+#include <miopen/export.h>
+
 namespace miopen {
 
-std::string demangle(const char* name);
+MIOPEN_EXPORT std::string demangle(const char* name);
 
 } // namespace miopen
 


### PR DESCRIPTION
## Motivation

Reduce boost usage by replacing calls to boost::core::demangle() with an equivalent internal implementation.

## Technical Details

Calls to boost::core::demangle() have been replaced with an equivalent internal implementation.

## Test Plan

The replacement function has been tested both on MS Windows and Linux.

## Test Result

Tests have been successfull.

## Submission Checklist

- [X] Ensure your code builds successfully
- [X] Do not break existing test cases
- [X] Target the default branch for integration
