### PR TITLE
[rocWMMA] Clean up windows build output

### DIFF
--- a/projects/rocwmma/test/CMakeLists.txt
+++ b/projects/rocwmma/test/CMakeLists.txt
@@ -37,7 +37,10 @@ if(ROCWMMA_CODE_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
     add_link_options(-fprofile-instr-generate)
 endif()
-add_link_options(-mcmodel=large -Wl,--gc-sections)
+add_link_options(-mcmodel=large)
+if(NOT WIN32)
+    add_link_options(-Wl,--gc-sections)
+endif()
 
 # Test/benchmark requires additional dependencies
 if(ROCWMMA_USE_SYSTEM_GOOGLETEST)


### PR DESCRIPTION
## Motivation

The --gc-sections flag produces a warning on Windows, polluting the build output.

## Technical Details

Conditionally add the offending flag, only when not on Windows.

## Test Plan

CI

## Test Result

TBD

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
