### PR TITLE
[rocRAND] fix warnings: HIP_CHECKs missing at hipgraphs_doc_sample.hpp

### DIFF
--- a/projects/rocrand/test/hipgraphs_doc_sample.hpp
+++ b/projects/rocrand/test/hipgraphs_doc_sample.hpp
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include "test_common.hpp"
+
 size_t        size = 1000;
 float*        data_0;
 unsigned int* data_1;

--- a/projects/rocrand/test/hipgraphs_doc_sample.hpp
+++ b/projects/rocrand/test/hipgraphs_doc_sample.hpp
@@ -2,36 +2,36 @@ size_t        size = 1000;
 float*        data_0;
 unsigned int* data_1;
 
-hipMalloc(&data_0, sizeof(*data_0) * size);
-hipMalloc(&data_1, sizeof(*data_1) * size);
+HIP_CHECK(hipMalloc(&data_0, sizeof(*data_0) * size));
+HIP_CHECK(hipMalloc(&data_1, sizeof(*data_1) * size));
 
 hipGraph_t graph;
-hipGraphCreate(&graph, 0);
+HIP_CHECK(hipGraphCreate(&graph, 0));
 
 hipStream_t stream;
-hipStreamCreateWithFlags(&stream, hipStreamNonBlocking);
+HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
 
 rocrand_generator generator;
 rocrand_create_generator(&generator, ROCRAND_RNG_PSEUDO_DEFAULT);
 rocrand_set_stream(generator, stream);
 rocrand_initialize_generator(generator);
 
-hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal);
+HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
 
 rocrand_generate_normal(generator, data_0, size, 10.0F, 2.0F);
 rocrand_generate_poisson(generator, data_1, size, 3);
 
-hipStreamEndCapture(stream, &graph);
+HIP_CHECK(hipStreamEndCapture(stream, &graph));
 
 hipGraphExec_t instance;
-hipGraphInstantiate(&instance, graph, nullptr, nullptr, 0);
+HIP_CHECK(hipGraphInstantiate(&instance, graph, nullptr, nullptr, 0));
 
-hipGraphLaunch(instance, stream);
-hipStreamSynchronize(stream);
+HIP_CHECK(hipGraphLaunch(instance, stream));
+HIP_CHECK(hipStreamSynchronize(stream));
 
-hipGraphExecDestroy(instance);
+HIP_CHECK(hipGraphExecDestroy(instance));
 rocrand_destroy_generator(generator);
-hipStreamDestroy(stream);
-hipGraphDestroy(graph);
-hipFree(data_1);
-hipFree(data_0);
+HIP_CHECK(hipStreamDestroy(stream));
+HIP_CHECK(hipGraphDestroy(graph));
+HIP_CHECK(hipFree(data_1));
+HIP_CHECK(hipFree(data_0));

--- a/projects/rocrand/test/hipgraphs_doc_sample.hpp
+++ b/projects/rocrand/test/hipgraphs_doc_sample.hpp
@@ -1,3 +1,23 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 size_t        size = 1000;
 float*        data_0;
 unsigned int* data_1;


### PR DESCRIPTION
## Motivation

Build warnings due to missing HIP_CHECKs 

## Technical Details

Add HIP_CHECK where needed

## Test Plan

Make a generic build, confirm that the warnings aren't there anymore 

## Test Result

👌

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
