### PR TITLE
[hipblaslt][CMS] Add support for disabling validator on a per-pass basis.

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -26,12 +26,25 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from collections import defaultdict
 from copy import deepcopy
-from enum import Enum
+from enum import Enum, auto
 from math import floor
 from typing import Optional, Union
 
 from rocisa.instruction import SWaitCnt, SBarrier
 from Tensile.Common.Utilities import printWarning
+
+
+class ValidatorPass(Enum):
+    # Structural checks
+    VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS = auto()
+    VERIFY_ASCENDING_ORDER = auto()
+    VERIFY_SCC_OVERLAP = auto()
+    VERIFY_GR_INC_ORDER = auto()
+    # Timeline passes
+    ADD_LOCAL_READ_CONSTRAINTS = auto()
+    ADD_PACK_CONSTRAINTS = auto()
+    ADD_GR_NOT_TOO_EARLY_CONSTRAINTS = auto()
+    ADD_GR_FINISH_BEFORE_LR_CONSTRAINTS = auto()
 
 
 def invert_mfma_reorder(mfma_reorder: list[int]) -> dict[int, int]:
@@ -2015,12 +2028,12 @@ def add_gr_finish_before_lr_constraints(timeline: Timeline, ctx: ValidatorPassCo
     apply_barriers(timeline)
 
 
-TIMELINE_PASSES: list[Callable[['Timeline', 'ValidatorPassContext'], None]] = [
-    add_local_read_constraints,
-    add_pack_constraints,
-    add_gr_not_too_early_constraints,
-    add_gr_finish_before_lr_constraints,
-]
+TIMELINE_PASSES: dict[ValidatorPass, Callable[['Timeline', 'ValidatorPassContext'], None]] = {
+    ValidatorPass.ADD_LOCAL_READ_CONSTRAINTS: add_local_read_constraints,
+    ValidatorPass.ADD_PACK_CONSTRAINTS: add_pack_constraints,
+    ValidatorPass.ADD_GR_NOT_TOO_EARLY_CONSTRAINTS: add_gr_not_too_early_constraints,
+    ValidatorPass.ADD_GR_FINISH_BEFORE_LR_CONSTRAINTS: add_gr_finish_before_lr_constraints,
+}
 
 
 def index_for_force_unroll_sub_iter(original_idx: int, M: int, N: int) -> int:
@@ -2126,6 +2139,14 @@ def verify_ascending_order(scheduleInfo, context: dict, code_path: int) -> tuple
     return True, ""
 
 
+STRUCTURAL_CHECKS: dict[ValidatorPass, Callable] = {
+    ValidatorPass.VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS: verify_correct_number_of_instructions,
+    ValidatorPass.VERIFY_ASCENDING_ORDER: verify_ascending_order,
+    ValidatorPass.VERIFY_SCC_OVERLAP: verify_scc_overlap,
+    ValidatorPass.VERIFY_GR_INC_ORDER: verify_gr_inc_order,
+}
+
+
 def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
     """
     Return True if all the validation rules pass, False otherwise.
@@ -2137,33 +2158,33 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
     Note 2: if False is returned, this is not proof that the schedule
     is invalid. It may be a false positive.
     """
-    # Case where there was an explicit request to skip validation.
-    if scheduleInfo.isValidationDisabled():
-        mt0 = context.get("kernel", {}).get("MacroTile0", "?")
-        mt1 = context.get("kernel", {}).get("MacroTile1", "?")
-        du = context.get("kernel", {}).get("DepthU", "?")
-        transA = context.get("kernel", {}).get("TransA")
-        transB = context.get("kernel", {}).get("TransB")
-        transA = "T" if transA else "N"
-        transB = "T" if transB else "N"
-        message = f"CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = {mt0}x{mt1}x{du} {transA}{transB}"
-        printWarning(f"{message}")
-
-        # All rules bypassed, considered valid.
-        return True, message
-
     kernel = context["kernel"]
 
-    structural_checks = [
-        verify_correct_number_of_instructions,
-        verify_ascending_order,
-        verify_scc_overlap,
-        verify_gr_inc_order,
-    ]
+    # Log disabled passes once, before iterating over code paths.
+    mt0 = kernel.get("MacroTile0", "?")
+    mt1 = kernel.get("MacroTile1", "?")
+    du = kernel.get("DepthU", "?")
+    transA = "T" if kernel.get("TransA") else "N"
+    transB = "T" if kernel.get("TransB") else "N"
+    kernel_desc = f"MT0xMT1xDepthU = {mt0}x{mt1}x{du} {transA}{transB}"
+
+    disabled_structural = {}
+    for pass_id in STRUCTURAL_CHECKS:
+        if reason := scheduleInfo.reasonForDisablingPass(pass_id):
+            disabled_structural[pass_id] = reason
+            printWarning(f"Skipping {pass_id.name} on {kernel_desc}: {reason}")
+
+    disabled_timeline = {}
+    for pass_id in TIMELINE_PASSES:
+        if reason := scheduleInfo.reasonForDisablingPass(pass_id):
+            disabled_timeline[pass_id] = reason
+            printWarning(f"Skipping {pass_id.name} on {kernel_desc}: {reason}")
 
     for code_path in range(scheduleInfo.numCodePaths):
         # === Structural checks (no Timeline needed) ===
-        for check in structural_checks:
+        for pass_id, check in STRUCTURAL_CHECKS.items():
+            if pass_id in disabled_structural:
+                continue
             status, message = check(scheduleInfo, context, code_path)
             if not status:
                 return False, f"Code path {code_path}: {message}"
@@ -2177,7 +2198,9 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
 
         timeline = create_unified_timeline(scheduleInfo, kernel, code_path)
 
-        for add_constraints in TIMELINE_PASSES:
+        for pass_id, add_constraints in TIMELINE_PASSES.items():
+            if pass_id in disabled_timeline:
+                continue
             add_constraints(timeline, ctx)
             if error := validate_timeline(timeline):
                 return False, f"Code path {code_path}: {error}"

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -2147,6 +2147,16 @@ STRUCTURAL_CHECKS: dict[ValidatorPass, Callable] = {
 }
 
 
+def format_kernel_string(kernel: 'Solution') -> str:
+    """Format a human-readable description of the kernel's tile dimensions and transpose modes."""
+    mt0 = kernel.get("MacroTile0", "?")
+    mt1 = kernel.get("MacroTile1", "?")
+    du = kernel.get("DepthU", "?")
+    transA = "T" if kernel.get("TransA") else "N"
+    transB = "T" if kernel.get("TransB") else "N"
+    return f"MT0xMT1xDepthU = {mt0}x{mt1}x{du} {transA}{transB}"
+
+
 def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
     """
     Return True if all the validation rules pass, False otherwise.
@@ -2161,12 +2171,7 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
     kernel = context["kernel"]
 
     # Log disabled passes once, before iterating over code paths.
-    mt0 = kernel.get("MacroTile0", "?")
-    mt1 = kernel.get("MacroTile1", "?")
-    du = kernel.get("DepthU", "?")
-    transA = "T" if kernel.get("TransA") else "N"
-    transB = "T" if kernel.get("TransB") else "N"
-    kernel_desc = f"MT0xMT1xDepthU = {mt0}x{mt1}x{du} {transA}{transB}"
+    kernel_desc = format_kernel_string(kernel)
 
     disabled_structural = {}
     for pass_id in STRUCTURAL_CHECKS:

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -2173,15 +2173,23 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
     # Log disabled passes once, before iterating over code paths.
     kernel_desc = format_kernel_string(kernel)
 
+    # Check if ALL passes are disabled — single warning + early return
+    all_disabled_reasons = {p: scheduleInfo.reasonForDisablingValidationPass(p) for p in ValidatorPass}
+    if all(all_disabled_reasons.values()):
+        reasons = set(all_disabled_reasons.values())
+        reason_str = "; ".join(reasons)
+        printWarning(f"All validation passes disabled on {kernel_desc}: {reason_str}")
+        return True, ""
+
     disabled_structural = {}
     for pass_id in STRUCTURAL_CHECKS:
-        if reason := scheduleInfo.reasonForDisablingPass(pass_id):
+        if reason := scheduleInfo.reasonForDisablingValidationPass(pass_id):
             disabled_structural[pass_id] = reason
             printWarning(f"Skipping {pass_id.name} on {kernel_desc}: {reason}")
 
     disabled_timeline = {}
     for pass_id in TIMELINE_PASSES:
-        if reason := scheduleInfo.reasonForDisablingPass(pass_id):
+        if reason := scheduleInfo.reasonForDisablingValidationPass(pass_id):
             disabled_timeline[pass_id] = reason
             printWarning(f"Skipping {pass_id.name} on {kernel_desc}: {reason}")
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -236,16 +236,29 @@ class ScheduleInfo:
         self.nllZeroDscnt = nllZeroDscnt
         self.mfmaReorder = mfmaReorder
         self.snopCode = snopCode
-        self._skipValidation = False
+        self._disabledPasses: dict[cmsv.ValidatorPass, str] = {}
 
-        # Empty list - validate all keys; list of keys - skip order validation for these keys 
-        self._skipOrderValidation : None | list[str] = []
+    def disablePass(self, pass_id: cmsv.ValidatorPass, reason: str) -> None:
+        """Disable a specific validator pass for this schedule.
 
-    def disableValidation(self):
-        self._skipValidation = True
+        Args:
+            pass_id: The ValidatorPass enum member to disable.
+            reason:  Mandatory explanation of why this pass is being disabled.
+        """
+        if not isinstance(pass_id, cmsv.ValidatorPass):
+            raise TypeError(f"pass_id must be a ValidatorPass enum member, got {type(pass_id).__name__}")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("Reason for disabling pass must be a non-empty string")
+        self._disabledPasses[pass_id] = reason
 
-    def isValidationDisabled(self):
-        return self._skipValidation
+    def reasonForDisablingPass(self, pass_id: cmsv.ValidatorPass) -> Optional[str]:
+        """Return the reason this pass was disabled, or None if it is enabled.
+
+        Raises TypeError if pass_id is not a ValidatorPass enum member.
+        """
+        if not isinstance(pass_id, cmsv.ValidatorPass):
+            raise TypeError(f"pass_id must be a ValidatorPass enum member, got {type(pass_id).__name__}")
+        return self._disabledPasses.get(pass_id)
 
     def pretty_print(self):
         klen = max(len(k) for k in self.optSchedule.keys())

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -238,7 +238,7 @@ class ScheduleInfo:
         self.snopCode = snopCode
         self._disabledPasses: dict[cmsv.ValidatorPass, str] = {}
 
-    def disablePass(self, pass_id: cmsv.ValidatorPass, reason: str) -> None:
+    def disableValidationPass(self, pass_id: cmsv.ValidatorPass, reason: str) -> None:
         """Disable a specific validator pass for this schedule.
 
         Args:
@@ -251,7 +251,12 @@ class ScheduleInfo:
             raise ValueError("Reason for disabling pass must be a non-empty string")
         self._disabledPasses[pass_id] = reason
 
-    def reasonForDisablingPass(self, pass_id: cmsv.ValidatorPass) -> Optional[str]:
+    def disableValidation(self, reason: str) -> None:
+        """Disable all validator passes for this schedule."""
+        for pass_id in cmsv.ValidatorPass:
+            self.disableValidationPass(pass_id, reason)
+
+    def reasonForDisablingValidationPass(self, pass_id: cmsv.ValidatorPass) -> Optional[str]:
         """Return the reason this pass was disabled, or None if it is enabled.
 
         Raises TypeError if pass_id is not a ValidatorPass enum member.
@@ -4153,7 +4158,7 @@ def _get_schedule_256x256x32_TF32(kernel, useLDSTr, TLDS):
     kernel["MfmaInitCVgprs"] = True
     opt1 = ScheduleInfo(2, numMfma, optSchedule, syncCode, nglshift, nllshift)
     if disable_validation:
-        opt1.disableValidation()
+        opt1.disableValidation("4x4MFMA with wider loads is not yet supported by validator")
     return True, opt1
 
 @RegisterSchedule(
@@ -4472,7 +4477,7 @@ def _get_schedule_128x128x32_TF32_plr1(kernel, useLDSTr, TLDS):
     kernel["UseMFMAF32XEmulation"] = True
     opt1 = ScheduleInfo(num_code_paths, n_mfma, optSchedule, syncCode, nglshift, nllshift)
     if disable_validation:
-        opt1.disableValidation()
+        opt1.disableValidation("swap instructions included in pack are not supported yet")
     return True, opt1
 
 @RegisterSchedule(
@@ -4614,7 +4619,7 @@ def _get_schedule_128x128x64_TF32(kernel, useLDSTr, TLDS):
     kernel["UsePLRPack"] = True
     opt1 = ScheduleInfo(2, n_mfma, optSchedule, syncCode, nglshift, nllshift)
     if disable_validation:
-        opt1.disableValidation()
+        opt1.disableValidation("NN transpose with wider loads is not yet supported by validator")
     return True, opt1
 
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -1118,55 +1118,72 @@ class TestCustomScheduleValidation:
         si = ScheduleInfo(1, 0, invalid_schedule, None, None, None, None)
         for p in ValidatorPass:
             if p != ValidatorPass.VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS:
-                si.disablePass(p, reason="Not relevant to this test")
+                si.disableValidationPass(p, reason="Not relevant to this test")
         status, message = isValid(si, {"kernel": kernel})
         # The ascending-order error is gone; the schedule passes the remaining enabled check.
         assert "Non-descending-order" not in message
         assert status == True
 
-    def test_disable_pass_reason_required(self):
-        """disablePass requires a non-empty reason string and a valid ValidatorPass enum member."""
+    def test_disable_validation_pass_reason_required(self):
+        """disableValidationPass requires a non-empty reason string and a valid ValidatorPass enum member."""
         si = ScheduleInfo(1, None, {}, None, None, None, None)
 
         with pytest.raises(ValueError):
-            si.disablePass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="")
+            si.disableValidationPass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="")
 
         with pytest.raises(ValueError):
-            si.disablePass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="   ")
+            si.disableValidationPass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="   ")
 
         with pytest.raises(TypeError):
-            si.disablePass("not_an_enum", reason="some reason")
+            si.disableValidationPass("not_an_enum", reason="some reason")
 
         with pytest.raises(TypeError):
-            si.disablePass(42, reason="some reason")
+            si.disableValidationPass(42, reason="some reason")
 
-    def test_disable_multiple_passes(self):
-        """Multiple passes can be disabled independently."""
+    def test_disable_multiple_validation_passes(self):
+        """Multiple validation passes can be disabled independently."""
         invalid_schedule = {"P": [[3, 2, 1]]}
         si = ScheduleInfo(1, None, invalid_schedule, None, None, None, None)
-        si.disablePass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="Reason A")
-        si.disablePass(ValidatorPass.VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS, reason="Reason B")
+        si.disableValidationPass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="Reason A")
+        si.disableValidationPass(ValidatorPass.VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS, reason="Reason B")
 
-        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_ASCENDING_ORDER) == "Reason A"
-        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS) == "Reason B"
+        assert si.reasonForDisablingValidationPass(ValidatorPass.VERIFY_ASCENDING_ORDER) == "Reason A"
+        assert si.reasonForDisablingValidationPass(ValidatorPass.VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS) == "Reason B"
         # Passes not disabled return None.
-        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_SCC_OVERLAP) is None
+        assert si.reasonForDisablingValidationPass(ValidatorPass.VERIFY_SCC_OVERLAP) is None
 
-    def test_reason_for_disabling_pass(self):
-        """reasonForDisablingPass returns the reason for disabled passes, None for enabled ones,
+    def test_reason_for_disabling_validation_pass(self):
+        """reasonForDisablingValidationPass returns the reason for disabled passes, None for enabled ones,
         and raises TypeError for non-enum arguments."""
         si = ScheduleInfo(1, None, {}, None, None, None, None)
 
         # Nothing disabled yet.
-        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_ASCENDING_ORDER) is None
+        assert si.reasonForDisablingValidationPass(ValidatorPass.VERIFY_ASCENDING_ORDER) is None
 
