### PR TITLE
[hipDNN] Add handle & stream management helpers to the frontend

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend.hpp
@@ -5,4 +5,5 @@
 
 #include <hipdnn_frontend/Error.hpp>
 #include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/Handle.hpp>
 #include <hipdnn_frontend/Types.hpp>

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
@@ -38,34 +38,6 @@ struct HipdnnHandleDeleter
 // Double indirection: unique_ptr holds pointer to hipdnnHandle_t
 using HipdnnHandlePtr = std::unique_ptr<hipdnnHandle_t, HipdnnHandleDeleter>;
 
-// Pair-return factory
-
-inline std::pair<HipdnnHandlePtr, Error> createHipdnnHandle(hipStream_t stream = nullptr)
-{
-    auto* handlePtr = new hipdnnHandle_t{nullptr};
-    auto status = detail::hipdnnBackend()->create(handlePtr);
-    if(status != HIPDNN_STATUS_SUCCESS)
-    {
-        delete handlePtr;
-        return {HipdnnHandlePtr{},
-                Error{ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to create hipdnn handle"}};
-    }
-
-    HipdnnHandlePtr handle(handlePtr);
-
-    if(stream != nullptr)
-    {
-        status = detail::hipdnnBackend()->setStream(*handle, stream);
-        if(status != HIPDNN_STATUS_SUCCESS)
-        {
-            return {
-                HipdnnHandlePtr{},
-                Error{ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to set stream on hipdnn handle"}};
-        }
-    }
-    return {std::move(handle), Error{}};
-}
-
 // Output-param factory
 
 inline Error createHipdnnHandle(HipdnnHandlePtr& handle, hipStream_t stream = nullptr)
@@ -82,9 +54,22 @@ inline Error createHipdnnHandle(HipdnnHandlePtr& handle, hipStream_t stream = nu
     if(stream != nullptr)
     {
         status = detail::hipdnnBackend()->setStream(*handle, stream);
-        HIPDNN_RETURN_ON_BACKEND_FAILURE(status, "Failed to set stream on hipdnn handle");
+        if(status != HIPDNN_STATUS_SUCCESS)
+        {
+            handle.reset(); // Clear the handle on failure
+            HIPDNN_RETURN_ON_BACKEND_FAILURE(status, "Failed to set stream on hipdnn handle");
+        }
     }
     return {};
+}
+
+// Pair-return factory
+
+inline std::pair<HipdnnHandlePtr, Error> createHipdnnHandle(hipStream_t stream = nullptr)
+{
+    HipdnnHandlePtr handle;
+    auto error = createHipdnnHandle(handle, stream);
+    return {std::move(handle), std::move(error)};
 }
 
 // Stream helpers
@@ -119,8 +104,8 @@ inline Error getHipdnnHandleStream(const HipdnnHandlePtr& handle, hipStream_t* s
 using hipdnn_handle_deleter = HipdnnHandleDeleter;
 using hipdnn_handle_ptr = HipdnnHandlePtr;
 
-inline auto create_hipdnn_handle(hipStream_t stream
-                                 = nullptr) // NOLINT(readability-identifier-naming)
+inline auto create_hipdnn_handle(hipStream_t stream // NOLINT(readability-identifier-naming)
+                                 = nullptr)
 {
     return createHipdnnHandle(stream);
 }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <memory>
-#include <stdexcept>
 
 #include <hipdnn_frontend/Error.hpp>
 #include <hipdnn_frontend/Utilities.hpp>
@@ -39,36 +38,9 @@ struct HipdnnHandleDeleter
 // Double indirection: unique_ptr holds pointer to hipdnnHandle_t
 using HipdnnHandlePtr = std::unique_ptr<hipdnnHandle_t, HipdnnHandleDeleter>;
 
-// Throwing factories
+// Pair-return factory
 
-inline HipdnnHandlePtr createHipdnnHandle()
-{
-    auto* handlePtr = new hipdnnHandle_t{nullptr};
-    auto status = detail::hipdnnBackend()->create(handlePtr);
-    if(status != HIPDNN_STATUS_SUCCESS)
-    {
-        delete handlePtr;
-        throw std::runtime_error("Failed to create hipdnn handle: status "
-                                 + std::to_string(static_cast<int>(status)));
-    }
-    return HipdnnHandlePtr(handlePtr);
-}
-
-inline HipdnnHandlePtr createHipdnnHandle(hipStream_t stream)
-{
-    auto handle = createHipdnnHandle();
-    auto status = detail::hipdnnBackend()->setStream(*handle, stream);
-    if(status != HIPDNN_STATUS_SUCCESS)
-    {
-        throw std::runtime_error("Failed to set stream on hipdnn handle: status "
-                                 + std::to_string(static_cast<int>(status)));
-    }
-    return handle;
-}
-
-// Non-throwing factories
-
-inline std::pair<HipdnnHandlePtr, Error> tryCreateHipdnnHandle()
+inline std::pair<HipdnnHandlePtr, Error> createHipdnnHandle(hipStream_t stream = nullptr)
 {
     auto* handlePtr = new hipdnnHandle_t{nullptr};
     auto status = detail::hipdnnBackend()->create(handlePtr);
@@ -78,23 +50,41 @@ inline std::pair<HipdnnHandlePtr, Error> tryCreateHipdnnHandle()
         return {HipdnnHandlePtr{},
                 Error{ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to create hipdnn handle"}};
     }
-    return {HipdnnHandlePtr(handlePtr), Error{}};
-}
 
-inline std::pair<HipdnnHandlePtr, Error> tryCreateHipdnnHandle(hipStream_t stream)
-{
-    auto [handle, error] = tryCreateHipdnnHandle();
-    if(error.is_bad())
+    HipdnnHandlePtr handle(handlePtr);
+
+    if(stream != nullptr)
     {
-        return {std::move(handle), error};
-    }
-    auto status = detail::hipdnnBackend()->setStream(*handle, stream);
-    if(status != HIPDNN_STATUS_SUCCESS)
-    {
-        return {HipdnnHandlePtr{},
+        status = detail::hipdnnBackend()->setStream(*handle, stream);
+        if(status != HIPDNN_STATUS_SUCCESS)
+        {
+            return {
+                HipdnnHandlePtr{},
                 Error{ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to set stream on hipdnn handle"}};
+        }
     }
     return {std::move(handle), Error{}};
+}
+
+// Output-param factory
+
+inline Error createHipdnnHandle(HipdnnHandlePtr& handle, hipStream_t stream = nullptr)
+{
+    auto* handlePtr = new hipdnnHandle_t{nullptr};
+    auto status = detail::hipdnnBackend()->create(handlePtr);
+    if(status != HIPDNN_STATUS_SUCCESS)
+    {
+        delete handlePtr;
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(status, "Failed to create hipdnn handle");
+    }
+    handle = HipdnnHandlePtr(handlePtr);
+
+    if(stream != nullptr)
+    {
+        status = detail::hipdnnBackend()->setStream(*handle, stream);
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(status, "Failed to set stream on hipdnn handle");
+    }
+    return {};
 }
 
 // Stream helpers
@@ -129,22 +119,15 @@ inline Error getHipdnnHandleStream(const HipdnnHandlePtr& handle, hipStream_t* s
 using hipdnn_handle_deleter = HipdnnHandleDeleter;
 using hipdnn_handle_ptr = HipdnnHandlePtr;
 
-inline HipdnnHandlePtr create_hipdnn_handle() // NOLINT(readability-identifier-naming)
-{
-    return createHipdnnHandle();
-}
-inline HipdnnHandlePtr
-    create_hipdnn_handle(hipStream_t stream) // NOLINT(readability-identifier-naming)
+inline auto create_hipdnn_handle(hipStream_t stream
+                                 = nullptr) // NOLINT(readability-identifier-naming)
 {
     return createHipdnnHandle(stream);
 }
-inline auto try_create_hipdnn_handle() // NOLINT(readability-identifier-naming)
+inline Error create_hipdnn_handle(HipdnnHandlePtr& handle, // NOLINT(readability-identifier-naming)
+                                  hipStream_t stream = nullptr)
 {
-    return tryCreateHipdnnHandle();
-}
-inline auto try_create_hipdnn_handle(hipStream_t stream) // NOLINT(readability-identifier-naming)
-{
-    return tryCreateHipdnnHandle(stream);
+    return createHipdnnHandle(handle, stream);
 }
 inline Error
     set_hipdnn_handle_stream(const HipdnnHandlePtr& h, // NOLINT(readability-identifier-naming)

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
@@ -1,0 +1,151 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <memory>
+#include <stdexcept>
+
+#include <hipdnn_frontend/Error.hpp>
+#include <hipdnn_frontend/Utilities.hpp>
+#include <hipdnn_frontend/detail/BackendWrapper.hpp>
+
+namespace hipdnn_frontend
+{
+
+struct HipdnnHandleDeleter
+{
+    void operator()(hipdnnHandle_t handle) const
+    {
+        if(handle == nullptr)
+        {
+            return;
+        }
+
+        auto status = detail::hipdnnBackend()->destroy(handle);
+        if(status != HIPDNN_STATUS_SUCCESS)
+        {
+            HIPDNN_FE_LOG_ERROR("Failed to destroy hipdnn handle: " << static_cast<int>(status));
+        }
+    }
+};
+
+using HipdnnHandlePtr = std::unique_ptr<hipdnnHandle, HipdnnHandleDeleter>;
+
+// Throwing factories
+
+inline HipdnnHandlePtr createHipdnnHandle()
+{
+    hipdnnHandle_t rawHandle = nullptr;
+    auto status = detail::hipdnnBackend()->create(&rawHandle);
+    if(status != HIPDNN_STATUS_SUCCESS)
+    {
+        throw std::runtime_error("Failed to create hipdnn handle");
+    }
+    return HipdnnHandlePtr(rawHandle);
+}
+
+inline HipdnnHandlePtr createHipdnnHandle(hipStream_t stream)
+{
+    auto handle = createHipdnnHandle();
+    auto status = detail::hipdnnBackend()->setStream(handle.get(), stream);
+    if(status != HIPDNN_STATUS_SUCCESS)
+    {
+        throw std::runtime_error("Failed to set stream on hipdnn handle");
+    }
+    return handle;
+}
+
+// Non-throwing factories
+
+inline std::pair<HipdnnHandlePtr, Error> tryCreateHipdnnHandle()
+{
+    hipdnnHandle_t rawHandle = nullptr;
+    auto status = detail::hipdnnBackend()->create(&rawHandle);
+    if(status != HIPDNN_STATUS_SUCCESS)
+    {
+        return {HipdnnHandlePtr{},
+                Error{ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to create hipdnn handle"}};
+    }
+    return {HipdnnHandlePtr(rawHandle), Error{}};
+}
+
+inline std::pair<HipdnnHandlePtr, Error> tryCreateHipdnnHandle(hipStream_t stream)
+{
+    auto [handle, error] = tryCreateHipdnnHandle();
+    if(error.is_bad())
+    {
+        return {std::move(handle), error};
+    }
+    auto status = detail::hipdnnBackend()->setStream(handle.get(), stream);
+    if(status != HIPDNN_STATUS_SUCCESS)
+    {
+        return {HipdnnHandlePtr{},
+                Error{ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to set stream on hipdnn handle"}};
+    }
+    return {std::move(handle), Error{}};
+}
+
+// Stream helpers
+
+inline Error setHipdnnHandleStream(const HipdnnHandlePtr& handle, hipStream_t stream)
+{
+    if(!handle)
+    {
+        return {ErrorCode::INVALID_VALUE, "Cannot set stream on null handle"};
+    }
+    auto status = detail::hipdnnBackend()->setStream(handle.get(), stream);
+    HIPDNN_RETURN_ON_BACKEND_FAILURE(status, "Failed to set stream on hipdnn handle");
+    return {};
+}
+
+inline Error getHipdnnHandleStream(const HipdnnHandlePtr& handle, hipStream_t* stream)
+{
+    if(!handle)
+    {
+        return {ErrorCode::INVALID_VALUE, "Cannot get stream from null handle"};
+    }
+    if(stream == nullptr)
+    {
+        return {ErrorCode::INVALID_VALUE, "Stream output pointer is null"};
+    }
+    auto status = detail::hipdnnBackend()->getStream(handle.get(), stream);
+    HIPDNN_RETURN_ON_BACKEND_FAILURE(status, "Failed to get stream from hipdnn handle");
+    return {};
+}
+
+// snake_case aliases
+using hipdnn_handle_deleter = HipdnnHandleDeleter;
+using hipdnn_handle_ptr = HipdnnHandlePtr;
+
+inline HipdnnHandlePtr create_hipdnn_handle() // NOLINT(readability-identifier-naming)
+{
+    return createHipdnnHandle();
+}
+inline HipdnnHandlePtr
+    create_hipdnn_handle(hipStream_t stream) // NOLINT(readability-identifier-naming)
+{
+    return createHipdnnHandle(stream);
+}
+inline auto try_create_hipdnn_handle() // NOLINT(readability-identifier-naming)
+{
+    return tryCreateHipdnnHandle();
+}
+inline auto try_create_hipdnn_handle(hipStream_t stream) // NOLINT(readability-identifier-naming)
+{
+    return tryCreateHipdnnHandle(stream);
+}
+inline Error
+    set_hipdnn_handle_stream(const HipdnnHandlePtr& h, // NOLINT(readability-identifier-naming)
+                             hipStream_t s)
+{
+    return setHipdnnHandleStream(h, s);
+}
+inline Error
+    get_hipdnn_handle_stream(const HipdnnHandlePtr& h, // NOLINT(readability-identifier-naming)
+                             hipStream_t* s)
+{
+    return getHipdnnHandleStream(h, s);
+}
+
+} // namespace hipdnn_frontend

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
@@ -15,41 +15,49 @@ namespace hipdnn_frontend
 
 struct HipdnnHandleDeleter
 {
-    void operator()(hipdnnHandle_t handle) const
+    void operator()(hipdnnHandle_t* handlePtr) const
     {
-        if(handle == nullptr)
+        if(handlePtr == nullptr)
         {
             return;
         }
 
-        auto status = detail::hipdnnBackend()->destroy(handle);
-        if(status != HIPDNN_STATUS_SUCCESS)
+        if(*handlePtr != nullptr)
         {
-            HIPDNN_FE_LOG_ERROR("Failed to destroy hipdnn handle: " << static_cast<int>(status));
+            auto status = detail::hipdnnBackend()->destroy(*handlePtr);
+            if(status != HIPDNN_STATUS_SUCCESS)
+            {
+                HIPDNN_FE_LOG_ERROR(
+                    "Failed to destroy hipdnn handle: " << static_cast<int>(status));
+            }
         }
+
+        delete handlePtr;
     }
 };
 
-using HipdnnHandlePtr = std::unique_ptr<hipdnnHandle, HipdnnHandleDeleter>;
+// Double indirection: unique_ptr holds pointer to hipdnnHandle_t
+using HipdnnHandlePtr = std::unique_ptr<hipdnnHandle_t, HipdnnHandleDeleter>;
 
 // Throwing factories
 
 inline HipdnnHandlePtr createHipdnnHandle()
 {
-    hipdnnHandle_t rawHandle = nullptr;
-    auto status = detail::hipdnnBackend()->create(&rawHandle);
+    auto* handlePtr = new hipdnnHandle_t{nullptr};
+    auto status = detail::hipdnnBackend()->create(handlePtr);
     if(status != HIPDNN_STATUS_SUCCESS)
     {
+        delete handlePtr;
         throw std::runtime_error("Failed to create hipdnn handle: status "
                                  + std::to_string(static_cast<int>(status)));
     }
-    return HipdnnHandlePtr(rawHandle);
+    return HipdnnHandlePtr(handlePtr);
 }
 
 inline HipdnnHandlePtr createHipdnnHandle(hipStream_t stream)
 {
     auto handle = createHipdnnHandle();
-    auto status = detail::hipdnnBackend()->setStream(handle.get(), stream);
+    auto status = detail::hipdnnBackend()->setStream(*handle, stream);
     if(status != HIPDNN_STATUS_SUCCESS)
     {
         throw std::runtime_error("Failed to set stream on hipdnn handle: status "
@@ -62,14 +70,15 @@ inline HipdnnHandlePtr createHipdnnHandle(hipStream_t stream)
 
 inline std::pair<HipdnnHandlePtr, Error> tryCreateHipdnnHandle()
 {
-    hipdnnHandle_t rawHandle = nullptr;
-    auto status = detail::hipdnnBackend()->create(&rawHandle);
+    auto* handlePtr = new hipdnnHandle_t{nullptr};
+    auto status = detail::hipdnnBackend()->create(handlePtr);
     if(status != HIPDNN_STATUS_SUCCESS)
     {
+        delete handlePtr;
         return {HipdnnHandlePtr{},
                 Error{ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to create hipdnn handle"}};
     }
-    return {HipdnnHandlePtr(rawHandle), Error{}};
+    return {HipdnnHandlePtr(handlePtr), Error{}};
 }
 
 inline std::pair<HipdnnHandlePtr, Error> tryCreateHipdnnHandle(hipStream_t stream)
@@ -79,7 +88,7 @@ inline std::pair<HipdnnHandlePtr, Error> tryCreateHipdnnHandle(hipStream_t strea
     {
         return {std::move(handle), error};
     }
-    auto status = detail::hipdnnBackend()->setStream(handle.get(), stream);
+    auto status = detail::hipdnnBackend()->setStream(*handle, stream);
     if(status != HIPDNN_STATUS_SUCCESS)
     {
         return {HipdnnHandlePtr{},
@@ -96,7 +105,7 @@ inline Error setHipdnnHandleStream(const HipdnnHandlePtr& handle, hipStream_t st
     {
         return {ErrorCode::INVALID_VALUE, "Cannot set stream on null handle"};
     }
-    auto status = detail::hipdnnBackend()->setStream(handle.get(), stream);
+    auto status = detail::hipdnnBackend()->setStream(*handle, stream);
     HIPDNN_RETURN_ON_BACKEND_FAILURE(status, "Failed to set stream on hipdnn handle");
     return {};
 }
@@ -111,7 +120,7 @@ inline Error getHipdnnHandleStream(const HipdnnHandlePtr& handle, hipStream_t* s
     {
         return {ErrorCode::INVALID_VALUE, "Stream output pointer is null"};
     }
-    auto status = detail::hipdnnBackend()->getStream(handle.get(), stream);
+    auto status = detail::hipdnnBackend()->getStream(*handle, stream);
     HIPDNN_RETURN_ON_BACKEND_FAILURE(status, "Failed to get stream from hipdnn handle");
     return {};
 }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
@@ -40,7 +40,8 @@ inline HipdnnHandlePtr createHipdnnHandle()
     auto status = detail::hipdnnBackend()->create(&rawHandle);
     if(status != HIPDNN_STATUS_SUCCESS)
     {
-        throw std::runtime_error("Failed to create hipdnn handle");
+        throw std::runtime_error("Failed to create hipdnn handle: status "
+                                 + std::to_string(static_cast<int>(status)));
     }
     return HipdnnHandlePtr(rawHandle);
 }
@@ -51,7 +52,8 @@ inline HipdnnHandlePtr createHipdnnHandle(hipStream_t stream)
     auto status = detail::hipdnnBackend()->setStream(handle.get(), stream);
     if(status != HIPDNN_STATUS_SUCCESS)
     {
-        throw std::runtime_error("Failed to set stream on hipdnn handle");
+        throw std::runtime_error("Failed to set stream on hipdnn handle: status "
+                                 + std::to_string(static_cast<int>(status)));
     }
     return handle;
 }

--- a/projects/hipdnn/frontend/tests/CMakeLists.txt
+++ b/projects/hipdnn/frontend/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(
     TestConvolutionWgradNode.cpp
     TestError.cpp
     TestGraph.cpp
+    TestHandle.cpp
     TestGraphAttributes.cpp
     TestGraphGenerated.cpp
     TestGraphSerialization.cpp

--- a/projects/hipdnn/frontend/tests/TestHandle.cpp
+++ b/projects/hipdnn/frontend/tests/TestHandle.cpp
@@ -49,7 +49,7 @@ TEST_F(TestHandle, CreateHandleSuccess)
 
     auto handle = createHipdnnHandle();
     EXPECT_NE(handle, nullptr);
-    EXPECT_EQ(handle.get(), fakeHandle);
+    EXPECT_EQ(*handle, fakeHandle);
 }
 
 TEST_F(TestHandle, CreateHandleFailure)
@@ -76,7 +76,7 @@ TEST_F(TestHandle, CreateHandleWithStreamSuccess)
 
     auto handle = createHipdnnHandle(fakeStream);
     EXPECT_NE(handle, nullptr);
-    EXPECT_EQ(handle.get(), fakeHandle);
+    EXPECT_EQ(*handle, fakeHandle);
 }
 
 TEST_F(TestHandle, CreateHandleWithStreamFailure)
@@ -108,7 +108,7 @@ TEST_F(TestHandle, TryCreateHandleSuccess)
     auto [handle, error] = tryCreateHipdnnHandle();
     EXPECT_TRUE(error.is_good());
     EXPECT_NE(handle, nullptr);
-    EXPECT_EQ(handle.get(), fakeHandle);
+    EXPECT_EQ(*handle, fakeHandle);
 }
 
 TEST_F(TestHandle, TryCreateHandleFailure)
@@ -138,7 +138,7 @@ TEST_F(TestHandle, TryCreateHandleWithStreamSuccess)
     auto [handle, error] = tryCreateHipdnnHandle(fakeStream);
     EXPECT_TRUE(error.is_good());
     EXPECT_NE(handle, nullptr);
-    EXPECT_EQ(handle.get(), fakeHandle);
+    EXPECT_EQ(*handle, fakeHandle);
 }
 
 TEST_F(TestHandle, TryCreateHandleWithStreamFailure)
@@ -189,11 +189,11 @@ TEST_F(TestHandle, MoveTransfersOwnership)
         .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
     auto handle1 = createHipdnnHandle();
-    EXPECT_EQ(handle1.get(), fakeHandle);
+    EXPECT_EQ(*handle1, fakeHandle);
 
     auto handle2 = std::move(handle1);
-    EXPECT_EQ(handle1.get(), nullptr); // NOLINT(bugprone-use-after-move)
-    EXPECT_EQ(handle2.get(), fakeHandle);
+    EXPECT_EQ(handle1, nullptr); // NOLINT(bugprone-use-after-move)
+    EXPECT_EQ(*handle2, fakeHandle);
 }
 
 TEST_F(TestHandle, NullHandleDeleterIsNoop)

--- a/projects/hipdnn/frontend/tests/TestHandle.cpp
+++ b/projects/hipdnn/frontend/tests/TestHandle.cpp
@@ -1,0 +1,273 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+
+#include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+#include <hipdnn_frontend/Handle.hpp>
+
+#include "fake_backend/MockHipdnnBackend.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_frontend::detail;
+using namespace ::testing;
+
+class TestHandle : public ::testing::Test
+{
+protected:
+    std::shared_ptr<Mock_hipdnn_backend> _mockBackend;
+
+    void SetUp() override
+    {
+        _mockBackend = std::make_shared<Mock_hipdnn_backend>();
+        IHipdnnBackend::setInstance(_mockBackend);
+
+        ON_CALL(*_mockBackend, getLastErrorString(_, _))
+            .WillByDefault([](char* errorString, size_t size) {
+                std::string fakeError = "Fake backend error";
+                hipdnn_data_sdk::utilities::copyMaxSizeWithNullTerminator(
+                    errorString, fakeError.c_str(), size - 1);
+            });
+    }
+
+    void TearDown() override
+    {
+        IHipdnnBackend::resetInstance();
+        _mockBackend.reset();
+    }
+};
+
+TEST_F(TestHandle, CreateHandleSuccess)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x1234);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto handle = createHipdnnHandle();
+    EXPECT_NE(handle, nullptr);
+    EXPECT_EQ(handle.get(), fakeHandle);
+}
+
+TEST_F(TestHandle, CreateHandleFailure)
+{
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([](hipdnnHandle_t*) {
+        return HIPDNN_STATUS_INTERNAL_ERROR;
+    });
+
+    EXPECT_THROW(createHipdnnHandle(), std::runtime_error);
+}
+
+TEST_F(TestHandle, CreateHandleWithStreamSuccess)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x2345);
+    auto fakeStream = reinterpret_cast<hipStream_t>(0xABCD);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, setStream(fakeHandle, fakeStream))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto handle = createHipdnnHandle(fakeStream);
+    EXPECT_NE(handle, nullptr);
+    EXPECT_EQ(handle.get(), fakeHandle);
+}
+
+TEST_F(TestHandle, CreateHandleWithStreamFailure)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x3456);
+    auto fakeStream = reinterpret_cast<hipStream_t>(0xBCDE);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, setStream(fakeHandle, fakeStream))
+        .WillOnce(Return(HIPDNN_STATUS_INTERNAL_ERROR));
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    EXPECT_THROW(createHipdnnHandle(fakeStream), std::runtime_error);
+}
+
+TEST_F(TestHandle, TryCreateHandleSuccess)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x4567);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto [handle, error] = tryCreateHipdnnHandle();
+    EXPECT_TRUE(error.is_good());
+    EXPECT_NE(handle, nullptr);
+    EXPECT_EQ(handle.get(), fakeHandle);
+}
+
+TEST_F(TestHandle, TryCreateHandleFailure)
+{
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([](hipdnnHandle_t*) {
+        return HIPDNN_STATUS_INTERNAL_ERROR;
+    });
+
+    auto [handle, error] = tryCreateHipdnnHandle();
+    EXPECT_TRUE(error.is_bad());
+    EXPECT_EQ(handle, nullptr);
+}
+
+TEST_F(TestHandle, TryCreateHandleWithStreamSuccess)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x5678);
+    auto fakeStream = reinterpret_cast<hipStream_t>(0xCDEF);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, setStream(fakeHandle, fakeStream))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto [handle, error] = tryCreateHipdnnHandle(fakeStream);
+    EXPECT_TRUE(error.is_good());
+    EXPECT_NE(handle, nullptr);
+    EXPECT_EQ(handle.get(), fakeHandle);
+}
+
+TEST_F(TestHandle, TryCreateHandleWithStreamFailure)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x6789);
+    auto fakeStream = reinterpret_cast<hipStream_t>(0xDEF0);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, setStream(fakeHandle, fakeStream))
+        .WillOnce(Return(HIPDNN_STATUS_INTERNAL_ERROR));
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto [handle, error] = tryCreateHipdnnHandle(fakeStream);
+    EXPECT_TRUE(error.is_bad());
+    EXPECT_EQ(handle, nullptr);
+}
+
+TEST_F(TestHandle, HandleDestroyedOnScopeExit)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x7890);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    {
+        auto handle = createHipdnnHandle();
+        EXPECT_NE(handle, nullptr);
+    }
+    // destroy is verified by the EXPECT_CALL expectation
+}
+
+TEST_F(TestHandle, MoveTransfersOwnership)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x8901);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle))
+        .Times(1)
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto handle1 = createHipdnnHandle();
+    EXPECT_EQ(handle1.get(), fakeHandle);
+
+    auto handle2 = std::move(handle1);
+    EXPECT_EQ(handle1.get(), nullptr); // NOLINT(bugprone-use-after-move)
+    EXPECT_EQ(handle2.get(), fakeHandle);
+}
+
+TEST_F(TestHandle, NullHandleDeleterIsNoop)
+{
+    EXPECT_CALL(*_mockBackend, destroy(_)).Times(0);
+
+    {
+        HipdnnHandlePtr handle{nullptr};
+    }
+}
+
+TEST_F(TestHandle, SetStreamOnValidHandle)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x9012);
+    auto fakeStream = reinterpret_cast<hipStream_t>(0xEF01);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, setStream(fakeHandle, fakeStream))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto handle = createHipdnnHandle();
+    auto error = setHipdnnHandleStream(handle, fakeStream);
+    EXPECT_TRUE(error.is_good());
+}
+
+TEST_F(TestHandle, SetStreamOnNullHandle)
+{
+    HipdnnHandlePtr handle{nullptr};
+    auto fakeStream = reinterpret_cast<hipStream_t>(0xF012);
+
+    auto error = setHipdnnHandleStream(handle, fakeStream);
+    EXPECT_TRUE(error.is_bad());
+    EXPECT_EQ(error.get_code(), ErrorCode::INVALID_VALUE);
+}
+
+TEST_F(TestHandle, GetStreamFromValidHandle)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0xA123);
+    auto fakeStream = reinterpret_cast<hipStream_t>(0x1234);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, getStream(fakeHandle, _))
+        .WillOnce([&fakeStream](hipdnnHandle_t, hipStream_t* out) {
+            *out = fakeStream;
+            return HIPDNN_STATUS_SUCCESS;
+        });
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto handle = createHipdnnHandle();
+    hipStream_t stream = nullptr;
+    auto error = getHipdnnHandleStream(handle, &stream);
+    EXPECT_TRUE(error.is_good());
+    EXPECT_EQ(stream, fakeStream);
+}
+
+TEST_F(TestHandle, GetStreamNullPointer)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0xB234);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto handle = createHipdnnHandle();
+    auto error = getHipdnnHandleStream(handle, nullptr);
+    EXPECT_TRUE(error.is_bad());
+    EXPECT_EQ(error.get_code(), ErrorCode::INVALID_VALUE);
+}

