### PR TITLE
[hipblaslt] Fix setLibrary race condition

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ExactLogicLibrary.hpp
@@ -108,9 +108,6 @@ namespace TensileLite
                 if(row.first.value->type() == "ExperimentalStreamK" && !streamK)
                     continue;
 
-                // Set library context for debug output
-                row.first.setLibrary(row.second);
-
                 if(row.first(problem, hardware))
                 {
                     rv = row.second->findBestSolution(problem, hardware, fitness);
@@ -154,9 +151,6 @@ namespace TensileLite
 
                 if(row.first.value->type() == "ExperimentalStreamK" && !streamK)
                     continue;
-
-                // Set library context for debug output
-                row.first.setLibrary(row.second);
 
                 if(row.first.value->type() == "AMDGPU" && !row.first(problem, hardware))
                     continue;
@@ -248,9 +242,6 @@ namespace TensileLite
                                      || (row.first.value->type() == "RangeMatching")))
                     continue;
 
-                // Set library context for debug output
-                row.first.setLibrary(row.second);
-
                 if(row.first(problem, hardware))
                 {
                     solutions
@@ -330,19 +321,11 @@ namespace TensileLite
     struct HardwarePredicate
     {
         std::shared_ptr<Predicates::Predicate<Hardware>> value;
-        mutable std::string libraryFileName;
 
         HardwarePredicate() = default;
         HardwarePredicate(std::shared_ptr<Predicates::Predicate<Hardware>> init)
             : value(init)
         {
-        }
-
-        template <typename MyProblem, typename MySolution>
-        void setLibrary(std::shared_ptr<SolutionLibrary<MyProblem, MySolution>> lib) const
-        {
-            if(lib)
-                libraryFileName = lib->getLibraryFileName();
         }
 
         template <typename Any>
@@ -353,12 +336,6 @@ namespace TensileLite
 
             if(debug)
             {
-                // Print library filename if available
-                if(!libraryFileName.empty())
-                {
-                    PredicateDebugger::printLibraryFileBanner(std::cout, libraryFileName);
-                }
-
                 PredicateDebugger::printHeader(std::cout, "ExactLogic: Hardware");
                 value->debugEval(hardware, std::cout);
                 PredicateDebugger::printFooter(std::cout, rv);
@@ -399,19 +376,11 @@ namespace TensileLite
     struct ProblemPredicate
     {
         std::shared_ptr<Predicates::Predicate<MyProblem>> value;
-        mutable std::string libraryFileName;
 
         ProblemPredicate() = default;
         ProblemPredicate(std::shared_ptr<Predicates::Predicate<MyProblem>> init)
             : value(init)
         {
-        }
-
-        template <typename MySolution>
-        void setLibrary(std::shared_ptr<SolutionLibrary<MyProblem, MySolution>> lib) const
-        {
-            if(lib)
-                libraryFileName = lib->getLibraryFileName();
         }
 
         bool operator()(MyProblem const& problem, Hardware const& hardware) const
@@ -421,12 +390,6 @@ namespace TensileLite
 
             if(debug)
             {
-                // Print library filename if available
-                if(!libraryFileName.empty())
-                {
-                    PredicateDebugger::printLibraryFileBanner(std::cout, libraryFileName);
-                }
-
                 PredicateDebugger::printHeader(std::cout, "ExactLogic: Problem");
                 value->debugEval(problem, std::cout);
                 PredicateDebugger::printFooter(std::cout, rv);

--- a/projects/hipblaslt/tensilelite/tests/ContractionSelectionLibrary_test.cpp
+++ b/projects/hipblaslt/tensilelite/tests/ContractionSelectionLibrary_test.cpp
@@ -33,6 +33,8 @@
 #include <Tensile/ContractionProblemProperties.hpp>
 #include <Tensile/Distance.hpp>
 #include <Tensile/ExactLogicLibrary.hpp>
+#include <thread>
+#include <vector>
 
 using namespace TensileLite;
 
@@ -217,4 +219,43 @@ TEST(ContractionSelectionLibraryTest, TransposeSelection)
     MasterContractionLibrary mlib;
     mlib.solutions = map;
     mlib.library   = lib;
+}
+
+TEST(ContractionSelectionLibraryTest, ConcurrentFindBestSolutionIsStable)
+{
+    std::shared_ptr<Hardware> hardware = std::make_shared<AMDGPU>(
+        AMDGPU::Processor::gfx900, 64, "AMD Radeon Vega Frontier Edition");
+    auto problem = std::make_shared<ContractionProblemGemm>();
+
+    auto selectedSolution = std::make_shared<ContractionSolution>();
+    auto fallbackSolution = std::make_shared<ContractionSolution>();
+
+    std::shared_ptr<ContractionLibrary> selectedLibrary
+        = std::make_shared<SingleContractionLibrary>(selectedSolution);
+    std::shared_ptr<ContractionLibrary> fallbackLibrary
+        = std::make_shared<SingleContractionLibrary>(fallbackSolution);
+
+    HardwarePredicate firstMatch(std::make_shared<Predicates::True<Hardware>>());
+    HardwarePredicate secondMatch(std::make_shared<Predicates::True<Hardware>>());
+
+    ContractionHardwareSelectionLibrary::Row selectedRow(firstMatch, selectedLibrary);
+    ContractionHardwareSelectionLibrary::Row fallbackRow(secondMatch, fallbackLibrary);
+    ContractionHardwareSelectionLibrary      lib({selectedRow, fallbackRow});
+
+    constexpr int numThreads          = 16;
+    constexpr int iterationsPerThread = 2000;
+
+    std::vector<std::thread> workers;
+    workers.reserve(numThreads);
+
+    for(int i = 0; i < numThreads; i++)
+    {
+        workers.emplace_back([&]() {
+            for(int j = 0; j < iterationsPerThread; j++)
+                EXPECT_EQ(lib.findBestSolution(*problem, *hardware), selectedSolution);
+        });
+    }
+
+    for(auto& worker : workers)
+        worker.join();
 }


### PR DESCRIPTION
## Motivation

Fix a race condition whereby setLibrary calls were not thread-safe and could potentially free the string buffer while another is writing to the buffer.

## Technical Details

Library printing is a convenience but is not a necessary component for troubleshooting kernel selection. It's addition added more harm than benefit. This PR simply removes the functionality and restores the behaviour to the previous standard.

## Test Plan

- Added multi-threaded regression testing
- standard CI testing 
- LLama inference and training testing (where defect was original caught)

## Test Result

- Regression tests pass
- See CI checks for standard tests
- LLama inference - in progress

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
