### PR TITLE
[MIOpen] SolverTest fix

### DIFF
--- a/projects/miopen/test/gtest/solver.cpp
+++ b/projects/miopen/test/gtest/solver.cpp
@@ -219,6 +219,7 @@ protected:
                                              miopen::conv::Direction::Forward};
         auto ctx = miopen::ExecutionContext{};
         ctx.SetStream(&get_handle());
+        ctx.disable_search_enforce = true;
         context_filler(ctx);
 
         const auto sol = FindSolution(ctx, problem, db_path);


### PR DESCRIPTION
## Motivation

The Smoke/CPU_SolverTest_NONE.TestSolver/SearchesDoneTest test fails with kernel_file =                         
  "SearchableTestSolver.NoSearch" when "SearchableTestSolver" is expected, 3 times.

## Technical Details

In `FindSolutionImpl`, the `Search()` call is nested inside the else branch of `if(enforce.IsDbClean(context))`. When the `MIOPEN_FIND_ENFORCE` environment variable is set to 5 (or CLEAN), or the Handle's tuning policy is `miopenTuningPolicyDbClean`, the `enforce.IsDbClean()` check returns true, causing the code to skip the entire else block — including the if(context.do_search) check that would invoke `Search()`. The function falls through  and returns `GetDefaultPerformanceConfig()` ("SearchableTestSolver.NoSearch") regardless of `do_search`.
  
Fix: Set `ctx.disable_search_enforce = true` in `ConstructTest()` before the context_filler runs. This disables the FindEnforce mechanism, ensuring the test's search behavior depends only on the `do_search` flag set by the test, not on external environment variables. The `disable_search_enforce` flag is set before `context_filler(ctx)` so test cases can still override it if needed.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
