### PR TITLE
[hipsparselt] Fix TensileLite symbol interposition and build errors

### DIFF
--- a/projects/hipsparselt/CMakeLists.txt
+++ b/projects/hipsparselt/CMakeLists.txt
@@ -176,6 +176,8 @@ if(HIPSPARSELT_ENABLE_HIP)
 
     set(ORIGAMI_ENABLE_INSTALL OFF)
     add_subdirectory("${HIPBLASLT_PATH}" hipblaslt)
+    # Hide TensileLite symbols to prevent interposition with hipblaslt's copy
+    target_compile_definitions(tensilelite-host PRIVATE TENSILE_STATIC_ONLY)
     endblock()
 endif()
 

--- a/projects/hipsparselt/library/src/hcc_detail/rocsparselt/src/tensile_host.cpp
+++ b/projects/hipsparselt/library/src/hcc_detail/rocsparselt/src/tensile_host.cpp
@@ -296,7 +296,7 @@ namespace
         TensileLite::TensorDescriptor scaleAlphaVec{"scaleAlphaVec"};
 
         // The ContractionProblemGemm
-        TensileLite::ContractionProblemGemm tensileProblem{a,
+        TensileLite::ContractionProblemGemm tensileProblem(a,
                                                        b,
                                                        c,
                                                        d,
@@ -310,8 +310,9 @@ namespace
                                                        freeIndex,
                                                        batchIndex,
                                                        boundIndex,
-                                                       *prob.beta,
-                                                       prob.workspaceSize};
+                                                       static_cast<double>(*prob.beta),
+                                                       prob.workspaceSize);
+
         tensileProblem.setComputeInputType(Tensile_Ti);
         tensileProblem.setAlphaType(Tensile_Tc);
         tensileProblem.setBetaType(Tensile_Tc);
@@ -1011,6 +1012,7 @@ rocsparselt_status getBestSolutions(const RocsparseltContractionProblem<Ti, To, 
 
     hardware          = TensileLite::hip::GetDevice(*deviceProp);
     auto tensile_prob = ConstructTensileProblem(prob);
+
     // auto handle = prob.handle;
     auto solutions = library->findTopSolutions(tensile_prob, *hardware, requestConfigs);
 


### PR DESCRIPTION
## Summary
- Add TENSILE_STATIC_ONLY compile definition to prevent TensileLite symbol interposition between hipsparselt and hipblaslt
- Fix ContractionProblemGemm constructor call (narrowing conversion, aggregate init)

## Test plan
- Built and tested with PyTorch semi-structured sparsity on MI300X, ROCm 7.2

## Important
This PR is a clone of PR #4531 and includes only a subset of the changes from that patch.