### PR TITLE
[rocPRIM] Fix or remove unnecessary warnings at default compiler level

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/iterator/texture_cache_iterator.hpp
@@ -123,8 +123,8 @@ struct match_texture_type
 /// * Can only be constructed within host functions, and can only be dereferenced within
 /// device functions.
 /// * Accepts any data type from memory, and loads through texture cache.
-/// * This iterator is not functional on gfx94x architectures, as native texture fetch functions 
-/// are not supported in gfx94x.
+/// * This iterator is not functional on gfx94x, gfx120x or gfx95x architectures,
+/// as native texture fetch functions are not supported in these architectures.
 ///
 /// \tparam T type of value that can be obtained by dereferencing the iterator.
 /// \tparam Difference a type used for identify distance between iterators.
@@ -221,7 +221,6 @@ public:
         texture_type words[multiple];
 
         #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx9_4_generic__) || defined(__GFX12__)
-        #pragma message "Texture cache iterator is not supported on gfx94x, gfx120x or gfx95x as the texture fetch functions in HIP are not available."
         __builtin_trap();
         #else
         ROCPRIM_UNROLL

--- a/projects/rocprim/test/rocprim/test_utils.hpp
+++ b/projects/rocprim/test/rocprim/test_utils.hpp
@@ -570,7 +570,7 @@ void iota_modulo(ForwardIt first, ForwardIt last, T lbound, const size_t ubound)
     const T value_mod = static_cast<size_t>(lbound) < ubound ? lbound : 0;
     using value_type  = typename std::iterator_traits<ForwardIt>::value_type;
 
-    for(T value = value_mod; first != last; value++, static_cast<void>(*first++))
+    for(T value = value_mod; first != last; value++, static_cast<void>(first++))
     {
         if(static_cast<size_t>(value) >= ubound)
         {
@@ -593,7 +593,7 @@ void iota_modulo(ForwardIt first, ForwardIt last, T lbound, const size_t ubound)
     const T value_mod = static_cast<size_t>(lbound) < ubound ? lbound : 0;
     using value_type  = rocprim::half;
 
-    for(T value = value_mod; first != last; value++, static_cast<void>(*first++))
+    for(T value = value_mod; first != last; value++, static_cast<void>(first++))
     {
         if(static_cast<float>(static_cast<value_type>(value)) >= ubound)
         {


### PR DESCRIPTION
## Motivation

This PR addresses https://github.com/ROCm/rocm-libraries/issues/4645.

We have two warnings that are thrown at the default compiler level which can lead to excessive console output.  This PR addresses them.

## Technical Details

The first fix is what is proposed in #4645.  The second fix removes the compile-time warning for texture_cache_iterator - it has been some years since support for it started to be gradually dropped so I think users (if any, that actually use texture_cache_iterator) are used to the limited support for it, hence we can remove the compile-time warning and just leave it in the documentation. 

## Test Plan

All tests pass locally.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
