### PR TITLE
[hipblaslt][CMS] Change validator passes to use unified interface and single timeline

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1956,16 +1956,75 @@ def verify_gr_inc_order(scheduleInfo, context: dict, code_path: int) -> tuple[bo
 
     return True, ""
 
+@dataclass
+class ValidatorPassContext:
+    """Context object containing all values needed by validator passes."""
+    kernel: 'Solution'
+    mfma_reorder: list[int]
+    swap_global_read_order: bool
+
+
+def add_local_read_constraints(timeline: Timeline, ctx: ValidatorPassContext) -> None:
+    """Add LR.needed_by and LR.guaranteed_by constraints to the provided timeline."""
+    set_lr_needed_by_for_VMFMA(timeline, ctx.kernel, ctx.mfma_reorder)
+    apply_swaits(timeline)
+    apply_barriers(timeline)
+
+
+def add_pack_constraints(timeline: Timeline, ctx: ValidatorPassContext) -> None:
+    """
+    Ensure that the Packs start and end at the correct indices.
+    The pack commands take the data loaded into registers by LR commands and manipulate it in various ways to prepare it for the VMFMA instructions.
+
+    There are several restrictions placed on Pack instructions:
+    1. For all gemm types (tf32, bf16, etc.) the Pack instructions must be issued after the data is guaranteed to be loaded into the registers (guaranteed by SWaitCnt instructions). And they must finish before the first VMFMA that uses their results.
+    2. For fp32 GEMMs, there are additional restrictions on:
+        1. The ordering of the Pack instructions.
+        2. The minimum number of quad-cycles that must pass between issuing certain pack instructions and when their results get used. These restrictions are defined in section 7.6 of the CDNA 4 ISA.
+    """
+    if ctx.kernel.get("UseF32XEmulation", False) and not ctx.kernel.get("UseDirect32XEmulation", False):
+        return
+    apply_swaits(timeline)
+    hook_up_packs(timeline, ctx.kernel, ctx.mfma_reorder)
+    estimate_quad_cycles(timeline, ctx.kernel)
+
+
+def add_gr_not_too_early_constraints(timeline: Timeline, ctx: ValidatorPassContext) -> None:
+    """
+    Ensure that GlobalReads are not issued before the corresponding LR0s are guaranteed complete.
+
+    Required ordering per operand:
+        last LR0 -> SWaitCnt (ensures LR0 done for wave) -> SBarrier (ensures LR0 done for workgroup) -> first GR
+
+    GRA writes (DDR->LDS) to the LDS that LRA0 reads from (LDS->VGPR).
+    We conservatively assume GRA always writes everywhere that a thread in the workgroup is reading from in LRA0.
+    Thus we must ensure that every thread in every wave in the workgroup has finished all of its LRA0 instructions
+    before GRA is issued. Same logic applies for B. No cross-operand constraints (LRA0 vs GRB are independent).
+    """
+    # apply_swaits must run first so that LR0.guaranteed_by (done_idx) is set before must_start_after hookup.
+    apply_swaits(timeline)
+    set_gr_must_start_after_from_lr0s(timeline, ctx.swap_global_read_order)
+    apply_must_start_after_barriers(timeline)
+
+
+def add_gr_finish_before_lr_constraints(timeline: Timeline, ctx: ValidatorPassContext) -> None:
+    """Add GR.needed_by and GR.barriered_at constraints."""
+    apply_swaits(timeline)
+    set_gr_needed_by_from_lrs(timeline, ctx.swap_global_read_order)
+    apply_barriers(timeline)
+
+
 def verify_grs_finish_before_lrs(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
     Ensure that the GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LR1/3 of this iteration.
     """
     kernel = context["kernel"]
-
-    # Apply standalone functions to populate timeline fields
-    set_gr_needed_by_from_lrs(timeline, kernel["SwapGlobalReadOrder"])
-    apply_swaits(timeline)
-    apply_barriers(timeline)
+    ctx = ValidatorPassContext(
+        kernel=kernel,
+        mfma_reorder=schedule_info.mfmaReorder or [],
+        swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
+    )
+    add_gr_finish_before_lr_constraints(timeline, ctx)
 
     message = validate_timeline(timeline)
     if message:
@@ -1986,11 +2045,12 @@ def verify_grs_not_too_early(timeline: Timeline, schedule_info: 'ScheduleInfo', 
     before GRA is issued. Same logic applies for B. No cross-operand constraints (LRA0 vs GRB are independent).
     """
     kernel = context["kernel"]
-
-    # apply_swaits must run first so that LR0.guaranteed_by (done_idx) is set before must_start_after hookup.
-    apply_swaits(timeline)
-    set_gr_must_start_after_from_lr0s(timeline, kernel.get("SwapGlobalReadOrder", False))
-    apply_must_start_after_barriers(timeline)
+    ctx = ValidatorPassContext(
+        kernel=kernel,
+        mfma_reorder=schedule_info.mfmaReorder or [],
+        swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
+    )
+    add_gr_not_too_early_constraints(timeline, ctx)
 
     message = validate_timeline(timeline)
     if message:
@@ -2049,10 +2109,12 @@ def verify_lrs_finished_before_vmfma(timeline: Timeline, schedule_info: 'Schedul
     Ensure that the LocalReads are guaranteed to be complete before the first VMFMA that uses their data.
     """
     kernel = context["kernel"]
-
-    set_lr_needed_by_for_VMFMA(timeline, kernel, schedule_info.mfmaReorder)
-    apply_swaits(timeline)
-    apply_barriers(timeline)
+    ctx = ValidatorPassContext(
+        kernel=kernel,
+        mfma_reorder=schedule_info.mfmaReorder or [],
+        swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
+    )
+    add_local_read_constraints(timeline, ctx)
 
     message = validate_timeline(timeline)
     if message:
@@ -2077,11 +2139,14 @@ def verify_packs_start_and_end_at_correct_indices(timeline: Timeline, schedule_i
         printWarning("UseF32XEmulation is set to True but UseDirect32XEmulation is not set to True. Skipping CMS validation for packs.")
         return True, ""
 
-    apply_swaits(timeline)
-    apply_barriers(timeline)
-    set_lr_needed_by_for_VMFMA(timeline, kernel, schedule_info.mfmaReorder)
-    hook_up_packs(timeline, kernel, schedule_info.mfmaReorder)
-    estimate_quad_cycles(timeline, kernel)
+    ctx = ValidatorPassContext(
+        kernel=kernel,
+        mfma_reorder=schedule_info.mfmaReorder or [],
+        swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
+    )
+    # LR constraints must be set before pack constraints (packs depend on LR.needed_by)
+    add_local_read_constraints(timeline, ctx)
+    add_pack_constraints(timeline, ctx)
 
     message = validate_timeline(timeline)
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -20,7 +20,9 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
+import functools
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from collections import defaultdict
 from copy import deepcopy
@@ -378,6 +380,25 @@ MAIN_LOOP = "ML"
 NO_GLOBAL_LOAD_LOOP = "NGL"
 NO_LOCAL_LOAD_LOOP = "NLL"
 
+ALL_INSTRUCTION_NAMES = [
+    "LRA0", "LRB0", "LRA1", "LRB1", "LRA3", "LRB3",
+    "GRA", "GRB",
+    "PackA0", "PackB0", "PackA1", "PackB1", "PackA3", "PackB3",
+    "SYNC", "SNOP",
+]
+
+
+def create_unified_timeline(
+    schedule_info: 'ScheduleInfo',
+    kernel: 'Solution',
+    code_path: int
+) -> 'Timeline':
+    """Create a single Timeline with all instruction types."""
+    available_names = set(schedule_info.optSchedule.keys())
+    names_to_add = [n for n in ALL_INSTRUCTION_NAMES if n in available_names]
+    return Timeline(names_to_add, code_path, schedule_info, kernel)
+
+
 class Timeline:
     def __init__(self, instruction_names_to_add: list[str], code_path: int, schedule_info: 'ScheduleInfo', kernel: 'Solution'):
         """
@@ -434,6 +455,9 @@ class Timeline:
         # Only index by instruction name.
         # Index is the index of the instruction in the combined timeline. index in [0, len(self.combined_timeline)-1]
         self._instructions_for_name_combined: dict[str, list[tuple[int, ValidatorInstruction]]] = defaultdict(list)
+
+        # Track which validation passes have already been applied to this timeline to avoid applying them multiple times.
+        self._applied_passes: set[Callable[['Timeline', 'ValidatorPassContext'], None]] = set()
 
         # Populate the timeline with instructions
         self._populate_instructions(instruction_names_to_add, code_path, schedule_info, kernel)
@@ -631,6 +655,19 @@ class Timeline:
             self.combined_timeline.extend(self._timelines[loop_name])
 
 
+def applies_only_once(func):
+    """Decorator: skips the function if it has already been applied to this timeline."""
+    @functools.wraps(func)
+    def wrapper(timeline, *args, **kwargs):
+        if func in timeline._applied_passes:
+            return
+        result = func(timeline, *args, **kwargs)
+        timeline._applied_passes.add(func)
+        return result
+    return wrapper
+
+
+@applies_only_once
 def apply_barriers(timeline: Timeline) -> None:
     """
     Apply the effect of SBarriers to the GlobalReads in the timeline by updating the barriered_at field of GlobalReads.
@@ -651,6 +688,7 @@ def apply_barriers(timeline: Timeline) -> None:
             instruction.barriered_at.append(barrier.issued_at)
 
 
+@applies_only_once
 def apply_must_start_after_barriers(timeline: Timeline) -> None:
     """
     Apply the effect of SBarriers to the must_start_after_barriered_at field of GlobalReads.
@@ -683,6 +721,7 @@ def _apply_must_start_after_barriers_single(timeline: Timeline, gr: GlobalRead, 
             gr.must_start_after_barriered_at.append(instruction.issued_at)
 
 
+@applies_only_once
 def apply_swaits(timeline: Timeline) -> None:
     """
     Apply the effect of SWaitCnts to the timeline by updating the guaranteed_by field of LocalReads and GlobalReads.
@@ -714,6 +753,7 @@ def apply_swaits(timeline: Timeline) -> None:
             apply(timeline.combined_timeline[i_swait-1::-1], swait, GlobalRead, swait.vlcnt)
 
 
+@applies_only_once
 def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int]) -> None:
     """
     Set the needed_by field of LocalReads based on the VMFMA index they are required for.
@@ -761,6 +801,7 @@ def set_lr_needed_by_for_VMFMA(timeline: Timeline, kernel: 'Solution', mfma_reor
                 lr.needed_by = mfmas_by_index[needed_by + loop_offset]
 
 
+@applies_only_once
 def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) -> None:
     """
     Set the needed_by field of GlobalReads based on the LR1/3 instructions.
@@ -800,6 +841,7 @@ def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) 
             for _, gr in grs:
                 gr.needed_by = LR_target.issued_at
 
+@applies_only_once
 def set_gr_must_start_after_from_lr0s(timeline: Timeline, swap_global_read_order: bool) -> None:
     """
     Set the must_start_after field of the first GlobalRead based on the last LR0 of the same loop.
@@ -1357,6 +1399,7 @@ def _get_lrs_for_pack(timeline: Timeline, use_plr_pack: bool, pack_name: str, lo
     local_reads = timeline.get_instructions(lr_names, loop_to_use)
     return [lr for _,lr in local_reads]
 
+@applies_only_once
 def hook_up_packs(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int]) -> None:
     """
     Set the needed_by fields 
@@ -1499,6 +1542,7 @@ def estimate_quad_cycles_precomputed(i_start: int, i_end: int, issue_times: list
     """
     return issue_times[i_end] - issue_times[i_start] - 1
 
+@applies_only_once
 def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
     """
     Perform a rough estimate on the number of quad-cycles that pass between when a instruction is issued and when its result is used.
@@ -1543,10 +1587,16 @@ def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
         
     # Estimate number of quad-cycles between being issued and result being used
     for i_instruction, instruction in enumerate(timeline.combined_timeline):
-        if not hasattr(instruction, "needed_by") or instruction.needed_by is None or instruction.needed_by.issued_at == float("inf"):
-            continue
-        
         if not hasattr(instruction, "min_quad_cycles_before_result_used") or instruction.min_quad_cycles_before_result_used == 0:
+            continue
+
+        if not hasattr(instruction, "needed_by") or instruction.needed_by is None:
+            continue
+        # needed_by can be a ValidatorInstruction or a float (e.g. GlobalRead.needed_by)
+        needed_by_obj = instruction.needed_by
+        if not isinstance(needed_by_obj, ValidatorInstruction):
+            continue
+        if needed_by_obj.issued_at == float("inf"):
             continue
 
         needed_by = instruction.needed_by
@@ -1906,14 +1956,12 @@ def verify_gr_inc_order(scheduleInfo, context: dict, code_path: int) -> tuple[bo
 
     return True, ""
 
-def verify_grs_finish_before_lrs(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
+def verify_grs_finish_before_lrs(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
     Ensure that the GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LR1/3 of this iteration.
     """
-    relevant_names = ["GRA", "GRB", "LRA1", "LRB1", "LRA3", "LRB3", "SYNC"]
     kernel = context["kernel"]
-    timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
-    
+
     # Apply standalone functions to populate timeline fields
     set_gr_needed_by_from_lrs(timeline, kernel["SwapGlobalReadOrder"])
     apply_swaits(timeline)
@@ -1925,7 +1973,7 @@ def verify_grs_finish_before_lrs(schedule_info: 'ScheduleInfo', context: dict, c
     return True, ""
 
 
-def verify_grs_not_too_early(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
+def verify_grs_not_too_early(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
     Ensure that GlobalReads are not issued before the corresponding LR0s are guaranteed complete.
 
@@ -1937,9 +1985,7 @@ def verify_grs_not_too_early(schedule_info: 'ScheduleInfo', context: dict, code_
     Thus we must ensure that every thread in every wave in the workgroup has finished all of its LRA0 instructions
     before GRA is issued. Same logic applies for B. No cross-operand constraints (LRA0 vs GRB are independent).
     """
-    relevant_names = ["GRA", "GRB", "LRA0", "LRB0", "LRA1", "LRB1", "LRA3", "LRB3", "SYNC"]
     kernel = context["kernel"]
-    timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
 
     # apply_swaits must run first so that LR0.guaranteed_by (done_idx) is set before must_start_after hookup.
     apply_swaits(timeline)
@@ -1998,14 +2044,11 @@ def index_for_force_unroll_sub_iter(original_idx: int, M: int, N: int) -> int:
     return block_idx * block_size + local_idx
 
 
-def verify_lrs_finished_before_vmfma(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
+def verify_lrs_finished_before_vmfma(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
     Ensure that the LocalReads are guaranteed to be complete before the first VMFMA that uses their data.
     """
     kernel = context["kernel"]
-
-    relevant_names = ["LRA0", "LRB0", "LRA1", "LRB1", "LRA3", "LRB3", "SYNC"]
-    timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
 
     set_lr_needed_by_for_VMFMA(timeline, kernel, schedule_info.mfmaReorder)
     apply_swaits(timeline)
@@ -2017,7 +2060,7 @@ def verify_lrs_finished_before_vmfma(schedule_info: 'ScheduleInfo', context: dic
     return True, ""
 
 
-def verify_packs_start_and_end_at_correct_indices(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
+def verify_packs_start_and_end_at_correct_indices(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
     Ensure that the Packs start and end at the correct indices.
     The pack commands take the data loaded into registers by LR commands and manipulate it in various ways to prepare it for the VMFMA instructions.
@@ -2028,19 +2071,12 @@ def verify_packs_start_and_end_at_correct_indices(schedule_info: 'ScheduleInfo',
         1. The ordering of the Pack instructions.
         2. The minimum number of quad-cycles that must pass between issuing certain pack instructions and when their results get used. These restrictions are defined in section 7.6 of the CDNA 4 ISA.
     """
-    relevant_names = ["SYNC", "SNOP"]
-    for num in [0, 1, 3]:
-        relevant_names.append(f"PackA{num}")
-        relevant_names.append(f"PackB{num}")
-        relevant_names.append(f"LRA{num}")
-        relevant_names.append(f"LRB{num}")
     kernel = context["kernel"]
-    timeline = Timeline(relevant_names, code_path, schedule_info, kernel)
-    
+
     if kernel.get("UseF32XEmulation", False) and not kernel.get("UseDirect32XEmulation", False):
         printWarning("UseF32XEmulation is set to True but UseDirect32XEmulation is not set to True. Skipping CMS validation for packs.")
         return True, ""
-    
+
     apply_swaits(timeline)
     apply_barriers(timeline)
     set_lr_needed_by_for_VMFMA(timeline, kernel, schedule_info.mfmaReorder)
@@ -2137,21 +2173,33 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
         # All rules bypassed, considered valid.
         return True, message
 
+    kernel = context["kernel"]
+
     # The set of validation rules to run (code-path aware)
-    rules = [
+    structural_rules = [
         verify_correct_number_of_instructions,
         verify_ascending_order,
+        verify_scc_overlap,
+        verify_gr_inc_order,
+    ]
+
+    # Timeline-based rules: each gets its own unified timeline (for now)
+    timeline_rules = [
         verify_lrs_finished_before_vmfma,
         verify_packs_start_and_end_at_correct_indices,
         verify_grs_not_too_early,
         verify_grs_finish_before_lrs,
-        verify_scc_overlap,
-        verify_gr_inc_order
     ]
 
     for code_path in range(scheduleInfo.numCodePaths):
-        for rule in rules:
+        for rule in structural_rules:
             status, message = rule(scheduleInfo, context, code_path)
+            if not status:
+                return False, f"Code path {code_path}: {message}"
+
+        for rule in timeline_rules:
+            timeline = create_unified_timeline(scheduleInfo, kernel, code_path)
+            status, message = rule(timeline, scheduleInfo, context, code_path)
             if not status:
                 return False, f"Code path {code_path}: {message}"
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -2014,6 +2014,14 @@ def add_gr_finish_before_lr_constraints(timeline: Timeline, ctx: ValidatorPassCo
     apply_barriers(timeline)
 
 
+TIMELINE_PASSES: list[Callable[['Timeline', 'ValidatorPassContext'], None]] = [
+    add_local_read_constraints,
+    add_pack_constraints,
+    add_gr_not_too_early_constraints,
+    add_gr_finish_before_lr_constraints,
+]
+
+
 def verify_grs_finish_before_lrs(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
     """
     Ensure that the GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LR1/3 of this iteration.
@@ -2240,33 +2248,33 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
 
     kernel = context["kernel"]
 
-    # The set of validation rules to run (code-path aware)
-    structural_rules = [
+    structural_checks = [
         verify_correct_number_of_instructions,
         verify_ascending_order,
         verify_scc_overlap,
         verify_gr_inc_order,
     ]
 
-    # Timeline-based rules: each gets its own unified timeline (for now)
-    timeline_rules = [
-        verify_lrs_finished_before_vmfma,
-        verify_packs_start_and_end_at_correct_indices,
-        verify_grs_not_too_early,
-        verify_grs_finish_before_lrs,
-    ]
-
     for code_path in range(scheduleInfo.numCodePaths):
-        for rule in structural_rules:
-            status, message = rule(scheduleInfo, context, code_path)
+        # === Structural checks (no Timeline needed) ===
+        for check in structural_checks:
+            status, message = check(scheduleInfo, context, code_path)
             if not status:
                 return False, f"Code path {code_path}: {message}"
 
-        for rule in timeline_rules:
-            timeline = create_unified_timeline(scheduleInfo, kernel, code_path)
-            status, message = rule(timeline, scheduleInfo, context, code_path)
-            if not status:
-                return False, f"Code path {code_path}: {message}"
+        # === Timeline-based checks ===
+        ctx = ValidatorPassContext(
+            kernel=kernel,
+            mfma_reorder=scheduleInfo.mfmaReorder or [],
+            swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
+        )
+
+        timeline = create_unified_timeline(scheduleInfo, kernel, code_path)
+
+        for add_constraints in TIMELINE_PASSES:
+            add_constraints(timeline, ctx)
+            if error := validate_timeline(timeline):
+                return False, f"Code path {code_path}: {error}"
 
     # All rules passed, considered valid.
     return True, ""

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1983,6 +1983,7 @@ def add_pack_constraints(timeline: Timeline, ctx: ValidatorPassContext) -> None:
         2. The minimum number of quad-cycles that must pass between issuing certain pack instructions and when their results get used. These restrictions are defined in section 7.6 of the CDNA 4 ISA.
     """
     if ctx.kernel.get("UseF32XEmulation", False) and not ctx.kernel.get("UseDirect32XEmulation", False):
+        printWarning("UseF32XEmulation is set to True but UseDirect32XEmulation is not set to True. Skipping CMS validation for packs.")
         return
     apply_swaits(timeline)
     hook_up_packs(timeline, ctx.kernel, ctx.mfma_reorder)
@@ -2020,50 +2021,6 @@ TIMELINE_PASSES: list[Callable[['Timeline', 'ValidatorPassContext'], None]] = [
     add_gr_not_too_early_constraints,
     add_gr_finish_before_lr_constraints,
 ]
-
-
-def verify_grs_finish_before_lrs(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
-    """
-    Ensure that the GlobalReads issued in the previous iteration are guaranteed to be complete before the first corresponding LR1/3 of this iteration.
-    """
-    kernel = context["kernel"]
-    ctx = ValidatorPassContext(
-        kernel=kernel,
-        mfma_reorder=schedule_info.mfmaReorder or [],
-        swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
-    )
-    add_gr_finish_before_lr_constraints(timeline, ctx)
-
-    message = validate_timeline(timeline)
-    if message:
-        return False, message
-    return True, ""
-
-
-def verify_grs_not_too_early(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
-    """
-    Ensure that GlobalReads are not issued before the corresponding LR0s are guaranteed complete.
-
-    Required ordering per operand:
-        last LR0 -> SWaitCnt (ensures LR0 done for wave) -> SBarrier (ensures LR0 done for workgroup) -> first GR
-
-    GRA writes (DDR->LDS) to the LDS that LRA0 reads from (LDS->VGPR).
-    We conservatively assume GRA always writes everywhere that a thread in the workgroup is reading from in LRA0.
-    Thus we must ensure that every thread in every wave in the workgroup has finished all of its LRA0 instructions
-    before GRA is issued. Same logic applies for B. No cross-operand constraints (LRA0 vs GRB are independent).
-    """
-    kernel = context["kernel"]
-    ctx = ValidatorPassContext(
-        kernel=kernel,
-        mfma_reorder=schedule_info.mfmaReorder or [],
-        swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
-    )
-    add_gr_not_too_early_constraints(timeline, ctx)
-
-    message = validate_timeline(timeline)
-    if message:
-        return False, message
-    return True, ""
 
 
 def index_for_force_unroll_sub_iter(original_idx: int, M: int, N: int) -> int:
@@ -2110,57 +2067,6 @@ def index_for_force_unroll_sub_iter(original_idx: int, M: int, N: int) -> int:
     local_idx = local_col * block_rows + local_row
     
     return block_idx * block_size + local_idx
-
-
-def verify_lrs_finished_before_vmfma(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
-    """
-    Ensure that the LocalReads are guaranteed to be complete before the first VMFMA that uses their data.
-    """
-    kernel = context["kernel"]
-    ctx = ValidatorPassContext(
-        kernel=kernel,
-        mfma_reorder=schedule_info.mfmaReorder or [],
-        swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
-    )
-    add_local_read_constraints(timeline, ctx)
-
-    message = validate_timeline(timeline)
-    if message:
-        return False, message
-    return True, ""
-
-
-def verify_packs_start_and_end_at_correct_indices(timeline: Timeline, schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:
-    """
-    Ensure that the Packs start and end at the correct indices.
-    The pack commands take the data loaded into registers by LR commands and manipulate it in various ways to prepare it for the VMFMA instructions.
-
-    There are several restrictions placed on Pack instructions:
-    1. For all gemm types (tf32, bf16, etc.) the Pack instructions must be issued after the data is guaranteed to be loaded into the registers (guaranteed by SWaitCnt instructions). And they must finish before the first VMFMA that uses their results.
-    2. For fp32 GEMMs, there are additional restrictions on:
-        1. The ordering of the Pack instructions.
-        2. The minimum number of quad-cycles that must pass between issuing certain pack instructions and when their results get used. These restrictions are defined in section 7.6 of the CDNA 4 ISA.
-    """
-    kernel = context["kernel"]
-
-    if kernel.get("UseF32XEmulation", False) and not kernel.get("UseDirect32XEmulation", False):
-        printWarning("UseF32XEmulation is set to True but UseDirect32XEmulation is not set to True. Skipping CMS validation for packs.")
-        return True, ""
-
-    ctx = ValidatorPassContext(
-        kernel=kernel,
-        mfma_reorder=schedule_info.mfmaReorder or [],
-        swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
-    )
-    # LR constraints must be set before pack constraints (packs depend on LR.needed_by)
-    add_local_read_constraints(timeline, ctx)
-    add_pack_constraints(timeline, ctx)
-
-    message = validate_timeline(timeline)
-
-    if message:
-        return False, message
-    return True, ""
 
 
 def verify_correct_number_of_instructions(schedule_info: 'ScheduleInfo', context: dict, code_path: int) -> tuple[bool, str]:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
@@ -27,24 +27,30 @@ from typing import Any, Optional
 import unittest
 
 from test_CustomSchedule import create_base_kernel, ScheduleInfo
+from Tensile.Components.CMSValidator import create_unified_timeline
 
 
 class CMSValidationTestBase(unittest.TestCase):
     """
     Base class for CMS validation tests that provides common setup and helper methods.
     """
+    # Structural-only tests (e.g. verify_ascending_order) should set this to False
+    # if their schedule format is incompatible with Timeline construction.
+    needs_timeline = True
+
     @abstractmethod
-    def validation_function(self, sched, kernel_dict, codePathIdx):
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
         """
         Method that must be implemented by subclasses.
         NOTE: Don't use abstractmethod. Pytest will fail if this method is abstract since it tries instantiating this class.
         Should call the appropriate validation function with the provided arguments.
-        
+
         Args:
             sched: ScheduleInfo object to validate
             kernel_dict: Dictionary containing kernel configuration
             codePathIdx: Code path index to validate
-            
+            timeline: Timeline object for timeline-based validation (None for structural checks)
+
         Returns:
             Tuple of (status: bool, message: str)
         """
@@ -103,7 +109,10 @@ class CMSValidationTestBase(unittest.TestCase):
         
         sched = ScheduleInfo(numCodePaths, self.num_vmfma, optSchedule, syncCode, nglshift, nllshift, nllZeroDscnt, mfmaReorder, snopCode)
 
-        status, message = self.validation_function(sched, {"kernel": self.kernel}, codePathIdx)
+        timeline = None
+        if self.needs_timeline:
+            timeline = create_unified_timeline(sched, self.kernel, codePathIdx)
+        status, message = self.validation_function(sched, {"kernel": self.kernel}, codePathIdx, timeline=timeline)
         
         if expected_message is None:
             assert status, f"Schedule should have passed validation but did not. {message}"

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
@@ -22,28 +22,40 @@
 #
 # SPDX-License-Identifier: MIT
 ################################################################################
-from abc import abstractmethod
+from collections.abc import Callable
 from typing import Any, Optional
 import unittest
 
 from test_CustomSchedule import create_base_kernel, ScheduleInfo
-from Tensile.Components.CMSValidator import create_unified_timeline
+from Tensile.Components.CMSValidator import (
+    create_unified_timeline, ValidatorPassContext, validate_timeline,
+)
 
 
 class CMSValidationTestBase(unittest.TestCase):
     """
     Base class for CMS validation tests that provides common setup and helper methods.
+
+    Timeline-based tests set ``validator_passes`` to a list of constraint
+    functions (e.g. ``[add_local_read_constraints]``).  The base
+    ``validation_function`` creates the ValidatorPassContext, calls each pass,
+    then runs ``validate_timeline``.
+
+    Structural-only tests (no Timeline needed) override ``validation_function``
+    directly and set ``needs_timeline = False``.
     """
     # Structural-only tests (e.g. verify_ascending_order) should set this to False
     # if their schedule format is incompatible with Timeline construction.
     needs_timeline = True
 
-    @abstractmethod
+    # Subclasses set this to the list of add_*_constraints functions to run.
+    validator_passes: list[Callable[['Timeline', 'ValidatorPassContext'], None]] = []
+
     def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
         """
-        Method that must be implemented by subclasses.
-        NOTE: Don't use abstractmethod. Pytest will fail if this method is abstract since it tries instantiating this class.
-        Should call the appropriate validation function with the provided arguments.
+        Run each pass in ``self.validator_passes`` on the timeline, then validate.
+
+        Structural-only tests override this method directly.
 
         Args:
             sched: ScheduleInfo object to validate
@@ -54,7 +66,20 @@ class CMSValidationTestBase(unittest.TestCase):
         Returns:
             Tuple of (status: bool, message: str)
         """
-        raise NotImplementedError("Subclasses must implement validation_function")
+        if not self.validator_passes:
+            raise NotImplementedError("Subclasses must set validator_passes or override validation_function")
+        kernel = kernel_dict["kernel"]
+        ctx = ValidatorPassContext(
+            kernel=kernel,
+            mfma_reorder=sched.mfmaReorder or [],
+            swap_global_read_order=kernel.get("SwapGlobalReadOrder", False),
+        )
+        for pass_fn in self.validator_passes:
+            pass_fn(timeline, ctx)
+        message = validate_timeline(timeline)
+        if message:
+            return False, message
+        return True, ""
     
     def setUp(self, kernel_updates: Optional[dict[str, Any]] = None):
         """Initialize kernel and compute number of VMFMAs."""

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -1078,7 +1078,7 @@ class TestCustomScheduleValidation:
 
         # A non-empty verification message means that the schedule info is considered invalid.
         status, message = isValid(
-            ScheduleInfo(1, None, invalid_schedule, None, None, None, None), {}
+            ScheduleInfo(1, None, invalid_schedule, None, None, None, None), {"kernel" : {"DepthU": 42}}
         )
         assert status == False
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateDescendingOrder.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateDescendingOrder.py
@@ -25,7 +25,9 @@ from Tensile.Components.CMSValidator import verify_ascending_order
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateDescendingOrder(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx):
+    needs_timeline = False
+
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
         return verify_ascending_order(sched, kernel_dict, codePathIdx)
 
     def test_non_descending_order_failure(self):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
@@ -24,12 +24,11 @@
 ################################################################################
 from rocisa.instruction import SWaitCnt, SBarrier
 
-from Tensile.Components.CMSValidator import verify_grs_finish_before_lrs
+from Tensile.Components.CMSValidator import add_gr_finish_before_lr_constraints
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_grs_finish_before_lrs(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_gr_finish_before_lr_constraints]
 
     def test_simple_case_success(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
@@ -28,8 +28,8 @@ from Tensile.Components.CMSValidator import verify_grs_finish_before_lrs
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_grs_finish_before_lrs(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_grs_finish_before_lrs(timeline, sched, kernel_dict, codePathIdx)
 
     def test_simple_case_success(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
@@ -20,14 +20,14 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-from Tensile.Components.CMSValidator import verify_grs_not_too_early
+from Tensile.Components.CMSValidator import add_gr_not_too_early_constraints
 from rocisa.instruction import SBarrier, SWaitCnt
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
     """
     Tests for the Timeline-based verify_grs_not_too_early validation.
-    
+
     num_vmfma = 8 for the default kernel (MIWaveTileA=2, MIWaveTileB=2, DepthU=64, MI[2]=32).
     Valid vmfma indices are [-1, 7].
 
@@ -35,8 +35,7 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
     paired entries: even indices are m0-pointer-updates (ignored), odd indices are actual
     buffer_loads. For example, GRA: [[3, 5]] means m0-update at 3, load at 5.
     """
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_grs_not_too_early(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_gr_not_too_early_constraints]
 
     def setUp(self):
         super().setUp()

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
@@ -35,8 +35,8 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
     paired entries: even indices are m0-pointer-updates (ignored), odd indices are actual
     buffer_loads. For example, GRA: [[3, 5]] means m0-update at 3, load at 5.
     """
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_grs_not_too_early(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_grs_not_too_early(timeline, sched, kernel_dict, codePathIdx)
 
     def setUp(self):
         super().setUp()

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -25,13 +25,16 @@
 from typing import Any, Optional
 from rocisa.instruction import SWaitCnt
 
-from Tensile.Components.CMSValidator import verify_lrs_finished_before_vmfma, index_for_force_unroll_sub_iter, lr_needed_by_mfma
+from Tensile.Components.CMSValidator import (
+    add_local_read_constraints,
+    index_for_force_unroll_sub_iter, lr_needed_by_mfma,
+)
 from cms_validation_base import CMSValidationTestBase
 from Tensile.Common import IsaVersion
 
+
 class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints]
 
     def test_simple_LR0(self):
         """
@@ -361,8 +364,7 @@ class TestValidateLRsCompleteBeforeVMFMA_tf32(CMSValidationTestBase):
         kernel_updates.update({"UseF32XEmulation": True, "ISA": IsaVersion(9,5,0), "DepthU": 32, "ForceUnrollSubIter": True})
         super().setUp(kernel_updates)
 
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints]
 
     def test_LR0s_pass(self):
         """
@@ -436,8 +438,7 @@ class TestValidateLRsCompleteBeforeVMFMA_tf32(CMSValidationTestBase):
         self.validate(optSchedule, syncCode, 1, None, None, 0, None)
 
 class TestValidateLRsCompleteBeforeVMFMA_MfmaReorder(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints]
 
     def test_simple_bf16(self):
         """
@@ -634,8 +635,7 @@ class TestValidateLRsCompleteBeforeVMFMA_ForceUnrollSubIter(CMSValidationTestBas
     def setUp(self, kernel_updates: Optional[dict[str, Any]] = None):
         super().setUp({"ForceUnrollSubIter": True, "MIWaveTileA": 4, "MIWaveTileB": 4, "DepthU": 32})
 
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints]
 
 
     def test_bf16_pass(self):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -30,8 +30,8 @@ from cms_validation_base import CMSValidationTestBase
 from Tensile.Common import IsaVersion
 
 class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
 
     def test_simple_LR0(self):
         """
@@ -361,8 +361,8 @@ class TestValidateLRsCompleteBeforeVMFMA_tf32(CMSValidationTestBase):
         kernel_updates.update({"UseF32XEmulation": True, "ISA": IsaVersion(9,5,0), "DepthU": 32, "ForceUnrollSubIter": True})
         super().setUp(kernel_updates)
 
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
 
     def test_LR0s_pass(self):
         """
@@ -436,8 +436,8 @@ class TestValidateLRsCompleteBeforeVMFMA_tf32(CMSValidationTestBase):
         self.validate(optSchedule, syncCode, 1, None, None, 0, None)
 
 class TestValidateLRsCompleteBeforeVMFMA_MfmaReorder(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
 
     def test_simple_bf16(self):
         """
@@ -634,8 +634,8 @@ class TestValidateLRsCompleteBeforeVMFMA_ForceUnrollSubIter(CMSValidationTestBas
     def setUp(self, kernel_updates: Optional[dict[str, Any]] = None):
         super().setUp({"ForceUnrollSubIter": True, "MIWaveTileA": 4, "MIWaveTileB": 4, "DepthU": 32})
 
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
 
 
     def test_bf16_pass(self):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -22,12 +22,14 @@
 
 from rocisa.instruction import SWaitCnt, SBarrier
 
-from Tensile.Components.CMSValidator import verify_grs_finish_before_lrs, verify_lrs_finished_before_vmfma
+from Tensile.Components.CMSValidator import (
+    add_local_read_constraints, add_gr_finish_before_lr_constraints,
+)
 from cms_validation_base import CMSValidationTestBase
 
+
 class TestValidateNgl(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_grs_finish_before_lrs(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_gr_finish_before_lr_constraints]
 
     def make_simple_schedule_and_sync(self) -> tuple[dict[str, list[list[int]]], list[SWaitCnt | SBarrier]]:
         """
@@ -82,8 +84,7 @@ class TestValidateNgl(CMSValidationTestBase):
         self.validate(optSchedule, syncCode, 1, shift_value, shift_value, 0, None)
 
 class TestValidateNll(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints]
 
     def test_lr0_swait_depends_on_lr1(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateNglAndNll.py
@@ -26,8 +26,8 @@ from Tensile.Components.CMSValidator import verify_grs_finish_before_lrs, verify
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateNgl(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_grs_finish_before_lrs(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_grs_finish_before_lrs(timeline, sched, kernel_dict, codePathIdx)
 
     def make_simple_schedule_and_sync(self) -> tuple[dict[str, list[list[int]]], list[SWaitCnt | SBarrier]]:
         """
@@ -82,8 +82,8 @@ class TestValidateNgl(CMSValidationTestBase):
         self.validate(optSchedule, syncCode, 1, shift_value, shift_value, 0, None)
 
 class TestValidateNll(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_lrs_finished_before_vmfma(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_lrs_finished_before_vmfma(timeline, sched, kernel_dict, codePathIdx)
 
     def test_lr0_swait_depends_on_lr1(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
@@ -38,8 +38,8 @@ class TestValidatePackBF16(CMSValidationTestBase):
     def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         super().setUp(kernel_updates)
     
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
 
     def test_passing(self):
         """
@@ -141,8 +141,8 @@ class TestValidatePackBF16MFMAReorder(CMSValidationTestBase):
         super().setUp(kernel_updates)
         self.mfma_reorder = [0, 2, 1, 3, 4, 6, 5, 7]
     
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
 
     def test_passing(self):
         """
@@ -223,8 +223,8 @@ class TestValidatePackBF16PLRPack(CMSValidationTestBase):
         kernel_updates["UsePLRPack"] = True
         super().setUp(kernel_updates)
     
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
 
     def test_passing_plr_pack(self):
         """
@@ -385,8 +385,8 @@ class TestValidatePackTF32(CMSValidationTestBase):
         self.q4s = self.q3e + 1
         self.q4e = self.num_vmfma - 1
     
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
     
     def test_passing(self):
         """
@@ -572,8 +572,8 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
         # MFMA reorder: swap Q2 (indices 12-23) and Q3 (indices 24-35)
         self.mfma_reorder = list(range(12)) + list(range(24, 36)) + list(range(12, 24)) + list(range(36, 48))
     
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
     
     def test_passing(self):
         """
@@ -640,8 +640,8 @@ class TestValidatePackTF32CrossPackInterleaving(CMSValidationTestBase):
         kernel_updates["MIWaveTileB"] = 4
         super().setUp(kernel_updates)
     
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
     
     def test_passing_interleaved(self):
         """
@@ -761,8 +761,8 @@ class TestValidatePackTF32MultipleGroups(CMSValidationTestBase):
         self.q4s = self.q3e + 1
         self.q4e = self.num_vmfma - 1
     
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
     
     def test_passing_two_groups_consecutive(self):
         """
@@ -900,8 +900,8 @@ class TestValidatePackTF32MFMA4x4x4(CMSValidationTestBase):
         self.q4s = self.q3e + 1
         self.q4e = self.num_vmfma - 1
     
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
     
     def test_passing(self):
         """
@@ -1201,8 +1201,8 @@ class TestValidatePackTF32MFMA4x4x4MultipleTiles(CMSValidationTestBase):
         self.q4s = self.q3e + 1  # 18
         self.q4e = self.num_vmfma - 1  # 23
     
-    def validation_function(self, sched, kernel_dict, codePathIdx):
-        return verify_packs_start_and_end_at_correct_indices(sched, kernel_dict, codePathIdx)
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
+        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
     
     def _make_valid_pack_group(self, base_idx: int) -> list[int]:
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
@@ -26,7 +26,9 @@
 from typing import Any, Optional
 from rocisa.instruction import SWaitCnt, SNop, SBarrier
 
-from Tensile.Components.CMSValidator import verify_packs_start_and_end_at_correct_indices, isValid
+from Tensile.Components.CMSValidator import (
+    add_local_read_constraints, add_pack_constraints, isValid,
+)
 from Tensile.Components.CustomSchedule import ScheduleInfo
 from cms_validation_base import CMSValidationTestBase
 
@@ -38,8 +40,7 @@ class TestValidatePackBF16(CMSValidationTestBase):
     def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         super().setUp(kernel_updates)
     
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints, add_pack_constraints]
 
     def test_passing(self):
         """
@@ -141,8 +142,7 @@ class TestValidatePackBF16MFMAReorder(CMSValidationTestBase):
         super().setUp(kernel_updates)
         self.mfma_reorder = [0, 2, 1, 3, 4, 6, 5, 7]
     
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints, add_pack_constraints]
 
     def test_passing(self):
         """
@@ -223,8 +223,7 @@ class TestValidatePackBF16PLRPack(CMSValidationTestBase):
         kernel_updates["UsePLRPack"] = True
         super().setUp(kernel_updates)
     
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints, add_pack_constraints]
 
     def test_passing_plr_pack(self):
         """
@@ -385,8 +384,7 @@ class TestValidatePackTF32(CMSValidationTestBase):
         self.q4s = self.q3e + 1
         self.q4e = self.num_vmfma - 1
     
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints, add_pack_constraints]
     
     def test_passing(self):
         """
@@ -572,8 +570,7 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
         # MFMA reorder: swap Q2 (indices 12-23) and Q3 (indices 24-35)
         self.mfma_reorder = list(range(12)) + list(range(24, 36)) + list(range(12, 24)) + list(range(36, 48))
     
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints, add_pack_constraints]
     
     def test_passing(self):
         """
@@ -640,8 +637,7 @@ class TestValidatePackTF32CrossPackInterleaving(CMSValidationTestBase):
         kernel_updates["MIWaveTileB"] = 4
         super().setUp(kernel_updates)
     
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints, add_pack_constraints]
     
     def test_passing_interleaved(self):
         """
@@ -761,8 +757,7 @@ class TestValidatePackTF32MultipleGroups(CMSValidationTestBase):
         self.q4s = self.q3e + 1
         self.q4e = self.num_vmfma - 1
     
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints, add_pack_constraints]
     
     def test_passing_two_groups_consecutive(self):
         """
@@ -900,8 +895,7 @@ class TestValidatePackTF32MFMA4x4x4(CMSValidationTestBase):
         self.q4s = self.q3e + 1
         self.q4e = self.num_vmfma - 1
     
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints, add_pack_constraints]
     
     def test_passing(self):
         """
@@ -1201,8 +1195,7 @@ class TestValidatePackTF32MFMA4x4x4MultipleTiles(CMSValidationTestBase):
         self.q4s = self.q3e + 1  # 18
         self.q4e = self.num_vmfma - 1  # 23
     
-    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
-        return verify_packs_start_and_end_at_correct_indices(timeline, sched, kernel_dict, codePathIdx)
+    validator_passes = [add_local_read_constraints, add_pack_constraints]
     
     def _make_valid_pack_group(self, base_idx: int) -> list[int]:
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateSCCoverlap.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateSCCoverlap.py
@@ -28,7 +28,9 @@ from Tensile.Components.CMSValidator import verify_scc_overlap
 from cms_validation_base import CMSValidationTestBase
 
 class TestValidateSCCOverlap(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx):
+    needs_timeline = False
+
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
         return verify_scc_overlap(sched, kernel_dict, codePathIdx)
 
     def setUp(self):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_gr_inc_order.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_gr_inc_order.py
@@ -28,7 +28,9 @@ from Tensile.Components.CMSValidator import verify_gr_inc_order
 from cms_validation_base import CMSValidationTestBase
 
 class TestGRIncOrder(CMSValidationTestBase):
-    def validation_function(self, sched, kernel_dict, codePathIdx):
+    needs_timeline = False
+
+    def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
         return verify_gr_inc_order(sched, kernel_dict, codePathIdx)
 
     def setUp(self):


### PR DESCRIPTION
## Motivation

Refactor validator to use a single timeline object rather than re-creating and re-applying rules for each pass. Instead each pass accepts a valid timeline object and modifies it in place by adding its constraints to it. The timeline is then immediately validated and either an error is produced or the still valid, but more constrained, timeline is provided to the next pass.

This cuts down the validation time by ~70%.

## Technical Details

1. Create a single timeline filled with all currently supported instructions.
2. Refactor out timeline creation from all relevant verify_* functions and convert them to add_X_constraint functions solely responsible for applying the required constraints.

Keep track of which constraints have already been applied to avoid applying them twice.

Also fix `test_schedule_validation_disable` which was incorrectly not passing the kernel info as part of the context.

## Test Plan

Run existing tests.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