-        si.disablePass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="test reason")
-        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_ASCENDING_ORDER) == "test reason"
+        si.disableValidationPass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="test reason")
+        assert si.reasonForDisablingValidationPass(ValidatorPass.VERIFY_ASCENDING_ORDER) == "test reason"
 
         # Non-enum argument raises TypeError.
         with pytest.raises(TypeError):
-            si.reasonForDisablingPass("not_an_enum")
+            si.reasonForDisablingValidationPass("not_an_enum")
 
         with pytest.raises(TypeError):
-            si.reasonForDisablingPass(42)
+            si.reasonForDisablingValidationPass(42)
+
+    def test_disable_validation_all_passes(self):
+        """disableValidation disables all passes with the given reason."""
+        si = ScheduleInfo(1, None, {}, None, None, None, None)
+        si.disableValidation("entire schedule unsupported")
+
+        for p in ValidatorPass:
+            assert si.reasonForDisablingValidationPass(p) == "entire schedule unsupported"
+
+    def test_disable_validation_isvalid_early_return(self):
+        """isValid returns (True, '') with a single warning when all passes are disabled."""
+        kernel = create_base_kernel()
+        si = ScheduleInfo(1, 0, {}, None, None, None, None)
+        si.disableValidation("not supported yet")
+        status, message = isValid(si, {"kernel": kernel})
+        assert status == True
+        assert message == ""
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -24,7 +24,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from Tensile.Components.CustomSchedule import hasCustomSchedule, ScheduleInfo
-from Tensile.Components.CMSValidator import isValid
+from Tensile.Components.CMSValidator import isValid, ValidatorPass
 from Tensile.Common import IsaVersion
 
 # Helper to create a mock data type
