### PR TITLE
[CK_TILE] Layout support mix precision microscale BQuant

### DIFF
--- a/projects/composablekernel/.pre-commit-config.yaml
+++ b/projects/composablekernel/.pre-commit-config.yaml
@@ -22,19 +22,19 @@ repos:
     hooks:
     -   id: copyright-header-checker
         name: Check copyright headers
-        entry: script/check_copyright_year.sh
+        entry: projects/composablekernel/script/check_copyright_year.sh
         verbose: false
         language: script
         types_or: [c++, python, shell, cmake]
     -   id: remove-exec-bit
         name: Remove executable bit from non-executable files
-        entry: script/remove_exec_bit.sh
+        entry: projects/composablekernel/script/remove_exec_bit.sh
         language: script
         types_or: [c++, text]
         verbose: true
     -   id: remod-ck-tile
         name: Run ck_tile remod.py
-        entry: python script/remod_for_ck_tile.py
+        entry: python projects/composablekernel/script/remod_for_ck_tile.py
         language: python
         files: '^(include|example)/ck_tile/.*$'
         additional_dependencies:

--- a/projects/composablekernel/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
+++ b/projects/composablekernel/example/ck_tile/38_block_scale_gemm/run_gemm_quant_example.inc
@@ -860,6 +860,7 @@ int run_gemm_example_with_layouts(const ck_tile::ArgParser& arg_parser,
                                                   AccDataType,
                                                   CDataType,
                                                   BQuantGroupSize,
+                                                  BLayout,
                                                   false>(
                     a_m_k, *bq_tensor_ptr, b_k_n, c_m_n_host_ref);
             else

--- a/projects/composablekernel/include/ck_tile/core/arch/amd_buffer_addressing_builtins.hpp
+++ b/projects/composablekernel/include/ck_tile/core/arch/amd_buffer_addressing_builtins.hpp
@@ -2865,6 +2865,12 @@ __device__ auto amd_transpose_load_to_vgpr(const T* __restrict__ in_ptr)
         auto lds_ptr = reinterpret_cast<__LDS_ADDR llvm_i32x2_t*>(in_ptr_);
         return bit_cast<thread_buffer<T, N>>(__builtin_amdgcn_ds_read_tr8_b64_v2i32(lds_ptr));
     }
+    else if constexpr(std::is_same_v<remove_cvref_t<T>, ck_tile::pk_fp4_t>)
+    {
+        typedef __attribute__((__vector_size__(2 * sizeof(index_t)))) index_t llvm_i32x2_t;
+        auto lds_ptr = reinterpret_cast<__LDS_ADDR llvm_i32x2_t*>(in_ptr_);
+        return bit_cast<thread_buffer<T, N>>(__builtin_amdgcn_ds_read_tr4_b64_v2i32(lds_ptr));
+    }
     else
     {
         static_assert(false, "not implemented");

--- a/projects/composablekernel/include/ck_tile/core/tensor/load_tile_transpose.hpp
+++ b/projects/composablekernel/include/ck_tile/core/tensor/load_tile_transpose.hpp
@@ -94,16 +94,46 @@ struct DefaultTranspose
                                        sequence<0>>;
     };
 
+    template <index_t LaneGroupSize>
+    struct Quad4
+    {
+        static_assert(LaneGroupSize == 64 || LaneGroupSize == 32 || LaneGroupSize == 16,
+                      "LaneGroupSize must be 64, 32, or 16");
+        using InputEncoding =
+            tile_distribution_encoding<sequence<>,
+                                       tuple<sequence<16>, sequence<LaneGroupSize / 16, 1, 16>>,
+                                       tuple<sequence<2, 1, 2>>,
+                                       tuple<sequence<0, 0, 1>>,
+                                       sequence<2>,
+                                       sequence<2>>;
+
+        using OutputEncoding =
+            tile_distribution_encoding<sequence<>,
+                                       tuple<sequence<LaneGroupSize>, sequence<16>>,
+                                       tuple<sequence<1>>,
+                                       tuple<sequence<0>>,
+                                       sequence<2>,
+                                       sequence<0>>;
+    };
+
+    static constexpr index_t PackedSize = numeric_traits<remove_cvref_t<DataType>>::PackedSize;
+
     // Select based on data size
     template <index_t LaneGroupSize>
-    using QuadInputEncoding = std::conditional_t<sizeof(DataType) == 2,
-                                                 typename Quad16<LaneGroupSize>::InputEncoding,
-                                                 typename Quad8<LaneGroupSize>::InputEncoding>;
+    using QuadInputEncoding =
+        std::conditional_t<sizeof(DataType) == 2,
+                           typename Quad16<LaneGroupSize>::InputEncoding,
+                           std::conditional_t<PackedSize == 1,
+                                              typename Quad8<LaneGroupSize>::InputEncoding,
+                                              typename Quad4<LaneGroupSize>::InputEncoding>>;
 
     template <index_t LaneGroupSize>
-    using QuadOutputEncoding = std::conditional_t<sizeof(DataType) == 2,
-                                                  typename Quad16<LaneGroupSize>::OutputEncoding,
-                                                  typename Quad8<LaneGroupSize>::OutputEncoding>;
+    using QuadOutputEncoding =
+        std::conditional_t<sizeof(DataType) == 2,
+                           typename Quad16<LaneGroupSize>::OutputEncoding,
+                           std::conditional_t<PackedSize == 1,
+                                              typename Quad8<LaneGroupSize>::OutputEncoding,
+                                              typename Quad4<LaneGroupSize>::OutputEncoding>>;
 
     // Always swap last two dimensions
     static constexpr auto transpose_dims = sequence<1, 0>{};

--- a/projects/composablekernel/include/ck_tile/core/tensor/load_tile_transpose.hpp
+++ b/projects/composablekernel/include/ck_tile/core/tensor/load_tile_transpose.hpp
@@ -50,90 +50,61 @@ constexpr bool is_sequence_suffix_v = is_sequence_suffix<Suffix, Sequence>::valu
 template <typename DataType>
 struct DefaultTranspose
 {
-    template <index_t LaneGroupSize>
-    struct Quad16
+    template <index_t LaneGroupSize, index_t NumBitType>
+    struct Quad
     {
         static_assert(LaneGroupSize == 64 || LaneGroupSize == 32 || LaneGroupSize == 16,
                       "LaneGroupSize must be 64, 32, or 16");
-        using InputEncoding =
-            tile_distribution_encoding<sequence<>,
-                                       tuple<sequence<4>, sequence<LaneGroupSize / 16, 4, 4>>,
-                                       tuple<sequence<2, 1, 2>>,
-                                       tuple<sequence<0, 0, 1>>,
-                                       sequence<2>,
-                                       sequence<2>>;
 
-        using OutputEncoding =
-            tile_distribution_encoding<sequence<>,
-                                       tuple<sequence<LaneGroupSize>, sequence<4>>,
-                                       tuple<sequence<1>>,
-                                       tuple<sequence<0>>,
-                                       sequence<2>,
-                                       sequence<0>>;
+        // The tile is defined by the LaneGroupSize, which defines the number of lanes in the M/N
+        // dimensions for the MMA instruction defined by warp gemm.
+        // The LaneGroupSize is subdivided into groups of 16 (finer granularity of MMA
+        // instructions), we define these as major subtiles Each of this major subtile is divided
+        // into minor subtiles which group the lanes exchanging data during the transpose Example
+        // LaneGroupSize = 16, 16 bit type:
+        //  - There is 1 group of 16 lanes (1 major subtile)
+        //  - Each major subtile is divided into 4 minor subtiles of (4x4) -> 4 lanes transpose
+        //    the minor subtile and each lane holds 4 elements
+
+        // all load transpose instructions use 64 bit right now
+        static constexpr index_t InstructionBits = 64;
+        // Subtile major dimension is fixed
+        static constexpr index_t SubtileMajorDimension = 16;
+        // Number of subtile major
+        static constexpr index_t NumSubtilesMajor = LaneGroupSize / 16;
+        // number of elements loaded by each lane with single instruction, but also number
+        // of consecutive lanes in a subtile. Subtile is squared (NLanes x NElementsPerLane)
+        static constexpr index_t SubtileMinorDimension = InstructionBits / NumBitType;
+        // Number of subtiles minor inside each subtile major
+        static constexpr index_t NumSubtilesMinor = 16 / SubtileMinorDimension;
+
+        using InputEncoding = tile_distribution_encoding<
+            sequence<>,
+            tuple<sequence<SubtileMinorDimension>,
+                  sequence<NumSubtilesMajor, NumSubtilesMinor, SubtileMinorDimension>>,
+            tuple<sequence<2, 1, 2>>,
+            tuple<sequence<0, 0, 1>>,
+            sequence<2>,
+            sequence<2>>;
+
+        using OutputEncoding = tile_distribution_encoding<
+            sequence<>,
+            tuple<sequence<LaneGroupSize>, sequence<SubtileMinorDimension>>,
+            tuple<sequence<1>>,
+            tuple<sequence<0>>,
+            sequence<2>,
+            sequence<0>>;
     };
 
-    template <index_t LaneGroupSize>
-    struct Quad8
-    {
-        static_assert(LaneGroupSize == 64 || LaneGroupSize == 32 || LaneGroupSize == 16,
-                      "LaneGroupSize must be 64, 32, or 16");
-        using InputEncoding =
-            tile_distribution_encoding<sequence<>,
-                                       tuple<sequence<8>, sequence<LaneGroupSize / 16, 2, 8>>,
-                                       tuple<sequence<2, 1, 2>>,
-                                       tuple<sequence<0, 0, 1>>,
-                                       sequence<2>,
-                                       sequence<2>>;
-
-        using OutputEncoding =
-            tile_distribution_encoding<sequence<>,
-                                       tuple<sequence<LaneGroupSize>, sequence<8>>,
-                                       tuple<sequence<1>>,
-                                       tuple<sequence<0>>,
-                                       sequence<2>,
-                                       sequence<0>>;
-    };
-
-    template <index_t LaneGroupSize>
-    struct Quad4
-    {
-        static_assert(LaneGroupSize == 64 || LaneGroupSize == 32 || LaneGroupSize == 16,
-                      "LaneGroupSize must be 64, 32, or 16");
-        using InputEncoding =
-            tile_distribution_encoding<sequence<>,
-                                       tuple<sequence<16>, sequence<LaneGroupSize / 16, 1, 16>>,
-                                       tuple<sequence<2, 1, 2>>,
-                                       tuple<sequence<0, 0, 1>>,
-                                       sequence<2>,
-                                       sequence<2>>;
-
-        using OutputEncoding =
-            tile_distribution_encoding<sequence<>,
-                                       tuple<sequence<LaneGroupSize>, sequence<16>>,
-                                       tuple<sequence<1>>,
-                                       tuple<sequence<0>>,
-                                       sequence<2>,
-                                       sequence<0>>;
-    };
-
-    static constexpr index_t PackedSize = numeric_traits<remove_cvref_t<DataType>>::PackedSize;
+    static constexpr index_t PackedSize      = numeric_traits<remove_cvref_t<DataType>>::PackedSize;
+    static constexpr index_t NumBitsDataType = (sizeof(DataType) * 8) / PackedSize;
 
     // Select based on data size
     template <index_t LaneGroupSize>
-    using QuadInputEncoding =
-        std::conditional_t<sizeof(DataType) == 2,
-                           typename Quad16<LaneGroupSize>::InputEncoding,
-                           std::conditional_t<PackedSize == 1,
-                                              typename Quad8<LaneGroupSize>::InputEncoding,
-                                              typename Quad4<LaneGroupSize>::InputEncoding>>;
+    using QuadInputEncoding = typename Quad<LaneGroupSize, NumBitsDataType>::InputEncoding;
 
     template <index_t LaneGroupSize>
-    using QuadOutputEncoding =
-        std::conditional_t<sizeof(DataType) == 2,
-                           typename Quad16<LaneGroupSize>::OutputEncoding,
-                           std::conditional_t<PackedSize == 1,
-                                              typename Quad8<LaneGroupSize>::OutputEncoding,
-                                              typename Quad4<LaneGroupSize>::OutputEncoding>>;
+    using QuadOutputEncoding = typename Quad<LaneGroupSize, NumBitsDataType>::OutputEncoding;
 
     // Always swap last two dimensions
     static constexpr auto transpose_dims = sequence<1, 0>{};

--- a/projects/composablekernel/include/ck_tile/core/tensor/tensor_view.hpp
+++ b/projects/composablekernel/include/ck_tile/core/tensor/tensor_view.hpp
@@ -287,8 +287,8 @@ struct tensor_view
     get_transpose_vectorized_elements(const TensorCoord& coord, index_t linear_offset) const
     {
         return buf_.template transpose_get<X>(
-            coord.get_offset(),
-            linear_offset,
+            coord.get_offset() / PackedSize,
+            linear_offset / PackedSize,
             coordinate_has_valid_offset_assuming_top_index_is_valid(desc_, coord));
     }
 
@@ -303,7 +303,8 @@ struct tensor_view
                                       bool is_valid_element // flag
     ) const
     {
-        return buf_.template transpose_get<X>(coord.get_offset(), linear_offset, is_valid_element);
+        return buf_.template transpose_get<X>(
+            coord.get_offset() / PackedSize, linear_offset / PackedSize, is_valid_element);
     }
     // X is vector of DataType.
     // "coord" is coordinate of DataType, not X. "coord" should be aligned to X

--- a/projects/composablekernel/include/ck_tile/core/tensor/tile_window.hpp
+++ b/projects/composablekernel/include/ck_tile/core/tensor/tile_window.hpp
@@ -742,7 +742,7 @@ struct tile_window_with_static_distribution
                         .template get_transpose_vectorized_elements<vector_t>(
                             bottom_tensor_thread_coord, offset);
                 // write into distributed tensor
