### PR TITLE
[hipblaslt] Fix hipblaslt-test abort issue on Windows

### DIFF
--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -34,6 +34,12 @@
 #include <cinttypes>
 #include <hipblaslt/hipblaslt.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/sysinfo.h>
+#endif
+
 #define MEM_MAX_GUARD_PAD 8192
 #define MAX_DTYPE_SIZE sizeof(double)
 
@@ -134,9 +140,19 @@ public:
         : hip_memory(size, capacity, false)
     {
         char* d = nullptr;
-        if(hipHostMalloc(&d, capacity) != hipSuccess)
+
+        // Keep 20% of the available system memory for room of emergency
+        size_t available_host_memory = get_available_host_memory() * 0.8;
+        // Need to ensure sufficient host memory, otherwise hipHostMalloc may OOM and hip api won't return error code,
+        // and will cause the gtest get aborted
+        if(available_host_memory < capacity)
         {
-            hipblaslt_cerr << "Error allocating (" << (m_size >> 30) << " GB) host memory"
+            d      = nullptr;
+            m_size = m_capacity = 0;
+        }
+        else if(hipHostMalloc(&d, capacity) != hipSuccess)
+        {
+            hipblaslt_cerr << "Error allocating (" << (capacity >> 30) << " GB) host memory, m_size is (" << (m_size >> 30) << " GB)"
                            << std::endl;
             d      = nullptr;
             m_size = m_capacity = 0;
@@ -151,6 +167,40 @@ public:
     const char* get() const
     {
         return m_d.get();
+    }
+
+    inline size_t get_available_host_memory()
+    {
+#ifdef __linux__
+        struct sysinfo info;
+        if(sysinfo(&info) == 0)
+        {
+            // In the linux system, the host memory(pinned memory)'s capacity is the same as the free memory
+            return info.freeram;
+        }
+        else
+        {
+            hipblaslt_cerr << "Error getting available host memory" << std::endl;
+            return 0;
+        }
+#elif _WIN32
+        MEMORYSTATUSEX memStatus = {};
+        memStatus.dwLength = sizeof(memStatus);
+        if(GlobalMemoryStatusEx(&memStatus))
+        {
+            // In the windows system, the host memory(pinned memory)'s capacity is the half of the physical memory
+            // Use available physical memory with a safety margin to avoid OOM
+            // Dividing by 2 provides a conservative estimate for hipHostMalloc
+            // during heavy testing scenarios
+            return memStatus.ullAvailPhys / 2;
+        }
+        else
+        {
+            hipblaslt_cerr << "Error getting available host memory" << std::endl;
+            return 0;
+        }
+#endif
+        return 0;
     }
 
 private:

--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -73,7 +73,7 @@ public:
         return capacity() < s;
     }
 
-    inline size_t get_available_host_memory()
+    size_t get_available_host_memory()
     {
 #ifdef __linux__
         struct sysinfo info;
@@ -87,7 +87,7 @@ public:
             hipblaslt_cerr << "Error getting available host memory" << std::endl;
             return 0;
         }
-#elif _WIN32
+#elif defined(_WIN32)
         MEMORYSTATUSEX memStatus = {};
         memStatus.dwLength = sizeof(memStatus);
         if(GlobalMemoryStatusEx(&memStatus))
@@ -103,8 +103,10 @@ public:
             hipblaslt_cerr << "Error getting available host memory" << std::endl;
             return 0;
         }
-#endif
+#else
+        hipblaslt_cerr << "Error getting available host memory: unsupported platform" << std::endl;
         return 0;
+#endif
     }
 
 protected:

--- a/projects/hipblaslt/clients/common/include/d_vector.hpp
+++ b/projects/hipblaslt/clients/common/include/d_vector.hpp
@@ -73,6 +73,40 @@ public:
         return capacity() < s;
     }
 
+    inline size_t get_available_host_memory()
+    {
+#ifdef __linux__
+        struct sysinfo info;
+        if(sysinfo(&info) == 0)
+        {
+            // In the linux system, the host memory(pinned memory)'s capacity is the same as the free memory
+            return info.freeram;
+        }
+        else
+        {
+            hipblaslt_cerr << "Error getting available host memory" << std::endl;
+            return 0;
+        }
+#elif _WIN32
+        MEMORYSTATUSEX memStatus = {};
+        memStatus.dwLength = sizeof(memStatus);
+        if(GlobalMemoryStatusEx(&memStatus))
+        {
+            // In the windows system, the host memory(pinned memory)'s capacity is the half of the physical memory
+            // Use available physical memory with a safety margin to avoid OOM
+            // Dividing by 2 provides a conservative estimate for hipHostMalloc
+            // during heavy testing scenarios
+            return memStatus.ullAvailPhys / 2;
+        }
+        else
+        {
+            hipblaslt_cerr << "Error getting available host memory" << std::endl;
+            return 0;
+        }
+#endif
+        return 0;
+    }
+
 protected:
     hip_memory(size_t size, size_t capacity, bool use_HMM = false)
         : m_size(size)
