### PR TITLE
[rocBLAS] solution library per gfx

### DIFF
--- a/projects/rocblas/library/src/include/utility.hpp
+++ b/projects/rocblas/library/src/include/utility.hpp
@@ -800,6 +800,9 @@ bool rocblas_internal_tensile_supports_ldc_ne_ldd(rocblas_handle handle);
 // We assume true if the value is between 942 to 1000
 ROCBLAS_INTERNAL_EXPORT bool rocblas_internal_tensile_supports_xdl_math_op(rocblas_math_mode mode);
 
+// for internal use
+std::string rocblas_internal_get_arch_name(int device);
+
 // for internal use during testing, fetch arch name
 ROCBLAS_INTERNAL_EXPORT std::string rocblas_internal_get_arch_name();
 

--- a/projects/rocblas/library/src/rocblas_auxiliary.cpp
+++ b/projects/rocblas/library/src/rocblas_auxiliary.cpp
@@ -893,14 +893,19 @@ bool rocblas_internal_tensile_supports_xdl_math_op(rocblas_math_mode mode)
     return (deviceString.find("gfx942") != std::string::npos);
 }
 
+std::string rocblas_internal_get_arch_name(int deviceId)
+{
+    hipDeviceProp_t deviceProperties;
+    PRINT_IF_HIP_ERROR(hipGetDeviceProperties(&deviceProperties, deviceId));
+    return ArchName<hipDeviceProp_t>{}(deviceProperties); // strips : and later
+}
+
 // exported. Get architecture name
 std::string rocblas_internal_get_arch_name()
 {
     int deviceId;
     PRINT_IF_HIP_ERROR(hipGetDevice(&deviceId));
-    hipDeviceProp_t deviceProperties;
-    PRINT_IF_HIP_ERROR(hipGetDeviceProperties(&deviceProperties, deviceId));
-    return ArchName<hipDeviceProp_t>{}(deviceProperties);
+    return rocblas_internal_get_arch_name(deviceId);
 }
 
 // exported. Get xnack mode

--- a/projects/rocblas/library/src/tensile_host.cpp
+++ b/projects/rocblas/library/src/tensile_host.cpp
@@ -229,16 +229,8 @@ namespace
         }
     }
 
