### PR TITLE
[rocfft] Encapsulate data-layout-related parameters in plan.cpp

### DIFF
--- a/projects/hipfft/shared/array_predicate.h
+++ b/projects/hipfft/shared/array_predicate.h
@@ -25,12 +25,23 @@
 
 namespace
 {
-    bool array_type_is_complex(rocfft_array_type type)
+    bool array_type_is_real(rocfft_array_type type)
+    {
+        return type == rocfft_array_type_real;
+    }
+    bool array_type_is_hermitian(rocfft_array_type type)
+    {
+        return type == rocfft_array_type_hermitian_interleaved
+               || type == rocfft_array_type_hermitian_planar;
+    }
+    bool array_type_is_complex_but_not_hermitian(rocfft_array_type type)
     {
         return type == rocfft_array_type_complex_interleaved
-               || type == rocfft_array_type_complex_planar
-               || type == rocfft_array_type_hermitian_interleaved
-               || type == rocfft_array_type_hermitian_planar;
+               || type == rocfft_array_type_complex_planar;
+    }
+    bool array_type_is_complex(rocfft_array_type type)
+    {
+        return array_type_is_complex_but_not_hermitian(type) || array_type_is_hermitian(type);
     }
     bool array_type_is_interleaved(rocfft_array_type type)
     {

--- a/projects/rocfft/CHANGELOG.md
+++ b/projects/rocfft/CHANGELOG.md
@@ -7,20 +7,20 @@ Documentation for rocFFT is available at
 
 ### Optimized
 
-* Allow plans to share hipModules if they use the same kernels.  This reduces time spent and memory used when 
+* Allow plans to share hipModules if they use the same kernels.  This reduces time spent and memory used when
   creating plans that exist concurrently.
 * Improved performance of unit-strided, complex-interleaved, forward/inverse FFTs on gfx1201, gfx90a, gfx942, and gfx950.
   Single-precision lengths:
-  - (160,72,72)
-  - (160,80,72)
-  - (160,80,80)
-  - (72,72,72)
-  - (80,80,80)
-  - (84,84,72)
-  - (96,96,96)
-  - (108,108,80)
+  * (160,72,72)
+  * (160,80,72)
+  * (160,80,80)
+  * (72,72,72)
+  * (80,80,80)
+  * (84,84,72)
+  * (96,96,96)
+  * (108,108,80)
   Double-precision length:
-  - (72,72,52)
+  * (72,72,52)
 
 ### Changed
 
@@ -38,6 +38,7 @@ Documentation for rocFFT is available at
 * Fixed incorrect results on some even-length real FFTs that have odd-length strides on higher dimensions.
 * Fixed callbacks on MPI transforms, when not all ranks have the same number of data bricks.
 * Fixed functional issues for multi-device, in-place real transforms.
+* Fixed functional issues for multi-dimensional, multi-device transforms involving some unit length(s).
 
 ## rocFFT 1.0.36 for ROCm 7.2.0
 
@@ -64,12 +65,12 @@ Documentation for rocFFT is available at
 
 * Implemented single-kernel plans for some 2D problem sizes, on devices with at least 160KiB of LDS.
 * Improved performance of unit-strided, complex-interleaved, forward/inverse FFTs for lengths:
-  - (64,64,128)
-  - (64,64,52)
-  - (60,60,60)
-  - (32,32,128)
-  - (32,32,64)
-  - (64,32,128)
+  * (64,64,128)
+  * (64,64,52)
+  * (60,60,60)
+  * (32,32,128)
+  * (32,32,64)
+  * (64,32,128)
 * Improved performance of 3D MPI pencil decompositions by using sub-communicators for global transpose operations.
 
 ## rocFFT 1.0.34 for ROCm 7.0.0
@@ -87,16 +88,16 @@ Documentation for rocFFT is available at
 
 * Removed unnecessary HIP event/stream allocation and synchronization during MPI transforms.
 * Implemented single-precision 1D kernels for lengths:
-  - 4704
-  - 5488
-  - 6144
-  - 6561
-  - 8192
+  * 4704
+  * 5488
+  * 6144
+  * 6561
+  * 8192
 * Implemented single-kernel plans for some large 1D problem sizes, on devices with at least 160KiB of LDS.
 
 ### Resolved issues
 
-* Fixed kernel faults on multi-device transforms that gather to a single device, when the input/output bricks are not 
+* Fixed kernel faults on multi-device transforms that gather to a single device, when the input/output bricks are not
   contiguous.
 
 ## rocFFT 1.0.32 for ROCm 6.4.0

--- a/projects/rocfft/clients/tests/multi_device_test.cpp
+++ b/projects/rocfft/clients/tests/multi_device_test.cpp
@@ -32,7 +32,15 @@ extern int                    mp_ranks;
 static const std::vector<std::vector<size_t>> multi_gpu_sizes = {
     {256},
     {256, 256},
+    {256, 1},
+    {1, 256},
     {256, 256, 256},
+    {256, 256, 1},
+    {256, 1, 256},
+    {1, 256, 256},
+    {256, 1, 1},
+    {1, 1, 256},
+    {1, 256, 1},
 };
 static const std::vector<size_t>        multi_gpu_batch_range = {4, 1};
 static std::vector<std::vector<size_t>> ioffset_range_zero    = {{0, 0}};
@@ -218,6 +226,15 @@ std::vector<fft_params> param_generator_multi_gpu(const SplitType type, const in
             default:
                 throw std::invalid_argument("param_generator_multi_gpu: unkonwn split type");
             }
+
+            bool too_short_lengths = false;
+            for(size_t dim = 0; !too_short_lengths && dim < p.length.size(); dim++)
+                too_short_lengths
+                    |= p.length[dim] < input_grid[dim + 1] || p.length[dim] < output_grid[dim + 1];
+            if(too_short_lengths)
+                continue;
+            if(mp_lib == fft_params::fft_mp_lib_mpi && p_dist.is_real() && p.length.back() == 1)
+                continue; // known issues to fix in mpi_worker.h
 
             p_dist.mp_lib = mp_lib;
             p_dist.distribute_field<fft_io::fft_io_in>(

--- a/projects/rocfft/library/src/CMakeLists.txt
+++ b/projects/rocfft/library/src/CMakeLists.txt
@@ -231,6 +231,7 @@ add_custom_command(
 # The following is a list of implementation files defining the library
 set( rocfft_source
   auxiliary.cpp
+  data_layout.cpp
   plan.cpp
   transform.cpp
   repo.cpp

--- a/projects/rocfft/library/src/data_layout.cpp
+++ b/projects/rocfft/library/src/data_layout.cpp
@@ -46,12 +46,17 @@ namespace
     }
 }
 
-std::string to_str(const io_data_label& io)
+std::string to_str(io_data_label io)
 {
-    if(io != io_data_label::INPUT && io != io_data_label::OUTPUT)
+    switch(io)
+    {
+    case io_data_label::INPUT:
+        return "input";
+    case io_data_label::OUTPUT:
+        return "output";
+    default:
         throw std::invalid_argument("Unknown io data label given to " + ROCFFT_CURRENT_FUNCTION);
-    return io == io_data_label::INPUT ? std::string{io_label_str<io_data_label::INPUT>::str}
-                                      : std::string{io_label_str<io_data_label::OUTPUT>::str};
+    }
 }
 
 #define IO_DATA_LAYOUT_ACCESSOR_BODY(AXIS_IDX)                                        \

--- a/projects/rocfft/library/src/data_layout.cpp
+++ b/projects/rocfft/library/src/data_layout.cpp
@@ -1,0 +1,528 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "data_layout.h"
+#include "../../shared/arithmetic.h"
+#include "../../shared/ptrdiff.h"
+#include "rocfft_current_function.h"
+
+#include <algorithm>
+#include <iterator>
+#include <numeric>
+#include <stdexcept>
+
+namespace
+{
+    std::vector<size_t> concatenate(const std::vector<size_t>& a, const std::vector<size_t>& b)
+    {
+        auto ret = a;
+        std::copy(b.begin(), b.end(), std::back_inserter(ret));
+        return ret;
+    }
+    std::vector<size_t> concatenate(const std::vector<size_t>& a, const size_t& b)
+    {
+        auto ret = a;
+        ret.push_back(b);
+        return ret;
+    }
+}
+
+std::string to_str(const io_data_label& io)
+{
+    if(io != io_data_label::INPUT && io != io_data_label::OUTPUT)
+        throw std::invalid_argument("Unknown io data label given to " + ROCFFT_CURRENT_FUNCTION);
+    return io == io_data_label::INPUT ? std::string{io_label_str<io_data_label::INPUT>::str}
+                                      : std::string{io_label_str<io_data_label::OUTPUT>::str};
+}
+
+#define IO_DATA_LAYOUT_ACCESSOR_BODY(AXIS_IDX)                                        \
+    do                                                                                \
+    {                                                                                 \
+        if(AXIS_IDX >= get_full_rank())                                               \
+            throw std::invalid_argument(ROCFFT_CURRENT_FUNCTION                       \
+                                        + " accessing an out-of-range layout axis."); \
+        return AXIS_IDX < len_axes.size() ? len_axes[AXIS_IDX]                        \
+                                          : batch_axes[AXIS_IDX - len_axes.size()];   \
+    } while(0)
+
+const data_layout_t::axis_t& data_layout_t::operator[](size_t axis_idx) const
+{
+    IO_DATA_LAYOUT_ACCESSOR_BODY(axis_idx);
+}
+
+data_layout_t::axis_t& data_layout_t::operator[](size_t axis_idx)
+{
+    IO_DATA_LAYOUT_ACCESSOR_BODY(axis_idx);
+}
+
+data_layout_t::data_layout_t(const std::vector<size_t>& lower,
+                             const std::vector<size_t>& upper,
+                             const std::vector<size_t>& strides,
+                             size_t                     batch_rank,
+                             bool                       is_partial)
+    : len_axes(batch_rank < lower.size() ? lower.size() - batch_rank : 0)
+    , batch_axes(batch_rank)
+{
+    if(get_batch_rank() == 0 || get_len_rank() == 0)
+        throw std::invalid_argument(
+            ROCFFT_CURRENT_FUNCTION
+            + " does not accept 0-dimensional length or batch coordinates.");
+    if(lower.size() != upper.size() || lower.size() != strides.size())
+        throw std::invalid_argument(
+            ROCFFT_CURRENT_FUNCTION
+            + " requires lower, upper, and strides to be of the same size.");
+
+    for(size_t dim = 0; dim < lower.size(); dim++)
+    {
+        if(lower[dim] > upper[dim])
+        {
+            throw std::invalid_argument(
+                ROCFFT_CURRENT_FUNCTION
+                + " detected an invalid range of logical indices along layout axis "
+                + std::to_string(dim) + ": lower (" + std::to_string(lower[dim])
+                + ") is larger than upper (" + std::to_string(upper[dim]) + ").");
+        }
+        if(!is_partial && lower[dim] != 0)
+            throw std::invalid_argument(ROCFFT_CURRENT_FUNCTION
+                                        + " requires the logical range's lower bounds to be 0 for "
+                                          "non-partial data layouts (lower["
+                                        + std::to_string(dim) + "] is " + std::to_string(lower[dim])
+                                        + ").");
+
+        (*this)[dim].lower           = lower[dim];
+        (*this)[dim].upper           = upper[dim];
+        (*this)[dim].inbuffer_stride = strides[dim];
+        (*this)[dim].is_partial      = is_partial;
+    }
+}
+
+data_layout_t::data_layout_t(const std::vector<size_t>& lengths,
+                             const std::vector<size_t>& strides,
+                             const std::vector<size_t>& batches,
+                             const std::vector<size_t>& distances)
+    : data_layout_t(std::vector<size_t>(lengths.size() + batches.size(), 0),
+                    concatenate(lengths, batches),
+                    concatenate(strides, distances),
+                    batches.size(),
+                    false /* : is_partial */)
+{
+    // If successful, the constructor delegation used above is fine iff
+    if(strides.size() != lengths.size() || distances.size() != batches.size())
+        throw std::invalid_argument(ROCFFT_CURRENT_FUNCTION
+                                    + " requires strides (resp. distances) and lengths (resp. "
+                                      "batches) to be of the same size.");
+}
+
+data_layout_t::data_layout_t(const std::vector<size_t>& lengths,
+                             const std::vector<size_t>& strides,
+                             size_t                     batch,
+                             size_t                     distance)
+    : data_layout_t(std::vector<size_t>(lengths.size() + 1, 0),
+                    concatenate(lengths, batch),
+                    concatenate(strides, distance),
+                    1,
+                    false /* : is_partial */)
+{
+}
+
+data_layout_t::data_layout_t(const std::vector<size_t>& lengths,
+                             const std::vector<size_t>& batches,
+                             bool                       real_case_with_padding)
+{
+    const std::vector<size_t> empty_for_default_strides_and_dist = {};
+    reset(lengths,
+          empty_for_default_strides_and_dist,
+          batches,
+          empty_for_default_strides_and_dist,
+          real_case_with_padding);
+}
+
+data_layout_t::data_layout_t(const std::vector<size_t>& lengths,
+                             size_t                     batch,
+                             bool                       real_case_with_padding)
+    : data_layout_t(lengths, std::vector<size_t>(1, batch), real_case_with_padding)
+{
+}
+
+size_t data_layout_t::get_len_rank() const
+{
+    return len_axes.size();
+}
+
+size_t data_layout_t::get_batch_rank() const
+{
+    return batch_axes.size();
+}
+size_t data_layout_t::get_full_rank() const
+{
+    return len_axes.size() + batch_axes.size();
+}
+
+std::vector<size_t> data_layout_t::lengths_and_batches() const
+{
+    std::vector<size_t> ret(get_full_rank());
+    for(size_t dim = 0; dim < get_full_rank(); dim++)
+        ret[dim] = (*this)[dim].logical_span();
+
+    return ret;
+}
+
+std::vector<size_t> data_layout_t::strides_and_distances() const
+{
+    std::vector<size_t> ret(get_full_rank());
+    for(size_t dim = 0; dim < get_full_rank(); dim++)
+        ret[dim] = (*this)[dim].inbuffer_stride;
+
+    return ret;
+}
+
+std::vector<size_t> data_layout_t::contiguous_strides_and_distances() const
+{
+    if(is_contiguous())
+    {
+        // a layout may be "contiguous" even if not ordered by increasing strides, e.g.,
+        // lower := {0, 0}, upper := {a, b} and strides := {b, 1} is continuous...
+        return strides_and_distances();
+    }
+
+    std::vector<size_t> ret(get_full_rank(), 1);
+    for(size_t dim = 1; dim < get_full_rank(); dim++)
+        ret[dim] = ret[dim - 1] * (*this)[dim - 1].logical_span();
+
+    return ret;
+}
+
+std::vector<size_t> data_layout_t::lengths() const
+{
+    std::vector<size_t> ret(len_axes.size());
+    for(size_t dim = 0; dim < len_axes.size(); dim++)
+        ret[dim] = len_axes[dim].logical_span();
+
+    return ret;
+}
+
+std::vector<size_t> data_layout_t::strides() const
+{
+    std::vector<size_t> ret(len_axes.size());
+    for(size_t dim = 0; dim < len_axes.size(); dim++)
+        ret[dim] = len_axes[dim].inbuffer_stride;
+
+    return ret;
+}
+
+std::vector<size_t> data_layout_t::batches() const
+{
+    std::vector<size_t> ret(batch_axes.size());
+    for(size_t dim = 0; dim < batch_axes.size(); dim++)
+        ret[dim] = batch_axes[dim].logical_span();
+
+    return ret;
+}
+
+std::vector<size_t> data_layout_t::distances() const
+{
+    std::vector<size_t> ret(batch_axes.size());
+    for(size_t dim = 0; dim < batch_axes.size(); dim++)
+        ret[dim] = batch_axes[dim].inbuffer_stride;
+
+    return ret;
+}
+
+size_t data_layout_t::batch() const
+{
+    if(batch_axes.size() != 1)
+        throw std::logic_error(ROCFFT_CURRENT_FUNCTION
+                               + " is restricted to data layouts with only one batch axis.");
+    return batch_axes[0].logical_span();
+}
+
+size_t data_layout_t::distance() const
+{
+    if(batch_axes.size() != 1)
+        throw std::logic_error(ROCFFT_CURRENT_FUNCTION
+                               + " is restricted to data layouts with only one batch axis.");
+    return batch_axes[0].inbuffer_stride;
+}
+
+std::vector<size_t> data_layout_t::upper() const
+{
+    std::vector<size_t> ret(get_full_rank());
+    for(size_t dim = 0; dim < get_full_rank(); dim++)
+        ret[dim] = (*this)[dim].upper;
+
+    return ret;
+}
+
+std::vector<size_t> data_layout_t::lower() const
+{
+    std::vector<size_t> ret(get_full_rank());
+    for(size_t dim = 0; dim < get_full_rank(); dim++)
+        ret[dim] = (*this)[dim].lower;
+
+    return ret;
+}
+
+bool data_layout_t::is_empty() const
+{
+    bool ret = len_axes.empty() || batch_axes.empty();
+    for(size_t dim = 0; !ret && dim < get_full_rank(); dim++)
+        ret |= (*this)[dim].logical_span() == 0;
+    return ret;
+}
+
+size_t data_layout_t::logical_count() const
+{
+    auto len_and_batches = lengths_and_batches();
+    return product(len_and_batches.begin(), len_and_batches.end());
+}
+
+size_t data_layout_t::buffer_element_count() const
+{
+    return compute_ptrdiff(lengths_and_batches(), strides_and_distances());
+}
+
+bool data_layout_t::is_contiguous() const
+{
+    return buffer_element_count() == logical_count();
+}
+
+bool data_layout_t::operator==(const data_layout_t& other) const
+{
+    return len_axes == other.len_axes && batch_axes == other.batch_axes;
+}
+
+bool data_layout_t::has_same_logical_range_as(const data_layout_t& other) const
+{
+    if(!is_dimensionally_consistent_with(other))
+        throw std::invalid_argument(
+            "This object is not dimensionally consistent with the argument of "
+            + ROCFFT_CURRENT_FUNCTION);
+    bool ret = true;
+    for(size_t dim = 0; ret && dim < get_full_rank(); dim++)
+        ret &= (*this)[dim].has_same_logical_range_as(other[dim]);
+    return ret;
+}
+
+data_layout_t data_layout_t::make_contiguous_intersection_of(const data_layout_t& first,
+                                                             const data_layout_t& second)
+{
+    if(!first.is_dimensionally_consistent_with(second))
+        throw std::invalid_argument("Dimensionally-inconsistent arguments for "
+                                    + ROCFFT_CURRENT_FUNCTION);
+
+    data_layout_t ret;
+    ret.len_axes.resize(first.len_axes.size());
+    ret.batch_axes.resize(first.batch_axes.size());
+    for(size_t dim = 0; dim < first.get_full_rank(); dim++)
+    {
+        ret[dim].lower = std::max(first[dim].lower, second[dim].lower);
+        ret[dim].upper = std::max(std::min(first[dim].upper, second[dim].upper), ret[dim].lower);
+        ret[dim].is_partial = first[dim].is_partial || second[dim].is_partial
+                              || !first[dim].has_same_logical_range_as(second[dim]);
+        if(dim == 0)
+            ret[dim].inbuffer_stride = 1;
+        else
+            ret[dim].inbuffer_stride = ret[dim - 1].inbuffer_stride * ret[dim - 1].logical_span();
+    }
+    return ret;
+}
+
+std::vector<size_t> data_layout_t::length_axes_by_increasing_strides(bool pin_innermost_axis) const
+{
+    std::vector<size_t> ret(get_len_rank(), 0);
+    if(ret.size() <= 1)
+        return ret;
+    std::iota(ret.begin(), ret.end(), 0);
+    if(ret.size() == 2 && pin_innermost_axis)
+        return ret;
+    std::sort(ret.begin() + (pin_innermost_axis ? 1 : 0),
+              ret.end(),
+              [this](size_t dim_idx_i, size_t dim_idx_j) {
+                  return len_axes[dim_idx_i].inbuffer_stride < len_axes[dim_idx_j].inbuffer_stride;
+              });
+    return ret;
+}
+
+void data_layout_t::reorder_length_axes(const std::vector<size_t>& len_axis_order)
+{
+    std::vector<size_t> current_order(get_len_rank(), 0);
+    std::iota(current_order.begin(), current_order.end(), 0);
+    if(!std::is_permutation(len_axis_order.begin(),
+                            len_axis_order.end(),
+                            current_order.begin(),
+                            current_order.end()))
+    {
+        throw std::invalid_argument("Invalid re-ordering of length axes requested to "
+                                    + ROCFFT_CURRENT_FUNCTION);
+    }
+    if(current_order != len_axis_order) // nothing to do otherwise
+    {
+        const auto len_axis_copy = len_axes;
+        for(size_t dim = 0; dim < get_len_rank(); dim++)
+            len_axes[dim] = len_axis_copy[len_axis_order[dim]];
+    }
+}
+
+size_t data_layout_t::slowest_varying_axis() const
+{
+    size_t ret = 0;
+    for(size_t dim = 1; dim < get_full_rank(); dim++)
+    {
+        if((*this)[dim].logical_span() == 1)
+            continue; // irrelevant unit length
+        if((*this)[ret].logical_span() == 1 /*current max is irrelevant (unit length)*/
+           || (*this)[ret].inbuffer_stride < (*this)[dim].inbuffer_stride)
+        {
+            ret = dim;
+        }
+    }
+    return ret;
+}
+
+size_t data_layout_t::offset_in(const data_layout_t& other) const
+{
+    if(!is_dimensionally_consistent_with(other))
+        throw std::invalid_argument(
+            "This object is not dimensionally consistent with the argument of "
+            + ROCFFT_CURRENT_FUNCTION);
+    for(size_t dim = 0; dim < get_full_rank(); dim++)
+        if(!other[dim].logically_contains((*this)[dim].lower))
+            throw std::invalid_argument(
+                ROCFFT_CURRENT_FUNCTION
+                + " requires this object's lower coordinate to be included in other.");
+
+    size_t offset = 0;
+    for(size_t dim = 0; dim < get_full_rank(); dim++)
+        offset += other[dim].inbuffer_stride * ((*this)[dim].lower - other[dim].lower);
+
+    return offset;
+}
+
+bool data_layout_t::is_continuous_in(const data_layout_t& other) const
+{
+    if(!is_dimensionally_consistent_with(other))
+        throw std::invalid_argument(
+            "This object is not dimensionally consistent with the argument of "
+            + ROCFFT_CURRENT_FUNCTION);
+
+    bool ret = true;
+    for(size_t dim = 0; ret && dim < get_full_rank(); dim++)
+    {
+        if(dim == other.slowest_varying_axis())
+        {
+            ret &= other[dim].logically_contains((*this)[dim]);
+            if((*this)[dim].logical_span() > 1)
+                ret &= (*this)[dim].inbuffer_stride == other[dim].inbuffer_stride;
+        }
+        else
+            ret &= other[dim] == (*this)[dim];
+    }
+    return ret;
+}
+
+std::string data_layout_t::str() const
+{
+    std::string ret;
+    ret += "lower";
+    for(const auto& l : lower())
+    {
+        ret += " ";
+        ret += std::to_string(l);
+    }
+
+    ret += " upper";
+    for(const auto& u : upper())
+    {
+        ret += " ";
+        ret += std::to_string(u);
+    }
+
+    ret += " stride";
+    for(const auto& s_or_d : strides_and_distances())
+    {
+        ret += " ";
+        ret += std::to_string(s_or_d);
+    }
+    return ret;
+}
+
+void data_layout_t::clear()
+{
+    len_axes.clear();
+    batch_axes.clear();
+}
+
+void data_layout_t::reset(const std::vector<size_t>& lengths,
+                          const std::vector<size_t>& strides,
+                          const std::vector<size_t>& batches,
+                          const std::vector<size_t>& distances,
+                          bool                       real_case_with_padding)
+{
+    if(lengths.empty() || batches.empty())
+        throw std::invalid_argument(ROCFFT_CURRENT_FUNCTION
+                                    + " requires non-empty lengths and batches");
+    if(!strides.empty() && strides.size() != lengths.size())
+        throw std::invalid_argument(
+            ROCFFT_CURRENT_FUNCTION
+            + " requires strides to be of the same size as lengths if not empty.");
+    if(!distances.empty() && distances.size() != batches.size())
+        throw std::invalid_argument(
+            ROCFFT_CURRENT_FUNCTION
+            + " requires distances to be of the same size as batches if not empty.");
+    clear();
+    len_axes.resize(lengths.size());
+    batch_axes.resize(batches.size());
+    for(size_t dim = 0; dim < get_full_rank(); dim++)
+    {
+        (*this)[dim].is_partial = false;
+        (*this)[dim].lower      = 0;
+        (*this)[dim].upper = dim < lengths.size() ? lengths[dim] : batches[dim - lengths.size()];
+        const bool set_default_axis_stride = (dim < lengths.size() && strides.empty())
+                                             || (dim >= lengths.size() && distances.empty());
+        if(dim == 0)
+        {
+            if(set_default_axis_stride)
+                (*this)[dim].inbuffer_stride = 1;
+            else
+            {
+                // dim == 0 cannot be a batch axis as empty lengths are not accepted
+                (*this)[dim].inbuffer_stride = strides[dim];
+            }
+        }
+        else if(real_case_with_padding && dim == 1 && set_default_axis_stride)
+            (*this)[dim].inbuffer_stride
+                = 2 * (lengths[dim - 1] / 2 + 1) * (*this)[dim - 1].inbuffer_stride;
+        else
+        {
+            if(set_default_axis_stride)
+                (*this)[dim].inbuffer_stride
+                    = (*this)[dim - 1].inbuffer_stride * (*this)[dim - 1].logical_span();
+            else if(dim < lengths.size())
+                (*this)[dim].inbuffer_stride = strides[dim];
+            else
+                (*this)[dim].inbuffer_stride = distances[dim - lengths.size()];
+        }
+    }
+}
+
+bool data_layout_t::is_dimensionally_consistent_with(const data_layout_t& other) const
+{
+    return get_batch_rank() == other.get_batch_rank() && get_len_rank() == other.get_len_rank();
+}

--- a/projects/rocfft/library/src/data_layout.cpp
+++ b/projects/rocfft/library/src/data_layout.cpp
@@ -113,54 +113,6 @@ data_layout_t::data_layout_t(const std::vector<size_t>& lower,
     }
 }
 
-data_layout_t::data_layout_t(const std::vector<size_t>& lengths,
-                             const std::vector<size_t>& strides,
-                             const std::vector<size_t>& batches,
-                             const std::vector<size_t>& distances)
-    : data_layout_t(std::vector<size_t>(lengths.size() + batches.size(), 0),
-                    concatenate(lengths, batches),
-                    concatenate(strides, distances),
-                    batches.size(),
-                    false /* : is_partial */)
-{
-    // If successful, the constructor delegation used above is fine iff
-    if(strides.size() != lengths.size() || distances.size() != batches.size())
-        throw std::invalid_argument(ROCFFT_CURRENT_FUNCTION
-                                    + " requires strides (resp. distances) and lengths (resp. "
-                                      "batches) to be of the same size.");
-}
-
-data_layout_t::data_layout_t(const std::vector<size_t>& lengths,
-                             const std::vector<size_t>& strides,
-                             size_t                     batch,
-                             size_t                     distance)
-    : data_layout_t(std::vector<size_t>(lengths.size() + 1, 0),
-                    concatenate(lengths, batch),
-                    concatenate(strides, distance),
-                    1,
-                    false /* : is_partial */)
-{
-}
-
-data_layout_t::data_layout_t(const std::vector<size_t>& lengths,
-                             const std::vector<size_t>& batches,
-                             bool                       real_case_with_padding)
-{
-    const std::vector<size_t> empty_for_default_strides_and_dist = {};
-    reset(lengths,
-          empty_for_default_strides_and_dist,
-          batches,
-          empty_for_default_strides_and_dist,
-          real_case_with_padding);
-}
-
-data_layout_t::data_layout_t(const std::vector<size_t>& lengths,
-                             size_t                     batch,
-                             bool                       real_case_with_padding)
-    : data_layout_t(lengths, std::vector<size_t>(1, batch), real_case_with_padding)
-{
-}
-
 size_t data_layout_t::get_len_rank() const
 {
     return len_axes.size();
@@ -469,11 +421,11 @@ void data_layout_t::clear()
     batch_axes.clear();
 }
 
-void data_layout_t::reset(const std::vector<size_t>& lengths,
-                          const std::vector<size_t>& strides,
-                          const std::vector<size_t>& batches,
-                          const std::vector<size_t>& distances,
-                          bool                       real_case_with_padding)
+void data_layout_t::full_range_reset(const std::vector<size_t>& lengths,
+                                     const std::vector<size_t>& strides,
+                                     const std::vector<size_t>& batches,
+                                     const std::vector<size_t>& distances,
+                                     bool                       real_case_with_padding)
 {
     if(lengths.empty() || batches.empty())
         throw std::invalid_argument(ROCFFT_CURRENT_FUNCTION

--- a/projects/rocfft/library/src/data_layout.cpp
+++ b/projects/rocfft/library/src/data_layout.cpp
@@ -30,13 +30,15 @@
 
 namespace
 {
-    std::vector<size_t> concatenate(const std::vector<size_t>& a, const std::vector<size_t>& b)
+    template <typename T>
+    std::vector<T> concatenate(const std::vector<T>& a, const std::vector<T>& b)
     {
         auto ret = a;
         std::copy(b.begin(), b.end(), std::back_inserter(ret));
         return ret;
     }
-    std::vector<size_t> concatenate(const std::vector<size_t>& a, const size_t& b)
+    template <typename T>
+    std::vector<T> concatenate(const std::vector<T>& a, const T& b)
     {
         auto ret = a;
         ret.push_back(b);

--- a/projects/rocfft/library/src/include/data_layout.h
+++ b/projects/rocfft/library/src/include/data_layout.h
@@ -25,7 +25,6 @@
 
 #include <cstring>
 #include <string>
-#include <string_view>
 #include <vector>
 
 // Label distinguishing between input and output data layouts where or
@@ -36,14 +35,6 @@ enum class io_data_label
     OUTPUT
 };
 
-// Convenience labeling strings, e.g., for constructing exceptions' info
-template <io_data_label io>
-struct io_label_str
-{
-    static_assert(io == io_data_label::INPUT || io == io_data_label::OUTPUT);
-    static constexpr std::string_view str = io == io_data_label::INPUT ? "input" : "output";
-};
-
 /**
  * @return An `std::string` of value "input" (resp. "output") if `io` is
  * `io_data_label::INPUT` (resp. `io_data_label::OUTPUT`).
@@ -51,7 +42,7 @@ struct io_label_str
  * @throw An `std::invalid_argument` is thrown if `io` is not `io_data_label::INPUT`
  * nor `io_data_label::OUTPUT`.
  */
-std::string to_str(const io_data_label& io);
+std::string to_str(io_data_label io);
 
 /**
  * @brief Helper structure encapsulating the details pertaining to the description

--- a/projects/rocfft/library/src/include/data_layout.h
+++ b/projects/rocfft/library/src/include/data_layout.h
@@ -105,78 +105,6 @@ struct data_layout_t
                   bool                       is_partial = true);
 
     /**
-     * @brief Construct a new `data_layout_t` object implicitly capturing a full
-     * range of logical indices.
-     * 
-     * @param[in] lengths spans of the logical index range along all length axes.
-     * @param[in] strides in-buffer strides associated with all length axes.
-     * @param[in] batches spans of the logical index range along all batch axes.
-     * @param[in] distances in-buffer strides associated with all batch axes.
-     * 
-     * @throw An `std::invalid_argument` is thrown if any of the following is detected:
-     * 
-     * - `lengths` or `strides` are empty or have different sizes;
-     * 
-     * - `batches` or `distances` are empty or have different sizes.
-     */
-    data_layout_t(const std::vector<size_t>& lengths,
-                  const std::vector<size_t>& strides,
-                  const std::vector<size_t>& batches,
-                  const std::vector<size_t>& distances);
-
-    /**
-     * @brief Construct a new `data_layout_t` object implicitly capturing a full
-     * range of logical indices with one batch axis.
-     * 
-     * @param[in] lengths spans of the logical index range along all length axes.
-     * @param[in] strides in-buffer strides associated with all length axes.
-     * @param[in] batch span of the logical index range along its batch axis.
-     * @param[in] distance in-buffer stride associated with the batch axis.
-     * 
-     * @throw An `std::invalid_argument` is thrown if `lengths` or `strides`
-     * are empty or have different sizes.
-     * 
-     */
-    data_layout_t(const std::vector<size_t>& lengths,
-                  const std::vector<size_t>& strides,
-                  size_t                     batch,
-                  size_t                     distance);
-
-    /**
-     * @brief Construct a new `data_layout_t` object implicitly capturing a full
-     * range of logical indices, with default in-buffer strides (enforcing in-buffer
-     * contiguity for the innermost length axis).
-     * 
-     * @param[in] lengths spans of the logical index range along all length axes.
-     * @param[in] batches spans of the logical index range along all batch axes.
-     * @param[in] real_case_with_padding flag setting the in-buffer stride of the
-     * layout's first non-contiguous axis to the value that is required in real
-     * domain for real, in-place Discrete Fourier Transforms.
-     * 
-     * @throw An `std::invalid_argument` is thrown if `lengths` or `batches` are empty.
-     */
-    data_layout_t(const std::vector<size_t>& lengths,
-                  const std::vector<size_t>& batches,
-                  bool                       real_case_with_padding = false);
-
-    /**
-     * @brief Construct a new `data_layout_t` object implicitly capturing a full
-     * range of logical indices with one batch axis, and default in-buffer strides
-     * (enforcing in-buffer contiguity for the innermost length axis).
-     * 
-     * @param[in] lengths spans of the logical index range along all length axes.
-     * @param[in] batch span of the logical index range along its batch axis.
-     * @param[in] real_case_with_padding flag setting the in-buffer stride of the
-     * layout's first non-contiguous axis to the value that is required in real
-     * domain for real, in-place Discrete Fourier Transforms.
-     * 
-     * @throw An `std::invalid_argument` is thrown if `lengths` is empty.
-     */
-    data_layout_t(const std::vector<size_t>& lengths,
-                  size_t                     batch,
-                  bool                       real_case_with_padding = false);
-
-    /**
      * @return The number of length axes.
      */
     size_t get_len_rank() const;
@@ -434,7 +362,7 @@ private:
     void reorder_length_axes(const std::vector<size_t>& len_axis_order);
 
     /**
-     * @brief Reset the object's state to to capture a full range of logical
+     * @brief Reset the object's state to capture a full range of logical
      * indices with either prescribed or default strides and/or distance.
      * 
      * @param[in] lengths spans of the logical index range along all length axes.
@@ -457,11 +385,11 @@ private:
      * - `strides` (resp. `distances`) is not empty and does not have the same
      * size as `lengths` (resp. `batches`).
      */
-    void reset(const std::vector<size_t>& lengths,
-               const std::vector<size_t>& strides,
-               const std::vector<size_t>& batches,
-               const std::vector<size_t>& distances,
-               bool                       real_case_with_padding);
+    void full_range_reset(const std::vector<size_t>& lengths,
+                          const std::vector<size_t>& strides,
+                          const std::vector<size_t>& batches,
+                          const std::vector<size_t>& distances,
+                          bool                       real_case_with_padding);
 
     // Friends that need access to private members and/or default constructor below.
     // -----------------------------------------------------------------------------

--- a/projects/rocfft/library/src/include/data_layout.h
+++ b/projects/rocfft/library/src/include/data_layout.h
@@ -108,11 +108,11 @@ struct data_layout_t
      */
     size_t get_full_rank() const;
     /**
-     * @return The spans of the logical index range along all its axes (length and batch).
+     * @return The spans of the logical index range along all its axes (length followed by batch axes).
      */
     std::vector<size_t> lengths_and_batches() const;
     /**
-     * @return The in-buffer strides associated with all (length and batch) axes.
+     * @return The in-buffer strides associated with all axes (length followed by batch axes).
      */
     std::vector<size_t> strides_and_distances() const;
     /**
@@ -330,8 +330,8 @@ private:
     axis_t&       operator[](size_t axis_idx);
 
     /**
-     * @return Flattened index of the layout's axis of largest stride
-     * (and non-trivial logical range)
+     * @return Flattened index of the layout's axis of largest in-buffer
+     * stride (and non-trivial logical range)
      */
     size_t slowest_varying_axis() const;
 
@@ -362,7 +362,8 @@ private:
      * the innermost length axis) are set.
      * @param[in] batches spans of the logical index range along all batch axes.
      * @param[in] distances in-buffer strides associated with all batch axes.
-     * If empty, default in-buffer strides are set.
+     * If empty, default in-buffer strides deduced from the last length axis are
+     * set.
      * @param[in] real_case_with_padding flag setting the in-buffer stride of the
      * layout's first non-contiguous axis to the value that is required in real
      * domain for real, in-place Discrete Fourier Transforms, if a default value

--- a/projects/rocfft/library/src/include/data_layout.h
+++ b/projects/rocfft/library/src/include/data_layout.h
@@ -1,0 +1,492 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef DATA_LAYOUT_H
+#define DATA_LAYOUT_H
+
+#include "rocfft/rocfft.h"
+
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Label distinguishing between input and output data layouts where or
+// when such distinction may be relevant.
+enum class io_data_label
+{
+    INPUT,
+    OUTPUT
+};
+
+// Convenience labeling strings, e.g., for constructing exceptions' info
+template <io_data_label io>
+struct io_label_str
+{
+    static_assert(io == io_data_label::INPUT || io == io_data_label::OUTPUT);
+    static constexpr std::string_view str = io == io_data_label::INPUT ? "input" : "output";
+};
+
+/**
+ * @return An `std::string` of value "input" (resp. "output") if `io` is
+ * `io_data_label::INPUT` (resp. `io_data_label::OUTPUT`).
+ * 
+ * @throw An `std::invalid_argument` is thrown if `io` is not `io_data_label::INPUT`
+ * nor `io_data_label::OUTPUT`.
+ */
+std::string to_str(const io_data_label& io);
+
+/**
+ * @brief Helper structure encapsulating the details pertaining to the description
+ * of data layouts mapping hyper-rectangular logical index ranges (full or partial)
+ * to locations ("offsets") within data allocations.
+ *
+ * The set of all logical coordinates in the data layout is defined as the
+ * Cartesian product between
+ * - the set of logical "length" coordinates;
+ * - the set of logical "batch" coordinates.
+ * Elements having different batch coordinates are considered strictly independent
+ * of one another.
+ * 
+ */
+struct data_layout_t
+{
+    /**
+     * @brief Construct a new `data_layout_t` object with explicit member values.
+     * 
+     * @param[in] lower lower bounds along all axes of the logical index range
+     * (lower bounds are included).
+     * @param[in] upper upper bounds along all axes of the logical index range
+     * (upper bounds are excluded).
+     * @param[in] strides in-buffer strides associated with all axes of the
+     * logical index range.
+     * @param[in] batch_rank number of batch axes in the logical index range.
+     * Default value is `1`.
+     * @param[in] is_partial flag indicating whether the constructed object covers
+     * a full data range (if `false`) or not (if `true`). Default value is `true`.
+     * 
+     * @note All vector arguments implicitly consider that length axes are listed
+     * first followed by `batch_rank` batch axes.
+     * 
+     * @throw An `std::invalid_argument` is thrown if any of the following is detected:
+     * 
+     * - the number of batch axes, i.e., `batch_rank`, or the (deduced) number of
+     * length axes is `0`;
+     * 
+     * - `lower`, `upper`, and/or `strides` do not have the same size;
+     * 
+     * - any element of `lower` is found strictly larger than the corresponding
+     *   element of `upper`;
+     * 
+     * - any element of `lower` is different than 0 yet `is_partial` is `false`.
+     * 
+     */
+    data_layout_t(const std::vector<size_t>& lower,
+                  const std::vector<size_t>& upper,
+                  const std::vector<size_t>& strides,
+                  size_t                     batch_rank = 1,
+                  bool                       is_partial = true);
+
+    /**
+     * @brief Construct a new `data_layout_t` object implicitly capturing a full
+     * range of logical indices.
+     * 
+     * @param[in] lengths spans of the logical index range along all length axes.
+     * @param[in] strides in-buffer strides associated with all length axes.
+     * @param[in] batches spans of the logical index range along all batch axes.
+     * @param[in] distances in-buffer strides associated with all batch axes.
+     * 
+     * @throw An `std::invalid_argument` is thrown if any of the following is detected:
+     * 
+     * - `lengths` or `strides` are empty or have different sizes;
+     * 
+     * - `batches` or `distances` are empty or have different sizes.
+     */
+    data_layout_t(const std::vector<size_t>& lengths,
+                  const std::vector<size_t>& strides,
+                  const std::vector<size_t>& batches,
+                  const std::vector<size_t>& distances);
+
+    /**
+     * @brief Construct a new `data_layout_t` object implicitly capturing a full
+     * range of logical indices with one batch axis.
+     * 
+     * @param[in] lengths spans of the logical index range along all length axes.
+     * @param[in] strides in-buffer strides associated with all length axes.
+     * @param[in] batch span of the logical index range along its batch axis.
+     * @param[in] distance in-buffer stride associated with the batch axis.
+     * 
+     * @throw An `std::invalid_argument` is thrown if `lengths` or `strides`
+     * are empty or have different sizes.
+     * 
+     */
+    data_layout_t(const std::vector<size_t>& lengths,
+                  const std::vector<size_t>& strides,
+                  size_t                     batch,
+                  size_t                     distance);
+
+    /**
+     * @brief Construct a new `data_layout_t` object implicitly capturing a full
+     * range of logical indices, with default in-buffer strides (enforcing in-buffer
+     * contiguity for the innermost length axis).
+     * 
+     * @param[in] lengths spans of the logical index range along all length axes.
+     * @param[in] batches spans of the logical index range along all batch axes.
+     * @param[in] real_case_with_padding flag setting the in-buffer stride of the
+     * layout's first non-contiguous axis to the value that is required in real
+     * domain for real, in-place Discrete Fourier Transforms.
+     * 
+     * @throw An `std::invalid_argument` is thrown if `lengths` or `batches` are empty.
+     */
+    data_layout_t(const std::vector<size_t>& lengths,
+                  const std::vector<size_t>& batches,
+                  bool                       real_case_with_padding = false);
+
+    /**
+     * @brief Construct a new `data_layout_t` object implicitly capturing a full
+     * range of logical indices with one batch axis, and default in-buffer strides
+     * (enforcing in-buffer contiguity for the innermost length axis).
+     * 
+     * @param[in] lengths spans of the logical index range along all length axes.
+     * @param[in] batch span of the logical index range along its batch axis.
+     * @param[in] real_case_with_padding flag setting the in-buffer stride of the
+     * layout's first non-contiguous axis to the value that is required in real
+     * domain for real, in-place Discrete Fourier Transforms.
+     * 
+     * @throw An `std::invalid_argument` is thrown if `lengths` is empty.
+     */
+    data_layout_t(const std::vector<size_t>& lengths,
+                  size_t                     batch,
+                  bool                       real_case_with_padding = false);
+
+    /**
+     * @return The number of length axes.
+     */
+    size_t get_len_rank() const;
+    /**
+     * @return The number of batch axes.
+     */
+    size_t get_batch_rank() const;
+    /**
+     * @return The total number of axes (length and batch axes).
+     */
+    size_t get_full_rank() const;
+    /**
+     * @return The spans of the logical index range along all its axes (length and batch).
+     */
+    std::vector<size_t> lengths_and_batches() const;
+    /**
+     * @return The in-buffer strides associated with all (length and batch) axes.
+     */
+    std::vector<size_t> strides_and_distances() const;
+    /**
+     * @return The upper bounds of the logical index range along all its axes (length and batch).
+     */
+    std::vector<size_t> upper() const;
+    /**
+     * @return The lower bounds of the logical index range along all its axes (length and batch).
+     */
+    std::vector<size_t> lower() const;
+    /**
+     * @return The spans of the logical index range along its length axes.
+     */
+    std::vector<size_t> lengths() const;
+    /**
+     * @return The in-buffer strides associated with length axes.
+     */
+    std::vector<size_t> strides() const;
+    /**
+     * @return The spans of the logical index range along its batch axes.
+     */
+    std::vector<size_t> batches() const;
+    /**
+     * @return The in-buffer strides associated with batch axes.
+     */
+    std::vector<size_t> distances() const;
+
+    /**
+     * @return The span of the logical index range along its (lone) batch axis.
+     * 
+     * @throw An `std::logic_error` is thrown if the object's number of batch axes is not 1.
+     */
+    size_t batch() const;
+
+    /**
+     * @return The in-buffer stride associated with the (lone) batch axis.
+     * 
+     * @throw An `std::logic_error` is thrown if the object's number of batch axes is not 1.
+     */
+    size_t distance() const;
+
+    /**
+     * @return `true` iff the logical index range is empty.
+     */
+    bool is_empty() const;
+
+    /**
+     * @return A vector of in-buffer strides that would make the data layout contiguous
+     * in memory. If the current layout is found to be contiguous, this object's in-buffer
+     * strides are returned unchanged. Otherwise, the returned values are such that the
+     * innermost layout axis is given a unit in-buffer stride.
+     */
+    std::vector<size_t> contiguous_strides_and_distances() const;
+
+    /**
+     * @param[in] other data layout which must be dimensionally consistent with this one
+     * (same number of length and batch axes) and must logically contain this layout's
+     * very first element.
+     * 
+     * @return The in-buffer offset for this layout's very first element in a buffer that
+     * observes the `other` data layout.
+     * 
+     * @throw An `std::invalid_argument` is thrown if `other` is not dimensionally consistent
+     * with this object or does not contain its very first element.
+     */
+    size_t offset_in(const data_layout_t& other) const;
+
+    /**
+     * @param[in] other data layout which must be dimensionally consistent with this one
+     * (same number of length and batch axes).
+     * 
+     * @return `true` iff this layout represents a continuous chunk of `other`, i.e., iff
+     * - both layouts have identical strides along all axes that have non-unit logical spans;
+     * - both layouts have identical logical index ranges along all axes except
+     *   for the `other`'s slowest-varying one;
+     * - this layout's logical range is contained by the `other` along its slowest-varying axis.
+     * 
+     * @throw An `std::invalid_argument` is thrown if `other` is not dimensionally consistent
+     * with this object.
+     */
+    bool is_continuous_in(const data_layout_t& other) const;
+
+    /**
+     * @return A string reporting this object's state.
+     */
+    std::string str() const;
+
+    /**
+     * @return The volume of this object's hyper-rectangular logical index range.
+     */
+    size_t logical_count() const;
+    /**
+     * @return The (minimum) number of elements required in a buffer to store the
+     * data layout described by this object.
+     */
+    size_t buffer_element_count() const;
+
+    /**
+     * @return `true` iff this object describes a contiguous data layout, i.e., iff all
+     * in-buffer elements between offset 0 and logical_count() (excluded) correspond
+     * to a distinct element in logical range.
+     */
+    bool is_contiguous() const;
+
+    /**
+     * @param[in] other data layout to be compared to this one.
+     * @return `true` iff this object and `other` are strictly identical.
+     */
+    bool operator==(const data_layout_t& other) const;
+
+    /**
+     * @param[in] other data layout which must be dimensionally consistent with this one
+     * (same number of length and batch axes).
+     * @return `true` iff all axes of either layout cover the same logical index range.
+     * 
+     * @throw An `std::invalid_argument` is thrown if `other` is not dimensionally consistent
+     * with this object.
+     */
+    bool has_same_logical_range_as(const data_layout_t& other) const;
+
+    /**
+     * @param[in] first a data_layout_t object
+     * @param[in] second a data_layout_t object that's dimensionally consistent with `first`
+     * @return A data_layout_t object capturing the intersection of the logical ranges
+     * between `first` and `second`. The in-buffer strides of the constructed intersection
+     * are set to their default contiguous values.
+     * 
+     * @throw An `std::invalid_argument` is thrown if `first` and `second` are not
+     * dimensionally consistent.
+     */
+    static data_layout_t make_contiguous_intersection_of(const data_layout_t& first,
+                                                         const data_layout_t& second);
+
+    /**
+     * @param[in] other data layout against which ranks are to be compared
+     * @return `true` if this data layout is dimensionally consistent with `other` 
+     */
+    bool is_dimensionally_consistent_with(const data_layout_t& other) const;
+
+    /**
+     * @brief Reports the order of length axis indices if sorting them by increasing
+     * in-buffer strides (possibly pinning the innermost axis).
+     * 
+     * @param[in] pin_innermost_axis flag enforcing the front element of the returned
+     * vector to be 0 regardless of the actual stride associated with the innermost
+     * length axis.
+     * @return A vector `v` that's a permutation of `{0, 1, ..., get_len_rank() - 1}`
+     * and such that `len_axes[v[i]].stride` is no greater than `len_axes[v[j]].stride`
+     * if `i` < `j` (excluding `i == 0` and `j == 0` if `pin_innermost_axis` is true)
+     */
+    std::vector<size_t> length_axes_by_increasing_strides(bool pin_innermost_axis) const;
+
+    //-------------------------------------------------------------------------
+    //                        DEFAULT COPIES AND MOVES
+    //-------------------------------------------------------------------------
+
+    data_layout_t(const data_layout_t&) = default;
+    data_layout_t& operator=(const data_layout_t&) = default;
+    data_layout_t(data_layout_t&&)                 = default;
+    data_layout_t& operator=(data_layout_t&&) = default;
+
+    // Prevent ill-defined objects as much as possible by privatizing
+    // content-modifying members and default constructor.
+private:
+    struct axis_t
+    {
+        size_t lower;
+        size_t upper;
+        size_t inbuffer_stride;
+        bool   is_partial;
+
+        inline bool has_same_logical_range_as(const axis_t& other) const
+        {
+            return lower == other.lower && upper == other.upper;
+        }
+        inline size_t logical_span() const
+        {
+            return upper - lower;
+        }
+        inline bool operator==(const axis_t& other) const
+        {
+            // stride is irrelevant when comparing two layout's axes of unit logical range
+            return has_same_logical_range_as(other) && is_partial == other.is_partial
+                   && (logical_span() == 1 || inbuffer_stride == other.inbuffer_stride);
+        }
+        inline bool logically_contains(const size_t& coordinate) const
+        {
+            return lower <= coordinate && coordinate < upper;
+        }
+
+        inline bool logically_contains(const axis_t& other) const
+        {
+            return logically_contains(other.lower) && logically_contains(other.upper - 1);
+        }
+        inline bool empty() const
+        {
+            return lower == upper;
+        }
+    };
+
+    data_layout_t() = default;
+
+    std::vector<axis_t> len_axes;
+    std::vector<axis_t> batch_axes;
+
+    /**
+     * @brief Implementation-simplifying helper accessor for the length and batch
+     * axes of the layout.
+     * 
+     * @param[in] axis_idx flattened axis index in [0, get_full_rank() [
+     * @return `len_axes[axis_idx]` if `axis_idx < get_len_rank()`,
+     * `batch_axes[axis_idx - get_len_rank()]` otherwise.
+     */
+    const axis_t& operator[](size_t axis_idx) const;
+    axis_t&       operator[](size_t axis_idx);
+
+    /**
+     * @return Flattened index of the layout's axis of largest stride
+     * (and non-trivial logical range)
+     */
+    size_t slowest_varying_axis() const;
+
+    /**
+     * @brief Empty all layout axes.
+     */
+    void clear();
+
+    /**
+     * @brief Shuffles the length axes of this layout such that, upon
+     * return, `len_axes[dim]` is the former `len_axes[len_axis_order[dim]]`
+     * 
+     * @param[in] len_axis_order a vector that is a permutation of
+     * `{0, 1, ..., get_len_rank() - 1}`
+     *
+     * @throw An `std::invalid_argument` is thrown if `len_axis_order`
+     * is not a permutation of `{0, 1, ..., get_len_rank() - 1}`.
+     */
+    void reorder_length_axes(const std::vector<size_t>& len_axis_order);
+
+    /**
+     * @brief Reset the object's state to to capture a full range of logical
+     * indices with either prescribed or default strides and/or distance.
+     * 
+     * @param[in] lengths spans of the logical index range along all length axes.
+     * @param[in] strides in-buffer strides associated with all length axes.
+     * If empty, default in-buffer strides (enforcing in-buffer contiguity for
+     * the innermost length axis) are set.
+     * @param[in] batches spans of the logical index range along all batch axes.
+     * @param[in] distances in-buffer strides associated with all batch axes.
+     * If empty, default in-buffer strides are set.
+     * @param[in] real_case_with_padding flag setting the in-buffer stride of the
+     * layout's first non-contiguous axis to the value that is required in real
+     * domain for real, in-place Discrete Fourier Transforms, if a default value
+     * must be set. This flag is this irrelevant if `strides.size() > 1` or if
+     * `lengths.size() == 1 && !distances.empty()`.
+     * 
+     * @throw An `std::invalid_argument` is thrown if any of the following is detected:
+     * 
+     * - `lengths` or `batches` is empty;
+     * 
+     * - `strides` (resp. `distances`) is not empty and does not have the same
+     * size as `lengths` (resp. `batches`).
+     */
+    void reset(const std::vector<size_t>& lengths,
+               const std::vector<size_t>& strides,
+               const std::vector<size_t>& batches,
+               const std::vector<size_t>& distances,
+               bool                       real_case_with_padding);
+
+    // Friends that need access to private members and/or default constructor below.
+    // -----------------------------------------------------------------------------
+    // Strides/distances are set by users via descriptions before even knowing the
+    // lengths/ranges
+    friend rocfft_status rocfft_plan_description_set_data_layout(rocfft_plan_description,
+                                                                 const rocfft_array_type,
+                                                                 const rocfft_array_type,
+                                                                 const size_t*,
+                                                                 const size_t*,
+                                                                 const size_t,
+                                                                 const size_t*,
+                                                                 const size_t,
+                                                                 const size_t,
+                                                                 const size_t*,
+                                                                 const size_t);
+    // Descriptions need access to private members to
+    // - complete the definitions data layouts once the lengths (full logical ranges) are known;
+    // - remove trivial axes (of unit logical range) from full and partial layouts upon finalization;
+    // - possibly re-order relevant layouts' length axes by increasing in-buffer strides.
+    friend struct rocfft_plan_description_t;
+    // Fields set the `is_partial` flags for axes of its bricks that are found to span the
+    // entire range of logical indices in the corresponding full layout's length or batch
+    // axes (upon field finalization)
+    friend struct rocfft_field_t;
+};
+
+#endif // DATA_LAYOUT_H

--- a/projects/rocfft/library/src/include/plan.h
+++ b/projects/rocfft/library/src/include/plan.h
@@ -301,6 +301,13 @@ struct rocfft_plan_t
     // after the space requirements are finalized.
     void AllocateInternalTempBuffers();
 
+    /**
+     * @return The lengths provided by the user at creation of this object
+     * @note Trivial unit-length dimensions are erased at plan creation,
+     * therefore *NOT* returned by this function.
+     */
+    std::vector<size_t> get_user_facing_lengths() const;
+
 private:
     // Multi-node or multi-GPU plan is built up from a vector of plan
     // items.  Items can launch kernels on a device, or move

--- a/projects/rocfft/library/src/include/plan.h
+++ b/projects/rocfft/library/src/include/plan.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "../../../shared/array_predicate.h"
+#include "data_layout.h"
 #include "function_pool.h"
 #include "load_store_ops.h"
 #include "rocfft_mpi.h"
@@ -65,73 +66,33 @@ static inline bool IsPow(size_t u)
 
 struct rocfft_brick_t
 {
-    // all vectors here are column-major, with same length as FFT
-    // dimension + 1 (for batch dimension)
-    rocfft_brick_t(const size_t*            field_lower,
-                   const size_t*            field_upper,
-                   const size_t*            brick_stride,
-                   size_t                   dim,
-                   const rocfft_location_t& location)
-        : lower(field_lower, field_lower + dim)
-        , upper(field_upper, field_upper + dim)
-        , stride(brick_stride, brick_stride + dim)
+    // no default constructor
+    rocfft_brick_t() = delete;
+    // default move and copy constructors
+    rocfft_brick_t(const rocfft_brick_t&) = default;
+    rocfft_brick_t& operator=(const rocfft_brick_t&) = default;
+    rocfft_brick_t(rocfft_brick_t&&)                 = default;
+    rocfft_brick_t& operator=(rocfft_brick_t&&) = default;
+
+    // all vectors here are column-major, with same size as FFT
+    // rank + 1 (batch axis last)
+    rocfft_brick_t(const std::vector<size_t>& field_lower,
+                   const std::vector<size_t>& field_upper,
+                   const std::vector<size_t>& brick_stride,
+                   const rocfft_location_t&   location)
+        : layout(field_lower, field_upper, brick_stride)
         , location(location)
     {
     }
-    rocfft_brick_t()                      = default;
-    rocfft_brick_t(const rocfft_brick_t&) = default;
-    rocfft_brick_t& operator=(const rocfft_brick_t&) = default;
 
-    // inclusive lower bound of brick
-    std::vector<size_t> lower;
-    // exclusive upper bound of brick
-    std::vector<size_t> upper;
-    // stride of brick in memory
-    std::vector<size_t> stride;
-
+    // Data layout of the brick
+    data_layout_t layout;
     // Location of the brick
     rocfft_location_t location;
 
-    // Compute the length of this brick
-    std::vector<size_t> length() const
-    {
-        std::vector<size_t> ret;
-        for(size_t i = 0; i < lower.size(); ++i)
-            ret.push_back(upper[i] > lower[i] ? upper[i] - lower[i] : 0);
-        return ret;
-    }
-
-    // Functions and operators
-
-    // check if brick is empty
-    bool empty() const;
-    // return intersection of *this and another brick.  note that
-    // strides and device are not set on the returned brick, as this
-    // method can't know if the caller wants to look at the result in
-    // *this or in other.
-    rocfft_brick_t intersect(const rocfft_brick_t& other) const;
-
-    // test whether this brick covers same coordinates as another
-    // brick.  strides are not considered.
-    bool equal_coords(const rocfft_brick_t& other) const;
-
-    // compute the number of elements in this brick
-    size_t count_elems() const;
-    bool   is_contiguous() const;
-    // Return strides for this brick, if it were transposed to be
-    // contiguous.
-    std::vector<size_t> contiguous_strides() const;
-
-    // return true if this brick is contiguous in the specified field
-    bool is_contiguous_in_field(const std::vector<size_t>& field_length) const;
-
-    // compute offset of this brick, given the field's stride
-    size_t offset_in_field(const std::vector<size_t>& fieldStride) const;
-
     bool operator==(const rocfft_brick_t& other) const
     {
-        return lower == other.lower && upper == other.upper && stride == other.stride
-               && location == other.location;
+        return layout == other.layout && location == other.location;
     }
 
     std::string str() const;
@@ -140,6 +101,28 @@ struct rocfft_brick_t
 struct rocfft_field_t
 {
     std::vector<rocfft_brick_t> bricks;
+
+    /**
+     * @return the minimal full (i.e., non-partial) data layout that logically includes
+     * all bricks' partial layouts. The returned layout is set with contiguous in-buffer
+     * strides.
+     * 
+     * @throw An `std::logic_error` is thrown if the field has no brick or some
+     * dimensionally inconsistent bricks. 
+     */
+    data_layout_t get_full_data_range() const;
+
+    /**
+     * @brief Finalize all the field's bricks, i.e., sort them by increasing rank (stable
+     * sort) and set the `is_partial` flags for all axes of their layouts.
+     */
+    void finalize();
+
+    /**
+     * @return true iff all parts of the field's full range of logical indices are covered
+     * once and only once by the field's bricks.
+     */
+    bool has_valid_tessellation() const;
 };
 
 struct rocfft_plan_description_t
@@ -147,11 +130,8 @@ struct rocfft_plan_description_t
     rocfft_array_type inArrayType  = rocfft_array_type_unset;
     rocfft_array_type outArrayType = rocfft_array_type_unset;
 
-    std::vector<size_t> inStrides;
-    std::vector<size_t> outStrides;
-
-    size_t inDist  = 0;
-    size_t outDist = 0;
+    data_layout_t input_layout;
+    data_layout_t output_layout;
 
     std::array<size_t, 2> inOffset  = {0, 0};
     std::array<size_t, 2> outOffset = {0, 0};
@@ -173,22 +153,68 @@ struct rocfft_plan_description_t
     rocfft_plan_description_t()  = default;
     ~rocfft_plan_description_t() = default;
 
-    // A plan description is created in a vacuum and does not know what
-    // type of transform it will be for.  Once that's known, we can
-    // initialize default values for in/out type, stride, dist if they're
-    // unspecified.
-    void init_defaults(rocfft_transform_type      transformType,
-                       rocfft_result_placement    placement,
-                       const std::vector<size_t>& lengths,
-                       const std::vector<size_t>& outputLengths);
+    /**
+     * @return The number of length dimensions.
+     */
+    size_t rank() const;
+    /**
+     * @return The batch size.
+     */
+    size_t batch() const;
 
     // Get the local communication rank
     int get_local_comm_rank() const;
     // Get number of ranks in the local communicator
     int get_local_comm_size() const;
-    // returns the current rocfft_location_t (process rank + current device ID)
+    // Returns the current rocfft_location_t (process rank + current device ID)
     // seen by this object
     rocfft_location_t get_current_location() const;
+
+    /**
+     * @brief Finalize the plan description by
+     * 
+     * - assigning default values for structure members that have not been explicitly set yet;
+     * 
+     * - gathering all the fields' bricks on all processes involved in the description's
+     *   communicator, if any;
+     * 
+     * - finalizing bricks for all member fields (see `rocfft_field_t::finalize()`);
+     * 
+     * - removing trivial unit-span axes from all layouts (including bricks' if any)
+     * and sorting length axes by increasing strides if that can be done consistently
+     * across all of them.
+     * 
+     * The description is also validated w.r.t. the following criteria:
+     * 
+     * - the number of user-defined strides matches the rank of the planned transform;
+     * 
+     * - I/O fields are dimensionally consistent with the planned transform, cover the
+     *   expected full ranges of logical indices and have valid tessellations;
+     * 
+     * - Input and output fields are both set for multi-process usage;
+     * 
+     * - I/O array types are not planar if the corresponding field(s) are set;
+     * 
+     * - I/O array types are consistent with the expected data types;
+     * 
+     * - I/O array types are consistent for in-place transforms (if requested);
+     *
+     * 
+     * @param[in] dft_type user-provided type of transform for the owning plan.
+     * @param[in] placement user-provided placement of transform results for the owning plan.
+     * @param[in] user_lengths user-provided lengths of the transform for the owning plan.
+     * @param[in] len_rank user-provided number of length dimensions for the owning plan.
+     * @param[in] number_of_transforms user-provided batch size for the owning plan.
+     * @return A `rocfft_status` value is returned, which should be escalated back to the user
+     * as is if different from `rocfft_status_success`. An `std::runtime_error` with
+     * insightful information (for logging purposes) is thrown instead if no dedicated error
+     * code exists yet.
+     */
+    rocfft_status finalize_and_validate_for(rocfft_transform_type   dft_type,
+                                            rocfft_result_placement placement,
+                                            const size_t*           user_lengths,
+                                            const size_t            len_rank,
+                                            const size_t            number_of_transforms);
 
     // Count the number of pointers required for either input or output
     // - planar data requires two pointers, real + complex require one.
@@ -214,18 +240,18 @@ struct rocfft_plan_description_t
     // returns true if a field has bricks such that any rank has
     // bricks on more than one device
     static bool multiple_devices_in_rank(const rocfft_field_t& field);
+
+private:
+#ifdef ROCFFT_MPI_ENABLE
+    // Communicate bricks on all ranks to all other ranks
+    rocfft_status allgather_brick_params_mpi();
+    rocfft_status allgather_brick_params_lus_mpi(rocfft_field_t& field,
+                                                 const size_t    global_brick_length);
+#endif
 };
 
 struct rocfft_plan_t
 {
-    size_t rank = 0;
-    // input lengths
-    std::vector<size_t> lengths;
-    // output lengths, which differ from input lengths for real-complex
-    // transforms
-    std::vector<size_t> outputLengths;
-    size_t              batch = 1;
-
     rocfft_result_placement placement     = rocfft_placement_inplace;
     rocfft_transform_type   transformType = rocfft_transform_type_complex_forward;
     rocfft_precision        precision     = rocfft_precision_single;
@@ -233,20 +259,6 @@ struct rocfft_plan_t
     rocfft_plan_description_t desc;
 
     rocfft_plan_t() = default;
-
-    // Users can provide lengths+strides in any order, but we'll
-    // construct the most sensible plans if they're in row-major order.
-    // Sort the FFT dimensions.
-    //
-    // This should be done when the plan parameters are known, but
-    // before we start creating any child nodes from the root plan.
-    void sort();
-
-    static bool is_contiguous(const std::vector<size_t>& length,
-                              const std::vector<size_t>& stride,
-                              size_t                     dist);
-    bool        is_contiguous_input();
-    bool        is_contiguous_output();
 
     // Add a multi-plan item for execution.  Returns the index of the
     // new item in the overall multi-GPU plan.  Also provide a
@@ -284,10 +296,6 @@ struct rocfft_plan_t
     // log field layout at plan level
     static void LogFields(const char* description, const std::vector<rocfft_field_t>& fields);
 
-    // throw exception if input/output fields are not valid (e.g. they
-    // don't cover the whole index space, or bricks overlap)
-    void ValidateFields() const;
-
     // During plan creation, InternalTempBuffer remembers how much
     // space will be needed but doesn't allocate.  Allocate the buffers
     // after the space requirements are finalized.
@@ -298,9 +306,6 @@ private:
     // items.  Items can launch kernels on a device, or move
     // data between devices.
     std::vector<std::unique_ptr<MultiPlanItem>> multiPlan;
-
-    // Communicate bricks on all ranks to all other ranks
-    rocfft_status allgather_brick_params_mpi(rocfft_plan& plan);
 
     // Adjacency list describing dependencies between multiPlan items.
     // Size of this vector == multiPlan.size().
@@ -331,8 +336,7 @@ private:
                                             const std::vector<rocfft_brick_t>& bricks,
                                             rocfft_precision                   precision,
                                             rocfft_array_type                  arrayType,
-                                            const std::vector<size_t>&         field_length,
-                                            const std::vector<size_t>&         field_stride,
+                                            const data_layout_t&               gathering_layout,
                                             BufferPtr                          output,
                                             const std::vector<size_t>&         antecedents,
                                             size_t                             elem_size);
@@ -342,8 +346,7 @@ private:
                                              BufferPtr                          input,
                                              rocfft_precision                   precision,
                                              rocfft_array_type                  arrayType,
-                                             const std::vector<size_t>&         field_length,
-                                             const std::vector<size_t>&         field_stride,
+                                             const data_layout_t&               layout_to_scatter,
                                              const std::vector<rocfft_brick_t>& bricks,
                                              const std::vector<size_t>&         antecedents,
                                              size_t                             elem_size);

--- a/projects/rocfft/library/src/include/rocfft_current_function.h
+++ b/projects/rocfft/library/src/include/rocfft_current_function.h
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ROCFFT_CURRENT_FUNCTION
+#include <string>
+
+#if defined(__GNUC__) || defined(__clang__)
+#define RAW_ROCFFT_CURRENT_FUNCTION __PRETTY_FUNCTION__
+#elif defined(_MSC_VER)
+#define RAW_ROCFFT_CURRENT_FUNCTION __FUNCSIG__
+#else
+// Always defined but maybe not pretty
+#define RAW_ROCFFT_CURRENT_FUNCTION __func__
+#endif
+
+#define ROCFFT_CURRENT_FUNCTION std::string(RAW_ROCFFT_CURRENT_FUNCTION)
+
+#endif // ROCFFT_CURRENT_FUNCTION

--- a/projects/rocfft/library/src/include/tree_node.h
+++ b/projects/rocfft/library/src/include/tree_node.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <vector>
 
 #include "../../../shared/device_properties.h"
@@ -838,6 +839,15 @@ struct rocfft_location_t
     bool operator==(const rocfft_location_t& other) const
     {
         return comm_rank == other.comm_rank && device == other.device;
+    }
+
+    std::string str() const
+    {
+        std::string ret = "comm rank ";
+        ret += std::to_string(comm_rank);
+        ret += " device ";
+        ret += std::to_string(device);
+        return ret;
     }
 
     int comm_rank = 0;

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -34,11 +34,13 @@
 #include "node_factory.h"
 #include "rocfft/rocfft-version.h"
 #include "rocfft/rocfft.h"
+#include "rocfft_current_function.h"
 #include "rocfft_exception.h"
 #include "rocfft_mpi.h"
 #include "rocfft_ostream.hpp"
 #include "rtc_kernel.h"
 #include "solution_map.h"
+#include "tree_node.h"
 #include "tuning_helper.h"
 #include "tuning_plan_tuner.h"
 
@@ -52,6 +54,8 @@
 #include <numeric>
 #include <set>
 #include <sstream>
+#include <stdexcept>
+#include <utility>
 #include <vector>
 
 #ifdef ROCFFT_MPI_ENABLE
@@ -92,118 +96,6 @@ static size_t offset_count(rocfft_array_type type)
                : 1;
 }
 
-void rocfft_plan_description_t::init_defaults(rocfft_transform_type      transformType,
-                                              rocfft_result_placement    placement,
-                                              const std::vector<size_t>& lengths,
-                                              const std::vector<size_t>& outputLengths)
-{
-    const size_t rank = lengths.size();
-
-    // assume interleaved data
-    if(inArrayType == rocfft_array_type_unset)
-    {
-        switch(transformType)
-        {
-        case rocfft_transform_type_complex_forward:
-        case rocfft_transform_type_complex_inverse:
-            inArrayType = rocfft_array_type_complex_interleaved;
-            break;
-        case rocfft_transform_type_real_inverse:
-            inArrayType = rocfft_array_type_hermitian_interleaved;
-            break;
-        case rocfft_transform_type_real_forward:
-            inArrayType = rocfft_array_type_real;
-            break;
-        }
-    }
-    if(outArrayType == rocfft_array_type_unset)
-    {
-        switch(transformType)
-        {
-        case rocfft_transform_type_complex_forward:
-        case rocfft_transform_type_complex_inverse:
-            outArrayType = rocfft_array_type_complex_interleaved;
-            break;
-        case rocfft_transform_type_real_forward:
-            outArrayType = rocfft_array_type_hermitian_interleaved;
-            break;
-        case rocfft_transform_type_real_inverse:
-            outArrayType = rocfft_array_type_real;
-            break;
-        }
-    }
-
-    // Set inStrides, if not specified
-    if(inStrides.empty())
-    {
-        inStrides.push_back(1);
-
-        if((transformType == rocfft_transform_type_real_forward)
-           && (placement == rocfft_placement_inplace))
-        {
-            // real-to-complex in-place
-            size_t dist = 2 * outputLengths[0];
-
-            for(size_t i = 1; i < rank; i++)
-            {
-                inStrides.push_back(dist);
-                dist *= lengths[i];
-            }
-        }
-        else
-        {
-            // Set the inStrides to deal with contiguous data
-            for(size_t i = 1; i < rank; i++)
-                inStrides.push_back(lengths[i - 1] * inStrides[i - 1]);
-        }
-    }
-
-    // Set outStrides, if not specified
-    if(outStrides.empty())
-    {
-        outStrides.push_back(1);
-
-        if((transformType == rocfft_transform_type_real_inverse)
-           && (placement == rocfft_placement_inplace))
-        {
-            // complex-to-real in-place
-            size_t dist = 2 * lengths[0];
-
-            for(size_t i = 1; i < rank; i++)
-            {
-                outStrides.push_back(dist);
-                dist *= lengths[i];
-            }
-        }
-        else
-        {
-            // Set the outStrides to deal with contiguous data
-            for(size_t i = 1; i < rank; i++)
-                outStrides.push_back(outputLengths[i - 1] * outStrides[i - 1]);
-        }
-    }
-
-    // Set in and out Distances, if not specified
-    if(inDist == 0)
-    {
-        // In-place 1D transforms need extra dist.
-        if(transformType == rocfft_transform_type_real_forward && lengths.size() == 1
-           && placement == rocfft_placement_inplace)
-            inDist = 2 * (lengths[0] / 2 + 1) * inStrides[0];
-        else
-            inDist = lengths[rank - 1] * inStrides[rank - 1];
-    }
-    if(outDist == 0)
-    {
-        // In-place 1D transforms need extra dist.
-        if(transformType == rocfft_transform_type_real_inverse && lengths.size() == 1
-           && placement == rocfft_placement_inplace)
-            outDist = 2 * lengths[0] * outStrides[0];
-        else
-            outDist = outputLengths[rank - 1] * outStrides[rank - 1];
-    }
-}
-
 bool rocfft_plan_description_t::multiple_devices_in_rank(const rocfft_field_t& field)
 {
     // map ranks to a set of distinct devices
@@ -223,94 +115,6 @@ bool rocfft_plan_description_t::multiple_devices_in_rank(const rocfft_field_t& f
             return true;
     }
     return false;
-}
-
-void rocfft_plan_t::sort()
-{
-    // copy the lengths + strides separately, and then sort them
-    // fastest to slowest.
-    struct rocfft_iodim
-    {
-        size_t length;
-        size_t olength;
-        size_t istride;
-        size_t ostride;
-    };
-
-    // complex-complex transforms can be freely reordered starting from
-    // the fastest dimension.  real-complex has to leave the fastest
-    // dimension alone
-    const size_t start_dim = (transformType == rocfft_transform_type_complex_forward
-                              || transformType == rocfft_transform_type_complex_inverse)
-                                 ? 0
-                                 : 1;
-
-    std::vector<rocfft_iodim> iodims;
-    for(size_t dim = start_dim; dim < rank; ++dim)
-        iodims.push_back(rocfft_iodim{
-            lengths[dim], outputLengths[dim], desc.inStrides[dim], desc.outStrides[dim]});
-    if(iodims.empty())
-        return;
-
-    bool sort_on_istride = true;
-    auto sorter          = [sort_on_istride](const rocfft_iodim& a, const rocfft_iodim& b) {
-        // move any lengths of 1 to the end
-        if(a.length == 1 && b.length != 1)
-            return false;
-        if(b.length == 1 && a.length != 1)
-            return true;
-        return sort_on_istride ? (a.istride < b.istride) : (a.ostride < b.ostride);
-    };
-
-    // sort on istride first
-    std::sort(iodims.begin(), iodims.end(), sorter);
-
-    // if that means ostride is no longer sorted, then don't bother
-    // changing anything - the user is asking for some kind of
-    // transposed FFT so let's just assume they know what they're doing
-    sort_on_istride = false;
-    if(!std::is_sorted(iodims.begin(), iodims.end(), sorter))
-        return;
-
-    // chop off any lengths of 1 from the end
-    while(iodims.size() > 1 && iodims.back().length == 1)
-    {
-        --rank;
-        iodims.pop_back();
-    }
-    // copy back the sorted lengths + strides
-    for(size_t dim = start_dim; dim < rank; ++dim)
-    {
-        lengths[dim]         = iodims[dim - start_dim].length;
-        outputLengths[dim]   = iodims[dim - start_dim].olength;
-        desc.inStrides[dim]  = iodims[dim - start_dim].istride;
-        desc.outStrides[dim] = iodims[dim - start_dim].ostride;
-    }
-}
-
-bool rocfft_plan_t::is_contiguous(const std::vector<size_t>& length,
-                                  const std::vector<size_t>& stride,
-                                  size_t                     dist)
-{
-    size_t expected_stride = 1;
-    auto   stride_it       = stride.begin();
-    auto   length_it       = length.begin();
-    for(; stride_it != stride.end() && length_it != length.end(); ++stride_it, ++length_it)
-    {
-        if(*stride_it != expected_stride)
-            return false;
-        expected_stride *= *length_it;
-    }
-    return expected_stride == dist;
-}
-
-bool rocfft_plan_t::is_contiguous_input()
-{
-    return is_contiguous(lengths, desc.inStrides, desc.inDist);
-}
-bool rocfft_plan_t::is_contiguous_output()
-{
-    return is_contiguous(outputLengths, desc.outStrides, desc.outDist);
 }
 
 size_t rocfft_plan_t::AddMultiPlanItem(std::unique_ptr<MultiPlanItem>&& item,
@@ -441,46 +245,51 @@ try
               "out_distance",
               out_distance);
 
-    description->inArrayType  = in_array_type;
-    description->outArrayType = out_array_type;
-
-    if(in_offsets != nullptr)
+    for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
     {
-        description->inOffset[0] = in_offsets[0];
-        if((in_array_type == rocfft_array_type_complex_planar)
-           || (in_array_type == rocfft_array_type_hermitian_planar))
-            description->inOffset[1] = in_offsets[1];
+        // object's I/O members to (re)set
+        auto& desc_io_array_type
+            = io == io_data_label::INPUT ? description->inArrayType : description->outArrayType;
+        auto& desc_io_offsets
+            = io == io_data_label::INPUT ? description->inOffset : description->outOffset;
+        auto& desc_io_layout
+            = io == io_data_label::INPUT ? description->input_layout : description->output_layout;
+        // user's setting
+        const auto& user_io_array_type
+            = io == io_data_label::INPUT ? in_array_type : out_array_type;
+        const auto& user_io_offsets = io == io_data_label::INPUT ? in_offsets : out_offsets;
+        const auto& user_io_strides_sz
+            = io == io_data_label::INPUT ? in_strides_size : out_strides_size;
+        const auto& user_io_strides = io == io_data_label::INPUT ? in_strides : out_strides;
+        const auto& user_io_dist    = io == io_data_label::INPUT ? in_distance : out_distance;
+        // -------------------------------
+        // Set/Reset description's members
+        // -------------------------------
+        // array type
+        desc_io_array_type = user_io_array_type;
+        // offsets
+        desc_io_offsets[0] = desc_io_offsets[1] = 0; // default if unspecified
+        if(user_io_offsets != nullptr)
+        {
+            desc_io_offsets[0] = user_io_offsets[0];
+            if(array_type_is_planar(desc_io_array_type))
+                desc_io_offsets[1] = user_io_offsets[1];
+        }
+        // layout parameters: implicit default strides (resp. distances) to be determined
+        // at plan creation if strides are unspecified here (resp. distances are 0)
+        desc_io_layout.clear();
+        if(user_io_strides)
+        {
+            desc_io_layout.len_axes.resize(user_io_strides_sz);
+            for(size_t dim = 0; dim < in_strides_size; dim++)
+                desc_io_layout.len_axes[dim].inbuffer_stride = user_io_strides[dim];
+        }
+        if(user_io_dist != 0)
+        {
+            desc_io_layout.batch_axes.resize(1);
+            desc_io_layout.batch_axes[0].inbuffer_stride = user_io_dist;
+        }
     }
-
-    if(out_offsets != nullptr)
-    {
-        description->outOffset[0] = out_offsets[0];
-        if((out_array_type == rocfft_array_type_complex_planar)
-           || (out_array_type == rocfft_array_type_hermitian_planar))
-            description->outOffset[1] = out_offsets[1];
-    }
-
-    if(in_strides != nullptr)
-    {
-        description->inStrides.clear();
-        std::copy(
-            in_strides, in_strides + in_strides_size, std::back_inserter(description->inStrides));
-    }
-
-    if(in_distance != 0)
-        description->inDist = in_distance;
-
-    if(out_strides != nullptr)
-    {
-        description->outStrides.clear();
-        std::copy(out_strides,
-                  out_strides + out_strides_size,
-                  std::back_inserter(description->outStrides));
-    }
-
-    if(out_distance != 0)
-        description->outDist = out_distance;
-
     return rocfft_status_success;
 }
 catch(...)
@@ -540,137 +349,22 @@ catch(...)
     return rocfft_handle_exception();
 }
 