-                static_for<0, Traits::ScalarPerVector, 1>{}([&](auto j) {
+                static_for<0, Traits::ScalarPerVector, Traits::PackedSize>{}([&](auto j) {
                     constexpr auto orig_idx_ys = generate_tuple(
                         [&](auto jj) {
                             return jj == Traits::VectorDimY ? (idx_ys_start[jj] + j)
@@ -753,10 +753,12 @@ struct tile_window_with_static_distribution
                     constexpr auto grouped_idx_ys = group_func(orig_idx_ys);
 
                     constexpr index_t linear_distributed_index =
-                        tile_dstr.get_ys_to_d_descriptor().calculate_offset(grouped_idx_ys);
+                        tile_dstr.get_ys_to_d_descriptor().calculate_offset(grouped_idx_ys) /
+                        Traits::PackedSize;
 
                     dst_tensor.get_thread_buffer().template at<linear_distributed_index>() =
-                        vec_value.template get_as<typename Base::DataType>()[j];
+                        vec_value
+                            .template get_as<typename Base::DataType>()[j / Traits::PackedSize];
                 });
                 // move thread coordinate
                 if constexpr(iCoordAccess != (NumAccessPerCoord - 1))

--- a/projects/composablekernel/include/ck_tile/host/reference/reference_gemm.hpp
+++ b/projects/composablekernel/include/ck_tile/host/reference/reference_gemm.hpp
@@ -411,33 +411,32 @@ CK_TILE_HOST void reference_mx_gemm_bquant(const HostTensor<ADataType>& a_m_k,
         ComputeType v_a;
         ComputeType v_b;
 
-        for(std::size_t k = 0; k < K; k++)
-        {
-            const auto b_scale = type_convert<float>(q(k / QuantGroupSize::kK, n));
-            v_a                = ck_tile::type_convert<ComputeType>(a_element_op(a_m_k(m, k)));
+        auto load_b = [&](std::size_t k) -> AccDataType {
             if constexpr(std::is_same_v<BDataType, pk_fp4_t>)
             {
                 const auto b_pack = type_convert<pk_fp4_t>(b_element_op(b_k_n(k, n)));
-
-                const auto pack_dim =
-                    std::is_same_v<BLayout, ck_tile::tensor_layout::gemm::RowMajor> ? n : k;
-
-                if(pack_dim % 2 == 0)
+                if constexpr(std::is_same_v<BLayout, ck_tile::tensor_layout::gemm::RowMajor>)
                 {
-                    const auto b_f4_lo = type_convert<pk_fp4_t>(b_pack.unpack(number<0>{}));
-                    v_b                = type_convert<ComputeType>(b_f4_lo);
+                    return (n & 1) ? type_convert<ComputeType>(b_pack.unpack(number<1>{}))
+                                   : type_convert<ComputeType>(b_pack.unpack(number<0>{}));
                 }
                 else
                 {
-                    const auto b_f4_hi = type_convert<pk_fp4_t>(b_pack.unpack(number<1>{}));
-                    v_b                = type_convert<ComputeType>(b_f4_hi);
+                    return (k & 1) ? type_convert<ComputeType>(b_pack.unpack(number<1>{}))
+                                   : type_convert<ComputeType>(b_pack.unpack(number<0>{}));
                 }
             }
             else
             {
-                v_b = ck_tile::type_convert<ComputeType>(b_element_op(b_k_n(k, n)));
+                return ck_tile::type_convert<ComputeType>(b_element_op(b_k_n(k, n)));
             }
-            v_b *= b_scale;
+        };
+
+        for(std::size_t k = 0; k < K; k++)
+        {
+            const auto b_scale = type_convert<float>(q(k / QuantGroupSize::kK, n));
+            v_a                = ck_tile::type_convert<ComputeType>(a_element_op(a_m_k(m, k)));
+            v_b                = load_b(k) * b_scale;
             v_acc += v_a * v_b;
         }
         c_m_n(m, n) = ck_tile::type_convert<CDataType>(acc_element_op(v_acc));

--- a/projects/composablekernel/include/ck_tile/host/reference/reference_gemm.hpp
+++ b/projects/composablekernel/include/ck_tile/host/reference/reference_gemm.hpp
@@ -388,6 +388,7 @@ template <typename ADataType,
           typename AccDataType,
           typename CDataType,
           typename QuantGroupSize,
+          typename BLayout,
           bool aquant,
           typename AElementOp   = ck_tile::identity,
           typename BElementOp   = ck_tile::identity,
@@ -418,7 +419,10 @@ CK_TILE_HOST void reference_mx_gemm_bquant(const HostTensor<ADataType>& a_m_k,
             {
                 const auto b_pack = type_convert<pk_fp4_t>(b_element_op(b_k_n(k, n)));
 
-                if(k % 2 == 0)
+                const auto pack_dim =
+                    std::is_same_v<BLayout, ck_tile::tensor_layout::gemm::RowMajor> ? n : k;
+
+                if(pack_dim % 2 == 0)
                 {
                     const auto b_f4_lo = type_convert<pk_fp4_t>(b_pack.unpack(number<0>{}));
                     v_b                = type_convert<ComputeType>(b_f4_lo);

--- a/projects/composablekernel/include/ck_tile/ops/elementwise/unary_element_wise_operation.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/elementwise/unary_element_wise_operation.hpp
@@ -407,6 +407,150 @@ CK_TILE_HOST_DEVICE bf16x8_t bf8x8_to_bf16x8_scale(const bf8x8_t& src, const flo
     return y;
 }
 
+CK_TILE_HOST_DEVICE bf16x8_t fp8x8_to_bf16x8_scale(const fp8x8_t& src, const float& scale)
+{
+    bf16x8_t y;
+#if defined(__gfx950__)
+    union
+    {
+        uint32_t i16val;
+        fp8_t i8val[4];
+    } input;
+
+    union
+    {
+        bf16x2_t bhalf_vec;
+        bf16_t bhalf_arr[2];
+    } output;
+
+    constexpr index_t USE_BOTTOM = 0;
+    constexpr index_t USE_TOP    = 1;
+
+    input.i8val[0]   = src[0];
+    input.i8val[1]   = src[1];
+    input.i8val[2]   = src[2];
+    input.i8val[3]   = src[3];
+    output.bhalf_vec = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp8(input.i16val, scale, USE_BOTTOM);
+    y[0]             = output.bhalf_arr[0];
+    y[1]             = output.bhalf_arr[1];
+    output.bhalf_vec = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp8(input.i16val, scale, USE_TOP);
+    y[2]             = output.bhalf_arr[0];
+    y[3]             = output.bhalf_arr[1];
+
+    input.i8val[0]   = src[4];
+    input.i8val[1]   = src[5];
+    input.i8val[2]   = src[6];
+    input.i8val[3]   = src[7];
+    output.bhalf_vec = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp8(input.i16val, scale, USE_BOTTOM);
+    y[4]             = output.bhalf_arr[0];
+    y[5]             = output.bhalf_arr[1];
+    output.bhalf_vec = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp8(input.i16val, scale, USE_TOP);
+    y[6]             = output.bhalf_arr[0];
+    y[7]             = output.bhalf_arr[1];
+#else
+    static_for<0, 8, 1>{}([&](auto i) {
+        y[i.value] = type_convert<bf16_t>(type_convert<float>(src[i.value]) * scale);
+    });
+#endif
+    return y;
+}
+
+CK_TILE_HOST_DEVICE fp16x8_t fp8x8_to_fp16x8_scale(const fp8x8_t& src, const float& scale)
+{
+    fp16x8_t y;
+#if defined(__gfx950__)
+    union
+    {
+        uint32_t i16val;
+        fp8_t i8val[4];
+    } input;
+
+    union
+    {
+        fp16x2_t half_vec;
+        fp16_t half_arr[2];
+    } output;
+
+    constexpr index_t USE_BOTTOM = 0;
+    constexpr index_t USE_TOP    = 1;
+
+    input.i8val[0]  = src[0];
+    input.i8val[1]  = src[1];
+    input.i8val[2]  = src[2];
+    input.i8val[3]  = src[3];
+    output.half_vec = __builtin_amdgcn_cvt_scalef32_pk_f16_fp8(input.i16val, scale, USE_BOTTOM);
+    y[0]            = output.half_arr[0];
+    y[1]            = output.half_arr[1];
+    output.half_vec = __builtin_amdgcn_cvt_scalef32_pk_f16_fp8(input.i16val, scale, USE_TOP);
+    y[2]            = output.half_arr[0];
+    y[3]            = output.half_arr[1];
+
+    input.i8val[0]  = src[4];
+    input.i8val[1]  = src[5];
+    input.i8val[2]  = src[6];
+    input.i8val[3]  = src[7];
+    output.half_vec = __builtin_amdgcn_cvt_scalef32_pk_f16_fp8(input.i16val, scale, USE_BOTTOM);
+    y[4]            = output.half_arr[0];
+    y[5]            = output.half_arr[1];
+    output.half_vec = __builtin_amdgcn_cvt_scalef32_pk_f16_fp8(input.i16val, scale, USE_TOP);
+    y[6]            = output.half_arr[0];
+    y[7]            = output.half_arr[1];
+#else
+    static_for<0, 8, 1>{}([&](auto i) {
+        y[i.value] = type_convert<fp16_t>(type_convert<float>(src[i.value]) * scale);
+    });
+#endif
+    return y;
+}
+
+CK_TILE_HOST_DEVICE fp16x8_t bf8x8_to_fp16x8_scale(const bf8x8_t& src, const float& scale)
+{
+    fp16x8_t y;
+#if defined(__gfx950__)
+    union
+    {
+        uint32_t i16val;
+        bf8_t i8val[4];
+    } input;
+
+    union
+    {
+        fp16x2_t half_vec;
+        fp16_t half_arr[2];
+    } output;
+
+    constexpr index_t USE_BOTTOM = 0;
+    constexpr index_t USE_TOP    = 1;
+
+    input.i8val[0]  = src[0];
+    input.i8val[1]  = src[1];
+    input.i8val[2]  = src[2];
+    input.i8val[3]  = src[3];
+    output.half_vec = __builtin_amdgcn_cvt_scalef32_pk_f16_bf8(input.i16val, scale, USE_BOTTOM);
+    y[0]            = output.half_arr[0];
+    y[1]            = output.half_arr[1];
+    output.half_vec = __builtin_amdgcn_cvt_scalef32_pk_f16_bf8(input.i16val, scale, USE_TOP);
+    y[2]            = output.half_arr[0];
+    y[3]            = output.half_arr[1];
+
+    input.i8val[0]  = src[4];
+    input.i8val[1]  = src[5];
+    input.i8val[2]  = src[6];
+    input.i8val[3]  = src[7];
+    output.half_vec = __builtin_amdgcn_cvt_scalef32_pk_f16_bf8(input.i16val, scale, USE_BOTTOM);
+    y[4]            = output.half_arr[0];
+    y[5]            = output.half_arr[1];
+    output.half_vec = __builtin_amdgcn_cvt_scalef32_pk_f16_bf8(input.i16val, scale, USE_TOP);
+    y[6]            = output.half_arr[0];
+    y[7]            = output.half_arr[1];
+#else
+    static_for<0, 8, 1>{}([&](auto i) {
+        y[i.value] = type_convert<fp16_t>(type_convert<float>(src[i.value]) * scale);
+    });
+#endif
+    return y;
+}
+
 CK_TILE_HOST_DEVICE bf16x8_t fp4x4_to_bf16x8_scale(const pk_fp4x4_t& src, const float& scale)
 {
     bf16x8_t y;
@@ -439,6 +583,45 @@ CK_TILE_HOST_DEVICE bf16x8_t fp4x4_to_bf16x8_scale(const pk_fp4x4_t& src, const 
 #else
     static_for<0, 4, 1>{}([&](auto i) {
         auto yi            = pk_fp4_to_bf16x2(src[i.value], scale);
+        y[2 * i.value]     = yi[0];
+        y[2 * i.value + 1] = yi[1];
+    });
+#endif
+    return y;
+}
+
+CK_TILE_HOST_DEVICE fp16x8_t fp4x4_to_fp16x8_scale(const pk_fp4x4_t& src, const float& scale)
+{
+    fp16x8_t y;
+#if defined(__gfx950__)
+    union
+    {
+        uint32_t u32;
+        pk_fp4x4_t pf4;
+    } cvt;
+
+    constexpr index_t USE_BYTE_0 = 0;
+    constexpr index_t USE_BYTE_1 = 1;
+    constexpr index_t USE_BYTE_2 = 2;
+    constexpr index_t USE_BYTE_3 = 3;
+
+    cvt.pf4     = src;
+    fp16x2_t y0 = __builtin_amdgcn_cvt_scalef32_pk_f16_fp4(cvt.u32, scale, USE_BYTE_0);
+    fp16x2_t y1 = __builtin_amdgcn_cvt_scalef32_pk_f16_fp4(cvt.u32, scale, USE_BYTE_1);
+    fp16x2_t y2 = __builtin_amdgcn_cvt_scalef32_pk_f16_fp4(cvt.u32, scale, USE_BYTE_2);
+    fp16x2_t y3 = __builtin_amdgcn_cvt_scalef32_pk_f16_fp4(cvt.u32, scale, USE_BYTE_3);
+
+    y[0] = y0[0];
+    y[1] = y0[1];
+    y[2] = y1[0];
+    y[3] = y1[1];
+    y[4] = y2[0];
+    y[5] = y2[1];
+    y[6] = y3[0];
+    y[7] = y3[1];
+#else
+    static_for<0, 4, 1>{}([&](auto i) {
+        auto yi            = pk_fp4_to_fp16x2(src[i.value], scale);
         y[2 * i.value]     = yi[0];
         y[2 * i.value + 1] = yi[1];
     });
@@ -531,9 +714,33 @@ struct DequantPack8
     }
 
     CK_TILE_HOST_DEVICE constexpr void
+    operator()(fp16x8_t& y, const pk_fp4x4_t& x, const float& z) const
+    {
+        y = fp4x4_to_fp16x8_scale(x, z);
+    }
+
+    CK_TILE_HOST_DEVICE constexpr void
     operator()(bf16x8_t& y, const bf8x8_t& x, const float& z) const
     {
         y = bf8x8_to_bf16x8_scale(x, z);
+    }
+
+    CK_TILE_HOST_DEVICE constexpr void
+    operator()(bf16x8_t& y, const fp8x8_t& x, const float& z) const
+    {
+        y = fp8x8_to_bf16x8_scale(x, z);
+    }
+
+    CK_TILE_HOST_DEVICE constexpr void
+    operator()(fp16x8_t& y, const fp8x8_t& x, const float& z) const
+    {
+        y = fp8x8_to_fp16x8_scale(x, z);
+    }
+
+    CK_TILE_HOST_DEVICE constexpr void
+    operator()(fp16x8_t& y, const bf8x8_t& x, const float& z) const
+    {
+        y = bf8x8_to_fp16x8_scale(x, z);
     }
 
     CK_TILE_HOST_DEVICE constexpr void

--- a/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_base.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_base.hpp
@@ -242,6 +242,12 @@ struct GemmPipelineAgBgCrImplBase
     CK_TILE_DEVICE constexpr auto MakeALdsWindows(const ALdsTensorView& a_lds_block_view,
                                                   const ALdsLoadTileDistr&) const
     {
+        // with pk_int4_t the LDS type is always BDataType
+        using ADataTypeLDS =
+            std::conditional_t<std::is_same_v<typename Problem::ADataType, pk_int4_t>,
+                               typename Problem::BDataType,
+                               typename Problem::ADataType>;
+
         auto a_lds_shape = []() {
             if constexpr(is_a_load_tr)
                 return make_tuple(number<KPerBlock>{}, number<MPerBlock>{});
@@ -254,9 +260,8 @@ struct GemmPipelineAgBgCrImplBase
         auto a_lds_load_tile_distr = []() {
             if constexpr(is_a_load_tr)
                 return make_static_tile_distribution(
-                    typename InputTileDistributionTraits<
-                        typename ALdsLoadTileDistr::DstrEncode,
-                        typename Problem::ADataType>::TransposedDstrEncode{});
+                    typename InputTileDistributionTraits<typename ALdsLoadTileDistr::DstrEncode,
+                                                         ADataTypeLDS>::TransposedDstrEncode{});
             else
                 return ALdsLoadTileDistr{};
         }();

--- a/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_base.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_base.hpp
@@ -11,11 +11,12 @@ namespace ck_tile {
 template <typename Problem, typename Policy>
 struct GemmPipelineAgBgCrImplBase
 {
-    using AsDataType     = remove_cvref_t<typename Problem::AsDataTypeTuple>;
-    using BsDataType     = remove_cvref_t<typename Problem::BsDataTypeTuple>;
-    using AsLayout       = remove_cvref_t<typename Problem::AsLayoutTuple>;
-    using BsLayout       = remove_cvref_t<typename Problem::BsLayoutTuple>;
-    using BlockGemmShape = remove_cvref_t<typename Problem::BlockGemmShape>;
+    using AsDataType      = remove_cvref_t<typename Problem::AsDataTypeTuple>;
+    using BsDataType      = remove_cvref_t<typename Problem::BsDataTypeTuple>;
+    using AsLayout        = remove_cvref_t<typename Problem::AsLayoutTuple>;
+    using BsLayout        = remove_cvref_t<typename Problem::BsLayoutTuple>;
+    using BlockGemmShape  = remove_cvref_t<typename Problem::BlockGemmShape>;
+    using ComputeDataType = remove_cvref_t<typename Problem::ComputeDataType>;
 
     using ADataType   = remove_cvref_t<std::tuple_element_t<number<0>{}, AsDataType>>;
     using ALayout     = remove_cvref_t<std::tuple_element_t<number<0>{}, AsLayout>>;
@@ -68,6 +69,9 @@ struct GemmPipelineAgBgCrImplBase
         if constexpr(std::is_same_v<BDataType, pk_int4_t>)
             return false;
         else if constexpr(kKWarpTile > kMaxKWarpTile)
+            return false;
+        else if constexpr(!std::is_same_v<BDataType, ComputeDataType> &&
+                          !IsBCastPolicyBeforeLDSWrite)
             return false;
         else
             return std::is_same_v<BLayout, tensor_layout::gemm::RowMajor>;

--- a/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_base.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_base.hpp
@@ -70,9 +70,6 @@ struct GemmPipelineAgBgCrImplBase
             return false;
         else if constexpr(kKWarpTile > kMaxKWarpTile)
             return false;
-        else if constexpr(!std::is_same_v<BDataType, ComputeDataType> &&
-                          !IsBCastPolicyBeforeLDSWrite)
-            return false;
         else
             return std::is_same_v<BLayout, tensor_layout::gemm::RowMajor>;
     }();

--- a/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_base.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_pipeline_ag_bg_cr_base.hpp
@@ -11,12 +11,11 @@ namespace ck_tile {
 template <typename Problem, typename Policy>
 struct GemmPipelineAgBgCrImplBase
 {
-    using AsDataType      = remove_cvref_t<typename Problem::AsDataTypeTuple>;
-    using BsDataType      = remove_cvref_t<typename Problem::BsDataTypeTuple>;
-    using AsLayout        = remove_cvref_t<typename Problem::AsLayoutTuple>;
-    using BsLayout        = remove_cvref_t<typename Problem::BsLayoutTuple>;
-    using BlockGemmShape  = remove_cvref_t<typename Problem::BlockGemmShape>;
-    using ComputeDataType = remove_cvref_t<typename Problem::ComputeDataType>;
+    using AsDataType     = remove_cvref_t<typename Problem::AsDataTypeTuple>;
+    using BsDataType     = remove_cvref_t<typename Problem::BsDataTypeTuple>;
+    using AsLayout       = remove_cvref_t<typename Problem::AsLayoutTuple>;
+    using BsLayout       = remove_cvref_t<typename Problem::BsLayoutTuple>;
+    using BlockGemmShape = remove_cvref_t<typename Problem::BlockGemmShape>;
 
     using ADataType   = remove_cvref_t<std::tuple_element_t<number<0>{}, AsDataType>>;
     using ALayout     = remove_cvref_t<std::tuple_element_t<number<0>{}, AsLayout>>;
@@ -242,7 +241,7 @@ struct GemmPipelineAgBgCrImplBase
     CK_TILE_DEVICE constexpr auto MakeALdsWindows(const ALdsTensorView& a_lds_block_view,
                                                   const ALdsLoadTileDistr&) const
     {
-        // with pk_int4_t the LDS type is always BDataType
+        // with pk_int4_t load transpose the LDS type is always BDataType
         using ADataTypeLDS =
             std::conditional_t<std::is_same_v<typename Problem::ADataType, pk_int4_t>,
                                typename Problem::BDataType,

--- a/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -76,7 +76,6 @@ struct UniversalGemmBasePolicy
     template <typename Problem>
     static constexpr bool is_b_load_tr = []() {
         using BDataType              = remove_cvref_t<typename Problem::BDataType>;
-        using ComputeDataType        = remove_cvref_t<typename Problem::ComputeDataType>;
         using WarpTile               = typename Problem::BlockGemmShape::WarpTile;
         constexpr index_t kKWarpTile = WarpTile::at(number<2>{});
         // Max K warp tile for transpose load based on data type size
@@ -84,9 +83,6 @@ struct UniversalGemmBasePolicy
         if constexpr(std::is_same_v<BDataType, pk_int4_t>)
             return false;
         else if constexpr(kKWarpTile > kMaxKWarpTile)
-            return false;
-        else if constexpr(!std::is_same_v<BDataType, ComputeDataType> &&
-                          !IsBCastPolicyBeforeLDSWrite_v<Problem>)
             return false;
         else
             return std::is_same_v<remove_cvref_t<typename Problem::BLayout>,

--- a/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -34,21 +34,6 @@ struct has_b_tile_access_pattern<T, std::void_t<decltype(T::BTileAccessPattern)>
 template <typename Derived>
 struct UniversalGemmBasePolicy
 {
-    template <typename T>
-    using has_bcastpolicy_type = decltype(T::BCastPolicy);
-
-    template <typename Problem>
-    static constexpr bool IsBCastPolicyBeforeLDSWrite_v = [] {
-        if constexpr(is_detected<has_bcastpolicy_type, Problem>{})
-        {
-            return Problem::BCastPolicy == CastPolicy::BeforeLDSWrite;
-        }
-        else
-        {
-            return false;
-        }
-    }();
-
 #if defined(__gfx950__)
     // The combination of pk_int4_t and transposed loading causes numerical errors.
     // Therefore do not use transposed loading in this case.
@@ -94,6 +79,21 @@ struct UniversalGemmBasePolicy
     template <typename Problem>
     static constexpr bool is_b_load_tr = false;
 #endif
+
+    template <typename T>
+    using has_bcastpolicy_type = decltype(T::BCastPolicy);
+
+    template <typename Problem>
+    static constexpr bool IsBCastPolicyBeforeLDSWrite_v = [] {
+        if constexpr(is_detected<has_bcastpolicy_type, Problem>{})
+        {
+            return Problem::BCastPolicy == CastPolicy::BeforeLDSWrite;
+        }
+        else
+        {
+            return false;
+        }
+    }();
 
     static constexpr auto I0 = number<0>{};
     static constexpr auto I1 = number<1>{};

--- a/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/pipeline/gemm_universal_pipeline_ag_bg_cr_policy.hpp
@@ -34,6 +34,21 @@ struct has_b_tile_access_pattern<T, std::void_t<decltype(T::BTileAccessPattern)>
 template <typename Derived>
 struct UniversalGemmBasePolicy
 {
+    template <typename T>
+    using has_bcastpolicy_type = decltype(T::BCastPolicy);
+
+    template <typename Problem>
+    static constexpr bool IsBCastPolicyBeforeLDSWrite_v = [] {
+        if constexpr(is_detected<has_bcastpolicy_type, Problem>{})
+        {
+            return Problem::BCastPolicy == CastPolicy::BeforeLDSWrite;
+        }
+        else
+        {
+            return false;
+        }
+    }();
+
 #if defined(__gfx950__)
     // The combination of pk_int4_t and transposed loading causes numerical errors.
     // Therefore do not use transposed loading in this case.
@@ -61,6 +76,7 @@ struct UniversalGemmBasePolicy
     template <typename Problem>
     static constexpr bool is_b_load_tr = []() {
         using BDataType              = remove_cvref_t<typename Problem::BDataType>;
+        using ComputeDataType        = remove_cvref_t<typename Problem::ComputeDataType>;
         using WarpTile               = typename Problem::BlockGemmShape::WarpTile;
         constexpr index_t kKWarpTile = WarpTile::at(number<2>{});
         // Max K warp tile for transpose load based on data type size
@@ -68,6 +84,9 @@ struct UniversalGemmBasePolicy
         if constexpr(std::is_same_v<BDataType, pk_int4_t>)
             return false;
         else if constexpr(kKWarpTile > kMaxKWarpTile)
+            return false;
+        else if constexpr(!std::is_same_v<BDataType, ComputeDataType> &&
+                          !IsBCastPolicyBeforeLDSWrite_v<Problem>)
             return false;
         else
             return std::is_same_v<remove_cvref_t<typename Problem::BLayout>,
@@ -79,21 +98,6 @@ struct UniversalGemmBasePolicy
     template <typename Problem>
     static constexpr bool is_b_load_tr = false;
 #endif
-
-    template <typename T>
-    using has_bcastpolicy_type = decltype(T::BCastPolicy);
-
-    template <typename Problem>
-    static constexpr bool IsBCastPolicyBeforeLDSWrite_v = [] {
-        if constexpr(is_detected<has_bcastpolicy_type, Problem>{})
-        {
-            return Problem::BCastPolicy == CastPolicy::BeforeLDSWrite;
-        }
-        else
-        {
-            return false;
-        }
-    }();
 
     static constexpr auto I0 = number<0>{};
     static constexpr auto I1 = number<1>{};

--- a/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm.hpp
@@ -192,11 +192,13 @@ using WarpGemmMfmaBf16Bf16F32M16N16K32 = WarpGemmImpl<
                           AttrNumAccessA,
                           AttrNumAccessB>>;
 
-template <WGAttrNumAccessEnum AttrNumAccess = WGAttrNumAccessEnum::Single>
+template <WGAttrNumAccessEnum AttrNumAccessA = WGAttrNumAccessEnum::Single,
+          WGAttrNumAccessEnum AttrNumAccessB = AttrNumAccessA>
 using WarpGemmMfmaBf16Bf16F32M16N16K64 = WarpGemmImpl<WarpGemmAttributeMfmaIterateK<
     WarpGemmAttributeMfmaImplBf16Bf16F32M16N16K32<WGAttrCtlEnum::Default_>,
     2,
-    AttrNumAccess>>;
+    AttrNumAccessA,
+    AttrNumAccessB>>;
 #else
 template <WGAttrNumAccessEnum AttrNumAccessA = WGAttrNumAccessEnum::Single,
           WGAttrNumAccessEnum AttrNumAccessB = AttrNumAccessA>
@@ -205,11 +207,13 @@ using WarpGemmMfmaBf16Bf16F32M16N16K32 = WarpGemmImpl<WarpGemmAttributeMfmaItera
     2,
     AttrNumAccessA>>;
 
-template <WGAttrNumAccessEnum AttrNumAccess = WGAttrNumAccessEnum::Single>
+template <WGAttrNumAccessEnum AttrNumAccessA = WGAttrNumAccessEnum::Single,
+          WGAttrNumAccessEnum AttrNumAccessB = AttrNumAccessA>
 using WarpGemmMfmaBf16Bf16F32M16N16K64 = WarpGemmImpl<WarpGemmAttributeMfmaIterateK<
     WarpGemmAttributeMfmaImplBf16Bf16F32M16N16K16<WGAttrCtlEnum::Default_>,
     4,
-    AttrNumAccess>>;
+    AttrNumAccessA,
+    AttrNumAccessB>>;
 #endif
 
 using WarpGemmMfmaBf16Bf16F32M32N32K8SwizzleA = WarpGemmImpl<WarpGemmAttributeMfmaIterateK_SwizzleA<

--- a/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm.hpp
@@ -185,10 +185,12 @@ using WarpGemmMfmaBf16Bf16F32M32N32K16 = WarpGemmImpl<WarpGemmAttributeMfmaItera
 #endif
 
 #if defined(__gfx950__)
-template <WGAttrNumAccessEnum AttrNumAccess = WGAttrNumAccessEnum::Single>
+template <WGAttrNumAccessEnum AttrNumAccessA = WGAttrNumAccessEnum::Single,
+          WGAttrNumAccessEnum AttrNumAccessB = AttrNumAccessA>
 using WarpGemmMfmaBf16Bf16F32M16N16K32 = WarpGemmImpl<
     WarpGemmAttributeMfma<WarpGemmAttributeMfmaImplBf16Bf16F32M16N16K32<WGAttrCtlEnum::Default_>,
-                          AttrNumAccess>>;
+                          AttrNumAccessA,
+                          AttrNumAccessB>>;
 
 template <WGAttrNumAccessEnum AttrNumAccess = WGAttrNumAccessEnum::Single>
 using WarpGemmMfmaBf16Bf16F32M16N16K64 = WarpGemmImpl<WarpGemmAttributeMfmaIterateK<
@@ -196,11 +198,12 @@ using WarpGemmMfmaBf16Bf16F32M16N16K64 = WarpGemmImpl<WarpGemmAttributeMfmaItera
     2,
     AttrNumAccess>>;
 #else
-template <WGAttrNumAccessEnum AttrNumAccess = WGAttrNumAccessEnum::Single>
+template <WGAttrNumAccessEnum AttrNumAccessA = WGAttrNumAccessEnum::Single,
+          WGAttrNumAccessEnum AttrNumAccessB = AttrNumAccessA>
 using WarpGemmMfmaBf16Bf16F32M16N16K32 = WarpGemmImpl<WarpGemmAttributeMfmaIterateK<
     WarpGemmAttributeMfmaImplBf16Bf16F32M16N16K16<WGAttrCtlEnum::Default_>,
     2,
-    AttrNumAccess>>;
+    AttrNumAccessA>>;
 
 template <WGAttrNumAccessEnum AttrNumAccess = WGAttrNumAccessEnum::Single>
 using WarpGemmMfmaBf16Bf16F32M16N16K64 = WarpGemmImpl<WarpGemmAttributeMfmaIterateK<

--- a/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm_attribute_mfma.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm_attribute_mfma.hpp
@@ -157,14 +157,19 @@ struct WarpGemmAttributeMfma
 
 template <typename WarpGemmAttributeMfmaImpl_,
           index_t kKIter,
-          WGAttrNumAccessEnum AttrNumAccess_ = WGAttrNumAccessEnum::Single>
+          WGAttrNumAccessEnum AttrNumAccessA_ = WGAttrNumAccessEnum::Single,
+          WGAttrNumAccessEnum AttrNumAccessB_ = AttrNumAccessA_>
 struct WarpGemmAttributeMfmaIterateK
 {
     static_assert(kKIter > 0, "wrong!");
 
-    using Impl                           = remove_cvref_t<WarpGemmAttributeMfmaImpl_>;
-    static constexpr auto AttrNumAccess  = AttrNumAccess_;
-    static constexpr auto AttrNumAccessV = static_cast<index_t>(AttrNumAccess);
+    using Impl                            = remove_cvref_t<WarpGemmAttributeMfmaImpl_>;
+    static constexpr auto AttrNumAccessA  = AttrNumAccessA_;
+    static constexpr auto AttrNumAccessAV = static_cast<index_t>(AttrNumAccessA);
+    static constexpr auto AttrNumAccessB  = AttrNumAccessB_;
+    static constexpr auto AttrNumAccessBV = static_cast<index_t>(AttrNumAccessB);
+
+    static constexpr bool UsePackNumAccess = AttrNumAccessAV != AttrNumAccessBV;
 
     using ADataType = typename Impl::ADataType;
     using BDataType = typename Impl::BDataType;
@@ -187,14 +192,15 @@ struct WarpGemmAttributeMfmaIterateK
     static_assert(Impl::kAMBlock == 1 || Impl::kBNBlock == 1,
                   "Multi-block on both M & N directions is not supported");
 
-    template <index_t kMNLane, index_t kMNBlock, index_t kNMBlock>
+    template <index_t kMNLane, index_t kMNBlock, index_t kNMBlock, index_t AttrNumAccessV_>
     CK_TILE_DEVICE static constexpr auto get_warp_dstr_encoding()
     {
         if constexpr(kMNBlock == 1 && kNMBlock == 1)
         {
-            static_assert(kKPerThread % AttrNumAccessV == 0,
+            static_assert(kKPerThread % AttrNumAccessV_ == 0,
                           "kKPerThread must be divisible by NumAccess");
-            if constexpr(AttrNumAccessV == 1)
+            if constexpr(AttrNumAccessV_ == 1)
+            {
                 return tile_distribution_encoding<
                     sequence<>,
                     tuple<sequence<kMNLane>, sequence<Impl::kABKLane, Impl::kABKPerLane * kKIter>>,
@@ -202,21 +208,40 @@ struct WarpGemmAttributeMfmaIterateK
                     tuple<sequence<0, 0>>,
                     sequence<2>,
                     sequence<1>>{};
+            }
             else
-                return tile_distribution_encoding<
-                    sequence<>,
-                    tuple<sequence<kMNLane>,
-                          sequence<AttrNumAccessV,
-                                   Impl::kABKLane,
-                                   Impl::kABKPerLane * kKIter / AttrNumAccessV>>,
-                    tuple<sequence<2, 1>>,
-                    tuple<sequence<1, 0>>,
-                    sequence<2, 2>,
-                    sequence<0, 2>>{};
+            {
+                if constexpr(UsePackNumAccess)
+                {
+                    return tile_distribution_encoding<
+                        sequence<>,
+                        tuple<sequence<kMNLane>,
+                              sequence<Impl::kABKLane,
+                                       AttrNumAccessV_,
+                                       Impl::kABKPerLane * kKIter / AttrNumAccessV_>>,
+                        tuple<sequence<2, 1>>,
+                        tuple<sequence<0, 0>>,
+                        sequence<2, 2>,
+                        sequence<1, 2>>{};
+                }
+                else
+                {
+                    return tile_distribution_encoding<
+                        sequence<>,
+                        tuple<sequence<kMNLane>,
+                              sequence<AttrNumAccessV_,
+                                       Impl::kABKLane,
+                                       Impl::kABKPerLane * kKIter / AttrNumAccessV_>>,
+                        tuple<sequence<2, 1>>,
+                        tuple<sequence<1, 0>>,
+                        sequence<2, 2>,
+                        sequence<0, 2>>{};
+                }
+            }
         }
         else if constexpr(kMNBlock == 1 && 1 < kNMBlock)
         {
-            static_assert(AttrNumAccessV == 1,
+            static_assert(AttrNumAccessV_ == 1,
                           "Multiple access is not supported when using multi-block");
             // each M/N blocks share the same data
             return tile_distribution_encoding<
@@ -229,7 +254,7 @@ struct WarpGemmAttributeMfmaIterateK
         }
         else if constexpr(1 < kMNBlock && kNMBlock == 1)
         {
-            static_assert(AttrNumAccessV == 1,
+            static_assert(AttrNumAccessV_ == 1,
                           "Multiple access is not supported when using multi-block");
             // single block to multi-block thread mapping
             return tile_distribution_encoding<
@@ -281,10 +306,14 @@ struct WarpGemmAttributeMfmaIterateK
         }
     }
 
-    using AWarpDstrEncoding =
-        decltype(get_warp_dstr_encoding<Impl::kAMLane, Impl::kAMBlock, Impl::kBNBlock>());
-    using BWarpDstrEncoding =
-        decltype(get_warp_dstr_encoding<Impl::kBNLane, Impl::kBNBlock, Impl::kAMBlock>());
+    using AWarpDstrEncoding = decltype(get_warp_dstr_encoding<Impl::kAMLane,
+                                                              Impl::kAMBlock,
+                                                              Impl::kBNBlock,
+                                                              AttrNumAccessAV>());
+    using BWarpDstrEncoding = decltype(get_warp_dstr_encoding<Impl::kBNLane,
+                                                              Impl::kBNBlock,
+                                                              Impl::kAMBlock,
+                                                              AttrNumAccessBV>());
     using CWarpDstrEncoding = decltype(get_cwarp_dstr_encoding());
 
     // c_vec += a_vec * b_vec

--- a/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm_attribute_mfma.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm_attribute_mfma.hpp
@@ -18,12 +18,17 @@ enum class WGAttrNumAccessEnum
 };
 
 template <typename WarpGemmAttributeMfmaImpl_,
-          WGAttrNumAccessEnum AttrNumAccess_ = WGAttrNumAccessEnum::Single>
+          WGAttrNumAccessEnum AttrNumAccessA_ = WGAttrNumAccessEnum::Single,
+          WGAttrNumAccessEnum AttrNumAccessB_ = AttrNumAccessA_>
 struct WarpGemmAttributeMfma
 {
-    using Impl                           = remove_cvref_t<WarpGemmAttributeMfmaImpl_>;
-    static constexpr auto AttrNumAccess  = AttrNumAccess_;
-    static constexpr auto AttrNumAccessV = static_cast<index_t>(AttrNumAccess);
+    using Impl                            = remove_cvref_t<WarpGemmAttributeMfmaImpl_>;
+    static constexpr auto AttrNumAccessA  = AttrNumAccessA_;
+    static constexpr auto AttrNumAccessAV = static_cast<index_t>(AttrNumAccessA);
+    static constexpr auto AttrNumAccessB  = AttrNumAccessB_;
+    static constexpr auto AttrNumAccessBV = static_cast<index_t>(AttrNumAccessB);
+
+    static constexpr bool UsePackNumAccess = AttrNumAccessAV != AttrNumAccessBV;
 
     using ADataType = typename Impl::ADataType;
     using BDataType = typename Impl::BDataType;
@@ -44,12 +49,13 @@ struct WarpGemmAttributeMfma
     static_assert(Impl::kAMBlock == 1 && Impl::kBNBlock == 1,
                   "Multi-block WarpGemmAttributeMfmaImpl is not supported");
 
-    template <index_t kMNLane>
+    template <index_t kMNLane, index_t AttrNumAccessV_>
     static constexpr auto get_warp_dstr_encoding()
     {
-        static_assert(kKPerThread % AttrNumAccessV == 0,
+        static_assert(kKPerThread % AttrNumAccessV_ == 0,
                       "kKPerThread must be divisible by NumAccess");
-        if constexpr(AttrNumAccessV == 1)
+        if constexpr(AttrNumAccessV_ == 1)
+        {
             return tile_distribution_encoding<
                 sequence<>,
                 tuple<sequence<kMNLane>, sequence<Impl::kABKLane, Impl::kABKPerLane>>,
@@ -57,18 +63,48 @@ struct WarpGemmAttributeMfma
                 tuple<sequence<0, 0>>,
                 sequence<2>,
                 sequence<1>>{};
+        }
         else
-            return tile_distribution_encoding<
-                sequence<>,
-                tuple<sequence<kMNLane>,
-                      sequence<AttrNumAccessV, Impl::kABKLane, Impl::kABKPerLane / AttrNumAccessV>>,
-                tuple<sequence<2, 1>>,
-                tuple<sequence<1, 0>>,
-                sequence<2, 2>,
-                sequence<0, 2>>{};
+        {
+            // AttrNumAccess splits the kABKPerLane
+            // We can split them but still have them contiguous (packed) or have them interleaved.
+            // The reason to split the dimension but still have it packed is to match load transpose
+            // encoding when A and B use different AttrNumAccess (they have different types in LDS)
+            // Example
+            // A: 16bit, B: 8bit
+            // Load transpose B: lane0 -> K=0..7 (only 1 instruction)
+            // Load transpose A: lane0 -> K=0..3 first instruction, K=4..7 second instruction
+            // In this way the data in register are consistent between A and B
+            if constexpr(UsePackNumAccess)
+            {
+                return tile_distribution_encoding<
+                    sequence<>,
+                    tuple<sequence<kMNLane>,
+                          sequence<Impl::kABKLane,
+                                   AttrNumAccessV_,
+                                   Impl::kABKPerLane / AttrNumAccessV_>>,
+                    tuple<sequence<2, 1>>,
+                    tuple<sequence<0, 0>>,
+                    sequence<2, 2>,
+                    sequence<1, 2>>{};
+            }
+            else
+            {
+                return tile_distribution_encoding<
+                    sequence<>,
+                    tuple<sequence<kMNLane>,
+                          sequence<AttrNumAccessV_,
+                                   Impl::kABKLane,
+                                   Impl::kABKPerLane / AttrNumAccessV_>>,
+                    tuple<sequence<2, 1>>,
+                    tuple<sequence<1, 0>>,
+                    sequence<2, 2>,
+                    sequence<0, 2>>{};
+            }
+        }
     }
-    using AWarpDstrEncoding = decltype(get_warp_dstr_encoding<Impl::kAMLane>());
-    using BWarpDstrEncoding = decltype(get_warp_dstr_encoding<Impl::kBNLane>());
+    using AWarpDstrEncoding = decltype(get_warp_dstr_encoding<Impl::kAMLane, AttrNumAccessAV>());
+    using BWarpDstrEncoding = decltype(get_warp_dstr_encoding<Impl::kBNLane, AttrNumAccessBV>());
 
     using CWarpDstrEncoding = tile_distribution_encoding<
         sequence<>,

--- a/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm_dispatcher.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm_dispatcher.hpp
@@ -80,6 +80,8 @@ template<> struct Dispatcher<bf16_t, bf16_t, float, 32, 32, 16, false, false, fa
 template<> struct Dispatcher<bf16_t, bf16_t, float, 32, 32, 16,  true, false, false, EDouble> { using Type = WarpGemmMfmaBf16Bf16F32M32N32K16TransposedCDistribution<EDouble>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 32, false> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K32<>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 32, false, false, false, EDouble, ESingle> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K32<EDouble, ESingle>; };
+template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 64, false, false, false, EQuad, ESingle> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K64<EQuad, ESingle>; };
+template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 64, false, false, false, EQuad> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K64<EQuad>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 64, false> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K64<>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 32,  true>  { using Type = WarpGemmMfmaBf16Bf16F32M16N16K32TransposedCDistribution<>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 32, false, false, false, EDouble> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K32<EDouble>; };

--- a/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm_dispatcher.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm/warp/warp_gemm_dispatcher.hpp
@@ -24,9 +24,10 @@ template <typename AType,
           index_t NPerWave,
           index_t KPerWave,
           bool TransposeC,
-          bool SwizzleA                     = false,
-          bool UseStructuredSparsity        = false,
-          WGAttrNumAccessEnum AttrNumAccess = ESingle>
+          bool SwizzleA                      = false,
+          bool UseStructuredSparsity         = false,
+          WGAttrNumAccessEnum AttrNumAccessA = ESingle,
+          WGAttrNumAccessEnum AttrNumAccessB = AttrNumAccessA>
 struct Dispatcher;
 
 // clang-format off
@@ -78,6 +79,7 @@ template<> struct Dispatcher<bf16_t, bf16_t, float, 32, 32, 16,  true>  { using 
 template<> struct Dispatcher<bf16_t, bf16_t, float, 32, 32, 16, false, false, false, EDouble> { using Type = WarpGemmMfmaBf16Bf16F32M32N32K16<EDouble>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 32, 32, 16,  true, false, false, EDouble> { using Type = WarpGemmMfmaBf16Bf16F32M32N32K16TransposedCDistribution<EDouble>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 32, false> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K32<>; };
+template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 32, false, false, false, EDouble, ESingle> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K32<EDouble, ESingle>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 64, false> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K64<>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 32,  true>  { using Type = WarpGemmMfmaBf16Bf16F32M16N16K32TransposedCDistribution<>; };
 template<> struct Dispatcher<bf16_t, bf16_t, float, 16, 16, 32, false, false, false, EDouble> { using Type = WarpGemmMfmaBf16Bf16F32M16N16K32<EDouble>; };
@@ -167,9 +169,10 @@ template <typename AType,
           index_t NPerWave,
           index_t KPerWave,
           bool TransposeC,
-          bool SwizzleA                     = false,
-          bool UseStructuredSparsity        = false,
-          WGAttrNumAccessEnum AttrNumAccess = WGAttrNumAccessEnum::Single>
+          bool SwizzleA                      = false,
+          bool UseStructuredSparsity         = false,
+          WGAttrNumAccessEnum AttrNumAccessA = WGAttrNumAccessEnum::Single,
+          WGAttrNumAccessEnum AttrNumAccessB = AttrNumAccessA>
 using WarpGemmDispatcher = typename impl::warp_gemm_dispatcher::Dispatcher< //
     AType,
     BType,
@@ -180,6 +183,7 @@ using WarpGemmDispatcher = typename impl::warp_gemm_dispatcher::Dispatcher< //
     TransposeC,
     SwizzleA,
     UseStructuredSparsity,
-    AttrNumAccess>::Type;
+    AttrNumAccessA,
+    AttrNumAccessB>::Type;
 
 } // namespace ck_tile

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/block/block_universal_gemm_as_bs_bquant_cr.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/block/block_universal_gemm_as_bs_bquant_cr.hpp
@@ -127,6 +127,8 @@ struct BQuantBlockUniversalGemmAsBsCr
     using CDataType       = remove_cvref_t<typename Traits::CDataType>;
 
     // BDataType gets converted from PkInt4 during loading
+    // This is only needed when BCastPolicy is CastBeforeLDSWrite. This is always the case
+    // for pk_int4_t but not for pk_fp4_t
     using OverrideBDataType = std::conditional_t<
         (std::is_same_v<BDataType, pk_int4_t> || std::is_same_v<BDataType, pk_fp4_t>) &&
             std::is_same_v<typename Traits::BLayout, tensor_layout::gemm::RowMajor>,

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/block/block_universal_gemm_as_bs_bquant_cr.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/block/block_universal_gemm_as_bs_bquant_cr.hpp
@@ -126,7 +126,7 @@ struct BQuantBlockUniversalGemmAsBsCr
 
     // BDataType gets converted from PkInt4 during loading
     using OverrideBDataType = std::conditional_t<
-        std::is_same_v<BDataType, pk_int4_t> &&
+        (std::is_same_v<BDataType, pk_int4_t> || std::is_same_v<BDataType, pk_fp4_t>) &&
             std::is_same_v<typename Traits::BLayout, tensor_layout::gemm::RowMajor>,
         ADataType,
         BDataType>;

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/block/block_universal_gemm_as_bs_bquant_cr.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/block/block_universal_gemm_as_bs_bquant_cr.hpp
@@ -102,12 +102,14 @@ struct BQuantBlockUniversalGemmAsBsCr
         // 2. bf8, bf8, fp32 -> f32
         // 3. i4,  fp8, (fp8/fp32) -> f32
         // 4. i4,  bf8, (fp8/fp32) -> f32
-        // 5. bf16, (bf16/bf8/fp4), e8m0 -> f32
-        static_assert(is_any_of<ADataType, fp8_t, bf8_t, bf16_t>::value &&
-                      is_any_of<BDataType, fp8_t, bf8_t, pk_int4_t, bf16_t, pk_fp4_t>::value &&
-                      is_any_of<BQDataType, float, fp8_t, bf8_t, e8m0_t>::value &&
-                      is_any_of<ComputeDataType, fp8_t, bf8_t, bf16_t>::value &&
-                      std::is_same_v<CDataType, fp32_t>);
+        // 5. bf16, (bf16/bf8/fp8/fp4), e8m0 -> f32
+        // 6. fp16, (fp16/fp8/bf8/fp4), e8m0 -> f32
+        static_assert(
+            is_any_of<ADataType, fp8_t, bf8_t, bf16_t, fp16_t>::value &&
+            is_any_of<BDataType, fp8_t, bf8_t, pk_int4_t, bf16_t, pk_fp4_t, fp16_t>::value &&
+            is_any_of<BQDataType, float, fp8_t, bf8_t, e8m0_t>::value &&
+            is_any_of<ComputeDataType, fp8_t, bf8_t, bf16_t, fp16_t>::value &&
+            std::is_same_v<CDataType, fp32_t>);
 
         static constexpr index_t InterWaveSchedulingMacClusters = 1;
 

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_base.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_base.hpp
@@ -42,10 +42,14 @@ struct GemmMicroscalePipelineAgBgCrImplBase : public GemmPipelineAgBgCrImplBase<
     CK_TILE_DEVICE constexpr auto
     GetBQDramLoadWindow(const BQDramBlockWindowTmp& bq_dram_block_window_tmp) const
     {
-        static_assert(std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>);
-
-        using YPerTile = number<NPerBlockBQ>;
-        using XPerTile = number<KPerBlockBQ>;
+        using YPerTile =
+            std::conditional_t<std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>,
+                               number<NPerBlockBQ>,
+                               number<KPerBlockBQ>>;
+        using XPerTile =
+            std::conditional_t<std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>,
+                               number<KPerBlockBQ>,
+                               number<NPerBlockBQ>>;
 
         auto bq_copy_dram_window =
             make_tile_window(bq_dram_block_window_tmp.get_bottom_tensor_view(),

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
@@ -33,7 +33,6 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
         }
         else
         {
-            static_assert(std::is_same_v<BQLayout, ck_tile::tensor_layout::gemm::ColumnMajor>);
             return GetABQGlobalVectorLoadSize<Problem, BQDataType, NPerBlockBQ, KPerBlockBQ>();
         }
     }

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
@@ -175,26 +175,49 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
         }
     }
 
+    template <typename DataType, bool UseLoadTranspose, index_t ThreadElements>
+    static constexpr auto GetAttrNumAccess(bool_constant<UseLoadTranspose>, number<ThreadElements>)
+    {
+        constexpr index_t vector_size = DS_READ_TR_SIZE() / sizeof(DataType);
+
+        return !UseLoadTranspose                   ? WGAttrNumAccessEnum::Single
+               : vector_size == ThreadElements     ? WGAttrNumAccessEnum::Single
+               : vector_size * 2 == ThreadElements ? WGAttrNumAccessEnum::Double
+               : vector_size * 4 == ThreadElements ? WGAttrNumAccessEnum::Quad
+                                                   : WGAttrNumAccessEnum::Invalid;
+    };
+
     template <typename Problem>
     CK_TILE_HOST_DEVICE static constexpr auto GetBlockGemm()
     {
         using BlockWarps      = typename Problem::BlockGemmShape::BlockWarps;
         using WarpTile        = typename Problem::BlockGemmShape::WarpTile;
         using ComputeDataType = typename Problem::ComputeDataType;
+        using LDSADataType    = typename Problem::ADataType;
+        using LDSBDataType = std::conditional_t<Problem::BCastPolicy == CastPolicy::BeforeLDSWrite,
+                                                ComputeDataType,
+                                                typename Problem::BDataType>;
 
         static_assert(Problem::BQuantGroupSize::kK % WarpTile::at(I2) == 0,
                       "KPerWarpGemm must be a multiple of QuantGroupSize!");
 
-        constexpr index_t vector_size     = DS_READ_TR_SIZE() / sizeof(ComputeDataType);
-        constexpr index_t thread_elements = WarpTile::at(I1) * WarpTile::at(I2) / get_warp_size();
-        constexpr bool use_load_tr_inst =
-            (Base::template is_a_load_tr<Problem> || Base::template is_b_load_tr<Problem>);
-        constexpr auto wg_attr_num_access =
-            !use_load_tr_inst                    ? WGAttrNumAccessEnum::Single
-            : vector_size == thread_elements     ? WGAttrNumAccessEnum::Single
-            : vector_size * 2 == thread_elements ? WGAttrNumAccessEnum::Double
-            : vector_size * 4 == thread_elements ? WGAttrNumAccessEnum::Quad
-                                                 : WGAttrNumAccessEnum::Invalid;
+        constexpr auto thread_elements =
+            number<WarpTile::at(I1) * WarpTile::at(I2) / get_warp_size()>{};
+
+        constexpr auto is_a_load_tr_v = bool_constant<Base::template is_a_load_tr<Problem>>{};
+        constexpr auto is_b_load_tr_v = bool_constant<Base::template is_b_load_tr<Problem>>{};
+        constexpr auto is_any_load_tr = is_a_load_tr_v || is_b_load_tr_v;
+
+        constexpr auto wg_attr_num_access_compute =
+            GetAttrNumAccess<ComputeDataType>(is_any_load_tr, thread_elements);
+        constexpr auto wg_attr_num_accessA =
+            std::is_same_v<LDSADataType, LDSBDataType>
+                ? wg_attr_num_access_compute
+                : GetAttrNumAccess<LDSADataType>(is_a_load_tr_v, thread_elements);
+        constexpr auto wg_attr_num_accessB =
+            std::is_same_v<LDSADataType, LDSBDataType>
+                ? wg_attr_num_access_compute
+                : GetAttrNumAccess<LDSBDataType>(is_b_load_tr_v, thread_elements);
 
         using WarpGemm = WarpGemmDispatcher<ComputeDataType,
                                             ComputeDataType,
@@ -205,7 +228,8 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
                                             Problem::TransposeC,
                                             false,
                                             false,
-                                            wg_attr_num_access>;
+                                            wg_attr_num_accessA,
+                                            wg_attr_num_accessB>;
         static_assert(is_any_of<ComputeDataType, fp8_t, bf8_t, bf16_t, fp16_t>::value);
         static_assert(std::is_same_v<typename Problem::CDataType, float>);
 

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
@@ -26,8 +26,16 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
         constexpr index_t KPerBlock   = Problem::BlockGemmShape::kK;
         constexpr index_t KPerBlockBQ = KPerBlock / Problem::BQuantGroupSize::kK;
 
-        static_assert(std::is_same_v<BQLayout, ck_tile::tensor_layout::gemm::ColumnMajor>);
-        return GetABQGlobalVectorLoadSize<Problem, BQDataType, NPerBlockBQ, KPerBlockBQ>();
+        // Support both RowMajor and ColumnMajor layouts for BQ
+        if constexpr(std::is_same_v<BQLayout, ck_tile::tensor_layout::gemm::RowMajor>)
+        {
+            return GetABQGlobalVectorLoadSize<Problem, BQDataType, KPerBlockBQ, NPerBlockBQ>();
+        }
+        else
+        {
+            static_assert(std::is_same_v<BQLayout, ck_tile::tensor_layout::gemm::ColumnMajor>);
+            return GetABQGlobalVectorLoadSize<Problem, BQDataType, NPerBlockBQ, KPerBlockBQ>();
+        }
     }
 
     template <typename Problem>
@@ -70,13 +78,13 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
     template <typename Problem>
     CK_TILE_HOST_DEVICE static constexpr auto MakeBQDramTileDistribution()
     {
+        using BQLayout = remove_cvref_t<typename Problem::BQLayout>;
         // If we apply scale before writing to LDS, we need a tile distribution for
         // BQuant consistent with global memory reading of matrix B, while
         // if we apply scale after reading from LDS, we need a tile distribution for
         // BQuant consistent with the MMA instructions layout
         if constexpr(Problem::BCastPolicy == CastPolicy::AfterLDSRead)
         {
-            using BQLayout       = remove_cvref_t<typename Problem::BQLayout>;
             using BlockGemmShape = typename Problem::BlockGemmShape;
 
             constexpr index_t BlockSize   = Problem::kBlockSize;
@@ -112,7 +120,6 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
             constexpr index_t NPerBlock = Problem::BlockGemmShape::kN;
             constexpr index_t KPerBlock = Problem::BlockGemmShape::kK;
 
-            constexpr index_t KScale = KPerBlock / Problem::BQuantGroupSize::kK; // k_scale num  //2
             constexpr index_t VecLoadSize =
                 Problem::FixedVectorSize ? Problem::VectorSizeB : GetVectorSizeB<Problem>();
             constexpr index_t NumWaveGroups = Problem::NumWaveGroups;
@@ -121,22 +128,50 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
             constexpr index_t num_warps  = BlockSize / get_warp_size();
             constexpr index_t LargestVec = (KPerBlock * NPerBlock) / (num_warps * warp_size);
             constexpr index_t b_vec      = VecLoadSize > LargestVec ? LargestVec : VecLoadSize;
-            constexpr index_t K0         = KPerBlock / b_vec;
-            constexpr index_t K1         = K0 / KScale;
-            constexpr index_t K3         = K0 / K1;
-            constexpr index_t K2         = 1;
 
-            constexpr index_t N0 = num_warps / NumWaveGroups;
-            constexpr index_t N1 = warp_size / K0;
-            constexpr index_t N2 = NPerBlock / (N0 * N1);
+            if constexpr(std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>)
+            {
+                constexpr index_t KScale =
+                    KPerBlock / Problem::BQuantGroupSize::kK; // k_scale num  //2
+                constexpr index_t K0 = KPerBlock / b_vec;     // # of threads in K dim for B Matrix
+                constexpr index_t K1 = K0 / KScale;
+                constexpr index_t K3 = KScale;
+                constexpr index_t K2 = 1;
 
-            return make_static_tile_distribution(
-                tile_distribution_encoding<sequence<K1>,
-                                           tuple<sequence<N0, N1, N2>, sequence<K3, K2>>,
-                                           tuple<sequence<1>, sequence<1, 2, 0>>,
-                                           tuple<sequence<0>, sequence<1, 0, 0>>,
-                                           sequence<1, 2>,
-                                           sequence<2, 1>>{});
+                constexpr index_t N0 = num_warps / NumWaveGroups;
+                constexpr index_t N1 = warp_size / K0;
+                constexpr index_t N2 = NPerBlock / (N0 * N1);
+
+                return make_static_tile_distribution(
+                    tile_distribution_encoding<sequence<K1>,
+                                               tuple<sequence<N0, N1, N2>, sequence<K3, K2>>,
+                                               tuple<sequence<1>, sequence<1, 2, 0>>,
+                                               tuple<sequence<0>, sequence<1, 0, 0>>,
+                                               sequence<1, 2>,
+                                               sequence<2, 1>>{});
+            }
+            else
+            {
+                constexpr index_t NScale = NPerBlock / Problem::BQuantGroupSize::kN;
+                constexpr index_t NLanes = NScale / b_vec;
+                constexpr index_t NVec   = b_vec;
+
+                constexpr index_t KLanes            = warp_size / NLanes;
+                constexpr index_t KVec              = KPerBlock / KLanes / num_warps;
+                constexpr index_t KScale            = KPerBlock / Problem::BQuantGroupSize::kK;
+                constexpr index_t KRepeat           = KPerBlock / KScale / KVec;
+                constexpr index_t KRepeatInWave     = KRepeat > KLanes ? KLanes : 1;
+                constexpr index_t KRepeatAcrossWave = KRepeat > KLanes ? KRepeat / KLanes : 1;
+
+                // TODO: fix second sequence
+                return make_static_tile_distribution(
+                    tile_distribution_encoding<sequence<KRepeatAcrossWave, KRepeatInWave>,
+                                               tuple<sequence<1, 1, 1>, sequence<NLanes, NVec>>,
+                                               tuple<sequence<1, 0>, sequence<1, 0, 2>>,
+                                               tuple<sequence<0, 0>, sequence<1, 1, 0>>,
+                                               sequence<1, 2>,
+                                               sequence<2, 1>>{});
+            }
         }
     }
 
@@ -149,13 +184,28 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
         static_assert(Problem::BQuantGroupSize::kK % WarpTile::at(I2) == 0,
                       "KPerWarpGemm must be a multiple of QuantGroupSize!");
 
+        constexpr index_t vector_size =
+            DS_READ_TR_SIZE() / sizeof(typename Problem::ComputeDataType);
+        constexpr index_t thread_elements = WarpTile::at(I1) * WarpTile::at(I2) / get_warp_size();
+        constexpr bool use_load_tr_inst =
+            (Base::template is_a_load_tr<Problem> || Base::template is_b_load_tr<Problem>);
+        constexpr auto wg_attr_num_access =
+            !use_load_tr_inst                    ? WGAttrNumAccessEnum::Single
+            : vector_size == thread_elements     ? WGAttrNumAccessEnum::Single
+            : vector_size * 2 == thread_elements ? WGAttrNumAccessEnum::Double
+            : vector_size * 4 == thread_elements ? WGAttrNumAccessEnum::Quad
+                                                 : WGAttrNumAccessEnum::Invalid;
+
         using WarpGemm = WarpGemmDispatcher<typename Problem::ComputeDataType,
                                             typename Problem::ComputeDataType,
                                             typename Problem::CDataType,
                                             WarpTile::at(I0),
                                             WarpTile::at(I1),
                                             WarpTile::at(I2),
-                                            Problem::TransposeC>;
+                                            Problem::TransposeC,
+                                            false,
+                                            false,
+                                            wg_attr_num_access>;
         static_assert(std::is_same_v<typename Problem::ComputeDataType, fp8_t> ||
                       std::is_same_v<typename Problem::ComputeDataType, bf8_t> ||
                       std::is_same_v<typename Problem::ComputeDataType, bf16_t>);

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
@@ -178,14 +178,14 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
     template <typename Problem>
     CK_TILE_HOST_DEVICE static constexpr auto GetBlockGemm()
     {
-        using BlockWarps = typename Problem::BlockGemmShape::BlockWarps;
-        using WarpTile   = typename Problem::BlockGemmShape::WarpTile;
+        using BlockWarps      = typename Problem::BlockGemmShape::BlockWarps;
+        using WarpTile        = typename Problem::BlockGemmShape::WarpTile;
+        using ComputeDataType = typename Problem::ComputeDataType;
 
         static_assert(Problem::BQuantGroupSize::kK % WarpTile::at(I2) == 0,
                       "KPerWarpGemm must be a multiple of QuantGroupSize!");
 
-        constexpr index_t vector_size =
-            DS_READ_TR_SIZE() / sizeof(typename Problem::ComputeDataType);
+        constexpr index_t vector_size     = DS_READ_TR_SIZE() / sizeof(ComputeDataType);
         constexpr index_t thread_elements = WarpTile::at(I1) * WarpTile::at(I2) / get_warp_size();
         constexpr bool use_load_tr_inst =
             (Base::template is_a_load_tr<Problem> || Base::template is_b_load_tr<Problem>);
@@ -196,8 +196,8 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
             : vector_size * 4 == thread_elements ? WGAttrNumAccessEnum::Quad
                                                  : WGAttrNumAccessEnum::Invalid;
 
-        using WarpGemm = WarpGemmDispatcher<typename Problem::ComputeDataType,
-                                            typename Problem::ComputeDataType,
+        using WarpGemm = WarpGemmDispatcher<ComputeDataType,
+                                            ComputeDataType,
                                             typename Problem::CDataType,
                                             WarpTile::at(I0),
                                             WarpTile::at(I1),
@@ -206,9 +206,7 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
                                             false,
                                             false,
                                             wg_attr_num_access>;
-        static_assert(std::is_same_v<typename Problem::ComputeDataType, fp8_t> ||
-                      std::is_same_v<typename Problem::ComputeDataType, bf8_t> ||
-                      std::is_same_v<typename Problem::ComputeDataType, bf16_t>);
+        static_assert(is_any_of<ComputeDataType, fp8_t, bf8_t, bf16_t, fp16_t>::value);
         static_assert(std::is_same_v<typename Problem::CDataType, float>);
 
         using BlockGemmPolicy = BlockGemmASmemBSmemCRegV1CustomPolicy<

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
@@ -178,7 +178,8 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
     template <typename DataType, bool UseLoadTranspose, index_t ThreadElements>
     static constexpr auto GetAttrNumAccess(bool_constant<UseLoadTranspose>, number<ThreadElements>)
     {
-        constexpr index_t vector_size = DS_READ_TR_SIZE() / sizeof(DataType);
+        constexpr index_t PackedSize  = numeric_traits<remove_cvref_t<DataType>>::PackedSize;
+        constexpr index_t vector_size = DS_READ_TR_SIZE() / sizeof(DataType) * PackedSize;
 
         return !UseLoadTranspose                   ? WGAttrNumAccessEnum::Single
                : vector_size == ThreadElements     ? WGAttrNumAccessEnum::Single

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
@@ -131,12 +131,12 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
 
             constexpr index_t KScale = KPerBlock / Problem::BQuantGroupSize::kK;
 
+            // For each BQ layout we need different encodings whether B has the same layout or not
+            // TODO: generalize encodings for different BQuantGroupSize granularity
             if constexpr(std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>)
             {
-
                 if constexpr(std::is_same_v<BQLayout, BLayout>)
                 {
-
                     constexpr index_t K0 = KPerBlock / b_vec;
                     constexpr index_t K1 = K0 / KScale;
                     constexpr index_t K3 = KScale;
@@ -156,11 +156,14 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
                 }
                 else
                 {
-                    constexpr index_t N1                = NPerBlock / b_vec;
-                    constexpr index_t N2                = b_vec;
+                    constexpr index_t N1 = NPerBlock / b_vec;
+                    constexpr index_t N2 = b_vec;
+
                     constexpr index_t KRepeatInWave     = warp_size / N1;
                     constexpr index_t KRepeatAcrossWave = num_warps / KScale;
-                    constexpr index_t K2                = num_warps / KRepeatAcrossWave;
+
+                    constexpr index_t K2 = num_warps / KRepeatAcrossWave;
+
                     return make_static_tile_distribution(
                         tile_distribution_encoding<sequence<KRepeatAcrossWave, KRepeatInWave>,
                                                    tuple<sequence<1, N1, N2>, sequence<K2, 1, 1>>,
@@ -175,10 +178,10 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
                 if constexpr(std::is_same_v<BQLayout, BLayout>)
                 {
                     constexpr index_t NScale = NPerBlock / Problem::BQuantGroupSize::kN;
-                    constexpr index_t NLanes = NScale / b_vec;
-                    constexpr index_t NVec   = b_vec;
+                    constexpr index_t N0     = NScale / b_vec;
+                    constexpr index_t N1     = b_vec;
 
-                    constexpr index_t KLanes  = warp_size / NLanes;
+                    constexpr index_t KLanes  = warp_size / N0;
                     constexpr index_t KVec    = KPerBlock / KLanes / num_warps;
                     constexpr index_t KRepeat = KPerBlock / KScale / KVec;
 
@@ -187,7 +190,7 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
 
                     return make_static_tile_distribution(
                         tile_distribution_encoding<sequence<KRepeatAcrossWave, KRepeatInWave>,
-                                                   tuple<sequence<1, 1, 1>, sequence<NLanes, NVec>>,
+                                                   tuple<sequence<1, 1, 1>, sequence<N0, N1>>,
                                                    tuple<sequence<1, 0>, sequence<1, 0, 2>>,
                                                    tuple<sequence<0, 0>, sequence<1, 1, 0>>,
                                                    sequence<1, 2>,
@@ -217,6 +220,7 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
         }
     }
 
+    // Return AttrNumAccess for a given warp tile (defined by ThreadElements) and data type
     template <typename DataType, bool UseLoadTranspose, index_t ThreadElements>
     static constexpr auto GetAttrNumAccess(bool_constant<UseLoadTranspose>, number<ThreadElements>)
     {

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_policy.hpp
@@ -78,6 +78,7 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
     CK_TILE_HOST_DEVICE static constexpr auto MakeBQDramTileDistribution()
     {
         using BQLayout = remove_cvref_t<typename Problem::BQLayout>;
+        using BLayout  = remove_cvref_t<typename Problem::BLayout>;
         // If we apply scale before writing to LDS, we need a tile distribution for
         // BQuant consistent with global memory reading of matrix B, while
         // if we apply scale after reading from LDS, we need a tile distribution for
@@ -128,48 +129,90 @@ struct GemmMicroscalePipelineAgBgCrPolicy : public UniversalGemmPipelineAgBgCrPo
             constexpr index_t LargestVec = (KPerBlock * NPerBlock) / (num_warps * warp_size);
             constexpr index_t b_vec      = VecLoadSize > LargestVec ? LargestVec : VecLoadSize;
 
+            constexpr index_t KScale = KPerBlock / Problem::BQuantGroupSize::kK;
+
             if constexpr(std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>)
             {
-                constexpr index_t KScale =
-                    KPerBlock / Problem::BQuantGroupSize::kK; // k_scale num  //2
-                constexpr index_t K0 = KPerBlock / b_vec;     // # of threads in K dim for B Matrix
-                constexpr index_t K1 = K0 / KScale;
-                constexpr index_t K3 = KScale;
-                constexpr index_t K2 = 1;
 
-                constexpr index_t N0 = num_warps / NumWaveGroups;
-                constexpr index_t N1 = warp_size / K0;
-                constexpr index_t N2 = NPerBlock / (N0 * N1);
+                if constexpr(std::is_same_v<BQLayout, BLayout>)
+                {
 
-                return make_static_tile_distribution(
-                    tile_distribution_encoding<sequence<K1>,
-                                               tuple<sequence<N0, N1, N2>, sequence<K3, K2>>,
-                                               tuple<sequence<1>, sequence<1, 2, 0>>,
-                                               tuple<sequence<0>, sequence<1, 0, 0>>,
-                                               sequence<1, 2>,
-                                               sequence<2, 1>>{});
+                    constexpr index_t K0 = KPerBlock / b_vec;
+                    constexpr index_t K1 = K0 / KScale;
+                    constexpr index_t K3 = KScale;
+                    constexpr index_t K2 = 1;
+
+                    constexpr index_t N0 = num_warps / NumWaveGroups;
+                    constexpr index_t N1 = warp_size / K0;
+                    constexpr index_t N2 = NPerBlock / (N0 * N1);
+
+                    return make_static_tile_distribution(
+                        tile_distribution_encoding<sequence<K1>,
+                                                   tuple<sequence<N0, N1, N2>, sequence<K3, K2>>,
+                                                   tuple<sequence<1>, sequence<1, 2, 0>>,
+                                                   tuple<sequence<0>, sequence<1, 0, 0>>,
+                                                   sequence<1, 2>,
+                                                   sequence<2, 1>>{});
+                }
+                else
+                {
+                    constexpr index_t N1                = NPerBlock / b_vec;
+                    constexpr index_t N2                = b_vec;
+                    constexpr index_t KRepeatInWave     = warp_size / N1;
+                    constexpr index_t KRepeatAcrossWave = num_warps / KScale;
+                    constexpr index_t K2                = num_warps / KRepeatAcrossWave;
+                    return make_static_tile_distribution(
+                        tile_distribution_encoding<sequence<KRepeatAcrossWave, KRepeatInWave>,
+                                                   tuple<sequence<1, N1, N2>, sequence<K2, 1, 1>>,
+                                                   tuple<sequence<1, 2, 0>, sequence<0, 1, 2>>,
+                                                   tuple<sequence<0, 0, 0>, sequence<1, 1, 1>>,
+                                                   sequence<1, 2>,
+                                                   sequence<2, 2>>{});
+                }
             }
             else
             {
-                constexpr index_t NScale = NPerBlock / Problem::BQuantGroupSize::kN;
-                constexpr index_t NLanes = NScale / b_vec;
-                constexpr index_t NVec   = b_vec;
+                if constexpr(std::is_same_v<BQLayout, BLayout>)
+                {
+                    constexpr index_t NScale = NPerBlock / Problem::BQuantGroupSize::kN;
+                    constexpr index_t NLanes = NScale / b_vec;
+                    constexpr index_t NVec   = b_vec;
 
-                constexpr index_t KLanes            = warp_size / NLanes;
-                constexpr index_t KVec              = KPerBlock / KLanes / num_warps;
-                constexpr index_t KScale            = KPerBlock / Problem::BQuantGroupSize::kK;
-                constexpr index_t KRepeat           = KPerBlock / KScale / KVec;
-                constexpr index_t KRepeatInWave     = KRepeat > KLanes ? KLanes : 1;
-                constexpr index_t KRepeatAcrossWave = KRepeat > KLanes ? KRepeat / KLanes : 1;
+                    constexpr index_t KLanes  = warp_size / NLanes;
+                    constexpr index_t KVec    = KPerBlock / KLanes / num_warps;
+                    constexpr index_t KRepeat = KPerBlock / KScale / KVec;
 
-                // TODO: fix second sequence
-                return make_static_tile_distribution(
-                    tile_distribution_encoding<sequence<KRepeatAcrossWave, KRepeatInWave>,
-                                               tuple<sequence<1, 1, 1>, sequence<NLanes, NVec>>,
-                                               tuple<sequence<1, 0>, sequence<1, 0, 2>>,
-                                               tuple<sequence<0, 0>, sequence<1, 1, 0>>,
-                                               sequence<1, 2>,
-                                               sequence<2, 1>>{});
+                    constexpr index_t KRepeatInWave     = KRepeat > KLanes ? KLanes : 1;
+                    constexpr index_t KRepeatAcrossWave = KRepeat > KLanes ? KRepeat / KLanes : 1;
+
+                    return make_static_tile_distribution(
+                        tile_distribution_encoding<sequence<KRepeatAcrossWave, KRepeatInWave>,
+                                                   tuple<sequence<1, 1, 1>, sequence<NLanes, NVec>>,
+                                                   tuple<sequence<1, 0>, sequence<1, 0, 2>>,
+                                                   tuple<sequence<0, 0>, sequence<1, 1, 0>>,
+                                                   sequence<1, 2>,
+                                                   sequence<2, 1>>{});
+                }
+                else
+                {
+                    constexpr index_t KRepeatInWave = Problem::BQuantGroupSize::kK / b_vec;
+                    constexpr index_t K1            = KScale;
+
+                    constexpr index_t N0 = num_warps / NumWaveGroups;
+                    constexpr index_t N1 = warp_size / (KRepeatInWave * K1);
+
+                    // Number of contiguous elements in N dimension when reading B matrix
+                    // becomes the vector size of BQ
+                    constexpr index_t N2 = NPerBlock / (BlockSize / (KPerBlock / b_vec));
+
+                    return make_static_tile_distribution(
+                        tile_distribution_encoding<sequence<1, 1, KRepeatInWave>,
+                                                   tuple<sequence<1, K1, 1>, sequence<N0, N1, N2>>,
+                                                   tuple<sequence<1, 0, 2>, sequence<2, 0, 1, 0>>,
+                                                   tuple<sequence<0, 0, 0>, sequence<1, 1, 1, 2>>,
+                                                   sequence<1, 2>,
+                                                   sequence<2, 2>>{});
+                }
             }
         }
     }

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_v3.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_v3.hpp
@@ -378,9 +378,6 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
 
                 sweep_tile_span(b_block[number<0>{}], [&](auto idx0) {
                     sweep_tile_span(b_block[number<1>{}], [&](auto idx1) {
-                        constexpr auto i_j_idx       = make_tuple(idx0, idx1);
-                        constexpr auto i_j_idx_scale = make_bq_index(idx0, idx1);
-                        float scale                  = float(scale_tile[i_j_idx_scale]);
                         if constexpr(std::is_same_v<BDataType, ck_tile::pk_fp4_t>)
                         {
                             if constexpr(idx1.impl_.at(0) % BPackedSize == 0)
@@ -388,16 +385,48 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
                                 constexpr auto idx1_lo = tile_distributed_index<idx1.impl_.at(0)>{};
                                 constexpr auto idx1_hi =
                                     tile_distributed_index<idx1.impl_.at(0) + 1>{};
-                                constexpr auto i_j_idx_lo   = make_tuple(idx0, idx1_lo);
-                                constexpr auto i_j_idx_hi   = make_tuple(idx0, idx1_hi);
-                                auto b_pack                 = block_tile[i_j_idx];
-                                auto cvt                    = pk_mxfp4_to_compute_v2(b_pack, scale);
-                                block_tile_cast(i_j_idx_lo) = cvt.x;
-                                block_tile_cast(i_j_idx_hi) = cvt.y;
+
+                                constexpr auto i_j_idx_lo = make_tuple(idx0, idx1_lo);
+                                constexpr auto i_j_idx_hi = make_tuple(idx0, idx1_hi);
+
+                                constexpr auto i_j_idx = make_tuple(idx0, idx1);
+                                auto b_pack            = block_tile[i_j_idx];
+
+                                constexpr auto i_j_idx_scale_lo = make_bq_index(idx0, idx1_lo);
+                                constexpr auto i_j_idx_scale_hi = make_bq_index(idx0, idx1_hi);
+                                if constexpr(i_j_idx_scale_lo[I0{}].impl_.at(0) ==
+                                                 i_j_idx_scale_hi[I0{}].impl_.at(0) &&
+                                             i_j_idx_scale_lo[I1{}].impl_.at(0) ==
+                                                 i_j_idx_scale_hi[I1{}].impl_.at(0))
+                                {
+                                    float scale = float(scale_tile[i_j_idx_scale_lo]);
+                                    auto cvt    = pk_mxfp4_to_compute_v2(b_pack, scale);
+
+                                    block_tile_cast(i_j_idx_lo) = cvt.x;
+                                    block_tile_cast(i_j_idx_hi) = cvt.y;
+                                }
+                                else
+                                {
+                                    float scale_lo = float(scale_tile[i_j_idx_scale_lo]);
+                                    auto b_f4_lo =
+                                        type_convert<pk_fp4_t>(b_pack.unpack(number<0>{}));
+                                    block_tile_cast(i_j_idx_lo) = type_convert<BDqDataType>(
+                                        type_convert<float>(b_f4_lo) * scale_lo);
+
+                                    float scale_hi = float(scale_tile[i_j_idx_scale_hi]);
+                                    auto b_f4_hi =
+                                        type_convert<pk_fp4_t>(b_pack.unpack(number<1>{}));
+                                    block_tile_cast(i_j_idx_hi) = type_convert<BDqDataType>(
+                                        type_convert<float>(b_f4_hi) * scale_hi);
+                                }
                             }
                         }
                         else
                         {
+                            constexpr auto i_j_idx       = make_tuple(idx0, idx1);
+                            constexpr auto i_j_idx_scale = make_bq_index(idx0, idx1);
+                            float scale                  = float(scale_tile[i_j_idx_scale]);
+
                             auto b_pack = block_tile[i_j_idx];
                             block_tile_cast(i_j_idx) =
                                 type_convert<BDqDataType>(type_convert<float>(b_pack) * scale);

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_v3.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_v3.hpp
@@ -92,6 +92,9 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
     static constexpr auto TailNum    = Problem::TailNum;
     static constexpr auto Scheduler  = Problem::Scheduler;
 
+    static constexpr auto is_a_load_tr_v = bool_constant<PipelineImplBase::is_a_load_tr>{};
+    static constexpr auto is_b_load_tr_v = bool_constant<PipelineImplBase::is_b_load_tr>{};
+
     using Base::PrefetchStages;
 
     [[nodiscard]] CK_TILE_HOST static const std::string GetName()
@@ -329,7 +332,6 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
             if constexpr(IsCastBeforeLDS)
             {
                 constexpr auto b_block = TileType::get_distributed_spans();
-                constexpr auto idx1_js = tile_distributed_index<0>{};
 
                 // Internally this is using V_CVT_SCALEF32_PK_BF16_FP4 or V_CVT_SCALEF32_PK_FP16_FP4
                 // on gfx950
@@ -348,10 +350,23 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
                     }
                 };
 
+                constexpr index_t BQuantGroupSizeIdx0 =
+                    std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>
+                        ? BQuantGroupSize::kN
+                        : BQuantGroupSize::kK;
+                constexpr index_t BQuantGroupSizeIdx1 =
+                    std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>
+                        ? BQuantGroupSize::kK
+                        : BQuantGroupSize::kN;
+
                 sweep_tile_span(b_block[number<0>{}], [&](auto idx0) {
                     sweep_tile_span(b_block[number<1>{}], [&](auto idx1) {
-                        constexpr auto i_j_idx       = make_tuple(idx0, idx1);
-                        constexpr auto i_j_idx_scale = make_tuple(idx0, idx1_js);
+                        constexpr auto i_j_idx = make_tuple(idx0, idx1);
+                        constexpr auto idx0_s =
+                            tile_distributed_index<idx0.impl_.at(0) / BQuantGroupSizeIdx0>{};
+                        constexpr auto idx1_s =
+                            tile_distributed_index<idx1.impl_.at(0) / BQuantGroupSizeIdx1>{};
+                        constexpr auto i_j_idx_scale = make_tuple(idx0_s, idx1_s);
                         float scale                  = float(scale_tile[i_j_idx_scale]);
                         if constexpr(std::is_same_v<BDataType, ck_tile::pk_fp4_t>)
                         {
@@ -384,7 +399,7 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
                                           const TileType& block_tile,
                                           const ElementwiseFunc& element_func) const
         {
-            if constexpr(is_a_col_major)
+            if constexpr(is_a_col_major && !is_a_load_tr_v())
             {
                 auto a_shuffle_tmp = make_static_distributed_tensor<ADataType>(
                     Policy::template MakeShuffledARegTileDistribution<Problem>());
@@ -418,7 +433,7 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
                 }
             };
 
-            if constexpr(is_b_row_major)
+            if constexpr(is_b_row_major && !is_b_load_tr_v())
             {
                 auto b_shuffle_tmp = make_static_distributed_tensor<BLDSType>(
                     Policy::template MakeShuffledBRegTileDistribution<Problem>());
@@ -445,11 +460,13 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
             // It can apply the scale and cast if we scale after reading from LDS
             if constexpr(IsCastBeforeLDS)
             {
-                block_gemm.LocalPrefetch(a_lds_window, b_lds_window);
+                block_gemm.LocalPrefetch(
+                    a_lds_window, b_lds_window, is_a_load_tr_v, is_b_load_tr_v);
             }
             else
             {
-                block_gemm.LocalPrefetch(a_lds_window, b_lds_window, q_block_tile);
+                block_gemm.LocalPrefetch(
+                    a_lds_window, b_lds_window, q_block_tile, is_a_load_tr_v, is_b_load_tr_v);
             }
         }
 
@@ -482,9 +499,11 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
             constexpr bool is_bq_col_major =
                 std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>;
 
-            static_assert(is_bq_col_major, "Bq must be col major (row major not supported yet)");
-            static_assert(NPerBlockBQ == BQDramBlockWindowTmp{}.get_window_lengths()[I0{}] &&
-                              KPerBlockBQ == BQDramBlockWindowTmp{}.get_window_lengths()[I1{}],
+            static_assert(is_bq_col_major
+                              ? (NPerBlockBQ == BQDramBlockWindowTmp{}.get_window_lengths()[I0{}] &&
+                                 KPerBlockBQ == BQDramBlockWindowTmp{}.get_window_lengths()[I1{}])
+                              : (KPerBlockBQ == BQDramBlockWindowTmp{}.get_window_lengths()[I0{}] &&
+                                 NPerBlockBQ == BQDramBlockWindowTmp{}.get_window_lengths()[I1{}]),
                           "Bq block window has incorrect lengths for defined BqLayout!");
 
             static_assert(is_a_col_major
@@ -548,15 +567,19 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
             ABlockTile a_block_tile;
             BBlockTile b_block_tile;
 
-            using ADramTileWindowStep = typename ADramBlockWindowTmp::BottomTensorIndex;
-            using BDramTileWindowStep = typename BDramBlockWindowTmp::BottomTensorIndex;
+            using ADramTileWindowStep  = typename ADramBlockWindowTmp::BottomTensorIndex;
+            using BDramTileWindowStep  = typename BDramBlockWindowTmp::BottomTensorIndex;
+            using BQDramTileWindowStep = typename BQDramBlockWindowTmp::BottomTensorIndex;
 
             constexpr ADramTileWindowStep a_dram_tile_window_step =
                 is_a_col_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
             constexpr BDramTileWindowStep b_dram_tile_window_step =
                 is_b_row_major ? make_array(KPerBlock, 0) : make_array(0, KPerBlock);
 
-            constexpr index_t b_scale_dram_tile_window_step = KPerBlock / BQuantGroupSize::kK;
+            constexpr BQDramTileWindowStep b_scale_dram_tile_window_step =
+                std::is_same_v<BQLayout, tensor_layout::gemm::ColumnMajor>
+                    ? make_array(0, KPerBlock / BQuantGroupSize::kK)
+                    : make_array(KPerBlock / BQuantGroupSize::kK, 0);
             // -----------------------------------------------------------------------------------------
             // Gemm pipeline start
 
@@ -569,7 +592,7 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
             // Vmem -> Vgpr 0 (Q matrix)
             // Scale and cast tile before writing to LDS (if IsCastBeforeLDS)
             bq_block_tile = load_tile(bq_copy_dram_window);
-            move_tile_window(bq_copy_dram_window, {0, b_scale_dram_tile_window_step});
+            move_tile_window(bq_copy_dram_window, b_scale_dram_tile_window_step);
             ScaleTile(b_block_tile, bdq_block_tile, bq_block_tile);
 
             // initialize C tile to zero
@@ -589,7 +612,7 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
             if constexpr(IsCastBeforeLDS)
             {
                 bq_block_tile = load_tile(bq_copy_dram_window);
-                move_tile_window(bq_copy_dram_window, {0, b_scale_dram_tile_window_step});
+                move_tile_window(bq_copy_dram_window, b_scale_dram_tile_window_step);
             }
             ScaleTile(b_block_tile, bdq_block_tile, bq_block_tile);
 
@@ -619,7 +642,7 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
                     // Vmem -> Vgpr (Q matrix)
                     // Scale and cast tile before writing to LDS (if IsCastBeforeLDS)
                     bq_block_tile = load_tile(bq_copy_dram_window);
-                    move_tile_window(bq_copy_dram_window, {0, b_scale_dram_tile_window_step});
+                    move_tile_window(bq_copy_dram_window, b_scale_dram_tile_window_step);
                     ScaleTile(b_block_tile, bdq_block_tile, bq_block_tile);
 
                     // Consume tile
@@ -653,7 +676,7 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
                 if constexpr(!IsCastBeforeLDS)
                 {
                     bq_block_tile = load_tile(bq_copy_dram_window);
-                    move_tile_window(bq_copy_dram_window, {0, b_scale_dram_tile_window_step});
+                    move_tile_window(bq_copy_dram_window, b_scale_dram_tile_window_step);
                 }
 
                 // Consume second to last tile

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_v3.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_v3.hpp
@@ -394,6 +394,9 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
 
                                 constexpr auto i_j_idx_scale_lo = make_bq_index(idx0, idx1_lo);
                                 constexpr auto i_j_idx_scale_hi = make_bq_index(idx0, idx1_hi);
+
+                                // If the scale is the same for packed values, use pk cvt scale
+                                // instructions, otherwise scale and cast element by element
                                 if constexpr(i_j_idx_scale_lo[I0{}].impl_.at(0) ==
                                                  i_j_idx_scale_hi[I0{}].impl_.at(0) &&
                                              i_j_idx_scale_lo[I1{}].impl_.at(0) ==

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_v3.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_microscale_pipeline_ag_bg_cr_v3.hpp
@@ -359,14 +359,27 @@ struct MicroscaleGemmPipelineAgBgCrCompV3 : public BaseGemmPipelineAgBgCrCompV3<
                         ? BQuantGroupSize::kK
                         : BQuantGroupSize::kN;
 
+                // The input indices are with respect to B block tile. If B and Bq have different
+                // layouts, the indices must be swapped
+                auto make_bq_index = [](auto idx0, auto idx1) {
+                    if constexpr(std::is_same_v<BLayout, BQLayout>)
+                    {
+                        return make_tuple(
+                            tile_distributed_index<idx0.impl_.at(0) / BQuantGroupSizeIdx0>{},
+                            tile_distributed_index<idx1.impl_.at(0) / BQuantGroupSizeIdx1>{});
+                    }
+                    else
+                    {
+                        return make_tuple(
+                            tile_distributed_index<idx1.impl_.at(0) / BQuantGroupSizeIdx0>{},
+                            tile_distributed_index<idx0.impl_.at(0) / BQuantGroupSizeIdx1>{});
+                    }
+                };
+
                 sweep_tile_span(b_block[number<0>{}], [&](auto idx0) {
                     sweep_tile_span(b_block[number<1>{}], [&](auto idx1) {
-                        constexpr auto i_j_idx = make_tuple(idx0, idx1);
-                        constexpr auto idx0_s =
-                            tile_distributed_index<idx0.impl_.at(0) / BQuantGroupSizeIdx0>{};
-                        constexpr auto idx1_s =
-                            tile_distributed_index<idx1.impl_.at(0) / BQuantGroupSizeIdx1>{};
-                        constexpr auto i_j_idx_scale = make_tuple(idx0_s, idx1_s);
+                        constexpr auto i_j_idx       = make_tuple(idx0, idx1);
+                        constexpr auto i_j_idx_scale = make_bq_index(idx0, idx1);
                         float scale                  = float(scale_tile[i_j_idx_scale]);
                         if constexpr(std::is_same_v<BDataType, ck_tile::pk_fp4_t>)
                         {

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_quant_pipeline_problem.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_quant_pipeline_problem.hpp
@@ -88,9 +88,9 @@ struct GemmQuantPipelineProblemBase
                     !std::is_same_v<BLayout, BQLayout>));
 
     // gfx950 supports load with transpose for 4bit types, so we can transpose
-    // pk_fp4_t from LDS in registers. But transpose without this instruction,
+    // pk_fp4_t from LDS in registers. But without this instruction,
     // the transpose is done in register between Vmem read and LDS write and
-    // the implementation does not support pk_fp4_t
+    // the implementation does not support 4 bit types
 #ifdef __gfx950__
     static constexpr auto BCastPolicy = BCastPolicy_;
 #else

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_quant_pipeline_problem.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_quant_pipeline_problem.hpp
@@ -87,7 +87,19 @@ struct GemmQuantPipelineProblemBase
     static_assert(!(BCastPolicy_ == CastPolicy::BeforeLDSWrite &&
                     !std::is_same_v<BLayout, BQLayout>));
 
+    // gfx950 supports load with transpose for 4bit types, so we can transpose
+    // pk_fp4_t from LDS in registers. But transpose without this instruction,
+    // the transpose is done in register between Vmem read and LDS write and
+    // the implementation does not support pk_fp4_t
+#ifdef __gfx950__
     static constexpr auto BCastPolicy = BCastPolicy_;
+#else
+    static constexpr auto BCastPolicy =
+        std::is_same_v<BDataType, pk_fp4_t> &&
+                std::is_same_v<BLayout, tensor_layout::gemm::RowMajor>
+            ? CastPolicy::BeforeLDSWrite
+            : BCastPolicy_;
+#endif
 
     static_assert(BlockGemmShape::kM % AQuantGroupSize::kM == 0);
     static_assert(BlockGemmShape::kK % AQuantGroupSize::kK == 0);

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_quant_pipeline_problem.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_quant_pipeline_problem.hpp
@@ -79,9 +79,14 @@ struct GemmQuantPipelineProblemBase
     using AQLayout = remove_cvref_t<typename Traits::AQLayout>;
     using BQLayout = remove_cvref_t<typename Traits::BQLayout>;
 
-    static constexpr auto Scheduler   = Scheduler_;
-    static constexpr auto HasHotLoop  = HasHotLoop_;
-    static constexpr auto TailNum     = TailNum_;
+    static constexpr auto Scheduler  = Scheduler_;
+    static constexpr auto HasHotLoop = HasHotLoop_;
+    static constexpr auto TailNum    = TailNum_;
+
+    // Limitations
+    static_assert(!(BCastPolicy_ == CastPolicy::BeforeLDSWrite &&
+                    !std::is_same_v<BLayout, BQLayout>));
+
     static constexpr auto BCastPolicy = BCastPolicy_;
 
     static_assert(BlockGemmShape::kM % AQuantGroupSize::kM == 0);

--- a/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_quant_pipeline_problem.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/gemm_quant/pipeline/gemm_quant_pipeline_problem.hpp
@@ -83,10 +83,6 @@ struct GemmQuantPipelineProblemBase
     static constexpr auto HasHotLoop = HasHotLoop_;
     static constexpr auto TailNum    = TailNum_;
 
-    // Limitations
-    static_assert(!(BCastPolicy_ == CastPolicy::BeforeLDSWrite &&
-                    !std::is_same_v<BLayout, BQLayout>));
-
     // gfx950 supports load with transpose for 4bit types, so we can transpose
     // pk_fp4_t from LDS in registers. But without this instruction,
     // the transpose is done in register between Vmem read and LDS write and

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/CMakeLists.txt
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/CMakeLists.txt
@@ -190,6 +190,47 @@ if(GPU_TARGETS MATCHES "gfx94|gfx95|gfx12")
     )
     target_compile_options(test_tile_gemm_quant_bquant_preshuffleQuant_prefill_2d PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
 
+    # BQuant microscale tests
+    add_gtest_executable(test_tile_gemm_quant_bquant_microscale_rcr_1d_64 
+        test_gemm_quant_bquant_microscale_rcr_1d_64.cpp
+    )
+    target_compile_options(test_tile_gemm_quant_bquant_microscale_rcr_1d_64 PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
+
+    add_gtest_executable(test_tile_gemm_quant_bquant_microscale_crr_1d_64 
+        test_gemm_quant_bquant_microscale_crr_1d_64.cpp
+    )
+    target_compile_options(test_tile_gemm_quant_bquant_microscale_crr_1d_64 PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
+
+    add_gtest_executable(test_tile_gemm_quant_bquant_microscale_rrr_1d_64 
+        test_gemm_quant_bquant_microscale_rrr_1d_64.cpp
+    )
+    target_compile_options(test_tile_gemm_quant_bquant_microscale_rrr_1d_64 PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
+
+    add_gtest_executable(test_tile_gemm_quant_bquant_microscale_ccr_1d_64 
+        test_gemm_quant_bquant_microscale_ccr_1d_64.cpp
+    )
+    target_compile_options(test_tile_gemm_quant_bquant_microscale_ccr_1d_64 PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
+
+    add_gtest_executable(test_tile_gemm_quant_bquant_microscale_rcr_1d_128 
+        test_gemm_quant_bquant_microscale_rcr_1d_128.cpp
+    )
+    target_compile_options(test_tile_gemm_quant_bquant_microscale_rcr_1d_128 PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
+
+    add_gtest_executable(test_tile_gemm_quant_bquant_microscale_crr_1d_128 
+        test_gemm_quant_bquant_microscale_crr_1d_128.cpp
+    )
+    target_compile_options(test_tile_gemm_quant_bquant_microscale_crr_1d_128 PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
+
+    add_gtest_executable(test_tile_gemm_quant_bquant_microscale_rrr_1d_128 
+        test_gemm_quant_bquant_microscale_rrr_1d_128.cpp
+    )
+    target_compile_options(test_tile_gemm_quant_bquant_microscale_rrr_1d_128 PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
+
+    add_gtest_executable(test_tile_gemm_quant_bquant_microscale_ccr_1d_128 
+        test_gemm_quant_bquant_microscale_ccr_1d_128.cpp
+    )
+    target_compile_options(test_tile_gemm_quant_bquant_microscale_ccr_1d_128 PRIVATE ${TEST_GEMM_COMPILE_OPTIONS})
+
     # RowColQuant tests
     add_gtest_executable(test_tile_gemm_quant_rowcol 
         test_gemm_quant_rowcol.cpp

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_128.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_128.cpp
@@ -14,6 +14,7 @@ using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
 using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
 using FP8           = ck_tile::fp8_t;
 using BF8           = ck_tile::bf8_t;
+using FP16          = ck_tile::fp16_t;
 using BF16          = ck_tile::bf16_t;
 using Half          = ck_tile::half_t;
 using PkInt4        = ck_tile::pk_int4_t;
@@ -31,9 +32,37 @@ using BQuant1D128Types = ::testing::Types<
     std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  FP8,    float, Half, BQuantGrouped, GemmConfigBase, GroupSize>,
     std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>,
     std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx,   GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx,   GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx,   GroupSize>
+
+    // Microscaling
+    // RCR BQ: C
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,   FP16, E8M0, FP16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    FP8, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,    FP8, E8M0, FP16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,    BF8, E8M0, FP16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,  PkFP4, E8M0, FP16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    // RCR BQ: R
+    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16,    BF8, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    // CRR BQ: C
+    std::tuple<ColumnMajor,    RowMajor, RowMajor, ColumnMajor, BF16,    BF8, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    // CRR BQ: R
+    std::tuple<ColumnMajor,    RowMajor, RowMajor,    RowMajor, BF16,   BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    // CCR BQ: C
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+
+    // RRR BQ: C
+    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16,    BF8, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    // RRR BQ: R
+    std::tuple<   RowMajor,    RowMajor, RowMajor,    RowMajor, BF16,   BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+
+    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16,  PkFP4, E8M0, BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize>,
+    std::tuple<ColumnMajor,    RowMajor, RowMajor, ColumnMajor, BF16,  PkFP4, E8M0, BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16,   BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>,
+    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16,   BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize>
 >;
 // clang-format on
 

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
@@ -31,20 +31,34 @@ using BQuant1D64Types = ::testing::Types<
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  BF8,    BF8, float, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  FP8, PkInt4,   FP8, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  BF8, PkInt4,   BF8, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
+    // Microscaling
+    // RCR BQ: C
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
-    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
-    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
-    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
-    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
-    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
-    std::tuple<   RowMajor,    RowMajor, RowMajor,    RowMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,   FP16,  E8M0, FP16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    FP8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,    FP8,  E8M0, FP16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,    BF8,  E8M0, FP16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
-    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,  PkFP4,  E8M0, FP16, BQuantGrouped,   GemmConfigMx,  GroupSize64>
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,  PkFP4,  E8M0, FP16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    // RCR BQ: R
+    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+
+    // CRR BQ: C
+    std::tuple<ColumnMajor,    RowMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    // CRR BQ: R
+    std::tuple<ColumnMajor,    RowMajor, RowMajor,    RowMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+
+    // CCR BQ: C
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+
+    // RRR BQ: C
+    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    // RRR BQ: R
+    std::tuple<   RowMajor,    RowMajor, RowMajor,    RowMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>
+
     // std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>, // not supported with CastBeforeLDSWrite
     // std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64> // not supported
 >;

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
@@ -14,6 +14,7 @@ using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
 using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
 using FP8           = ck_tile::fp8_t;
 using BF8           = ck_tile::bf8_t;
+using FP16          = ck_tile::fp16_t;
 using BF16          = ck_tile::bf16_t;
 using Half          = ck_tile::half_t;
 using PkInt4        = ck_tile::pk_int4_t;
@@ -27,18 +28,23 @@ using GroupSize64   = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 64>>;
 // QuantType, GemmConfig, QuantGroupSize>
 // clang-format off
 using BQuant1D64Types = ::testing::Types<
-    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  BF8,    float, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
-    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
-    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
-    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
-    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
-    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
-    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
-    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
-    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
-    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
-    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
-    std::tuple<   RowMajor,    RowMajor, RowMajor,    RowMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  BF8,    BF8, float, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  FP8, PkInt4,   FP8, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  BF8, PkInt4,   BF8, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor,    RowMajor, RowMajor,    RowMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,   FP16,  E8M0, FP16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    FP8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,    FP8,  E8M0, FP16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,    BF8,  E8M0, FP16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,  PkFP4,  E8M0, FP16, BQuantGrouped,   GemmConfigMx,  GroupSize64>
     // std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>, // not supported with CastBeforeLDSWrite
     // std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64> // not supported
 >;

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
@@ -59,9 +59,11 @@ using BQuant1D64Types = ::testing::Types<
     // RRR BQ: R
     std::tuple<   RowMajor,    RowMajor, RowMajor,    RowMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
 
-    // std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>, // not supported with CastBeforeLDSWrite
     std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize64>,
-    std::tuple<ColumnMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize64>
+    std::tuple<ColumnMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize64>,
+
+    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>
 >;
 // clang-format on
 

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
@@ -31,8 +31,8 @@ using BQuant1D64Types = ::testing::Types<
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  BF8,    BF8, float, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  FP8, PkInt4,   FP8, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  BF8, PkInt4,   BF8, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
-    // // Microscaling
-    // // RCR BQ: C
+    // Microscaling
+    // RCR BQ: C
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
@@ -61,9 +61,8 @@ using BQuant1D64Types = ::testing::Types<
 
     std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize64>,
     std::tuple<ColumnMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize64>,
-
-    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>,
-    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>
+    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped,    GemmConfigMx, GroupSize64>,
+    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped,    GemmConfigMx, GroupSize64>
 >;
 // clang-format on
 

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
@@ -27,13 +27,20 @@ using GroupSize64   = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 64>>;
 // QuantType, GemmConfig, QuantGroupSize>
 // clang-format off
 using BQuant1D64Types = ::testing::Types<
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  FP8,    float, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  BF8,    float, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  BF8,    float, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
+    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
+    std::tuple<   RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16, BF8,    E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>,
+    std::tuple<   RowMajor,    RowMajor, RowMajor,    RowMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx,    GroupSize64>
+    // std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>, // not supported with CastBeforeLDSWrite
+    // std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64> // not supported
 >;
 // clang-format on
 

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_1d_64.cpp
@@ -31,8 +31,8 @@ using BQuant1D64Types = ::testing::Types<
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  BF8,    BF8, float, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  FP8, PkInt4,   FP8, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor,  BF8, PkInt4,   BF8, Half, BQuantGrouped, GemmConfigBase,  GroupSize64>,
-    // Microscaling
-    // RCR BQ: C
+    // // Microscaling
+    // // RCR BQ: C
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     std::tuple<   RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
@@ -57,10 +57,11 @@ using BQuant1D64Types = ::testing::Types<
     // RRR BQ: C
     std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
     // RRR BQ: R
-    std::tuple<   RowMajor,    RowMajor, RowMajor,    RowMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>
+    std::tuple<   RowMajor,    RowMajor, RowMajor,    RowMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
 
     // std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, BF16,   E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64>, // not supported with CastBeforeLDSWrite
-    // std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMx, GroupSize64> // not supported
+    std::tuple<   RowMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize64>,
+    std::tuple<ColumnMajor,    RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0,  BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize64>
 >;
 // clang-format on
 

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_ccr_1d_128.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_ccr_1d_128.cpp
@@ -12,22 +12,22 @@
 // Type aliases for readability
 using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
 using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
-using FP8           = ck_tile::fp8_t;
 using BF8           = ck_tile::bf8_t;
-using Half          = ck_tile::half_t;
-using PkInt4        = ck_tile::pk_int4_t;
+using BF16          = ck_tile::bf16_t;
+using PkFP4         = ck_tile::pk_fp4_t;
+using E8M0          = ck_tile::e8m0_t;
 using BQuantGrouped = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::BQuantGrouped>;
-using GroupSize     = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 128>>;
+using GroupSize128  = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 128>>;
 
 // Type combinations for BQuant tests - 1D GroupSize 128
 // Tuple format: <ALayout, BLayout, CLayout, BQLayout, ADataType, BDataType, QDataType, CDataType,
 // QuantType, GemmConfig, QuantGroupSize>
 // clang-format off
 using BQuant1D128Types = ::testing::Types<
-    // 1d cases with grouping only on k axis
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  FP8,    float, Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>
+    // CCR BQ: C
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize128>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize128>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize128>
 >;
 // clang-format on
 

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_ccr_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_ccr_1d_64.cpp
@@ -14,25 +14,29 @@ using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
 using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
 using FP8           = ck_tile::fp8_t;
 using BF8           = ck_tile::bf8_t;
+using FP16          = ck_tile::fp16_t;
+using BF16          = ck_tile::bf16_t;
 using Half          = ck_tile::half_t;
 using PkInt4        = ck_tile::pk_int4_t;
+using PkFP4         = ck_tile::pk_fp4_t;
+using E8M0          = ck_tile::e8m0_t;
 using BQuantGrouped = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::BQuantGrouped>;
-using GroupSize     = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 128>>;
+using GroupSize64   = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 64>>;
 
-// Type combinations for BQuant tests - 1D GroupSize 128
+// Type combinations for BQuant tests - 1D GroupSize 64
 // Tuple format: <ALayout, BLayout, CLayout, BQLayout, ADataType, BDataType, QDataType, CDataType,
 // QuantType, GemmConfig, QuantGroupSize>
 // clang-format off
-using BQuant1D128Types = ::testing::Types<
-    // 1d cases with grouping only on k axis
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  FP8,    float, Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>
+using BQuant1D64Types = ::testing::Types<
+    // CCR BQ: C
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF16,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,    BF8,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>,
+    std::tuple<ColumnMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  PkFP4,  E8M0, BF16, BQuantGrouped,   GemmConfigMx,  GroupSize64>
 >;
 // clang-format on
 
-// Test suite for BQuant 1D 128
-TYPED_TEST_SUITE(TestCkTileGemmBQuant, BQuant1D128Types);
+// Test suite for BQuant 1D 64
+TYPED_TEST_SUITE(TestCkTileGemmBQuant, BQuant1D64Types);
 
 // BQuant tests
 TYPED_TEST(TestCkTileGemmBQuant, BQuantGroupedTest)

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_crr_1d_128.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_crr_1d_128.cpp
@@ -12,22 +12,23 @@
 // Type aliases for readability
 using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
 using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
-using FP8           = ck_tile::fp8_t;
 using BF8           = ck_tile::bf8_t;
-using Half          = ck_tile::half_t;
-using PkInt4        = ck_tile::pk_int4_t;
+using BF16          = ck_tile::bf16_t;
+using PkFP4         = ck_tile::pk_fp4_t;
+using E8M0          = ck_tile::e8m0_t;
 using BQuantGrouped = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::BQuantGrouped>;
-using GroupSize     = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 128>>;
+using GroupSize128  = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 128>>;
 
 // Type combinations for BQuant tests - 1D GroupSize 128
 // Tuple format: <ALayout, BLayout, CLayout, BQLayout, ADataType, BDataType, QDataType, CDataType,
 // QuantType, GemmConfig, QuantGroupSize>
 // clang-format off
 using BQuant1D128Types = ::testing::Types<
-    // 1d cases with grouping only on k axis
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  FP8,    float, Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>
+    // CRR BQ: C
+    std::tuple<ColumnMajor, RowMajor, RowMajor, ColumnMajor, BF16,   BF8,  E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize128>,
+    // CRR BQ: R
+    std::tuple<ColumnMajor, RowMajor, RowMajor,    RowMajor, BF16,  BF16,  E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize128>,
+    std::tuple<ColumnMajor, RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0, BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize128>
 >;
 // clang-format on
 

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_crr_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_crr_1d_64.cpp
@@ -12,27 +12,28 @@
 // Type aliases for readability
 using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
 using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
-using FP8           = ck_tile::fp8_t;
 using BF8           = ck_tile::bf8_t;
-using Half          = ck_tile::half_t;
-using PkInt4        = ck_tile::pk_int4_t;
+using BF16          = ck_tile::bf16_t;
+using PkFP4         = ck_tile::pk_fp4_t;
+using E8M0          = ck_tile::e8m0_t;
 using BQuantGrouped = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::BQuantGrouped>;
-using GroupSize     = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 128>>;
+using GroupSize64   = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 64>>;
 
-// Type combinations for BQuant tests - 1D GroupSize 128
+// Type combinations for BQuant tests - 1D GroupSize 64
 // Tuple format: <ALayout, BLayout, CLayout, BQLayout, ADataType, BDataType, QDataType, CDataType,
 // QuantType, GemmConfig, QuantGroupSize>
 // clang-format off
-using BQuant1D128Types = ::testing::Types<
-    // 1d cases with grouping only on k axis
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  FP8,    float, Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>
+using BQuant1D64Types = ::testing::Types<
+    // CRR BQ: C
+    std::tuple<ColumnMajor, RowMajor, RowMajor, ColumnMajor, BF16,   BF8,  E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize64>,
+    // CRR BQ: R
+    std::tuple<ColumnMajor, RowMajor, RowMajor,    RowMajor, BF16,  BF16,  E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize64>,
+    std::tuple<ColumnMajor, RowMajor, RowMajor, ColumnMajor, BF16, PkFP4,  E8M0, BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize64>
 >;
 // clang-format on
 
-// Test suite for BQuant 1D 128
-TYPED_TEST_SUITE(TestCkTileGemmBQuant, BQuant1D128Types);
+// Test suite for BQuant 1D 64
+TYPED_TEST_SUITE(TestCkTileGemmBQuant, BQuant1D64Types);
 
 // BQuant tests
 TYPED_TEST(TestCkTileGemmBQuant, BQuantGroupedTest)

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_rcr_1d_128.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_rcr_1d_128.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "ck_tile/host.hpp"
+#include "ck_tile/ops/gemm.hpp"
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "test_gemm_quant_fixtures.hpp"
+
+// Type aliases for readability
+using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
+using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
+using FP8           = ck_tile::fp8_t;
+using BF8           = ck_tile::bf8_t;
+using FP16          = ck_tile::fp16_t;
+using BF16          = ck_tile::bf16_t;
+using PkFP4         = ck_tile::pk_fp4_t;
+using E8M0          = ck_tile::e8m0_t;
+using BQuantGrouped = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::BQuantGrouped>;
+using GroupSize128  = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 128>>;
+
+// Type combinations for BQuant tests - 1D GroupSize 128
+// Tuple format: <ALayout, BLayout, CLayout, BQLayout, ADataType, BDataType, QDataType, CDataType,
+// QuantType, GemmConfig, QuantGroupSize>
+// clang-format off
+using BQuant1D128Types = ::testing::Types<
+    // RCR BQ: C
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, PkFP4, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize128>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF8, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize128>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  BF16, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize128>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,  FP16, E8M0, FP16, BQuantGrouped, GemmConfigMx, GroupSize128>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   FP8, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize128>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,   FP8, E8M0, FP16, BQuantGrouped, GemmConfigMx, GroupSize128>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,   BF8, E8M0, FP16, BQuantGrouped, GemmConfigMx, GroupSize128>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16, PkFP4, E8M0, FP16, BQuantGrouped, GemmConfigMx, GroupSize128>,
+    // RCR BQ: R
+    std::tuple< RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16,   BF8, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize128>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16,  BF16, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize128>
+>;
+// clang-format on
+
+// Test suite for BQuant 1D 128
+TYPED_TEST_SUITE(TestCkTileGemmBQuant, BQuant1D128Types);
+
+// BQuant tests
+TYPED_TEST(TestCkTileGemmBQuant, BQuantGroupedTest)
+{
+    this->run_test_with_validation(1024, 1024, 1024);
+}

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_rcr_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_rcr_1d_64.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "ck_tile/host.hpp"
+#include "ck_tile/ops/gemm.hpp"
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "test_gemm_quant_fixtures.hpp"
+
+// Type aliases for readability
+using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
+using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
+using FP8           = ck_tile::fp8_t;
+using BF8           = ck_tile::bf8_t;
+using FP16          = ck_tile::fp16_t;
+using BF16          = ck_tile::bf16_t;
+using PkFP4         = ck_tile::pk_fp4_t;
+using E8M0          = ck_tile::e8m0_t;
+using BQuantGrouped = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::BQuantGrouped>;
+using GroupSize64   = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 64>>;
+
+// Type combinations for BQuant tests - 1D GroupSize 64
+// Tuple format: <ALayout, BLayout, CLayout, BQLayout, ADataType, BDataType, QDataType, CDataType,
+// QuantType, GemmConfig, QuantGroupSize>
+// clang-format off
+using BQuant1D64Types = ::testing::Types<
+    // RCR BQ: C
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16, PkFP4, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   BF8, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,  BF16, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,  FP16, E8M0, FP16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF16,   FP8, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,   FP8, E8M0, FP16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16,   BF8, E8M0, FP16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP16, PkFP4, E8M0, FP16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    // RCR BQ: R
+    std::tuple< RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16,   BF8, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize64>,
+    std::tuple< RowMajor, ColumnMajor, RowMajor,    RowMajor, BF16,  BF16, E8M0, BF16, BQuantGrouped, GemmConfigMx, GroupSize64>
+>;
+// clang-format on
+
+// Test suite for BQuant 1D 64
+TYPED_TEST_SUITE(TestCkTileGemmBQuant, BQuant1D64Types);
+
+// BQuant tests
+TYPED_TEST(TestCkTileGemmBQuant, BQuantGroupedTest)
+{
+    this->run_test_with_validation(1024, 1024, 1024);
+}

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_rrr_1d_128.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_rrr_1d_128.cpp
@@ -12,22 +12,24 @@
 // Type aliases for readability
 using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
 using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
-using FP8           = ck_tile::fp8_t;
 using BF8           = ck_tile::bf8_t;
-using Half          = ck_tile::half_t;
-using PkInt4        = ck_tile::pk_int4_t;
+using BF16          = ck_tile::bf16_t;
+using PkFP4         = ck_tile::pk_fp4_t;
+using E8M0          = ck_tile::e8m0_t;
 using BQuantGrouped = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::BQuantGrouped>;
-using GroupSize     = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 128>>;
+using GroupSize128  = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 128>>;
 
 // Type combinations for BQuant tests - 1D GroupSize 128
 // Tuple format: <ALayout, BLayout, CLayout, BQLayout, ADataType, BDataType, QDataType, CDataType,
 // QuantType, GemmConfig, QuantGroupSize>
 // clang-format off
 using BQuant1D128Types = ::testing::Types<
-    // 1d cases with grouping only on k axis
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  FP8,    float, Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8,  PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8,  PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase, GroupSize>
+    // RRR BQ: C
+    std::tuple< RowMajor, RowMajor, RowMajor, ColumnMajor, BF16,   BF8, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize128>,
+    std::tuple< RowMajor, RowMajor, RowMajor, ColumnMajor, BF16, PkFP4, E8M0, BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize128>,
+    std::tuple< RowMajor, RowMajor, RowMajor, ColumnMajor, BF16,  BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize128>,
+    // RRR BQ: R
+    std::tuple< RowMajor, RowMajor, RowMajor,    RowMajor, BF16,  BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize128>
 >;
 // clang-format on
 

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_rrr_1d_64.cpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_bquant_microscale_rrr_1d_64.cpp
@@ -12,10 +12,10 @@
 // Type aliases for readability
 using RowMajor      = ck_tile::tensor_layout::gemm::RowMajor;
 using ColumnMajor   = ck_tile::tensor_layout::gemm::ColumnMajor;
-using FP8           = ck_tile::fp8_t;
 using BF8           = ck_tile::bf8_t;
-using Half          = ck_tile::half_t;
-using PkInt4        = ck_tile::pk_int4_t;
+using BF16          = ck_tile::bf16_t;
+using PkFP4         = ck_tile::pk_fp4_t;
+using E8M0          = ck_tile::e8m0_t;
 using BQuantGrouped = std::integral_constant<ck_tile::QuantType, ck_tile::QuantType::BQuantGrouped>;
 using GroupSize64   = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 64>>;
 
@@ -24,10 +24,12 @@ using GroupSize64   = ck_tile::QuantGroupShape<ck_tile::sequence<1, 1, 64>>;
 // QuantType, GemmConfig, QuantGroupSize>
 // clang-format off
 using BQuant1D64Types = ::testing::Types<
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8, FP8,    float, Half, BQuantGrouped, GemmConfigBase, GroupSize64>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8, BF8,    float, Half, BQuantGrouped, GemmConfigBase, GroupSize64>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, FP8, PkInt4, FP8,   Half, BQuantGrouped, GemmConfigBase, GroupSize64>,
-    std::tuple<RowMajor, ColumnMajor, RowMajor, ColumnMajor, BF8, PkInt4, BF8,   Half, BQuantGrouped, GemmConfigBase, GroupSize64>
+    // RRR BQ: C
+    std::tuple< RowMajor, RowMajor, RowMajor, ColumnMajor, BF16,   BF8, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize64>,
+    std::tuple< RowMajor, RowMajor, RowMajor, ColumnMajor, BF16, PkFP4, E8M0, BF16, BQuantGrouped, GemmConfigMxFP4, GroupSize64>,
+    std::tuple< RowMajor, RowMajor, RowMajor, ColumnMajor, BF16,  BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize64>,
+    // RRR BQ: R
+    std::tuple< RowMajor, RowMajor, RowMajor,    RowMajor, BF16,  BF16, E8M0, BF16, BQuantGrouped,    GemmConfigMx, GroupSize64>
 >;
 // clang-format on
 

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_fixtures.hpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_fixtures.hpp
@@ -109,6 +109,9 @@ struct GemmConfigMx : public GemmConfigBase
     static constexpr ck_tile::index_t K_Tile = 128;
 };
 
+// This configuration uses K_Warp_Tile = 64 on CDNA. In this way, on gfx950 we can use
+// LDS load transpose on matrix B (FP4) because the instruction requires each
+// lane to load 16 4bits elements
 struct GemmConfigMxFP4 : public GemmConfigBase
 {
     static constexpr ck_tile::index_t M_Tile      = 128;

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_fixtures.hpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_fixtures.hpp
@@ -109,6 +109,14 @@ struct GemmConfigMx : public GemmConfigBase
     static constexpr ck_tile::index_t K_Tile = 128;
 };
 
+struct GemmConfigMxFP4 : public GemmConfigBase
+{
+    static constexpr ck_tile::index_t M_Tile      = 128;
+    static constexpr ck_tile::index_t N_Tile      = 128;
+    static constexpr ck_tile::index_t K_Tile      = 128;
+    static constexpr ck_tile::index_t K_Warp_Tile = 64;
+};
+
 struct GemmConfigPreshuffleQuant : public GemmConfigBase
 {
     static constexpr bool APreshuffleQuant = true;
@@ -798,6 +806,7 @@ class TestCkTileGemmBQuant : public TestCkTileGemmQuantBase<Tuple, TestCkTileGem
                                               AccDataType,
                                               CDataType,
                                               QuantGroupSize,
+                                              BLayout,
                                               false>(a_m_k, bq_bqk_bqn, b_k_n, c_m_n_host_ref);
         else
             ck_tile::reference_gemm_quant<ADataType,

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_fixtures.hpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_fixtures.hpp
@@ -863,8 +863,11 @@ class TestCkTileGemmBQuant : public TestCkTileGemmQuantBase<Tuple, TestCkTileGem
         const ck_tile::TailNumber tail_num = BaseGemmPipeline::GetBlockLoopTailNum(num_loop);
 
         const auto Run = [&](const auto has_hot_loop_, const auto tail_number_) {
-            constexpr bool has_hot_loop_v = has_hot_loop_.value;
-            constexpr auto tail_number_v  = tail_number_.value;
+            constexpr bool has_hot_loop_v  = has_hot_loop_.value;
+            constexpr auto tail_number_v   = tail_number_.value;
+            constexpr auto b_cast_policy_v = std::is_same_v<ADataType, BDataType>
+                                                 ? ck_tile::CastPolicy::BeforeLDSWrite
+                                                 : ck_tile::CastPolicy::AfterLDSRead;
 
             using PipelineProblem =
                 ck_tile::GemmBQuantPipelineProblem<ADataType,
@@ -877,7 +880,8 @@ class TestCkTileGemmBQuant : public TestCkTileGemmQuantBase<Tuple, TestCkTileGem
                                                    ComputeDataType,
                                                    ck_tile::GemmPipelineScheduler::Intrawave,
                                                    has_hot_loop_v,
-                                                   tail_number_v>;
+                                                   tail_number_v,
+                                                   b_cast_policy_v>;
 
             using GemmPipeline = std::conditional_t<
                 PreshuffleB == false,

--- a/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_fixtures.hpp
+++ b/projects/composablekernel/test/ck_tile/gemm_block_scale/test_gemm_quant_fixtures.hpp
@@ -114,7 +114,7 @@ struct GemmConfigMxFP4 : public GemmConfigBase
     static constexpr ck_tile::index_t M_Tile      = 128;
     static constexpr ck_tile::index_t N_Tile      = 128;
     static constexpr ck_tile::index_t K_Tile      = 128;
-    static constexpr ck_tile::index_t K_Warp_Tile = 64;
+    static constexpr ck_tile::index_t K_Warp_Tile = get_k_warp_tile<true>();
 };
 
 struct GemmConfigPreshuffleQuant : public GemmConfigBase


### PR DESCRIPTION
## Motivation

Extend functionalities of mix precision microscale BQuant.

## Technical Details

 - Support combinations of A 16 bit and B 16/8/4 bit using scale cvt instructions on gfx950
 - Enable LDS load transpose for 4 bit types in ck tile
 - Allow to use LDS load transpose when A and B have different data types in LDS
   - Define `AttrNumAccessEnum` for A and B separately
   - If `AttrNumAccessA != AttrNumAccessB`, use packed NumAccess instead of interleaved one
 - Support all layouts combinations with `BCastAfterLDSRead`
 - Initial support for different layouts with `BCastBeforeLDSWrite`. BQuant encodings still need to be generalized (will be targeted in follow-up PR).
 - Add tests for different layouts and split them into multiple  files

Minor change to CK pre-commit config to fix the path (after transition to mono-repo)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
