### PR TITLE
[fft_params.h] Expand I/O layout checks for real, in-place cases

### DIFF
--- a/projects/hipfft/shared/fft_params.h
+++ b/projects/hipfft/shared/fft_params.h
@@ -1677,7 +1677,7 @@ public:
                     std::cout << "istride:";
                     for(const auto& i : istride)
                         std::cout << " " << i;
-                    std::cout << " ostride0:";
+                    std::cout << " ostride:";
                     for(const auto& i : ostride)
                         std::cout << " " << i;
                     std::cout << " differ; skipped for in-place transforms: skipping test"
@@ -1702,20 +1702,48 @@ public:
                 return false;
             }
 
-            if((transform_type == fft_transform_type_real_forward
-                || transform_type == fft_transform_type_real_inverse)
-               && (istride.back() != 1 || ostride.back() != 1) && length.back() > 1)
+            if(transform_type == fft_transform_type_real_forward
+               || transform_type == fft_transform_type_real_inverse)
             {
-                // In-place real/complex transforms require unit strides.
-                if(verbose)
+                bool invalid = length.back() > 1 && (istride.back() != 1 || ostride.back() != 1);
+                if(invalid)
                 {
-                    std::cout
-                        << "istride.back(): " << istride.back()
-                        << " ostride.back(): " << ostride.back()
-                        << " must be unitary for in-place real/complex transforms: skipping test"
-                        << std::endl;
+                    // In-place real/complex transforms require unit strides.
+                    if(verbose)
+                    {
+                        std::cout << "istride.back(): " << istride.back()
+                                  << " ostride.back(): " << ostride.back()
+                                  << " must be unitary for in-place real/complex transforms: "
+                                     "skipping test"
+                                  << std::endl;
+                    }
+                    return false;
                 }
-                return false;
+                const auto& real_strides
+                    = transform_type == fft_transform_type_real_forward ? istride : ostride;
+                const auto& hermitian_strides
+                    = transform_type == fft_transform_type_real_forward ? ostride : istride;
+                const auto& real_dist
+                    = transform_type == fft_transform_type_real_forward ? idist : odist;
+                const auto& hermitian_dist
+                    = transform_type == fft_transform_type_real_forward ? odist : idist;
+                for(size_t dim = 0; dim < stridesize - 1; dim++)
+                {
+                    if(length[dim] == 1)
+                        continue;
+                    invalid |= real_strides[dim] != 2 * hermitian_strides[dim];
+                }
+                if(nbatch > 1)
+                    invalid |= real_dist != 2 * hermitian_dist;
+                if(invalid)
+                {
+                    if(verbose)
+                    {
+                        std::cout << "Inconsistency detected in strides/distances for in-place "
+                                     "real/complex transforms; skipped\n";
+                    }
+                    return false;
+                }
             }
 
             if((itype == fft_array_type_complex_interleaved

--- a/projects/rocfft/shared/fft_params.h
+++ b/projects/rocfft/shared/fft_params.h
@@ -1677,7 +1677,7 @@ public:
                     std::cout << "istride:";
                     for(const auto& i : istride)
                         std::cout << " " << i;
-                    std::cout << " ostride0:";
+                    std::cout << " ostride:";
                     for(const auto& i : ostride)
                         std::cout << " " << i;
                     std::cout << " differ; skipped for in-place transforms: skipping test"
@@ -1702,20 +1702,48 @@ public:
                 return false;
             }
 
-            if((transform_type == fft_transform_type_real_forward
-                || transform_type == fft_transform_type_real_inverse)
-               && (istride.back() != 1 || ostride.back() != 1) && length.back() > 1)
+            if(transform_type == fft_transform_type_real_forward
+               || transform_type == fft_transform_type_real_inverse)
             {
-                // In-place real/complex transforms require unit strides.
-                if(verbose)
+                bool invalid = length.back() > 1 && (istride.back() != 1 || ostride.back() != 1);
+                if(invalid)
                 {
-                    std::cout
-                        << "istride.back(): " << istride.back()
-                        << " ostride.back(): " << ostride.back()
-                        << " must be unitary for in-place real/complex transforms: skipping test"
-                        << std::endl;
+                    // In-place real/complex transforms require unit strides.
+                    if(verbose)
+                    {
+                        std::cout << "istride.back(): " << istride.back()
+                                  << " ostride.back(): " << ostride.back()
+                                  << " must be unitary for in-place real/complex transforms: "
+                                     "skipping test"
+                                  << std::endl;
+                    }
+                    return false;
                 }
-                return false;
+                const auto& real_strides
+                    = transform_type == fft_transform_type_real_forward ? istride : ostride;
+                const auto& hermitian_strides
+                    = transform_type == fft_transform_type_real_forward ? ostride : istride;
+                const auto& real_dist
+                    = transform_type == fft_transform_type_real_forward ? idist : odist;
+                const auto& hermitian_dist
+                    = transform_type == fft_transform_type_real_forward ? odist : idist;
+                for(size_t dim = 0; dim < stridesize - 1; dim++)
+                {
+                    if(length[dim] == 1)
+                        continue;
+                    invalid |= real_strides[dim] != 2 * hermitian_strides[dim];
+                }
+                if(nbatch > 1)
+                    invalid |= real_dist != 2 * hermitian_dist;
+                if(invalid)
+                {
+                    if(verbose)
+                    {
+                        std::cout << "Inconsistency detected in strides/distances for in-place "
+                                     "real/complex transforms; skipped\n";
+                    }
+                    return false;
+                }
             }
 
             if((itype == fft_array_type_complex_interleaved


### PR DESCRIPTION
## Motivation

Several automatically-generated test parameters are being tested despite breaking the [documented requirements](https://rocmdocs.amd.com/projects/rocFFT/en/latest/how-to/real-data.html) for real, in-place transforms, _e.g._, 
`real_forward_len_64_20_8_single_ip_batch_1_istride_200_10_1_R_ostride_160_8_1_HI_idist_12800_odist_1_ioffset_0_0_ooffset_0_0` or `real_forward_len_32_4_4_single_ip_batch_1_istride_16_4_1_R_ostride_16_4_1_HI_idist_1_odist_1_ioffset_0_0_ooffset_0_0`.

## Technical Details

The suggested changes expand the token-validation logic for real, in-place cases to account for strides and distances as well, whenever relevant.

## Test Plan

Current tests suffice.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