-bool rocfft_brick_t::empty() const
-{
-    auto len = length();
-    return std::any_of(len.begin(), len.end(), [](int l) { return l == 0; });
-}
-
-size_t rocfft_brick_t::count_elems() const
-{
-    auto len = length();
-    return product(len.begin(), len.end());
-}
-
-std::vector<size_t> rocfft_brick_t::contiguous_strides() const
-{
-    std::vector<size_t> ret;
-    size_t              dist = 1;
-
-    auto len = length();
-    for(size_t i = 0; i < len.size(); ++i)
-    {
-        ret.push_back(dist);
-        dist *= len[i];
-    }
-    return ret;
-}
-
-bool rocfft_brick_t::is_contiguous() const
-{
-    auto contiguous = contiguous_strides();
-
-    auto len = length();
-    // only care about dimensions whose length is greater than 1
-    for(size_t i = 1; i < len.size(); ++i)
-    {
-        if(len[i] > 1)
-        {
-            if(contiguous[i] != stride[i])
-                return false;
-        }
-    }
-    return true;
-}
-
-bool rocfft_brick_t::is_contiguous_in_field(const std::vector<size_t>& field_length) const
-{
-    const auto brick_len = length();
-
-    // a contiguous brick in a field is shorter than field length
-    // only on the highest dimension (ignoring dimensions of
-    // length-1), and its strides must be consistent with contiguous
-    // storage of the field.
-    size_t shortDim        = std::numeric_limits<size_t>::max();
-    size_t highestNot1Dim  = std::numeric_limits<size_t>::max();
-    size_t expected_stride = 1;
-    for(size_t i = 0; i < brick_len.size(); ++i)
-    {
-        if(field_length[i] == 1)
-            continue;
-
-        highestNot1Dim = i;
-        if(brick_len[i] < field_length[i])
-        {
-            // another dim is already short?  this isn't contiguous
-            if(shortDim != std::numeric_limits<size_t>::max())
-                return false;
-            shortDim = i;
-        }
-        if(stride[i] != expected_stride)
-            return false;
-        expected_stride *= field_length[i];
-    }
-
-    return shortDim == highestNot1Dim;
-}
-
-rocfft_brick_t rocfft_brick_t::intersect(const rocfft_brick_t& other) const
-{
-    rocfft_brick_t ret;
-
-    for(size_t i = 0; i < lower.size(); ++i)
-        ret.lower.push_back(std::max(lower[i], other.lower[i]));
-
-    for(size_t i = 0; i < upper.size(); ++i)
-        ret.upper.push_back(std::min(upper[i], other.upper[i]));
-
-    return ret;
-}
-
-bool rocfft_brick_t::equal_coords(const rocfft_brick_t& other) const
-{
-    return this->lower == other.lower && this->upper == other.upper;
-}
-
-size_t rocfft_brick_t::offset_in_field(const std::vector<size_t>& fieldStride) const
-{
-    return std::inner_product(lower.begin(), lower.end(), fieldStride.begin(), 0);
-}
-
 std::string rocfft_brick_t::str() const
 {
-    std::string ret;
-    ret += "lower ";
-    for(auto i : lower)
-    {
-        ret += " ";
-        ret += std::to_string(i);
-    }
-
-    ret += " upper ";
-    for(auto i : upper)
-    {
-        ret += " ";
-        ret += std::to_string(i);
-    }
-
-    ret += " stride ";
-    for(auto i : stride)
-    {
-        ret += " ";
-        ret += std::to_string(i);
-    }
-    ret += " comm rank ";
-    ret += std::to_string(location.comm_rank);
-    ret += " device ";
-    ret += std::to_string(location.device);
-    return ret;
+    return layout.str() + " " + location.str();
 }
 
 // internal brick-adding API
 static void rocfft_field_add_brick_internal(rocfft_field_t& field, const rocfft_brick_t& brick)
 {
+    if(!field.bricks.empty()
+       && !brick.layout.is_dimensionally_consistent_with(field.bricks[0].layout))
+    {
+        // could motivate a new "rocfft_status_invalid_brick{_dimensions}" error code
+        throw std::runtime_error(
+            "Brick to be added is not dimensionally consistent with other brick(s) in field.");
+    }
+
     field.bricks.emplace_back(brick);
 }
 
