### PR TITLE
Workaround the TensileCI failure

### DIFF
--- a/shared/tensile/HostLibraryTests/CMakeLists.txt
+++ b/shared/tensile/HostLibraryTests/CMakeLists.txt
@@ -162,12 +162,13 @@ if(TENSILE_USE_HIP)
     add_subdirectory(hip)
     # Added the below line to workaround the CI failure issue manifesting from 
     # amdclang++ v7.2.0 host optimization pass 140079 for the below compilation unit
-    # which was doing a tail call optimization. So below command line is stopping the 
-    # optimization one short of the problematic optimization. Will be consulting with 
-    # compiler team to understand the LLVM IR before and after the optimization to understand
-    # why the failure is occuring.
+    # which was doing a tail call optimization on a gfx942 GPU but the same optimization pass 
+    # comes in pass number 136477 for gfx908 GPU. So below command line is stopping the 
+    # optimization one short of the problematic optimization for the minimum of two optimization 
+    # pass numbers. Will be consulting with compiler team to understand the LLVM IR before and 
+    # after the optimization to understand why the failure is occuring.
     set_source_files_properties(hip/RunGEMMKernel_test.cpp PROPERTIES
-	    COMPILE_OPTIONS "-mllvm;-opt-bisect-limit=140078")
+	    COMPILE_OPTIONS "-mllvm;-opt-bisect-limit=136476")
 endif()
 
 add_executable(TensileTests ${test_sources})

--- a/shared/tensile/HostLibraryTests/CMakeLists.txt
+++ b/shared/tensile/HostLibraryTests/CMakeLists.txt
@@ -163,12 +163,12 @@ if(TENSILE_USE_HIP)
     # Added the below line to workaround the CI failure issue manifesting from 
     # amdclang++ v7.2.0 host optimization pass 140079 for the below compilation unit
     # which was doing a tail call optimization on a gfx942 GPU but the same optimization pass 
-    # comes in pass number 136477 for gfx908 GPU. So below command line is stopping the 
-    # optimization one short of the problematic optimization for the minimum of two optimization 
-    # pass numbers. Will be consulting with compiler team to understand the LLVM IR before and 
+    # comes in pass number 136477 for gfx908 GPU.
+    # As temporary workaround, the optimization for this compilation unit is disabled 
+    # Will be consulting with compiler team to understand the LLVM IR before and 
     # after the optimization to understand why the failure is occuring.
     set_source_files_properties(hip/RunGEMMKernel_test.cpp PROPERTIES
-	    COMPILE_OPTIONS "-mllvm;-opt-bisect-limit=136476")
+	    COMPILE_OPTIONS "-O0")
 endif()
 
 add_executable(TensileTests ${test_sources})

--- a/shared/tensile/HostLibraryTests/CMakeLists.txt
+++ b/shared/tensile/HostLibraryTests/CMakeLists.txt
@@ -160,6 +160,14 @@ endif()
 
 if(TENSILE_USE_HIP)
     add_subdirectory(hip)
+    # Added the below line to workaround the CI failure issue manifesting from 
+    # amdclang++ v7.2.0 host optimization pass 140079 for the below compilation unit
+    # which was doing a tail call optimization. So below command line is stopping the 
+    # optimization one short of the problematic optimization. Will be consulting with 
+    # compiler team to understand the LLVM IR before and after the optimization to understand
+    # why the failure is occuring.
+    set_source_files_properties(hip/RunGEMMKernel_test.cpp PROPERTIES
+	    COMPILE_OPTIONS "-mllvm;-opt-bisect-limit=140078")
 endif()
 
 add_executable(TensileTests ${test_sources})


### PR DESCRIPTION
## Motivation

Tensile project's MathCI status was in red from mid of last September. The failure was mainly happening in the precheck-in stage. The fix in this PR will mitigate those failures and restore the Tensile CI status back to green.

## Technical Details

Investigation of the issue nailed down the problematic compilation unit as RunGEMMKernel_tests.cpp under shared/tensile/HostLibraryTests/hip directory. Manually disabling the compiler optimization and linking this unoptimized object file to static library and eventually to the final TensileTests executable mitigated the test failures. Further used the LLVM utility -opt-bisect-limit to identify the optimization pass which was triggering the test failures. The identified optimization pass was on the host side and doing a tail call optimization (pass number 140079). So the workaround was to stop the optimization pass for this specific compilation unit at 140078. This workaround is enabled in the CMakeLists.txt under shared/tensile/HostLibraryTests. 

## Test Plan

Ran all the gtests under TensileTests and all tests pass.

## Test Result

All tests are passing with this fix.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