--- a/projects/hipdnn/frontend/tests/TestHandle.cpp
+++ b/projects/hipdnn/frontend/tests/TestHandle.cpp
@@ -233,6 +233,16 @@ TEST_F(TestHandle, SetStreamOnNullHandle)
     EXPECT_EQ(error.get_code(), ErrorCode::INVALID_VALUE);
 }
 
+TEST_F(TestHandle, GetStreamFromNullHandle)
+{
+    HipdnnHandlePtr handle{nullptr};
+    hipStream_t stream = nullptr;
+
+    auto error = getHipdnnHandleStream(handle, &stream);
+    EXPECT_TRUE(error.is_bad());
+    EXPECT_EQ(error.get_code(), ErrorCode::INVALID_VALUE);
+}
+
 TEST_F(TestHandle, GetStreamFromValidHandle)
 {
     auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0xA123);

--- a/projects/hipdnn/frontend/tests/TestHandle.cpp
+++ b/projects/hipdnn/frontend/tests/TestHandle.cpp
@@ -37,6 +37,70 @@ protected:
     }
 };
 
+TEST_F(TestHandle, CreateHandlePairReturnSuccess)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x4567);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto [handle, error] = createHipdnnHandle();
+    EXPECT_TRUE(error.is_good());
+    EXPECT_NE(handle, nullptr);
+    EXPECT_EQ(*handle, fakeHandle);
+}
+
+TEST_F(TestHandle, CreateHandlePairReturnFailure)
+{
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([](hipdnnHandle_t*) {
+        return HIPDNN_STATUS_INTERNAL_ERROR;
+    });
+
+    auto [handle, error] = createHipdnnHandle();
+    EXPECT_TRUE(error.is_bad());
+    EXPECT_EQ(handle, nullptr);
+}
+
+TEST_F(TestHandle, CreateHandlePairReturnWithStreamSuccess)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x5678);
+    auto fakeStream = reinterpret_cast<hipStream_t>(0xCDEF);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, setStream(fakeHandle, fakeStream))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto [handle, error] = createHipdnnHandle(fakeStream);
+    EXPECT_TRUE(error.is_good());
+    EXPECT_NE(handle, nullptr);
+    EXPECT_EQ(*handle, fakeHandle);
+}
+
+TEST_F(TestHandle, CreateHandlePairReturnWithStreamFailure)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x6789);
+    auto fakeStream = reinterpret_cast<hipStream_t>(0xDEF0);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, setStream(fakeHandle, fakeStream))
+        .WillOnce(Return(HIPDNN_STATUS_INTERNAL_ERROR));
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    auto [handle, error] = createHipdnnHandle(fakeStream);
+    EXPECT_TRUE(error.is_bad());
+    EXPECT_EQ(handle, nullptr);
+}
+
 TEST_F(TestHandle, CreateHandleSuccess)
 {
     auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x1234);
