### PR TITLE
Tensile/.../Toolchain.py: handle no suitable versioned bin dir

### DIFF
--- a/shared/tensile/Tensile/Utilities/Toolchain.py
+++ b/shared/tensile/Tensile/Utilities/Toolchain.py
@@ -48,6 +48,8 @@ def _windowsLatestRocmBin(path: Union[Path, str]) -> Path:
     Returns:
         The path to the ROCm bin directory for the latest ROCm version.
         Typically of the form ``C:/Program Files/AMD/ROCm/X.Y/bin``.
+    Exceptions:
+        Raises ValueError if no dir matching ``X.Y`` exists under path
     """
     path = Path(path)
     pattern = re.compile(r"^\d+\.\d+$")
@@ -65,7 +67,10 @@ def _windowsSearchPaths() -> List[Path]:
         searchPaths.extend(hipPaths)
 
     if Path(defaultPath).exists():
-        searchPaths.append(_windowsLatestRocmBin(defaultPath))
+        try:
+            searchPaths.append(_windowsLatestRocmBin(defaultPath))
+        except ValueError:
+            pass
 
     if os.environ.get("PATH"):
         envPath = [Path(p) for p in os.environ["PATH"].split(os.pathsep)]


### PR DESCRIPTION
Tensile/.../Toolchain.py: handle no suitable versioned bin dir under Windows

Handle the case where `C:/Program Files/AMD/ROCm` contains no directories matching the pattern `X.Y` where X and Y are digits in `_windowsLatestRocmBin`.

## Motivation

Created from actual user report from @TaiXeflar

## Technical Details

```
BEGIN	1771578136.972128
EXEC	E:\TheRock\build\math-libs\BLAS\rocBLAS\build	C:/Developer/Strawberry/c/bin/cmake.exe -E env --unset=ROCM_PATH --unset=ROCM_DIR --unset=HIP_PATH --unset=HIP_DIR -- C:/Developer/Strawberry/c/bin/cmake.exe --build E:/TheRock/build/math-libs/BLAS/rocBLAS/build
0.1	[0/2] Re-checking globbed directories...
0.1	[0/626] Generating libraries with TensileCreateLibrary
2.2	Traceback (most recent call last):
2.2	  File "E:\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\bin\TensileCreateLibrary", line 43, in <module>
2.2	    TensileCreateLibrary()
2.2	    ~~~~~~~~~~~~~~~~~~~~^^
2.2	  File "E:\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\TensileCreateLibrary.py", line 1357, in TensileCreateLibrary
2.2	    args = parseArguments()
2.2	  File "E:\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\TensileCreateLib\ParseArguments.py", line 331, in parseArguments
2.2	    ) = validateToolchain(
2.2	        ~~~~~~~~~~~~~~~~~^
2.2	        arguments["CxxCompiler"],
2.2	        ^^^^^^^^^^^^^^^^^^^^^^^^^
2.2	    ...<3 lines>...
2.2	        ToolchainDefaults.HIP_CONFIG,
2.2	        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2.2	    )
2.2	    ^
2.2	  File "E:\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\Utilities\Toolchain.py", line 258, in validateToolchain
2.2	    searchPaths = _windowsSearchPaths() if os.name == "nt" else _posixSearchPaths()
2.2	                  ~~~~~~~~~~~~~~~~~~~^^
2.2	  File "E:\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\Utilities\Toolchain.py", line 68, in _windowsSearchPaths
2.2	    searchPaths.append(_windowsLatestRocmBin(defaultPath))
2.2	                       ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
2.2	  File "E:\TheRock\build\math-libs\BLAS\rocBLAS\build\virtualenv\Lib\site-packages\Tensile\Utilities\Toolchain.py", line 55, in _windowsLatestRocmBin
2.2	    latest = max(versions, key=lambda d: tuple(map(int, d.name.split("."))))
2.2	ValueError: max() iterable argument is empty
3.1	[1/626] C:\Windows\system32\cmd.exe /C "cd /D E:\TheRock\build\math-libs\BLAS\rocBLAS\build && C:\Developer\Strawberry\c\bin\cmake.exe -E rm -f E:/TheRock/build/math-libs/BLAS/rocBLAS/stamp/stage.stamp"
3.1	FAILED: [code=1] Tensile/library E:/TheRock/build/math-libs/BLAS/rocBLAS/build/Tensile/library 
3.1	C:\Windows\system32\cmd.exe /C "cd /D E:\TheRock\build\math-libs\BLAS\rocBLAS\build\library\src && C:\Developer\Strawberry\c\bin\cmake.exe -E env "PATH=E:/TheRock/build/core/clr/dist/bin;E:/TheRock/build/core/clr/dist/lib/llvm/bin;E:\TheRock\.venv/Scripts;C:\Developer\Microsoft\VisualStudio\2022\VC\Tools\MSVC\14.44.35207\bin\HostX64\x64;C:\Developer\Microsoft\VisualStudio\2022\Common7\IDE\VC\VCPackages;C:\Developer\Microsoft\VisualStudio\2022\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Developer\Microsoft\VisualStudio\2022\MSBuild\Current\bin\Roslyn;C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\;C:\Developer\Microsoft\VisualStudio\2022\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;C:\Developer\Microsoft\VisualStudio\2022\Team Tools\DiagnosticsHub\Collector;C:\Developer\Microsoft\VisualStudio\2022\Common7\IDE\Extensions\Microsoft\CodeCoverage.Console;C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\\x64;C:\Program Files (x86)\Windows Kits\10\bin\\x64;C:\Developer\Microsoft\VisualStudio\2022\\MSBuild\Current\Bin\amd64;C:\Windows\Microsoft.NET\Framework64\v4.0.30319;C:\Developer\Microsoft\VisualStudio\2022\Common7\IDE\;C:\Developer\Microsoft\VisualStudio\2022\Common7\Tools\;C:\Program Files\PowerShell\7;C:\Program Files\gsudo\Current;C:\Developer\Tclsh\9.0.2\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\NVIDIA Corporation\NVIDIA App\NvDLISR;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Developer\Git\cmd;C:\Program Files\PowerShell\7\;C:\Program Files\NVIDIA Corporation\Nsight Compute 2024.3.2\;C:\Program Files\dotnet\;C:\Program Files (x86)\DVC (Data Version Control);C:\Developer\Strawberry\perl\site\bin;C:\Developer\Strawberry\perl\bin;C:\Developer\Python\3.13.2\Scripts;C:\Developer\Python\3.13.2\;C:/Developer/NVIDIA/CUDA/12.6\bin;C:/Developer/NVIDIA/CUDA/12.6\bin\x64;C:\Developer\NVIDIA\CUDA\12.6\bin;C:\Developer\InnoSetup\6.7.0;C:\Developer\Strawberry\c\bin;C:\Developer\Rust\.cargo\bin;C:\Developer\codon\lib\llvm\bin\;C:\Developer\Microsoft\Code\bin;C:\Users\Miku\.local\bin;C:\Users\Miku\AppData\Local\Microsoft\WinGet\Links;C:\Users\Miku\AppData\Local\Microsoft\WindowsApps\;C:\Users\Miku\AppData\Local\PowerToys\DSCModules\;C:\Users\Miku\.dotnet\tools;C:\Developer\Microsoft\VisualStudio\2022\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\Developer\Microsoft\VisualStudio\2022\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;C:\Developer\Microsoft\VisualStudio\2022\Common7\IDE\VC\Linux\bin\ConnectionManagerExe;C:\Developer\Microsoft\VisualStudio\2022\VC\vcpkg" -- E:/TheRock/build/math-libs/BLAS/rocBLAS/build/virtualenv/Scripts/python.exe E:/TheRock/build/math-libs/BLAS/rocBLAS/build/virtualenv/Lib/site-packages/Tensile/bin/TensileCreateLibrary --merge-files --separate-architectures --lazy-library-loading --no-short-file-names --verbose=0 --code-object-version=default --cxx-compiler=E:/TheRock/build/core/clr/dist/lib/llvm/bin/clang++.exe --library-format=msgpack --architecture=gfx1100_gfx1101_gfx1102_gfx1103_gfx1150_gfx1151_gfx1152_gfx1200_gfx1201 --no-enumerate E:/TheRock/rocm-libraries/projects/rocblas/library/src/blas3/Tensile/Logic/asm_full E:/TheRock/build/math-libs/BLAS/rocBLAS/build/Tensile HIP"
3.1	ninja: build stopped: subcommand failed.
END	1771578140.1462548	3.1741268634796143	1
```

