### PR TITLE
[hipblaslt] Fix swizzle sample crash and simplify host-side swizzle flow

### DIFF
--- a/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a.cpp
+++ b/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a.cpp
@@ -306,15 +306,11 @@ void simpleGemm(hipblasLtHandle_t  handle,
             hipblasLtOrder_t orderA = HIPBLASLT_ORDER_COL16_4R16;
             CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
                 matA, HIPBLASLT_MATRIX_LAYOUT_ORDER, &orderA, sizeof(orderA)));
-            hipblaslt_f8_fnuz* src;
-            hipblaslt_f8_fnuz* dst;
-            CHECK_HIP_ERROR(
-                hipMalloc(&src, m * k * sizeof(hipblaslt_f8_fnuz))); // Allocate memory on device
-            CHECK_HIP_ERROR(
-                hipMalloc(&dst, m * k * sizeof(hipblaslt_f8_fnuz))); // Allocate memory on device
-            CHECK_HIP_ERROR(hipMemcpy(src, d_a, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyDeviceToHost));
-            swizzleTensor(dst, src, m, k, true);
-            CHECK_HIP_ERROR(hipMemcpy(d_a, dst, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyHostToDevice));
+            std::vector<hipblaslt_f8_fnuz> src(m * k, 0);
+            std::vector<hipblaslt_f8_fnuz> dst(m * k, 0);
+            CHECK_HIP_ERROR(hipMemcpy(src.data(), d_a, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyDeviceToHost));
+            swizzleTensor(dst.data(), src.data(), m, k, true);
+            CHECK_HIP_ERROR(hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyHostToDevice));
         }
     }
     else

--- a/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a.cpp
+++ b/projects/hipblaslt/clients/samples/25_hipblaslt_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a.cpp
@@ -80,6 +80,25 @@ void swizzleTensor(T* dst, const T* src, size_t m, size_t k, bool colMaj)
     std::copy(static_cast<const T*>(permuted.template as<void>()), static_cast<const T*>(permuted.template as<void>()) + m * k, dst);
 }
 
+template <typename T>
+void host_swizzle_copy_back(void* d_a, int m, int k, bool is_col_major)
+{
+    const size_t count = static_cast<size_t>(m) * static_cast<size_t>(k);
+
+    std::vector<T> src(count, static_cast<T>(0));
+    std::vector<T> dst(count, static_cast<T>(0));
+
+    CHECK_HIP_ERROR(hipMemcpy(src.data(), d_a,
+                              sizeof(T) * count,
+                              hipMemcpyDeviceToHost));
+
+    swizzleTensor(dst.data(), src.data(), m, k, is_col_major);
+
+    CHECK_HIP_ERROR(hipMemcpy(d_a, dst.data(),
+                              sizeof(T) * count,
+                              hipMemcpyHostToDevice));
+}
+
 void simpleGemm(hipblasLtHandle_t  handle,
                 hipblasOperation_t trans_a,
                 hipblasOperation_t trans_b,
@@ -295,22 +314,16 @@ void simpleGemm(hipblasLtHandle_t  handle,
             hipblasLtOrder_t orderA = HIPBLASLT_ORDER_COL16_4R8;
             CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
                 matA, HIPBLASLT_MATRIX_LAYOUT_ORDER, &orderA, sizeof(orderA)));
-            std::vector<hipblasLtHalf> src(m * k, 0);
-            std::vector<hipblasLtHalf> dst(m * k, 0);
-            CHECK_HIP_ERROR(hipMemcpy(src.data(), d_a, m * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToHost));
-            swizzleTensor(dst.data(), src.data(), m, k, true);
-            CHECK_HIP_ERROR(hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblasLtHalf), hipMemcpyHostToDevice));
+
+            host_swizzle_copy_back<hipblasLtHalf>(d_a, m, k, true);
         }
         else if(swizzleA && TiAB == HIP_R_8F_E4M3_FNUZ)
         {
             hipblasLtOrder_t orderA = HIPBLASLT_ORDER_COL16_4R16;
             CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
                 matA, HIPBLASLT_MATRIX_LAYOUT_ORDER, &orderA, sizeof(orderA)));
-            std::vector<hipblaslt_f8_fnuz> src(m * k, 0);
-            std::vector<hipblaslt_f8_fnuz> dst(m * k, 0);
-            CHECK_HIP_ERROR(hipMemcpy(src.data(), d_a, m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyDeviceToHost));
-            swizzleTensor(dst.data(), src.data(), m, k, true);
-            CHECK_HIP_ERROR(hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblaslt_f8_fnuz), hipMemcpyHostToDevice));
+
+            host_swizzle_copy_back<hipblaslt_f8_fnuz>(d_a, m, k, true);
         }
     }
     else


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR fixes a segmentation fault in the swizzle sample code and simplifies the duplicated host-side swizzle workflow.
The original FP8 swizzle path incorrectly mixed device pointers with hipMemcpyDeviceToHost, causing invalid memory access.
Additionally, the swizzle logic for different datatypes (HIP_R_16F, HIP_R_8F_E4M3_FNUZ) duplicated the same “D -> H -> swizzle -> H -> D” process. The goal is to fix correctness issues and consolidate the common flow into a clean, reusable helper.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Fixed incorrect host/device memory usage that caused a segmentation fault.
- Introduced host_swizzle_copy_back<T> to unify D -> H -> swizzle -> H -> D flow.
- Removed duplicated swizzle code in FP16/FP8 branches, simplifying maintenance.

## Test Plan
<!-- Explain any relevant testing done to verify this PR. -->
Executing build/release/clients/samples/25_hipblaslt_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a should not crash.

## Test Result
<!-- Briefly summarize test outcomes. -->
Not crash and find no solution since Navi does not support swizzle yet.
<img width="324" height="66" alt="image" src="https://github.com/user-attachments/assets/5f9aca7a-6731-4391-9ad0-33c4b043e7c8" />

## Related Tickets
- https://amd-hub.atlassian.net/browse/ROCM-2704
- https://ontrack-internal.amd.com/browse/SWDEV-573222

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