@@ -1101,26 +1101,72 @@ class TestCustomScheduleTF32:
         assert valid, message
 
 class TestCustomScheduleValidation:
-    def test_schedule_validation_disable(self):
-        """
-        Test of the flag that custom mainloop schedule (CMS) developers can use to override the
-        validation checks.
-        """
+    def test_disable_single_pass(self):
+        """Disabling a single pass allows an otherwise-invalid schedule to pass that check."""
         kernel = create_base_kernel()
         invalid_schedule = {"P": [[3, 2, 1]]}
 
-        # No verification message means that the schedule info is considered valid.
-        scheduleInfo = ScheduleInfo(
-            1, None, invalid_schedule, None, None, None, None
-        )
-        scheduleInfo.disableValidation()
-        status, message = isValid(scheduleInfo, {"kernel" : {"DepthU": 42}})
-        assert status == True
-        assert message == "CMS validation explicitly disabled. Running on kernel with MT0xMT1xDepthU = ?x?x42 NN"
-
-        # A non-empty verification message means that the schedule info is considered invalid.
-        status, message = isValid(
-            ScheduleInfo(1, None, invalid_schedule, None, None, None, None), {"kernel" : {"DepthU": 42}}
-        )
+        # Without disabling, the non-ascending schedule fails on ascending order.
+        si = ScheduleInfo(1, None, invalid_schedule, None, None, None, None)
+        status, message = isValid(si, {"kernel": kernel})
         assert status == False
