### PR TITLE
[Hipblaslt] Fix timing analysis script not handling scientific notation properly.

### DIFF
--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -135,13 +135,15 @@ class ProblemTiming:
 
 def parse_timing_line(line: str) -> Optional[TimingRecord]:
     """Parse a TIMING: line and return a TimingRecord."""
-    match = re.match(r'TIMING:(\w+):([\d.]+)', line)
-    if match:
-        return TimingRecord(
-            category=match.group(1),
-            duration_ms=float(match.group(2))
-        )
-    return None
+    if not line.startswith('TIMING:'):
+        return None
+    parts = line.split(':', 2)
+    if len(parts) != 3:
+        return None
+    try:
+        return TimingRecord(category=parts[1], duration_ms=float(parts[2]))
+    except ValueError:
+        return None
 
 
 def parse_context_line(line: str) -> Optional[Dict[str, str]]:


### PR DESCRIPTION
## Motivation

Current regex incorrectly parses scientific notation, which will get outputed in the log if the timing is very short.

E.g. `TIMING:test:7e-5` should be 7e-5 ms, but it gets parsed as 7 ms.

## Technical Details

Replace with simpler split and float conversion.

## Test Plan

Manually tested.

## Test Result

Passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
