### PR TITLE
[MIOpen][NFC] Document usage of barrier in BN kernels

### DIFF
--- a/projects/miopen/src/kernels/MIOpenBatchNormActivBwdSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormActivBwdSpatial.cpp
@@ -411,7 +411,7 @@ __forceinline__ __device__ void activbwdspatial(const T* __restrict__ x,
             // and has memory access strides of CHW size once all the elements in a single
             // sample have been processed, which may be large.
             //
-            // `__syncthreads()` helps to coaclesce memory accesses as each work-item accesses
+            // `__syncthreads()` helps to coalesce memory accesses as each work-item accesses
             // adjacent elements to its neighbours on the same loop iteration, leading to contiguous
             // memory access across all the waves in a workgroup. By keeping all the waves on the
             // same loop iteration it prevents waves on different loop iterations from stalling

--- a/projects/miopen/src/kernels/MIOpenBatchNormActivBwdSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormActivBwdSpatial.cpp
@@ -404,6 +404,22 @@ __forceinline__ __device__ void activbwdspatial(const T* __restrict__ x,
                 FLOAT_ACCUM tmp2 = -xhat * ds;
                 values[j]        = tmp3 * (tmp2 + tmp1);
             }
+
+            // Synchronization is not required for correctness but enhances performance.
+            //
+            // Loop is memory bound as it iterates across all the batches in the tensor,
+            // and has memory access strides of CHW size once all the elements in a single
+            // sample have been processed, which may be large.
+            //
+            // `__syncthreads()` helps to coaclesce memory accesses as each work-item accesses
+            // adjacent elements to its neighbours on the same loop iteration, leading to contiguous
+            // memory access across all the waves in a workgroup. By keeping all the waves on the
+            // same loop iteration it prevents waves on different loop iterations from stalling
+            // as they wait for memory.
+            //
+            // This can be seen by profiling the kernel with rocprofv3 and comparing the
+            // `TCP_PENDING_STALL_CYCLES_sum` counter and also looking at a thread trace in
+            // compute viewer and seeing the impact on occupancy.
             __syncthreads();
             for(unsigned int j = 0; j < MAX_READ; ++j)
             {

--- a/projects/miopen/src/kernels/MIOpenBatchNormActivFwdTrainSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormActivFwdTrainSpatial.cpp
@@ -367,7 +367,7 @@ struct MIOpenBatchNormActivFwdTrainSpatialHIPImpl<1, FpType, FpPrecType, FpAccum
                 // and has memory access strides of CHW size once all the elements in a single
                 // sample have been processed, which may be large.
                 //
-                // `__syncthreads()` helps to coaclesce memory accesses as each work-item accesses
+                // `__syncthreads()` helps to coalesce memory accesses as each work-item accesses
                 // adjacent elements to its neighbours on the same loop iteration, leading to
                 // contiguous memory access across all the waves in a workgroup. By keeping all the
                 // waves on the same loop iteration it prevents waves on different loop iterations

--- a/projects/miopen/src/kernels/MIOpenBatchNormActivFwdTrainSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormActivFwdTrainSpatial.cpp
@@ -360,6 +360,22 @@ struct MIOpenBatchNormActivFwdTrainSpatialHIPImpl<1, FpType, FpPrecType, FpAccum
                     index          = nidx * mio_bn_config::chw + chwid + hwidx;
                     xhat[j]        = (cast<FpPrecType>(in[index]) - mean) * invVariance;
                 }
+
+                // Synchronization is not required for correctness but enhances performance.
+                //
+                // Loop is memory bound as it iterates across all the batches in the tensor,
+                // and has memory access strides of CHW size once all the elements in a single
+                // sample have been processed, which may be large.
+                //
+                // `__syncthreads()` helps to coaclesce memory accesses as each work-item accesses
+                // adjacent elements to its neighbours on the same loop iteration, leading to
+                // contiguous memory access across all the waves in a workgroup. By keeping all the
+                // waves on the same loop iteration it prevents waves on different loop iterations
+                // from stalling as they wait for memory.
+                //
+                // This can be seen by profiling the kernel with rocprofv3 and comparing the
+                // `TCP_PENDING_STALL_CYCLES_sum` counter and also looking at a thread trace in
+                // compute viewer and seeing the impact on occupancy.
                 __syncthreads();
                 for(unsigned int j = 0; j < max_read; j++)
                 {

--- a/projects/miopen/src/kernels/MIOpenBatchNormBwdSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormBwdSpatial.cpp
@@ -658,7 +658,7 @@ struct MIOpenBatchNormBwdSpatialHIPImpl<1, FpType, FpPrecType, FpAccumType>
             // and has memory access strides of CHW size once all the elements in a single
             // sample have been processed, which may be large.
             //
-            // `__syncthreads()` helps to coaclesce memory accesses as each work-item accesses
+            // `__syncthreads()` helps to coalesce memory accesses as each work-item accesses
             // adjacent elements to its neighbours on the same loop iteration, leading to contiguous
             // memory access across all the waves in a workgroup. By keeping all the waves on the
             // same loop iteration it prevents waves on different loop iterations from stalling

--- a/projects/miopen/src/kernels/MIOpenBatchNormBwdSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormBwdSpatial.cpp
@@ -652,7 +652,21 @@ struct MIOpenBatchNormBwdSpatialHIPImpl<1, FpType, FpPrecType, FpAccumType>
                                              INHW);
             }
 