-    Tensile::LazyLoadingInit getLazyLoadingArch(int deviceID)
+    Tensile::LazyLoadingInit getLazyLoadingArch(const std::string& deviceString)
     {
-        hipDeviceProp_t deviceProperties;
-        if(hipGetDeviceProperties(&deviceProperties, deviceID) != hipSuccess)
-            return Tensile::LazyLoadingInit::None;
-
-        // strip out xnack/ecc from name
-        std::string deviceFullString(deviceProperties.gcnArchName);
-        std::string deviceString = deviceFullString.substr(0, deviceFullString.find(":"));
-
         if(deviceString.find("gfx803") != std::string::npos)
         {
             return Tensile::LazyLoadingInit::gfx803;
@@ -625,8 +617,14 @@ namespace
      **************************************************/
     class TensileHost
     {
-        // The library object
-        std::shared_ptr<Tensile::MasterSolutionLibrary<Tensile::ContractionProblem>> m_library;
+        // Map of libraries per GPU architecture (e.g., "gfx1030", "gfx906", "gfx908")
+        // This allows multi-GPU systems with different architectures to each have their own library
+        mutable std::unordered_map<
+            std::string,
+            std::shared_ptr<Tensile::MasterSolutionLibrary<Tensile::ContractionProblem>>>
+                           m_libraryMap;
+        mutable std::mutex m_libraryMapMutex; // Protects m_libraryMap during initialization
+
         std::unordered_map<std::string, std::shared_ptr<hipDeviceProp_t>> m_devicePropMap;
 
         // The adapter object. mutable is used to allow adapters to be modified
@@ -635,6 +633,8 @@ namespace
         {
             mutable std::atomic<Tensile::hip::SolutionAdapter*> adapter{nullptr};
             mutable std::mutex                                  mutex;
+            mutable std::shared_ptr<Tensile::MasterSolutionLibrary<Tensile::ContractionProblem>>
+                library;
         };
 
         // Each device contains an adapter
@@ -674,11 +674,6 @@ namespace
                 delete a.adapter;
         }
 
-        auto& get_library() const
-        {
-            return m_library;
-        }
-
         auto& get_device_property(const std::string& deviceName) const
         {
             return m_devicePropMap.at(deviceName);
@@ -701,112 +696,106 @@ namespace
 #endif
         }
 
+        static int determine_tensile_base_path(std::string& base_path)
+        {
+            const char* env = getenv("ROCBLAS_TENSILE_LIBPATH");
+            if(env)
+            {
+                base_path = env;
+            }
+            else
+            {
+                base_path = ROCBLAS_LIB_PATH;
+
+                // Find the location of librocblas.dll/.so
+                // Fall back on hard-coded path if static library or not found
+
+#ifndef ROCBLAS_STATIC_LIB
+
+#ifdef WIN32
+                std::vector<TCHAR> dll_path(MAX_PATH + 1);
+                if(GetModuleFileNameA(
+                       GetModuleHandleA("rocblas.dll"), dll_path.data(), MAX_PATH + 1))
+                {
+                    std::string           tmp(dll_path.begin(), dll_path.end());
+                    std::filesystem::path exepath = tmp;
+                    if(exepath.has_filename())
+                    {
+                        base_path = exepath.remove_filename().string();
+                    }
+                }
+#else
+                dl_iterate_phdr(rocblas_dl_iterate_phdr_callback, NULL);
+                if(rocblas_so_path.size())
+                    base_path = std::string{dirname(&rocblas_so_path[0])};
+#endif
+
+                // Find the location of the Tensile libraries relative to shared library
+                if(TestPath(base_path + "/../../Tensile/library"))
+                    base_path += "/../../Tensile/library";
+                else if(TestPath(base_path + "/library"))
+                    base_path += "/library";
+                else if(TestPath(base_path + "/../rocblas/library"))
+                    // For ASAN packaging, library file directory will be lib/asan
+                    // so need to prefix ../ to set search base_path to lib/rocblas/library
+                    base_path += "/../rocblas/library";
+                else if(TestPath(base_path + "/../Tensile/library"))
+                    // The build tree can lay out its library directory in this way when Tensile
+                    // is added as a subdirectory, but the install tree will never use this form
+                    base_path += "/../Tensile/library";
+                else
+                    base_path += "/rocblas/library";
+
+#else
+                // First location relative to standard static library install, then relative to current executable
+                if(TestPath(base_path + "/rocblas/library"))
+                    base_path += "/rocblas/library";
+                else
+                {
+                    std::string exe_path = rocblas_exepath();
+                    if(TestPath(exe_path + "rocblas/library"))
+                        base_path = exe_path + "rocblas/library";
+                    else if(TestPath(exe_path + "../../Tensile/library"))
+                        base_path = exe_path + "../../Tensile/library";
+                    else
+                        base_path += "/rocblas/library";
+                }
+#endif // ROCBLAS_STATIC_LIB
+            }
+            return 0;
+        }
+
         /*********************************************************************
-         * Initialize adapter and library according to environment variables *
+         * Initialize adapter and return library                             *
          * and default paths based on librocblas.so location and GPU         *
          *********************************************************************/
-        void initialize(Tensile::hip::SolutionAdapter& adapter, rocblas_int deviceId)
+        auto& initialize(Tensile::hip::SolutionAdapter& adapter, rocblas_int deviceId)
         {
             std::string path;
             std::string tensileLibraryPath;
-            bool        tensile_lazy_load_enabled = false;
-            //Function local static-variables are used to gaurantee thread-safe initialization,
-            //avoids static initialization order fiasco
-            static std::future<
-                std::shared_ptr<Tensile::SolutionLibrary<Tensile::ContractionProblem>>>
-                                                                ftr_lib;
-            static std::unordered_set<Tensile::LazyLoadingInit> tensileDeviceSet;
+            bool        tensile_lazy_load_enabled = true;
+
+            // Function local static-variables are used to gaurantee thread-safe initialization
+
+            // Map of futures per architecture to handle multi-GPU systems
+            static std::unordered_map<
+                std::string,
+                std::future<std::shared_ptr<Tensile::SolutionLibrary<Tensile::ContractionProblem>>>>
+                ftr_lib_map;
+
+            static std::mutex ftr_lib_map_mutex;
+            static std::unordered_map<std::string, std::vector<Tensile::LazyLoadingInit>>
+                m_tensileLazyLoadInit;
 
 #ifndef WIN32
             path.reserve(PATH_MAX);
 #endif
 
             // The name of the current GPU platform
-            std::string processor = rocblas_internal_get_arch_name();
-            // Get current xnack mode
-            std::string xnack = rocblas_internal_get_xnack_mode();
-
-            // If xnack mode is set, skip loading kernels for the opposite mode
-            std::string skip_xnack;
-            if(xnack == "xnack+")
-                skip_xnack = "xnack-";
-            else if(xnack == "xnack-")
-                skip_xnack = "xnack+";
+            std::string processor = rocblas_internal_get_arch_name(deviceId);
 
             static std::string base_path;
-            static int         determine_tensile_base_path = [&] {
-                const char* env = getenv("ROCBLAS_TENSILE_LIBPATH");
-                if(env)
-                {
-                    base_path = env;
-                }
-                else
-                {
-                    base_path = ROCBLAS_LIB_PATH;
-
-                    // Find the location of librocblas.dll/.so
-                    // Fall back on hard-coded path if static library or not found
-
-#ifndef ROCBLAS_STATIC_LIB
-
-#ifdef WIN32
-                    // wchar_t wpath[MAX_PATH + 1] = {0};
-                    // if(GetModuleFileNameW(GetModuleHandle("rocblas.dll"), wpath, MAX_PATH + 1))
-                    // {
-                    //     std::wstring          wspath(wpath);
-                    //     std::string           tmp(wspath.begin(), wspath.end());
-
-                    std::vector<TCHAR> dll_path(MAX_PATH + 1);
-                    if(GetModuleFileNameA(
-                           GetModuleHandleA("rocblas.dll"), dll_path.data(), MAX_PATH + 1))
-                    {
-                        std::string           tmp(dll_path.begin(), dll_path.end());
-                        std::filesystem::path exepath = tmp;
-                        if(exepath.has_filename())
-                        {
-                            base_path = exepath.remove_filename().string();
-                        }
-                    }
-#else
-                    dl_iterate_phdr(rocblas_dl_iterate_phdr_callback, NULL);
-                    if(rocblas_so_path.size())
-                        base_path = std::string{dirname(&rocblas_so_path[0])};
-#endif
-
-                    // Find the location of the Tensile libraries relative to shared library
-                    if(TestPath(base_path + "/../../Tensile/library"))
-                        base_path += "/../../Tensile/library";
-                    else if(TestPath(base_path + "/library"))
-                        base_path += "/library";
-                    else if(TestPath(base_path + "/../rocblas/library"))
-                        // For ASAN packaging, library file directory will be lib/asan
-                        // so need to prefix ../ to set search base_path to lib/rocblas/library
-                        base_path += "/../rocblas/library";
-                    else if(TestPath(base_path + "/../Tensile/library"))
-                        // The build tree can lay out its library directory in this way when Tensile
-                        // is added as a subdirectory, but the install tree will never use this form
-                        base_path += "/../Tensile/library";
-                    else
-                        base_path += "/rocblas/library";
-
-#else
-                    // First location relative to standard static library install, then relative to current executable
-                    if(TestPath(base_path + "/rocblas/library"))
-                        base_path += "/rocblas/library";
-                    else
-                    {
-                        std::string exe_path = rocblas_exepath();
-                        if(TestPath(exe_path + "rocblas/library"))
-                            base_path = exe_path + "rocblas/library";
-                        else if(TestPath(exe_path + "../../Tensile/library"))
-                            base_path = exe_path + "../../Tensile/library";
-                        else
-                            base_path += "/rocblas/library";
-                    }
-#endif // ROCBLAS_STATIC_LIB
-                }
-                return 0;
-            }();
+            static int         determined_path = determine_tensile_base_path(base_path);
 
             path = base_path;
             if(TestPath(path + "/" + processor))
@@ -819,6 +808,7 @@ namespace
 #endif
             if(!TestPath(tensileLibraryPath))
             {
+                tensile_lazy_load_enabled = false;
 
 #ifdef TENSILE_YAML
                 tensileLibraryPath = path + "/TensileLibrary_" + processor + ".yaml";
@@ -859,48 +849,62 @@ namespace
                     }
                 }
             }
-            else
-                tensile_lazy_load_enabled = true;
 
-            //Supports multi architecture configuration in lazy library loading mode
+            // Supports multi architecture configuration
             static int initialize_once = [&] {
                 hipDeviceProp_t prop;
                 int             count;
                 HIP_CHECK_EXC(hipGetDeviceCount(&count));
 
+                // iterate over all devices to determine gfx arch for each
+                std::unordered_set<Tensile::LazyLoadingInit> deviceSet;
                 for(int devId = 0; devId < count; devId++)
                 {
-                    auto deviceArch = getLazyLoadingArch(devId);
-                    if(tensileDeviceSet.find(deviceArch) == tensileDeviceSet.end())
+                    // strip out xnack/ecc from name
+                    std::string deviceString = rocblas_internal_get_arch_name(devId);
+
+                    auto deviceLazyArch = getLazyLoadingArch(deviceString);
+                    if(deviceSet.find(deviceLazyArch) == deviceSet.end())
                     {
-                        //future work: populate the arch list for heterogeneous support
-                        tensileDeviceSet.insert(deviceArch);
-                        //populate device property map, used in finding solutions based on arch
+                        deviceSet.insert(deviceLazyArch);
+
+                        // populate device property map, used in finding solutions based on arch
                         HIP_CHECK_EXC(hipGetDeviceProperties(&prop, devId));
-                        // strip out xnack/ecc from name
-                        std::string deviceFullString(prop.gcnArchName);
-                        std::string deviceString
-                            = deviceFullString.substr(0, deviceFullString.find(":"));
                         m_devicePropMap[deviceString] = std::make_shared<hipDeviceProp_t>(prop);
+                        m_tensileLazyLoadInit[deviceString].push_back(
+                            deviceLazyArch); // will have only 1 entry
                     }
                 }
                 return 0;
             }();
 
+            {
+                // Launch async solution library load for gfx specific library
+                std::lock_guard<std::mutex> ftrLock(ftr_lib_map_mutex);
+                if(ftr_lib_map.find(processor) == ftr_lib_map.end())
+                {
+                    ftr_lib_map[processor]
+                        = std::async(std::launch::async,
+                                     Tensile::LoadLibraryFilePreload<Tensile::ContractionProblem>,
+                                     tensileLibraryPath,
+                                     m_tensileLazyLoadInit[processor]);
+                }
+            }
+
             if(!tensile_lazy_load_enabled || rocblas_initialize_called())
             {
-
-                static int once = [&] {
-                    ftr_lib = std::async(
-                        std::launch::async,
-                        Tensile::LoadLibraryFilePreload<Tensile::ContractionProblem>,
-                        tensileLibraryPath,
-                        std::vector<Tensile::LazyLoadingInit>{Tensile::LazyLoadingInit::All});
-                    return 0;
-                }();
-
                 // only load modules for the current architecture
                 auto dir = path + "/*" + processor + "*co";
+
+                // Get current xnack mode
+                std::string xnack = rocblas_internal_get_xnack_mode();
+
+                // If xnack mode is set, skip loading kernels for the opposite mode
+                std::string skip_xnack;
+                if(xnack == "xnack+")
+                    skip_xnack = "xnack-";
+                else if(xnack == "xnack-")
+                    skip_xnack = "xnack+";
 
                 bool no_match = false;
 #ifdef WIN32
@@ -967,40 +971,57 @@ namespace
                           << std::endl;
                 }
             }
