### PR TITLE
[rocfft docs + rocfft-test] Revise rocfft's documentaton w.r.t. default strides and distance + guarantee test coverage thereof

### DIFF
--- a/projects/rocfft/library/include/rocfft/rocfft.h
+++ b/projects/rocfft/library/include/rocfft/rocfft.h
@@ -266,10 +266,12 @@ ROCFFT_EXPORT rocfft_status rocfft_plan_description_set_scale_factor(
  *      * Hermitian and complex data defaults to interleaved if a specific
           format is not specified.
  *  * Offset of first data element in the data buffer.  Defaults to 0 if unspecified.
- *  * Stride between consecutive elements in each dimension.  Defaults
-      to contiguous data in all dimensions if unspecified.
- *  * Distance between consecutive batches.  Defaults to contiguous
-      batches if unspecified.
+ *  * Stride between consecutive elements in each dimension. Defaults to packed data
+      layout consistent with the type of transform and its placement (requested at
+      plan creation), if unspecified.
+ *  * Distance between consecutive batches. Zero values are interpreted as defaults
+      to be deduced from the corresponding length and stride along the last transform
+      dimension.
  *
  *  Not all combinations of array types are supported and error codes
  *  will be returned for unsupported cases.

--- a/projects/rocfft/shared/rocfft_params.h
+++ b/projects/rocfft/shared/rocfft_params.h
@@ -220,18 +220,21 @@ public:
             if(fft_status != rocfft_status_success)
                 return fft_status_from_rocfftparams(fft_status);
 
-            fft_status
-                = rocfft.plan_description_set_data_layout(desc,
-                                                          rocfft_array_type_from_fftparams(itype),
-                                                          rocfft_array_type_from_fftparams(otype),
-                                                          ioffset.data(),
-                                                          ooffset.data(),
-                                                          istride_cm().size(),
-                                                          istride_cm().data(),
-                                                          idist,
-                                                          ostride_cm().size(),
-                                                          ostride_cm().data(),
-                                                          odist);
+            const bool test_default_strides_and_dist
+                = is_using_default_layout() && std::hash<std::string>()(token()) % 2 == 1;
+
+            fft_status = rocfft.plan_description_set_data_layout(
+                desc,
+                rocfft_array_type_from_fftparams(itype),
+                rocfft_array_type_from_fftparams(otype),
+                test_default_strides_and_dist ? nullptr : ioffset.data(),
+                test_default_strides_and_dist ? nullptr : ooffset.data(),
+                test_default_strides_and_dist ? 0 : istride_cm().size(),
+                test_default_strides_and_dist ? nullptr : istride_cm().data(),
+                test_default_strides_and_dist ? 0 : idist,
+                test_default_strides_and_dist ? 0 : ostride_cm().size(),
+                test_default_strides_and_dist ? nullptr : ostride_cm().data(),
+                test_default_strides_and_dist ? 0 : odist);
             if(fft_status != rocfft_status_success)
             {
                 throw std::runtime_error("rocfft_plan_description_set_data_layout failed");


### PR DESCRIPTION
## Motivation

Operation meant to declutter https://github.com/ROCm/rocm-libraries/pull/4072.

Current documentation is misleading since
- default layouts are not "contiguous" for real, in-place cases (hence the suggested change to "packed");
- distances cannot be "unspecified" but distances specified as "0" are re-interpreted as "default" values.

`rocfft_params.h` was modified to make sure that the document behavior is actually tested.

## Technical Details

Self-explanatory.

## Test Plan

Current tests suffice.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
