### PR TITLE
[hipblaslt] Reject solutions with boolean UseCustomMainLoopSchedule

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1607,6 +1607,8 @@ class Solution(collections.abc.Mapping):
         state["UseDirect32XEmulation"] = False
 
     # Check if CMS is available for this solution
+    if type(state['UseCustomMainLoopSchedule']) == bool:
+      reject(state, printRejectionReason, "Detected boolean, UseCustomMainLoopSchedule should be -1, 0 or 1")
     if state["UseCustomMainLoopSchedule"] in [-1, 1]:
       hasCMS,_ = hasCustomSchedule(state)
       if state["UseCustomMainLoopSchedule"] == 1 and not hasCMS:


### PR DESCRIPTION
AIGESOLSEL-82

## Motivation

Library logic solutions with boolean UseCustomMainLoopSchedule cause "solution not found" errors at runtime.

## Technical Details

Allow boolean type UseCustomMainLoopSchedule to fail at build time.

## Test Plan

Tested with boolean type UseCustomMainLoopSchedule and build failed with appropriate rejection reason.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