@@ -47,7 +111,9 @@ TEST_F(TestHandle, CreateHandleSuccess)
     });
     EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
-    auto handle = createHipdnnHandle();
+    HipdnnHandlePtr handle;
+    auto error = createHipdnnHandle(handle);
+    EXPECT_TRUE(error.is_good());
     EXPECT_NE(handle, nullptr);
     EXPECT_EQ(*handle, fakeHandle);
 }
@@ -58,7 +124,10 @@ TEST_F(TestHandle, CreateHandleFailure)
         return HIPDNN_STATUS_INTERNAL_ERROR;
     });
 
-    EXPECT_THROW(createHipdnnHandle(), std::runtime_error);
+    HipdnnHandlePtr handle;
+    auto error = createHipdnnHandle(handle);
+    EXPECT_TRUE(error.is_bad());
+    EXPECT_EQ(handle, nullptr);
 }
 
 TEST_F(TestHandle, CreateHandleWithStreamSuccess)
@@ -74,7 +143,9 @@ TEST_F(TestHandle, CreateHandleWithStreamSuccess)
         .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
     EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
-    auto handle = createHipdnnHandle(fakeStream);
+    HipdnnHandlePtr handle;
+    auto error = createHipdnnHandle(handle, fakeStream);
+    EXPECT_TRUE(error.is_good());
     EXPECT_NE(handle, nullptr);
     EXPECT_EQ(*handle, fakeHandle);
 }
