### PR TITLE
[rocsolver] Fix stebz synchronization bug

### DIFF
--- a/projects/rocsolver/CHANGELOG.md
+++ b/projects/rocsolver/CHANGELOG.md
@@ -16,6 +16,7 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ### Optimized
 ### Resolved issues
 
+* Fixed synchronization issue in STEBZ and downstream functions such as SYEVX and SYEVDX
 * Fixed synchronization issue in GETF2.
 
 ### Known issues

--- a/projects/rocsolver/CHANGELOG.md
+++ b/projects/rocsolver/CHANGELOG.md
@@ -16,8 +16,8 @@ Full documentation for rocSOLVER is available at the [rocSOLVER documentation](h
 ### Optimized
 ### Resolved issues
 
-* Fixed synchronization issue in STEBZ and downstream functions such as SYEVX and SYEVDX
-* Fixed synchronization issue in GETF2.
+* Fixed a synchronization issue in STEBZ and downstream functions, such as SYEVX and SYEVDX.
+* Fixed a synchronization issue in GETF2.
 
 ### Known issues
 ### Upcoming changes

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
@@ -251,7 +251,7 @@ __device__ void run_stebz_splitting(const int tid,
         tmp = E[j];
         tmp2 = tmp * tmp;
 
-        if(std::abs((D[j] * eps) * (D[j+1] * eps)) + sfmin > tmp2)
+        if(std::abs((D[j] * eps) * (D[j + 1] * eps)) + sfmin > tmp2)
         {
             // found split
             tmpIS[tmpns] = j;

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
@@ -230,7 +230,11 @@ __device__ void run_stebz_splitting(const int tid,
     // thus, this thread offset is:
     rocblas_int offset = 0;
     for(int i = 0; i < tid; ++i)
+    {
         offset += sidx[i];
+    }
+    __syncthreads();
+
 
     // local helper variables
     T tmp, tmp2, vl, vu;

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
@@ -4,7 +4,7 @@
  *     Univ. of Tennessee, Univ. of California Berkeley,
  *     Univ. of Colorado Denver and NAG Ltd..
  *     December 2016
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
@@ -235,7 +235,6 @@ __device__ void run_stebz_splitting(const int tid,
     }
     __syncthreads();
 
-
     // local helper variables
     T tmp, tmp2, vl, vu;
     rocblas_int j, nu, nl;

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_stebz.hpp
@@ -251,7 +251,7 @@ __device__ void run_stebz_splitting(const int tid,
         tmp = E[j];
         tmp2 = tmp * tmp;
 
-        if(std::abs(D[j] * D[j + 1]) * eps * eps + sfmin > tmp2)
+        if(std::abs((D[j] * eps) * (D[j+1] * eps)) + sfmin > tmp2)
         {
             // found split
             tmpIS[tmpns] = j;


### PR DESCRIPTION
## Motivation
STEBZ and downstream functions show intermittent failing tests in some architectures. A synchronization error in the splitting kernel is the cause of this issue. 

## Technical Details
The bug can be fixed by adding an extra thread synchronization to avoid racing read-write conditions. 

## Test Plan
The errors show up more frequently on Windows with navi cards. We need to closely monitor related CI jobs.
A local test was run by forcing the threads to go out of sync, which caused all tests to fail; then by adding the extra syncthreds, all tests passed again. 
