### PR TITLE
Add a check for detecting Pack3 in NLL

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -435,7 +435,7 @@ def customMainLoopSchedule(writer, kernel, tensorParametersA, tensorParametersB,
                 return "\\useGRInc == 1"
             elif key in ['GRA', 'GRB', 'LWSA', 'LWSB']:
                 return "\\useGR == 1"
-            elif key in ['LRA%u' % lastIter, 'LRB%u' % lastIter, 'LRSA', 'LRSB']:
+            elif key in ['LRA%u' % lastIter, 'LRB%u' % lastIter, 'LRSA', 'LRSB', 'PackA%u' % lastIter, 'PackB%u' % lastIter]:
                 return "\\usePLR == 1"
             elif key in ['LCC']:
                 return "\\useLoop == 1"


### PR DESCRIPTION
The last Iteration of PACK are not needed in NLL, hence we can safely condition and these redundant packs