@@ -714,12 +408,21 @@ try
     if(!brick)
         return rocfft_status_invalid_arg_value;
 
+    if(dim < 2 || dim > 4) // {1,2,3} length dimensions + 1 batch dimension
+        return rocfft_status_invalid_dimensions;
+
+    if(!field_lower || !field_upper || !brick_stride)
+        return rocfft_status_invalid_arg_value;
+
     // Assume comm rank 0, as we don't have a communicator at
     // this point.  If this is actually an MPI transform, these
     // bricks will be recreated with correct rank when we gather all
     // of the brick data at plan creation time.
-    auto brick_ptr = std::make_unique<rocfft_brick_t>(
-        field_lower, field_upper, brick_stride, dim, rocfft_location_t{0, deviceID});
+    auto brick_ptr
+        = std::make_unique<rocfft_brick_t>(std::vector<size_t>{field_lower, field_lower + dim},
+                                           std::vector<size_t>{field_upper, field_upper + dim},
+                                           std::vector<size_t>{brick_stride, brick_stride + dim},
+                                           rocfft_location_t{0, deviceID});
     *brick = brick_ptr.release();
     return rocfft_status_success;
 }
@@ -774,20 +477,26 @@ std::string rocfft_bench_command(const rocfft_plan& plan)
 {
     rocfft_params params;
 
-    params.nbatch         = plan->batch;
+    params.nbatch         = plan->desc.batch();
     params.placement      = fft_result_placement_from_rocfft_result_placement(plan->placement);
     params.transform_type = fft_transform_type_from_rocfft_transform_type(plan->transformType);
     params.precision      = fft_precision_from_rocfft_precision(plan->precision);
     params.itype          = fft_array_type_from_rocfft_array_type(plan->desc.inArrayType);
     params.otype          = fft_array_type_from_rocfft_array_type(plan->desc.outArrayType);
-    params.idist          = plan->desc.inDist;
-    params.odist          = plan->desc.outDist;
+    params.idist          = plan->desc.input_layout.distance();
+    params.odist          = plan->desc.output_layout.distance();
     params.scale_factor   = plan->desc.storeOps.scale_factor;
 
     // reverse-copy lengths and strides (col-major to row-major)
-    params.length.assign(plan->lengths.rbegin(), plan->lengths.rend());
-    params.istride.assign(plan->desc.inStrides.rbegin(), plan->desc.inStrides.rend());
-    params.ostride.assign(plan->desc.outStrides.rbegin(), plan->desc.outStrides.rend());
+    const auto lengths  = plan->transformType == rocfft_transform_type_complex_forward
+                                 || plan->transformType == rocfft_transform_type_real_forward
+                              ? plan->desc.input_layout.lengths()
+                              : plan->desc.output_layout.lengths();
+    const auto istrides = plan->desc.input_layout.strides();
+    const auto ostrides = plan->desc.output_layout.strides();
+    params.length.assign(lengths.rbegin(), lengths.rend());
+    params.istride.assign(istrides.rbegin(), istrides.rend());
+    params.ostride.assign(ostrides.rbegin(), ostrides.rend());
     // copy offsets
     params.ioffset.assign(plan->desc.inOffset.begin(), plan->desc.inOffset.end());
     params.ooffset.assign(plan->desc.outOffset.begin(), plan->desc.outOffset.end());
@@ -798,14 +507,18 @@ std::string rocfft_bench_command(const rocfft_plan& plan)
               for(size_t fidx = 0; fidx < src.size(); ++fidx)
               {
                   dest[fidx].bricks.resize(src[fidx].bricks.size());
-                  for(size_t bidx = 0; bidx < src.size(); ++bidx)
+                  for(size_t bidx = 0; bidx < src[fidx].bricks.size(); ++bidx)
                   {
                       fft_params::fft_brick& dest_brick = dest[fidx].bricks[bidx];
                       const rocfft_brick_t&  src_brick  = src[fidx].bricks[bidx];
                       // reverse-copy bricks' coordinates and strides (col-major to row-major)
-                      dest_brick.lower.assign(src_brick.lower.rbegin(), src_brick.lower.rend());
-                      dest_brick.upper.assign(src_brick.upper.rbegin(), src_brick.upper.rend());
-                      dest_brick.stride.assign(src_brick.stride.rbegin(), src_brick.stride.rend());
+                      const auto& src_layout = src_brick.layout;
+                      const auto  lower_cm   = src_layout.lower();
+                      const auto  upper_cm   = src_layout.upper();
+                      const auto  strides_cm = src_layout.strides_and_distances();
+                      dest_brick.lower.assign(lower_cm.rbegin(), lower_cm.rend());
+                      dest_brick.upper.assign(upper_cm.rbegin(), upper_cm.rend());
+                      dest_brick.stride.assign(strides_cm.rbegin(), strides_cm.rend());
                       dest_brick.rank   = src_brick.location.comm_rank;
                       dest_brick.device = src_brick.location.device;
                   }
@@ -831,75 +544,22 @@ rocfft_location_t rocfft_plan_description_t::get_current_location() const
     return current_loc;
 }
 
-// Verify that the transform type, array type, and placement are coherent.
-rocfft_status check_array_type_validity(const rocfft_plan plan)
-{
-    switch(plan->transformType)
-    {
-    case rocfft_transform_type_complex_forward:
-    case rocfft_transform_type_complex_inverse:
-        // We need complex input data
-        if(!((plan->desc.inArrayType == rocfft_array_type_complex_interleaved)
-             || (plan->desc.inArrayType == rocfft_array_type_complex_planar)))
-            return rocfft_status_invalid_array_type;
-        // We need complex output data
-        if(!((plan->desc.outArrayType == rocfft_array_type_complex_interleaved)
-             || (plan->desc.outArrayType == rocfft_array_type_complex_planar)))
-            return rocfft_status_invalid_array_type;
-        // In-place transform requires that the input and output
-        // format be identical
-        if(plan->placement == rocfft_placement_inplace)
-        {
-            if(plan->desc.inArrayType != plan->desc.outArrayType)
-                return rocfft_status_invalid_array_type;
-        }
-        break;
-    case rocfft_transform_type_real_forward:
-        // Input must be real
-        if(plan->desc.inArrayType != rocfft_array_type_real)
-            return rocfft_status_invalid_array_type;
-        // Output must be Hermitian
-        if(!((plan->desc.outArrayType == rocfft_array_type_hermitian_interleaved)
-             || (plan->desc.outArrayType == rocfft_array_type_hermitian_planar)))
-            return rocfft_status_invalid_array_type;
-        // In-place transform must output to interleaved format
-        if((plan->placement == rocfft_placement_inplace)
-           && (plan->desc.outArrayType != rocfft_array_type_hermitian_interleaved))
-            return rocfft_status_invalid_array_type;
-        break;
-    case rocfft_transform_type_real_inverse:
-        // Output must be real
-        if(plan->desc.outArrayType != rocfft_array_type_real)
-            return rocfft_status_invalid_array_type;
-        // Input must be Hermitian
-        if(!((plan->desc.inArrayType == rocfft_array_type_hermitian_interleaved)
-             || (plan->desc.inArrayType == rocfft_array_type_hermitian_planar)))
-            return rocfft_status_invalid_array_type;
-        // In-place transform must have interleaved input
-        if((plan->placement == rocfft_placement_inplace)
-           && (plan->desc.inArrayType != rocfft_array_type_hermitian_interleaved))
-            return rocfft_status_invalid_array_type;
-        break;
-    }
-    return rocfft_status_success;
-}
-
 // Given a rocfft_plan with validated parameters, set the transform parameters for the root of the
 // tree plan.
 void set_rootplan_params(const rocfft_plan plan, NodeMetaData& planData)
 {
-    planData.dimension = plan->rank;
-    planData.batch     = plan->batch;
-    for(size_t i = 0; i < plan->rank; i++)
+    planData.dimension = plan->desc.rank();
+    planData.batch     = plan->desc.batch();
+    for(size_t i = 0; i < plan->desc.rank(); i++)
     {
-        planData.length.push_back(plan->lengths[i]);
-        planData.outputLength.push_back(plan->outputLengths[i]);
+        planData.length       = plan->desc.input_layout.lengths();
+        planData.outputLength = plan->desc.output_layout.lengths();
 
-        planData.inStride.push_back(plan->desc.inStrides[i]);
-        planData.outStride.push_back(plan->desc.outStrides[i]);
+        planData.inStride  = plan->desc.input_layout.strides();
+        planData.outStride = plan->desc.output_layout.strides();
     }
-    planData.iDist     = plan->desc.inDist;
-    planData.oDist     = plan->desc.outDist;
+    planData.iDist     = plan->desc.input_layout.distance();
+    planData.oDist     = plan->desc.output_layout.distance();
     planData.placement = plan->placement;
 
     // If in+out fields are specified, currently that means we're
@@ -936,7 +596,7 @@ void set_rootplan_params(const rocfft_plan plan, NodeMetaData& planData)
     {
         // If output is contiguous and this is c2c then we can
         // gather to the output buf and do an inplace FFT.
-        if(plan->is_contiguous_output()
+        if(plan->desc.output_layout.is_contiguous()
            && (plan->transformType == rocfft_transform_type_complex_forward
                || plan->transformType == rocfft_transform_type_complex_inverse))
             planData.placement = rocfft_placement_inplace;
@@ -969,16 +629,15 @@ void set_bluestein_strides(const rocfft_plan plan, NodeMetaData& planData)
 
     const auto precision     = plan->precision;
     const auto transformType = plan->transformType;
-    const auto rank          = plan->rank;
-    const auto lengths       = plan->lengths;
+    const auto rank          = plan->desc.rank();
+    const auto fftLength     = transformType == rocfft_transform_type_complex_forward
+                                   || transformType == rocfft_transform_type_real_forward
+                                   ? plan->desc.input_layout.lengths()
+                                   : plan->desc.output_layout.lengths();
     const auto placement     = plan->placement;
     const auto dimension     = planData.dimension;
 
     assert(rank == dimension);
-
-    // for real inverse transforms we need to look at the complex length
-    auto fftLength
-        = transformType == rocfft_transform_type_real_inverse ? plan->outputLengths : plan->lengths;
 
     lengthsBlue[0] = NodeFactory::SupportedLength(pool, precision, fftLength[0])
                          ? fftLength[0]
@@ -1186,6 +845,393 @@ std::unique_ptr<ExecPlan> transpose_brick(int                        local_comm_
     return execPlanMultiItem;
 }
 
+size_t rocfft_plan_description_t::rank() const
+{
+    const auto ret = input_layout.get_len_rank();
+    if(ret != output_layout.get_len_rank())
+        throw std::logic_error("Inconsistent ranks between input and output layouts detected by "
+                               + ROCFFT_CURRENT_FUNCTION);
+
+    return ret;
+}
+
+size_t rocfft_plan_description_t::batch() const
+{
+    if(input_layout.get_batch_rank() != 1 || output_layout.get_batch_rank() != 1)
+        throw std::logic_error(
+            "Unexpected number of batch dimensions detected in input or output layout by "
+            + ROCFFT_CURRENT_FUNCTION);
+    const auto ret = input_layout.batch();
+    if(ret != output_layout.batch())
+        throw std::logic_error(
+            "Inconsistent batch values between input and output layouts detected by "
+            + ROCFFT_CURRENT_FUNCTION);
+
+    return ret;
+}
+
+data_layout_t rocfft_field_t::get_full_data_range() const
+{
+    if(bricks.empty())
+        throw std::logic_error(ROCFFT_CURRENT_FUNCTION + " cannot operate on empty fields");
+    data_layout_t ret;
+    ret.len_axes.resize(bricks[0].layout.get_len_rank());
+    ret.batch_axes.resize(bricks[0].layout.get_batch_rank());
+    for(const auto& brick : bricks)
+    {
+        if(!brick.layout.is_dimensionally_consistent_with(ret))
+        {
+            throw std::logic_error(ROCFFT_CURRENT_FUNCTION
+                                   + " detected a pair of dimensionally-inconsistent bricks");
+        }
+        for(size_t dim = 0; dim < ret.get_full_rank(); dim++)
+            ret[dim].upper = std::max(ret[dim].upper, brick.layout[dim].upper);
+    }
+    // finalize: set contiguous strides and mark all layout's axes as full
+    for(size_t dim = 0; dim < ret.get_full_rank(); dim++)
+    {
+        ret[dim].is_partial = false;
+        if(dim == 0)
+            ret[dim].inbuffer_stride = 1;
+        else
+            ret[dim].inbuffer_stride = ret[dim - 1].inbuffer_stride * ret[dim - 1].logical_span();
+    }
+    return ret;
+}
+
+void rocfft_field_t::finalize()
+{
+    const auto full_data_range = get_full_data_range();
+
+    // make sure bricks are sorted by increasing ranks (without modifying
+    // brick ordering within ranks)
+    std::stable_sort(
+        bricks.begin(), bricks.end(), [](const rocfft_brick_t& a, const rocfft_brick_t& b) {
+            return a.location.comm_rank < b.location.comm_rank;
+        });
+
+    // Set the `is_partial` flags for all dimensions of the bricks' layouts, according to
+    // the given full range of logical indices
+    std::for_each(bricks.begin(), bricks.end(), [&full_data_range](auto& brick) {
+        for(size_t dim = 0; dim < brick.layout.get_full_rank(); dim++)
+        {
+            brick.layout[dim].is_partial
+                = !brick.layout[dim].has_same_logical_range_as(full_data_range[dim]);
+        }
+    });
+}
+
+bool rocfft_field_t::has_valid_tessellation() const
+{
+    size_t total_brick_logical_count = 0;
+    for(auto brickI = bricks.begin(); brickI != bricks.end(); ++brickI)
+    {
+        for(auto brickJ = brickI + 1; brickJ != bricks.end(); ++brickJ)
+        {
+            const auto ij_intersection
+                = data_layout_t::make_contiguous_intersection_of(brickI->layout, brickJ->layout);
+            if(!ij_intersection.is_empty())
+                return false;
+        }
+        // Add up the brick's logical count
+        total_brick_logical_count += brickI->layout.logical_count();
+    }
+
+    const auto full_data_range = get_full_data_range();
+    // The bricks cover the whole index space iff their total number of
+    // logical elements is the same as the full data layout
+    return full_data_range.logical_count() == total_brick_logical_count;
+}
+
+rocfft_status
+    rocfft_plan_description_t::finalize_and_validate_for(rocfft_transform_type   dft_type,
+                                                         rocfft_result_placement placement,
+                                                         const size_t*           user_lengths,
+                                                         const size_t            len_rank,
+                                                         const size_t number_of_transforms)
+{
+    // -------------------------------------
+    //   Finalize and validate I/O layouts
+    // -------------------------------------
+    for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
+    {
+        const bool is_real_domain
+            = (dft_type == rocfft_transform_type_real_forward && io == io_data_label::INPUT)
+              || (dft_type == rocfft_transform_type_real_inverse && io == io_data_label::OUTPUT);
+        const bool is_hermitian_domain
+            = (dft_type == rocfft_transform_type_real_forward && io == io_data_label::OUTPUT)
+              || (dft_type == rocfft_transform_type_real_inverse && io == io_data_label::INPUT);
+        // Finalize the I/O layouts with the user-provided lengths
+        auto&               io_layout = io == io_data_label::INPUT ? input_layout : output_layout;
+        std::vector<size_t> io_lengths(user_lengths, user_lengths + len_rank);
+        if(is_hermitian_domain)
+            io_lengths[0] = user_lengths[0] / 2 + 1;
+        else
+            io_lengths[0] = user_lengths[0];
+        const auto current_strides = io_layout.strides();
+        // Current strides may be empty (if unset by user for implicit default)
+        // If not, users must have set len_rank of them
+        if(!current_strides.empty() && current_strides.size() != len_rank)
+        {
+            return rocfft_status_invalid_strides;
+        }
+        const auto current_distances = io_layout.distances();
+        // Current distances may be empty (if 0-initialized by the user for implicit default)
+        // If not, users cannot possibly have set more than 1 (multi-dimensional batches not
+        // exposed to users)
+        if(!current_distances.empty() && current_distances.size() != 1)
+        {
+            // cannot happen, theoretically
+            throw std::logic_error(ROCFFT_CURRENT_FUNCTION
+                                   + " detected an unexpected batch rank in a plan description");
+        }
+        io_layout.reset(io_lengths,
+                        current_strides /* default strides set if empty */,
+                        {number_of_transforms},
+                        current_distances /* default distances if empty */,
+                        is_real_domain && placement == rocfft_placement_inplace);
+    }
+    // -------------------------------------------
+    //   Finalize and validate I/O fields if any
+    // -------------------------------------------
+#ifdef ROCFFT_MPI_ENABLE
+    const auto rc_mpi = allgather_brick_params_mpi();
+    if(rc_mpi != rocfft_status_success)
+        return rc_mpi;
+#endif
+    for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
+    {
+        const auto& expected_full_range = io == io_data_label::INPUT ? input_layout : output_layout;
+        auto&       io_fields           = io == io_data_label::INPUT ? inFields : outFields;
+        std::for_each(
+            io_fields.begin(), io_fields.end(), [](auto& io_field) { io_field.finalize(); });
+        if(std::any_of(io_fields.begin(), io_fields.end(), [&expected_full_range](auto& io_field) {
+               const auto field_full_range = io_field.get_full_data_range();
+               return !expected_full_range.is_dimensionally_consistent_with(field_full_range)
+                      || !expected_full_range.has_same_logical_range_as(field_full_range);
+           }))
+        {
+            // This would warrant a dedicated error code. For now, throw an std::runtime_error so
+            // that ROCFFT_LAYER reports something insightful
+            throw std::runtime_error("Inconsistent full data range detected for an " + to_str(io)
+                                     + " field");
+        }
+        if(io_fields.empty() && comm_type != rocfft_comm_none)
+        {
+            // This would warrant a dedicated error code. For now, throw an std::runtime_error so
+            // that ROCFFT_LAYER reports something insightful
+            throw std::runtime_error(
+                "Multi-process transforms require both input and output fields to be specified");
+        }
+        if(std::any_of(io_fields.begin(), io_fields.end(), [](auto& field) {
+               return !field.has_valid_tessellation();
+           }))
+        {
+            throw std::runtime_error("Invalid tessellation detected for an " + to_str(io)
+                                     + " field");
+        }
+    }
+
+    // -------------------------------------------------------------------------------
+    // Remove trivial axes of unit lengths from layouts (and from all bricks' layouts,
+    // too) and sort length axes by increasing strides (in corresponding bricks, too)
+    // if that can be done consistently across ALL (full AND partial) data layouts at
+    // play.
+    // -------------------------------------------------------------------------------
+
+    if(rank() > 1)
+    {
+        auto may_erase_length_dimension = [this](size_t len_dim, io_data_label io) -> bool {
+            const auto& io_full_layout = io == io_data_label::INPUT ? input_layout : output_layout;
+            const auto& io_fields      = io == io_data_label::INPUT ? inFields : outFields;
+            return len_dim < io_full_layout.get_len_rank()
+                   && io_full_layout[len_dim].logical_span() == 1
+                   && std::all_of(
+                       io_fields.begin(), io_fields.end(), [&len_dim](const auto& field) {
+                           return std::all_of(field.bricks.begin(),
+                                              field.bricks.end(),
+                                              [&len_dim](const auto& brick) {
+                                                  return len_dim < brick.layout.get_len_rank()
+                                                         && brick.layout[len_dim].logical_span()
+                                                                == 1;
+                                              });
+                       });
+        };
+
+        // 0th length dimension must not be modified for real DFTs
+        const bool is_real_dft = dft_type == rocfft_transform_type_real_forward
+                                 || dft_type == rocfft_transform_type_real_inverse;
+        size_t len_dim = is_real_dft ? 1 : 0;
+        while(len_dim < rank() && 1 < rank())
+        {
+            if(may_erase_length_dimension(len_dim, io_data_label::INPUT)
+               && may_erase_length_dimension(len_dim, io_data_label::OUTPUT))
+            {
+                for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
+                {
+                    auto& io_layout = io == io_data_label::INPUT ? input_layout : output_layout;
+                    auto& io_fields = io == io_data_label::INPUT ? inFields : outFields;
+                    io_layout.len_axes.erase(io_layout.len_axes.begin() + len_dim);
+                    std::for_each(io_fields.begin(), io_fields.end(), [&len_dim](auto& field) {
+                        std::for_each(
+                            field.bricks.begin(), field.bricks.end(), [&len_dim](auto& brick) {
+                                brick.layout.len_axes.erase(brick.layout.len_axes.begin()
+                                                            + len_dim);
+                            });
+                    });
+                }
+                // no incrementing of len_dim
+            }
+            else
+                len_dim++;
+        }
+        if(rank() > (is_real_dft ? 2 : 1))
+        {
+            // Sort qualifying dimensions by increasing strides, if that can be done
+            // consistently across all relevant layouts at play
+            auto bricks_have_consistent_stride_ordering
+                = [this, is_real_dft](io_data_label io) -> bool {
+                const auto& io_full_layout
+                    = io == io_data_label::INPUT ? input_layout : output_layout;
+                const auto& io_fields = io == io_data_label::INPUT ? inFields : outFields;
+                return std::all_of(
+                    io_fields.begin(),
+                    io_fields.end(),
+                    [&io_full_layout, is_real_dft](const auto& field) {
+                        return std::all_of(
+                            field.bricks.begin(),
+                            field.bricks.end(),
+                            [&io_full_layout, is_real_dft](const auto& brick) {
+                                return io_full_layout.length_axes_by_increasing_strides(is_real_dft)
+                                       == brick.layout.length_axes_by_increasing_strides(
+                                           is_real_dft);
+                            });
+                    });
+            };
+
+            if(input_layout.length_axes_by_increasing_strides(is_real_dft)
+                   == output_layout.length_axes_by_increasing_strides(is_real_dft)
+               && bricks_have_consistent_stride_ordering(io_data_label::INPUT)
+               && bricks_have_consistent_stride_ordering(io_data_label::OUTPUT))
+            {
+                const auto reordered_length_axes
+                    = input_layout.length_axes_by_increasing_strides(is_real_dft);
+                for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
+                {
+                    auto& io_layout = io == io_data_label::INPUT ? input_layout : output_layout;
+                    auto& io_fields = io == io_data_label::INPUT ? inFields : outFields;
+                    io_layout.reorder_length_axes(reordered_length_axes);
+                    std::for_each(
+                        io_fields.begin(), io_fields.end(), [&reordered_length_axes](auto& field) {
+                            std::for_each(field.bricks.begin(),
+                                          field.bricks.end(),
+                                          [&reordered_length_axes](auto& brick) {
+                                              brick.layout.reorder_length_axes(
+                                                  reordered_length_axes);
+                                          });
+                        });
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------
+    //   Finalize and validate I/O array types
+    // -----------------------------------------
+    for(auto io : {io_data_label::INPUT, io_data_label::OUTPUT})
+    {
+        auto&      io_array_type = io == io_data_label::INPUT ? inArrayType : outArrayType;
+        const bool is_real_domain
+            = (dft_type == rocfft_transform_type_real_forward && io == io_data_label::INPUT)
+              || (dft_type == rocfft_transform_type_real_inverse && io == io_data_label::OUTPUT);
+        const bool is_hermitian_domain
+            = (dft_type == rocfft_transform_type_real_forward && io == io_data_label::OUTPUT)
+              || (dft_type == rocfft_transform_type_real_inverse && io == io_data_label::INPUT);
+
+        if(io_array_type == rocfft_array_type_unset)
+        {
+            switch(dft_type)
+            {
+            case rocfft_transform_type_complex_forward:
+            case rocfft_transform_type_complex_inverse:
+                io_array_type = rocfft_array_type_complex_interleaved;
+                break;
+            case rocfft_transform_type_real_forward:
+            case rocfft_transform_type_real_inverse:
+                io_array_type = is_real_domain ? rocfft_array_type_real
+                                               : rocfft_array_type_hermitian_interleaved;
+                break;
+            default:
+                throw std::invalid_argument("Unexpected type of transform given to "
+                                            + ROCFFT_CURRENT_FUNCTION);
+            }
+        }
+
+        // planar array types only supported with empty fields
+        const auto& io_fields = io == io_data_label::INPUT ? inFields : outFields;
+        if(array_type_is_planar(io_array_type) && !io_fields.empty())
+            return rocfft_status_invalid_array_type;
+
+        switch(dft_type)
+        {
+        case rocfft_transform_type_complex_forward:
+        case rocfft_transform_type_complex_inverse:
+            if(!array_type_is_complex_but_not_hermitian(io_array_type))
+                return rocfft_status_invalid_array_type;
+            break;
+        case rocfft_transform_type_real_forward:
+        case rocfft_transform_type_real_inverse:
+            if((is_real_domain && !array_type_is_real(io_array_type))
+               || (is_hermitian_domain && !array_type_is_hermitian(io_array_type)))
+                return rocfft_status_invalid_array_type;
+            break;
+        default:
+            throw std::invalid_argument("Unexpected type of transform given to "
+                                        + ROCFFT_CURRENT_FUNCTION);
+        }
+    }
+    // -----------------------------------------
+    //        In-place specific validations
+    // -----------------------------------------
+    if(placement == rocfft_placement_inplace)
+    {
+        // ----------------------------------------------------
+        //      Validate array types for in-place operations
+        // ----------------------------------------------------
+        switch(dft_type)
+        {
+        case rocfft_transform_type_complex_forward:
+        case rocfft_transform_type_complex_inverse:
+            // We need same array type for input and output
+            if(inArrayType != outArrayType)
+                return rocfft_status_invalid_array_type;
+            break;
+        case rocfft_transform_type_real_forward:
+        case rocfft_transform_type_real_inverse:
+        {
+            // Hermitian array must be interleaved
+            const auto hermitian_array_type
+                = dft_type == rocfft_transform_type_real_forward ? outArrayType : inArrayType;
+            if(!array_type_is_interleaved(hermitian_array_type))
+                return rocfft_status_invalid_array_type;
+        }
+        break;
+        default:
+            throw std::invalid_argument("Unexpected type of transform given to "
+                                        + ROCFFT_CURRENT_FUNCTION);
+        }
+        // MORE TO BE DONE:
+        // - layout consistency requirements for single-device usage (including
+        //   offset values, if not ignored)
+        // - identical locations for I/O data buffers if fields are not empty
+        // - ...
+        // Will be integrated when more unifying logic is added (e.g., when
+        // unifying code paths between empty-fields usage and
+        // single-io-fields-with-lone-bricks-on-current-device usage)
+    }
+    return rocfft_status_success;
+}
+
 // RAII struct to 'lease' a temp buffer from a multimap of per-device
 // buffers.  When this struct is destroyed, the buffer is returned to
 // the map for reuse.
@@ -1343,8 +1389,7 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
                                                        const std::vector<rocfft_brick_t>& bricks,
                                                        rocfft_precision                   precision,
                                                        rocfft_array_type                  arrayType,
-                                                       const std::vector<size_t>& field_length,
-                                                       const std::vector<size_t>& field_stride,
+                                                       const data_layout_t&       gathering_layout,
                                                        BufferPtr                  output,
                                                        const std::vector<size_t>& antecedents,
                                                        size_t                     elem_size)
@@ -1360,18 +1405,18 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
     BufferPtr  gatherDest;
     const bool gatherToTemp
         = std::any_of(bricks.begin(), bricks.end(), [&](const rocfft_brick_t& brick) {
-              return !brick.is_contiguous() || !brick.is_contiguous_in_field(field_length);
+              return !brick.layout.is_contiguous()
+                     || !brick.layout.is_continuous_in(gathering_layout);
           });
     if(gatherToTemp)
     {
         // this is from source-rank to source-rank, before MPI comm.
-        gatherDestBuf
-            = std::make_optional<TempBufferLease>(tempBuffers,
-                                                  local_comm_rank,
-                                                  currentLocation,
-                                                  product(field_length.begin(), field_length.end()),
-                                                  elem_size);
-        gatherDest = BufferPtr::temp(gatherDestBuf->data());
+        gatherDestBuf = std::make_optional<TempBufferLease>(tempBuffers,
+                                                            local_comm_rank,
+                                                            currentLocation,
+                                                            gathering_layout.logical_count(),
+                                                            elem_size);
+        gatherDest    = BufferPtr::temp(gatherDestBuf->data());
     }
     else
     {
@@ -1403,36 +1448,40 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
         size_t& packOffset
             = packOffsets.emplace(brick.location, static_cast<size_t>(0)).first->second;
 
-        if(brick.is_contiguous())
+        if(brick.layout.is_contiguous())
         {
             // Contiguous brick, just copy the data
-            gather->AddOperation(local_comm_rank,
-                                 {brick.location,
-                                  inputBufs[brickIdx],
-                                  0,
-                                  gatherToTemp ? gatherOffset : brick.offset_in_field(field_stride),
-                                  brick.count_elems()});
+            gather->AddOperation(
+                local_comm_rank,
+                {brick.location,
+                 inputBufs[brickIdx],
+                 0,
+                 gatherToTemp ? gatherOffset : brick.layout.offset_in(gathering_layout),
+                 brick.layout.logical_count()});
         }
         else
         {
             // Allocate temp memory for the pack
-            gatherPackBufs.emplace_back(
-                tempBuffers, local_comm_rank, brick.location, brick.count_elems(), elem_size);
+            gatherPackBufs.emplace_back(tempBuffers,
+                                        local_comm_rank,
+                                        brick.location,
+                                        brick.layout.logical_count(),
+                                        elem_size);
 
             // Brick is not contiguous, insert a pack node on the brick's device
             std::string description = "pack brick " + std::to_string(brickIdx) + " before gather";
             auto        packIdx
                 = AddMultiPlanItem(transpose_brick(local_comm_rank,
                                                    brick.location,
-                                                   brick.length(),
+                                                   brick.layout.lengths_and_batches(),
                                                    precision,
                                                    arrayType,
                                                    inputBufs[brickIdx],
                                                    0,
-                                                   brick.stride,
+                                                   brick.layout.strides_and_distances(),
                                                    BufferPtr::temp(gatherPackBufs.back().data()),
                                                    packOffset,
-                                                   brick.contiguous_strides(),
+                                                   brick.layout.contiguous_strides_and_distances(),
                                                    std::move(description)),
                                    antecedents);
             AddAntecedent(gatherIdx, packIdx);
@@ -1442,34 +1491,34 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
                                   BufferPtr::temp(gatherPackBufs.back().data()),
                                   0,
                                   gatherOffset,
-                                  brick.count_elems()});
+                                  brick.layout.logical_count()});
         }
 
         // if brick is not contiguous in the field, it was packed to
         // be contiguous for communication.  unpack it so it's
         // contiguous in the field.
-        if(!brick.is_contiguous() || !brick.is_contiguous_in_field(field_length))
+        if(!brick.layout.is_contiguous() || !brick.layout.is_continuous_in(gathering_layout))
         {
             std::string description = "unpack brick " + std::to_string(brickIdx) + " after gather";
 
             outputPlanItems.push_back(
                 AddMultiPlanItem(transpose_brick(local_comm_rank,
                                                  currentLocation,
-                                                 brick.length(),
+                                                 brick.layout.lengths_and_batches(),
                                                  precision,
                                                  arrayType,
                                                  BufferPtr::temp(gatherDestBuf->data()),
                                                  gatherOffset,
-                                                 brick.contiguous_strides(),
+                                                 brick.layout.contiguous_strides_and_distances(),
                                                  output,
-                                                 brick.offset_in_field(field_stride),
-                                                 field_stride,
+                                                 brick.layout.offset_in(gathering_layout),
+                                                 gathering_layout.strides_and_distances(),
                                                  std::move(description)),
                                  {gatherIdx}));
         }
 
-        packOffset += brick.count_elems();
-        gatherOffset += brick.count_elems();
+        packOffset += brick.layout.logical_count();
+        gatherOffset += brick.layout.logical_count();
     }
 
     if(outputPlanItems.empty())
@@ -1480,12 +1529,11 @@ std::vector<size_t> rocfft_plan_t::GatherBricksToField(rocfft_location_t current
     return outputPlanItems;
 }
 
-std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t          currentLocation,
-                                                        BufferPtr                  input,
-                                                        rocfft_precision           precision,
-                                                        rocfft_array_type          arrayType,
-                                                        const std::vector<size_t>& field_length,
-                                                        const std::vector<size_t>& field_stride,
+std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t    currentLocation,
+                                                        BufferPtr            input,
+                                                        rocfft_precision     precision,
+                                                        rocfft_array_type    arrayType,
+                                                        const data_layout_t& layout_to_scatter,
                                                         const std::vector<rocfft_brick_t>& bricks,
                                                         const std::vector<size_t>& antecedents,
                                                         size_t                     elem_size)
@@ -1501,17 +1549,16 @@ std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t       
     BufferPtr  scatterSrc;
     const bool scatterFromTemp
         = std::any_of(bricks.begin(), bricks.end(), [&](const rocfft_brick_t& b) {
-              return !b.is_contiguous_in_field(field_length);
+              return !b.layout.is_contiguous() || !b.layout.is_continuous_in(layout_to_scatter);
           });
     if(scatterFromTemp)
     {
-        scatterSrcBuf
-            = std::make_optional<TempBufferLease>(tempBuffers,
-                                                  local_comm_rank,
-                                                  currentLocation,
-                                                  product(field_length.begin(), field_length.end()),
-                                                  elem_size);
-        scatterSrc = BufferPtr::temp(scatterSrcBuf->data());
+        scatterSrcBuf = std::make_optional<TempBufferLease>(tempBuffers,
+                                                            local_comm_rank,
+                                                            currentLocation,
+                                                            layout_to_scatter.logical_count(),
+                                                            elem_size);
+        scatterSrc    = BufferPtr::temp(scatterSrcBuf->data());
     }
     else
     {
@@ -1535,51 +1582,57 @@ std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t       
     {
         const auto& brick = bricks[brickIdx];
 
-        if(brick.is_contiguous_in_field(field_length))
+        if(brick.layout.is_contiguous() && brick.layout.is_continuous_in(layout_to_scatter))
         {
             // contiguous brick, just copy the data
             scatter->AddOperation(
                 local_comm_rank,
                 {brick.location,
                  outputBufs[brickIdx],
-                 scatterFromTemp ? scatterOffset : brick.offset_in_field(field_stride),
+                 scatterFromTemp ? scatterOffset : brick.layout.offset_in(layout_to_scatter),
                  0,
-                 brick.count_elems()});
+                 brick.layout.logical_count()});
         }
         else
         {
             // pack data to be contiguous
             std::string description = "pack brick " + std::to_string(brickIdx) + " before scatter";
 
-            const auto brickLen = brick.length();
-            auto       packIdx  = AddMultiPlanItem(transpose_brick(local_comm_rank,
-                                                            currentLocation,
-                                                            brick.length(),
-                                                            precision,
-                                                            arrayType,
-                                                            input,
-                                                            brick.offset_in_field(field_stride),
-                                                            field_stride,
-                                                            BufferPtr::temp(scatterSrcBuf->data()),
-                                                            scatterOffset,
-                                                            brick.contiguous_strides(),
-                                                            std::move(description)),
-                                            antecedents);
+            auto packIdx
+                = AddMultiPlanItem(transpose_brick(local_comm_rank,
+                                                   currentLocation,
+                                                   brick.layout.lengths_and_batches(),
+                                                   precision,
+                                                   arrayType,
+                                                   input,
+                                                   brick.layout.offset_in(layout_to_scatter),
+                                                   layout_to_scatter.strides_and_distances(),
+                                                   BufferPtr::temp(scatterSrcBuf->data()),
+                                                   scatterOffset,
+                                                   brick.layout.contiguous_strides_and_distances(),
+                                                   std::move(description)),
+                                   antecedents);
             AddAntecedent(scatterIdx, packIdx);
 
             // Bricks are packed to be contiguous - if output is the
             // same shape, then there's no need for unpacking
-            if(brick.is_contiguous())
+            if(brick.layout.is_contiguous())
             {
-                scatter->AddOperation(
-                    local_comm_rank,
-                    {brick.location, outputBufs[brickIdx], scatterOffset, 0, brick.count_elems()});
+                scatter->AddOperation(local_comm_rank,
+                                      {brick.location,
+                                       outputBufs[brickIdx],
+                                       scatterOffset,
+                                       0,
+                                       brick.layout.logical_count()});
             }
             else
             {
                 // allocate memory for packed data
-                scatterPackBufs.emplace_back(
-                    tempBuffers, local_comm_rank, brick.location, brick.count_elems(), elem_size);
+                scatterPackBufs.emplace_back(tempBuffers,
+                                             local_comm_rank,
+                                             brick.location,
+                                             brick.layout.logical_count(),
+                                             elem_size);
 
                 // send the data
                 scatter->AddOperation(local_comm_rank,
@@ -1587,28 +1640,28 @@ std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t       
                                        BufferPtr::temp(scatterPackBufs.back().data()),
                                        scatterOffset,
                                        0,
-                                       brick.count_elems()});
+                                       brick.layout.logical_count()});
 
                 // unpack data after sending
                 description = "unpack brick " + std::to_string(brickIdx) + " after scatter";
 
-                outputPlanItems.push_back(
-                    AddMultiPlanItem(transpose_brick(local_comm_rank,
-                                                     brick.location,
-                                                     brick.length(),
-                                                     precision,
-                                                     arrayType,
-                                                     BufferPtr::temp(scatterPackBufs.back().data()),
-                                                     0,
-                                                     brick.contiguous_strides(),
-                                                     outputBufs[brickIdx],
-                                                     0,
-                                                     brick.stride,
-                                                     std::move(description)),
-                                     {scatterIdx}));
+                outputPlanItems.push_back(AddMultiPlanItem(
+                    transpose_brick(local_comm_rank,
+                                    brick.location,
+                                    brick.layout.lengths_and_batches(),
+                                    precision,
+                                    arrayType,
+                                    BufferPtr::temp(scatterPackBufs.back().data()),
+                                    0,
+                                    brick.layout.contiguous_strides_and_distances(),
+                                    outputBufs[brickIdx],
+                                    0,
+                                    brick.layout.strides_and_distances(),
+                                    std::move(description)),
+                    {scatterIdx}));
             }
         }
