### PR TITLE
[hip-kernel-provider] Use hipdnn SDK portable types

### DIFF
--- a/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGpuBatchnormForwardInference.cpp
@@ -28,7 +28,7 @@ class BatchnormForwardInference
     : public IntegrationGraphVerificationHarness<DataType, BatchnormTestCase>
 {
 protected:
-    void runGraphTest(DataType tolerance, const TensorLayout& layout = TensorLayout::NCHW) override
+    void runGraphTest(float tolerance, const TensorLayout& layout = TensorLayout::NCHW) override
     {
         const BatchnormTestCase& testCase = this->GetParam();
 
@@ -86,28 +86,28 @@ protected:
 using IntegrationGpuBatchnormForwardInferenceNchwFp32 = BatchnormForwardInference<float, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNchwBfp16
-    = BatchnormForwardInference<hip_bfloat16, float>;
+    = BatchnormForwardInference<bfloat16, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNchwFp16 = BatchnormForwardInference<half, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNhwcFp32 = BatchnormForwardInference<float, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNhwcBfp16
-    = BatchnormForwardInference<hip_bfloat16, float>;
+    = BatchnormForwardInference<bfloat16, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNhwcFp16 = BatchnormForwardInference<half, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNcdhwFp32 = BatchnormForwardInference<float, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNcdhwBfp16
-    = BatchnormForwardInference<hip_bfloat16, float>;
+    = BatchnormForwardInference<bfloat16, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNcdhwFp16 = BatchnormForwardInference<half, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNdhwcFp32 = BatchnormForwardInference<float, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNdhwcBfp16
-    = BatchnormForwardInference<hip_bfloat16, float>;
+    = BatchnormForwardInference<bfloat16, float>;
 
 using IntegrationGpuBatchnormForwardInferenceNdhwcFp16 = BatchnormForwardInference<half, float>;
 
@@ -128,7 +128,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNchwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCHW);
+    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -167,7 +167,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NHWC);
+    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -202,7 +202,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNcdhwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCDHW);
+    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
@@ -229,7 +229,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceNdhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NDHWC);
+    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,

--- a/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGpuBatchnormForwardInferenceAndActivation.cpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGpuBatchnormForwardInferenceAndActivation.cpp
@@ -29,7 +29,7 @@ class BatchnormForwardInferenceAndActivation
     : public IntegrationGraphVerificationHarness<DataType, TestCaseType>
 {
 protected:
-    void runGraphTest(DataType tolerance, const TensorLayout& layout = TensorLayout::NCHW) override
+    void runGraphTest(float tolerance, const TensorLayout& layout = TensorLayout::NCHW) override
     {
         const auto& [testCase, activeCase] = this->GetParam();
 
@@ -122,7 +122,7 @@ using IntegrationGpuBatchnormForwardInferenceAndActivationNchwFp32
 
 using IntegrationGpuBatchnormForwardInferenceAndActivationNchwBfp16
     = BatchnormForwardInferenceAndActivation<
-        hip_bfloat16,
+        bfloat16,
         float,
         std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
 
@@ -140,7 +140,7 @@ using IntegrationGpuBatchnormForwardInferenceAndActivationNhwcFp32
 
 using IntegrationGpuBatchnormForwardInferenceAndActivationNhwcBfp16
     = BatchnormForwardInferenceAndActivation<
-        hip_bfloat16,
+        bfloat16,
         float,
         std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
 
@@ -158,7 +158,7 @@ using IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwFp32
 
 using IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwBfp16
     = BatchnormForwardInferenceAndActivation<
-        hip_bfloat16,
+        bfloat16,
         float,
         std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
 
@@ -176,7 +176,7 @@ using IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcFp32
 
 using IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcBfp16
     = BatchnormForwardInferenceAndActivation<
-        hip_bfloat16,
+        bfloat16,
         float,
         std::tuple<BatchnormTestCase, test_activation_common::ActivTestCase>>;
 
@@ -207,7 +207,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNchwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCHW);
+    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NCHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -258,7 +258,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NHWC);
+    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -303,7 +303,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNcdhwBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NCDHW);
+    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NCDHW);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -336,7 +336,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(IntegrationGpuBatchnormForwardInferenceAndActivationNdhwcBfp16, Correctness)
 {
-    runGraphTest(batchnorm::getToleranceInference<hip_bfloat16>(), TensorLayout::NDHWC);
+    runGraphTest(batchnorm::getToleranceInference<bfloat16>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
+++ b/dnn-providers/hip-kernel-provider/integration_tests/IntegrationGraphVerificationHarness.hpp
@@ -64,7 +64,7 @@ protected:
         }
     }
 
-    virtual void runGraphTest(DataType tolerance,
+    virtual void runGraphTest(float tolerance,
                               const hipdnn_data_sdk::utilities::TensorLayout& layout
                               = hipdnn_data_sdk::utilities::TensorLayout::NCHW)
         = 0;


### PR DESCRIPTION
Reflects the changes from https://github.com/ROCm/rocm-libraries/pull/4504/ but for the hip-kernel-provider.

Tested by building and running the `hip_kernel_plugin_integration_tests`  on MI210