### PR TITLE
Fix SIOF bug in gfx11 matrix instruction map initialization

### DIFF
--- a/shared/origami/include/origami/hardware.hpp
+++ b/shared/origami/include/origami/hardware.hpp
@@ -39,27 +39,6 @@
 
 namespace origami {
 
-namespace details {
-/**
- * @brief Map of matrix instruction latencies for gfx11 architectures.
- *
- * Inline to prevent ODR violations when included in multiple shared libraries.
- * This ensures only one definition exists across all translation units. (PR#1862)
- */
-static inline const std::unordered_map<matrix_instruction, size_t> gfx11_matrix_instructions_map = {
-    // clang-format off
-          // F16
-          {matrix_instruction(16, 16, 16, data_type_t::Half), 32},  // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
-          // BF16
-          {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32},  // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
-          // I8
-          {matrix_instruction(16, 16, 16, data_type_t::Int8), 32},  // v_wmma_i32_16x16x16_iu8
-          // I4
-          {matrix_instruction(16, 16, 16, data_type_t::Int4), 16},  // v_wmma_i32_16x16x16_iu4
-                                                          // clang-format on
-};
-}  // namespace details
-
 /**
  * @brief Represents hardware characteristics and capabilities of GPU architectures.
  *
@@ -412,11 +391,61 @@ class hardware_t {
              {matrix_instruction(16, 16, 16, data_type_t::Int4), 8}, // v_wmma_i32_16x16x16_iu4
              {matrix_instruction(16, 16, 32, data_type_t::Int4), 8}, // v_wmma_i32_16x16x32_iu4
          }},
-        {architecture_t::gfx1100, details::gfx11_matrix_instructions_map},
-        {architecture_t::gfx1150, details::gfx11_matrix_instructions_map},
-        {architecture_t::gfx1151, details::gfx11_matrix_instructions_map},
-        {architecture_t::gfx1152, details::gfx11_matrix_instructions_map},
-        {architecture_t::gfx1153, details::gfx11_matrix_instructions_map},
+        {architecture_t::gfx1100,
+         {
+             // F16
+             {matrix_instruction(16, 16, 16, data_type_t::Half), 32},  // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
+             // BF16
+             {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32},  // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
+             // I8
+             {matrix_instruction(16, 16, 16, data_type_t::Int8), 32},  // v_wmma_i32_16x16x16_iu8
+             // I4
+             {matrix_instruction(16, 16, 16, data_type_t::Int4), 16},  // v_wmma_i32_16x16x16_iu4
+         }},
+        {architecture_t::gfx1150,
+         {
+             // F16
+             {matrix_instruction(16, 16, 16, data_type_t::Half), 32},  // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
+             // BF16
+             {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32},  // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
+             // I8
+             {matrix_instruction(16, 16, 16, data_type_t::Int8), 32},  // v_wmma_i32_16x16x16_iu8
+             // I4
+             {matrix_instruction(16, 16, 16, data_type_t::Int4), 16},  // v_wmma_i32_16x16x16_iu4
+         }},
+        {architecture_t::gfx1151,
+         {
+             // F16
+             {matrix_instruction(16, 16, 16, data_type_t::Half), 32},  // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
+             // BF16
+             {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32},  // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
+             // I8
+             {matrix_instruction(16, 16, 16, data_type_t::Int8), 32},  // v_wmma_i32_16x16x16_iu8
+             // I4
+             {matrix_instruction(16, 16, 16, data_type_t::Int4), 16},  // v_wmma_i32_16x16x16_iu4
+         }},
+        {architecture_t::gfx1152,
+         {
+             // F16
+             {matrix_instruction(16, 16, 16, data_type_t::Half), 32},  // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
+             // BF16
+             {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32},  // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
+             // I8
+             {matrix_instruction(16, 16, 16, data_type_t::Int8), 32},  // v_wmma_i32_16x16x16_iu8
+             // I4
+             {matrix_instruction(16, 16, 16, data_type_t::Int4), 16},  // v_wmma_i32_16x16x16_iu4
+         }},
+        {architecture_t::gfx1153,
+         {
+             // F16
+             {matrix_instruction(16, 16, 16, data_type_t::Half), 32},  // v_wmma_f32_16x16x16_f16/v_wmma_f16_16x16x16_f16
+             // BF16
+             {matrix_instruction(16, 16, 16, data_type_t::BFloat16), 32},  // v_wmma_f32_16x16x16_bf16/v_wmma_bf16_16x16x16_bf16
+             // I8
+             {matrix_instruction(16, 16, 16, data_type_t::Int8), 32},  // v_wmma_i32_16x16x16_iu8
+             // I4
+             {matrix_instruction(16, 16, 16, data_type_t::Int4), 16},  // v_wmma_i32_16x16x16_iu4
+         }},
       };
   // clang-format on
 


### PR DESCRIPTION
## Motivation

This is a Static Initialization Order Fiasco(SIOF) bug.

The gfx11 architectures (gfx1100, gfx1150, gfx1151, gfx1152, gfx1153) were referencing a static map defined in the details namespace from within INSTRUCTION_MAP. Due to C++ static initialization order being undefined across translation units, this caused the gfx11 map to be copied before it was initialized, resulting in empty instruction maps for these architectures.

Fix by inlining the matrix instruction definitions directly into INSTRUCTION_MAP, matching the pattern used for other architectures like gfx1201.

This fixes get_valid_matrix_instructions() returning empty results for gfx1100 and other gfx11 architectures.

## Test Plan

Tested locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
