### PR TITLE
[hipblaslt][cms] Add CMS for 128x128x64 NT BF16

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -3341,6 +3341,60 @@ def _get_schedule_128x192x64_16bit(kernel, useLDSTr, TLDS):
     return True, opt1
 
 @RegisterSchedule(
+    tile_config=TileConfig(128, 128, 64, 2, 1, 1, False, 0, 0),
+    dtype_predicate=is16bit,
+    vector_widths=[8, 8, 8],
+    matrix_inst=[16, 16, 32, 1],
+    mfma_wave_group=[2, 2]
+)
+def _get_schedule_128x128x64_16bit(kernel, useLDSTr, TLDS):
+    numMfma = 32
+    optSchedule = dict()
+    syncs = SyncSchedule()
+    if isNT(kernel) and useLDSTr and TLDS==0:
+        kernel["MfmaInitCVgprs"] = True
+        syncs.add(-1, dscnt=0, comment="wait for prior local read local write")
+        syncs.add(8, dscnt=0, barrier=True, comment="Wait for LRA0 to finish before issuing GRA+LRB0")
+        syncs.add(15, dscnt=5, comment="Finish partial LRB0")
+        syncs.add(17, dscnt=0, vlcnt=4, barrier=True, comment="Wait for GRs from previous iteration before starting LR1s")
+
+        lra0 = [0,1,2,3,4,5,6,7]
+
+        # Interleave GRA+LRB0 after finishing LRA0.
+        lrb0 = [8,9,10,11,12,13,14,15]
+        grA  = [8,8,10,10,12,12,16,16]
+
+        # Interleave GRB+LRA1 after LRB0 completes
+        # and let LRB1 tail on them.
+        lra1 = [18,19,20,21,22,26,28,30]
+        grB  = [17,17,19,19,21,21,24,24]
+        lrb1 = [24,25,26,27,28,29,30,31]
+
+        optSchedule = {
+            'SYNC': [syncs.get_indicies()],
+            'GRA': [grA],
+            'GRB': [grB],
+            'GRIncA': [[0,0,0,1,1,1,2,2,2]],
+            'GRIncB': [[3,3,3,4,4,4,5,5,5]],
+            'LRA0': [lra0],
+            'LRB0': [lrb0],
+            'LRSA': [[17]],
+            'LRSB': [[17]],
+            'LRA1': [lra1],
+            'LRB1': [lrb1],
+            'LWSA': [[31]],
+            'LWSB': [[31]],
+            'LCC': [[31,31]],
+        }
+
+        opt1 = ScheduleInfo(1, numMfma, optSchedule, nllshift=8, nglshift=8, syncCode=syncs.get_code())
+    else:
+        return False, None
+
+    return True, opt1
+
+
+@RegisterSchedule(
     tile_config=TileConfig(128, 192, 32, 2, 1, 1, False, 0, 0),
     dtype_predicate=isTF32,
     vector_widths=[4, 4, 4],

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
@@ -716,6 +716,42 @@ BenchmarkProblems:
           - Range: [[224], [256], [1], [ 1, 17,  64]]
           - Range: [[224], [256], [1], [32, 64, 256]]
         - BiasTypeArgs: ['b']        
+    - # BenchmarkProblemSizeGroup - 128x128x64 NT
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:          
+          - [16,16,32,1,1,4,4,2,2]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [0]
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - LDSTrInst: [true]
+        - StreamK: [3]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - StaggerU: [0]
+        - 1LDSBuffer: [0]
+        - NonTemporalD: [4]
+        - SourceSwap: [1]
+        - UseSgprForGRO: [0]
+        - UseCustomMainLoopSchedule: [1]
+        - MaxLDS: [163840]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[128], [128], [1], [1, 17, 64]]
+          - Range: [[128], [128], [1], [32, 64, 256]]
+        - BiasTypeArgs: ['b']
+        - ICacheFlush: [True]
+
   ########################################
   # HHS NN - standard
   ########################################

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -777,6 +777,33 @@ class TestCustomScheduleBF16:
         valid, message = isValid(schedule_info, {"kernel" : kernel})
         assert valid, message
 
+    def test_schedule_128x128x64_16bit(self):
+        """Tests the 128x128x64  NT schedule."""
+        kernel = create_base_kernel()
+        dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
+        kernel["ProblemType"].update({
+            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+            "TransposeA": False, "TransposeB": True
+        })
+
+        kernel.update({
+            "MacroTile0": 128, "MacroTile1": 128, "DepthU": 64,
+            "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
+            "DirectToLds": True,
+            "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidth": 8,
+            "MatrixInstruction": [16, 16, 32, 1], "MIWaveGroup": [2, 2],
+            "LDSTrInst": True, "TransposeLDS": 0, "MIWaveTileA": 4, "MIWaveTileB": 4,
+        })
+
+        has_schedule, schedule_info = hasCustomSchedule(kernel)
+        assert has_schedule
+        assert isinstance(schedule_info, ScheduleInfo)
+        assert schedule_info.numCodePaths == 1
+        assert schedule_info.numMfma == TestCustomScheduleBF16.get_num_mfma(kernel)
+        valid, message = isValid(schedule_info, {"kernel": kernel})
+        assert valid, message
+
+
 class TestCustomScheduleTF32:
     @staticmethod
     def get_num_mfma(kernel):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule_LayoutAutoDetection.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule_LayoutAutoDetection.py
@@ -252,6 +252,7 @@ class TestLayoutAutoDetection:
             "_get_schedule_160x128x64_TF32": ["NN", "TN"],
             "_get_schedule_128x256x64_16bit": ["NN"],
             "_get_schedule_224x320x64_16bit": ["TN"],
+            "_get_schedule_128x128x64_16bit": ["NT"],
         }
 
         for info in _SCHEDULE_METADATA:


### PR DESCRIPTION
## Motivation

Adds CMS for `128x128x64 NT bf16`.

## Technical Details

### Tensile, no CMS vs CMS
#### MNK = 128x128x64
- Time: 1.8% improvement
- Efficiency:  52.8% --> 54.5%

### Bench, Baseline vs CMS
#### MNK = 128x128x64
- Time: 7.85% improvement
- Efficiency:  40.0% --> 41.5%

## Test Plan

New test added for the CMS.

## Test Result

Old and new tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

AIGECORE-174