### PR TITLE
[MIOpen][NFC] Fix gtest clang-format errors

### DIFF
--- a/projects/miopen/test/gtest/log.cpp
+++ b/projects/miopen/test/gtest/log.cpp
@@ -117,8 +117,11 @@ struct Tensor
         auto err = hipMalloc(&data, data_size);
         if(err != hipSuccess)
         {
-            fprintf(stderr, "hipMalloc failed: %s at %s:%d\n",
-                    hipGetErrorString(err), __FILE__, __LINE__);
+            fprintf(stderr,
+                    "hipMalloc failed: %s at %s:%d\n",
+                    hipGetErrorString(err),
+                    __FILE__,
+                    __LINE__);
             abort();
         }
 #endif

--- a/projects/miopen/test/gtest/platform.cpp
+++ b/projects/miopen/test/gtest/platform.cpp
@@ -129,8 +129,8 @@ DevMem::~DevMem()
     auto err = hipFree(ptr);
     if(err != hipSuccess)
     {
-        fprintf(stderr, "hipFree failed: %s at %s:%d\n",
-                hipGetErrorString(err), __FILE__, __LINE__);
+        fprintf(
+            stderr, "hipFree failed: %s at %s:%d\n", hipGetErrorString(err), __FILE__, __LINE__);
         abort();
     }
 }


### PR DESCRIPTION

Fix the clang-format errors introduced by https://github.com/ROCm/rocm-libraries/pull/4635#issuecomment-3932789902


