### PR TITLE
[hipBLASLt] Add block size into predicate for correct solution selection

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Contractions.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Contractions.py
@@ -402,6 +402,8 @@ class ProblemType:
             predicates.append(ProblemPredicate("SupportDeviceUserArguments", value=self.supportDeviceUserArguments))
             predicates.append(ProblemPredicate("SwizzleTensorA", value=self.swizzleTensorA))
             predicates.append(ProblemPredicate("SwizzleTensorB", value=self.swizzleTensorB))
+            predicates.append(ProblemPredicate("MXBlockA", value=self.mxBlockA))
+            predicates.append(ProblemPredicate("MXBlockB", value=self.mxBlockB))
 
         return predicates
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -2715,6 +2715,78 @@ namespace TensileLite
                 }
             };
 
+	    struct MXBlockACheck : public Predicate_CRTP<MXBlockACheck, ContractionProblemGemm>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = true
+                };
+                int value;
+
+                MXBlockACheck() = default;
+                MXBlockACheck(int value)
+                    : value(value)
+                {
+                }
+
+                static std::string Type()
+                {
+                    return "MXBlockA";
+                }
+
+                virtual bool operator()(ContractionProblemGemm const& problem) const override
+                {
+                    return (problem.mxBlockA() == value);
+                }
+
+                virtual bool debugEval(ContractionProblemGemm const& problem,
+                                       std::ostream&                 stream) const override
+                {
+                    bool rv = (*this)(problem);
+
+                    stream << *this << ": prob: " << problem.mxBlockA()
+                           << ", Is sol support: " << value << std::endl;
+                    return rv;
+                }
+            };
+
+	    struct MXBlockBCheck : public Predicate_CRTP<MXBlockBCheck, ContractionProblemGemm>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = true
+                };
+                int value;
+
+                MXBlockBCheck() = default;
+                MXBlockBCheck(int value)
+                    : value(value)
+                {
+                }
+
+                static std::string Type()
+                {
+                    return "MXBlockB";
+                }
+
+                virtual bool operator()(ContractionProblemGemm const& problem) const override
+                {
+                    return (problem.mxBlockB() == value);
+                }
+
+                virtual bool debugEval(ContractionProblemGemm const& problem,
+                                       std::ostream&                 stream) const override
+                {
+                    bool rv = (*this)(problem);
+
+                    stream << *this << ": prob: " << problem.mxBlockB()
+                           << ", Is sol support: " << value << std::endl;
+                    return rv;
+                }
+            };
+
             struct F32XdlMathOpEqual
                 : public Predicate_CRTP<F32XdlMathOpEqual, ContractionProblemGemm>
             {

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/ContractionPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/ContractionPredicates.hpp
@@ -126,7 +126,9 @@ namespace TensileLite
                      Base::template Pair<Predicates::Contraction::SupportDeviceUserArguments>(),
                      Base::template Pair<Predicates::Contraction::WorkgroupMappingXCCCheck>(),
                      Base::template Pair<Predicates::Contraction::SwizzleTensorA>(),
-                     Base::template Pair<Predicates::Contraction::SwizzleTensorB>()});
+                     Base::template Pair<Predicates::Contraction::SwizzleTensorB>(),
+                     Base::template Pair<Predicates::Contraction::MXBlockACheck>(),
+                     Base::template Pair<Predicates::Contraction::MXBlockBCheck>()});
 
                 auto gmap = Generic::GetSubclasses();
                 rv.insert(gmap.begin(), gmap.end());
@@ -550,6 +552,18 @@ namespace TensileLite
         template <typename IO>
         struct MappingTraits<Predicates::Contraction::SwizzleTensorB, IO>
             : public AutoMappingTraits<Predicates::Contraction::SwizzleTensorB, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::MXBlockACheck, IO>
+            : public AutoMappingTraits<Predicates::Contraction::MXBlockACheck, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::MXBlockBCheck, IO>
+            : public AutoMappingTraits<Predicates::Contraction::MXBlockBCheck, IO>
         {
         };
 


### PR DESCRIPTION
## Motivation

This PR updates the predicate to check the block size of mx data types. If block size is not considered, wrong solution might be selected.

## Technical Details

- Add MX block size A and B into predicate and serialization

## Test Plan

Manually tried:

`./clients/hipblaslt-bench --iters 0 --cold_iters 0 --transA T --transB N --a_type f8_r --b_type f8_r --c_type f32_r --d_type f32_r -m 256 -n 256 --alpha 2.1 --beta 0.7 --scaleA 3 --scaleB 3 --scale_type f32_r  --verify`

And no solution found (currently there is no solution for mx f8).

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