@@ -92,71 +163,9 @@ TEST_F(TestHandle, CreateHandleWithStreamFailure)
         .WillOnce(Return(HIPDNN_STATUS_INTERNAL_ERROR));
     EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
-    EXPECT_THROW(createHipdnnHandle(fakeStream), std::runtime_error);
-}
-
-TEST_F(TestHandle, TryCreateHandleSuccess)
-{
-    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x4567);
-
-    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
-        *out = fakeHandle;
-        return HIPDNN_STATUS_SUCCESS;
-    });
-    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
-
-    auto [handle, error] = tryCreateHipdnnHandle();
-    EXPECT_TRUE(error.is_good());
-    EXPECT_NE(handle, nullptr);
-    EXPECT_EQ(*handle, fakeHandle);
-}
-
-TEST_F(TestHandle, TryCreateHandleFailure)
-{
-    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([](hipdnnHandle_t*) {
-        return HIPDNN_STATUS_INTERNAL_ERROR;
-    });
-
-    auto [handle, error] = tryCreateHipdnnHandle();
+    HipdnnHandlePtr handle;
+    auto error = createHipdnnHandle(handle, fakeStream);
     EXPECT_TRUE(error.is_bad());
-    EXPECT_EQ(handle, nullptr);
-}
-
-TEST_F(TestHandle, TryCreateHandleWithStreamSuccess)
-{
-    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x5678);
-    auto fakeStream = reinterpret_cast<hipStream_t>(0xCDEF);
-
-    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
-        *out = fakeHandle;
-        return HIPDNN_STATUS_SUCCESS;
-    });
-    EXPECT_CALL(*_mockBackend, setStream(fakeHandle, fakeStream))
-        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
-    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
-
-    auto [handle, error] = tryCreateHipdnnHandle(fakeStream);
-    EXPECT_TRUE(error.is_good());
-    EXPECT_NE(handle, nullptr);
-    EXPECT_EQ(*handle, fakeHandle);
-}
-
-TEST_F(TestHandle, TryCreateHandleWithStreamFailure)
-{
-    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x6789);
-    auto fakeStream = reinterpret_cast<hipStream_t>(0xDEF0);
-
-    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
-        *out = fakeHandle;
-        return HIPDNN_STATUS_SUCCESS;
-    });
-    EXPECT_CALL(*_mockBackend, setStream(fakeHandle, fakeStream))
-        .WillOnce(Return(HIPDNN_STATUS_INTERNAL_ERROR));
-    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
-
-    auto [handle, error] = tryCreateHipdnnHandle(fakeStream);
-    EXPECT_TRUE(error.is_bad());
-    EXPECT_EQ(handle, nullptr);
 }
 
 TEST_F(TestHandle, HandleDestroyedOnScopeExit)
