### PR TITLE
[hipblaslt] Add --build-only flag

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/BenchmarkProblems.py
+++ b/projects/hipblaslt/tensilelite/Tensile/BenchmarkProblems.py
@@ -624,19 +624,22 @@ def main(
                         )
                 totalTestFails += benchmarkErrors
 
-                print("clientExit={} {} for {}" \
-                        .format(totalTestFails, "(ERROR)" if totalTestFails else "(PASS)", \
-                        globalParameters["ConfigPath"]) )
+                if compileOnly:
+                    print1("# Compile-only mode: skipping result collection.")
+                else:
+                    print("clientExit={} {} for {}" \
+                            .format(totalTestFails, "(ERROR)" if totalTestFails else "(PASS)", \
+                            globalParameters["ConfigPath"]) )
 
-                # copy data
-                resultsFileBase = resultsFileBaseFinal
-                resultsFileName = resultsFileBase + ".csv"
-                solutionsFileName = resultsFileBase + ".yaml"
-                granularityFileName = resultsFileBase + "_Granularity.csv"
-                shutil.copy(resultsFileName, newResultsFileName)
-                shutil.copy(solutionsFileName, newSolutionsFileName)
-                if os.path.isfile(granularityFileName):
-                    shutil.copy(granularityFileName, newGranularityFileName)
+                    # copy data
+                    resultsFileBase = resultsFileBaseFinal
+                    resultsFileName = resultsFileBase + ".csv"
+                    solutionsFileName = resultsFileBase + ".yaml"
+                    granularityFileName = resultsFileBase + "_Granularity.csv"
+                    shutil.copy(resultsFileName, newResultsFileName)
+                    shutil.copy(solutionsFileName, newSolutionsFileName)
+                    if os.path.isfile(granularityFileName):
+                        shutil.copy(granularityFileName, newGranularityFileName)
             else:
                 print1("# {}_{:02d} already benchmarked; skipping." \
                         .format(str(problemTypeObj), idx) )

--- a/projects/hipblaslt/tensilelite/Tensile/BenchmarkProblems.py
+++ b/projects/hipblaslt/tensilelite/Tensile/BenchmarkProblems.py
@@ -359,9 +359,14 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
                          asmToolchain: AssemblyToolchain, srcToolchain: SourceToolchain, cCompiler: str,
                          buildTmpPath: Path, benchmarkProblemsPath: Path,
                          debugConfig: DebugConfig, deviceId: int,
-                         gfxName: str, isaInfoMap: Dict[str, IsaInfo], probSolMap: dict
+                         gfxName: str, isaInfoMap: Dict[str, IsaInfo], probSolMap: dict,
+                         compileOnly: bool = False,
     ):
-    """Run the benchmarking for a single entry in the BenchmarkProblems of a Tensile config"""
+    """Run the benchmarking for a single entry in the BenchmarkProblems of a Tensile config
+
+    Args:
+        compileOnly: If True, generate and compile kernels but skip benchmarking.
+    """
     benchmarkTestFails = 0
 
     print1("")
@@ -520,7 +525,9 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
             benchmarkStep.activationArgs, solutions, cacheValid)
 
         # run benchmarking client
-        if not os.path.exists(resultsFileName) or globalParameters["ForceRedoBenchmarkProblems"]:
+        if compileOnly:
+            print1("# Compile-only mode: skipping benchmark.")
+        elif not os.path.exists(resultsFileName) or globalParameters["ForceRedoBenchmarkProblems"]:
             libraryLogicPath = None
             forBenchmark = True
             returncode = runClient(libraryLogicPath, forBenchmark, enableTileSelection, srcToolchain.compiler, cCompiler, shortNamePath)
@@ -553,9 +560,14 @@ def main(
     deviceId: int,
     gfxName: str,
     isaInfoMap: Dict[str, IsaInfo],
-    probSolMap: dict
+    probSolMap: dict,
+    compileOnly: bool = False,
 ):
-    """Entry point for the "BenchmarkProblems" section of a Tensile config yaml"""
+    """Entry point for the "BenchmarkProblems" section of a Tensile config yaml
+
+    Args:
+        compileOnly: If True, generate and compile kernels but skip benchmarking.
+    """
     getClientExecutablePath()
 
     if config is None:
@@ -607,7 +619,8 @@ def main(
                             deviceId,
                             gfxName,
                             isaInfoMap,
-                            probSolMap
+                            probSolMap,
+                            compileOnly,
                         )
                 totalTestFails += benchmarkErrors
 

