### PR TITLE
[hipCUB] Add missing header include to device_segmented_reduce

### DIFF
--- a/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
+++ b/projects/hipcub/hipcub/include/hipcub/backend/rocprim/device/device_segmented_reduce.hpp
@@ -38,6 +38,7 @@
 #include "../util_sync.hpp"
 #include "device_reduce.hpp"
 
+#include <rocprim/device/config_types.hpp>
 #include <rocprim/device/device_segmented_reduce.hpp> // IWYU pragma: export
 #include <rocprim/type_traits.hpp> // IWYU pragma: export
 


### PR DESCRIPTION
## Motivation

We're missing a header include in hipcub's rocprim backend.

## Technical Details

This change adds the missing header include to fix some CI build failures.
The missing header didn't seem to cause any issues locally.

## Test Plan

Build hipcub - ensure the build succeeds, both locally and in CI.

## Test Result

The build completes without errors locally. Will observe the results in CI with this PR.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