+        assert "Non-descending-order" in message
+
+        # Disabling VERIFY_ASCENDING_ORDER skips that check.
+        # Remaining structural and timeline passes are also disabled because this
+        # minimal schedule lacks the keys/data they require.
+        si = ScheduleInfo(1, 0, invalid_schedule, None, None, None, None)
+        for p in ValidatorPass:
+            if p != ValidatorPass.VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS:
+                si.disablePass(p, reason="Not relevant to this test")
+        status, message = isValid(si, {"kernel": kernel})
+        # The ascending-order error is gone; the schedule passes the remaining enabled check.
+        assert "Non-descending-order" not in message
+        assert status == True
+
+    def test_disable_pass_reason_required(self):
+        """disablePass requires a non-empty reason string and a valid ValidatorPass enum member."""
+        si = ScheduleInfo(1, None, {}, None, None, None, None)
+
+        with pytest.raises(ValueError):
+            si.disablePass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="")
+
+        with pytest.raises(ValueError):
+            si.disablePass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="   ")
+
+        with pytest.raises(TypeError):
+            si.disablePass("not_an_enum", reason="some reason")
+
+        with pytest.raises(TypeError):
+            si.disablePass(42, reason="some reason")
+
+    def test_disable_multiple_passes(self):
+        """Multiple passes can be disabled independently."""
+        invalid_schedule = {"P": [[3, 2, 1]]}
+        si = ScheduleInfo(1, None, invalid_schedule, None, None, None, None)
+        si.disablePass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="Reason A")
+        si.disablePass(ValidatorPass.VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS, reason="Reason B")
+
+        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_ASCENDING_ORDER) == "Reason A"
+        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_CORRECT_NUMBER_OF_INSTRUCTIONS) == "Reason B"
+        # Passes not disabled return None.
+        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_SCC_OVERLAP) is None
+
+    def test_reason_for_disabling_pass(self):
+        """reasonForDisablingPass returns the reason for disabled passes, None for enabled ones,
+        and raises TypeError for non-enum arguments."""
+        si = ScheduleInfo(1, None, {}, None, None, None, None)
+
+        # Nothing disabled yet.
+        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_ASCENDING_ORDER) is None
+
+        si.disablePass(ValidatorPass.VERIFY_ASCENDING_ORDER, reason="test reason")
+        assert si.reasonForDisablingPass(ValidatorPass.VERIFY_ASCENDING_ORDER) == "test reason"
+
+        # Non-enum argument raises TypeError.
+        with pytest.raises(TypeError):
+            si.reasonForDisablingPass("not_an_enum")
+
+        with pytest.raises(TypeError):
+            si.reasonForDisablingPass(42)
 


