### PR TITLE
[CK] Updated pre-commit entry points

### DIFF
--- a/projects/composablekernel/.pre-commit-config.yaml
+++ b/projects/composablekernel/.pre-commit-config.yaml
@@ -22,19 +22,19 @@ repos:
     hooks:
     -   id: copyright-header-checker
         name: Check copyright headers
-        entry: script/check_copyright_year.sh
+        entry: projects/composablekernel/script/check_copyright_year.sh
         verbose: false
         language: script
         types_or: [c++, python, shell, cmake]
     -   id: remove-exec-bit
         name: Remove executable bit from non-executable files
-        entry: script/remove_exec_bit.sh
+        entry: projects/composablekernel/script/remove_exec_bit.sh
         language: script
         types_or: [c++, text]
         verbose: true
     -   id: remod-ck-tile
         name: Run ck_tile remod.py
-        entry: python script/remod_for_ck_tile.py
+        entry: python projects/composablekernel/script/remod_for_ck_tile.py
         language: python
         files: '^(include|example)/ck_tile/.*$'
         additional_dependencies:


### PR DESCRIPTION
## Motivation

Pre-commit fails after the transition to the monorepo. This fixes it.

## Technical Details

-

## Test Plan

Try to commit on CK with pre-commit enabled.

## Test Result

Pre-commit should pass. (Scripts are correctly found)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