--- a/projects/hipblaslt/tensilelite/Tensile/BenchmarkProblems.py
+++ b/projects/hipblaslt/tensilelite/Tensile/BenchmarkProblems.py
@@ -360,12 +360,12 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
                          buildTmpPath: Path, benchmarkProblemsPath: Path,
                          debugConfig: DebugConfig, deviceId: int,
                          gfxName: str, isaInfoMap: Dict[str, IsaInfo], probSolMap: dict,
-                         compileOnly: bool = False,
+                         buildOnly: bool = False,
     ):
     """Run the benchmarking for a single entry in the BenchmarkProblems of a Tensile config
 
     Args:
-        compileOnly: If True, generate and compile kernels but skip benchmarking.
+        buildOnly: If True, generate and build kernels but skip benchmarking.
     """
     benchmarkTestFails = 0
 
@@ -525,8 +525,8 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
             benchmarkStep.activationArgs, solutions, cacheValid)
 
         # run benchmarking client
-        if compileOnly:
-            print1("# Compile-only mode: skipping benchmark.")
+        if buildOnly:
+            print1("# Build-only mode: skipping benchmark.")
         elif not os.path.exists(resultsFileName) or globalParameters["ForceRedoBenchmarkProblems"]:
             libraryLogicPath = None
             forBenchmark = True
@@ -561,12 +561,12 @@ def main(
     gfxName: str,
     isaInfoMap: Dict[str, IsaInfo],
     probSolMap: dict,
-    compileOnly: bool = False,
+    buildOnly: bool = False,
 ):
     """Entry point for the "BenchmarkProblems" section of a Tensile config yaml
 
     Args:
-        compileOnly: If True, generate and compile kernels but skip benchmarking.
+        buildOnly: If True, generate and build kernels but skip benchmarking.
     """
     getClientExecutablePath()
 
@@ -620,12 +620,12 @@ def main(
                             gfxName,
                             isaInfoMap,
                             probSolMap,
-                            compileOnly,
+                            buildOnly,
                         )
                 totalTestFails += benchmarkErrors
 
-                if compileOnly:
-                    print1("# Compile-only mode: skipping result collection.")
+                if buildOnly:
+                    print1("# Build-only mode: skipping result collection.")
                 else:
                     print("clientExit={} {} for {}" \
                             .format(totalTestFails, "(ERROR)" if totalTestFails else "(PASS)", \

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -84,7 +84,8 @@ def executeStepsInConfig(
         cCompiler: str,
         debugConfig: DebugConfig,
         deviceId: int,
-        probSolDict: dict
+        probSolDict: dict,
+        compileOnly: bool = False,
    ):
     """Conducts the steps in the provided ``config`` according to the Tensile workflow.
 
@@ -102,6 +103,7 @@ def executeStepsInConfig(
         asmToolchain (AssemblyToolchain): The toolchain for making assembly kernels.
         srcToolchain (SourceToolchain): The toolchain for making source kernels.
         cCompiler (str): The C compiler to use.
+        compileOnly (bool): If True, generate and compile kernels but skip benchmarking.
     """
 
     buildTmpPath = outputPath / "build_tmp"
@@ -127,11 +129,16 @@ def executeStepsInConfig(
             gfxName,
             isaInfoMap,
             probSolDict,
+            compileOnly,
         )
         if timingEnabled:
             elapsed = (time.time_ns() - startTime) / 1_000_000
             _timing_logger.info(f"TIMING:python_benchmark_problems:{elapsed:.3f}")
         print1("")
+
+    if compileOnly:
+        print1("# Compile-only mode: skipping LibraryLogic and LibraryClient.")
+        return
 
     ##############################################################################
     # Library Logic
@@ -494,6 +501,9 @@ def Tensile(userArgs):
             "and optional second file is size list")
     argParser.add_argument("--use-cache", dest="useCache", action="store_true",
             help="Ignore cache; redo parameter forking and solution generation")
+    argParser.add_argument("--compile-only", dest="compileOnly", action="store_true",
+            help="Generate and compile kernels but skip benchmarking. "
+                 "Use with --use-cache on target machine to run benchmarks.")
     argParser.add_argument("--restore-from-log", type=str, dest="RestoreLog",
             help="A log file captured in previous tuning. ONLY RELIABLE when configs yaml not changes")
 
@@ -502,6 +512,7 @@ def Tensile(userArgs):
     configPaths = args.ConfigFile
     altFormat = args.AlternateFormat
     useCache = args.useCache
+    compileOnly = args.compileOnly
     outputPath = Path(ensurePath(os.path.abspath(args.OutputPath)))
     print1(f"#  OutputPath: {str(outputPath)}")
 
@@ -632,7 +643,7 @@ def Tensile(userArgs):
     if "MaxFileName" in globalParameters or "MaxFileName" in config:
         printWarning("MaxFileName is no longer configurable, it will be automatically set to 64")
 
-    executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, device_id, prob_sol_map)
+    executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, device_id, prob_sol_map, compileOnly)
 
 def TensileConfigPath(*args):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "Configs", *args)

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -85,7 +85,7 @@ def executeStepsInConfig(
         debugConfig: DebugConfig,
         deviceId: int,
         probSolDict: dict,
-        compileOnly: bool = False,
+        buildOnly: bool = False,
    ):
     """Conducts the steps in the provided ``config`` according to the Tensile workflow.
 
@@ -103,7 +103,7 @@ def executeStepsInConfig(
         asmToolchain (AssemblyToolchain): The toolchain for making assembly kernels.
         srcToolchain (SourceToolchain): The toolchain for making source kernels.
         cCompiler (str): The C compiler to use.
-        compileOnly (bool): If True, generate and compile kernels but skip benchmarking.
+        buildOnly (bool): If True, generate and build kernels but skip benchmarking.
     """
 
     buildTmpPath = outputPath / "build_tmp"