-            // This synchronization is not required but somehow the kernel runs faster with it
+            // Synchronization is not required for correctness but enhances performance.
+            //
+            // Loop is memory bound as it iterates across all the batches in the tensor,
+            // and has memory access strides of CHW size once all the elements in a single
+            // sample have been processed, which may be large.
+            //
+            // `__syncthreads()` helps to coaclesce memory accesses as each work-item accesses
+            // adjacent elements to its neighbours on the same loop iteration, leading to contiguous
+            // memory access across all the waves in a workgroup. By keeping all the waves on the
+            // same loop iteration it prevents waves on different loop iterations from stalling
+            // as they wait for memory.
+            //
+            // This can be seen by profiling the kernel with rocprofv3 and comparing the
+            // `TCP_PENDING_STALL_CYCLES_sum` counter and also looking at a thread trace in
+            // compute viewer and seeing the impact on occupancy.
             __syncthreads();
 
             if(l < lessout)

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
@@ -421,7 +421,7 @@ struct MIOpenBatchNormFwdTrainSpatialImpl<1, FpType, FpPrecType, FpAccumType>
                     // and has memory access strides of CHW size once all the elements in a single
                     // sample have been processed, which may be large.
                     //
-                    // `__syncthreads()` helps to coaclesce memory accesses as each work-item
+                    // `__syncthreads()` helps to coalesce memory accesses as each work-item
                     // accesses adjacent elements to its neighbours on the same loop iteration,
                     // leading to contiguous memory access across all the waves in a workgroup. By
                     // keeping all the waves on the same loop iteration it prevents waves on
@@ -430,6 +430,10 @@ struct MIOpenBatchNormFwdTrainSpatialImpl<1, FpType, FpPrecType, FpAccumType>
                     // This can be seen by profiling the kernel with rocprofv3 and comparing the
                     // `TCP_PENDING_STALL_CYCLES_sum` counter and also looking at a thread trace in
                     // compute viewer and seeing the impact on occupancy.
+                    //
+                    // TODO: This call is within the scope of an `if` condition, but it is not clear
+                    // that this control flow is guanteed to be uniform across all threads in a
+                    // workgroup, risking deadlock. Further investigation is needed.
                     __syncthreads();
 
                     for(unsigned int j = 0; j < max_read; ++j)

--- a/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
+++ b/projects/miopen/src/kernels/MIOpenBatchNormFwdTrainSpatial.cpp
@@ -415,9 +415,24 @@ struct MIOpenBatchNormFwdTrainSpatialImpl<1, FpType, FpPrecType, FpAccumType>
                         xhat[j]              = (cast<FpPrecType>(in[index]) - mean) * invVariance;
                     }
 
+                    // Synchronization is not required for correctness but enhances performance.
+                    //
+                    // Loop is memory bound as it iterates across all the batches in the tensor,
+                    // and has memory access strides of CHW size once all the elements in a single
+                    // sample have been processed, which may be large.
+                    //
+                    // `__syncthreads()` helps to coaclesce memory accesses as each work-item
+                    // accesses adjacent elements to its neighbours on the same loop iteration,
+                    // leading to contiguous memory access across all the waves in a workgroup. By
+                    // keeping all the waves on the same loop iteration it prevents waves on
+                    // different loop iterations from stalling as they wait for memory.
+                    //
+                    // This can be seen by profiling the kernel with rocprofv3 and comparing the
+                    // `TCP_PENDING_STALL_CYCLES_sum` counter and also looking at a thread trace in
+                    // compute viewer and seeing the impact on occupancy.
                     __syncthreads();
 
-                    for(unsigned int j = 0; j < max_read; ++j) // This part takes 0.405
+                    for(unsigned int j = 0; j < max_read; ++j)
                     {
                         const unsigned int l = k + (max_read * lid) + j;
                         nidx                 = l / mio_bn_config::hw;


### PR DESCRIPTION
## Motivation

Several MIOpen Batchnorm kernels exhibit the same pattern of a loop using `__syncthreads()` for peformance rather than correctness.

This detail was discovered using the OpenCL to HIP porting work but separately investigated. The outcome of the investigation was that the barrier helps to coalesce memory accesses in a memory bound loop.

Alternative implementations were experiemented with such as changing the loop unrolling factor and workgroup size, however they were not universally more performance across all BN shapes as the barrier.

Therefore this PR documents the barrier in source code so that it is clear that it's presence is intentional and why it exists.

## Technical Details

Non functional change (NFC) which adds code comments to relevant code locations where this pattern exists.

## Test Plan

Verify no regressions to existing MIOpen Batchnorm unit tests.

## Test Result

No regressions seen on MI210

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