-        scatterOffset += brick.count_elems();
+        scatterOffset += brick.layout.logical_count();
     }
 
     // following items in the plan just depend on the scatter
@@ -1626,7 +1679,7 @@ std::vector<size_t> rocfft_plan_t::ScatterFieldToBricks(rocfft_location_t       
 static bool DimensionSplitInField(size_t length, size_t dimIdx, const rocfft_field_t& field)
 {
     for(const auto& b : field.bricks)
-        if(b.length()[dimIdx] != length)
+        if(b.layout.lengths_and_batches()[dimIdx] != length)
             return true;
     return false;
 }
@@ -1661,7 +1714,7 @@ void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& ex
     const auto in_elem_size = element_size(precision, desc.inArrayType);
     // We do in-place transforms here, so allocate a buffer for the
     // complex side of real-complex transforms, since it's bigger.
-    const size_t in_elem_count = compute_ptrdiff(lengths, desc.inStrides, batch, desc.inDist);
+    const size_t in_elem_count = desc.input_layout.buffer_element_count();
 
     const auto local_comm_rank = desc.get_local_comm_rank();
 
@@ -1671,7 +1724,7 @@ void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& ex
 
     BufferPtr gatherBuf;
     {
-        if(!desc.inFields.empty() && desc.outFields.empty() && is_contiguous_output()
+        if(!desc.inFields.empty() && desc.outFields.empty() && desc.output_layout.is_contiguous()
            && execPlan->rootPlan->placement == rocfft_placement_inplace)
         {
             // We can gather directly to the output buffer and will operate in-place
@@ -1695,9 +1748,8 @@ void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& ex
     if(execPlan->rootPlan->placement == rocfft_placement_notinplace && !desc.outFields.empty())
     {
         const auto   out_elem_size  = element_size(precision, desc.outArrayType);
-        const size_t out_elem_count = compute_ptrdiff(
-            execPlan->rootPlan->GetOutputLength(), desc.outStrides, batch, desc.outDist);
-        fftOutBuf = std::make_shared<TempBufferLease>(
+        const size_t out_elem_count = desc.output_layout.buffer_element_count();
+        fftOutBuf                   = std::make_shared<TempBufferLease>(
             tempBuffers, local_comm_rank, execPlanPtr->location, out_elem_count, out_elem_size);
     }
 
@@ -1705,19 +1757,11 @@ void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& ex
     {
         for(const auto& inField : desc.inFields)
         {
-            // brick indexes include batch so create a set of comparable field strides
-            auto fieldStrideWithBatch = desc.inStrides;
-            fieldStrideWithBatch.push_back(desc.inDist);
-
-            auto fieldLengthWithBatch = lengths;
-            fieldLengthWithBatch.push_back(batch);
-
             auto curIndexes = GatherBricksToField(execPlan->location,
                                                   inField.bricks,
                                                   precision,
                                                   desc.inArrayType,
-                                                  fieldLengthWithBatch,
-                                                  fieldStrideWithBatch,
+                                                  desc.input_layout,
                                                   gatherBuf,
                                                   {},
                                                   element_size(precision, desc.inArrayType));
@@ -1741,12 +1785,6 @@ void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& ex
     for(const auto& outField : desc.outFields)
     {
         // brick indexes include batch so create a set of comparable field strides
-        auto fieldStrideWithBatch = desc.outStrides;
-        fieldStrideWithBatch.push_back(desc.outDist);
-
-        auto fieldLengthWithBatch = outputLengths;
-        fieldLengthWithBatch.push_back(batch);
-
         auto scatterSrcBuf = execPlan->rootPlan->placement == rocfft_placement_notinplace
                                  ? fftOutBuf->data()
                                  : fftBuf->data();
@@ -1755,8 +1793,7 @@ void rocfft_plan_t::GatherScatterSingleDevicePlan(std::unique_ptr<ExecPlan>&& ex
                              BufferPtr::temp(scatterSrcBuf),
                              execPlan->rootPlan->precision,
                              execPlan->rootPlan->outArrayType,
-                             fieldLengthWithBatch,
-                             fieldStrideWithBatch,
+                             desc.output_layout,
                              outField.bricks,
                              {fftIdx},
                              element_size(precision, execPlan->rootPlan->outArrayType));
@@ -1981,8 +2018,8 @@ void rocfft_plan_t::C2CField(const rocfft_field_t&          field,
             auto transformItem              = C2CBrickOneDimension(*this,
                                                       dimIdx,
                                                       inBrick.location,
-                                                      inBrick.length(),
-                                                      inBrick.stride,
+                                                      inBrick.layout.lengths_and_batches(),
+                                                      inBrick.layout.strides_and_distances(),
                                                       fftInput,
                                                       output[i],
                                                       appliedLoadOps,
@@ -2021,40 +2058,40 @@ static rocfft_field_t MakeFieldDimContiguous(const rocfft_field_t&      field,
     if(!splitDim)
         throw std::runtime_error("not enough lengths to split to make dim contiguous");
 
+    std::vector<size_t> brick_lower(length.size()), brick_upper(length.size()),
+        brick_strides(length.size());
     for(size_t i = 0; i < out.bricks.size(); ++i)
     {
-        auto& outBrick = out.bricks[i];
-
-        // start lower and upper at origin and max, respectively
-        std::fill(outBrick.lower.begin(), outBrick.lower.end(), 0);
-        outBrick.upper = length;
+        // reset lower and upper to origin and max
+        std::fill(brick_lower.begin(), brick_lower.end(), 0);
+        std::copy(length.begin(), length.end(), brick_upper.begin());
 
         // divide up the split dim
-        outBrick.lower[*splitDim] = length[*splitDim] / out.bricks.size() * i;
+        brick_lower[*splitDim] = length[*splitDim] / out.bricks.size() * i;
         // last brick needs to include the whole length
         if(i == out.bricks.size() - 1)
-            outBrick.upper[*splitDim] = length[*splitDim];
+            brick_upper[*splitDim] = length[*splitDim];
         else
-            outBrick.upper[*splitDim] = length[*splitDim] / out.bricks.size() * (i + 1);
-
-        auto brickLength = outBrick.length();
-
+            brick_upper[*splitDim] = length[*splitDim] / out.bricks.size() * (i + 1);
         // set strides - contiguous dim has stride 1
-        size_t dist             = 1;
-        outBrick.stride[dimIdx] = dist;
-        dist *= brickLength[dimIdx];
+        size_t dist           = 1;
+        brick_strides[dimIdx] = dist;
+        dist *= (brick_upper[dimIdx] - brick_lower[dimIdx]);
         // split dim is contiguous after that
-        outBrick.stride[*splitDim] = dist;
-        dist *= brickLength[*splitDim];
+        brick_strides[*splitDim] = dist;
+        dist *= (brick_upper[*splitDim] - brick_lower[*splitDim]);
         // fill in remaining strides
-        for(size_t s = 0; s < outBrick.stride.size(); ++s)
+        for(size_t s = 0; s < brick_strides.size(); ++s)
         {
             if(s == dimIdx || s == *splitDim)
                 continue;
-            outBrick.stride[s] = dist;
-            dist *= brickLength[s];
+            brick_strides[s] = dist;
+            dist *= (brick_upper[s] - brick_lower[s]);
         }
+
+        out.bricks[i].layout = data_layout_t{brick_lower, brick_upper, brick_strides};
     }
+    out.finalize();
     return out;
 }
 
@@ -2114,38 +2151,36 @@ void rocfft_plan_t::GlobalTransposeP2P(size_t                     elem_size,
         {
             const auto& outBrick = outField.bricks[outBrickIdx];
 
-            auto intersection = inBrick.intersect(outBrick);
-            if(intersection.empty())
+            const auto intersection
+                = data_layout_t::make_contiguous_intersection_of(inBrick.layout, outBrick.layout);
+            if(intersection.is_empty())
                 continue;
-            intersection.stride = intersection.contiguous_strides();
 
             // pack data for communication
             packBufs.reserve(packBufs.size() + 2);
-            TempBufferLease& pack = packBufs.emplace_back(tempBuffers,
+            TempBufferLease& pack     = packBufs.emplace_back(tempBuffers,
                                                           local_comm_rank,
                                                           inBrick.location,
-                                                          intersection.count_elems(),
+                                                          intersection.logical_count(),
                                                           elem_size);
-            TempBufferLease& recv = packBufs.emplace_back(tempBuffers,
+            TempBufferLease& recv     = packBufs.emplace_back(tempBuffers,
                                                           local_comm_rank,
                                                           outBrick.location,
-                                                          intersection.count_elems(),
+                                                          intersection.logical_count(),
                                                           elem_size);
-            auto             packIdx
-                = AddMultiPlanItem(transpose_brick(local_comm_rank,
-                                                   inBrick.location,
-                                                   intersection.length(),
-                                                   precision,
-                                                   desc.inArrayType,
-                                                   input[inBrickIdx],
-                                                   intersection.offset_in_field(inBrick.stride)
-                                                       - inBrick.offset_in_field(inBrick.stride),
-                                                   inBrick.stride,
-                                                   BufferPtr::temp(pack.data()),
-                                                   0,
-                                                   intersection.stride,
-                                                   "pack brick for global transpose"),
-                                   {inputAntecedents[inBrickIdx]});
+            auto             packIdx  = AddMultiPlanItem(transpose_brick(local_comm_rank,
+                                                            inBrick.location,
+                                                            intersection.lengths_and_batches(),
+                                                            precision,
+                                                            desc.inArrayType,
+                                                            input[inBrickIdx],
+                                                            intersection.offset_in(inBrick.layout),
+                                                            inBrick.layout.strides_and_distances(),
+                                                            BufferPtr::temp(pack.data()),
+                                                            0,
+                                                            intersection.strides_and_distances(),
+                                                            "pack brick for global transpose"),
+                                            {inputAntecedents[inBrickIdx]});
             multiPlan[packIdx]->group = itemGroup;
             multiPlan[packIdx]->description
                 = "pack " + std::to_string(inBrickIdx) + " + " + std::to_string(outBrickIdx);
@@ -2154,7 +2189,7 @@ void rocfft_plan_t::GlobalTransposeP2P(size_t                     elem_size,
             auto sendOp = std::make_unique<CommPointToPoint>(local_comm_rank,
                                                              precision,
                                                              desc.inArrayType,
-                                                             intersection.count_elems(),
+                                                             intersection.logical_count(),
                                                              inBrick.location,
                                                              BufferPtr::temp(pack.data()),
                                                              0,
@@ -2171,16 +2206,15 @@ void rocfft_plan_t::GlobalTransposeP2P(size_t                     elem_size,
             auto unpackIdx
                 = AddMultiPlanItem(transpose_brick(local_comm_rank,
                                                    outBrick.location,
-                                                   intersection.length(),
+                                                   intersection.lengths_and_batches(),
                                                    precision,
                                                    desc.inArrayType,
                                                    BufferPtr::temp(recv.data()),
                                                    0,
-                                                   intersection.stride,
+                                                   intersection.strides_and_distances(),
                                                    output[outBrickIdx],
-                                                   intersection.offset_in_field(outBrick.stride)
-                                                       - outBrick.offset_in_field(outBrick.stride),
-                                                   outBrick.stride,
+                                                   intersection.offset_in(outBrick.layout),
+                                                   outBrick.layout.strides_and_distances(),
                                                    "unpack brick for global transpose"),
                                    {sendIdx});
             multiPlan[unpackIdx]->group = itemGroup;
@@ -2296,13 +2330,14 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
             const auto& outBrick = outField.bricks[outBrickIdx];
             const auto  outRank  = outBrick.location.comm_rank;
 
-            auto intersection = inBrick.intersect(outBrick);
-            if(intersection.empty())
+            const auto intersection
+                = data_layout_t::make_contiguous_intersection_of(inBrick.layout, outBrick.layout);
+            if(intersection.is_empty())
                 continue;
 
             conn.add_connection(inRank, outRank);
 
-            const auto elems = intersection.count_elems();
+            const auto elems = intersection.logical_count();
 
             if(inRank == local_comm_rank)
             {
@@ -2358,10 +2393,10 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
             const auto& outBrick = outField.bricks[outBrickIdx];
             const auto  outRank  = outBrick.location.comm_rank;
 
-            auto intersection = inBrick.intersect(outBrick);
-            if(intersection.empty())
+            const auto intersection
+                = data_layout_t::make_contiguous_intersection_of(inBrick.layout, outBrick.layout);
+            if(intersection.is_empty())
                 continue;
-            intersection.stride = intersection.contiguous_strides();
 
             // this transpose will only actually run if inRank ==
             // local_comm_rank, but adding it to the plan so all
@@ -2369,21 +2404,20 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
             //
             // if(inRank == local_comm_rank)
             {
-                auto pack_op = AddMultiPlanItem(
-                    transpose_brick(local_comm_rank,
-                                    inBrick.location,
-                                    intersection.length(),
-                                    precision,
-                                    desc.inArrayType,
-                                    input[inBrickIdx],
-                                    intersection.offset_in_field(inBrick.stride)
-                                        - inBrick.offset_in_field(inBrick.stride),
-                                    inBrick.stride,
-                                    BufferPtr::temp(send_buf.data()),
-                                    send_offsets[outRank],
-                                    intersection.stride,
-                                    "pack brick for global transpose"),
-                    inputAntecedents);
+                auto pack_op
+                    = AddMultiPlanItem(transpose_brick(local_comm_rank,
+                                                       inBrick.location,
+                                                       intersection.lengths_and_batches(),
+                                                       precision,
+                                                       desc.inArrayType,
+                                                       input[inBrickIdx],
+                                                       intersection.offset_in(inBrick.layout),
+                                                       inBrick.layout.strides_and_distances(),
+                                                       BufferPtr::temp(send_buf.data()),
+                                                       send_offsets[outRank],
+                                                       intersection.strides_and_distances(),
+                                                       "pack brick for global transpose"),
+                                       inputAntecedents);
                 multiPlan[pack_op]->group = itemGroup;
                 multiPlan[pack_op]->description
                     = "pack " + std::to_string(inBrickIdx) + " + " + std::to_string(outBrickIdx);
@@ -2396,21 +2430,20 @@ void rocfft_plan_t::GlobalTransposeA2A(size_t                     elem_size,
             //
             // if(outRank == local_comm_rank)
             {
-                auto unpack_op = AddMultiPlanItem(
-                    transpose_brick(local_comm_rank,
-                                    outBrick.location,
-                                    intersection.length(),
-                                    precision,
-                                    desc.inArrayType,
-                                    BufferPtr::temp(recv_buf.data()),
-                                    recv_offsets[inRank],
-                                    intersection.stride,
-                                    output[outBrickIdx],
-                                    intersection.offset_in_field(outBrick.stride)
-                                        - outBrick.offset_in_field(outBrick.stride),
-                                    outBrick.stride,
-                                    "unpack brick for global transpose"),
-                    {});
+                auto unpack_op
+                    = AddMultiPlanItem(transpose_brick(local_comm_rank,
+                                                       outBrick.location,
+                                                       intersection.lengths_and_batches(),
+                                                       precision,
+                                                       desc.inArrayType,
+                                                       BufferPtr::temp(recv_buf.data()),
+                                                       recv_offsets[inRank],
+                                                       intersection.strides_and_distances(),
+                                                       output[outBrickIdx],
+                                                       intersection.offset_in(outBrick.layout),
+                                                       outBrick.layout.strides_and_distances(),
+                                                       "unpack brick for global transpose"),
+                                       {});
                 multiPlan[unpack_op]->group = itemGroup;
                 multiPlan[unpack_op]->description
                     = "unpack " + std::to_string(inBrickIdx) + " + " + std::to_string(outBrickIdx);
@@ -2480,12 +2513,13 @@ inline std::array<int, 3> infer_grid_from_bricks(const std::vector<rocfft_brick_
     std::set<size_t> xset, yset, zset;
     for(const auto& b : bricks)
     {
-        if(b.lower.size() >= 1)
-            xset.insert(b.lower[0]);
-        if(b.lower.size() >= 2)
-            yset.insert(b.lower[1]);
-        if(b.lower.size() >= 3)
-            zset.insert(b.lower[2]);
+        const auto brick_lower = b.layout.lower();
+        if(brick_lower.size() >= 1)
+            xset.insert(brick_lower[0]);
+        if(brick_lower.size() >= 2)
+            yset.insert(brick_lower[1]);
+        if(brick_lower.size() >= 3)
+            zset.insert(brick_lower[2]);
     }
     int nx = std::max(1, static_cast<int>(xset.size()));
     int ny = std::max(1, static_cast<int>(yset.size()));
@@ -2504,10 +2538,11 @@ rocfft_field_t MakeFieldWithPencilSplit(const rocfft_field_t&      currentField,
     int P = split_sizes[0], Q = split_sizes[1];
     int n_bricks = P * Q;
 
-    rocfft_field_t out = currentField;
-    out.bricks.resize(n_bricks);
+    rocfft_field_t out;
+    out.bricks.reserve(n_bricks);
 
-    const int ndim = static_cast<int>(lengthsWithBatch.size());
+    const int           ndim = static_cast<int>(lengthsWithBatch.size());
+    std::vector<size_t> brick_lower(ndim), brick_upper(ndim), brick_strides(ndim);
     for(int i = 0; i < 2; ++i)
     {
         int ax = split_axes[i];
@@ -2526,42 +2561,37 @@ rocfft_field_t MakeFieldWithPencilSplit(const rocfft_field_t&      currentField,
     // distribute location/device assignments round-robin
     for(int i = 0; i < n_bricks; ++i)
     {
-        auto& brick = out.bricks[i];
-
         // compute 2D (p, q) indices for this brick
         int p = i / Q;
         int q = i % Q;
 
         // set bounds for each axis
-        for(int d = 0; d < ndim; ++d)
-        {
-            brick.lower[d] = 0;
-            brick.upper[d] = lengthsWithBatch[d];
-        }
+        std::fill(brick_lower.begin(), brick_lower.end(), 0);
+        std::copy(lengthsWithBatch.begin(), lengthsWithBatch.end(), brick_upper.begin());
 
         int axis_p = split_axes[0];
         int axis_q = split_axes[1];
 
         int len_p           = lengthsWithBatch[axis_p];
         int len_q           = lengthsWithBatch[axis_q];
-        brick.lower[axis_p] = len_p * p / P;
-        brick.upper[axis_p] = len_p * (p + 1) / P;
-        brick.lower[axis_q] = len_q * q / Q;
-        brick.upper[axis_q] = len_q * (q + 1) / Q;
+        brick_lower[axis_p] = len_p * p / P;
+        brick_upper[axis_p] = len_p * (p + 1) / P;
+        brick_lower[axis_q] = len_q * q / Q;
+        brick_upper[axis_q] = len_q * (q + 1) / Q;
 
         // contiguous strides
-        const auto brickLength = brick.length();
-        int        dist        = 1;
-        for(size_t s = 0; s < brick.stride.size(); ++s)
+        int dist = 1;
+        for(size_t s = 0; s < brick_strides.size(); ++s)
         {
-            brick.stride[s] = dist;
-            dist *= brickLength[s];
+            brick_strides[s] = dist;
+            dist *= brick_upper[s] - brick_lower[s];
         }
 
         // assign device/rank in a round-robin fashion
         const auto& ref_brick = currentField.bricks[i % currentField.bricks.size()];
-        brick.location        = ref_brick.location;
+        out.bricks.emplace_back(brick_lower, brick_upper, brick_strides, ref_brick.location);
     }
+    out.finalize();
 
     return out;
 }
@@ -2709,11 +2739,12 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
     std::vector<size_t> contiguousInputDims;
     std::vector<size_t> contiguousOutputDims;
     std::vector<size_t> nonContiguousDims;
-    for(size_t dimIdx = 0; dimIdx < rank; ++dimIdx)
+    const auto          input_lengths = desc.input_layout.lengths();
+    for(size_t dimIdx = 0; dimIdx < desc.rank(); ++dimIdx)
     {
-        if(!DimensionSplitInField(lengths[dimIdx], dimIdx, desc.inFields.front()))
+        if(!DimensionSplitInField(input_lengths[dimIdx], dimIdx, desc.inFields.front()))
             contiguousInputDims.push_back(dimIdx);
-        else if(!DimensionSplitInField(lengths[dimIdx], dimIdx, desc.outFields.front()))
+        else if(!DimensionSplitInField(input_lengths[dimIdx], dimIdx, desc.outFields.front()))
             contiguousOutputDims.push_back(dimIdx);
         else
             nonContiguousDims.push_back(dimIdx);
@@ -2740,8 +2771,11 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
     for(size_t inBrickIdx = 0; inBrickIdx < desc.inFields.front().bricks.size(); ++inBrickIdx)
     {
         const auto& inBrick = desc.inFields.front().bricks[inBrickIdx];
-        inputTemp.emplace_back(
-            tempBuffers, local_comm_rank, inBrick.location, inBrick.count_elems(), elem_size);
+        inputTemp.emplace_back(tempBuffers,
+                               local_comm_rank,
+                               inBrick.location,
+                               inBrick.layout.logical_count(),
+                               elem_size);
         inputFFTBufs.emplace_back(BufferPtr::temp(inputTemp.back().data()));
     }
 
@@ -2760,11 +2794,11 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
              {},
              inputFFTItems);
 
-    auto lengthsWithBatch = lengths;
-    lengthsWithBatch.push_back(batch);
+    auto lengthsWithBatch = input_lengths;
+    lengthsWithBatch.push_back(desc.batch());
 
     // track which dimensions have already been FFTed
-    std::vector<int> fft_done(rank, 0);
+    std::vector<int> fft_done(desc.rank(), 0);
     for(auto d : contiguousInputDims)
         fft_done[d] = 1;
 
@@ -2784,11 +2818,11 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
 
     bool pencil_to_pencil = false;
     // plan transposition steps
-    if(num_split_dims_in >= 2 && num_split_dims_out >= 2 && rank == 3)
+    if(num_split_dims_in >= 2 && num_split_dims_out >= 2 && desc.rank() == 3)
     {
         get_transpose_plan(in_grid,
                            out_grid,
-                           {lengths[0], lengths[1], lengths[2]},
+                           {input_lengths[0], input_lengths[1], input_lengths[2]},
                            grids_sequence,
                            transpose_sequence);
 
@@ -2861,7 +2895,7 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
                         tempLeases.emplace_back(tempBuffers,
                                                 local_comm_rank,
                                                 nextField.bricks[b].location,
-                                                nextField.bricks[b].count_elems(),
+                                                nextField.bricks[b].layout.logical_count(),
                                                 elem_size);
                         tempBufs[b] = BufferPtr::temp(tempLeases.back().data());
                     }
@@ -2930,7 +2964,7 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
             for(auto& b : transposedField.bricks)
             {
                 transposeOutputTemp.emplace_back(
-                    tempBuffers, local_comm_rank, b.location, b.count_elems(), elem_size);
+                    tempBuffers, local_comm_rank, b.location, b.layout.logical_count(), elem_size);
                 transposeOutputBufs.emplace_back(
                     BufferPtr::temp(transposeOutputTemp.back().data()));
             }
@@ -2995,19 +3029,25 @@ bool rocfft_plan_t::BuildOptMultiDevicePlan()
 }
 
 // All-gather all of the brick parameters for a given field.
-rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
-                                             rocfft_field_t& field,
-                                             const size_t    global_brick_length)
+#ifdef ROCFFT_MPI_ENABLE
+rocfft_status
+    rocfft_plan_description_t::allgather_brick_params_lus_mpi(rocfft_field_t& field,
+                                                              const size_t    global_brick_length)
 {
-#if !defined ROCFFT_MPI_ENABLE
-    return rocfft_status_failure;
-#else
+    if(comm_type == rocfft_comm_none)
+        return rocfft_status_success;
+    if(!mpi_comm)
+    {
+        // If the comm type is MPI, but the comm pointer is null, then return an error.
+        return rocfft_status_failure;
+    }
+
     auto rcmpi = MPI_SUCCESS;
 
     // TODO: make async.
 
     // First, compute the number of bricks per field.
-    std::vector<int> global_brick_count(plan->desc.get_local_comm_size());
+    std::vector<int>                                 global_brick_count(get_local_comm_size());
     typeof(decltype(global_brick_count)::value_type) local_brick_count = field.bricks.size();
     {
         // OpenMPI has a runtime error if this is const, so make sure it isn't.
@@ -3018,7 +3058,7 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
                               global_brick_count.data(),
                               1,
                               type_to_mpi_type<typeof(decltype(global_brick_count)::value_type)>(),
-                              plan->desc.mpi_comm);
+                              mpi_comm);
         if(rcmpi != MPI_SUCCESS)
         {
             throw std::runtime_error("MPI_Allgather failed: " + std::to_string(rcmpi));
@@ -3026,7 +3066,7 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
     }
 
     // We need the displacments (as an int[]) for MPI_Allgatherv:
-    typeof(global_brick_count) displacements(plan->desc.get_local_comm_size());
+    typeof(global_brick_count) displacements(get_local_comm_size());
     displacements[0] = 0;
     std::partial_sum(
         global_brick_count.begin(), global_brick_count.end() - 1, displacements.begin() + 1);
@@ -3040,35 +3080,38 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
     const auto num_global_bricks = std::accumulate(
         global_brick_count.begin(), global_brick_count.end(), static_cast<size_t>(0));
 
-    std::vector<typeof(decltype(rocfft_brick_t::lower)::value_type)> global_lowers(
-        num_global_bricks * global_brick_length);
-    std::vector<typeof(decltype(rocfft_brick_t::upper)::value_type)> global_uppers(
-        num_global_bricks * global_brick_length);
-    std::vector<typeof(decltype(rocfft_brick_t::stride)::value_type)> global_strides(
-        num_global_bricks * global_brick_length);
+    std::vector<size_t> global_lowers(num_global_bricks * global_brick_length);
+    std::vector<size_t> global_uppers(num_global_bricks * global_brick_length);
+    std::vector<size_t> global_strides(num_global_bricks * global_brick_length);
     std::vector<decltype(rocfft_location_t::device)>    global_devices(num_global_bricks);
     std::vector<decltype(rocfft_location_t::comm_rank)> global_comm_ranks(num_global_bricks);
 
     // Make a contiguous copy for the MPI routine:
-    std::vector<typeof(decltype(rocfft_brick_t::lower)::value_type)>  local_lowers;
-    std::vector<typeof(decltype(rocfft_brick_t::upper)::value_type)>  local_uppers;
-    std::vector<typeof(decltype(rocfft_brick_t::stride)::value_type)> local_strides;
-    std::vector<int>                                                  local_devices;
-    std::vector<int>                                                  local_comm_ranks;
+    decltype(global_lowers)     local_lowers;
+    decltype(global_uppers)     local_uppers;
+    decltype(global_strides)    local_strides;
+    decltype(global_devices)    local_devices;
+    decltype(global_comm_ranks) local_comm_ranks;
     local_lowers.reserve(local_brick_count * global_brick_length);
     local_uppers.reserve(local_brick_count * global_brick_length);
     local_strides.reserve(local_brick_count * global_brick_length);
     for(const auto& brick : field.bricks)
     {
-        for(auto v : brick.lower)
+        static_assert(std::is_same_v<decltype(brick.layout.lower())::value_type,
+                                     decltype(local_lowers)::value_type>);
+        static_assert(std::is_same_v<decltype(brick.layout.upper())::value_type,
+                                     decltype(local_uppers)::value_type>);
+        static_assert(std::is_same_v<decltype(brick.layout.strides_and_distances())::value_type,
+                                     decltype(local_strides)::value_type>);
+        for(auto v : brick.layout.lower())
         {
             local_lowers.push_back(v);
         }
-        for(auto v : brick.upper)
+        for(auto v : brick.layout.upper())
         {
             local_uppers.push_back(v);
         }
-        for(auto v : brick.stride)
+        for(auto v : brick.layout.strides_and_distances())
         {
             local_strides.push_back(v);
         }
@@ -3091,13 +3134,13 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
         std::is_same_v<std::underlying_type<typeof(decltype(local_lowers)::value_type)>,
                        std::underlying_type<typeof(decltype(global_lowers)::value_type)>>);
     rcmpi = MPI_Allgatherv(local_lowers.data(),
-                           recvcount[plan->desc.get_local_comm_rank()],
+                           recvcount[get_local_comm_rank()],
                            type_to_mpi_type<typeof(decltype(local_lowers)::value_type)>(),
                            global_lowers.data(),
                            recvcount.data(),
                            displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_lowers)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3108,13 +3151,13 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
         std::is_same_v<std::underlying_type<typeof(decltype(local_uppers)::value_type)>,
                        std::underlying_type<typeof(decltype(global_uppers)::value_type)>>);
     rcmpi = MPI_Allgatherv(local_uppers.data(),
-                           recvcount[plan->desc.get_local_comm_rank()],
+                           recvcount[get_local_comm_rank()],
                            type_to_mpi_type<typeof(decltype(local_uppers)::value_type)>(),
                            global_uppers.data(),
                            recvcount.data(),
                            displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_uppers)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3125,13 +3168,13 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
         std::is_same_v<std::underlying_type<typeof(decltype(local_strides)::value_type)>,
                        std::underlying_type<typeof(decltype(global_strides)::value_type)>>);
     rcmpi = MPI_Allgatherv(local_strides.data(),
-                           recvcount[plan->desc.get_local_comm_rank()],
+                           recvcount[get_local_comm_rank()],
                            type_to_mpi_type<typeof(decltype(local_strides)::value_type)>(),
                            global_strides.data(),
                            recvcount.data(),
                            displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_strides)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3142,13 +3185,13 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
         std::is_same_v<std::underlying_type<typeof(decltype(local_devices)::value_type)>,
                        std::underlying_type<typeof(decltype(global_devices)::value_type)>>);
     rcmpi = MPI_Allgatherv(local_devices.data(),
-                           global_brick_count[plan->desc.get_local_comm_rank()],
+                           global_brick_count[get_local_comm_rank()],
                            type_to_mpi_type<typeof(decltype(local_devices)::value_type)>(),
                            global_devices.data(),
                            global_brick_count.data(),
                            scalar_displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_devices)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3159,13 +3202,13 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
         std::is_same_v<std::underlying_type<typeof(decltype(local_comm_ranks)::value_type)>,
                        std::underlying_type<typeof(decltype(global_comm_ranks)::value_type)>>);
     rcmpi = MPI_Allgatherv(local_comm_ranks.data(),
-                           global_brick_count[plan->desc.get_local_comm_rank()],
+                           global_brick_count[get_local_comm_rank()],
                            type_to_mpi_type<typeof(decltype(local_comm_ranks)::value_type)>(),
                            global_comm_ranks.data(),
                            global_brick_count.data(),
                            scalar_displacements.data(),
                            type_to_mpi_type<typeof(decltype(global_comm_ranks)::value_type)>(),
-                           plan->desc.mpi_comm);
+                           mpi_comm);
     if(rcmpi != MPI_SUCCESS)
     {
         throw std::runtime_error("MPI_Allgatherv failed: " + std::to_string(rcmpi));
@@ -3173,21 +3216,29 @@ rocfft_status allgather_brick_params_lus_mpi(rocfft_plan&    plan,
 
     field.bricks.clear();
     field.bricks.reserve(num_global_bricks);
+    std::vector<size_t> brick_lower(global_brick_length);
+    std::vector<size_t> brick_upper(global_brick_length);
+    std::vector<size_t> brick_strides(global_brick_length);
     for(std::remove_const_t<decltype(num_global_bricks)> ibrick = 0; ibrick < num_global_bricks;
         ++ibrick)
     {
+        brick_lower.assign(global_lowers.data() + ibrick * global_brick_length,
+                           global_lowers.data() + (ibrick + 1) * global_brick_length);
+        brick_upper.assign(global_uppers.data() + ibrick * global_brick_length,
+                           global_uppers.data() + (ibrick + 1) * global_brick_length);
+        brick_strides.assign(global_strides.data() + ibrick * global_brick_length,
+                             global_strides.data() + (ibrick + 1) * global_brick_length);
         // Add bricks one by one.
-        rocfft_brick_t brick{global_lowers.data() + ibrick * global_brick_length,
-                             global_uppers.data() + ibrick * global_brick_length,
-                             global_strides.data() + ibrick * global_brick_length,
-                             global_brick_length,
+        rocfft_brick_t brick{brick_lower,
+                             brick_upper,
+                             brick_strides,
                              {global_comm_ranks[ibrick], global_devices[ibrick]}};
         rocfft_field_add_brick_internal(field, brick);
     }
 
     return rocfft_status_success;
-#endif
 }
+#endif
 
 #if defined ROCFFT_MPI_ENABLE
 // Helper function to check that all of the values of a scalar are identical on all MPI ranks.
@@ -3211,12 +3262,12 @@ bool all_mpi_ranks_same_scalar(const Tval val, MPI_Comm comm)
 }
 #endif
 
-rocfft_status allgather_brick_params_mpi(rocfft_plan& plan)
+#ifdef ROCFFT_MPI_ENABLE
+rocfft_status rocfft_plan_description_t::allgather_brick_params_mpi()
 {
-#if !defined ROCFFT_MPI_ENABLE
-    return rocfft_status_failure;
-#else
-    if(!plan->desc.mpi_comm)
+    if(comm_type == rocfft_comm_none)
+        return rocfft_status_success;
+    if(!mpi_comm)
     {
         // If the comm type is MPI, but the comm pointer is null, then return an error.
         return rocfft_status_failure;
@@ -3230,36 +3281,36 @@ rocfft_status allgather_brick_params_mpi(rocfft_plan& plan)
 
     // Get the local brick array length.  If there are no bricks, this is zero.
     size_t local_bricklength = 0;
-    for(auto& ifield : plan->desc.inFields)
+    for(auto& ifield : inFields)
     {
         for(auto& ibrick : ifield.bricks)
         {
-            ibrick.location.comm_rank = plan->desc.get_local_comm_rank();
+            ibrick.location.comm_rank = get_local_comm_rank();
             if(local_bricklength == 0)
             {
-                local_bricklength = ibrick.lower.size();
+                local_bricklength = ibrick.layout.get_full_rank();
             }
             else
             {
-                if(local_bricklength != ibrick.lower.size())
+                if(local_bricklength != ibrick.layout.get_full_rank())
                 {
                     return rocfft_status_failure;
                 }
             }
         }
     }
-    for(auto& ofield : plan->desc.outFields)
+    for(auto& ofield : outFields)
     {
         for(auto& obrick : ofield.bricks)
         {
-            obrick.location.comm_rank = plan->desc.get_local_comm_rank();
+            obrick.location.comm_rank = get_local_comm_rank();
             if(local_bricklength == 0)
             {
-                local_bricklength = obrick.lower.size();
+                local_bricklength = obrick.layout.get_full_rank();
             }
             else
             {
-                if(local_bricklength != obrick.lower.size())
+                if(local_bricklength != obrick.layout.get_full_rank())
                 {
                     return rocfft_status_failure;
                 }
@@ -3273,15 +3324,14 @@ rocfft_status allgather_brick_params_mpi(rocfft_plan& plan)
     // which is ok.  However, it should not build its house out of straw.
     size_t global_brick_length = 0;
     {
-        std::vector<decltype(local_bricklength)> all_brick_lengths(
-            plan->desc.get_local_comm_size());
+        std::vector<decltype(local_bricklength)> all_brick_lengths(get_local_comm_size());
         rcmpi = MPI_Allgather(&local_bricklength,
                               1,
                               type_to_mpi_type<typeof(local_bricklength)>(),
                               all_brick_lengths.data(),
                               1,
                               type_to_mpi_type<typeof(decltype(all_brick_lengths)::value_type)>(),
-                              plan->desc.mpi_comm);
+                              mpi_comm);
         if(rcmpi != MPI_SUCCESS)
         {
             throw std::runtime_error("MPI_Allgather failed: " + std::to_string(rcmpi));
@@ -3308,9 +3358,9 @@ rocfft_status allgather_brick_params_mpi(rocfft_plan& plan)
     // Verify that all ranks have the same number of input and output fields.
     try
     {
-        if(!all_mpi_ranks_same_scalar(plan->desc.inFields.size(), plan->desc.mpi_comm))
+        if(!all_mpi_ranks_same_scalar(inFields.size(), mpi_comm))
             return rocfft_status_failure;
-        if(!all_mpi_ranks_same_scalar(plan->desc.outFields.size(), plan->desc.mpi_comm))
+        if(!all_mpi_ranks_same_scalar(outFields.size(), mpi_comm))
             return rocfft_status_failure;
     }
     catch(std::exception& e)
@@ -3323,17 +3373,17 @@ rocfft_status allgather_brick_params_mpi(rocfft_plan& plan)
     }
 
     // Communicate the brick info so that all ranks know about all the bricks.
-    for(auto& field : plan->desc.inFields)
+    for(auto& field : inFields)
     {
-        const auto rcfft = allgather_brick_params_lus_mpi(plan, field, global_brick_length);
+        const auto rcfft = allgather_brick_params_lus_mpi(field, global_brick_length);
         if(rcfft != rocfft_status_success)
         {
             return rcfft;
         }
     }
-    for(auto& field : plan->desc.outFields)
+    for(auto& field : outFields)
     {
-        const auto rcfft = allgather_brick_params_lus_mpi(plan, field, global_brick_length);
+        const auto rcfft = allgather_brick_params_lus_mpi(field, global_brick_length);
         if(rcfft != rocfft_status_success)
         {
             return rcfft;
@@ -3344,75 +3394,8 @@ rocfft_status allgather_brick_params_mpi(rocfft_plan& plan)
     // sub-communicator.  Need to figure out how to deal with completion though.
 
     return rocfft_status_success;
+}
 #endif
-}
-
-void rocfft_plan_t::ValidateFields() const
-{
-    auto validateField = [](const char*                type,
-                            const std::vector<size_t>& lengths,
-                            size_t                     batch,
-                            const rocfft_field_t&      field) {
-        // make sure all bricks have enough dimensions (FFT + batch dimensions)
-        for(const auto& b : field.bricks)
-        {
-            if(b.lower.size() != lengths.size() + 1 || b.upper.size() != lengths.size() + 1
-               || b.stride.size() != lengths.size() + 1)
-                throw std::runtime_error(std::string(type)
-                                         + " brick has wrong number of dimensions, expected "
-                                         + std::to_string(lengths.size() + 1));
-        }
-
-        // construct a brick that covers the whole field
-        rocfft_brick_t whole_field;
-        whole_field.lower.resize(lengths.size() + 1);
-        whole_field.upper = lengths;
-        whole_field.upper.push_back(batch);
-
-        // ensure no bricks in the field overlap - check each brick
-        // against each other brick
-        for(auto brickI = field.bricks.begin(); brickI != field.bricks.end(); ++brickI)
-        {
-            for(auto brickJ = brickI + 1; brickJ != field.bricks.end(); ++brickJ)
-            {
-                if(!brickI->intersect(*brickJ).empty())
-                {
-                    throw std::runtime_error(std::string(type) + " brick " + brickI->str()
-                                             + " overlaps with brick " + brickJ->str());
-                }
-            }
-
-            // ensure each brick is within the field
-            if(!brickI->equal_coords(brickI->intersect(whole_field)))
-                throw std::runtime_error(std::string(type) + " brick " + brickI->str()
-                                         + " is not within field");
-        }
-
-        // check that the bricks cover the whole index space
-        const size_t whole_field_elems = whole_field.count_elems();
-
-        // add up total number of elements in all bricks,
-        // should be the same since we know there are no
-        // overlaps
-        size_t total_brick_elems = 0;
-        for(const auto& b : field.bricks)
-            total_brick_elems += b.count_elems();
-        if(whole_field_elems != total_brick_elems)
-            throw std::runtime_error(std::string(type) + " field has "
-                                     + std::to_string(whole_field_elems) + " elems but bricks have "
-                                     + std::to_string(total_brick_elems) + " elems");
-    };
-
-    if(!desc.inFields.empty())
-        validateField("input", lengths, batch, desc.inFields.front());
-    if(!desc.outFields.empty())
-        validateField("output", outputLengths, batch, desc.outFields.front());
-
-    // multi-process transforms must use fields for both input and output
-    if(desc.comm_type != rocfft_comm_none && (desc.inFields.empty() || desc.outFields.empty()))
-        throw std::runtime_error(
-            "multi-process transforms require both input and output fields to be specified");
-}
 
 int rocfft_plan_description_t::get_local_comm_rank() const
 {
@@ -3463,55 +3446,22 @@ rocfft_status rocfft_plan_create_internal(rocfft_plan                   plan,
         return rocfft_status_invalid_dimensions;
     try
     {
-        plan->rank = dimensions;
-        std::copy(lengths, lengths + dimensions, std::back_inserter(plan->lengths));
-        plan->batch         = number_of_transforms;
         plan->placement     = placement;
         plan->precision     = precision;
         plan->transformType = transform_type;
 
-        plan->outputLengths = plan->lengths;
-        if(transform_type == rocfft_transform_type_real_forward
-           || transform_type == rocfft_transform_type_real_inverse)
-        {
-            plan->outputLengths.front() = plan->outputLengths.front() / 2 + 1;
-        }
-        if(transform_type == rocfft_transform_type_real_inverse)
-            std::swap(plan->outputLengths, plan->lengths);
-
-        if(description != nullptr)
+        if(description)
         {
             plan->desc = *description;
         }
-        plan->desc.init_defaults(
-            plan->transformType, plan->placement, plan->lengths, plan->outputLengths);
-
-        auto rcfft = rocfft_status_success;
-
-#ifdef ROCFFT_MPI_ENABLE
-        if(plan->desc.comm_type == rocfft_comm_mpi)
-        {
-            // Each rank needs to know the global data distribution for plan generation, so we
-            // gather all the brick information here.
-            rcfft = allgather_brick_params_mpi(plan);
-            if(rcfft != rocfft_status_success)
-                throw std::runtime_error("gather brick params failed");
-        }
-#endif
-
-        // Sort the parameters to be row major, in case they're not
-        plan->sort();
-
-        rcfft = check_array_type_validity(plan);
+        const auto rcfft = plan->desc.finalize_and_validate_for(
+            transform_type, placement, lengths, dimensions, number_of_transforms);
         if(rcfft != rocfft_status_success)
             return rcfft;
 
         log_bench(rocfft_bench_command(plan));
 
         // Construct the plan
-
-        // Build an optimized multi-device plan, if possible
-        plan->ValidateFields();
 
         // If we have no input/output fields, then the single ExecPlan is
         // exactly what we need to do.
@@ -3746,13 +3696,17 @@ try
     rocfft_cout << std::endl;
     rocfft_cout << std::endl;
 
-    rocfft_cout << "dimensions: " << plan->rank << std::endl;
+    rocfft_cout << "dimensions: " << plan->desc.rank() << std::endl;
 
-    rocfft_cout << "lengths: " << plan->lengths[0];
-    for(size_t i = 1; i < plan->rank; i++)
-        rocfft_cout << ", " << plan->lengths[i];
+    const auto lengths = plan->transformType == rocfft_transform_type_complex_forward
+                                 || plan->transformType == rocfft_transform_type_real_forward
+                             ? plan->desc.input_layout.lengths()
+                             : plan->desc.output_layout.lengths();
+    rocfft_cout << "lengths: " << lengths[0];
+    for(size_t i = 1; i < plan->desc.rank(); i++)
+        rocfft_cout << ", " << lengths[i];
     rocfft_cout << std::endl;
-    rocfft_cout << "batch size: " << plan->batch << std::endl;
+    rocfft_cout << "batch size: " << plan->desc.batch() << std::endl;
     rocfft_cout << std::endl;
 
     rocfft_cout << "input offset: " << plan->desc.inOffset[0];
@@ -3768,18 +3722,22 @@ try
     rocfft_cout << std::endl;
     rocfft_cout << std::endl;
 
-    rocfft_cout << "input strides: " << plan->desc.inStrides[0];
-    for(size_t i = 1; i < plan->rank; i++)
-        rocfft_cout << ", " << plan->desc.inStrides[i];
+    const auto input_strides = plan->desc.input_layout.strides();
+    if(!input_strides.empty())
+        rocfft_cout << "input strides: " << input_strides[0];
+    for(size_t i = 1; i < input_strides.size(); i++)
+        rocfft_cout << ", " << input_strides[i];
     rocfft_cout << std::endl;
 
-    rocfft_cout << "output strides: " << plan->desc.outStrides[0];
-    for(size_t i = 1; i < plan->rank; i++)
-        rocfft_cout << ", " << plan->desc.outStrides[i];
+    const auto output_strides = plan->desc.output_layout.strides();
+    if(!output_strides.empty())
+        rocfft_cout << "output strides: " << output_strides[0];
+    for(size_t i = 1; i < output_strides.size(); i++)
+        rocfft_cout << ", " << output_strides[i];
     rocfft_cout << std::endl;
 
-    rocfft_cout << "input distance: " << plan->desc.inDist << std::endl;
-    rocfft_cout << "output distance: " << plan->desc.outDist << std::endl;
+    rocfft_cout << "input distance: " << plan->desc.input_layout.distance() << std::endl;
+    rocfft_cout << "output distance: " << plan->desc.output_layout.distance() << std::endl;
     rocfft_cout << std::endl;
 
     plan->desc.loadOps.print(rocfft_cout, {});

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -281,7 +281,7 @@ try
         if(user_io_strides)
         {
             desc_io_layout.len_axes.resize(user_io_strides_sz);
-            for(size_t dim = 0; dim < in_strides_size; dim++)
+            for(size_t dim = 0; dim < user_io_strides_sz; dim++)
                 desc_io_layout.len_axes[dim].inbuffer_stride = user_io_strides[dim];
         }
         if(user_io_dist != 0)
@@ -473,6 +473,16 @@ catch(...)
     return rocfft_handle_exception();
 }
 
+std::vector<size_t> rocfft_plan_t::get_user_facing_lengths() const
+{
+    if(transformType == rocfft_transform_type_complex_forward
+       || transformType == rocfft_transform_type_real_forward)
+    {
+        return desc.input_layout.lengths();
+    }
+    return desc.output_layout.lengths();
+}
+
 std::string rocfft_bench_command(const rocfft_plan& plan)
 {
     rocfft_params params;
@@ -488,10 +498,7 @@ std::string rocfft_bench_command(const rocfft_plan& plan)
     params.scale_factor   = plan->desc.storeOps.scale_factor;
 
     // reverse-copy lengths and strides (col-major to row-major)
-    const auto lengths  = plan->transformType == rocfft_transform_type_complex_forward
-                                 || plan->transformType == rocfft_transform_type_real_forward
-                              ? plan->desc.input_layout.lengths()
-                              : plan->desc.output_layout.lengths();
+    const auto lengths  = plan->get_user_facing_lengths();
     const auto istrides = plan->desc.input_layout.strides();
     const auto ostrides = plan->desc.output_layout.strides();
     params.length.assign(lengths.rbegin(), lengths.rend());
@@ -548,19 +555,15 @@ rocfft_location_t rocfft_plan_description_t::get_current_location() const
 // tree plan.
 void set_rootplan_params(const rocfft_plan plan, NodeMetaData& planData)
 {
-    planData.dimension = plan->desc.rank();
-    planData.batch     = plan->desc.batch();
-    for(size_t i = 0; i < plan->desc.rank(); i++)
-    {
-        planData.length       = plan->desc.input_layout.lengths();
-        planData.outputLength = plan->desc.output_layout.lengths();
-
-        planData.inStride  = plan->desc.input_layout.strides();
-        planData.outStride = plan->desc.output_layout.strides();
-    }
-    planData.iDist     = plan->desc.input_layout.distance();
-    planData.oDist     = plan->desc.output_layout.distance();
-    planData.placement = plan->placement;
+    planData.dimension    = plan->desc.rank();
+    planData.batch        = plan->desc.batch();
+    planData.length       = plan->desc.input_layout.lengths();
+    planData.outputLength = plan->desc.output_layout.lengths();
+    planData.inStride     = plan->desc.input_layout.strides();
+    planData.outStride    = plan->desc.output_layout.strides();
+    planData.iDist        = plan->desc.input_layout.distance();
+    planData.oDist        = plan->desc.output_layout.distance();
+    planData.placement    = plan->placement;
 
     // If in+out fields are specified, currently that means we're
     // gathering the data to one device and doing FFT there.  So
@@ -630,10 +633,7 @@ void set_bluestein_strides(const rocfft_plan plan, NodeMetaData& planData)
     const auto precision     = plan->precision;
     const auto transformType = plan->transformType;
     const auto rank          = plan->desc.rank();
-    const auto fftLength     = transformType == rocfft_transform_type_complex_forward
-                                   || transformType == rocfft_transform_type_real_forward
-                                   ? plan->desc.input_layout.lengths()
-                                   : plan->desc.output_layout.lengths();
+    const auto fftLength     = plan->get_user_facing_lengths();
     const auto placement     = plan->placement;
     const auto dimension     = planData.dimension;
 
@@ -3698,10 +3698,7 @@ try
 
     rocfft_cout << "dimensions: " << plan->desc.rank() << std::endl;
 
-    const auto lengths = plan->transformType == rocfft_transform_type_complex_forward
-                                 || plan->transformType == rocfft_transform_type_real_forward
-                             ? plan->desc.input_layout.lengths()
-                             : plan->desc.output_layout.lengths();
+    const auto lengths = plan->get_user_facing_lengths();
     rocfft_cout << "lengths: " << lengths[0];
     for(size_t i = 1; i < plan->desc.rank(); i++)
         rocfft_cout << ", " << lengths[i];

--- a/projects/rocfft/library/src/plan.cpp
+++ b/projects/rocfft/library/src/plan.cpp
@@ -985,11 +985,11 @@ rocfft_status
             throw std::logic_error(ROCFFT_CURRENT_FUNCTION
                                    + " detected an unexpected batch rank in a plan description");
         }
-        io_layout.reset(io_lengths,
-                        current_strides /* default strides set if empty */,
-                        {number_of_transforms},
-                        current_distances /* default distances if empty */,
-                        is_real_domain && placement == rocfft_placement_inplace);
+        io_layout.full_range_reset(io_lengths,
+                                   current_strides /* default strides set if empty */,
+                                   {number_of_transforms},
+                                   current_distances /* default distances if empty */,
+                                   is_real_domain && placement == rocfft_placement_inplace);
     }
     // -------------------------------------------
     //   Finalize and validate I/O fields if any

--- a/projects/rocfft/library/src/transform.cpp
+++ b/projects/rocfft/library/src/transform.cpp
@@ -183,26 +183,25 @@ void rocfft_plan_t::LogFields(const char* description, const std::vector<rocfft_
             os << "    comm_rank: " << b.location.comm_rank << std::endl;
             os << "    device: " << b.location.device << std::endl;
             os << "    lower bound:";
-            for(auto i : b.lower)
+            for(auto i : b.layout.lower())
                 os << " " << i;
             os << std::endl;
             os << "    upper bound:";
-            for(auto i : b.upper)
+            for(auto i : b.layout.upper())
                 os << " " << i;
             os << std::endl;
 
             os << "    stride:";
-            for(auto i : b.stride)
+            for(auto i : b.layout.strides_and_distances())
                 os << " " << i;
             os << std::endl;
 
-            auto len = b.length();
             os << "    length:";
-            for(auto i : len)
+            for(auto i : b.layout.lengths_and_batches())
                 os << " " << i;
             os << std::endl;
 
-            os << "    elements: " << b.count_elems() << std::endl;
+            os << "    elements: " << b.layout.logical_count() << std::endl;
         }
     }
 }

--- a/projects/rocfft/shared/array_predicate.h
+++ b/projects/rocfft/shared/array_predicate.h
@@ -25,12 +25,23 @@
 
 namespace
 {
-    bool array_type_is_complex(rocfft_array_type type)
+    bool array_type_is_real(rocfft_array_type type)
+    {
+        return type == rocfft_array_type_real;
+    }
+    bool array_type_is_hermitian(rocfft_array_type type)
+    {
+        return type == rocfft_array_type_hermitian_interleaved
+               || type == rocfft_array_type_hermitian_planar;
+    }
+    bool array_type_is_complex_but_not_hermitian(rocfft_array_type type)
     {
         return type == rocfft_array_type_complex_interleaved
-               || type == rocfft_array_type_complex_planar
-               || type == rocfft_array_type_hermitian_interleaved
-               || type == rocfft_array_type_hermitian_planar;
+               || type == rocfft_array_type_complex_planar;
+    }
+    bool array_type_is_complex(rocfft_array_type type)
+    {
+        return array_type_is_complex_but_not_hermitian(type) || array_type_is_hermitian(type);
     }
     bool array_type_is_interleaved(rocfft_array_type type)
     {


### PR DESCRIPTION
## Motivation

Operation meant to declutter https://github.com/ROCm/rocm-libraries/pull/4072.

Implementation details for data-layout-related logic for `rocfft_plan_t` objects and their possible fields' bricks are impractical. Storing such parameters (_e.g._, range bounds and strides) without encapsulation
- increases the risk of producing inconsistent states across different objects that would expect consistency between one another;
- results in risks of producing invalid or inconsistent object states, intrinsically, _e.g._, different sizes for lengths and strides and/or `rank` being different than `length.size()`;
- results in exploding complexity for function signatures and argument validation;
- etc.

The main motivation of this PR is to alleviate the above concerns by introducing a `data_layout_t` structure which unifies logic between full and partial ranges of logical indices. It is introduced in `rocfft_brick_t` and `rocfft_plan_description_t` objects for capturing their corresponding relevant data layouts. 

Generalization to all translation units across rocfft will be handled in future task(s), in order to minimize the scope of this PR.

## Technical details
- The header of the introduced `data_layout_t` structure is heavily documented and captures the technical details pertaining to the structure;
- The various, separately-handled data-layout related members of `rocfft_brick_t`, `rocfft_plan_description_t`, and `rocfft_plan_t` objects are replaced by `data_layout_t` structures within `rocfft_plan_description_t` and `rocfft_brick_t` structures;
- The following functions are no longer needed as member functions of `data_layout_t` replace them:
     - `rocfft_brick_t::length`;
     - `rocfft_brick_t::empty`;
     - `rocfft_brick_t::intersect`;
     - `rocfft_brick_t::equal_coords`;
     - `rocfft_brick_t::count_elems`;
     - `rocfft_brick_t::is_contiguous`;
     - `rocfft_brick_t::contiguous_strides`;
     - `rocfft_brick_t::is_contiguous_in_field`;
     - `rocfft_brick_t::offset_in_field`;
     - `rocfft_plan_t::is_contiguous`;
     - `rocfft_plan_t::is_contiguous_input`;
     - `rocfft_plan_t::is_contiguous_output`;
- The `rocfft_plan_t::sort` function was found to possibly introduce an inconsistent states between a plan and its description by removing some length dimension in the former but not in the latter's possible bricks. This motivated the introduction of `rocfft_plan_description_t::finalize_and_validate` (heavily documented as well). Incomplete states for `rocfft_plan_description_t` instances are unavoidable due to the nature of the user-exposed APIs: `rocfft_plan_description_t::finalize_and_validate` finalizes these objects (and validates them upon finalization) as soon as possible when entering plan creation.

## Test Plan

No change of behavior is expected from this PR so current tests suffice. Some multi-device tests with unit lengths were added to cover the bug that `rocfft_plan_t::sort` was responsible for.

- The full test suite was executed manually on a `gfx90a` node with 8 devices;
- Multi-process tests were also executed on the same node (using 8 tasks).

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