@@ -170,7 +179,8 @@ TEST_F(TestHandle, HandleDestroyedOnScopeExit)
     EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
     {
-        auto handle = createHipdnnHandle();
+        auto [handle, error] = createHipdnnHandle();
+        EXPECT_TRUE(error.is_good());
         EXPECT_NE(handle, nullptr);
     }
     // destroy is verified by the EXPECT_CALL expectation
@@ -188,7 +198,8 @@ TEST_F(TestHandle, MoveTransfersOwnership)
         .Times(1)
         .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
-    auto handle1 = createHipdnnHandle();
+    auto [handle1, error] = createHipdnnHandle();
+    EXPECT_TRUE(error.is_good());
     EXPECT_EQ(*handle1, fakeHandle);
 
     auto handle2 = std::move(handle1);
@@ -205,6 +216,24 @@ TEST_F(TestHandle, NullHandleDeleterIsNoop)
     }
 }
 
+TEST_F(TestHandle, DestroyerHandlesFailure)
+{
+    auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0xBEEF);
+
+    EXPECT_CALL(*_mockBackend, create(_)).WillOnce([&fakeHandle](hipdnnHandle_t* out) {
+        *out = fakeHandle;
+        return HIPDNN_STATUS_SUCCESS;
+    });
+    EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
+
+    {
+        HipdnnHandlePtr handle;
+        auto error = createHipdnnHandle(handle);
+        EXPECT_TRUE(error.is_good());
+    }
+    // Scope exits, deleter runs, destroy fails but logs error without throwing
+}
+
 TEST_F(TestHandle, SetStreamOnValidHandle)
 {
     auto fakeHandle = reinterpret_cast<hipdnnHandle_t>(0x9012);
@@ -218,9 +247,10 @@ TEST_F(TestHandle, SetStreamOnValidHandle)
         .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
     EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
-    auto handle = createHipdnnHandle();
-    auto error = setHipdnnHandleStream(handle, fakeStream);
+    auto [handle, error] = createHipdnnHandle();
     EXPECT_TRUE(error.is_good());
+    auto streamError = setHipdnnHandleStream(handle, fakeStream);
+    EXPECT_TRUE(streamError.is_good());
 }
 
 TEST_F(TestHandle, SetStreamOnNullHandle)