-            else // initialize lazy loading
-            {
-                static int once = [&] {
-                    ftr_lib
-                        = std::async(std::launch::async,
-                                     Tensile::LoadLibraryFilePreload<Tensile::ContractionProblem>,
-                                     tensileLibraryPath,
-                                     std::vector<Tensile::LazyLoadingInit>{});
-                    return 0;
-                }();
-            }
 
             {
                 // initialize adapter for lazy loading or experimental code objects
                 PRINT_IF_HIP_ERROR(adapter.initializeLazyLoading(processor, path));
 
-                static int once = [&] {
-                    auto lib = ftr_lib.get();
-                    if(!lib)
-                        rocblas_cerr << "\nrocBLAS error: Could not load " << tensileLibraryPath
-                                     << std::endl;
-                    else
+                // Load library for this specific architecture if not already loaded
+
+                std::lock_guard<std::mutex> libLock(m_libraryMapMutex);
+                if(m_libraryMap.find(processor) == m_libraryMap.end())
+                {
+                    // Get the future for this architecture
+                    std::future<
+                        std::shared_ptr<Tensile::SolutionLibrary<Tensile::ContractionProblem>>>*
+                        ftr_lib_ptr
+                        = nullptr;
                     {
-                        using MSL = Tensile::MasterSolutionLibrary<Tensile::ContractionProblem>;
-                        m_library = std::dynamic_pointer_cast<MSL>(lib);
+                        std::lock_guard<std::mutex> ftrLock(ftr_lib_map_mutex);
+                        auto                        it = ftr_lib_map.find(processor);
+                        if(it != ftr_lib_map.end())
+                        {
+                            ftr_lib_ptr = &(it->second);
+                        }
                     }
-                    return 0;
-                }();
-            }
-            if(!m_library)
-            {
-                rocblas_cerr << "\nrocBLAS error: Could not initialize Tensile library"
-                             << std::endl;
-                rocblas_abort();
+
+                    if(ftr_lib_ptr)
+                    {
+                        auto lib = ftr_lib_ptr->get();
+                        if(!lib)
+                        {
+                            rocblas_cerr << "\nrocBLAS error: Could not load " << tensileLibraryPath
+                                         << " for architecture: " << processor << std::endl;
+                        }
+                        else
+                        {
+                            auto masterLib = std::dynamic_pointer_cast<
+                                Tensile::MasterSolutionLibrary<Tensile::ContractionProblem>>(lib);
+                            if(masterLib)
+                            {
+                                m_libraryMap[processor] = masterLib;
+                            }
+                        }
+                    }
+                }
+
+                if(m_libraryMap.find(processor) == m_libraryMap.end())
+                {
+                    rocblas_cerr << "\nrocBLAS error: Could not initialize Tensile library for "
+                                    "architecture: "
+                                 << processor << std::endl;
+                    rocblas_abort();
+                }
             }
 
             // Preload problem/solution mappings
