### PR TITLE
[MIOpen] CPU_SolverTest_NONE.TestSolver fix

### DIFF
--- a/projects/miopen/test/gtest/solver.cpp
+++ b/projects/miopen/test/gtest/solver.cpp
@@ -224,7 +224,7 @@ protected:
         const auto sol = FindSolution(ctx, problem, db_path);
 
         EXPECT_TRUE(sol.construction_params.size() > 0);
-        EXPECT_EQ(sol.construction_params[0].kernel_file, expected_kernel);
+        EXPECT_EQ(sol.construction_params[0].kernel_file, std::string(expected_kernel));
     }
 };
 


### PR DESCRIPTION
## Motivation

The issue was that fs::path's comparison operator with const char* wasn't working as expected (treating it as a pointer), which doesn't work properly in some environments. So explicitly converting to std::string ensures the proper comparison operator is used.

[[MIOpen] Enable Batched Transpose Solvers for 4D and 5D Tensor Layouts · ROCm/rocm-libraries@770d421](https://github.com/ROCm/rocm-libraries/actions/runs/22123327436/job/64037415193)

```
2026-02-18T05:18:45.9326762Z [----------] 1 test from Smoke/CPU_SolverTest_NONE
2026-02-18T05:18:45.9327093Z [ RUN      ] Smoke/CPU_SolverTest_NONE.TestSolver/SearchesDoneTest
2026-02-18T05:18:45.9330311Z /__w/rocm-libraries/rocm-libraries/projects/miopen/test/gtest/solver.cpp:227: Failure
2026-02-18T05:18:45.9330922Z Expected equality of these values:
2026-02-18T05:18:45.9331179Z   sol.construction_params[0].kernel_file
2026-02-18T05:18:45.9331464Z     Which is: "SearchableTestSolver.NoSearch"
2026-02-18T05:18:45.9331710Z   expected_kernel
2026-02-18T05:18:45.9331894Z     Which is: 0x561bd6ae9bd0
2026-02-18T05:18:45.9332014Z 
2026-02-18T05:18:45.9332214Z /__w/rocm-libraries/rocm-libraries/projects/miopen/test/gtest/solver.cpp:227: Failure
2026-02-18T05:18:45.9332565Z Expected equality of these values:
2026-02-18T05:18:45.9332778Z   sol.construction_params[0].kernel_file
2026-02-18T05:18:45.9333020Z     Which is: "SearchableTestSolver.NoSearch"
2026-02-18T05:18:45.9333242Z   expected_kernel
2026-02-18T05:18:45.9333404Z     Which is: 0x561be1e25700
2026-02-18T05:18:45.9333525Z 
2026-02-18T05:18:45.9333710Z /__w/rocm-libraries/rocm-libraries/projects/miopen/test/gtest/solver.cpp:227: Failure
2026-02-18T05:18:45.9334043Z Expected equality of these values:
2026-02-18T05:18:45.9334254Z   sol.construction_params[0].kernel_file
2026-02-18T05:18:45.9334483Z     Which is: "SearchableTestSolver.NoSearch"
2026-02-18T05:18:45.9334696Z   expected_kernel
2026-02-18T05:18:45.9334919Z     Which is: 0x561be2563bf0
2026-02-18T05:18:45.9335034Z 
2026-02-18T05:18:45.9338395Z [  FAILED  ] Smoke/CPU_SolverTest_NONE.TestSolver/SearchesDoneTest, where GetParam() = ({ 88-byte object <10-B7 17-7D 1B-56 00-00 11-00 00-00 00-00 00-00 11-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 F0-B6 18-7D 1B-56 00-00 10-B7 18-7D 1B-56 00-00 10-B7 18-7D 1B-56 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 70-3D 6A-4A 1B-56 00-00 60-3D 6A-4A 1B-56 00-00>, 88-byte object <70-B6 17-7D 1B-56 00-00 11-00 00-00 00-00 00-00 11-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 40-B8 17-7D 1B-56 00-00 60-B8 17-7D 1B-56 00-00 60-B8 17-7D 1B-56 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 A0-3D 6A-4A 1B-56 00-00 90-3D 6A-4A 1B-56 00-00>, 88-byte object <00-B9 17-7D 1B-56 00-00 1D-00 00-00 00-00 00-00 1D-00 00-00 00-00 00-00 00-4F 6D-7C 1B-56 00-00 20-62 17-7D 1B-56 00-00 40-62 17-7D 1B-56 00-00 40-62 17-7D 1B-56 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 D0-3D 6A-4A 1B-56 00-00 C0-3D 6A-4A 1B-56 00-00>, 88-byte object <D0-B6 17-7D 1B-56 00-00 14-00 00-00 00-00 00-00 14-00 00-00 00-00 00-00 10-D9 6A-7C 1B-56 00-00 B0-6E 17-7D 1B-56 00-00 D0-6E 17-7D 1B-56 00-00 D0-6E 17-7D 1B-56 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-3E 6A-4A 1B-56 00-00 F0-3D 6A-4A 1B-56 00-00> }, { 88-byte object <40-BB 16-7D 1B-56 00-00 14-00 00-00 00-00 00-00 14-00 00-00 00-00 00-00 1D-00 00-00 00-00 00-00 80-B3 18-7D 1B-56 00-00 A0-B3 18-7D 1B-56 00-00 A0-B3 18-7D 1B-56 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 30-3E 6A-4A 1B-56 00-00 20-3E 6A-4A 1B-56 00-00>, 88-byte object <B0-B6 17-7D 1B-56 00-00 14-00 00-00 00-00 00-00 14-00 00-00 00-00 00-00 02-00 00-00 FF-7F 00-00 10-B6 17-7D 1B-56 00-00 30-B6 17-7D 1B-56 00-00 30-B6 17-7D 1B-56 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 60-3E 6A-4A 1B-56 00-00 50-3E 6A-4A 1B-56 00-00> }) (0 ms)
2026-02-18T05:18:45.9342168Z [----------] 1 test from Smoke/CPU_SolverTest_NONE (0 ms total)
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

The test continues to pass locally, relying on CI to make sure failure is resolved

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