@@ -259,10 +289,11 @@ TEST_F(TestHandle, GetStreamFromValidHandle)
         });
     EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
-    auto handle = createHipdnnHandle();
-    hipStream_t stream = nullptr;
-    auto error = getHipdnnHandleStream(handle, &stream);
+    auto [handle, error] = createHipdnnHandle();
     EXPECT_TRUE(error.is_good());
+    hipStream_t stream = nullptr;
+    auto streamError = getHipdnnHandleStream(handle, &stream);
+    EXPECT_TRUE(streamError.is_good());
     EXPECT_EQ(stream, fakeStream);
 }
 
@@ -276,8 +307,9 @@ TEST_F(TestHandle, GetStreamNullPointer)
     });
     EXPECT_CALL(*_mockBackend, destroy(fakeHandle)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
-    auto handle = createHipdnnHandle();
-    auto error = getHipdnnHandleStream(handle, nullptr);
-    EXPECT_TRUE(error.is_bad());
-    EXPECT_EQ(error.get_code(), ErrorCode::INVALID_VALUE);
+    auto [handle, error] = createHipdnnHandle();
+    EXPECT_TRUE(error.is_good());
+    auto streamError = getHipdnnHandleStream(handle, nullptr);
+    EXPECT_TRUE(streamError.is_bad());
+    EXPECT_EQ(streamError.get_code(), ErrorCode::INVALID_VALUE);
 }

--- a/projects/hipdnn/python/hipdnn_frontend/__init__.py
+++ b/projects/hipdnn/python/hipdnn_frontend/__init__.py
@@ -49,4 +49,7 @@ __all__ = [
     "BatchnormMode",
     "Handle",
     "create_handle",
+    "destroy_handle",
+    "set_stream",
+    "get_stream",
 ]

--- a/projects/hipdnn/python/hipdnn_frontend/__init__.py
+++ b/projects/hipdnn/python/hipdnn_frontend/__init__.py
@@ -47,5 +47,6 @@ __all__ = [
     "ActivationMode",
     "PoolingMode",
     "BatchnormMode",
-    # Add other exported symbols as needed
+    "Handle",
+    "create_handle",
 ]

--- a/projects/hipdnn/python/hipdnn_frontend/samples/conv_dgrad.py
+++ b/projects/hipdnn/python/hipdnn_frontend/samples/conv_dgrad.py
@@ -50,7 +50,7 @@ def run_convolution_dgrad():
 
     # Create a handle for backend operations
     print("\nCreating hipdnn handle...")
-    handle = hipdnn.Handle()
+    handle = hipdnn.create_handle()
 
     # Create a graph
     graph = hipdnn.Graph()

--- a/projects/hipdnn/python/hipdnn_frontend/samples/conv_fprop.py
+++ b/projects/hipdnn/python/hipdnn_frontend/samples/conv_fprop.py
@@ -49,7 +49,7 @@ def run_convolution_fprop():
 
     # Create a handle for backend operations
     print("\nCreating hipdnn handle...")
-    handle = hipdnn.Handle()
+    handle = hipdnn.create_handle()
 
     # Create a graph
     graph = hipdnn.Graph()

--- a/projects/hipdnn/python/hipdnn_frontend/samples/conv_wgrad.py
+++ b/projects/hipdnn/python/hipdnn_frontend/samples/conv_wgrad.py
@@ -50,7 +50,7 @@ def run_convolution_wgrad():
 
     # Create a handle for backend operations
     print("\nCreating hipdnn handle...")
-    handle = hipdnn.Handle()
+    handle = hipdnn.create_handle()
 
     # Create a graph
     graph = hipdnn.Graph()

--- a/projects/hipdnn/python/hipdnn_frontend/samples/matmul.py
+++ b/projects/hipdnn/python/hipdnn_frontend/samples/matmul.py
@@ -18,7 +18,7 @@ def run_matmul():
 
     # Create a handle and graph
     print("\nCreating hipdnn handle...")
-    handle = hipdnn.Handle()
+    handle = hipdnn.create_handle()
 
     graph = hipdnn.Graph()
     graph.set_name("matmul_graph")

--- a/projects/hipdnn/python/src/handle_bindings.cpp
+++ b/projects/hipdnn/python/src/handle_bindings.cpp
@@ -26,13 +26,21 @@ private:
 
 public:
     HandleWrapper()
-        : _handle(createHipdnnHandle())
     {
+        auto error = createHipdnnHandle(_handle);
+        if(error.is_bad())
+        {
+            throw std::runtime_error("Failed to create hipdnn handle: " + error.get_message());
+        }
     }
 
     explicit HandleWrapper(uintptr_t streamPtr)
-        : _handle(createHipdnnHandle(reinterpret_cast<hipStream_t>(streamPtr)))
     {
+        auto error = createHipdnnHandle(_handle, reinterpret_cast<hipStream_t>(streamPtr));
+        if(error.is_bad())
+        {
+            throw std::runtime_error("Failed to create hipdnn handle: " + error.get_message());
+        }
     }
 
     hipdnnHandle_t get() const

--- a/projects/hipdnn/python/src/handle_bindings.cpp
+++ b/projects/hipdnn/python/src/handle_bindings.cpp
@@ -38,7 +38,7 @@ public:
     hipdnnHandle_t get() const
     {
         checkNotDestroyed();
-        return _handle.get();
+        return *_handle;
     }
 
     bool isValid() const

--- a/projects/hipdnn/python/src/handle_bindings.cpp
+++ b/projects/hipdnn/python/src/handle_bindings.cpp
@@ -4,6 +4,8 @@
 #include <hipdnn_frontend.hpp>
 #include <memory>
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
 #include <stdexcept>
 
 namespace nb = nanobind;
@@ -35,7 +37,8 @@ public:
         auto error = setHipdnnHandleStream(_handle, reinterpret_cast<hipStream_t>(streamPtr));
         if(error.is_bad())
         {
-            throw std::runtime_error("Failed to set stream on hipdnn handle");
+            throw std::runtime_error("Failed to set stream on hipdnn handle: "
+                                     + error.get_message());
         }
     }
 
@@ -45,7 +48,8 @@ public:
         auto error = getHipdnnHandleStream(_handle, &stream);
         if(error.is_bad())
         {
-            throw std::runtime_error("Failed to get stream from hipdnn handle");
+            throw std::runtime_error("Failed to get stream from hipdnn handle: "
+                                     + error.get_message());
         }
         return reinterpret_cast<uintptr_t>(stream);
     }

