### PR TITLE
Fix DLLS_COPIED guard scoping for Windows DLL copying

### DIFF
--- a/projects/hipcub/test/hipcub/CMakeLists.txt
+++ b/projects/hipcub/test/hipcub/CMakeLists.txt
@@ -31,6 +31,13 @@ endfunction()
 function(add_hipcub_test TEST_NAME TEST_SOURCES)
   get_hipcub_test_target(${TEST_SOURCES} TEST_TARGET)
   add_hipcub_test_internal(${TEST_NAME} "${TEST_SOURCES}" ${TEST_TARGET})
+  # Re-propagate DLLS_COPIED from add_hipcub_test_internal's scope to our
+  # caller (file scope). PARENT_SCOPE only propagates one level, so without
+  # this relay the guard resets on every call and each test target gets
+  # duplicate POST_BUILD copy commands that race on parallel builds.
+  if(DEFINED DLLS_COPIED)
+    set(DLLS_COPIED "${DLLS_COPIED}" PARENT_SCOPE)
+  endif()
 endfunction()
 
 function(add_hipcub_test_internal TEST_NAME TEST_SOURCES TEST_TARGET)
@@ -205,6 +212,10 @@ ${TEST_TYPE_SLICE_COUNT} test type slice(s) for test target ${TEST_TARGET}")
 
   add_hipcub_test_internal(${TEST_NAME} "${SOURCES}" ${TEST_TARGET})
   target_include_directories("${TEST_TARGET}" PRIVATE "../../test/hipcub")
+  # Re-propagate DLLS_COPIED (see comment in add_hipcub_test).
+  if(DEFINED DLLS_COPIED)
+    set(DLLS_COPIED "${DLLS_COPIED}" PARENT_SCOPE)
+  endif()
 endfunction()
 
 # ****************************************************************************

--- a/projects/rocprim/test/rocprim/CMakeLists.txt
+++ b/projects/rocprim/test/rocprim/CMakeLists.txt
@@ -32,9 +32,16 @@ endfunction()
 function(add_rocprim_test TEST_NAME TEST_SOURCES)
   get_rocprim_test_target(${TEST_SOURCES} TEST_TARGET)
   add_rocprim_test_internal(${TEST_NAME} "${TEST_SOURCES}" ${TEST_TARGET})
+  # Re-propagate DLLS_COPIED_2 from add_rocprim_test_internal's scope to our
+  # caller (file scope). PARENT_SCOPE only propagates one level, so without
+  # this relay the guard resets on every call and each test target gets
+  # duplicate POST_BUILD copy commands that race on parallel builds.
+  if(DEFINED DLLS_COPIED_2)
+    set(DLLS_COPIED_2 "${DLLS_COPIED_2}" PARENT_SCOPE)
+  endif()
   if(WITH_ROCRAND)
     find_package(rocrand REQUIRED)
-    target_link_libraries(${TEST_TARGET} PRIVATE roc::rocrand) 
+    target_link_libraries(${TEST_TARGET} PRIVATE roc::rocrand)
     target_compile_definitions(${TEST_TARGET} PRIVATE WITH_ROCRAND)
   endif()
   if(BUILD_CODE_COVERAGE)

--- a/projects/rocthrust/examples/CMakeLists.txt
+++ b/projects/rocthrust/examples/CMakeLists.txt
@@ -2,10 +2,6 @@
 # Copyright 2020-2025 Advanced Micro Devices, Inc.
 # ########################################################################
 
-if (WIN32)
-  set(DLLS_COPIED OFF)
-endif()
-
 function(add_thrust_example EXAMPLE)
     set(EXAMPLE_SOURCE "${EXAMPLE}.cu")
     set(EXAMPLE_TARGET "example_thrust_${EXAMPLE}")


### PR DESCRIPTION
> [!NOTE]
> This is a more minimal / less invasive version of https://github.com/ROCm/rocm-libraries/pull/4783
>
> This just fixes `PARENT_SCOPE` settings and other surface level bugs.

## Motivation

We've been experiencing flaky builds on and off for many months in TheRock, such as https://github.com/ROCm/TheRock/issues/763 and https://github.com/ROCm/TheRock/pull/3483#issuecomment-3935891724.

For example: https://github.com/ROCm/TheRock/actions/runs/22211620761/job/64289124893#step:12:445