@@ -1008,17 +1029,25 @@ namespace
             if(overrideEnv)
             {
                 std::string                        overridePath = overrideEnv;
-                std::shared_ptr<Tensile::Hardware> hardware     = Tensile::hip::GetDevice(
-                    *(get_device_property(rocblas_internal_get_arch_name())));
-                bool success = m_library->setOverridesFromFile(*hardware, overridePath);
+                std::shared_ptr<Tensile::Hardware> hardware
+                    = Tensile::hip::GetDevice(*(get_device_property(processor)));
 
-                if(!success)
+                std::lock_guard<std::mutex> libLock(m_libraryMapMutex);
+                auto                        archLib = m_libraryMap[processor];
+                if(archLib)
                 {
-                    rocblas_cerr
-                        << "\nrocBLAS warning: One or more problem overrides failed to load from: "
-                        << overridePath << std::endl;
+                    bool success = archLib->setOverridesFromFile(*hardware, overridePath);
+                    if(!success)
+                    {
+                        rocblas_cerr << "\nrocBLAS warning: One or more problem overrides failed "
+                                        "to load from: "
+                                     << overridePath << std::endl;
+                    }
                 }
             }
+
+            std::lock_guard<std::mutex> lock(m_libraryMapMutex);
+            return m_libraryMap[processor];
         }
     };
 
