### PR TITLE
[hipBLASLt] Fix numeric regression of MXFP4

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Contractions.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Contractions.py
@@ -402,6 +402,8 @@ class ProblemType:
             predicates.append(ProblemPredicate("SupportDeviceUserArguments", value=self.supportDeviceUserArguments))
             predicates.append(ProblemPredicate("SwizzleTensorA", value=self.swizzleTensorA))
             predicates.append(ProblemPredicate("SwizzleTensorB", value=self.swizzleTensorB))
+            predicates.append(ProblemPredicate("MXBlockA", value=self.mxBlockA))
+            predicates.append(ProblemPredicate("MXBlockB", value=self.mxBlockB))
 
         return predicates
 

--- a/projects/hipblaslt/tensilelite/Tensile/Contractions.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Contractions.py
@@ -402,8 +402,6 @@ class ProblemType:
             predicates.append(ProblemPredicate("SupportDeviceUserArguments", value=self.supportDeviceUserArguments))
             predicates.append(ProblemPredicate("SwizzleTensorA", value=self.swizzleTensorA))
             predicates.append(ProblemPredicate("SwizzleTensorB", value=self.swizzleTensorB))
-            predicates.append(ProblemPredicate("MXBlockA", value=self.mxBlockA))
-            predicates.append(ProblemPredicate("MXBlockB", value=self.mxBlockB))
 
         return predicates
 

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -809,8 +809,7 @@ namespace TensileLite
 
 	// NOTE: an assumption here is A & B must be both MX data types or non-MX data types.
 	//       Mixing is not supported.
-        if(!problemType.useScaleAB.empty() or
-           (problemType.mxBlockA != 0 && problemType.mxBlockB != 0)) //kernel input data
+        if(!problemType.useScaleAB.empty())
         {
             args.template append<void const*>("scaleA", inputs.scaleA);
             args.template append<void const*>("scaleB", inputs.scaleB);

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -807,8 +807,6 @@ namespace TensileLite
                                           autoWGMXCCCHUNK,
                                           autoGsuVal);
 
-	// NOTE: an assumption here is A & B must be both MX data types or non-MX data types.
-	//       Mixing is not supported.
         if(!problemType.useScaleAB.empty())
         {
             args.template append<void const*>("scaleA", inputs.scaleA);


### PR DESCRIPTION
## Motivation

This PR fixes the numeric regression caused by https://github.com/ROCm/rocm-libraries/pull/4599

## Technical Details

Revert attaching scaleA and scaleB data pointers when MX block size is non-zero.

## Test Plan

Manually build tensileLite and ran the test with mx32f4_tn.yaml and it passed.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
