### PR TITLE
[Tensilelite] StoreVectorWidth Fix for Complex Datatypes

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -2400,9 +2400,14 @@ class Solution(collections.abc.Mapping):
         state["StoreVectorWidth"] = state["VectorWidthA"]
       else:
         if state["EnableMatrixInstruction"]:
-          state["StoreVectorWidth"] = state["MIOutputVectorWidth"]
-          if state["VectorWidthA"] * state["MIOutputVectorWidth"] <= 4 / state["ProblemType"]["DestDataType"].numRegisters():
-            state["StoreVectorWidth"] = state["VectorWidthA"] * state["MIOutputVectorWidth"]
+          # Adjusting StoreVectorWidth for larger CGEMM register count
+          if state["ProblemType"]["DestDataType"].isSingleComplex():
+            adjustedVectorWidth = 4 // state["ProblemType"]["DestDataType"].numRegisters()
+          else:
+            adjustedVectorWidth = state["MIOutputVectorWidth"]
+          state["StoreVectorWidth"] = adjustedVectorWidth
+          if state["VectorWidthA"] * adjustedVectorWidth <= 4 / state["ProblemType"]["DestDataType"].numRegisters():
+            state["StoreVectorWidth"] = state["VectorWidthA"] * adjustedVectorWidth
           if state["LocalSplitU"] > 1:
             state["StoreVectorWidth"] = state["VectorWidthA"]
         else:

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -2402,12 +2402,11 @@ class Solution(collections.abc.Mapping):
         if state["EnableMatrixInstruction"]:
           # Adjusting StoreVectorWidth for larger CGEMM register count
           if state["ProblemType"]["DestDataType"].isSingleComplex():
-            adjustedVectorWidth = 4 // state["ProblemType"]["DestDataType"].numRegisters()
+            state["StoreVectorWidth"] = 4 // state["ProblemType"]["DestDataType"].numRegisters()
           else:
-            adjustedVectorWidth = state["MIOutputVectorWidth"]
-          state["StoreVectorWidth"] = adjustedVectorWidth
-          if state["VectorWidthA"] * adjustedVectorWidth <= 4 / state["ProblemType"]["DestDataType"].numRegisters():
-            state["StoreVectorWidth"] = state["VectorWidthA"] * adjustedVectorWidth
+            state["StoreVectorWidth"] = state["MIOutputVectorWidth"]
+            if state["VectorWidthA"] * state["MIOutputVectorWidth"] <= 4 / state["ProblemType"]["DestDataType"].numRegisters():
+              state["StoreVectorWidth"] = state["VectorWidthA"] * state["MIOutputVectorWidth"]
           if state["LocalSplitU"] > 1:
             state["StoreVectorWidth"] = state["VectorWidthA"]
         else:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/cgemm.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/cgemm.yaml
@@ -61,6 +61,7 @@ BenchmarkProblems:
           # - [16, 16, 4, 1, 1, 2, 2, 2, 2]
         - ScheduleIterAlg: [1, 3] #,3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         # - StreamK: [3]
@@ -117,6 +118,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -159,6 +161,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -201,6 +204,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -243,6 +247,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -285,6 +290,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -327,6 +333,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -369,6 +376,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -411,6 +419,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/zgemm.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/zgemm.yaml
@@ -63,6 +63,7 @@ BenchmarkProblems:
           # - [16, 16, 4, 1, 1, 2, 2, 2, 2]
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         # - StreamK: [3]
@@ -125,6 +126,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -167,6 +169,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -209,6 +212,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -251,6 +255,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -293,6 +298,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -335,6 +341,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -377,6 +384,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]
@@ -419,6 +427,7 @@ BenchmarkProblems:
           - [16, 16, 4, 1, 1, 1, 1, 2, 2] #32x32
         - ScheduleIterAlg: [1, 3]
         - MIArchVgpr: [0, 1]
+        - 1LDSBuffer: [0, 1]
         - GlobalSplitU: [1, 2, 4, 8]
         - GlobalSplitUAlgorithm: [MultipleBuffer]
         - PrefetchLocalRead: [0, 1]


### PR DESCRIPTION
## Motivation

Tensilelite throws Register Pool Occupancy error for certain Complex Datatype configurations. Fixed register pool occupancy bug when 1LDSB parameter was enabled in conjunction with MIArchVgpr for certain complex type kernel configurations,

## Technical Details

Certain kernel configurations require more register allocation, specifically for CGEMM/ZGEMM, where 2 or 4 registers are required to store the result. Register Pool Occupancy error was thrown because StoreVectorWidth was computed incorrectly for CGEMM.

## Test Plan

Implementation tested on gfx942 & gfx950 for all CGEMM/ZGEMM transpose and complex conjugate combinations, in conjunction with MultiBuffer postGSU, PGR and PLR, as well as MIArchVgpr and 1LDSB on or off.

## Test Result

Results are functionally correct.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
