### PR TITLE
[Cancelled] Fix hipfftw so lib name in tests

### DIFF
--- a/projects/hipfft/clients/hipfftw_helper.h
+++ b/projects/hipfft/clients/hipfftw_helper.h
@@ -81,7 +81,7 @@ private:
     dynamically_loaded_hipfftw()
     {
 #ifdef __HIP_PLATFORM_AMD__
-        const std::string lib_basename = "hipfftw";
+        const std::string lib_basename = "hipfftw0";
 #else
         const std::string lib_basename = "cufftw";
 #endif


### PR DESCRIPTION
## Motivation

Tests were failing due to library not being available in the testing container, thus this PR is cancelled/withdrawn

## Technical Details

Tests were failing due to library not being available in the testing container, thus this PR is cancelled/withdrawn

```
[ RUN      ] hipfftw_test.utility_functions
clients/tests/hipfftw_test.cpp:330: Failure
Failed
Undefined function pointers detected. Error info: failed to open library libhipfftw.so. System's error message = libhipfftw.so: cannot open shared object file: No such file or directory

clients/tests/hipfftw_test.cpp:330: Failure
Failed
Undefined function pointers detected. Error info: failed to open library libhipfftw.so. System's error message = libhipfftw.so: cannot open shared object file: No such file or directory

[  FAILED  ] hipfftw_test.utility_functions (0 ms)
```

## Test Plan

As part of our [effort](https://canonical.com/blog/canonical-amd-rocm-ai-ml-hpc-libraries) to distribute AMD ROCm AI/ML and HPC libraries in Ubuntu, we have CI/CD pipeline running the tests.

## Test Result

Results will be shared once available.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