@@ -1054,8 +1083,8 @@ namespace
                 // Allocate a new adapter using the current HIP device
                 adapter = new Tensile::hip::SolutionAdapter;
 
-                // Initialize the adapter and possibly the library
-                host.initialize(*adapter, device);
+                // Initialize the adapter and get the library (all of the same gfx use the same library)
+                a.library = host.initialize(*adapter, device);
 
                 // Atomically change the adapter stored for this device ID
                 a.adapter.store(adapter, std::memory_order_release);
@@ -1063,10 +1092,13 @@ namespace
         }
 
         // If an adapter is found, it is assumed that the library is initialized
+        // Get the architecture name for the current device
+        std::string archName = rocblas_internal_get_arch_name(device);
+
         if(library)
-            *library = host.get_library();
+            *library = a.library;
         if(deviceProp)
-            *deviceProp = host.get_device_property(rocblas_internal_get_arch_name());
+            *deviceProp = host.get_device_property(archName);
 
         return *adapter;
     }


### PR DESCRIPTION
### Why this change

On systems with multiple GPUs of different architectures (e.g. gfx90a and gfx942), rocBLAS previously used a single, process-wide Tensile solution library. The library was effectively chosen for whichever device was used first, so other devices could get the wrong solution library and wrong kernels for their architecture. That leads to wrong results or failures (see [#3413](https://github.com/ROCm/rocm-libraries/issues/3413)).

This PR addresses that by tying the solution library to each GPU architecture and caching it in the adapter array, so each device can use the correct library for its gfx.

### What was changed

- **Library per architecture:** Replaced the single `m_library` with `m_libraryMap` keyed by architecture name (e.g. `gfx1030`, `gfx906`). Each gfx gets its own Tensile solution library, and multi-GPU systems with mixed architectures can each use the right one.
- **Caching in the adapter array:** Each adapter (per device) now stores the library for that device's architecture (`adapter_s.library`), so we don't look up by arch on every call and the device is unambiguous when the adapter is used.
- **Correct device in one initialization path:** In `initialize(adapter, deviceId)`, the architecture is now derived with `rocblas_internal_get_arch_name(deviceId)` instead of the current HIP device, so the right library is loaded and cached for that device. **Note:** The current device in a thread still must be set correctly elsewhere; this change fixes one call path (the one that receives an explicit device index). Other paths still rely on the current device (e.g. hip query), and further testing (e.g. pre_load of non-gfx files) may follow.
- **Lazy loading and paths:** Refactored to remove duplication: base path logic moved to `determine_tensile_base_path()`, `getLazyLoadingArch()` takes an arch string, and lazy-load futures are per-arch (`ftr_lib_map` keyed by processor name). Device-property and lazy-init maps are populated for all devices up front to support heterogeneous systems.

### Motivation (original bullets, slightly expanded)

- Revise the solution system so the library is **per gfx** (not global).
- Cache that library **in the adapter array** after initialization.
- Remove duplicate code and simplify the structure before and as part of this revision.

---

*Description expanded to clarify the problem (why) and the approach (what). Caveats added per author feedback so the fix scope is accurate.—Tony*