### PR TITLE
[Origami] Avoid parsing environment variables repeatedly

### DIFF
--- a/shared/origami/include/origami/types.hpp
+++ b/shared/origami/include/origami/types.hpp
@@ -277,11 +277,6 @@ struct runtime_options {
   double heuristics_variance;
 
   /**
-   * @brief Default constructor that reads from environment variables.
-   */
-  runtime_options();
-
-  /**
    * @brief Constructor with explicit values (does not read from environment).
    */
   runtime_options(bool debug, bool heuristics, double variance);
@@ -311,7 +306,7 @@ struct runtime_options {
 
   /**
    * @brief Read heuristics variance from environment variable.
-   * @return double Variance value from ANALYTICAL_GEMM_HEURISTICS_VARIANCE, or 0.0 if not set
+   * @return double Variance value from ANALYTICAL_GEMM_HEURISTICS_VARIANCE, or 0.01 if not set
    */
   static double read_heuristics_variance_from_env();
 
@@ -319,6 +314,14 @@ struct runtime_options {
    * @brief Update runtime options from environment variables.
    */
   void update_from_env();
+
+  private:
+  /**
+   * @brief Default constructor that reads from environment variables.
+   *
+   * This is made private because it should only be used through the static get() member.
+   */
+  runtime_options();
 };
 
 /**

--- a/shared/origami/src/origami/gemm.cpp
+++ b/shared/origami/src/origami/gemm.cpp
@@ -566,7 +566,7 @@ double compute_memory_latency(const problem_t& problem,
                               size_t num_active_cus,
                               size_t splitting_factor) {
   
-  bool debug = runtime_options().get().debug_enabled;
+  bool debug = runtime_options::get().debug_enabled;
 
   // Extract parameters from structured types
   const auto a_bytes = data_type_to_bytes(problem.a_dtype);
@@ -717,7 +717,7 @@ double compute_tile_latency(const problem_t& problem,
                             size_t num_active_cus,
                             size_t splitting_factor) {
   
-  bool debug = runtime_options().get().debug_enabled;
+  bool debug = runtime_options::get().debug_enabled;
 
   // Extract parameters from structured types
   const size_t K = problem.size.k;
@@ -903,7 +903,7 @@ double compute_total_latency(const problem_t& problem,
                              const config_t& config,
                              size_t max_cus) {
   assert(config.is_valid());
-  bool debug = runtime_options().get().debug_enabled;
+  bool debug = runtime_options::get().debug_enabled;
 
   // Extract parameters from structured types
   size_t M     = problem.size.m;

--- a/shared/origami/src/origami/hardware.cpp
+++ b/shared/origami/src/origami/hardware.cpp
@@ -156,7 +156,7 @@ size_t hardware_t::get_mi_latency(size_t MI_M,
   if (it != instruction_map.end()) {
     return it->second / parallel_mi_cu;
   } else {
-    if (origami::runtime_options().get().debug_enabled)
+    if (origami::runtime_options::get().debug_enabled)
       std::cerr << "Warning: Latency not found for MI_M=" << MI_M << ", MI_N=" << MI_N
                 << ", MI_K=" << MI_K << ", mi_input_type=" << datatype_to_string(mi_input_type)
                 << ". Returning latency value of 32 (really slow).\n";

--- a/shared/origami/src/origami/heuristics.cpp
+++ b/shared/origami/src/origami/heuristics.cpp
@@ -173,7 +173,7 @@ heuristic_params_t heuristics_database_t::lookup(const problem_t& problem,
                                                  const hardware_t& hardware,
                                                  const config_t& config) const {
   // When heuristics are disabled, always return default parameters (no overrides).
-  if (!origami::runtime_options().get().heuristics_enabled) { return default_params_; }
+  if (!origami::runtime_options::get().heuristics_enabled) { return default_params_; }
 
   // Start with default parameters
   heuristic_params_t result = default_params_;
@@ -190,7 +190,7 @@ heuristic_params_t heuristics_database_t::lookup(const problem_t& problem,
 
     auto it = hand_optimized_map_.find(fast_key);
     if (it != hand_optimized_map_.end()) {
-      if (origami::runtime_options().get().debug_enabled) {
+      if (origami::runtime_options::get().debug_enabled) {
         OLOG_DEBUG("Hand-optimized kernel " << fast_key.to_string() << ", efficiency: "
                    << it->second.main_loop_efficiency);
       }

--- a/shared/origami/src/origami/origami.cpp
+++ b/shared/origami/src/origami/origami.cpp
@@ -350,7 +350,7 @@ std::vector<prediction_result_t> rank_configs(const problem_t& problem,
   constexpr double epsilon = 1e-9;
   // variance is set through environment variable ANALYTICAL_GEMM_HEURISTICS_VARIANCE
   // Use runtime_options from first config if available, otherwise global singleton
-  const double top_N_heuristic = get_runtime_options(configs.front()).heuristics_variance;
+  const double top_N_heuristic = origami::runtime_options::get().heuristics_variance;
   for (const auto& res : results) {
     bool within_top;
     const double diff = std::abs(res.latency - best_latency);


### PR DESCRIPTION

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This speeds up Origami solution selection.

## Technical Details

Do not call the `runtime_options()` constructor, then the static `get()` member.
Instread, directly call the static `runtime_options::get()` member.

This avoids always re-parsing the environment variables.

The `runtime_options` is made private so it can only be called by from the static `runtime_options::get()` to prevent previous behavior.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