@@ -129,15 +129,15 @@ def executeStepsInConfig(
             gfxName,
             isaInfoMap,
             probSolDict,
-            compileOnly,
+            buildOnly,
         )
         if timingEnabled:
             elapsed = (time.time_ns() - startTime) / 1_000_000
             _timing_logger.info(f"TIMING:python_benchmark_problems:{elapsed:.3f}")
         print1("")
 
-    if compileOnly:
-        print1("# Compile-only mode: skipping LibraryLogic and LibraryClient.")
+    if buildOnly:
+        print1("# Build-only mode: skipping LibraryLogic and LibraryClient.")
         return
 
     ##############################################################################
@@ -501,7 +501,7 @@ def Tensile(userArgs):
             "and optional second file is size list")
     argParser.add_argument("--use-cache", dest="useCache", action="store_true",
             help="Ignore cache; redo parameter forking and solution generation")
-    argParser.add_argument("--compile-only", dest="compileOnly", action="store_true",
+    argParser.add_argument("--build-only", dest="buildOnly", action="store_true",
             help="Generate and compile kernels but skip benchmarking. "
                  "Use with --use-cache on target machine to run benchmarks.")
     argParser.add_argument("--restore-from-log", type=str, dest="RestoreLog",
@@ -512,7 +512,7 @@ def Tensile(userArgs):
     configPaths = args.ConfigFile
     altFormat = args.AlternateFormat
     useCache = args.useCache
-    compileOnly = args.compileOnly
+    buildOnly = args.buildOnly
     outputPath = Path(ensurePath(os.path.abspath(args.OutputPath)))
     print1(f"#  OutputPath: {str(outputPath)}")
 
@@ -643,7 +643,7 @@ def Tensile(userArgs):
     if "MaxFileName" in globalParameters or "MaxFileName" in config:
         printWarning("MaxFileName is no longer configurable, it will be automatically set to 64")
 
-    executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, device_id, prob_sol_map, compileOnly)
+    executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, device_id, prob_sol_map, buildOnly)
 
 def TensileConfigPath(*args):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "Configs", *args)

