### PR TITLE
[hipdnn] Fix hip-kernel-provider build

### DIFF
--- a/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
+++ b/dnn-providers/hip-kernel-provider/HipKernelPlugin.cpp
@@ -93,7 +93,7 @@ hipdnnPluginStatus_t hipdnnPluginSetLoggingCallbackImpl(hipdnnCallback_t callbac
 {
     return hipdnn_plugin_sdk::tryCatch([&, apiName = __func__]() {
         throwIfNull(callback);
-        hipdnn::logging::initializeCallbackLogging(pluginName, callback);
+        hipdnn_plugin_sdk::logging::initializeCallbackLogging(pluginName, callback);
         LOG_API_SUCCESS(apiName, "");
     });
 }

--- a/dnn-providers/hip-kernel-provider/tests/main.cpp
+++ b/dnn-providers/hip-kernel-provider/tests/main.cpp
@@ -13,8 +13,8 @@ SPDX-License-Identifier: MIT
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
-    hipdnn::logging::initializeCallbackLogging("hip_kernel_plugin",
-                                               hipdnn_test_sdk::utilities::testLoggingCallback);
+    hipdnn_plugin_sdk::logging::initializeCallbackLogging(
+        "hip_kernel_plugin", hipdnn_test_sdk::utilities::testLoggingCallback);
 
     // Register HipErrorHandler to check and clear HIP errors after each test
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();


### PR DESCRIPTION
Seeing build fails on feature branch as `logging::initializeCallbackLogging` is part of the `hipdnn_plugin_sdk` namespace not `hipdnn`