```
[rocPRIM] [82/248] Linking CXX executable test\rocprim\test_internal_merge_path.exe
[rocPRIM] FAILED: test/rocprim/test_internal_merge_path.exe 
[rocPRIM] C:\Windows\system32\cmd.exe /C "cd . && B:\build\core\clr\dist\lib\llvm\bin\clang++.exe -nostartfiles -nostdlib -DWIN32 -DWIN32_LEAN_AND_MEAN -D_CRT_SECURE_NO_WARNINGS -DNOMINMAX -fms-extensions -fms-compatibility -D_ENABLE_EXTENDED_ALIGNED_STORAGE  -Wno-documentation-unknown-command -Wno-documentation-pedantic -Wno-unused-command-line-argument -Wno-explicit-specialization-storage-class -Wno-ignored-attributes -Wno-unknown-attributes -Wno-duplicate-decl-specifier --hip-path=B:/build/core/clr/dist --hip-device-lib-path=B:/build/core/clr/dist/lib/llvm/amdgcn/bitcode --offload-compress -O3 -DNDEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrt -LB:/build/third-party/sysdeps/windows/zlib/build/stage/lib/rocm_sysdeps/lib  -LB:/build/third-party/sysdeps/windows/zstd/build/stage/lib/rocm_sysdeps/lib  -LB:/build/compiler/amd-llvm/stage/lib/llvm/lib  -LB:/build/compiler/amd-comgr/stage/lib  -LB:/build/core/clr/stage/lib   -Xlinker /subsystem:console  -fuse-ld=lld-link test/rocprim/CMakeFiles/test_internal_merge_path.dir/internal/test_internal_merge_path.cpp.obj -o test\rocprim\test_internal_merge_path.exe -Xlinker /MANIFEST:EMBED -Xlinker /implib:test\rocprim\test_internal_merge_path.lib -Xlinker /pdb:test\rocprim\test_internal_merge_path.pdb -Xlinker /version:0.0   B:/build/third-party/googletest/dist/lib/gtest.lib  B:/build/third-party/googletest/dist/lib/gtest_main.lib  B:/build/third-party/googletest/dist/lib/gtest.lib  B:/build/core/clr/dist/lib/amdhip64.lib  --hip-link  --offload-arch=gfx1151  C:/3C32FF7D-5F4B-4089-931F-F8950D20B0A3/build/core/clr/dist/lib/llvm/lib/clang/22/lib/windows/clang_rt.builtins-x86_64.lib  -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 -loldnames  && C:\Windows\system32\cmd.exe /C "cd /D B:\build\math-libs\rocPRIM\build\test\rocprim && "C:\Program Files\CMake\bin\cmake.exe" -E copy_if_different C:/home/runner/_work/TheRock/TheRock/rocm-libraries/projects/rocprim/rtest.py B:/build/math-libs/rocPRIM/build/test/rocprim && cd /D B:\build\math-libs\rocPRIM\build\test\rocprim && "C:\Program Files\CMake\bin\cmake.exe" -E copy_if_different C:/home/runner/_work/TheRock/TheRock/rocm-libraries/projects/rocprim/rtest.xml B:/build/math-libs/rocPRIM/build/test/rocprim""
[rocPRIM] Error copying file (if different) from "C:/home/runner/_work/TheRock/TheRock/rocm-libraries/projects/rocprim/rtest.py" to "B:/build/math-libs/rocPRIM/build/test/rocprim".
[rocPRIM] [83/248] Building CXX object test/rocprim/CMakeFiles/test_device_segmented_radix_sort.dir/test_device_segmented_radix_sort.parallel/test_device_segmented_radix_sort_typed_4_6.cpp.obj
```

Some debugging pointed to a race condition in this file copying code that runs the same set of file copies for _every individual test case_. Some of these functions avoided the race by using a shared `DLLS_COPIED` variable, but a few of those were not propagating/persisting that variable at the appropriate CMake scope (`PARENT_SCOPE` up one or even two levels).

## Technical Details

Note: testing for race conditions is difficult, so there is still some element of speculation here on whether this fully resolves the issue.

Relevant commits from history:

Commit | Date | Details
-- | -- | --
rocprim
https://github.com/ROCm/rocm-libraries/commit/5ddc9ae8203428579d37be7babb8d58031b3af79 | 2021-07-28 | initial rocprim HIP on Windows support with DLL copying code, used local scope `DLLS_COPIED` variable
https://github.com/ROCm/rocm-libraries/commit/d319e9c1499633b7d46deb528983e1b7232cbca2 | 2022-06-16 | "Develop stream" commit that added `add_rocprim_test_internal()` function, breaking the `PARENT_SCOPE` propagation
(red herring) ~~https://github.com/ROCm/rocm-libraries/commit/efddce3c938a2ca608c6e29b32c6ab30ecda753a~~ | ~~2025-11-12~~ | ~~rocprim "build system overhaul" **introduced a bug by not propagating via `PARENT_SCOPE`**~~
rocthrust
https://github.com/ROCm/rocm-libraries/commit/a1074c831367e86f7ee34c6cf069034bd907c66e | 2021-07-27 | initial rocthrust HIP on Windows support with DLL copying code, started `DLLS_COPIED` variable at `OFF`
https://github.com/ROCm/rocm-libraries/commit/b863886381aa9f559afbf2a75b5ccb456e66faff | 2021-07-28 | rocthrust updated DLL copying code **introduced a bug by checking for `NOT DEFINED DLLS_COPIED` and missing that the code above still set `set(DLLS_COPIED OFF)`**

I did not find bugs in the other libraries, but they did copy these patterns at some point in history.

## Test Plan

* CI on the PR itself

## Test Result

* I don't know where to look or how to read internal pipeline logs that might be affected by these changes. Need guidance there.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.