--- a/projects/hipdnn/python/src/handle_bindings.cpp
+++ b/projects/hipdnn/python/src/handle_bindings.cpp
@@ -16,6 +16,14 @@ class HandleWrapper
 private:
     HipdnnHandlePtr _handle;
 
+    void checkNotDestroyed() const
+    {
+        if(!_handle)
+        {
+            throw std::runtime_error("Handle has been destroyed");
+        }
+    }
+
 public:
     HandleWrapper()
         : _handle(createHipdnnHandle())
@@ -29,11 +37,23 @@ public:
 
     hipdnnHandle_t get() const
     {
+        checkNotDestroyed();
         return _handle.get();
+    }
+
+    bool isValid() const
+    {
+        return _handle != nullptr;
+    }
+
+    void destroy()
+    {
+        _handle.reset();
     }
 
     void setStream(uintptr_t streamPtr)
     {
+        checkNotDestroyed();
         auto error = setHipdnnHandleStream(_handle, reinterpret_cast<hipStream_t>(streamPtr));
         if(error.is_bad())
         {
@@ -44,6 +64,7 @@ public:
 
     uintptr_t getStream() const
     {
+        checkNotDestroyed();
         hipStream_t stream = nullptr;
         auto error = getHipdnnHandleStream(_handle, &stream);
         if(error.is_bad())
@@ -69,12 +90,18 @@ void handle_bindings(nb::module_& m)
              nb::arg("stream"),
              "Set the HIP stream (as integer pointer)")
         .def("get_stream", &HandleWrapper::getStream, "Get the HIP stream (as integer pointer)")
+        .def("__int__", [](const HandleWrapper& h) { return reinterpret_cast<uintptr_t>(h.get()); })
+        .def("__index__",
+             [](const HandleWrapper& h) { return reinterpret_cast<uintptr_t>(h.get()); })
         .def("__repr__", [](const HandleWrapper& h) {
+            if(!h.isValid())
+            {
+                return std::string("<hipdnn_frontend.Handle (destroyed)>");
+            }
             return "<hipdnn_frontend.Handle at "
                    + std::to_string(reinterpret_cast<uintptr_t>(h.get())) + ">";
         });
 
-    // Convenience functions to create handles
     m.def(
         "create_handle",
         []() { return std::make_shared<HandleWrapper>(); },
@@ -84,4 +111,20 @@ void handle_bindings(nb::module_& m)
         [](uintptr_t stream) { return std::make_shared<HandleWrapper>(stream); },
         nb::arg("stream"),
         "Create a new hipdnn handle with a stream");
+    m.def(
+        "destroy_handle",
+        [](HandleWrapper& h) { h.destroy(); },
+        nb::arg("handle"),
+        "Destroy a hipdnn handle. The handle object should not be used after this call.");
+    m.def(
+        "set_stream",
+        [](HandleWrapper& h, uintptr_t stream) { h.setStream(stream); },
+        nb::arg("handle"),
+        nb::arg("stream"),
+        "Set the HIP stream on a handle");
+    m.def(
+        "get_stream",
+        [](const HandleWrapper& h) { return h.getStream(); },
+        nb::arg("handle"),
+        "Get the HIP stream from a handle");
 }

--- a/projects/hipdnn/python/src/handle_bindings.cpp
+++ b/projects/hipdnn/python/src/handle_bindings.cpp
@@ -1,7 +1,6 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
-#include <hipdnn_backend.h>
 #include <hipdnn_frontend.hpp>
 #include <memory>
 #include <nanobind/nanobind.h>
@@ -13,64 +12,42 @@ using namespace hipdnn_frontend;
 class HandleWrapper
 {
 private:
-    hipdnnHandle_t _handle;
-    bool _ownsHandle;
+    HipdnnHandlePtr _handle;
 
 public:
     HandleWrapper()
-        : _handle(nullptr)
-        , _ownsHandle(true)
+        : _handle(createHipdnnHandle())
     {
-        auto backend = hipdnnBackend();
-        auto status = backend->create(&_handle);
-        if(status != HIPDNN_STATUS_SUCCESS)
-        {
-            throw std::runtime_error("Failed to create hipdnn handle");
-        }
     }
 
-    ~HandleWrapper()
+    explicit HandleWrapper(uintptr_t streamPtr)
+        : _handle(createHipdnnHandle(reinterpret_cast<hipStream_t>(streamPtr)))
     {
-        if(_ownsHandle && _handle)
-        {
-            auto backend = hipdnnBackend();
-            backend->destroy(_handle);
-        }
-    }
-
-    // Disable copy
-    HandleWrapper(const HandleWrapper&) = delete;
-    HandleWrapper& operator=(const HandleWrapper&) = delete;
-
-    // Enable move
-    HandleWrapper(HandleWrapper&& other) noexcept
-        : _handle(other._handle)
-        , _ownsHandle(other._ownsHandle)
-    {
-        other._handle = nullptr;
-        other._ownsHandle = false;
-    }
-
-    HandleWrapper& operator=(HandleWrapper&& other) noexcept
-    {
-        if(this != &other)
-        {
-            if(_ownsHandle && _handle)
-            {
-                auto backend = hipdnnBackend();
-                backend->destroy(_handle);
-            }
-            _handle = other._handle;
-            _ownsHandle = other._ownsHandle;
-            other._handle = nullptr;
-            other._ownsHandle = false;
-        }
-        return *this;
     }
 
     hipdnnHandle_t get() const
     {
-        return _handle;
+        return _handle.get();
+    }
+
+    void setStream(uintptr_t streamPtr)
+    {
+        auto error = setHipdnnHandleStream(_handle, reinterpret_cast<hipStream_t>(streamPtr));
+        if(error.is_bad())
+        {
+            throw std::runtime_error("Failed to set stream on hipdnn handle");
+        }
+    }
+
+    uintptr_t getStream() const
+    {
+        hipStream_t stream = nullptr;
+        auto error = getHipdnnHandleStream(_handle, &stream);
+        if(error.is_bad())
+        {
+            throw std::runtime_error("Failed to get stream from hipdnn handle");
+        }
+        return reinterpret_cast<uintptr_t>(stream);
     }
 };
 
@@ -78,18 +55,29 @@ void handle_bindings(nb::module_& m)
 {
     nb::class_<HandleWrapper>(m, "Handle")
         .def(nb::init<>(), "Create a new hipdnn handle")
+        .def(nb::init<uintptr_t>(), nb::arg("stream"), "Create a handle with a stream")
         .def(
             "get",
             [](const HandleWrapper& h) { return reinterpret_cast<uintptr_t>(h.get()); },
             "Get the handle pointer as an integer")
+        .def("set_stream",
+             &HandleWrapper::setStream,
+             nb::arg("stream"),
+             "Set the HIP stream (as integer pointer)")
+        .def("get_stream", &HandleWrapper::getStream, "Get the HIP stream (as integer pointer)")
         .def("__repr__", [](const HandleWrapper& h) {
             return "<hipdnn_frontend.Handle at "
                    + std::to_string(reinterpret_cast<uintptr_t>(h.get())) + ">";
         });
 
-    // Add a convenience function to create handles
+    // Convenience functions to create handles
     m.def(
         "create_handle",
         []() { return std::make_shared<HandleWrapper>(); },
         "Create a new hipdnn handle");
+    m.def(
+        "create_handle",
+        [](uintptr_t stream) { return std::make_shared<HandleWrapper>(stream); },
+        nb::arg("stream"),
+        "Create a new hipdnn handle with a stream");
 }

--- a/projects/hipdnn/samples/batchnorm/BnBackward.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnBackward.cpp
@@ -156,12 +156,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/BnBackward.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnBackward.cpp
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/BnBackward.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnBackward.cpp
@@ -156,7 +156,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/batchnorm/BnInference.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInference.cpp
@@ -122,7 +122,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/batchnorm/BnInference.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInference.cpp
@@ -122,12 +122,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/BnInference.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInference.cpp
@@ -124,7 +124,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/BnInferenceWithVariance.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInferenceWithVariance.cpp
@@ -128,7 +128,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/batchnorm/BnInferenceWithVariance.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInferenceWithVariance.cpp
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/BnInferenceWithVariance.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnInferenceWithVariance.cpp
@@ -128,12 +128,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/BnTraining.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnTraining.cpp
@@ -314,7 +314,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/BnTraining.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnTraining.cpp
@@ -312,12 +312,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/BnTraining.cpp
+++ b/projects/hipdnn/samples/batchnorm/BnTraining.cpp
@@ -312,7 +312,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/batchnorm/FusedBnInfDReluBnBwd.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInfDReluBnBwd.cpp
@@ -212,7 +212,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/batchnorm/FusedBnInfDReluBnBwd.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInfDReluBnBwd.cpp
@@ -214,7 +214,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/FusedBnInfDReluBnBwd.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInfDReluBnBwd.cpp
@@ -212,12 +212,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/FusedBnInferenceActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInferenceActiv.cpp
@@ -151,12 +151,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/FusedBnInferenceActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInferenceActiv.cpp
@@ -153,7 +153,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/FusedBnInferenceActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInferenceActiv.cpp
@@ -151,7 +151,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/batchnorm/FusedBnInferenceVarianceActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInferenceVarianceActiv.cpp
@@ -158,12 +158,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/FusedBnInferenceVarianceActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInferenceVarianceActiv.cpp
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/FusedBnInferenceVarianceActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnInferenceVarianceActiv.cpp
@@ -158,7 +158,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/batchnorm/FusedBnTrainingActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnTrainingActiv.cpp
@@ -293,7 +293,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/batchnorm/FusedBnTrainingActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnTrainingActiv.cpp
@@ -291,7 +291,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/batchnorm/FusedBnTrainingActiv.cpp
+++ b/projects/hipdnn/samples/batchnorm/FusedBnTrainingActiv.cpp
@@ -291,12 +291,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/ConvDgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvDgrad.cpp
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/ConvDgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvDgrad.cpp
@@ -130,12 +130,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/ConvDgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvDgrad.cpp
@@ -130,7 +130,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/convolution/ConvFprop.cpp
+++ b/projects/hipdnn/samples/convolution/ConvFprop.cpp
@@ -125,7 +125,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/convolution/ConvFprop.cpp
+++ b/projects/hipdnn/samples/convolution/ConvFprop.cpp
@@ -125,12 +125,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/ConvFprop.cpp
+++ b/projects/hipdnn/samples/convolution/ConvFprop.cpp
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/ConvWgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvWgrad.cpp
@@ -134,7 +134,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/convolution/ConvWgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvWgrad.cpp
@@ -134,12 +134,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/ConvWgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvWgrad.cpp
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/FusedConvFpropActiv.cpp
+++ b/projects/hipdnn/samples/convolution/FusedConvFpropActiv.cpp
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/FusedConvFpropActiv.cpp
+++ b/projects/hipdnn/samples/convolution/FusedConvFpropActiv.cpp
@@ -147,12 +147,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/FusedConvFpropActiv.cpp
+++ b/projects/hipdnn/samples/convolution/FusedConvFpropActiv.cpp
@@ -147,7 +147,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/convolution/FusedConvFpropBiasActiv.cpp
+++ b/projects/hipdnn/samples/convolution/FusedConvFpropBiasActiv.cpp
@@ -172,7 +172,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/convolution/FusedConvFpropBiasActiv.cpp
+++ b/projects/hipdnn/samples/convolution/FusedConvFpropBiasActiv.cpp
@@ -172,12 +172,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/convolution/FusedConvFpropBiasActiv.cpp
+++ b/projects/hipdnn/samples/convolution/FusedConvFpropBiasActiv.cpp
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/serialization/SerializationRoundTrip.cpp
+++ b/projects/hipdnn/samples/serialization/SerializationRoundTrip.cpp
@@ -165,7 +165,8 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    auto handle = create_hipdnn_handle();
+    auto [handle, handleError] = createHipdnnHandle();
+    HIPDNN_FE_CHECK(handleError);
 
     bool allPassed = run(SampleRunner{*handle, config});
 

--- a/projects/hipdnn/samples/serialization/SerializationRoundTrip.cpp
+++ b/projects/hipdnn/samples/serialization/SerializationRoundTrip.cpp
@@ -167,7 +167,7 @@ int main(int argc, char* argv[])
 
     auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle.get(), config});
