### PR TITLE
[`hipfft/shared`] syncing with `rocfft/shared`

### DIFF
--- a/projects/hipfft/shared/device_properties.h
+++ b/projects/hipfft/shared/device_properties.h
@@ -45,13 +45,22 @@ static hipDeviceProp_t get_curr_device_prop()
     return prop;
 }
 
-// Get current device GCN arch name without any suffix after ':'
-// If no devices are found, return empty string
-static std::string get_curr_gcn_arch_name()
+// Check if there are any visible HIP devices visible to the runtime
+static bool check_any_devices_visible()
 {
     int  dev_count = 0;
     auto ret       = hipGetDeviceCount(&dev_count);
     if(ret != hipSuccess || dev_count == 0)
+        return false;
+
+    return true;
+}
+
+// Get current device GCN arch name without any suffix after ':'
+// If no devices are found, return empty string
+static std::string get_curr_gcn_arch_name()
+{
+    if(!check_any_devices_visible())
         return "";
 
     auto        dev_prop       = get_curr_device_prop();


### PR DESCRIPTION
## Motivation

Realigning the contents of misnamed `shared` directories after some recent changes.

## Technical Details

Self-explanatory.

## Test Plan

Current tests suffice.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
