### PR TITLE
[hipDNN] Fix absolute build paths leaking into hipDNN installed CMake targets & enable additional tests

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -83,11 +83,17 @@ additional_options = {
     "hipdnn": {
         "cmake_options": [
             "-DTHEROCK_ENABLE_MIOPEN_PLUGIN=ON",
+            "-DTHEROCK_ENABLE_HIPDNN_SAMPLES=ON",
             "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
             "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON",
             "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel",
         ],
-        "projects_to_test": ["hipdnn", "miopen_plugin"],
+        "projects_to_test": [
+            "hipdnn",
+            "hipdnn_install",
+            "hipdnn-samples",
+            "miopen_plugin",
+        ],
         "project_to_add": "miopen",
     },
     "miopen-provider": {

--- a/projects/hipdnn/cmake/Dependencies.cmake
+++ b/projects/hipdnn/cmake/Dependencies.cmake
@@ -85,8 +85,10 @@ function(hipdnn_add_dependency_includes TARGET_NAME HEADER_LIB_TARGET_NAME)
 
     get_target_property(_dep_includes ${HEADER_LIB_TARGET_NAME} INTERFACE_INCLUDE_DIRECTORIES)
     if(_dep_includes)
-        message(VERBOSE "${TARGET_NAME} adding includes from ${HEADER_LIB_TARGET_NAME}: ${_dep_includes}")
-        target_include_directories(${TARGET_NAME} SYSTEM ${_visibility} ${_dep_includes})
+        foreach(_include IN LISTS _dep_includes)
+            message(VERBOSE "${TARGET_NAME} adding include from ${HEADER_LIB_TARGET_NAME}: ${_include}")
+            target_include_directories(${TARGET_NAME} SYSTEM ${_visibility} $<BUILD_INTERFACE:${_include}>)
+        endforeach()
     endif()
 
     if(ARG_COMPILE_DEFINITIONS)


### PR DESCRIPTION
## Motivation

We are seeing dependency build paths leaking into installed artifacts in TheRock. This is limited to TheRock builds because flatbuffers is built as a separate projects with resolved absolute paths, so hipDNN needs to wrap these in `$<BUILD_INTERFACE:...>` so they're dropped for the install.

## Technical Details

Wrapping the extracted dependency include directories in `$<BUILD_INTERFACE:...>` ensures they're available during build but stripped from `install(EXPORT)` output.

Also enable the hipdnn-samples and hipdnn_install tests from TheRock to catch these issues earlier.

## Test Plan

- Build the rock, remove `~/TheRock/build/third-party/flatbuffers/dist/` (hardcoded path), run hipdnn_install tests
- Observe `INTERFACE_INCLUDE_DIRS` in `/TheRock/build/dist/rocm/lib/cmake/hipdnn_data_sdk/hipdnn_data_sdkTargets.cmake` to ensure no leaked build paths

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
