### PR TITLE
Temporarily disable benchmark_warp_sort cases

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projects/rocPRIM/en/latest/](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/).
 
-## rocPRIM x.y.z for ROCm 8.0
+## rocPRIM 4.3.0 for ROCm 7.12
 
 ### Optimizations
 
@@ -20,6 +20,10 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 
 * Removed unused `equality`, `inequality`, `sum`, `max`, `min` from thread_operator.hpp.
 * Removed duplicate `inequality_operator` from binary_op_warpper.hpp
+
+### Known issues
+
+* benchmark_warp_sort may hang on Navi GPUs on Windows when running logical warp sizes > hardware warp size.
 
 ## rocPRIM 4.2.0 for ROCm 7.2
 

--- a/projects/rocprim/benchmark/benchmark_warp_sort.cpp
+++ b/projects/rocprim/benchmark/benchmark_warp_sort.cpp
@@ -196,6 +196,7 @@ void run_benchmark(benchmark_utils::state&& state)
                       run_benchmark<K, BS, WS, IPT, V, true>);
 
 // clang-format off
+#ifndef ROCPRIM_NAVI					    
 #define BENCHMARK_TYPE(type)                \
     CREATE_SORT_BENCHMARK(type, 64, 64, 1)  \
     CREATE_SORT_BENCHMARK(type, 64, 64, 2)  \
@@ -211,16 +212,34 @@ void run_benchmark(benchmark_utils::state&& state)
     CREATE_SORT_BENCHMARK(type, 64, 16, 1)  \
     CREATE_SORT_BENCHMARK(type, 64, 16, 2)  \
     CREATE_SORT_BENCHMARK(type, 64, 16, 4)
+#elif defined(_WIN32) // Currently, running a logical warpSize > hardware warpSize on Windows on Navi cards leads to a hang.
+#define BENCHMARK_TYPE(type)                \
+    CREATE_SORT_BENCHMARK(type, 64, 32, 1)  \
+    CREATE_SORT_BENCHMARK(type, 64, 32, 1)  \
+    CREATE_SORT_BENCHMARK(type, 64, 16, 2)  \
+    CREATE_SORT_BENCHMARK(type, 64, 16, 2)  \
+    CREATE_SORT_BENCHMARK(type, 64, 16, 4)	
+#endif
 // clang-format on
 
 // clang-format off
+#ifndef ROCPRIM_NAVI					    			
 #define BENCHMARK_KEY_TYPE(type, value)                 \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 64, 1)  \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 64, 2)  \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 64, 4)  \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 64, 1) \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 64, 2) \
-    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 64, 4)
+    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 64, 4) 
+#elif defined(_WIN32) // Currently, running a logical warpSize > hardware warpSize on Windows on Navi cards leads to a hang.											    
+#define BENCHMARK_KEY_TYPE(type, value)                 \
+    CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 32, 1)  \
+    CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 32, 2)  \
+    CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 32, 4)  \
+    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 32, 1) \
+    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 32, 2) \
+    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 32, 4) 
+#endif
 // clang-format on
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
 Temporarily disable benchmark_warp_sort cases where logical warpSize > hardware warpSize for Navi GPUs in Windows.

## Motivation

Currently on Windows, benchmark_warp_sort completely hangs at the beginning of execution on Navi cards.  This appears to be root caused when the logical warp size requested exceeds the hardware warp size of the GPU (which on Navi cards is defaulted to 32).  I am not entirely certain why it hangs, it may be due to the builtin_trap() call .

## Technical Details

Temporarily disable the affected benchmark cases when appropriate to alleviate the hang.

## Test Plan

Reran the benchmarks to verify hang is gone.

## Test Result

Benchmark still works.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