+    bool allPassed = run(SampleRunner{*handle, config});
 
     if(allPassed)
     {

--- a/projects/hipdnn/samples/serialization/SerializationRoundTrip.cpp
+++ b/projects/hipdnn/samples/serialization/SerializationRoundTrip.cpp
@@ -165,12 +165,9 @@ int main(int argc, char* argv[])
 
     initializeFrontendLogging();
 
-    hipdnnHandle_t handle = nullptr;
-    HIPDNN_CHECK(hipdnnCreate(&handle));
+    auto handle = create_hipdnn_handle();
 
-    bool allPassed = run(SampleRunner{handle, config});
-
-    HIPDNN_CHECK(hipdnnDestroy(handle));
+    bool allPassed = run(SampleRunner{handle.get(), config});
 
     if(allPassed)
     {


### PR DESCRIPTION
## Motivation

hipDNN exposes handle lifecycle through a C API (`hipdnnCreate`, `hipdnnDestroy`, `hipdnnSetStream`, `hipdnnGetStream`), requiring manual cleanup. The frontend already provides RAII for backend descriptors (`ScopedHipdnnBackendDescriptor`) but has no equivalent for handles. This adds a `unique_ptr`-based RAII handle wrapper to the C++ frontend and exposes stream APIs in the Python frontend.

## Technical Details

**C++ frontend (`Handle.hpp`)**
- `HipdnnHandleDeleter` struct calling `detail::hipdnnBackend()->destroy()`, logging errors without throwing
- `HipdnnHandlePtr` type alias (`std::unique_ptr<hipdnnHandle_t, HipdnnHandleDeleter>`)
- Non-throwing factories: `createHipdnnHandle(hipStream_t)` / `createHipdnnHandle(HipdnnHandlePtr&, hipStream_t)`
- Stream helpers: `setHipdnnHandleStream()` / `getHipdnnHandleStream()`
- Snake_case aliases for all public symbols

**Python bindings (`handle_bindings.cpp`)**
- Refactored `HandleWrapper` to use `HipdnnHandlePtr` internally, removing manual `_ownsHandle` tracking and custom destructor/move operators
- Added extra methods (python convention) and free-form functions.

**Tests (`TestHandle.cpp`)**
- Unit tests using `Mock_hipdnn_backend`: creation success/failure, stream-aware creation, `tryCreate` variants, RAII destruction, move semantics, null handle safety, stream get/set on valid and null handles

## Test Plan

- [x] C++ frontend unit tests pass
- [x] Python bindings build via `pip install -v .`
- [x] Python handle smoke test (create, get/set stream, factory functions, repr)
- [x] Python and C++ samples
- [x] Simple python scripting: `python3 -c "import hipdnn_frontend as fe; h = fe.create_handle(); fe.set_stream(h, 1); fe.get_stream(h); fe.destroy_handle(h); fe.get_stream(h) # gives a readable error"`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
