### PR TITLE
Add gesdd to the documentation

### DIFF
--- a/projects/rocsolver/docs/reference/intro.rst
+++ b/projects/rocsolver/docs/reference/intro.rst
@@ -182,6 +182,7 @@ LAPACK main functions
 
     :ref:`rocsolver_gesvd <gesvd>`, x, x, x, x
     :ref:`rocsolver_gesvdx <gesvdx>`, x, x, x, x
+    :ref:`rocsolver_gesdd <gesdd>`, x, x, x, x
 
 LAPACK-like functions
 ----------------------------

--- a/projects/rocsolver/docs/reference/lapack.rst
+++ b/projects/rocsolver/docs/reference/lapack.rst
@@ -1544,3 +1544,36 @@ rocsolver_<type>gesvdx_strided_batched()
 .. doxygenfunction:: rocsolver_dgesvdx_strided_batched
    :outline:
 .. doxygenfunction:: rocsolver_sgesvdx_strided_batched
+
+.. _gesdd:
+
+rocsolver_<type>gesdd()
+---------------------------------------------------
+.. doxygenfunction:: rocsolver_zgesdd
+   :outline:
+.. doxygenfunction:: rocsolver_cgesdd
+   :outline:
+.. doxygenfunction:: rocsolver_dgesdd
+   :outline:
+.. doxygenfunction:: rocsolver_sgesdd
+
+rocsolver_<type>gesdd_batched()
+---------------------------------------------------
+.. doxygenfunction:: rocsolver_zgesdd_batched
+   :outline:
+.. doxygenfunction:: rocsolver_cgesdd_batched
+   :outline:
+.. doxygenfunction:: rocsolver_dgesdd_batched
+   :outline:
+.. doxygenfunction:: rocsolver_sgesdd_batched
+
+rocsolver_<type>gesdd_strided_batched()
+---------------------------------------------------
+.. doxygenfunction:: rocsolver_zgesdd_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_cgesdd_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_dgesdd_strided_batched
+   :outline:
+.. doxygenfunction:: rocsolver_sgesdd_strided_batched
+


### PR DESCRIPTION
## Motivation
We forgot to properly include gesdd in the documentation when the API was added to the library.

## Technical Details
This PR adds gesdd descriptions to the documentation. 
 
## Test Plan
no need CI, just check that gesdd appears in the documentation


