### PR TITLE
[miopen][CI] Replace clinfo with rocminfo

### DIFF
--- a/projects/miopen/vars/utils.groovy
+++ b/projects/miopen/vars/utils.groovy
@@ -392,6 +392,12 @@ def getDockerImageWithStatus(Map conf=[:]) {
     }
 }
 
+def runShell(String command){
+    def responseCode = sh returnStatus: true, script: "${command} > tmp.txt"
+    def output = readFile(file: "tmp.txt")
+    return (output != "")
+}
+
 def buildHipClangJob(Map conf=[:]){
         show_node_info()
         /*
@@ -426,9 +432,14 @@ def buildHipClangJob(Map conf=[:]){
                 (retimage, image) = getDockerImage(conf)
                 if (needs_gpu) {
                     withDockerContainer(image: image, args: dockerOpts) {
-                        timeout(time: 5, unit: 'MINUTES')
-                        {
-                            sh 'PATH="/opt/rocm/opencl/bin:/opt/rocm/opencl/bin/x86_64:$PATH" clinfo'
+                        timeout(time: 2, unit: 'MINUTES'){
+                            sh 'rocminfo | tee rocminfo.log'
+                            if ( !runShell('grep -n "gfx" rocminfo.log') ){
+                                throw new Exception ("GPU not found")
+                            }
+                            else{
+                                echo "GPU is OK"
+                            }
                         }
                     }
                 }
@@ -441,9 +452,14 @@ def buildHipClangJob(Map conf=[:]){
                 (retimage, image) = getDockerImage(conf)
                 if (needs_gpu) {
                     withDockerContainer(image: image, args: dockerOpts) {
-                        timeout(time: 5, unit: 'MINUTES')
-                        {
-                            sh 'PATH="/opt/rocm/opencl/bin:/opt/rocm/opencl/bin/x86_64:$PATH" clinfo'
+                        timeout(time: 2, unit: 'MINUTES'){
+                            sh 'rocminfo | tee rocminfo.log'
+                            if ( !runShell('grep -n "gfx" rocminfo.log') ){
+                                throw new Exception ("GPU not found")
+                            }
+                            else{
+                                echo "GPU is OK"
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This pull request updates the GPU detection logic in the `buildHipClangJob` function to use a more reliable method for verifying GPU presence in Docker containers, as we have already deprecated the OpenCL backend and this has been causing hangs in some CI machines. It also introduces a new utility function to help with shell command execution and output handling.

**Improvements to GPU detection and job reliability:**

* Replaced the previous `clinfo`-based GPU check with a new approach that runs `rocminfo`, saves the output to `rocminfo.log`, and verifies the presence of a GPU by searching for `"gfx"` in the log. If no GPU is found, the job throws an exception. [[1]](diffhunk://#diff-7353cc460f44de226e0b2b406367f005868a15742091c357bab7db44bb36c99bL429-R442) [[2]](diffhunk://#diff-7353cc460f44de226e0b2b406367f005868a15742091c357bab7db44bb36c99bL444-R462)

**Utility function addition:**

* Added a new `runShell` function that executes a shell command, captures its output, and returns whether the output is non-empty. This is used to streamline and standardize shell command execution and output checking in the pipeline.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
