### PR TITLE
[CK] Fix windows build issues

### DIFF
--- a/projects/composablekernel/example/ck_tile/01_fmha/rotary.hpp
+++ b/projects/composablekernel/example/ck_tile/01_fmha/rotary.hpp
@@ -49,9 +49,7 @@ generate_rotary_cos_sin(ck_tile::index_t seqlen,
     using std::begin, std::end;
 
     ck_tile::HostTensor<float> angle({num_rows, num_cols});
-    std::generate(begin(angle), end(angle), [&] {
-        return generator(random_engine) * 2 * M_PI;
-    });
+    std::generate(begin(angle), end(angle), [&] { return generator(random_engine) * 2 * M_PI; });
 
     ck_tile::HostTensor<DataType> cos({num_rows, num_cols});
     std::transform(begin(angle), end(angle), begin(cos), [](float origin_value) {

--- a/projects/composablekernel/example/ck_tile/01_fmha/rotary.hpp
+++ b/projects/composablekernel/example/ck_tile/01_fmha/rotary.hpp
@@ -7,7 +7,7 @@
 #include "ck_tile/host/host_tensor.hpp"
 
 #include <cassert>
-#include <cmath>
+#include <numbers>
 #include <functional>
 #include <iterator>
 #include <optional>
@@ -44,7 +44,7 @@ generate_rotary_cos_sin(ck_tile::index_t seqlen,
     using std::begin, std::end;
 
     ck_tile::HostTensor<float> angle({num_rows, num_cols});
-    std::generate(begin(angle), end(angle), [&] { return generator(random_engine) * 2 * M_PI; });
+    std::generate(begin(angle), end(angle), [&] { return generator(random_engine) * 2 * std::numbers::pi_v<float>; });
 
     ck_tile::HostTensor<DataType> cos({num_rows, num_cols});
     std::transform(begin(angle), end(angle), begin(cos), [](float origin_value) {

--- a/projects/composablekernel/example/ck_tile/01_fmha/rotary.hpp
+++ b/projects/composablekernel/example/ck_tile/01_fmha/rotary.hpp
@@ -7,7 +7,12 @@
 #include "ck_tile/host/host_tensor.hpp"
 
 #include <cassert>
-#include <numbers>
+#include <cmath>
+
+#ifndef M_PI // Not there on windows...
+#define M_PI 3.141592653589793238462643383279502884
+#endif
+
 #include <functional>
 #include <iterator>
 #include <optional>
@@ -45,7 +50,7 @@ generate_rotary_cos_sin(ck_tile::index_t seqlen,
 
     ck_tile::HostTensor<float> angle({num_rows, num_cols});
     std::generate(begin(angle), end(angle), [&] {
-        return generator(random_engine) * 2 * std::numbers::pi_v<float>;
+        return generator(random_engine) * 2 * M_PI;
     });
 
     ck_tile::HostTensor<DataType> cos({num_rows, num_cols});

--- a/projects/composablekernel/example/ck_tile/01_fmha/rotary.hpp
+++ b/projects/composablekernel/example/ck_tile/01_fmha/rotary.hpp
@@ -44,7 +44,9 @@ generate_rotary_cos_sin(ck_tile::index_t seqlen,
     using std::begin, std::end;
 
     ck_tile::HostTensor<float> angle({num_rows, num_cols});
-    std::generate(begin(angle), end(angle), [&] { return generator(random_engine) * 2 * std::numbers::pi_v<float>; });
+    std::generate(begin(angle), end(angle), [&] {
+        return generator(random_engine) * 2 * std::numbers::pi_v<float>;
+    });
 
     ck_tile::HostTensor<DataType> cos({num_rows, num_cols});
     std::transform(begin(angle), end(angle), begin(cos), [](float origin_value) {

--- a/projects/composablekernel/example/ck_tile/41_batched_contraction/run_batched_contraction_example.inc
+++ b/projects/composablekernel/example/ck_tile/41_batched_contraction/run_batched_contraction_example.inc
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <algorithm>
 #include <cmath>
+#include <chrono>
 #include "contraction_utils.hpp"
 #include "ck_tile/host/reference/reference_batched_contraction.hpp"
 

--- a/projects/composablekernel/include/ck_tile/host/high_res_cpu_clock.hpp
+++ b/projects/composablekernel/include/ck_tile/host/high_res_cpu_clock.hpp
@@ -4,6 +4,16 @@
 #pragma once
 
 #include <stdint.h>
+#if defined(_WIN32) || defined(_WIN64)
+// Windows
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#endif
 
 namespace ck_tile {
 
@@ -15,8 +25,6 @@ struct timepoint_t
 
 // Platform-specific includes and implementation
 #if defined(_WIN32) || defined(_WIN64)
-// Windows
-#include <windows.h>
 
 static inline timepoint_t high_res_now()
 {

--- a/projects/composablekernel/include/ck_tile/ops/fused_moe/pipeline/fused_moegemm_pipeline_flatmm_ex.hpp
+++ b/projects/composablekernel/include/ck_tile/ops/fused_moe/pipeline/fused_moegemm_pipeline_flatmm_ex.hpp
@@ -109,8 +109,8 @@ struct FusedMoeGemmPipeline_FlatmmEx
         constexpr auto NEG1  = number<-1>{};
         constexpr auto I0    = number<0>{};
         constexpr auto I1    = number<1>{};
-        constexpr auto TRUE  = bool_constant<true>{};
-        constexpr auto FALSE = bool_constant<false>{};
+        constexpr auto True  = bool_constant<true>{};
+        constexpr auto False = bool_constant<false>{};
 
         CK_TILE_LDS_ADDR ADataType* smem_0 = reinterpret_cast<CK_TILE_LDS_ADDR ADataType*>(smem);
         CK_TILE_LDS_ADDR ADataType* smem_1 = reinterpret_cast<CK_TILE_LDS_ADDR ADataType*>(
@@ -291,7 +291,7 @@ struct FusedMoeGemmPipeline_FlatmmEx
                         g_win.bottom_tensor_view_ = u_view;
                     }
                 }
-                load_tile_raw(g_, g_win, i_access, FALSE, PreNop{});
+                load_tile_raw(g_, g_win, i_access, False, PreNop{});
             };
         auto move_g = [&]() {
             move_tile_window(g_win, {number<0>{}, number<BlockShape::Block_Kr0>{}, number<0>{}});
@@ -300,7 +300,7 @@ struct FusedMoeGemmPipeline_FlatmmEx
 
         auto gld_d =
             [&]<typename PreNop = bool_constant<false>>(auto& d_, auto i_access, PreNop = {}) {
-                load_tile_raw(d_, d_win, i_access, FALSE, PreNop{});
+                load_tile_raw(d_, d_win, i_access, False, PreNop{});
             };
         auto move_d = [&]() {
             // d move along gemm-n
@@ -309,7 +309,7 @@ struct FusedMoeGemmPipeline_FlatmmEx
 
         auto atomic_add_o =
             [&]<typename PreNop = bool_constant<false>>(auto& o_, auto i_access, PreNop = {}) {
-                update_tile_raw(o_win, o_, i_access, TRUE, PreNop{});
+                update_tile_raw(o_win, o_, i_access, True, PreNop{});
             };
 
         auto acc_0  = Policy::template MakeCBlockTile_Gemm0<Problem>();
@@ -502,9 +502,9 @@ struct FusedMoeGemmPipeline_FlatmmEx
             static_for<0, total_loops, 1>{}([&](auto i_issue) {
                 constexpr auto last_nop = [&]() {
                     if constexpr(i_issue == (total_loops - 1))
-                        return TRUE;
+                        return True;
                     else
-                        return FALSE;
+                        return False;
                 }();
                 gemm_0(acc_0, as[I1], gs[I1], i_issue, last_nop); // last gemm has nop
             });
@@ -607,8 +607,8 @@ struct FusedMoeGemmPipeline_FlatmmEx
 
         // start of pipeline
         // clang-format off
-        gld_a(a_sst_win0, NEG1, TRUE);
-        gld_g(gs[I0], NEG1, TRUE);
+        gld_a(a_sst_win0, NEG1, True);
+        gld_g(gs[I0], NEG1, True);
         move_a();
         move_g();
         clear_tile(acc_0);


### PR DESCRIPTION
## Motivation

Full build on Windows is currently broken due to compiler errors, this PR should help fix that. This is also holding up the following PR in the TheRock: https://github.com/ROCm/TheRock/pull/3382

## Technical Details

1. I don't see a good reason to be nesting a windows include inside the ck_tile namespace. It was causing compiler errors too: Windows.h comes with min and max, which was conflicting with ck_tile::min and ck_tile::max, so I moved it out. I also defined NOMINMAX to prevent this inclusion in the future.
2. The TRUE/FALSE macros are already used by Windows.h, which causes an error. So I've opted for True/False. You can see this pattern in other rocm-libraries.
3. The M_PI macro isn't available, at least in the WIN32_LEAN_AND_MEAN context, from \<cmath\> on Windows. We'll be able to use std::numbers::v_pi\<float\> when we have C++20 support.
4. There was a missing \<chrono\> include.


## Test Plan

Test locally and make sure this doesn't impact existing CI.

## Test Result

Compiles locally and passes existing ci.

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
