### PR TITLE
[CK_BUILDER] Fix two staging-compiler errors in CK builder code

### DIFF
--- a/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/tensor_descriptor.hpp
+++ b/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/tensor_descriptor.hpp
@@ -106,7 +106,7 @@ struct Extent : std::array<size_t, RANK>
     /// @param i The index to index the array with.
     ///
     /// @see std::array::operator[]
-    __device__ __host__ size_t& operator[](size_t i)
+    __device__ __host__ size_t& operator[](size_t i) [[clang::lifetimebound]]
     {
         if constexpr(RANK > 0)
         {

--- a/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/tensor_descriptor.hpp
+++ b/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/tensor_descriptor.hpp
@@ -450,7 +450,8 @@ struct TensorDescriptor
     /// @brief Print tensor descriptor details.
     ///
     /// Print tensor descriptor details - lengths and strides.
-    friend std::ostream& operator<<(std::ostream& os, const TensorDescriptor<DT, RANK>& tensor_desc)
+    friend std::ostream& operator<<([[clang::lifetimebound]] std::ostream& os,
+                                    const TensorDescriptor<DT, RANK>& tensor_desc)
     {
         os << tensor_desc.inner_descriptor_;
         return os;

--- a/projects/composablekernel/experimental/builder/test/unit_device_buffer.cpp
+++ b/projects/composablekernel/experimental/builder/test/unit_device_buffer.cpp
@@ -48,7 +48,7 @@ TEST(DeviceBuffer, AutoFree)
     const auto size = 12345;
     std::byte* ptr  = nullptr;
 
-    // In this test we are explicitly testing a pointer that is out of scope, so 
+    // In this test we are explicitly testing a pointer that is out of scope, so
     // we have to disable the clang compiler's lifestime safety checks.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wlifetime-safety-permissive"

--- a/projects/composablekernel/experimental/builder/test/unit_device_buffer.cpp
+++ b/projects/composablekernel/experimental/builder/test/unit_device_buffer.cpp
@@ -48,6 +48,10 @@ TEST(DeviceBuffer, AutoFree)
     const auto size = 12345;
     std::byte* ptr  = nullptr;
 
+    // In this test we are explicitly testing a pointer that is out of scope, so 
+    // we have to disable the clang compiler's lifestime safety checks.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wlifetime-safety-permissive"
     {
         auto buffer = ckt::alloc_buffer(size);
         ptr         = buffer.get();
@@ -55,6 +59,7 @@ TEST(DeviceBuffer, AutoFree)
 
     // Trying to use a pointer after freeing should return en error in HIP.
     EXPECT_THAT(hipMemset(ptr, 0xFF, size), HipError(hipErrorInvalidValue));
+#pragma clang diagnostic pop
 
     // Reset internal HIP error state.
     // Otherwise, the error may leak into other tests, triggering anything that


### PR DESCRIPTION
This PR fixes two compiler warnings that report as errors with the latest compiler:

1. In tensor descriptor, the `operator[]` accessor needs a `[[clang::lifetimebound]]` attribute.
2. In the unit tests for device buffer, there is a test that explicitly checks for an error on a pointer that went out of scope, so it needs a to disable `-Wlifetime-safety-permissive` in the test code.

I ran the CK `smoke-builder` tests with the staging compiler to verify.