### PR DESCRIPTION
## Motivation

The CMS validator previously only supported an all-or-nothing `disableValidation()` toggle. When rolling out new CMS techniques that only conflict with a subset of passes, disabling everything throws away useful safety checks. This PR adds per-pass granularity so schedule authors can disable only the passes that don't support a new pattern while keeping the rest enforced.

## Technical Details
- Introduced a `ValidatorPass` enum enumerating all structural checks and timeline passes.
- Replaced the flat `structural_checks` list and `TIMELINE_PASSES` list with `dict[ValidatorPass, Callable]` maps so passes are keyed by enum.
- Replaced `disableValidation()` / `isValidationDisabled()` on `ScheduleInfo` with `disablePass(pass_id, reason)` / `reasonForDisablingPass(pass_id)`. A
non-empty reason string is mandatory; passing a non-enum value raises `TypeError`.
- `isValid()` now skips only the explicitly disabled passes and emits a warning per skip (including kernel dimensions for traceability).
- Updated and expanded unit tests to cover single-pass disable, multi-pass disable, reason retrieval, and input validation.

Depends on #4622.

## Test Plan
- Ran existing unit tests (`test_CustomSchedule.py`).
- New tests verify:
  - Disabling a single pass skips that check while others remain active.
  - `disablePass` rejects empty reasons and non-enum arguments.
  - Multiple passes can be independently disabled and queried.
  - `reasonForDisablingPass` returns `None` for enabled passes and raises on bad input.

## Test Result

All unit tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.