### PR TITLE
Gate Bwd Implicit Deterministic applicability behind CK availability

### DIFF
--- a/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupBwdXdlops.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvHipImplicitGemmGroupBwdXdlops.cpp
@@ -92,6 +92,16 @@ const auto& GetTestParams()
     return params;
 }
 
+Gpu GetDeterministicSupportedDevices()
+{
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+    return Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X | Gpu::gfx950 | Gpu::gfx110X | Gpu::gfx115X |
+           Gpu::gfx120X;
+#else
+    return Gpu::None;
+#endif
+}
+
 } // namespace
 
 using GPU_UnitTestConvSolverImplicitGemmGroupBwdXdlops_FP16 =
@@ -210,6 +220,5 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
     CPU_UnitTestConvSolverImplicitGemmGroupBwdXdlopsDeterministicApplicability_NONE,
-    testing::Combine(testing::Values(Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X | Gpu::gfx950 |
-                                     Gpu::gfx110X | Gpu::gfx115X | Gpu::gfx120X),
+    testing::Combine(testing::Values(GetDeterministicSupportedDevices()),
                      testing::Values(GetDeterministicConvCase())));


### PR DESCRIPTION
## Motivation

The unit test for Bwd deterministic applicability did not take into account whether CK is available or not. This led to the test failing when MIOpen is built without CK, even though this is a valid configuration.

## Technical Details

Adds a compile-time gate depending on the existing `MIOPEN_USE_COMPOSABLEKERNEL` flag. If this flag is disabled, the test expects CK kernels to not be applicable for deterministic problems, otherwise the behavior is as previous.

## Test Plan

Run the test with the flag enabled and disabled.

## Test Result

Test still passes with default `MIOPEN_USE_COMPOSABLEKERNEL=1`.
Test also passes with `MIOPEN_USE_COMPOSABLEKERNEL=0`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
