### PR TITLE
[rocroller] Run fix-format in CI

### DIFF
--- a/shared/rocroller/.jenkins/common.groovy
+++ b/shared/rocroller/.jenkins/common.groovy
@@ -50,6 +50,17 @@ def runCompileCommand(platform, project, jobName, boolean codeCoverage=false, bo
     String yamlBackendFlag = useYamlCpp ? '' : '-DROCROLLER_ENABLE_YAML_CPP=OFF'
     String useCppCheck = staticAnalysis ? '-DROCROLLER_ENABLE_CPPCHECK=ON' : ''
 
+    String formatCheckCommand = staticAnalysis ? """
+                                                # Formatting check
+                                                scripts/fix-format
+                                                if git diff --exit-code; then
+                                                    echo "Files appear properly formatted."
+                                                else
+                                                    echo "Error: formatting of files not in expected state (run scripts/fix-format)."
+                                                    exit 1
+                                                fi
+                                                """ : ''
+
     withSSH(platform) {
         sshBlock ->
         def command = """#!/usr/bin/env bash
@@ -57,6 +68,8 @@ def runCompileCommand(platform, project, jobName, boolean codeCoverage=false, bo
                 cd ${project.paths.project_build_prefix}
 
                 ${sshBlock}
+
+                ${formatCheckCommand}
 
                 mkdir -p build
                 cd build

--- a/shared/rocroller/scripts/run-tests-sharded
+++ b/shared/rocroller/scripts/run-tests-sharded
@@ -13,9 +13,10 @@ import select
 import subprocess
 import sys
 import time
-import yaml
 from dataclasses import dataclass
 from pathlib import Path
+
+import yaml
 
 
 @dataclass


### PR DESCRIPTION
## Motivation

clang-format checks are run against C++ code in CI, but RocRoller also has formatted Python files. This change runs the fix-format script in the CI Static Analysis job and checks the result.

## Technical Details

Updated the build command in common.groovy to run and check scripts/fix-format output.

## Test Plan

CI should pass except when unformatted code is committed.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
