### PR TITLE
rocBLAS: Add NO_DEFAULT_PATH to OpenMP CONFIG find in clients

### DIFF
--- a/projects/rocblas/clients/CMakeLists.txt
+++ b/projects/rocblas/clients/CMakeLists.txt
@@ -114,8 +114,12 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # Look for openmp config in ROCm install to populate openmp_LIB_DIR and openmp_LIB_INSTALL_DIR
-  find_package(OpenMP CONFIG PATHS "${HIP_CLANG_ROOT}/lib/cmake")
+  # Look for openmp config in ROCm install to populate openmp_LIB_DIR and openmp_LIB_INSTALL_DIR.
+  # NO_DEFAULT_PATH prevents CMake from discovering system-installed OpenMP configs
+  # via PATH-derived prefixes (e.g. /opt/rocm), which can inject -isystem flags
+  # for the Clang resource directory, breaking HIP device compilation with GCC 15
+  # host headers on the amdgcn target.
+  find_package(OpenMP CONFIG NO_DEFAULT_PATH PATHS "${HIP_CLANG_ROOT}/lib/cmake")
 endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND TARGET OpenMP::omp)


### PR DESCRIPTION
## Summary

- Adds `NO_DEFAULT_PATH` to the `find_package(OpenMP CONFIG ...)` call in `projects/rocblas/clients/CMakeLists.txt`
- Prevents CMake from discovering system-installed OpenMP configs via PATH-derived prefixes (e.g. `/opt/rocm/lib/cmake/openmp`), which inject `-isystem` flags for the Clang resource directory
- Fixes HIP device compilation failure with GCC 15 host headers on amdgcn targets where `int_fast8_t` is missing from the global namespace

## Problem

When building rocBLAS clients with TheRock's built-in Clang compiler and GCC 15 system headers (e.g. Fedora 43), `find_package(OpenMP CONFIG)` without `NO_DEFAULT_PATH` allows CMake to discover OpenMP configs outside the build sandbox. The resulting `OpenMP::omp` target adds `INTERFACE_INCLUDE_DIRECTORIES` pointing to the Clang resource directory, which when passed as `-isystem` to HIP device compilation causes:

```
error: no member named 'int_fast8_t' in the global namespace
```

This happens because the system `stdint.h` checks `__x86_64__` (not defined for amdgcn), leading to missing type definitions. See: https://gcc.gnu.org/gcc-15/porting_to.html

## Fix

Adding `NO_DEFAULT_PATH` restricts the CONFIG search to the explicit `HIP_CLANG_ROOT` path. If that path doesn't contain an OpenMP config, the existing fallback to `find_package(OpenMP)` in MODULE mode correctly finds OpenMP without the problematic include directories.

## Test plan

- [x] Built full rocBLAS (647/647 targets) with TheRock on Fedora 43 (GCC 15 + Clang/amdgcn)
- [x] Verified SGEMM 4096x4096: **14,984 GFLOPS** on gfx1201 (RDNA 4 / Radeon AI PRO R9700)
- [x] Verified FP16 GEMM 4096x4096: **126,829 GFLOPS** on gfx1201
- [x] `rocblas-bench` and `rocblas-test` link and run correctly
- [x] Tensile kernel library loads successfully for gfx1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>