@@ -101,7 +135,22 @@ public:
         : hip_memory(size, capacity, use_HMM)
     {
         char* d = nullptr;
-        if((use_HMM ? hipMallocManaged(&d, capacity) : hipMalloc(&d, capacity)) != hipSuccess)
+
+        if(use_HMM)
+        {
+            // Keep 20% of the available system memory for room of emergency
+            size_t available_host_memory = get_available_host_memory() * 0.8;
+            // Need to ensure sufficient host memory, otherwise hipMallocManaged may OOM and hip api won't return error code,
+            // and will cause the gtest get aborted
+            if(available_host_memory < capacity || hipMallocManaged(&d, capacity) != hipSuccess)
+            {
+                hipblaslt_cerr << "Error allocating (" << (capacity >> 30) << " GB) unified memory, m_size is (" << (m_size >> 30) << " GB)"
+                               << std::endl;
+                d      = nullptr;
+                m_size = m_capacity = 0;
+            }
+        }
+        else if(hipMalloc(&d, capacity) != hipSuccess)
         {
             size_t free_device_mem, total_device_mem;
             (void)hipMemGetInfo(&free_device_mem, &total_device_mem);
@@ -145,12 +194,7 @@ public:
         size_t available_host_memory = get_available_host_memory() * 0.8;
         // Need to ensure sufficient host memory, otherwise hipHostMalloc may OOM and hip api won't return error code,
         // and will cause the gtest get aborted
-        if(available_host_memory < capacity)
-        {
-            d      = nullptr;
-            m_size = m_capacity = 0;
-        }
-        else if(hipHostMalloc(&d, capacity) != hipSuccess)
+        if(available_host_memory < capacity || hipHostMalloc(&d, capacity) != hipSuccess)
         {
             hipblaslt_cerr << "Error allocating (" << (capacity >> 30) << " GB) host memory, m_size is (" << (m_size >> 30) << " GB)"
                            << std::endl;
@@ -167,40 +211,6 @@ public:
     const char* get() const
     {
         return m_d.get();
-    }
-
-    inline size_t get_available_host_memory()
-    {
-#ifdef __linux__
-        struct sysinfo info;
-        if(sysinfo(&info) == 0)
-        {
-            // In the linux system, the host memory(pinned memory)'s capacity is the same as the free memory
-            return info.freeram;
-        }
-        else
-        {
-            hipblaslt_cerr << "Error getting available host memory" << std::endl;
-            return 0;
-        }
-#elif _WIN32
-        MEMORYSTATUSEX memStatus = {};
-        memStatus.dwLength = sizeof(memStatus);
-        if(GlobalMemoryStatusEx(&memStatus))
-        {
-            // In the windows system, the host memory(pinned memory)'s capacity is the half of the physical memory
-            // Use available physical memory with a safety margin to avoid OOM
-            // Dividing by 2 provides a conservative estimate for hipHostMalloc
-            // during heavy testing scenarios
-            return memStatus.ullAvailPhys / 2;
-        }
-        else
-        {
-            hipblaslt_cerr << "Error getting available host memory" << std::endl;
-            return 0;
-        }
-#endif
-        return 0;
     }
 
 private:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
According to [SWDEV-574584](https://ontrack-internal.amd.com/browse/SWDEV-574584), the gtest aborts on the Windows environment with a gfx1201 arch GPU when running a series of large problem sizes.

The root cause is an out-of-memory condition during host memory allocation. This commit fixes the issue by using Linux/Windows system APIs to check the available host meomry before calling **hipHostMalloc**.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
The original memory-pool manager keeps the allocated space from the previous problems so it can be reused for the next one.
It use **hipMalloc**/**hipHostMalloc** to determine whether the device/host memory allocation succeeds. If an allocation fails(i.e., it returns a hipError), the pool is cleared (all previously allocated memory is freed, except for the space required by the current problem), and the allocation is attempted again.

However, only **hipMalloc** guarantees that it will return an error when the GPU runs out of memory. In contrast, **hipHostMalloc** may be terminated by OOM killer before it has a chance to return an error code.

The changes in this commit avoid OOM by freeing all unused allocated memory segments that are not large enough to be reused.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
The same issue can be reproduced on **[TheRock CI / Windows(hipblaslt | gfx1151)]** when the **matmul_grid_limit_single** probelm set is enabled.

After enabling the large problem set, the CI result:
<img width="414" height="353" alt="image" src="https://github.com/user-attachments/assets/ca83b8a7-52f4-4995-b040-0ad9a0f2244f" />
Raw logs (the same error as shown in the ticket):
<img width="1566" height="208" alt="image" src="https://github.com/user-attachments/assets/0bfe6f70-26b9-437d-8b23-af3cf912e67e" />

## Test Result

<!-- Briefly summarize test outcomes. -->
After enabling the large probelm set and applying this commit, the CI result:
<img width="380" height="354" alt="image" src="https://github.com/user-attachments/assets/b1980f4a-bd84-416f-bf32-a453836fd49b" />

Since this large problem set was not originally intended for gfx1151, the above tests were run only on the [draft PR](https://github.com/ROCm/rocm-libraries/pull/4490) to verify correctness on the Windows system. This commit does not enable large problem set on gfx1151, because it is meant to fix the issue on Windows environments with gfx1201.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[SWDEV-574584]: https://amd-hub.atlassian.net/browse/SWDEV-574584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ROCM-3237