--- a/projects/hipblaslt/tensilelite/Tensile/Tensile.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tensile.py
@@ -500,10 +500,11 @@ def Tensile(userArgs):
             help="Alternate format for config_file(s): first file is alternate config "
             "and optional second file is size list")
     argParser.add_argument("--use-cache", dest="useCache", action="store_true",
-            help="Ignore cache; redo parameter forking and solution generation")
+            help="Bypass redo parameter forking and solution generation and used existing solutions.")
     argParser.add_argument("--build-only", dest="buildOnly", action="store_true",
             help="Generate and compile kernels but skip benchmarking. "
-                 "Use with --use-cache on target machine to run benchmarks.")
+                 "Useful for splitting compilation and benchmarking across runs/nodes. "
+                 "First run using this flag, then rerun with --use-cache.")
     argParser.add_argument("--restore-from-log", type=str, dest="RestoreLog",
             help="A log file captured in previous tuning. ONLY RELIABLE when configs yaml not changes")
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/flags/gfx942/test_build_only.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/flags/gfx942/test_build_only.py
@@ -1,0 +1,130 @@
+################################################################################
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+import os
+import pytest
+import subprocess
+from pathlib import Path
+
+from Tensile import Tensile
+
+# The yaml config is defined inline (rather than as a separate .yaml file) to
+# prevent test_config.py's findConfigs() from picking it up as a standalone
+# parametrized test.  This config is only meant to be used by the tests below.
+#
+# Trimmed from Tensile/Tests/common/gemm/fp16_tn.yaml to a single solution
+# (one MatrixInstruction) and a single benchmark problem size.
+_CONFIG = """\
+GlobalParameters:
+  ISA: [[9,5,0]]
+  MinimumRequiredVersion: 5.0.0
+  NumElementsToValidate: 0
+  DataInitTypeBeta: 0
+  DataInitTypeAlpha: 1
+  NewClient: 2
+  Device: 0
+
+BenchmarkProblems:
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1, 1, 1, 1, 4, 1]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - DepthU: [32]
+        - LocalReadVectorWidth: [8]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1]
+        - SourceSwap: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [256, 256, 1, 256]
+"""
+
+def _get_available_archs() -> list[str]:
+    """Get list of available GPU architectures via rocm_agent_enumerator."""
+    rocmpath = os.environ.get("TENSILE_ROCM_PATH",
+                              os.environ.get("ROCM_PATH", "/opt/rocm"))
+    rocm_agent_enum = os.path.join(rocmpath, "bin/rocm_agent_enumerator")
+    try:
+        output = subprocess.check_output([rocm_agent_enum, "-t", "GPU"])
+        return [line.strip() for line in output.decode().splitlines()
+                if line.strip() and "gfx000" not in line]
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+
+_HAS_GFX942 = any("gfx950" in arch for arch in _get_available_archs())
+
+
+def _write_config(path: str) -> None:
+    """Write the test config to a yaml file."""
+    with open(path, "w") as f:
+        f.write(_CONFIG)
+
+
+def test_compile(tensile_args: list[str], tmp_path: Path) -> None:
+    """
+    Compile the kernel. This can run on any machine.
+    """
+    config_path = str(tmp_path / "config.yaml")
+    _write_config(config_path)
+    output_dir = str(tmp_path / "output")
+    Tensile.Tensile([config_path, output_dir, "--build-only", *tensile_args])
+
+
+@pytest.mark.skipif(not _HAS_GFX942, reason="gfx942 GPU not available")
+def test_use_cache(tensile_args: list[str], tmp_path: Path) -> None:
+    """
+    Compile with --build-only, then run again using --use-cache and see that it doesn't crash.
+    """
+    config_path = str(tmp_path / "config.yaml")
+    _write_config(config_path)
+    output_dir = str(tmp_path / "output")
+
+    # First run: compile only
+    Tensile.Tensile([config_path, output_dir, "--build-only", *tensile_args])
+
+    # Second run: use cache
+    Tensile.Tensile([config_path, output_dir, "--use-cache", *tensile_args])


### PR DESCRIPTION
## Motivation

In order to better utilize CI machines (and local testing) we would like to split a Tensile run into two stages:

1. Generate and compile all of the kernels.
2. Run kernels, run reference, compare numerics, and calculate statistics.

Stage 1 can be run on a CPU-only node, while Stage 2 would need to be run on the target GPU node. Would let us pipeline our execution and make better use of GPU nodes. E.g. for a single yaml file, stage 1 takes 10 minutes of CPU-only work while stage 2 takes 2 minutes (10 minutes is it's own problem which is being worked on).

Example workflow:
1. Add `ISA: ...` to `GlobalParameters` in the YAML file to specify target ISA. (e.g. `ISA: [[9,5,0]]` for gfx950)
2. Run on CPU node with `Tensile in.yaml out_dir --build-only`. (new flag)
3. Zip and transfer `in.yaml` and `out_dir` to GPU node then unzip.
4. Run on GPU node with `Tensile in.yaml out_dir --use-cache`. (existing flag)

## Technical Details

Add `--build-only` flag that bypasses running the kernels.

Depends on #4550.

## Test Plan

Run existing tests.

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
