### PR TITLE
[hipblaslt] Allow deserialization of customMainLoopScheduling as boolean or int

### DIFF
--- a/projects/hipblaslt/clients/tests/src/hipblaslt_test.cpp
+++ b/projects/hipblaslt/clients/tests/src/hipblaslt_test.cpp
@@ -27,6 +27,7 @@
 #include <cerrno>
 #include <csetjmp>
 #include <csignal>
+#include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <regex>
@@ -35,6 +36,11 @@
 #define strcasecmp(A, B) _stricmp(A, B)
 #else
 #include <pthread.h>
+#include <unistd.h>
+#endif
+#if defined(__linux__) && defined(__GLIBC__)
+#include <cxxabi.h>
+#include <execinfo.h>
 #include <unistd.h>
 #endif
 
@@ -249,6 +255,80 @@ void catch_signals_and_exceptions_as_failures(std::function<void()> test, bool s
         try
         {
             test();
+        }
+        catch(const std::bad_cast& e)
+        {
+#if defined(__linux__) && defined(__GLIBC__)
+            // Capture backtrace (note: stack is already unwound, so this shows catch path)
+            void* array[64];
+            int   nptrs = backtrace(array, 64);
+            // Resolve addresses to file:line via addr2line / llvm-addr2line
+            char exe_path[1024];
+            ssize_t exe_len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+            if(exe_len > 0)
+            {
+                exe_path[exe_len] = '\0';
+                const char* addr2line_cmd = "llvm-addr2line -e %s -f -C 2>/dev/null || addr2line -e %s -f -C 2>/dev/null";
+                std::fprintf(stderr,
+                             "\n[hipblaslt-test] std::bad_cast backtrace (%d frames, resolved with addr2line):\n",
+                             nptrs);
+                for(int i = 0; i < nptrs; i++)
+                {
+                    char cmd[2048];
+                    std::snprintf(cmd,
+                                  sizeof(cmd),
+                                  "llvm-addr2line -e %s -f -C -a %p 2>/dev/null || addr2line -e %s -f -C -a %p 2>/dev/null",
+                                  exe_path,
+                                  array[i],
+                                  exe_path,
+                                  array[i]);
+                    FILE* fp = popen(cmd, "r");
+                    if(fp)
+                    {
+                        char line[512];
+                        int  first = 1;
+                        while(std::fgets(line, sizeof(line), fp))
+                        {
+                            for(char* p = line; *p; p++)
+                                if(*p == '\n')
+                                {
+                                    *p = '\0';
+                                    break;
+                                }
+                            if(first)
+                                std::fprintf(stderr, "  %2d: %s\n", i, line);
+                            else
+                                std::fprintf(stderr, "      %s\n", line);
+                            first = 0;
+                        }
+                        if(first)
+                            std::fprintf(stderr, "  %2d: %p\n", i, array[i]);
+                        pclose(fp);
+                    }
+                    else
+                    {
+                        std::fprintf(stderr, "  %2d: %p (addr2line failed)\n", i, array[i]);
+                    }
+                }
+                std::fprintf(stderr,
+                             "[hipblaslt-test] For exact throw site, run: gdb -ex \"catch throw\" -ex run -ex \"bt full\" -ex quit --args ./hipblaslt-test <args>\n");
+            }
+            else
+            {
+                char** strings = backtrace_symbols(array, nptrs);
+                if(strings)
+                {
+                    std::fprintf(stderr,
+                                 "\n[hipblaslt-test] std::bad_cast backtrace (%d frames):\n",
+                                 nptrs);
+                    for(int i = 0; i < nptrs; i++)
+                        std::fprintf(stderr, "  %2d: %s\n", i, strings[i]);
+                    std::free(strings);
+                }
+            }
+#endif
+            FAIL() << "Received uncaught exception: " << e.what()
+                   << " (check stderr for backtrace)";
         }
         catch(const std::exception& e)
         {

--- a/projects/hipblaslt/library/src/amd_detail/include/hipblaslt_ostream.hpp
+++ b/projects/hipblaslt/library/src/amd_detail/include/hipblaslt_ostream.hpp
@@ -306,6 +306,27 @@ public:
         return os;
     }
 
+    // Print first element when value is pointer to int64_t array (M, N, K, lda, etc. in Arguments)
+    friend hipblaslt_internal_ostream& operator<<(hipblaslt_internal_ostream& os,
+                                                  std::pair<char const*, int64_t*> p)
+    {
+        os << p.first << ": ";
+        os.m_yaml = true;
+        os << (p.second ? *p.second : int64_t(0));
+        os.m_yaml = false;
+        return os;
+    }
+
+    friend hipblaslt_internal_ostream& operator<<(hipblaslt_internal_ostream& os,
+                                                  std::pair<char const*, int64_t const*> p)
+    {
+        os << p.first << ": ";
+        os.m_yaml = true;
+        os << (p.second ? *p.second : int64_t(0));
+        os.m_yaml = false;
+        return os;
+    }
+
     // Floating-point output
     friend hipblaslt_internal_ostream& operator<<(hipblaslt_internal_ostream& os, double x)
     {

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/Base.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/Base.hpp
@@ -47,6 +47,12 @@ namespace TensileLite
         {
         };
 
+        /** Helper for deserializing a field that may be stored as bool or int (e.g. customMainLoopScheduling). */
+        struct IntFromBoolOrInt
+        {
+            int value = 0;
+        };
+
         template <typename IO>
         struct IOTraits
         {

--- a/projects/hipblaslt/tensilelite/include/Tensile/Serialization/ContractionSolution.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/Serialization/ContractionSolution.hpp
@@ -128,7 +128,9 @@ namespace TensileLite
                 iot::mapRequired(io, "synchronizerSizePerWG", s.synchronizerSizePerWG);
                 iot::mapRequired(io, "nonTemporalA", s.nonTemporalA);
                 iot::mapRequired(io, "nonTemporalB", s.nonTemporalB);
-                iot::mapRequired(io, "customMainLoopScheduling", s.customMainLoopScheduling);
+                IntFromBoolOrInt customMainLoopSchedulingTmp;
+                iot::mapRequired(io, "customMainLoopScheduling", customMainLoopSchedulingTmp);
+                s.customMainLoopScheduling = customMainLoopSchedulingTmp.value;
                 iot::mapRequired(io, "NonTemporalD", s.NonTemporalD);
                 iot::mapRequired(io, "WaveSeparateGlobalReadA", s.WaveSeparateGlobalReadA);
                 iot::mapRequired(io, "WaveSeparateGlobalReadB", s.WaveSeparateGlobalReadB);

--- a/projects/hipblaslt/tensilelite/include/Tensile/msgpack/MessagePack.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/msgpack/MessagePack.hpp
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <string>
 #include <type_traits>
 
 #include <Tensile/ContractionLibrary.hpp>
@@ -93,6 +94,9 @@ namespace TensileLite
         void objectToMap(const msgpack::object&                            object,
                          std::unordered_map<std::string, msgpack::object>& map);
 
+        // Instrumentation: current key being deserialized (for bad_cast / error logging)
+        inline thread_local std::string g_msgpack_debug_current_key;
+
         struct MessagePackInput
         {
             msgpack::object          object;
@@ -132,6 +136,7 @@ namespace TensileLite
                 {
                     auto&            value  = iterator->second;
                     MessagePackInput subRef = createSubRef(value);
+                    g_msgpack_debug_current_key = key;
                     subRef.input(obj);
                     error.insert(error.end(), subRef.error.begin(), subRef.error.end());
                     if(TensileLite::Debug::Instance().printDataInit())
@@ -165,6 +170,7 @@ namespace TensileLite
                 if(iterator != objectMap.end())
                 {
                     auto& value = iterator->second;
+                    g_msgpack_debug_current_key = key;
                     createSubRef(value).input(obj);
                     if(TensileLite::Debug::Instance().printDataInit())
                         usedKeys.insert(key);
@@ -342,6 +348,25 @@ namespace TensileLite
                 }
 
                 return v[index];
+            }
+        };
+
+        /** Deserialize int from either bool (false->0, true->1) or integer (for MessagePack .dat compatibility). */
+        template <>
+        struct MappingTraits<IntFromBoolOrInt, MessagePackInput>
+        {
+            static void mapping(MessagePackInput& io, IntFromBoolOrInt& obj)
+            {
+                try
+                {
+                    bool b = false;
+                    io.object.convert(b);
+                    obj.value = b ? 1 : 0;
+                }
+                catch(...)
+                {
+                    io.object.convert(obj.value);
+                }
             }
         };
 

--- a/projects/hipblaslt/tensilelite/src/msgpack/MessagePack.cpp
+++ b/projects/hipblaslt/tensilelite/src/msgpack/MessagePack.cpp
@@ -28,6 +28,8 @@
 
 #include <Tensile/msgpack/Loading.hpp>
 
+#include <cstdio>
+#include <exception>
 #include <fstream>
 
 namespace TensileLite
@@ -160,6 +162,7 @@ namespace TensileLite
             return nullptr;
 
         // copy data from msgpack::object_handle into MasterSolutionLibrary
+        std::fprintf(stderr, "[hipblaslt msgpack] Loading library file: %s\n", filename.c_str());
         try
         {
             std::shared_ptr<MasterSolutionLibrary<MyProblem, MySolution>> rv;
@@ -182,6 +185,16 @@ namespace TensileLite
 
             return rv;
         }
+        catch(std::bad_cast const& e)
+        {
+            std::fprintf(stderr,
+                        "[hipblaslt msgpack] std::bad_cast while loading file: %s\n",
+                        filename.c_str());
+            std::fprintf(stderr,
+                        "[hipblaslt msgpack] variable being deserialized: \"%s\"\n",
+                        Serialization::g_msgpack_debug_current_key.c_str());
+            throw;
+        }
         catch(std::runtime_error const& exc)
         {
             if(Debug::Instance().printDataInit())
@@ -195,6 +208,7 @@ namespace TensileLite
     std::shared_ptr<SolutionLibrary<MyProblem, MySolution>>
         MessagePackLoadLibraryData(std::vector<uint8_t> const& data)
     {
+        std::fprintf(stderr, "[hipblaslt msgpack] Loading library data (in-memory, %zu bytes)\n", data.size());
         try
         {
             std::shared_ptr<MasterSolutionLibrary<MyProblem, MySolution>> rv;
@@ -217,6 +231,15 @@ namespace TensileLite
             }
 
             return rv;
+        }
+        catch(std::bad_cast const& e)
+        {
+            std::fprintf(stderr,
+                        "[hipblaslt msgpack] std::bad_cast while loading library data (in-memory)\n");
+            std::fprintf(stderr,
+                        "[hipblaslt msgpack] variable being deserialized: \"%s\"\n",
+                        Serialization::g_msgpack_debug_current_key.c_str());
+            throw;
         }
         catch(std::runtime_error const& exc)
         {


### PR DESCRIPTION
## Motivation

New features:
- Allow deserialization of customMainLoopScheduling as boolean or int
- Add instrumentation to show which .dat file is loaded and what key is being deserialized - these are useful when deserialization throws an exception.
- Add backtrace print when exception occurs to help debugging the issue. 

DISCLAMER: Changes in the first commit were generated by AI.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
