### PR TITLE
[hipDNN] Add GraphDescriptor operation-based lowering through c-api

### DIFF
--- a/projects/hipdnn/backend/include/HipdnnBackendAttributeName.h
+++ b/projects/hipdnn/backend/include/HipdnnBackendAttributeName.h
@@ -165,6 +165,18 @@ typedef enum
     /** @brief Whether dynamic shapes are enabled for this graph */
     HIPDNN_ATTR_OPERATIONGRAPH_IS_DYNAMIC_SHAPE_ENABLED = 603,
 
+    /** @brief Compute data type for the operation graph (hipdnnDataType_t, extension) */
+    HIPDNN_ATTR_OPERATIONGRAPH_COMPUTE_DATA_TYPE_EXT = 604,
+
+    /** @brief Intermediate data type for the operation graph (hipdnnDataType_t, extension) */
+    HIPDNN_ATTR_OPERATIONGRAPH_INTERMEDIATE_DATA_TYPE_EXT = 605,
+
+    /** @brief I/O data type for the operation graph (hipdnnDataType_t, extension) */
+    HIPDNN_ATTR_OPERATIONGRAPH_IO_DATA_TYPE_EXT = 606,
+
+    /** @brief Preferred engine ID for execution plan selection (int64_t, extension) */
+    HIPDNN_ATTR_OPERATIONGRAPH_PREFERRED_ENGINE_ID_EXT = 607,
+
     /** @} */
 
     /**

--- a/projects/hipdnn/backend/include/HipdnnBackendAttributeType.h
+++ b/projects/hipdnn/backend/include/HipdnnBackendAttributeType.h
@@ -93,6 +93,9 @@ typedef enum
     /** @brief Random number generator distribution */
     HIPDNN_TYPE_RNG_DISTRIBUTION,
 
+    /** @brief Convolution mode enumeration (hipdnnConvolutionMode_t) */
+    HIPDNN_TYPE_CONVOLUTION_MODE,
+
     /**
      * @name Extension Types
      * hipDNN-specific extension types

--- a/projects/hipdnn/backend/include/HipdnnConvolutionMode.h
+++ b/projects/hipdnn/backend/include/HipdnnConvolutionMode.h
@@ -1,0 +1,25 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file HipdnnConvolutionMode.h
+ * @brief Convolution mode enumeration for hipDNN backend operations
+ *
+ * Defines the convolution mode used when setting the
+ * HIPDNN_ATTR_CONVOLUTION_CONV_MODE attribute on convolution descriptors.
+ */
+
+#pragma once
+
+/**
+ * @enum hipdnnConvolutionMode_t
+ * @brief Convolution mode for backend convolution operations
+ *
+ * Determines how the convolution filter is applied to the input tensor.
+ */
+typedef enum
+{
+    HIPDNN_CONVOLUTION_MODE_CONVOLUTION = 0, ///< Mathematical convolution (filter is flipped)
+    HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION
+    = 1 ///< Cross-correlation mode (standard deep learning)
+} hipdnnConvolutionMode_t;

--- a/projects/hipdnn/backend/include/hipdnn_backend.h
+++ b/projects/hipdnn/backend/include/hipdnn_backend.h
@@ -52,6 +52,7 @@
 #include "HipdnnBackendLimits.h"
 #include "HipdnnBackendPluginLoadingMode.h"
 #include "HipdnnBackendPluginUnloadingMode.h"
+#include "HipdnnConvolutionMode.h"
 #include "HipdnnDataType.h"
 #include "HipdnnStatus.h"
 
@@ -339,6 +340,36 @@ HIPDNN_BACKEND_EXPORT void hipdnnPeekLastErrorString_ext(char* message, size_t m
  */
 HIPDNN_BACKEND_EXPORT hipdnnStatus_t hipdnnBackendCreateAndDeserializeGraph_ext(
     hipdnnBackendDescriptor_t* descriptor, const uint8_t* serializedGraph, size_t graphByteSize);
+
+/*!
+ * @brief Retrieves the binary-serialized graph from a finalized operation graph descriptor.
+ *
+ * Uses the standard two-call pattern: call first with @p serializedGraph set to @c nullptr to query
+ * the required buffer size, then call again with a caller-allocated buffer to receive the data.
+ * The descriptor must be of type HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR and must be finalized.
+ *
+ * @param [in]  descriptor        A finalized operation graph descriptor.
+ * @param [in]  requestedByteSize Size of the caller-allocated buffer in bytes.
+ *                                Ignored when @p serializedGraph is @c nullptr.
+ * @param [out] graphByteSize     Pointer to receive the size of the serialized graph in bytes.
+ *                                Always written on success.
+ * @param [out] serializedGraph   Caller-allocated buffer to receive the serialized graph data,
+ *                                or @c nullptr to query the required size only.
+ *
+ * @retval HIPDNN_STATUS_SUCCESS              The serialized graph was successfully retrieved,
+ *                                            or the size query completed successfully.
+ * @retval HIPDNN_STATUS_BAD_PARAM_NULL_POINTER  descriptor or graphByteSize is null.
+ * @retval HIPDNN_STATUS_BAD_PARAM            The descriptor is not an operation graph descriptor.
+ * @retval HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED  The descriptor is not finalized.
+ * @retval HIPDNN_STATUS_BAD_PARAM_SIZE_INSUFFICIENT  The requestedByteSize is smaller than the
+ *                                                     serialized graph size.
+ * @retval HIPDNN_STATUS_INTERNAL_ERROR       An internal error occurred during serialization.
+ */
+HIPDNN_BACKEND_EXPORT hipdnnStatus_t
+    hipdnnBackendGetSerializedBinaryGraph_ext(hipdnnBackendDescriptor_t descriptor,
+                                              size_t requestedByteSize,
+                                              size_t* graphByteSize,
+                                              uint8_t* serializedGraph);
 
 /*!
  * @brief Callback function for logging messages.

--- a/projects/hipdnn/backend/src/BackendEnumStringUtils.hpp
+++ b/projects/hipdnn/backend/src/BackendEnumStringUtils.hpp
@@ -8,6 +8,7 @@
 #include "HipdnnBackendDescriptorType.h"
 #include "HipdnnBackendPluginLoadingMode.h"
 #include "HipdnnBackendPluginUnloadingMode.h"
+#include "HipdnnConvolutionMode.h"
 #include "HipdnnDataType.h"
 #include "HipdnnStatus.h"
 
@@ -130,6 +131,8 @@ inline const char* hipdnnGetAttributeTypeString(hipdnnBackendAttributeType_t typ
         return "HIPDNN_TYPE_NORM_FWD_PHASE";
     case HIPDNN_TYPE_RNG_DISTRIBUTION:
         return "HIPDNN_TYPE_RNG_DISTRIBUTION";
+    case HIPDNN_TYPE_CONVOLUTION_MODE:
+        return "HIPDNN_TYPE_CONVOLUTION_MODE";
 
     // Extension API
     case HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT:
@@ -242,6 +245,14 @@ inline const char* hipdnnGetAttributeNameString(hipdnnBackendAttributeName_t att
         return "HIPDNN_ATTR_OPERATIONGRAPH_ENGINE_GLOBAL_COUNT";
     case HIPDNN_ATTR_OPERATIONGRAPH_IS_DYNAMIC_SHAPE_ENABLED:
         return "HIPDNN_ATTR_OPERATIONGRAPH_IS_DYNAMIC_SHAPE_ENABLED";
+    case HIPDNN_ATTR_OPERATIONGRAPH_COMPUTE_DATA_TYPE_EXT:
+        return "HIPDNN_ATTR_OPERATIONGRAPH_COMPUTE_DATA_TYPE_EXT";
+    case HIPDNN_ATTR_OPERATIONGRAPH_INTERMEDIATE_DATA_TYPE_EXT:
+        return "HIPDNN_ATTR_OPERATIONGRAPH_INTERMEDIATE_DATA_TYPE_EXT";
+    case HIPDNN_ATTR_OPERATIONGRAPH_IO_DATA_TYPE_EXT:
+        return "HIPDNN_ATTR_OPERATIONGRAPH_IO_DATA_TYPE_EXT";
+    case HIPDNN_ATTR_OPERATIONGRAPH_PREFERRED_ENGINE_ID_EXT:
+        return "HIPDNN_ATTR_OPERATIONGRAPH_PREFERRED_ENGINE_ID_EXT";
 
     case HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS:
         return "HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS";
@@ -365,6 +376,19 @@ inline const char* hipdnnGetPluginUnloadingModeString(hipdnnPluginUnloadingMode_
         return "HIPDNN_PLUGIN_UNLOAD_EAGER";
     default:
         return "HIPDNN_PLUGIN_UNLOAD_UNKNOWN";
+    }
+}
+
+inline const char* hipdnnGetConvolutionModeString(hipdnnConvolutionMode_t mode)
+{
+    switch(mode)
+    {
+    case HIPDNN_CONVOLUTION_MODE_CONVOLUTION:
+        return "HIPDNN_CONVOLUTION_MODE_CONVOLUTION";
+    case HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION:
+        return "HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION";
+    default:
+        return "HIPDNN_CONVOLUTION_MODE_UNKNOWN";
     }
 }
 

--- a/projects/hipdnn/backend/src/HipdnnBackend.cpp
+++ b/projects/hipdnn/backend/src/HipdnnBackend.cpp
@@ -6,6 +6,7 @@
 #include "HipdnnException.hpp"
 #include "descriptors/BackendDescriptor.hpp"
 #include "descriptors/DescriptorFactory.hpp"
+#include "descriptors/GraphDescriptor.hpp"
 #include "descriptors/VariantDescriptor.hpp"
 #include "handle/Handle.hpp"
 #include "handle/HandleFactory.hpp"
@@ -15,6 +16,8 @@
 
 #include <hipdnn_backend/version.h>
 #include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+
+#include <cstring>
 
 using namespace hipdnn_backend;
 
@@ -241,6 +244,43 @@ HIPDNN_BACKEND_EXPORT hipdnnStatus_t hipdnnBackendCreateAndDeserializeGraph_ext(
             descriptor, serializedGraph, graphByteSize);
 
         LOG_API_SUCCESS(apiName, "created_descriptor={}", logPtr(*descriptor));
+    });
+}
+
+HIPDNN_BACKEND_EXPORT hipdnnStatus_t
+    hipdnnBackendGetSerializedBinaryGraph_ext(hipdnnBackendDescriptor_t descriptor,
+                                              size_t requestedByteSize,
+                                              size_t* graphByteSize,
+                                              uint8_t* serializedGraph)
+{
+    LOG_API_ENTRY("descriptor={}, requestedByteSize={}, graphByteSize_ptr={:p}, "
+                  "serializedGraph_ptr={:p}",
+                  logPtr(descriptor),
+                  requestedByteSize,
+                  static_cast<void*>(graphByteSize),
+                  static_cast<void*>(serializedGraph));
+
+    return hipdnn_backend::tryCatch([&, apiName = __func__]() {
+        throwIfInvalidDescriptor(descriptor);
+        throwIfNull(graphByteSize);
+
+        auto graphDesc = descriptor->asDescriptor<hipdnn_backend::GraphDescriptor>();
+        auto data = graphDesc->getSerializedGraph();
+
+        *graphByteSize = data.size;
+
+        if(serializedGraph != nullptr)
+        {
+            THROW_IF_LT(requestedByteSize,
+                        data.size,
+                        HIPDNN_STATUS_BAD_PARAM_SIZE_INSUFFICIENT,
+                        "Requested buffer size (" + std::to_string(requestedByteSize)
+                            + ") is smaller than the serialized graph size ("
+                            + std::to_string(data.size) + ")");
+            std::memcpy(serializedGraph, data.ptr, data.size);
+        }
+
+        LOG_API_SUCCESS(apiName, "graphByteSize={}", *graphByteSize);
     });
 }
 

--- a/projects/hipdnn/backend/src/descriptors/ConvolutionFwdOperationDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/ConvolutionFwdOperationDescriptor.cpp
@@ -159,20 +159,29 @@ void ConvolutionFwdOperationDescriptor::setConvMode(hipdnnBackendAttributeType_t
                                                     int64_t elementCount,
                                                     const void* arrayOfElements)
 {
-    checkSetArgs(HIPDNN_TYPE_INT64,
+    checkSetArgs(HIPDNN_TYPE_CONVOLUTION_MODE,
                  attributeType,
                  arrayOfElements,
                  "ConvolutionFwdOperationDescriptor::setAttribute()");
     THROW_IF_FALSE(elementCount == 1,
                    HIPDNN_STATUS_BAD_PARAM,
                    "ConvolutionFwdOperationDescriptor::setAttribute(): elementCount is not 1");
-    auto mode = static_cast<hipdnn_data_sdk::data_objects::ConvMode>(
-        *static_cast<const int64_t*>(arrayOfElements));
-    THROW_IF_TRUE(mode < hipdnn_data_sdk::data_objects::ConvMode::MIN
-                      || mode > hipdnn_data_sdk::data_objects::ConvMode::MAX,
-                  HIPDNN_STATUS_BAD_PARAM,
-                  "ConvolutionFwdOperationDescriptor::setAttribute(): invalid ConvMode value");
-    _data.conv_mode = mode;
+    auto mode = *static_cast<const hipdnnConvolutionMode_t*>(arrayOfElements);
+
+    // Map hipdnnConvolutionMode_t to Data SDK ConvMode
+    switch(mode)
+    {
+    case HIPDNN_CONVOLUTION_MODE_CONVOLUTION:
+        _data.conv_mode = hipdnn_data_sdk::data_objects::ConvMode::CONVOLUTION;
+        break;
+    case HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION:
+        _data.conv_mode = hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION;
+        break;
+    default:
+        throw HipdnnException(HIPDNN_STATUS_BAD_PARAM,
+                              "ConvolutionFwdOperationDescriptor::setAttribute(): invalid "
+                              "hipdnnConvolutionMode_t value");
+    }
 }
 
 // ============================================================================
@@ -302,8 +311,9 @@ void ConvolutionFwdOperationDescriptor::getConvMode(hipdnnBackendAttributeType_t
                                                     int64_t* elementCount,
                                                     void* arrayOfElements) const
 {
-    checkGetArgs(
-        HIPDNN_TYPE_INT64, attributeType, "ConvolutionFwdOperationDescriptor::getAttribute()");
+    checkGetArgs(HIPDNN_TYPE_CONVOLUTION_MODE,
+                 attributeType,
+                 "ConvolutionFwdOperationDescriptor::getAttribute()");
 
     if(arrayOfElements == nullptr || requestedElementCount == 0)
     {
@@ -322,7 +332,24 @@ void ConvolutionFwdOperationDescriptor::getConvMode(hipdnnBackendAttributeType_t
     {
         *elementCount = 1;
     }
-    *static_cast<int64_t*>(arrayOfElements) = static_cast<int64_t>(_data.conv_mode);
+
+    // Map Data SDK ConvMode to hipdnnConvolutionMode_t
+    hipdnnConvolutionMode_t result;
+    switch(_data.conv_mode)
+    {
+    case hipdnn_data_sdk::data_objects::ConvMode::CONVOLUTION:
+        result = HIPDNN_CONVOLUTION_MODE_CONVOLUTION;
+        break;
+    case hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION:
+        result = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
+        break;
+    default:
+        throw HipdnnException(HIPDNN_STATUS_BAD_PARAM,
+                              "ConvolutionFwdOperationDescriptor::getAttribute(): invalid "
+                              "internal ConvMode value");
+        break;
+    }
+    *static_cast<hipdnnConvolutionMode_t*>(arrayOfElements) = result;
 }
 
 // ============================================================================

--- a/projects/hipdnn/backend/src/descriptors/ConvolutionFwdOperationDescriptor.hpp
+++ b/projects/hipdnn/backend/src/descriptors/ConvolutionFwdOperationDescriptor.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "BackendDescriptor.hpp"
+#include "HipdnnConvolutionMode.h"
 #include "IGraphOperation.hpp"
 #include "TensorDescriptor.hpp"
 #include <hipdnn_data_sdk/data_objects/convolution_fwd_attributes_generated.h>

--- a/projects/hipdnn/backend/src/descriptors/GraphDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/GraphDescriptor.cpp
@@ -3,18 +3,123 @@
 
 #include "GraphDescriptor.hpp"
 #include "BackendEnumStringUtils.hpp"
+#include "DataTypeConversion.hpp"
+#include "DescriptorAttributeUtils.hpp"
 #include "FlatbufferUtilities.hpp"
 #include "HipdnnBackendDescriptorType.h"
 #include "HipdnnException.hpp"
+
+#include <unordered_map>
 
 namespace hipdnn_backend
 {
 
 void GraphDescriptor::finalize()
 {
-    THROW_IF_NULL(_graph, HIPDNN_STATUS_BAD_PARAM, "GraphDescriptor::finalize: graph is null");
     THROW_IF_NULL(_handle, HIPDNN_STATUS_BAD_PARAM, "GraphDescriptor::finalize: handle is null");
+
+    // If operations were set, build graph from them
+    if(!_operations.empty())
+    {
+        buildGraphFromOperations();
+    }
+
+    THROW_IF_NULL(_graph, HIPDNN_STATUS_BAD_PARAM, "GraphDescriptor::finalize: graph is null");
     HipdnnBackendDescriptorImpl<GraphDescriptor>::finalize();
+}
+
+void GraphDescriptor::buildGraphFromOperations()
+{
+    _graph = std::make_unique<hipdnn_data_sdk::data_objects::GraphT>();
+
+    // Apply graph-level attributes
+    _graph->compute_data_type = _computeDataType;
+    _graph->intermediate_data_type = _intermediateDataType;
+    _graph->io_data_type = _ioDataType;
+    _graph->preferred_engine_id = _preferredEngineId;
+
+    std::unordered_map<int64_t, std::shared_ptr<TensorDescriptor>> seenTensors;
+
+    for(const auto& op : _operations)
+    {
+        // Collect unique tensors (deduplicated by UID)
+        for(const auto& tensorDesc : op->getTensorDescriptors())
+        {
+            auto uid = tensorDesc->getData().uid;
+            auto it = seenTensors.find(uid);
+            if(it != seenTensors.end())
+            {
+                THROW_IF_FALSE(it->second.get() == tensorDesc.get(),
+                               HIPDNN_STATUS_BAD_PARAM,
+                               "GraphDescriptor::buildGraphFromOperations: Tensor UID "
+                                   + std::to_string(uid)
+                                   + " used with different descriptor objects");
+            }
+            else
+            {
+                seenTensors[uid] = tensorDesc;
+                _graph->tensors.push_back(
+                    std::make_unique<hipdnn_data_sdk::data_objects::TensorAttributesT>(
+                        tensorDesc->getData()));
+            }
+        }
+
+        // Build node from operation
+        _graph->nodes.push_back(op->buildNode());
+    }
+
+    // TODO: Keep _operations instead of clearing, and add a getAttribute path
+    // for HIPDNN_ATTR_OPERATIONGRAPH_OPS to allow retrieving the operations.
+    // This will enable rebuilding graphs in the frontend from a serialized
+    // backend graph.
+    _operations.clear();
+}
+
+void GraphDescriptor::setDataType(hipdnnBackendAttributeName_t attributeName,
+                                  hipdnnBackendAttributeType_t attributeType,
+                                  int64_t elementCount,
+                                  const void* arrayOfElements)
+{
+    const char* errorPrefix = "GraphDescriptor::setDataType";
+
+    switch(attributeName)
+    {
+    case HIPDNN_ATTR_OPERATIONGRAPH_COMPUTE_DATA_TYPE_EXT:
+        hipdnn_backend::setDataType(
+            _computeDataType, attributeType, elementCount, arrayOfElements, errorPrefix);
+        break;
+    case HIPDNN_ATTR_OPERATIONGRAPH_INTERMEDIATE_DATA_TYPE_EXT:
+        hipdnn_backend::setDataType(
+            _intermediateDataType, attributeType, elementCount, arrayOfElements, errorPrefix);
+        break;
+    case HIPDNN_ATTR_OPERATIONGRAPH_IO_DATA_TYPE_EXT:
+        hipdnn_backend::setDataType(
+            _ioDataType, attributeType, elementCount, arrayOfElements, errorPrefix);
+        break;
+    default:
+        throw HipdnnException(HIPDNN_STATUS_BAD_PARAM,
+                              "GraphDescriptor::setDataType: Unsupported attribute name "
+                                  + std::string(hipdnnGetAttributeNameString(attributeName)));
+    }
+}
+
+void GraphDescriptor::setPreferredEngineId(hipdnnBackendAttributeType_t attributeType,
+                                           int64_t elementCount,
+                                           const void* arrayOfElements)
+{
+    THROW_IF_NE(attributeType,
+                HIPDNN_TYPE_INT64,
+                HIPDNN_STATUS_BAD_PARAM,
+                "GraphDescriptor::setPreferredEngineId: Invalid attribute type.");
+    THROW_IF_NE(elementCount,
+                1,
+                HIPDNN_STATUS_BAD_PARAM,
+                "GraphDescriptor::setPreferredEngineId: Invalid element count.");
+    THROW_IF_NULL(arrayOfElements,
+                  HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                  "GraphDescriptor::setPreferredEngineId: Null pointer.");
+
+    _preferredEngineId = *static_cast<const int64_t*>(arrayOfElements);
 }
 
 void GraphDescriptor::setHandle(hipdnnBackendAttributeType_t attributeType,
@@ -52,6 +157,45 @@ void GraphDescriptor::getAttribute([[maybe_unused]] hipdnnBackendAttributeName_t
                           "GraphDescriptor::getAttribute: not supported");
 }
 
+void GraphDescriptor::setOperations(hipdnnBackendAttributeType_t attributeType,
+                                    int64_t elementCount,
+                                    const void* arrayOfElements)
+{
+    THROW_IF_NE(attributeType,
+                HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                HIPDNN_STATUS_BAD_PARAM,
+                "GraphDescriptor::setOperations: attributeType mismatch");
+    THROW_IF_NULL(arrayOfElements,
+                  HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                  "GraphDescriptor::setOperations: arrayOfElements is null");
+
+    auto descriptors = static_cast<HipdnnBackendDescriptor* const*>(arrayOfElements);
+
+    // Validate all descriptors into a temporary vector before modifying state,
+    // so that a validation failure doesn't leave _operations in a partial state.
+    std::vector<std::shared_ptr<IGraphOperation>> newOperations;
+    newOperations.reserve(static_cast<size_t>(elementCount));
+
+    for(int64_t i = 0; i < elementCount; ++i)
+    {
+        THROW_IF_NULL(descriptors[i],
+                      HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                      "GraphDescriptor::setOperations: descriptor is null");
+        THROW_IF_FALSE(descriptors[i]->isFinalized(),
+                       HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED,
+                       "GraphDescriptor::setOperations: Operation descriptor not finalized");
+
+        auto graphOp = descriptors[i]->tryAsInterface<IGraphOperation>();
+        THROW_IF_NULL(graphOp,
+                      HIPDNN_STATUS_NOT_SUPPORTED,
+                      "GraphDescriptor::setOperations: Descriptor does not implement "
+                      "IGraphOperation");
+        newOperations.push_back(graphOp);
+    }
+
+    _operations = std::move(newOperations);
+}
+
 void GraphDescriptor::setAttribute(hipdnnBackendAttributeName_t attributeName,
                                    hipdnnBackendAttributeType_t attributeType,
                                    int64_t elementCount,
@@ -66,17 +210,22 @@ void GraphDescriptor::setAttribute(hipdnnBackendAttributeName_t attributeName,
     case HIPDNN_ATTR_OPERATIONGRAPH_HANDLE:
         setHandle(attributeType, elementCount, arrayOfElements);
         break;
+    case HIPDNN_ATTR_OPERATIONGRAPH_OPS:
+        setOperations(attributeType, elementCount, arrayOfElements);
+        break;
+    case HIPDNN_ATTR_OPERATIONGRAPH_COMPUTE_DATA_TYPE_EXT:
+    case HIPDNN_ATTR_OPERATIONGRAPH_INTERMEDIATE_DATA_TYPE_EXT:
+    case HIPDNN_ATTR_OPERATIONGRAPH_IO_DATA_TYPE_EXT:
+        setDataType(attributeName, attributeType, elementCount, arrayOfElements);
+        break;
+    case HIPDNN_ATTR_OPERATIONGRAPH_PREFERRED_ENGINE_ID_EXT:
+        setPreferredEngineId(attributeType, elementCount, arrayOfElements);
+        break;
     default:
         throw HipdnnException(
             HIPDNN_STATUS_NOT_SUPPORTED,
             std::string("GraphDescriptor::setAttribute() is not supported for attribute ")
                 + hipdnn_backend::hipdnnGetAttributeNameString(attributeName) + ".");
-    }
-
-    if(attributeName != HIPDNN_ATTR_OPERATIONGRAPH_HANDLE)
-    {
-        // Clear the serialized graph when the graph is modified
-        _graphSerializedBuffer = flatbuffers::DetachedBuffer();
     }
 }
 
@@ -95,6 +244,12 @@ void GraphDescriptor::deserializeGraph(const uint8_t* serializedGraph, size_t gr
 
 hipdnnPluginConstData_t GraphDescriptor::getSerializedGraph() const
 {
+    // TODO: Support serializing a graph without finalization, and deserializing
+    // without a handle set.
+    THROW_IF_FALSE(isFinalized(),
+                   HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED,
+                   "GraphDescriptor::getSerializedGraph: graph is not finalized");
+
     if(_graphSerializedBuffer.size() == 0)
     {
         THROW_IF_NULL(_graph,
@@ -105,6 +260,16 @@ hipdnnPluginConstData_t GraphDescriptor::getSerializedGraph() const
         builder.Finish(hipdnn_data_sdk::data_objects::Graph::Pack(builder, _graph.get()));
 
         _graphSerializedBuffer = builder.Release();
+
+        flatbuffers::Verifier verifier(_graphSerializedBuffer.data(),
+                                       _graphSerializedBuffer.size());
+        if(!hipdnn_data_sdk::data_objects::VerifyGraphBuffer(verifier))
+        {
+            _graphSerializedBuffer = flatbuffers::DetachedBuffer();
+            throw HipdnnException(HIPDNN_STATUS_INTERNAL_ERROR,
+                                  "GraphDescriptor::getSerializedGraph: serialized graph "
+                                  "failed verification");
+        }
     }
 
     return {_graphSerializedBuffer.data(), _graphSerializedBuffer.size()};

--- a/projects/hipdnn/backend/src/descriptors/GraphDescriptor.hpp
+++ b/projects/hipdnn/backend/src/descriptors/GraphDescriptor.hpp
@@ -4,10 +4,12 @@
 #pragma once
 
 #include "BackendDescriptor.hpp"
+#include "IGraphOperation.hpp"
 #include <flatbuffers/detached_buffer.h>
 #include <hipdnn_data_sdk/data_objects/graph_generated.h>
 #include <hipdnn_plugin_sdk/PluginApiDataTypes.h>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace hipdnn_backend
@@ -20,9 +22,37 @@ private:
     hipdnnHandle_t _handle = nullptr;
     mutable flatbuffers::DetachedBuffer _graphSerializedBuffer;
 
+    // For building graph from operation descriptors (type-agnostic)
+    std::vector<std::shared_ptr<IGraphOperation>> _operations;
+
+    // Graph-level attributes set via setAttribute (applied during buildGraphFromOperations)
+    hipdnn_data_sdk::data_objects::DataType _computeDataType
+        = hipdnn_data_sdk::data_objects::DataType::UNSET;
+    hipdnn_data_sdk::data_objects::DataType _intermediateDataType
+        = hipdnn_data_sdk::data_objects::DataType::UNSET;
+    hipdnn_data_sdk::data_objects::DataType _ioDataType
+        = hipdnn_data_sdk::data_objects::DataType::UNSET;
+    std::optional<int64_t> _preferredEngineId;
+
     void setHandle(hipdnnBackendAttributeType_t attributeType,
                    int64_t elementCount,
                    const void* arrayOfElements);
+
+    void setOperations(hipdnnBackendAttributeType_t attributeType,
+                       int64_t elementCount,
+                       const void* arrayOfElements);
+
+    void setDataType(hipdnnBackendAttributeName_t attributeName,
+                     hipdnnBackendAttributeType_t attributeType,
+                     int64_t elementCount,
+                     const void* arrayOfElements);
+
+    void setPreferredEngineId(hipdnnBackendAttributeType_t attributeType,
+                              int64_t elementCount,
+                              const void* arrayOfElements);
+
+    // Build GraphT from operation descriptors
+    void buildGraphFromOperations();
 
 public:
     void finalize() override;

--- a/projects/hipdnn/backend/tests/CMakeLists.txt
+++ b/projects/hipdnn/backend/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
     descriptors/TestGraphDescriptor.cpp
     descriptors/TestTensorDescriptor.cpp
     descriptors/TestConvolutionFwdOperationDescriptor.cpp
+    descriptors/TestGraphDescriptorOps.cpp
     descriptors/TestDescriptorAttributeUtils.cpp
     descriptors/TestVariantPackDescriptor.cpp
     main.cpp

--- a/projects/hipdnn/backend/tests/TestBackendEnumStringUtils.cpp
+++ b/projects/hipdnn/backend/tests/TestBackendEnumStringUtils.cpp
@@ -110,6 +110,15 @@ TEST(TestBackendEnumStringUtils, GetBackendAttributeName)
                  "HIPDNN_ATTR_OPERATIONGRAPH_ENGINE_GLOBAL_COUNT");
     EXPECT_STREQ(hipdnnGetAttributeNameString(HIPDNN_ATTR_OPERATIONGRAPH_IS_DYNAMIC_SHAPE_ENABLED),
                  "HIPDNN_ATTR_OPERATIONGRAPH_IS_DYNAMIC_SHAPE_ENABLED");
+    EXPECT_STREQ(hipdnnGetAttributeNameString(HIPDNN_ATTR_OPERATIONGRAPH_COMPUTE_DATA_TYPE_EXT),
+                 "HIPDNN_ATTR_OPERATIONGRAPH_COMPUTE_DATA_TYPE_EXT");
+    EXPECT_STREQ(
+        hipdnnGetAttributeNameString(HIPDNN_ATTR_OPERATIONGRAPH_INTERMEDIATE_DATA_TYPE_EXT),
+        "HIPDNN_ATTR_OPERATIONGRAPH_INTERMEDIATE_DATA_TYPE_EXT");
+    EXPECT_STREQ(hipdnnGetAttributeNameString(HIPDNN_ATTR_OPERATIONGRAPH_IO_DATA_TYPE_EXT),
+                 "HIPDNN_ATTR_OPERATIONGRAPH_IO_DATA_TYPE_EXT");
+    EXPECT_STREQ(hipdnnGetAttributeNameString(HIPDNN_ATTR_OPERATIONGRAPH_PREFERRED_ENGINE_ID_EXT),
+                 "HIPDNN_ATTR_OPERATIONGRAPH_PREFERRED_ENGINE_ID_EXT");
 
     EXPECT_STREQ(hipdnnGetAttributeNameString(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS),
                  "HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS");
@@ -267,6 +276,8 @@ TEST(TestBackendEnumStringUtils, GetAttributeTypeString)
                  "HIPDNN_TYPE_NORM_FWD_PHASE");
     EXPECT_STREQ(hipdnnGetAttributeTypeString(HIPDNN_TYPE_RNG_DISTRIBUTION),
                  "HIPDNN_TYPE_RNG_DISTRIBUTION");
+    EXPECT_STREQ(hipdnnGetAttributeTypeString(HIPDNN_TYPE_CONVOLUTION_MODE),
+                 "HIPDNN_TYPE_CONVOLUTION_MODE");
 
     EXPECT_STREQ(hipdnnGetAttributeTypeString(HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT),
                  "HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT");
@@ -311,4 +322,15 @@ TEST(TestBackendEnumStringUtils, GetPluginUnloadingModeString)
     EXPECT_STREQ(
         hipdnnGetPluginUnloadingModeString(static_cast<hipdnnPluginUnloadingMode_ext_t>(-1)),
         "HIPDNN_PLUGIN_UNLOAD_UNKNOWN");
+}
+
+TEST(TestBackendEnumStringUtils, GetConvolutionModeString)
+{
+    EXPECT_STREQ(hipdnnGetConvolutionModeString(HIPDNN_CONVOLUTION_MODE_CONVOLUTION),
+                 "HIPDNN_CONVOLUTION_MODE_CONVOLUTION");
+    EXPECT_STREQ(hipdnnGetConvolutionModeString(HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION),
+                 "HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION");
+
+    EXPECT_STREQ(hipdnnGetConvolutionModeString(static_cast<hipdnnConvolutionMode_t>(-1)),
+                 "HIPDNN_CONVOLUTION_MODE_UNKNOWN");
 }

--- a/projects/hipdnn/backend/tests/descriptors/DescriptorTestUtils.hpp
+++ b/projects/hipdnn/backend/tests/descriptors/DescriptorTestUtils.hpp
@@ -53,9 +53,9 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
     desc->setAttribute(HIPDNN_ATTR_CONVOLUTION_FILTER_STRIDES, HIPDNN_TYPE_INT64, 2, stride.data());
     desc->setAttribute(HIPDNN_ATTR_CONVOLUTION_DILATIONS, HIPDNN_TYPE_INT64, 2, dilation.data());
     desc->setAttribute(HIPDNN_ATTR_CONVOLUTION_COMP_TYPE, HIPDNN_TYPE_DATA_TYPE, 1, &computeType);
-    auto convMode
-        = static_cast<int64_t>(hipdnn_data_sdk::data_objects::ConvMode::CROSS_CORRELATION);
-    desc->setAttribute(HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 1, &convMode);
+    hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
+    desc->setAttribute(
+        HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode);
 
     desc->finalize();
     return wrapper;

--- a/projects/hipdnn/backend/tests/descriptors/TestConvolutionFwdOperationDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestConvolutionFwdOperationDescriptor.cpp
@@ -77,9 +77,9 @@ public:
         auto computeType = HIPDNN_DATA_FLOAT;
         getDescriptor()->setAttribute(
             HIPDNN_ATTR_CONVOLUTION_COMP_TYPE, HIPDNN_TYPE_DATA_TYPE, 1, &computeType);
-        auto convMode = static_cast<int64_t>(ConvMode::CROSS_CORRELATION);
+        hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
         getDescriptor()->setAttribute(
-            HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 1, &convMode);
+            HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode);
     }
 
     void makeFinalized() const
@@ -242,9 +242,9 @@ TEST_F(TestConvolutionFwdOperationDescriptor, FinalizeFailsWithoutComputeType)
 {
     setTensors();
     setConvParams();
-    auto convMode = static_cast<int64_t>(ConvMode::CROSS_CORRELATION);
+    hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
     getDescriptor()->setAttribute(
-        HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 1, &convMode);
+        HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode);
     ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->finalize(), HIPDNN_STATUS_BAD_PARAM);
 }
 
@@ -395,21 +395,43 @@ TEST_F(TestConvolutionFwdOperationDescriptor, SetConvolutionDilation)
 TEST_F(TestConvolutionFwdOperationDescriptor, SetConvMode)
 {
     auto desc = getDescriptor();
-    auto convMode = static_cast<int64_t>(ConvMode::CROSS_CORRELATION);
+    hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
 
-    ASSERT_NO_THROW(
-        desc->setAttribute(HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 1, &convMode));
+    ASSERT_NO_THROW(desc->setAttribute(
+        HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode));
 
     ASSERT_EQ(desc->getData().conv_mode, ConvMode::CROSS_CORRELATION);
+}
+
+TEST_F(TestConvolutionFwdOperationDescriptor, SetConvModeConvolution)
+{
+    auto desc = getDescriptor();
+    hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CONVOLUTION;
+
+    ASSERT_NO_THROW(desc->setAttribute(
+        HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode));
+
+    ASSERT_EQ(desc->getData().conv_mode, ConvMode::CONVOLUTION);
 }
 
 TEST_F(TestConvolutionFwdOperationDescriptor, SetConvModeWrongElementCount)
 {
     auto desc = getDescriptor();
-    int64_t convMode = 0;
+    hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
 
     ASSERT_THROW_HIPDNN_STATUS(
-        desc->setAttribute(HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 2, &convMode),
+        desc->setAttribute(
+            HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 2, &convMode),
+        HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestConvolutionFwdOperationDescriptor, SetConvModeWrongTypeInt64ReturnsError)
+{
+    auto desc = getDescriptor();
+    int64_t convMode = 2; // Using int64_t with old HIPDNN_TYPE_INT64 should fail
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        desc->setAttribute(HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 1, &convMode),
         HIPDNN_STATUS_BAD_PARAM);
 }
 
@@ -541,12 +563,15 @@ TEST_F(TestConvolutionFwdOperationDescriptor, GetAttributeConvParams)
     EXPECT_EQ(dilation, toVec(K_CONV_DILATION));
 
     // conv mode
-    int64_t convMode = -1;
+    hipdnnConvolutionMode_t convMode = {};
     int64_t convModeCount = 0;
-    ASSERT_NO_THROW(desc->getAttribute(
-        HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 1, &convModeCount, &convMode));
+    ASSERT_NO_THROW(desc->getAttribute(HIPDNN_ATTR_CONVOLUTION_CONV_MODE,
+                                       HIPDNN_TYPE_CONVOLUTION_MODE,
+                                       1,
+                                       &convModeCount,
+                                       &convMode));
     ASSERT_EQ(convModeCount, 1);
-    EXPECT_EQ(convMode, static_cast<int64_t>(ConvMode::CROSS_CORRELATION));
+    EXPECT_EQ(convMode, HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION);
 }
 
 TEST_F(TestConvolutionFwdOperationDescriptor, GetAttributeComputeType)
@@ -660,8 +685,11 @@ TEST_F(TestConvolutionFwdOperationDescriptor, GetAttributeConvModeQueryReturnsOn
     auto desc = getDescriptor();
 
     int64_t elementCount = 0;
-    ASSERT_NO_THROW(desc->getAttribute(
-        HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 0, &elementCount, nullptr));
+    ASSERT_NO_THROW(desc->getAttribute(HIPDNN_ATTR_CONVOLUTION_CONV_MODE,
+                                       HIPDNN_TYPE_CONVOLUTION_MODE,
+                                       0,
+                                       &elementCount,
+                                       nullptr));
     ASSERT_EQ(elementCount, 1);
 }
 
@@ -730,7 +758,7 @@ TEST_F(TestConvolutionFwdOperationDescriptor, GetAttributeConvModeQueryFailsNull
 
     ASSERT_THROW_HIPDNN_STATUS(
         desc->getAttribute(
-            HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 0, nullptr, nullptr),
+            HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 0, nullptr, nullptr),
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptor.cpp
@@ -41,6 +41,10 @@ TEST_F(TestGraphDescriptor, SerializeDeserializeGraph)
     GraphDescriptor descriptor;
     descriptor.deserializeGraph(serializedGraph.data(), serializedGraph.size());
 
+    auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
+    descriptor.setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+    descriptor.finalize();
+
     auto output = descriptor.getSerializedGraph();
     flatbuffers::Verifier verifier(static_cast<const uint8_t*>(output.ptr), output.size);
     ASSERT_TRUE(verifier.VerifyBuffer<hipdnn_data_sdk::data_objects::Graph>());

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorOps.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorOps.cpp
@@ -1,0 +1,1545 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "DescriptorTestUtils.hpp"
+#include "HipdnnException.hpp"
+#include "TensorDescriptorTestUtils.hpp"
+#include "TestMacros.hpp"
+#include "descriptors/ConvolutionFwdOperationDescriptor.hpp"
+#include "descriptors/DataTypeConversion.hpp"
+#include "descriptors/GraphDescriptor.hpp"
+#include "descriptors/TensorDescriptor.hpp"
+#include "hipdnn_backend.h"
+#include "mocks/MockHandle.hpp"
+
+#include <flatbuffers/flatbuffers.h>
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/data_objects/convolution_fwd_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_data_sdk/data_objects/tensor_attributes_generated.h>
+#include <hipdnn_test_sdk/constants/ConvFpropConstants.hpp>
+#include <hipdnn_test_sdk/utilities/ToVec.hpp>
+
+#include <array>
+#include <map>
+#include <memory>
+#include <set>
+#include <vector>
+
+using namespace hipdnn_backend;
+using namespace hipdnn_backend::test_utilities;
+using namespace hipdnn_data_sdk::data_objects;
+using namespace hipdnn_tests::constants;
+using hipdnn_tests::toVec;
+
+namespace
+{
+// Second convolution layer tensors (for multi-operation graph tests)
+constexpr int64_t K_TENSOR_X2_UID = 4;
+constexpr std::array<int64_t, 4> K_TENSOR_X2_DIMS = {1, 64, 32, 32};
+constexpr std::array<int64_t, 4> K_TENSOR_X2_STRIDES = {65536, 1024, 32, 1};
+
+constexpr int64_t K_TENSOR_W2_UID = 5;
+constexpr std::array<int64_t, 4> K_TENSOR_W2_DIMS = {128, 64, 3, 3};
+constexpr std::array<int64_t, 4> K_TENSOR_W2_STRIDES = {576, 9, 3, 1};
+
+constexpr int64_t K_TENSOR_Y2_UID = 6;
+constexpr std::array<int64_t, 4> K_TENSOR_Y2_DIMS = {1, 128, 32, 32};
+constexpr std::array<int64_t, 4> K_TENSOR_Y2_STRIDES = {131072, 1024, 32, 1};
+
+// Alternate UIDs for testing attribute-order independence
+constexpr int64_t K_ALT_TENSOR_X_UID = 11;
+constexpr int64_t K_ALT_TENSOR_W_UID = 12;
+constexpr int64_t K_ALT_TENSOR_Y_UID = 13;
+
+// UIDs for the second conv op in SharedTensorDifferentPositions
+constexpr int64_t K_SHARED_TENSOR_W_UID = 14;
+constexpr int64_t K_SHARED_TENSOR_Y_UID = 15;
+} // namespace
+
+class TestGraphDescriptorOps : public ::testing::Test
+{
+public:
+    // Find a tensor in a GraphT by UID, returns nullptr if not found
+    static const TensorAttributesT* findTensorByUid(const GraphT& graphT, int64_t uid)
+    {
+        for(const auto& tensor : graphT.tensors)
+        {
+            if(tensor->uid == uid)
+            {
+                return tensor.get();
+            }
+        }
+        return nullptr;
+    }
+
+    // Validate a tensor's fields against expected values
+    static void verifyTensor(const TensorAttributesT* tensor,
+                             int64_t expectedUid,
+                             const std::vector<int64_t>& expectedDims,
+                             const std::vector<int64_t>& expectedStrides,
+                             DataType expectedDataType,
+                             bool expectedVirtual = false)
+    {
+        ASSERT_NE(tensor, nullptr) << "Tensor with UID " << expectedUid << " not found";
+        EXPECT_EQ(tensor->uid, expectedUid);
+        EXPECT_EQ(tensor->dims, expectedDims);
+        EXPECT_EQ(tensor->strides, expectedStrides);
+        EXPECT_EQ(tensor->data_type, expectedDataType);
+        EXPECT_EQ(tensor->virtual_, expectedVirtual);
+    }
+
+    // Validate a node's convolution forward attributes
+    static void verifyConvFwdNode(const NodeT& node,
+                                  DataType expectedComputeType,
+                                  int64_t expectedXUid,
+                                  int64_t expectedWUid,
+                                  int64_t expectedYUid,
+                                  const std::vector<int64_t>& expectedPrePadding,
+                                  const std::vector<int64_t>& expectedPostPadding,
+                                  const std::vector<int64_t>& expectedStride,
+                                  const std::vector<int64_t>& expectedDilation)
+    {
+        EXPECT_EQ(node.compute_data_type, expectedComputeType);
+        ASSERT_EQ(node.attributes.type, NodeAttributes::ConvolutionFwdAttributes);
+
+        auto* convAttrs = node.attributes.AsConvolutionFwdAttributes();
+        ASSERT_NE(convAttrs, nullptr);
+
+        EXPECT_EQ(convAttrs->x_tensor_uid, expectedXUid);
+        EXPECT_EQ(convAttrs->w_tensor_uid, expectedWUid);
+        EXPECT_EQ(convAttrs->y_tensor_uid, expectedYUid);
+        EXPECT_EQ(convAttrs->pre_padding, expectedPrePadding);
+        EXPECT_EQ(convAttrs->post_padding, expectedPostPadding);
+        EXPECT_EQ(convAttrs->stride, expectedStride);
+        EXPECT_EQ(convAttrs->dilation, expectedDilation);
+    }
+
+    struct ConvOpBundle
+    {
+        std::unique_ptr<HipdnnBackendDescriptor> xDesc;
+        std::unique_ptr<HipdnnBackendDescriptor> wDesc;
+        std::unique_ptr<HipdnnBackendDescriptor> yDesc;
+        std::unique_ptr<HipdnnBackendDescriptor> convOp;
+    };
+
+    static ConvOpBundle createDefaultConvOp(hipdnnDataType_t computeType = HIPDNN_DATA_FLOAT)
+    {
+        ConvOpBundle bundle;
+        bundle.xDesc = createFinalizedTensor(K_TENSOR_X_UID);
+        bundle.wDesc = createFinalizedTensor(
+            K_TENSOR_W_UID, toVec(K_TENSOR_W_DIMS), toVec(K_TENSOR_W_STRIDES));
+        bundle.yDesc = createFinalizedTensor(
+            K_TENSOR_Y_UID, toVec(K_TENSOR_Y_DIMS), toVec(K_TENSOR_Y_STRIDES));
+        bundle.convOp = createFinalizedConvOp(
+            bundle.xDesc.get(), bundle.wDesc.get(), bundle.yDesc.get(), computeType);
+        return bundle;
+    }
+
+    std::shared_ptr<GraphDescriptor> getDescriptor() const
+    {
+        return _wrapper->asDescriptor<GraphDescriptor>();
+    }
+
+    void setHandle() const
+    {
+        auto desc = getDescriptor();
+        hipdnnHandle_t handle = &_mockHandle;
+        desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+    }
+
+protected:
+    std::unique_ptr<HipdnnBackendDescriptor> _wrapper = nullptr;
+    mutable MockHandle _mockHandle;
+
+    void SetUp() override
+    {
+        _wrapper = createDescriptor<GraphDescriptor>();
+    }
+
+    void TearDown() override
+    {
+        _wrapper.reset();
+    }
+};
+
+// =============================================================================
+// Build From Operations Tests
+// =============================================================================
+
+TEST_F(TestGraphDescriptorOps, BuildFromSingleOperation)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    ASSERT_NO_THROW(desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()));
+    ASSERT_NO_THROW(desc->finalize());
+
+    // Verify the built graph
+    auto serialized = desc->getSerializedGraph();
+    ASSERT_NE(serialized.ptr, nullptr);
+    ASSERT_GT(serialized.size, 0UL);
+
+    flatbuffers::Verifier verifier(static_cast<const uint8_t*>(serialized.ptr), serialized.size);
+    ASSERT_TRUE(verifier.VerifyBuffer<Graph>());
+
+    auto graph = GetGraph(serialized.ptr);
+    auto graphT = graph->UnPack();
+
+    ASSERT_EQ(graphT->nodes.size(), 1);
+    ASSERT_EQ(graphT->tensors.size(), 3);
+
+    // Verify each tensor has correct fields
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                 K_TENSOR_X_UID,
+                 toVec(K_TENSOR_X_DIMS),
+                 toVec(K_TENSOR_X_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                 K_TENSOR_W_UID,
+                 toVec(K_TENSOR_W_DIMS),
+                 toVec(K_TENSOR_W_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                 K_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify the node's convolution attributes and tensor UID references
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::FLOAT,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+}
+
+TEST_F(TestGraphDescriptorOps, BuildFromMultipleOperations)
+{
+    // First conv: primary tensor set
+    auto conv1 = createDefaultConvOp();
+
+    // Second conv: second tensor set
+    auto xDesc2 = createFinalizedTensor(
+        K_TENSOR_X2_UID, toVec(K_TENSOR_X2_DIMS), toVec(K_TENSOR_X2_STRIDES));
+    auto wDesc2 = createFinalizedTensor(
+        K_TENSOR_W2_UID, toVec(K_TENSOR_W2_DIMS), toVec(K_TENSOR_W2_STRIDES));
+    auto yDesc2 = createFinalizedTensor(
+        K_TENSOR_Y2_UID, toVec(K_TENSOR_Y2_DIMS), toVec(K_TENSOR_Y2_STRIDES));
+    auto convOp2 = createFinalizedConvOp(xDesc2.get(), wDesc2.get(), yDesc2.get());
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 2> ops = {conv1.convOp.get(), convOp2.get()};
+    ASSERT_NO_THROW(desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, ops.data()));
+    ASSERT_NO_THROW(desc->finalize());
+
+    auto serialized = desc->getSerializedGraph();
+    auto graph = GetGraph(serialized.ptr);
+    auto graphT = graph->UnPack();
+
+    ASSERT_EQ(graphT->nodes.size(), 2);
+    ASSERT_EQ(graphT->tensors.size(), 6);
+
+    // Verify all tensors from first conv op
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                 K_TENSOR_X_UID,
+                 toVec(K_TENSOR_X_DIMS),
+                 toVec(K_TENSOR_X_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                 K_TENSOR_W_UID,
+                 toVec(K_TENSOR_W_DIMS),
+                 toVec(K_TENSOR_W_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                 K_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify all tensors from second conv op
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X2_UID),
+                 K_TENSOR_X2_UID,
+                 toVec(K_TENSOR_X2_DIMS),
+                 toVec(K_TENSOR_X2_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W2_UID),
+                 K_TENSOR_W2_UID,
+                 toVec(K_TENSOR_W2_DIMS),
+                 toVec(K_TENSOR_W2_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y2_UID),
+                 K_TENSOR_Y2_UID,
+                 toVec(K_TENSOR_Y2_DIMS),
+                 toVec(K_TENSOR_Y2_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify first node references primary tensors
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::FLOAT,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+
+    // Verify second node references second tensor set
+    verifyConvFwdNode(*graphT->nodes[1],
+                      DataType::FLOAT,
+                      K_TENSOR_X2_UID,
+                      K_TENSOR_W2_UID,
+                      K_TENSOR_Y2_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+}
+
+TEST_F(TestGraphDescriptorOps, TensorDeduplication)
+{
+    // Two operations sharing the same output tensor (Y from first op)
+    auto conv1 = createDefaultConvOp();
+
+    auto xDesc2 = createFinalizedTensor(
+        K_TENSOR_X2_UID, toVec(K_TENSOR_X2_DIMS), toVec(K_TENSOR_X2_STRIDES));
+    auto wDesc2 = createFinalizedTensor(
+        K_TENSOR_W2_UID, toVec(K_TENSOR_W2_DIMS), toVec(K_TENSOR_W2_STRIDES));
+
+    // Reuse conv1.yDesc (uid 3) as Y for the second op
+    auto convOp2 = createFinalizedConvOp(xDesc2.get(), wDesc2.get(), conv1.yDesc.get());
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 2> ops = {conv1.convOp.get(), convOp2.get()};
+    ASSERT_NO_THROW(desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, ops.data()));
+    ASSERT_NO_THROW(desc->finalize());
+
+    auto serialized = desc->getSerializedGraph();
+    auto graph = GetGraph(serialized.ptr);
+    auto graphT = graph->UnPack();
+
+    ASSERT_EQ(graphT->nodes.size(), 2);
+    // Should have 5 unique tensors, not 6 (tensor Y deduplicated)
+    ASSERT_EQ(graphT->tensors.size(), 5);
+
+    // Verify tensor UIDs are unique
+    std::set<int64_t> tensorUids;
+    for(const auto& tensor : graphT->tensors)
+    {
+        tensorUids.insert(tensor->uid);
+    }
+    EXPECT_EQ(tensorUids.size(), 5);
+
+    // Verify each tensor's fields
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                 K_TENSOR_X_UID,
+                 toVec(K_TENSOR_X_DIMS),
+                 toVec(K_TENSOR_X_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                 K_TENSOR_W_UID,
+                 toVec(K_TENSOR_W_DIMS),
+                 toVec(K_TENSOR_W_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                 K_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X2_UID),
+                 K_TENSOR_X2_UID,
+                 toVec(K_TENSOR_X2_DIMS),
+                 toVec(K_TENSOR_X2_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W2_UID),
+                 K_TENSOR_W2_UID,
+                 toVec(K_TENSOR_W2_DIMS),
+                 toVec(K_TENSOR_W2_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify first node: primary tensors
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::FLOAT,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+
+    // Verify second node also references Y (the shared tensor)
+    verifyConvFwdNode(*graphT->nodes[1],
+                      DataType::FLOAT,
+                      K_TENSOR_X2_UID,
+                      K_TENSOR_W2_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+}
+
+TEST_F(TestGraphDescriptorOps, ComputeDataTypePreserved)
+{
+    auto conv = createDefaultConvOp(HIPDNN_DATA_HALF);
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graph = GetGraph(serialized.ptr);
+    auto graphT = graph->UnPack();
+
+    ASSERT_EQ(graphT->nodes.size(), 1);
+    ASSERT_EQ(graphT->tensors.size(), 3);
+
+    // Verify tensors retain FLOAT data type (tensor data type is independent of compute type)
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                 K_TENSOR_X_UID,
+                 toVec(K_TENSOR_X_DIMS),
+                 toVec(K_TENSOR_X_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                 K_TENSOR_W_UID,
+                 toVec(K_TENSOR_W_DIMS),
+                 toVec(K_TENSOR_W_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                 K_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify node compute data type is HALF and all conv attributes are correct
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::HALF,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+}
+
+TEST_F(TestGraphDescriptorOps, ConvolutionAttributesPreserved)
+{
+    auto conv = createDefaultConvOp();
+
+    // Create conv op with non-default parameters to test graph roundtrip
+    auto wrapper = createDescriptor<ConvolutionFwdOperationDescriptor>();
+    auto convDesc = wrapper->asDescriptor<ConvolutionFwdOperationDescriptor>();
+
+    HipdnnBackendDescriptor* x = conv.xDesc.get();
+    HipdnnBackendDescriptor* w = conv.wDesc.get();
+    HipdnnBackendDescriptor* y = conv.yDesc.get();
+
+    convDesc->setAttribute(
+        HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &x);
+    convDesc->setAttribute(
+        HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &w);
+    convDesc->setAttribute(
+        HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &y);
+
+    const std::vector<int64_t> kCustomPrePadding = {2, 3};
+    const std::vector<int64_t> kCustomPostPadding = {4, 5};
+    const std::vector<int64_t> kCustomStride = {2, 2};
+    auto dilation = toVec(K_CONV_DILATION);
+
+    convDesc->setAttribute(
+        HIPDNN_ATTR_CONVOLUTION_PRE_PADDINGS, HIPDNN_TYPE_INT64, 2, kCustomPrePadding.data());
+    convDesc->setAttribute(
+        HIPDNN_ATTR_CONVOLUTION_POST_PADDINGS, HIPDNN_TYPE_INT64, 2, kCustomPostPadding.data());
+    convDesc->setAttribute(
+        HIPDNN_ATTR_CONVOLUTION_FILTER_STRIDES, HIPDNN_TYPE_INT64, 2, kCustomStride.data());
+    convDesc->setAttribute(
+        HIPDNN_ATTR_CONVOLUTION_DILATIONS, HIPDNN_TYPE_INT64, 2, dilation.data());
+
+    auto computeType = HIPDNN_DATA_FLOAT;
+    convDesc->setAttribute(
+        HIPDNN_ATTR_CONVOLUTION_COMP_TYPE, HIPDNN_TYPE_DATA_TYPE, 1, &computeType);
+    hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
+    convDesc->setAttribute(
+        HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode);
+    convDesc->finalize();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {wrapper.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graph = GetGraph(serialized.ptr);
+    auto graphT = graph->UnPack();
+
+    ASSERT_EQ(graphT->nodes.size(), 1);
+    ASSERT_EQ(graphT->tensors.size(), 3);
+
+    // Verify tensors
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                 K_TENSOR_X_UID,
+                 toVec(K_TENSOR_X_DIMS),
+                 toVec(K_TENSOR_X_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                 K_TENSOR_W_UID,
+                 toVec(K_TENSOR_W_DIMS),
+                 toVec(K_TENSOR_W_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                 K_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify node with asymmetric padding and non-unit stride
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::FLOAT,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      kCustomPrePadding,
+                      kCustomPostPadding,
+                      kCustomStride,
+                      toVec(K_CONV_DILATION));
+}
+
+// =============================================================================
+// SetAttribute Order Tests
+// =============================================================================
+
+TEST_F(TestGraphDescriptorOps, SetOperationsAndHandleAnyOrder)
+{
+    // Test: operations first, then handle
+    {
+        auto graphWrapper = createDescriptor<GraphDescriptor>();
+        auto desc = graphWrapper->asDescriptor<GraphDescriptor>();
+
+        auto conv = createDefaultConvOp();
+
+        std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+        ASSERT_NO_THROW(desc->setAttribute(
+            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()));
+
+        hipdnnHandle_t handle = &_mockHandle;
+        ASSERT_NO_THROW(
+            desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+
+        ASSERT_NO_THROW(desc->finalize());
+
+        auto serialized = desc->getSerializedGraph();
+        auto graphT = GetGraph(serialized.ptr)->UnPack();
+
+        ASSERT_EQ(graphT->tensors.size(), 3);
+        ASSERT_EQ(graphT->nodes.size(), 1);
+        verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                     K_TENSOR_X_UID,
+                     toVec(K_TENSOR_X_DIMS),
+                     toVec(K_TENSOR_X_STRIDES),
+                     DataType::FLOAT);
+        verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                     K_TENSOR_W_UID,
+                     toVec(K_TENSOR_W_DIMS),
+                     toVec(K_TENSOR_W_STRIDES),
+                     DataType::FLOAT);
+        verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                     K_TENSOR_Y_UID,
+                     toVec(K_TENSOR_Y_DIMS),
+                     toVec(K_TENSOR_Y_STRIDES),
+                     DataType::FLOAT);
+        verifyConvFwdNode(*graphT->nodes[0],
+                          DataType::FLOAT,
+                          K_TENSOR_X_UID,
+                          K_TENSOR_W_UID,
+                          K_TENSOR_Y_UID,
+                          toVec(K_CONV_PADDING),
+                          toVec(K_CONV_PADDING),
+                          toVec(K_CONV_STRIDE),
+                          toVec(K_CONV_DILATION));
+    }
+
+    // Test: handle first, then operations (with alternate UIDs)
+    {
+        auto graphWrapper = createDescriptor<GraphDescriptor>();
+        auto desc = graphWrapper->asDescriptor<GraphDescriptor>();
+
+        auto xDesc = createFinalizedTensor(K_ALT_TENSOR_X_UID);
+        auto wDesc = createFinalizedTensor(
+            K_ALT_TENSOR_W_UID, toVec(K_TENSOR_W_DIMS), toVec(K_TENSOR_W_STRIDES));
+        auto yDesc = createFinalizedTensor(
+            K_ALT_TENSOR_Y_UID, toVec(K_TENSOR_Y_DIMS), toVec(K_TENSOR_Y_STRIDES));
+        auto convOp = createFinalizedConvOp(xDesc.get(), wDesc.get(), yDesc.get());
+
+        hipdnnHandle_t handle = &_mockHandle;
+        ASSERT_NO_THROW(
+            desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+
+        std::array<HipdnnBackendDescriptor*, 1> ops = {convOp.get()};
+        ASSERT_NO_THROW(desc->setAttribute(
+            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()));
+
+        ASSERT_NO_THROW(desc->finalize());
+
+        auto serialized = desc->getSerializedGraph();
+        auto graphT = GetGraph(serialized.ptr)->UnPack();
+
+        ASSERT_EQ(graphT->tensors.size(), 3);
+        ASSERT_EQ(graphT->nodes.size(), 1);
+        verifyTensor(findTensorByUid(*graphT, K_ALT_TENSOR_X_UID),
+                     K_ALT_TENSOR_X_UID,
+                     toVec(K_TENSOR_X_DIMS),
+                     toVec(K_TENSOR_X_STRIDES),
+                     DataType::FLOAT);
+        verifyTensor(findTensorByUid(*graphT, K_ALT_TENSOR_W_UID),
+                     K_ALT_TENSOR_W_UID,
+                     toVec(K_TENSOR_W_DIMS),
+                     toVec(K_TENSOR_W_STRIDES),
+                     DataType::FLOAT);
+        verifyTensor(findTensorByUid(*graphT, K_ALT_TENSOR_Y_UID),
+                     K_ALT_TENSOR_Y_UID,
+                     toVec(K_TENSOR_Y_DIMS),
+                     toVec(K_TENSOR_Y_STRIDES),
+                     DataType::FLOAT);
+        verifyConvFwdNode(*graphT->nodes[0],
+                          DataType::FLOAT,
+                          K_ALT_TENSOR_X_UID,
+                          K_ALT_TENSOR_W_UID,
+                          K_ALT_TENSOR_Y_UID,
+                          toVec(K_CONV_PADDING),
+                          toVec(K_CONV_PADDING),
+                          toVec(K_CONV_STRIDE),
+                          toVec(K_CONV_DILATION));
+    }
+}
+
+TEST_F(TestGraphDescriptorOps, SetOperationsMultipleBatches)
+{
+    auto conv1 = createDefaultConvOp();
+
+    auto xDesc2 = createFinalizedTensor(
+        K_TENSOR_X2_UID, toVec(K_TENSOR_X2_DIMS), toVec(K_TENSOR_X2_STRIDES));
+    auto wDesc2 = createFinalizedTensor(
+        K_TENSOR_W2_UID, toVec(K_TENSOR_W2_DIMS), toVec(K_TENSOR_W2_STRIDES));
+    auto yDesc2 = createFinalizedTensor(
+        K_TENSOR_Y2_UID, toVec(K_TENSOR_Y2_DIMS), toVec(K_TENSOR_Y2_STRIDES));
+    auto convOp2 = createFinalizedConvOp(xDesc2.get(), wDesc2.get(), yDesc2.get());
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    // Set multiple operations in a single setAttribute call
+    std::array<HipdnnBackendDescriptor*, 2> ops = {conv1.convOp.get(), convOp2.get()};
+    ASSERT_NO_THROW(desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, ops.data()));
+
+    ASSERT_NO_THROW(desc->finalize());
+
+    auto serialized = desc->getSerializedGraph();
+    auto graph = GetGraph(serialized.ptr);
+    auto graphT = graph->UnPack();
+
+    // Both operations should be present in the graph
+    ASSERT_EQ(graphT->nodes.size(), 2);
+    ASSERT_EQ(graphT->tensors.size(), 6);
+
+    // Verify tensors from first operation
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                 K_TENSOR_X_UID,
+                 toVec(K_TENSOR_X_DIMS),
+                 toVec(K_TENSOR_X_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                 K_TENSOR_W_UID,
+                 toVec(K_TENSOR_W_DIMS),
+                 toVec(K_TENSOR_W_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                 K_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify tensors from second operation
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X2_UID),
+                 K_TENSOR_X2_UID,
+                 toVec(K_TENSOR_X2_DIMS),
+                 toVec(K_TENSOR_X2_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W2_UID),
+                 K_TENSOR_W2_UID,
+                 toVec(K_TENSOR_W2_DIMS),
+                 toVec(K_TENSOR_W2_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y2_UID),
+                 K_TENSOR_Y2_UID,
+                 toVec(K_TENSOR_Y2_DIMS),
+                 toVec(K_TENSOR_Y2_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify both nodes reference correct tensor UIDs
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::FLOAT,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+    verifyConvFwdNode(*graphT->nodes[1],
+                      DataType::FLOAT,
+                      K_TENSOR_X2_UID,
+                      K_TENSOR_W2_UID,
+                      K_TENSOR_Y2_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+}
+
+// =============================================================================
+// Error Cases
+// =============================================================================
+
+TEST_F(TestGraphDescriptorOps, SetOperationsFailsUnfinalized)
+{
+    auto desc = getDescriptor();
+
+    // Create unfinalized operation
+    auto unfinalizedOp = createDescriptor<ConvolutionFwdOperationDescriptor>();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {unfinalizedOp.get()};
+    ASSERT_THROW_HIPDNN_STATUS(
+        desc->setAttribute(
+            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()),
+        HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+}
+
+TEST_F(TestGraphDescriptorOps, SetOperationsFailsNullDescriptor)
+{
+    auto desc = getDescriptor();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {nullptr};
+    ASSERT_THROW_HIPDNN_STATUS(
+        desc->setAttribute(
+            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+}
+
+TEST_F(TestGraphDescriptorOps, SetOperationsFailsWrongType)
+{
+    auto desc = getDescriptor();
+
+    // Use a TensorDescriptor instead of an operation descriptor
+    auto tensorDesc = createFinalizedTensor(K_TENSOR_X_UID);
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {tensorDesc.get()};
+    ASSERT_THROW_HIPDNN_STATUS(
+        desc->setAttribute(
+            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+}
+
+TEST_F(TestGraphDescriptorOps, SetOperationsFailsAfterFinalize)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    // Try to set operations after finalize
+    ASSERT_THROW_HIPDNN_STATUS(
+        desc->setAttribute(
+            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()),
+        HIPDNN_STATUS_NOT_INITIALIZED);
+}
+
+TEST_F(TestGraphDescriptorOps, FinalizeFailsWithoutHandle)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    // Don't set handle
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+
+    ASSERT_THROW_HIPDNN_STATUS(desc->finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestGraphDescriptorOps, FinalizeFailsWithoutOperationsOrGraph)
+{
+    auto desc = getDescriptor();
+    setHandle();
+    // Don't set operations or deserialize graph
+
+    ASSERT_THROW_HIPDNN_STATUS(desc->finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
+
+// =============================================================================
+// Serialization Tests
+// =============================================================================
+
+TEST_F(TestGraphDescriptorOps, SerializedGraphVerifiable)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+
+    // Verify FlatBuffer is valid
+    flatbuffers::Verifier verifier(static_cast<const uint8_t*>(serialized.ptr), serialized.size);
+    ASSERT_TRUE(verifier.VerifyBuffer<Graph>());
+
+    // Verify the verified buffer contains the expected graph structure
+    auto graphT = GetGraph(serialized.ptr)->UnPack();
+    ASSERT_EQ(graphT->tensors.size(), 3);
+    ASSERT_EQ(graphT->nodes.size(), 1);
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::FLOAT,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+}
+
+TEST_F(TestGraphDescriptorOps, SerializedGraphUnpackable)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graph = GetGraph(serialized.ptr);
+    ASSERT_NE(graph, nullptr);
+
+    // Unpack should work and produce correct values
+    auto graphT = graph->UnPack();
+    ASSERT_NE(graphT, nullptr);
+    ASSERT_EQ(graphT->tensors.size(), 3);
+    ASSERT_EQ(graphT->nodes.size(), 1);
+
+    // Verify unpacked tensor values match input
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                 K_TENSOR_X_UID,
+                 toVec(K_TENSOR_X_DIMS),
+                 toVec(K_TENSOR_X_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                 K_TENSOR_W_UID,
+                 toVec(K_TENSOR_W_DIMS),
+                 toVec(K_TENSOR_W_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                 K_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify unpacked node values match input
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::FLOAT,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+}
+
+TEST_F(TestGraphDescriptorOps, GetSerializedGraphMultipleCalls)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    // Call getSerializedGraph multiple times
+    auto serialized1 = desc->getSerializedGraph();
+    auto serialized2 = desc->getSerializedGraph();
+
+    // Should return same data
+    EXPECT_EQ(serialized1.ptr, serialized2.ptr);
+    EXPECT_EQ(serialized1.size, serialized2.size);
+
+    // Both should unpack to identical graph values
+    auto graphT1 = GetGraph(serialized1.ptr)->UnPack();
+    auto graphT2 = GetGraph(serialized2.ptr)->UnPack();
+
+    ASSERT_EQ(graphT1->tensors.size(), 3);
+    ASSERT_EQ(graphT2->tensors.size(), 3);
+    ASSERT_EQ(graphT1->nodes.size(), 1);
+    ASSERT_EQ(graphT2->nodes.size(), 1);
+
+    // Verify both unpacked graphs contain identical tensor data
+    for(size_t i = 0; i < graphT1->tensors.size(); ++i)
+    {
+        EXPECT_EQ(graphT1->tensors[i]->uid, graphT2->tensors[i]->uid);
+        EXPECT_EQ(graphT1->tensors[i]->dims, graphT2->tensors[i]->dims);
+        EXPECT_EQ(graphT1->tensors[i]->strides, graphT2->tensors[i]->strides);
+        EXPECT_EQ(graphT1->tensors[i]->data_type, graphT2->tensors[i]->data_type);
+    }
+
+    // Verify both unpacked graphs contain identical node data
+    EXPECT_EQ(graphT1->nodes[0]->compute_data_type, graphT2->nodes[0]->compute_data_type);
+    EXPECT_EQ(graphT1->nodes[0]->attributes.type, graphT2->nodes[0]->attributes.type);
+}
+
+// =============================================================================
+// Graph Structure Verification Tests
+// =============================================================================
+
+TEST_F(TestGraphDescriptorOps, GraphHasCorrectNodeCount)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graph = GetGraph(serialized.ptr);
+    auto graphT = graph->UnPack();
+
+    ASSERT_EQ(graphT->nodes.size(), 1);
+
+    // Verify node has ConvolutionFwdAttributes and correct tensor UID references
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::FLOAT,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+}
+
+TEST_F(TestGraphDescriptorOps, GraphHasCorrectTensorCount)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graph = GetGraph(serialized.ptr);
+    auto graphT = graph->UnPack();
+
+    ASSERT_EQ(graphT->tensors.size(), 3);
+
+    // Verify each tensor's full field values (not just UIDs)
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                 K_TENSOR_X_UID,
+                 toVec(K_TENSOR_X_DIMS),
+                 toVec(K_TENSOR_X_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                 K_TENSOR_W_UID,
+                 toVec(K_TENSOR_W_DIMS),
+                 toVec(K_TENSOR_W_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                 K_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+}
+
+// =============================================================================
+// Equivalence Tests - Compare FlatBuffer path vs Descriptor path
+// =============================================================================
+
+struct ConvEquivalenceParams
+{
+    std::string name;
+    int64_t xUid;
+    int64_t wUid;
+    int64_t yUid;
+    std::vector<int64_t> xDims;
+    std::vector<int64_t> xStrides;
+    std::vector<int64_t> wDims;
+    std::vector<int64_t> wStrides;
+    std::vector<int64_t> yDims;
+    std::vector<int64_t> yStrides;
+    std::vector<int64_t> prePadding;
+    std::vector<int64_t> postPadding;
+    std::vector<int64_t> stride;
+    std::vector<int64_t> dilation;
+    hipdnnDataType_t tensorDataType;
+    hipdnnDataType_t computeDataType;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const ConvEquivalenceParams& p)
+{
+    return os << p.name;
+}
+
+class TestGraphDescriptorEquivalence : public TestGraphDescriptorOps,
+                                       public ::testing::WithParamInterface<ConvEquivalenceParams>
+{
+public:
+    // Build a graph via FlatBuffer serialization (the "old" path)
+    static flatbuffers::DetachedBuffer
+        buildGraphViaFlatBuffer(const TensorAttributesT& xTensor,
+                                const TensorAttributesT& wTensor,
+                                const TensorAttributesT& yTensor,
+                                const ConvolutionFwdAttributesT& convAttrs,
+                                DataType computeDataType)
+    {
+        flatbuffers::FlatBufferBuilder builder;
+
+        // Build tensors
+        std::vector<flatbuffers::Offset<TensorAttributes>> tensorOffsets;
+        tensorOffsets.push_back(TensorAttributes::Pack(builder, &xTensor));
+        tensorOffsets.push_back(TensorAttributes::Pack(builder, &wTensor));
+        tensorOffsets.push_back(TensorAttributes::Pack(builder, &yTensor));
+
+        // Build node with conv attributes
+        NodeT nodeT;
+        nodeT.compute_data_type = computeDataType;
+        nodeT.attributes.Set(ConvolutionFwdAttributesT(convAttrs));
+
+        std::vector<flatbuffers::Offset<Node>> nodeOffsets;
+        nodeOffsets.push_back(Node::Pack(builder, &nodeT));
+
+        // Build graph
+        auto graphOffset = CreateGraphDirect(builder,
+                                             nullptr, // name
+                                             DataType::UNSET,
+                                             DataType::UNSET,
+                                             DataType::UNSET,
+                                             &tensorOffsets,
+                                             &nodeOffsets);
+        builder.Finish(graphOffset);
+        return builder.Release();
+    }
+
+    // Build a graph via descriptors (the "new" path)
+    std::unique_ptr<GraphT> buildGraphViaDescriptors(int64_t xUid,
+                                                     int64_t wUid,
+                                                     int64_t yUid,
+                                                     const std::vector<int64_t>& xDims,
+                                                     const std::vector<int64_t>& xStrides,
+                                                     const std::vector<int64_t>& wDims,
+                                                     const std::vector<int64_t>& wStrides,
+                                                     const std::vector<int64_t>& yDims,
+                                                     const std::vector<int64_t>& yStrides,
+                                                     const std::vector<int64_t>& prePadding,
+                                                     const std::vector<int64_t>& postPadding,
+                                                     const std::vector<int64_t>& stride,
+                                                     const std::vector<int64_t>& dilation,
+                                                     hipdnnDataType_t tensorDataType,
+                                                     hipdnnDataType_t computeDataType)
+    {
+        // Create tensor descriptors
+        auto xDesc = createFinalizedTensor(xUid, xDims, xStrides, tensorDataType);
+        auto wDesc = createFinalizedTensor(wUid, wDims, wStrides, tensorDataType);
+        auto yDesc = createFinalizedTensor(yUid, yDims, yStrides, tensorDataType);
+
+        // Create conv op descriptor
+        auto convWrapper = createDescriptor<ConvolutionFwdOperationDescriptor>();
+        auto convDesc = convWrapper->asDescriptor<ConvolutionFwdOperationDescriptor>();
+
+        HipdnnBackendDescriptor* x = xDesc.get();
+        HipdnnBackendDescriptor* w = wDesc.get();
+        HipdnnBackendDescriptor* y = yDesc.get();
+
+        convDesc->setAttribute(
+            HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &x);
+        convDesc->setAttribute(
+            HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &w);
+        convDesc->setAttribute(
+            HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &y);
+        convDesc->setAttribute(HIPDNN_ATTR_CONVOLUTION_PRE_PADDINGS,
+                               HIPDNN_TYPE_INT64,
+                               static_cast<int64_t>(prePadding.size()),
+                               prePadding.data());
+        convDesc->setAttribute(HIPDNN_ATTR_CONVOLUTION_POST_PADDINGS,
+                               HIPDNN_TYPE_INT64,
+                               static_cast<int64_t>(postPadding.size()),
+                               postPadding.data());
+        convDesc->setAttribute(HIPDNN_ATTR_CONVOLUTION_FILTER_STRIDES,
+                               HIPDNN_TYPE_INT64,
+                               static_cast<int64_t>(stride.size()),
+                               stride.data());
+        convDesc->setAttribute(HIPDNN_ATTR_CONVOLUTION_DILATIONS,
+                               HIPDNN_TYPE_INT64,
+                               static_cast<int64_t>(dilation.size()),
+                               dilation.data());
+        convDesc->setAttribute(
+            HIPDNN_ATTR_CONVOLUTION_COMP_TYPE, HIPDNN_TYPE_DATA_TYPE, 1, &computeDataType);
+        hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
+        convDesc->setAttribute(
+            HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode);
+        convDesc->finalize();
+
+        // Build graph via GraphDescriptor
+        auto graphWrapper = createDescriptor<GraphDescriptor>();
+        auto graphDesc = graphWrapper->asDescriptor<GraphDescriptor>();
+
+        hipdnnHandle_t handle = &_mockHandle;
+        graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+
+        std::array<HipdnnBackendDescriptor*, 1> ops = {convWrapper.get()};
+        graphDesc->setAttribute(
+            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+        graphDesc->finalize();
+
+        auto serialized = graphDesc->getSerializedGraph();
+        auto graph = GetGraph(serialized.ptr);
+        return std::unique_ptr<GraphT>(graph->UnPack());
+    }
+
+    void verifyEquivalence(const ConvEquivalenceParams& p)
+    {
+        // Build via FlatBuffer path
+        auto sdkTensorDt = hipdnn_backend::toSdkDataType(p.tensorDataType);
+        auto sdkComputeDt = hipdnn_backend::toSdkDataType(p.computeDataType);
+
+        TensorAttributesT xTensor;
+        xTensor.uid = p.xUid;
+        xTensor.dims = p.xDims;
+        xTensor.strides = p.xStrides;
+        xTensor.data_type = sdkTensorDt;
+
+        TensorAttributesT wTensor;
+        wTensor.uid = p.wUid;
+        wTensor.dims = p.wDims;
+        wTensor.strides = p.wStrides;
+        wTensor.data_type = sdkTensorDt;
+
+        TensorAttributesT yTensor;
+        yTensor.uid = p.yUid;
+        yTensor.dims = p.yDims;
+        yTensor.strides = p.yStrides;
+        yTensor.data_type = sdkTensorDt;
+
+        ConvolutionFwdAttributesT convAttrs;
+        convAttrs.x_tensor_uid = p.xUid;
+        convAttrs.w_tensor_uid = p.wUid;
+        convAttrs.y_tensor_uid = p.yUid;
+        convAttrs.pre_padding = p.prePadding;
+        convAttrs.post_padding = p.postPadding;
+        convAttrs.stride = p.stride;
+        convAttrs.dilation = p.dilation;
+
+        auto flatbufferBuffer
+            = buildGraphViaFlatBuffer(xTensor, wTensor, yTensor, convAttrs, sdkComputeDt);
+        auto flatbufferGraphT = GetGraph(flatbufferBuffer.data())->UnPack();
+
+        // Build via descriptor path
+        auto descriptorGraphT = buildGraphViaDescriptors(p.xUid,
+                                                         p.wUid,
+                                                         p.yUid,
+                                                         p.xDims,
+                                                         p.xStrides,
+                                                         p.wDims,
+                                                         p.wStrides,
+                                                         p.yDims,
+                                                         p.yStrides,
+                                                         p.prePadding,
+                                                         p.postPadding,
+                                                         p.stride,
+                                                         p.dilation,
+                                                         p.tensorDataType,
+                                                         p.computeDataType);
+
+        // Verify structural equivalence
+        ASSERT_EQ(flatbufferGraphT->tensors.size(), descriptorGraphT->tensors.size());
+        ASSERT_EQ(flatbufferGraphT->nodes.size(), descriptorGraphT->nodes.size());
+
+        // Compare tensors (order may differ, so compare by UID)
+        std::map<int64_t, const TensorAttributesT*> fbTensors;
+        for(const auto& t : flatbufferGraphT->tensors)
+        {
+            fbTensors[t->uid] = t.get();
+        }
+
+        for(const auto& descTensor : descriptorGraphT->tensors)
+        {
+            auto it = fbTensors.find(descTensor->uid);
+            ASSERT_NE(it, fbTensors.end())
+                << "Tensor UID " << descTensor->uid << " not found in FlatBuffer graph";
+
+            const auto* fbTensor = it->second;
+            EXPECT_EQ(fbTensor->uid, descTensor->uid);
+            EXPECT_EQ(fbTensor->dims, descTensor->dims);
+            EXPECT_EQ(fbTensor->strides, descTensor->strides);
+            EXPECT_EQ(fbTensor->data_type, descTensor->data_type);
+        }
+
+        // Compare nodes
+        ASSERT_EQ(flatbufferGraphT->nodes.size(), 1);
+        ASSERT_EQ(descriptorGraphT->nodes.size(), 1);
+
+        const auto& fbNode = flatbufferGraphT->nodes[0];
+        const auto& descNode = descriptorGraphT->nodes[0];
+
+        EXPECT_EQ(fbNode->compute_data_type, descNode->compute_data_type);
+        EXPECT_EQ(fbNode->attributes.type, descNode->attributes.type);
+        EXPECT_EQ(fbNode->attributes.type, NodeAttributes::ConvolutionFwdAttributes);
+
+        const auto* fbConv = fbNode->attributes.AsConvolutionFwdAttributes();
+        const auto* descConv = descNode->attributes.AsConvolutionFwdAttributes();
+
+        ASSERT_NE(fbConv, nullptr);
+        ASSERT_NE(descConv, nullptr);
+
+        EXPECT_EQ(fbConv->x_tensor_uid, descConv->x_tensor_uid);
+        EXPECT_EQ(fbConv->w_tensor_uid, descConv->w_tensor_uid);
+        EXPECT_EQ(fbConv->y_tensor_uid, descConv->y_tensor_uid);
+        EXPECT_EQ(fbConv->pre_padding, descConv->pre_padding);
+        EXPECT_EQ(fbConv->post_padding, descConv->post_padding);
+        EXPECT_EQ(fbConv->stride, descConv->stride);
+        EXPECT_EQ(fbConv->dilation, descConv->dilation);
+    }
+};
+
+TEST_P(TestGraphDescriptorEquivalence, ConvOpEquivalence)
+{
+    verifyEquivalence(GetParam());
+}
+
+std::string convEquivalenceParamName(const ::testing::TestParamInfo<ConvEquivalenceParams>& info)
+{
+    return info.param.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(ConvOps,
+                         TestGraphDescriptorEquivalence,
+                         ::testing::Values(ConvEquivalenceParams{"SingleConvOp",
+                                                                 K_TENSOR_X_UID,
+                                                                 K_TENSOR_W_UID,
+                                                                 K_TENSOR_Y_UID,
+                                                                 toVec(K_TENSOR_X_DIMS),
+                                                                 toVec(K_TENSOR_X_STRIDES),
+                                                                 toVec(K_TENSOR_W_DIMS),
+                                                                 toVec(K_TENSOR_W_STRIDES),
+                                                                 toVec(K_TENSOR_Y_DIMS),
+                                                                 toVec(K_TENSOR_Y_STRIDES),
+                                                                 toVec(K_CONV_PADDING),
+                                                                 toVec(K_CONV_PADDING),
+                                                                 toVec(K_CONV_STRIDE),
+                                                                 toVec(K_CONV_DILATION),
+                                                                 HIPDNN_DATA_FLOAT,
+                                                                 HIPDNN_DATA_FLOAT},
+                                           ConvEquivalenceParams{"HalfPrecision",
+                                                                 10,
+                                                                 20,
+                                                                 30,
+                                                                 {2, 64, 56, 56},
+                                                                 {200704, 3136, 56, 1},
+                                                                 {128, 64, 3, 3},
+                                                                 {576, 9, 3, 1},
+                                                                 {2, 128, 56, 56},
+                                                                 {401408, 3136, 56, 1},
+                                                                 {1, 1},
+                                                                 {1, 1},
+                                                                 {1, 1},
+                                                                 {1, 1},
+                                                                 HIPDNN_DATA_HALF,
+                                                                 HIPDNN_DATA_HALF},
+                                           ConvEquivalenceParams{"NonUnitStrideAndDilation",
+                                                                 100,
+                                                                 200,
+                                                                 300,
+                                                                 {1, 256, 28, 28},
+                                                                 {200704, 784, 28, 1},
+                                                                 {512, 256, 3, 3},
+                                                                 {2304, 9, 3, 1},
+                                                                 {1, 512, 14, 14},
+                                                                 {100352, 196, 14, 1},
+                                                                 {2, 2},
+                                                                 {2, 2},
+                                                                 {2, 2},
+                                                                 {2, 2},
+                                                                 HIPDNN_DATA_FLOAT,
+                                                                 HIPDNN_DATA_FLOAT}),
+                         convEquivalenceParamName);
+
+// =============================================================================
+// Graph-Level Attribute Tests
+// =============================================================================
+
+TEST_F(TestGraphDescriptorOps, GraphLevelDataTypesPreserved)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+
+    // Set graph-level data types before finalize
+    auto computeDt = HIPDNN_DATA_HALF;
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_COMPUTE_DATA_TYPE_EXT, HIPDNN_TYPE_DATA_TYPE, 1, &computeDt);
+
+    auto intermediateDt = HIPDNN_DATA_BFLOAT16;
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_INTERMEDIATE_DATA_TYPE_EXT,
+                       HIPDNN_TYPE_DATA_TYPE,
+                       1,
+                       &intermediateDt);
+
+    auto ioDt = HIPDNN_DATA_FLOAT;
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_IO_DATA_TYPE_EXT, HIPDNN_TYPE_DATA_TYPE, 1, &ioDt);
+
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graphT = GetGraph(serialized.ptr)->UnPack();
+
+    EXPECT_EQ(graphT->compute_data_type, DataType::HALF);
+    EXPECT_EQ(graphT->intermediate_data_type, DataType::BFLOAT16);
+    EXPECT_EQ(graphT->io_data_type, DataType::FLOAT);
+}
+
+TEST_F(TestGraphDescriptorOps, PreferredEngineIdPreserved)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+
+    int64_t engineId = 42;
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_PREFERRED_ENGINE_ID_EXT, HIPDNN_TYPE_INT64, 1, &engineId);
+
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graphT = GetGraph(serialized.ptr)->UnPack();
+
+    EXPECT_EQ(graphT->preferred_engine_id, 42);
+}
+
+TEST_F(TestGraphDescriptorOps, GraphLevelDataTypesDefaultToUnset)
+{
+    auto conv = createDefaultConvOp();
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+
+    // Finalize without setting any graph-level data types
+    desc->finalize();
+
+    auto serialized = desc->getSerializedGraph();
+    auto graphT = GetGraph(serialized.ptr)->UnPack();
+
+    EXPECT_EQ(graphT->compute_data_type, DataType::UNSET);
+    EXPECT_EQ(graphT->intermediate_data_type, DataType::UNSET);
+    EXPECT_EQ(graphT->io_data_type, DataType::UNSET);
+}
+
+TEST_F(TestGraphDescriptorOps, SharedTensorDifferentPositions)
+{
+    // Same tensor used as Y in first op and X in second op
+    auto graphWrapper = createDescriptor<GraphDescriptor>();
+    auto graphDesc = graphWrapper->asDescriptor<GraphDescriptor>();
+
+    auto handle = reinterpret_cast<hipdnnHandle_t>(&_mockHandle);
+    graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+
+    // Create tensors (Y tensor shared between ops)
+    auto xDesc1 = createFinalizedTensor(K_TENSOR_X_UID);
+    auto wDesc1
+        = createFinalizedTensor(K_TENSOR_W_UID, toVec(K_TENSOR_W_DIMS), toVec(K_TENSOR_W_STRIDES));
+    auto sharedTensor
+        = createFinalizedTensor(K_TENSOR_Y_UID, toVec(K_TENSOR_Y_DIMS), toVec(K_TENSOR_Y_STRIDES));
+    // 64->64 channel weights unique to this test (not in the shared constant set)
+    auto wDesc2 = createFinalizedTensor(K_SHARED_TENSOR_W_UID, {64, 64, 3, 3}, {576, 9, 3, 1});
+    auto yDesc2 = createFinalizedTensor(
+        K_SHARED_TENSOR_Y_UID, toVec(K_TENSOR_Y_DIMS), toVec(K_TENSOR_Y_STRIDES));
+
+    // Op1: x=1, w=2, y=3
+    auto op1 = createFinalizedConvOp(xDesc1.get(), wDesc1.get(), sharedTensor.get());
+    // Op2: x=3, w=4, y=5 (shares tensor 3 with op1 in a different position)
+    auto op2 = createFinalizedConvOp(sharedTensor.get(), wDesc2.get(), yDesc2.get());
+
+    std::array<HipdnnBackendDescriptor*, 2> opDescs = {op1.get(), op2.get()};
+    graphDesc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, opDescs.data());
+
+    graphDesc->finalize();
+
+    auto serialized = graphDesc->getSerializedGraph();
+    auto graph = GetGraph(serialized.ptr);
+    ASSERT_NE(graph, nullptr);
+    auto graphT = graph->UnPack();
+
+    // 5 unique tensors, shared tensor is deduplicated
+    ASSERT_EQ(graphT->tensors.size(), 5);
+    ASSERT_EQ(graphT->nodes.size(), 2);
+
+    // Verify each tensor's fields
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_X_UID),
+                 K_TENSOR_X_UID,
+                 toVec(K_TENSOR_X_DIMS),
+                 toVec(K_TENSOR_X_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_W_UID),
+                 K_TENSOR_W_UID,
+                 toVec(K_TENSOR_W_DIMS),
+                 toVec(K_TENSOR_W_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_TENSOR_Y_UID),
+                 K_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_SHARED_TENSOR_W_UID),
+                 K_SHARED_TENSOR_W_UID,
+                 {64, 64, 3, 3},
+                 {576, 9, 3, 1},
+                 DataType::FLOAT);
+    verifyTensor(findTensorByUid(*graphT, K_SHARED_TENSOR_Y_UID),
+                 K_SHARED_TENSOR_Y_UID,
+                 toVec(K_TENSOR_Y_DIMS),
+                 toVec(K_TENSOR_Y_STRIDES),
+                 DataType::FLOAT);
+
+    // Verify first node: x=1, w=2, y=3 (shared tensor used as Y here)
+    verifyConvFwdNode(*graphT->nodes[0],
+                      DataType::FLOAT,
+                      K_TENSOR_X_UID,
+                      K_TENSOR_W_UID,
+                      K_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+
+    // Verify second node: x=3, w=4, y=5 (shared tensor reused as X here)
+    verifyConvFwdNode(*graphT->nodes[1],
+                      DataType::FLOAT,
+                      K_TENSOR_Y_UID,
+                      K_SHARED_TENSOR_W_UID,
+                      K_SHARED_TENSOR_Y_UID,
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_PADDING),
+                      toVec(K_CONV_STRIDE),
+                      toVec(K_CONV_DILATION));
+}
+
+TEST_F(TestGraphDescriptorOps, FinalizeFailsDuplicateTensorUidDifferentDescriptors)
+{
+    // Create two distinct tensor descriptors with the same UID
+    auto xDesc1 = createFinalizedTensor(K_TENSOR_X_UID);
+    auto xDesc2 = createFinalizedTensor(K_TENSOR_X_UID);
+    auto wDesc
+        = createFinalizedTensor(K_TENSOR_W_UID, toVec(K_TENSOR_W_DIMS), toVec(K_TENSOR_W_STRIDES));
+    auto yDesc
+        = createFinalizedTensor(K_TENSOR_Y_UID, toVec(K_TENSOR_Y_DIMS), toVec(K_TENSOR_Y_STRIDES));
+
+    // Op1 uses xDesc1, Op2 uses xDesc2 (different object, same UID)
+    auto op1 = createFinalizedConvOp(xDesc1.get(), wDesc.get(), yDesc.get());
+
+    auto xDesc2a = createFinalizedTensor(
+        K_TENSOR_X2_UID, toVec(K_TENSOR_X2_DIMS), toVec(K_TENSOR_X2_STRIDES));
+    auto wDesc2 = createFinalizedTensor(
+        K_TENSOR_W2_UID, toVec(K_TENSOR_W2_DIMS), toVec(K_TENSOR_W2_STRIDES));
+    // Use xDesc2 (same UID as xDesc1, different descriptor object) as Y
+    auto op2 = createFinalizedConvOp(xDesc2a.get(), wDesc2.get(), xDesc2.get());
+
+    auto desc = getDescriptor();
+    setHandle();
+
+    std::array<HipdnnBackendDescriptor*, 2> ops = {op1.get(), op2.get()};
+    desc->setAttribute(
+        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, ops.data());
+
+    ASSERT_THROW_HIPDNN_STATUS(desc->finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestGraphDescriptorOps, SetOperationsRejectsNonOperationDescriptor)
+{
+    auto graphWrapper = createDescriptor<GraphDescriptor>();
+    auto graphDesc = graphWrapper->asDescriptor<GraphDescriptor>();
+
+    // Set handle first
+    auto handle = reinterpret_cast<hipdnnHandle_t>(&_mockHandle);
+    graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+
+    // Create a tensor descriptor (does NOT implement IGraphOperation)
+    auto tensorWrapper = createFinalizedTensor(99);
+    HipdnnBackendDescriptor* tensorDescPtr = tensorWrapper.get();
+
+    // Attempting to set a non-operation descriptor as an operation should throw
+    ASSERT_THROW_HIPDNN_STATUS(
+        graphDesc->setAttribute(
+            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &tensorDescPtr),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+}

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -83,6 +83,7 @@
 #include <hipdnn_frontend/detail/CreateBackendDescriptor.hpp>
 #include <hipdnn_frontend/detail/EngineOverrideUtils.hpp>
 #include <hipdnn_frontend/detail/GraphDetail.hpp>
+#include <hipdnn_frontend/detail/GraphPacker.hpp>
 #include <hipdnn_frontend/detail/ScopedHipdnnBackendDescriptor.hpp>
 #include <hipdnn_frontend/knob/Knob.hpp>
 #include <hipdnn_frontend/node/BatchnormBackwardNode.hpp>
@@ -820,6 +821,16 @@ public:
      */
     Error build_operation_graph(hipdnnHandle_t handle) // NOLINT(readability-identifier-naming)
     {
+        // TODO: Remove this feature flag once all operation types support descriptor-based
+        // lowering and the flatbuffer path is no longer needed.
+        static const bool s_useDescriptorApi
+            = hipdnn_data_sdk::utilities::getEnv("HIPDNN_USE_DESCRIPTOR_API") == "1";
+
+        if(s_useDescriptorApi)
+        {
+            return build_operation_graph_via_descriptors(handle);
+        }
+
         HIPDNN_FE_LOG_INFO("Building operation graph " << graph_attributes.get_name());
 
         if(!_preferredEngineId.has_value())
@@ -853,6 +864,71 @@ public:
         return {ErrorCode::OK, ""};
     }
 
+protected:
+    // Returns the raw backend graph descriptor, or nullptr if the graph has not been built.
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    hipdnnBackendDescriptor_t get_raw_graph_descriptor() const
+    {
+        return _graphDesc ? _graphDesc->get() : nullptr;
+    }
+
+    /// Builds the operation graph using the backend descriptor C API.
+    /// Each node creates its operation descriptor(s) via virtual dispatch,
+    /// then the GraphDescriptor is assembled and finalized.
+    ///
+    /// NOTE: This method is intentionally not yet exposed publicly. It will replace
+    /// the FlatBuffer-based build_operation_graph() once all operation types are implemented.
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error build_operation_graph_via_descriptors(hipdnnHandle_t handle)
+    {
+        HIPDNN_FE_LOG_INFO("Building operation graph via descriptors "
+                           << graph_attributes.get_name());
+
+        assignUnsetTensorUids();
+
+        if(!_preferredEngineId.has_value())
+        {
+            _preferredEngineId
+                = hipdnn_frontend::engine_override::getPreferredIdFromOverrideConfig(*this);
+        }
+
+        // Collect all tensor descriptors (keyed by UID for deduplication)
+        std::unordered_map<int64_t, detail::ScopedHipdnnBackendDescriptor> tensorDescs;
+
+        // Collect operation descriptors
+        std::vector<detail::ScopedHipdnnBackendDescriptor> operations;
+
+        // Each node creates its operation descriptor(s) via virtual dispatch
+        for(const auto& node : _sub_nodes)
+        {
+            HIPDNN_CHECK_ERROR(node->create_operation(tensorDescs, operations));
+        }
+
+        if(operations.empty())
+        {
+            return {ErrorCode::INVALID_VALUE, "No operations created for graph"};
+        }
+
+        // Assemble the graph descriptor from operations
+        auto computeDt = toHipdnnDataType(graph_attributes.get_compute_data_type());
+        auto intermediateDt = toHipdnnDataType(graph_attributes.get_intermediate_data_type());
+        auto ioDt = toHipdnnDataType(graph_attributes.get_io_data_type());
+        if(!computeDt || !intermediateDt || !ioDt)
+        {
+            return {ErrorCode::INVALID_VALUE, "Unsupported data type in graph attributes"};
+        }
+        HIPDNN_CHECK_ERROR(detail::assembleGraphDescriptor(operations,
+                                                           handle,
+                                                           *computeDt,
+                                                           *intermediateDt,
+                                                           *ioDt,
+                                                           _preferredEngineId,
+                                                           _graphDesc));
+
+        return {ErrorCode::OK, ""};
+    }
+
+public:
     /**
      * @brief Get available configuration knobs for a specific engine
      * @param engineId The engine ID to query
@@ -1311,7 +1387,8 @@ public:
     /**
      * @brief Execute the graph with tensor pointers mapped by tensor handles
      * @param handle The hipDNN handle
-     * @param tensorLookup Map from std::shared_ptr<TensorAttributes> (tensor handles) to device memory pointers
+     * @param tensorLookup Map from std::shared_ptr<TensorAttributes> (tensor handles) to device
+     * memory pointers
      * @param workspace Pointer to workspace memory (can be nullptr if size is 0)
      * @return Error indicating success or failure
      *

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <HipdnnBackendHeuristicType.h>
+#include <HipdnnConvolutionMode.h>
 #include <HipdnnDataType.h>
 #include <hipdnn_data_sdk/data_objects/convolution_fwd_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/data_types_generated.h>
@@ -257,6 +258,28 @@ inline hipdnn_data_sdk::data_objects::ConvMode toSdkType(const ConvolutionMode& 
         return hipdnn_data_sdk::data_objects::ConvMode::CONVOLUTION;
     default:
         return hipdnn_data_sdk::data_objects::ConvMode::UNSET;
+    }
+}
+
+/**
+ * @brief Convert frontend ConvolutionMode to backend hipdnnConvolutionMode_t
+ *
+ * Maps frontend convolution mode enum to the backend C API enum type for use
+ * with HIPDNN_TYPE_CONVOLUTION_MODE attributes.
+ *
+ * @param type The frontend ConvolutionMode value
+ * @return The corresponding hipdnnConvolutionMode_t value, or std::nullopt if not set
+ */
+inline std::optional<hipdnnConvolutionMode_t> toBackendConvMode(const ConvolutionMode& type)
+{
+    switch(type)
+    {
+    case ConvolutionMode::CROSS_CORRELATION:
+        return HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
+    case ConvolutionMode::CONVOLUTION:
+        return HIPDNN_CONVOLUTION_MODE_CONVOLUTION;
+    default:
+        return std::nullopt;
     }
 }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/ConvolutionFpropPacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/ConvolutionFpropPacker.hpp
@@ -64,10 +64,16 @@ inline Error createConvFpropOperation(
                                             "conv dilation"));
 
     // Set conv mode and compute data type
-    auto convMode
-        = static_cast<int64_t>(hipdnn_frontend::toSdkType(attributes.get_convolution_mode()));
-    HIPDNN_CHECK_ERROR(setDescriptorAttrScalar(
-        opDesc.get(), HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, convMode, "conv mode"));
+    auto convMode = hipdnn_frontend::toBackendConvMode(attributes.get_convolution_mode());
+    if(!convMode.has_value())
+    {
+        return {ErrorCode::INVALID_VALUE, "Unsupported convolution mode"};
+    }
+    HIPDNN_CHECK_ERROR(setDescriptorAttrScalar(opDesc.get(),
+                                               HIPDNN_ATTR_CONVOLUTION_CONV_MODE,
+                                               HIPDNN_TYPE_CONVOLUTION_MODE,
+                                               *convMode,
+                                               "conv mode"));
 
     HIPDNN_CHECK_ERROR(setDescriptorAttrDataType(opDesc.get(),
                                                  HIPDNN_ATTR_CONVOLUTION_COMP_TYPE,

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/GraphPacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/GraphPacker.hpp
@@ -1,0 +1,97 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <HipdnnDataType.h>
+#include <hipdnn_frontend/Error.hpp>
+#include <hipdnn_frontend/Utilities.hpp>
+#include <hipdnn_frontend/detail/BackendWrapper.hpp>
+#include <hipdnn_frontend/detail/DescriptorHelpers.hpp>
+#include <hipdnn_frontend/detail/ScopedHipdnnBackendDescriptor.hpp>
+#include <hipdnn_frontend/node/Node.hpp>
+
+#include <optional>
+#include <vector>
+
+namespace hipdnn_frontend::detail
+{
+
+// Assembles a GraphDescriptor from pre-built operation descriptors.
+// Sets the handle, operations, graph-level data types, preferred engine ID,
+// then finalizes and returns the scoped descriptor.
+inline Error assembleGraphDescriptor(const std::vector<ScopedHipdnnBackendDescriptor>& operations,
+                                     hipdnnHandle_t handle,
+                                     hipdnnDataType_t computeDataType,
+                                     hipdnnDataType_t intermediateDataType,
+                                     hipdnnDataType_t ioDataType,
+                                     const std::optional<int64_t>& preferredEngineId,
+                                     std::unique_ptr<ScopedHipdnnBackendDescriptor>& outGraphDesc)
+{
+    ScopedHipdnnBackendDescriptor graphDesc(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR);
+    if(!graphDesc.valid())
+    {
+        return {ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to create GraphDescriptor"};
+    }
+
+    // Set handle on graph
+    HIPDNN_RETURN_ON_BACKEND_FAILURE(
+        hipdnnBackend()->backendSetAttribute(
+            graphDesc.get(), HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+        "Failed to set handle on GraphDescriptor");
+
+    // Set operations on graph
+    std::vector<hipdnnBackendDescriptor_t> opDescPtrs;
+    opDescPtrs.reserve(operations.size());
+    for(const auto& desc : operations)
+    {
+        opDescPtrs.push_back(desc.get());
+    }
+    HIPDNN_RETURN_ON_BACKEND_FAILURE(
+        hipdnnBackend()->backendSetAttribute(graphDesc.get(),
+                                             HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                             static_cast<int64_t>(opDescPtrs.size()),
+                                             opDescPtrs.data()),
+        "Failed to set operations on GraphDescriptor");
+
+    // Set graph-level data types
+    HIPDNN_CHECK_ERROR(setDescriptorAttrScalar(graphDesc.get(),
+                                               HIPDNN_ATTR_OPERATIONGRAPH_COMPUTE_DATA_TYPE_EXT,
+                                               HIPDNN_TYPE_DATA_TYPE,
+                                               computeDataType,
+                                               "compute data type on GraphDescriptor"));
+
+    HIPDNN_CHECK_ERROR(
+        setDescriptorAttrScalar(graphDesc.get(),
+                                HIPDNN_ATTR_OPERATIONGRAPH_INTERMEDIATE_DATA_TYPE_EXT,
+                                HIPDNN_TYPE_DATA_TYPE,
+                                intermediateDataType,
+                                "intermediate data type on GraphDescriptor"));
+
+    HIPDNN_CHECK_ERROR(setDescriptorAttrScalar(graphDesc.get(),
+                                               HIPDNN_ATTR_OPERATIONGRAPH_IO_DATA_TYPE_EXT,
+                                               HIPDNN_TYPE_DATA_TYPE,
+                                               ioDataType,
+                                               "io data type on GraphDescriptor"));
+
+    // Set preferred engine ID if specified
+    if(preferredEngineId.has_value())
+    {
+        auto engineId = preferredEngineId.value();
+        HIPDNN_CHECK_ERROR(
+            setDescriptorAttrScalar(graphDesc.get(),
+                                    HIPDNN_ATTR_OPERATIONGRAPH_PREFERRED_ENGINE_ID_EXT,
+                                    HIPDNN_TYPE_INT64,
+                                    engineId,
+                                    "preferred engine ID on GraphDescriptor"));
+    }
+
+    // Finalize the graph
+    HIPDNN_CHECK_ERROR(finalizeDescriptor(graphDesc.get(), "GraphDescriptor"));
+
+    outGraphDesc = std::make_unique<ScopedHipdnnBackendDescriptor>(std::move(graphDesc));
+    return {};
+}
+
+} // namespace hipdnn_frontend::detail

--- a/projects/hipdnn/frontend/tests/TestDescriptorHelpers.cpp
+++ b/projects/hipdnn/frontend/tests/TestDescriptorHelpers.cpp
@@ -25,7 +25,6 @@ namespace
 
 constexpr int64_t K_DEFAULT_TENSOR_UID = 42;
 constexpr int64_t K_MISSING_TENSOR_UID = 999;
-constexpr int64_t K_TEST_SCALAR_VALUE = 42;
 
 constexpr std::array<int64_t, 4> K_DEFAULT_TENSOR_DIMS = {1, 3, 4, 4};
 constexpr std::array<int64_t, 4> K_DEFAULT_TENSOR_STRIDES = {48, 16, 4, 1};
@@ -215,15 +214,19 @@ TEST_F(TestDescriptorHelpers, SetDescriptorAttrScalarSucceeds)
     EXPECT_CALL(*_mockBackend,
                 backendSetAttribute(_,
                                     HIPDNN_ATTR_CONVOLUTION_CONV_MODE,
-                                    HIPDNN_TYPE_INT64,
+                                    HIPDNN_TYPE_CONVOLUTION_MODE,
                                     1,
-                                    pointsToScalar<int64_t>(K_TEST_SCALAR_VALUE)))
+                                    pointsToScalar<hipdnnConvolutionMode_t>(
+                                        HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION)))
         .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
-    int64_t value = K_TEST_SCALAR_VALUE;
+    hipdnnConvolutionMode_t value = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
     hipdnnBackendDescriptor_t desc = nullptr;
-    auto err = setDescriptorAttrScalar(
-        desc, HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, value, "test scalar");
+    auto err = setDescriptorAttrScalar(desc,
+                                       HIPDNN_ATTR_CONVOLUTION_CONV_MODE,
+                                       HIPDNN_TYPE_CONVOLUTION_MODE,
+                                       value,
+                                       "test scalar");
     EXPECT_TRUE(err.is_good());
 }
 
@@ -282,10 +285,13 @@ TEST_F(TestDescriptorHelpers, SetDescriptorAttrScalarReturnsErrorOnFailure)
     EXPECT_CALL(*_mockBackend, backendSetAttribute(_, _, _, _, _))
         .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
 
-    int64_t value = K_TEST_SCALAR_VALUE;
+    hipdnnConvolutionMode_t value = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
     hipdnnBackendDescriptor_t desc = nullptr;
-    auto err = setDescriptorAttrScalar(
-        desc, HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, value, "test scalar");
+    auto err = setDescriptorAttrScalar(desc,
+                                       HIPDNN_ATTR_CONVOLUTION_CONV_MODE,
+                                       HIPDNN_TYPE_CONVOLUTION_MODE,
+                                       value,
+                                       "test scalar");
     EXPECT_TRUE(err.is_bad());
     EXPECT_EQ(err.code, ErrorCode::HIPDNN_BACKEND_ERROR);
 }

--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -9,21 +9,32 @@
 #include <hipdnn_frontend/attributes/ConvolutionFpropAttributes.hpp>
 #include <hipdnn_frontend/attributes/LayernormAttributes.hpp>
 #include <hipdnn_frontend/attributes/PointwiseAttributes.hpp>
+#include <hipdnn_test_sdk/constants/ConvFpropConstants.hpp>
+#include <hipdnn_test_sdk/utilities/ToVec.hpp>
 
+#include "fake_backend/BackendTestMatchers.hpp"
 #include "fake_backend/MockHipdnnBackend.hpp"
+
+#include <algorithm>
+#include <cstring>
 
 using namespace hipdnn_frontend;
 using namespace hipdnn_frontend::graph;
+using namespace hipdnn_frontend::test;
+using namespace hipdnn_tests::constants;
+using hipdnn_tests::toVec;
 using namespace ::testing;
 
 namespace hipdnn_frontend
 {
 
-// Utility class to access private members of Graph for testing purposes
+// Utility class to access private/protected members of Graph for testing purposes
 class GraphTestUtils : public Graph
 {
 public:
     GraphTestUtils() = default;
+
+    using Graph::build_operation_graph_via_descriptors;
 
     std::vector<std::shared_ptr<INode>>& getPrivateGraphSubnodes()
     {
@@ -1994,6 +2005,110 @@ TEST_F(TestGraph, WillCorrectlyBuildOperationGraphDescriptor)
 
     auto result = graph.build_operation_graph(_handle);
     EXPECT_TRUE(result.is_good());
+}
+
+TEST_F(TestGraph, BuildOperationGraphViaDescriptorsFailsWhenNodeFails)
+{
+    ::testing::FLAGS_gmock_verbose = "error";
+    GraphTestUtils graph;
+    graph.set_name("FailTest").set_compute_data_type(DataType::FLOAT);
+
+    auto x = std::make_shared<TensorAttributes>();
+    x->set_uid(K_TENSOR_X_UID)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim(toVec(K_TENSOR_X_DIMS))
+        .set_stride(toVec(K_TENSOR_X_STRIDES));
+    auto w = std::make_shared<TensorAttributes>();
+    w->set_uid(K_TENSOR_W_UID)
+        .set_name("W")
+        .set_data_type(DataType::FLOAT)
+        .set_dim(toVec(K_TENSOR_W_DIMS))
+        .set_stride(toVec(K_TENSOR_W_STRIDES));
+
+    ConvFpropAttributes convAttrs;
+    convAttrs.set_x(x);
+    convAttrs.set_w(w);
+    convAttrs.set_pre_padding(toVec(K_CONV_PADDING));
+    convAttrs.set_post_padding(toVec(K_CONV_PADDING));
+    convAttrs.set_stride(toVec(K_CONV_STRIDE));
+    convAttrs.set_dilation(toVec(K_CONV_DILATION));
+
+    graph.conv_fprop(x, w, convAttrs);
+
+    // All descriptor creation fails
+    EXPECT_CALL(*_mockBackend, backendCreateDescriptor(_, _))
+        .WillRepeatedly(Return(HIPDNN_STATUS_INTERNAL_ERROR));
+    EXPECT_CALL(*_mockBackend, getLastErrorString(_, _)).Times(AnyNumber());
+
+    auto result = graph.build_operation_graph_via_descriptors(_handle);
+    EXPECT_TRUE(result.is_bad());
+    EXPECT_EQ(result.code, ErrorCode::HIPDNN_BACKEND_ERROR);
+}
+
+TEST_F(TestGraph, BuildOperationGraphViaDescriptorsFailsWhenGraphCreateFails)
+{
+    ::testing::FLAGS_gmock_verbose = "error";
+    GraphTestUtils graph;
+    graph.set_name("GraphCreateFail")
+        .set_compute_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT)
+        .set_io_data_type(DataType::FLOAT);
+
+    auto x = std::make_shared<TensorAttributes>();
+    x->set_uid(K_TENSOR_X_UID)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim(toVec(K_TENSOR_X_DIMS))
+        .set_stride(toVec(K_TENSOR_X_STRIDES));
+    auto w = std::make_shared<TensorAttributes>();
+    w->set_uid(K_TENSOR_W_UID)
+        .set_name("W")
+        .set_data_type(DataType::FLOAT)
+        .set_dim(toVec(K_TENSOR_W_DIMS))
+        .set_stride(toVec(K_TENSOR_W_STRIDES));
+
+    ConvFpropAttributes convAttrs;
+    convAttrs.set_x(x);
+    convAttrs.set_w(w);
+    convAttrs.set_compute_data_type(DataType::FLOAT);
+    convAttrs.set_pre_padding(toVec(K_CONV_PADDING));
+    convAttrs.set_post_padding(toVec(K_CONV_PADDING));
+    convAttrs.set_stride(toVec(K_CONV_STRIDE));
+    convAttrs.set_dilation(toVec(K_CONV_DILATION));
+
+    graph.conv_fprop(x, w, convAttrs);
+
+    // Validate graph to propagate graph-level attributes (e.g. io_data_type)
+    // to node/tensor attributes, matching the real build() flow
+    ASSERT_TRUE(graph.validate().is_good());
+
+    // Tensor/operation descriptors succeed, but graph descriptor creation fails
+    EXPECT_CALL(*_mockBackend,
+                backendCreateDescriptor(Ne(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR), _))
+        .WillRepeatedly(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, backendCreateDescriptor(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR, _))
+        .WillOnce(Return(HIPDNN_STATUS_INTERNAL_ERROR));
+    EXPECT_CALL(*_mockBackend, backendDestroyDescriptor(_))
+        .WillRepeatedly(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, backendSetAttribute(_, _, _, _, _))
+        .WillRepeatedly(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, backendFinalize(_)).WillRepeatedly(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, getLastErrorString(_, _)).Times(AnyNumber());
+
+    auto result = graph.build_operation_graph_via_descriptors(_handle);
+    EXPECT_TRUE(result.is_bad());
+    EXPECT_EQ(result.code, ErrorCode::HIPDNN_BACKEND_ERROR);
+}
+
+TEST_F(TestGraph, BuildOperationGraphViaDescriptorsFailsOnEmptyGraph)
+{
+    GraphTestUtils graph;
+    graph.set_name("EmptyGraph").set_compute_data_type(DataType::FLOAT);
+
+    auto result = graph.build_operation_graph_via_descriptors(_handle);
+    EXPECT_TRUE(result.is_bad());
+    EXPECT_EQ(result.code, ErrorCode::INVALID_VALUE);
 }
 
 TEST_F(TestGraph, CreatingExecutionPlansFailsWithNoGraph)

--- a/projects/hipdnn/tests/backend/CMakeLists.txt
+++ b/projects/hipdnn/tests/backend/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
     IntegrationBackendDescriptor.cpp
     IntegrationBackendExecuteApi.cpp
     IntegrationConvOperationDescriptorApi.cpp
+    IntegrationGraphDescriptorApi.cpp
     IntegrationEngineApi.cpp
     IntegrationEngineConfigApi.cpp
     IntegrationEngineHeuristicApi.cpp

--- a/projects/hipdnn/tests/backend/IntegrationBackendDescriptor.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationBackendDescriptor.cpp
@@ -4,13 +4,7 @@
 #include "hipdnn_backend.h"
 #include <array>
 #include <gtest/gtest.h>
-#include <hipdnn_data_sdk/data_objects/graph_generated.h>
-#include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>
-#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
 #include <test_plugins/TestPluginConstants.hpp>
-#include <vector>
-
-namespace fs = std::filesystem;
 
 class IntegrationBackendDescriptor : public ::testing::Test
 {
@@ -105,68 +99,4 @@ TEST_F(IntegrationBackendDescriptor, SetAttributeWithNullDescriptor)
         descriptor, attributeName, attributeType, elementCount, arrayOfElements);
 
     EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-}
-
-TEST_F(IntegrationBackendDescriptor, CreateAndDeserializeGraphExtWithNullGraph)
-{
-    hipdnnBackendDescriptor_t descriptor = nullptr;
-
-    auto status = hipdnnBackendCreateAndDeserializeGraph_ext(&descriptor, nullptr, 0);
-
-    EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
-    EXPECT_EQ(descriptor, nullptr);
-}
-
-TEST_F(IntegrationBackendDescriptor, SetOperationGraph)
-{
-    SKIP_IF_NO_DEVICES();
-    flatbuffers::FlatBufferBuilder builder;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
-        tensorAttributes;
-    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
-    auto graph = hipdnn_data_sdk::data_objects::CreateGraphDirect(
-        builder,
-        "Test GRAPH!",
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        hipdnn_data_sdk::data_objects::DataType::FLOAT,
-        &tensorAttributes,
-        &nodes);
-    builder.Finish(graph);
-    flatbuffers::DetachedBuffer serializedGraph = builder.Release();
-
-    hipdnnBackendDescriptor_t descriptor = nullptr;
-
-    auto status = hipdnnBackendCreateAndDeserializeGraph_ext(
-        &descriptor, serializedGraph.data(), serializedGraph.size());
-
-    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
-
-    hipdnnHandle_t handle = nullptr;
-    status = hipdnnCreate(&handle);
-    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
-
-    status = hipdnnBackendSetAttribute(
-        descriptor, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
-    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
-
-    status = hipdnnBackendFinalize(descriptor);
-    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
-
-    hipdnnBackendDestroyDescriptor(descriptor);
-    EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
-}
-
-TEST_F(IntegrationBackendDescriptor, FinalizeInvalidOperationGraph)
-{
-    hipdnnBackendDescriptor_t descriptor = nullptr;
-    auto status
-        = hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR, &descriptor);
-    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
-
-    status = hipdnnBackendFinalize(descriptor);
-    EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM);
-
-    status = hipdnnBackendDestroyDescriptor(descriptor);
-    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
 }

--- a/projects/hipdnn/tests/backend/IntegrationConvOperationDescriptorApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationConvOperationDescriptorApi.cpp
@@ -112,10 +112,11 @@ TEST_F(IntegrationConvOperationDescriptorApi, CreateAndFinalizeConvOperation)
                                         dilation.data()),
               HIPDNN_STATUS_SUCCESS);
 
-    auto convMode = static_cast<int64_t>(ConvMode::CROSS_CORRELATION);
-    EXPECT_EQ(hipdnnBackendSetAttribute(
-                  opDesc, HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 1, &convMode),
-              HIPDNN_STATUS_SUCCESS);
+    hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
+    EXPECT_EQ(
+        hipdnnBackendSetAttribute(
+            opDesc, HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode),
+        HIPDNN_STATUS_SUCCESS);
 
     auto computeType = HIPDNN_DATA_FLOAT;
     EXPECT_EQ(
@@ -191,10 +192,11 @@ TEST_F(IntegrationConvOperationDescriptorApi, GetAfterSetVerifiesAllAttributes)
                                         dilation.data()),
               HIPDNN_STATUS_SUCCESS);
 
-    auto convMode = static_cast<int64_t>(ConvMode::CROSS_CORRELATION);
-    EXPECT_EQ(hipdnnBackendSetAttribute(
-                  opDesc, HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 1, &convMode),
-              HIPDNN_STATUS_SUCCESS);
+    hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
+    EXPECT_EQ(
+        hipdnnBackendSetAttribute(
+            opDesc, HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode),
+        HIPDNN_STATUS_SUCCESS);
 
     auto computeType = HIPDNN_DATA_FLOAT;
     EXPECT_EQ(
@@ -295,17 +297,17 @@ TEST_F(IntegrationConvOperationDescriptorApi, GetAfterSetVerifiesAllAttributes)
     EXPECT_EQ(retrievedDilation, dilation);
 
     // Verify conv mode
-    int64_t retrievedConvMode = 0;
+    hipdnnConvolutionMode_t retrievedConvMode = {};
     elementCount = 0;
     EXPECT_EQ(hipdnnBackendGetAttribute(opDesc,
                                         HIPDNN_ATTR_CONVOLUTION_CONV_MODE,
-                                        HIPDNN_TYPE_INT64,
+                                        HIPDNN_TYPE_CONVOLUTION_MODE,
                                         1,
                                         &elementCount,
                                         &retrievedConvMode),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(elementCount, 1);
-    EXPECT_EQ(retrievedConvMode, static_cast<int64_t>(ConvMode::CROSS_CORRELATION));
+    EXPECT_EQ(retrievedConvMode, HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION);
 
     // Verify compute type
     hipdnnDataType_t retrievedCompType = {};
@@ -355,9 +357,9 @@ TEST_F(IntegrationConvOperationDescriptorApi, ConvOperationFailsWithoutTensorRef
                               static_cast<int64_t>(dilation.size()),
                               dilation.data());
 
-    auto convMode = static_cast<int64_t>(ConvMode::CROSS_CORRELATION);
+    hipdnnConvolutionMode_t convMode = HIPDNN_CONVOLUTION_MODE_CROSS_CORRELATION;
     hipdnnBackendSetAttribute(
-        opDesc, HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_INT64, 1, &convMode);
+        opDesc, HIPDNN_ATTR_CONVOLUTION_CONV_MODE, HIPDNN_TYPE_CONVOLUTION_MODE, 1, &convMode);
 
     auto computeType = HIPDNN_DATA_FLOAT;
     hipdnnBackendSetAttribute(

--- a/projects/hipdnn/tests/backend/IntegrationGraphDescriptorApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationGraphDescriptorApi.cpp
@@ -1,0 +1,333 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include "BackendTestHelpers.hpp"
+#include "hipdnn_backend.h"
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/data_objects/convolution_common_generated.h>
+#include <hipdnn_data_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_test_sdk/constants/ConvFpropConstants.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+#include <test_plugins/TestPluginConstants.hpp>
+#include <vector>
+
+using namespace backend_test;
+using namespace hipdnn_tests::constants;
+using hipdnn_data_sdk::data_objects::ConvMode;
+using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
+
+class IntegrationGraphDescriptorApi : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        const std::array<const char*, 1> paths
+            = {hipdnn_tests::plugin_constants::testGoodPluginPath().c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+    }
+};
+
+TEST_F(IntegrationGraphDescriptorApi, CreateAndDeserializeGraphExtWithNullGraph)
+{
+    hipdnnBackendDescriptor_t descriptor = nullptr;
+
+    auto status = hipdnnBackendCreateAndDeserializeGraph_ext(&descriptor, nullptr, 0);
+
+    EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    EXPECT_EQ(descriptor, nullptr);
+}
+
+TEST_F(IntegrationGraphDescriptorApi, SetOperationGraph)
+{
+    SKIP_IF_NO_DEVICES();
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto graph = hipdnn_data_sdk::data_objects::CreateGraphDirect(builder,
+                                                                  "Test GRAPH!",
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  &tensorAttributes,
+                                                                  &nodes);
+    builder.Finish(graph);
+    flatbuffers::DetachedBuffer serializedGraph = builder.Release();
+
+    hipdnnBackendDescriptor_t descriptor = nullptr;
+
+    auto status = hipdnnBackendCreateAndDeserializeGraph_ext(
+        &descriptor, serializedGraph.data(), serializedGraph.size());
+
+    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
+
+    hipdnnHandle_t handle = nullptr;
+    status = hipdnnCreate(&handle);
+    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
+
+    status = hipdnnBackendSetAttribute(
+        descriptor, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
+
+    status = hipdnnBackendFinalize(descriptor);
+    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
+
+    hipdnnBackendDestroyDescriptor(descriptor);
+    EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+}
+
+TEST_F(IntegrationGraphDescriptorApi, FinalizeInvalidOperationGraph)
+{
+    hipdnnBackendDescriptor_t descriptor = nullptr;
+    auto status
+        = hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR, &descriptor);
+    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
+
+    status = hipdnnBackendFinalize(descriptor);
+    EXPECT_EQ(status, HIPDNN_STATUS_BAD_PARAM);
+
+    status = hipdnnBackendDestroyDescriptor(descriptor);
+    EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
+}
+
+TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphFailsIfNotFinalized)
+{
+    hipdnnBackendDescriptor_t desc = nullptr;
+    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR, &desc),
+              HIPDNN_STATUS_SUCCESS);
+
+    size_t size = 0;
+    EXPECT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(desc, 0, &size, nullptr),
+              HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+
+    hipdnnBackendDestroyDescriptor(desc);
+}
+
+TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphFailsWithNullParams)
+{
+    size_t size = 0;
+    EXPECT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(nullptr, 0, &size, nullptr),
+              HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+}
+
+TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphFailsWithNullSizeParam)
+{
+    hipdnnBackendDescriptor_t desc = nullptr;
+    ASSERT_EQ(hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR, &desc),
+              HIPDNN_STATUS_SUCCESS);
+
+    EXPECT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(desc, 0, nullptr, nullptr),
+              HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+
+    hipdnnBackendDestroyDescriptor(desc);
+}
+
+TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphSizeQueryMatchesCopySize)
+{
+    // Build a graph via FlatBuffer deserialization
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto graph = hipdnn_data_sdk::data_objects::CreateGraphDirect(builder,
+                                                                  "SizeTestGraph",
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  &tensorAttributes,
+                                                                  &nodes);
+    builder.Finish(graph);
+    flatbuffers::DetachedBuffer serializedGraph = builder.Release();
+
+    hipdnnBackendDescriptor_t desc = nullptr;
+    ASSERT_EQ(hipdnnBackendCreateAndDeserializeGraph_ext(
+                  &desc, serializedGraph.data(), serializedGraph.size()),
+              HIPDNN_STATUS_SUCCESS);
+
+    hipdnnHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(
+                  desc, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendFinalize(desc), HIPDNN_STATUS_SUCCESS);
+
+    // Query size
+    size_t queriedSize = 0;
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(desc, 0, &queriedSize, nullptr),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_GT(queriedSize, 0u);
+
+    // Copy with queried size
+    std::vector<uint8_t> buffer(queriedSize);
+    size_t copySize = 0;
+    ASSERT_EQ(
+        hipdnnBackendGetSerializedBinaryGraph_ext(desc, queriedSize, &copySize, buffer.data()),
+        HIPDNN_STATUS_SUCCESS);
+    EXPECT_EQ(copySize, queriedSize);
+
+    // Verify data is valid FlatBuffer
+    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(buffer.data());
+    ASSERT_NE(graphFb, nullptr);
+
+    hipdnnBackendDestroyDescriptor(desc);
+    EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+}
+
+TEST_F(IntegrationGraphDescriptorApi, SerializedGraphRoundTripPreservesGraphProperties)
+{
+    // Build a graph via FlatBuffer with known properties
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto graph = hipdnn_data_sdk::data_objects::CreateGraphDirect(builder,
+                                                                  "TestGraph",
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  &tensorAttributes,
+                                                                  &nodes);
+    builder.Finish(graph);
+    flatbuffers::DetachedBuffer serializedGraph = builder.Release();
+
+    // Deserialize, set handle, finalize
+    hipdnnBackendDescriptor_t desc = nullptr;
+    ASSERT_EQ(hipdnnBackendCreateAndDeserializeGraph_ext(
+                  &desc, serializedGraph.data(), serializedGraph.size()),
+              HIPDNN_STATUS_SUCCESS);
+
+    hipdnnHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(
+                  desc, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendFinalize(desc), HIPDNN_STATUS_SUCCESS);
+
+    // Use two-call pattern to get serialized data
+    size_t size = 0;
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(desc, 0, &size, nullptr),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_GT(size, 0u);
+
+    std::vector<uint8_t> buffer(size);
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(desc, size, &size, buffer.data()),
+              HIPDNN_STATUS_SUCCESS);
+
+    // Verify graph properties match what we set
+    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(buffer.data());
+    ASSERT_NE(graphFb, nullptr);
+    hipdnn_data_sdk::data_objects::GraphT graphT;
+    graphFb->UnPackTo(&graphT);
+
+    EXPECT_EQ(graphT.name, "TestGraph");
+    EXPECT_EQ(graphT.io_data_type, DataTypeSdk::FLOAT);
+    EXPECT_EQ(graphT.intermediate_data_type, DataTypeSdk::FLOAT);
+    EXPECT_EQ(graphT.compute_data_type, DataTypeSdk::FLOAT);
+    EXPECT_TRUE(graphT.tensors.empty());
+    EXPECT_TRUE(graphT.nodes.empty());
+
+    hipdnnBackendDestroyDescriptor(desc);
+    EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+}
+
+TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphFailsWithInsufficientBuffer)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto graph = hipdnn_data_sdk::data_objects::CreateGraphDirect(builder,
+                                                                  "BufferSizeTest",
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  &tensorAttributes,
+                                                                  &nodes);
+    builder.Finish(graph);
+    flatbuffers::DetachedBuffer serializedGraph = builder.Release();
+
+    hipdnnBackendDescriptor_t desc = nullptr;
+    ASSERT_EQ(hipdnnBackendCreateAndDeserializeGraph_ext(
+                  &desc, serializedGraph.data(), serializedGraph.size()),
+              HIPDNN_STATUS_SUCCESS);
+
+    hipdnnHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(
+                  desc, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendFinalize(desc), HIPDNN_STATUS_SUCCESS);
+
+    // Query actual size
+    size_t queriedSize = 0;
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(desc, 0, &queriedSize, nullptr),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_GT(queriedSize, 1u);
+
+    // Attempt copy with undersized buffer
+    std::vector<uint8_t> buffer(1);
+    size_t reportedSize = 0;
+    EXPECT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(desc, 1, &reportedSize, buffer.data()),
+              HIPDNN_STATUS_BAD_PARAM_SIZE_INSUFFICIENT);
+
+    hipdnnBackendDestroyDescriptor(desc);
+    EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+}
+
+TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphSucceedsWithOversizedBuffer)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+    std::vector<::flatbuffers::Offset<hipdnn_data_sdk::data_objects::Node>> nodes;
+    auto graph = hipdnn_data_sdk::data_objects::CreateGraphDirect(builder,
+                                                                  "OversizedBufferTest",
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  DataTypeSdk::FLOAT,
+                                                                  &tensorAttributes,
+                                                                  &nodes);
+    builder.Finish(graph);
+    flatbuffers::DetachedBuffer serializedGraph = builder.Release();
+
+    hipdnnBackendDescriptor_t desc = nullptr;
+    ASSERT_EQ(hipdnnBackendCreateAndDeserializeGraph_ext(
+                  &desc, serializedGraph.data(), serializedGraph.size()),
+              HIPDNN_STATUS_SUCCESS);
+
+    hipdnnHandle_t handle = nullptr;
+    ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
+
+    ASSERT_EQ(hipdnnBackendSetAttribute(
+                  desc, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendFinalize(desc), HIPDNN_STATUS_SUCCESS);
+
+    // Query actual size
+    size_t queriedSize = 0;
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(desc, 0, &queriedSize, nullptr),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_GT(queriedSize, 0u);
+
+    // Copy with oversized buffer
+    auto oversizedSize = queriedSize * 2;
+    std::vector<uint8_t> buffer(oversizedSize);
+    size_t reportedSize = 0;
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(
+                  desc, oversizedSize, &reportedSize, buffer.data()),
+              HIPDNN_STATUS_SUCCESS);
+    EXPECT_EQ(reportedSize, queriedSize);
+
+    // Verify data is valid
+    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(buffer.data());
+    ASSERT_NE(graphFb, nullptr);
+
+    hipdnnBackendDestroyDescriptor(desc);
+    EXPECT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+}

--- a/projects/hipdnn/tests/frontend/CMakeLists.txt
+++ b/projects/hipdnn/tests/frontend/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
     IntegrationConvolutionBackwardWeight.cpp
     IntegrationGraphEngineFiltering.cpp
     IntegrationGraphKnobsApi.cpp
+    IntegrationConvFpropDescriptorLowering.cpp
 )
 
 target_compile_options(public_hipdnn_frontend_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})

--- a/projects/hipdnn/tests/frontend/IntegrationConvFpropDescriptorLowering.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationConvFpropDescriptorLowering.cpp
@@ -1,0 +1,289 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <hipdnn_data_sdk/data_objects/convolution_fwd_attributes_generated.h>
+#include <hipdnn_data_sdk/data_objects/graph_generated.h>
+#include <hipdnn_frontend.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+#include <hipdnn_test_sdk/utilities/ToVec.hpp>
+
+#include "test_plugins/TestPluginConstants.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_frontend::graph;
+using hipdnn_tests::toVec;
+using DataTypeSdk = hipdnn_data_sdk::data_objects::DataType;
+using ConvModeSdk = hipdnn_data_sdk::data_objects::ConvMode;
+using NodeAttrType = hipdnn_data_sdk::data_objects::NodeAttributes;
+
+namespace
+{
+
+// Exposes protected Graph methods for testing
+class TestableGraph : public Graph
+{
+public:
+    using Graph::build_operation_graph_via_descriptors;
+    using Graph::get_raw_graph_descriptor;
+};
+
+// -- Test constants for ConvFpropGraphRoundTrip --
+// These use different values from the shared constants (different dims/strides/UIDs)
+// and are specific to the conv fprop lowering tests.
+
+constexpr int64_t K_TENSOR_X_UID = 10;
+constexpr int64_t K_TENSOR_W_UID = 20;
+constexpr int64_t K_TENSOR_Y_UID = 30;
+
+constexpr std::array<int64_t, 4> K_TENSOR_X_DIMS = {2, 3, 14, 14};
+constexpr std::array<int64_t, 4> K_TENSOR_X_STRIDES = {588, 196, 14, 1};
+constexpr std::array<int64_t, 4> K_TENSOR_W_DIMS = {8, 3, 3, 3};
+constexpr std::array<int64_t, 4> K_TENSOR_W_STRIDES = {27, 9, 3, 1};
+
+constexpr std::array<int64_t, 2> K_CONV_PRE_PADDING = {1, 1};
+constexpr std::array<int64_t, 2> K_CONV_POST_PADDING = {1, 1};
+constexpr std::array<int64_t, 2> K_CONV_STRIDE = {2, 2};
+constexpr std::array<int64_t, 2> K_CONV_DILATION = {1, 1};
+
+// -- Test constants for AutoAssignedUidsPreservedInRoundTrip --
+
+constexpr std::array<int64_t, 4> K_AUTO_X_DIMS = {1, 3, 8, 8};
+constexpr std::array<int64_t, 4> K_AUTO_X_STRIDES = {192, 64, 8, 1};
+constexpr std::array<int64_t, 4> K_AUTO_W_DIMS = {16, 3, 3, 3};
+constexpr std::array<int64_t, 4> K_AUTO_W_STRIDES = {27, 9, 3, 1};
+
+constexpr std::array<int64_t, 2> K_AUTO_PADDING = {0, 0};
+constexpr std::array<int64_t, 2> K_AUTO_STRIDE = {1, 1};
+constexpr std::array<int64_t, 2> K_AUTO_DILATION = {1, 1};
+
+// Lowers a frontend graph via build_operation_graph_via_descriptors, then
+// retrieves the serialized graph and deserializes it for verification.
+class IntegrationConvFpropDescriptorLowering : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        SKIP_IF_NO_DEVICES();
+
+        ASSERT_EQ(hipInit(0), hipSuccess);
+
+        const std::array<const char*, 1> paths
+            = {hipdnn_tests::plugin_constants::testGoodPluginPath().c_str()};
+        ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(
+                      paths.size(), paths.data(), HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+                  HIPDNN_STATUS_SUCCESS);
+
+        ASSERT_EQ(hipdnnCreate(&_handle), HIPDNN_STATUS_SUCCESS);
+    }
+
+    void TearDown() override
+    {
+        if(_handle != nullptr)
+        {
+            hipdnnDestroy(_handle);
+        }
+    }
+
+    hipdnnHandle_t _handle = nullptr;
+};
+
+// Builds a conv_fprop graph via the frontend API, lowers it to the backend
+// via build_operation_graph_via_descriptors, retrieves the serialized graph,
+// and verifies all tensor and operation attributes match the values set
+// in the frontend.
+TEST_F(IntegrationConvFpropDescriptorLowering, ConvFpropGraphRoundTrip)
+{
+    auto graph = std::make_shared<TestableGraph>();
+    graph->set_name("TestConvGraph")
+        .set_io_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT);
+
+    auto x = std::make_shared<TensorAttributes>();
+    x->set_uid(K_TENSOR_X_UID).set_name("X").set_data_type(DataType::FLOAT);
+    x->set_dim(toVec(K_TENSOR_X_DIMS)).set_stride(toVec(K_TENSOR_X_STRIDES));
+
+    auto w = std::make_shared<TensorAttributes>();
+    w->set_uid(K_TENSOR_W_UID).set_name("W").set_data_type(DataType::FLOAT);
+    w->set_dim(toVec(K_TENSOR_W_DIMS)).set_stride(toVec(K_TENSOR_W_STRIDES));
+
+    ConvFpropAttributes convAttrs;
+    convAttrs.set_name("conv_fprop_op");
+    convAttrs.set_pre_padding(toVec(K_CONV_PRE_PADDING));
+    convAttrs.set_post_padding(toVec(K_CONV_POST_PADDING));
+    convAttrs.set_stride(toVec(K_CONV_STRIDE));
+    convAttrs.set_dilation(toVec(K_CONV_DILATION));
+    convAttrs.set_convolution_mode(ConvolutionMode::CROSS_CORRELATION);
+
+    auto y = graph->conv_fprop(x, w, convAttrs);
+    y->set_uid(K_TENSOR_Y_UID).set_output(true).set_name("Y");
+
+    // -- Validate and lower --
+    auto result = graph->validate();
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    result = graph->build_operation_graph_via_descriptors(_handle);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    // -- Retrieve serialized graph --
+    auto rawDesc = graph->get_raw_graph_descriptor();
+    ASSERT_NE(rawDesc, nullptr);
+
+    size_t serializedSize = 0;
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(rawDesc, 0, &serializedSize, nullptr),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_GT(serializedSize, 0u);
+
+    std::vector<uint8_t> serializedData(serializedSize);
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(
+                  rawDesc, serializedSize, &serializedSize, serializedData.data()),
+              HIPDNN_STATUS_SUCCESS);
+
+    // -- Deserialize into GraphT --
+    auto graphFb = hipdnn_data_sdk::data_objects::GetGraph(serializedData.data());
+    ASSERT_NE(graphFb, nullptr);
+    hipdnn_data_sdk::data_objects::GraphT graphT;
+    graphFb->UnPackTo(&graphT);
+
+    // -- Verify graph-level attributes --
+    EXPECT_EQ(graphT.compute_data_type, DataTypeSdk::FLOAT);
+    EXPECT_EQ(graphT.intermediate_data_type, DataTypeSdk::FLOAT);
+    EXPECT_EQ(graphT.io_data_type, DataTypeSdk::FLOAT);
+
+    // -- Verify tensors --
+    ASSERT_EQ(graphT.tensors.size(), 3u);
+
+    std::unordered_map<int64_t, const hipdnn_data_sdk::data_objects::TensorAttributesT*> tensorMap;
+    for(const auto& t : graphT.tensors)
+    {
+        tensorMap[t->uid] = t.get();
+    }
+
+    // Verify X tensor
+    ASSERT_NE(tensorMap.count(K_TENSOR_X_UID), 0u);
+    auto* xT = tensorMap[K_TENSOR_X_UID];
+    EXPECT_EQ(xT->name, "X");
+    EXPECT_EQ(xT->data_type, DataTypeSdk::FLOAT);
+    EXPECT_EQ(xT->dims, toVec(K_TENSOR_X_DIMS));
+    EXPECT_EQ(xT->strides, toVec(K_TENSOR_X_STRIDES));
+    EXPECT_FALSE(xT->virtual_);
+
+    // Verify W tensor
+    ASSERT_NE(tensorMap.count(K_TENSOR_W_UID), 0u);
+    auto* wT = tensorMap[K_TENSOR_W_UID];
+    EXPECT_EQ(wT->name, "W");
+    EXPECT_EQ(wT->data_type, DataTypeSdk::FLOAT);
+    EXPECT_EQ(wT->dims, toVec(K_TENSOR_W_DIMS));
+    EXPECT_EQ(wT->strides, toVec(K_TENSOR_W_STRIDES));
+    EXPECT_FALSE(wT->virtual_);
+
+    // Verify Y tensor
+    ASSERT_NE(tensorMap.count(K_TENSOR_Y_UID), 0u);
+    auto* yT = tensorMap[K_TENSOR_Y_UID];
+    EXPECT_EQ(yT->name, "Y");
+    EXPECT_EQ(yT->data_type, DataTypeSdk::FLOAT);
+    EXPECT_FALSE(yT->virtual_);
+
+    // -- Verify conv operation node --
+    ASSERT_EQ(graphT.nodes.size(), 1u);
+    auto& node = graphT.nodes[0];
+    EXPECT_EQ(node->compute_data_type, DataTypeSdk::FLOAT);
+    EXPECT_EQ(node->attributes.type, NodeAttrType::ConvolutionFwdAttributes);
+
+    auto* convFwd = node->attributes.AsConvolutionFwdAttributes();
+    ASSERT_NE(convFwd, nullptr);
+
+    EXPECT_EQ(convFwd->x_tensor_uid, K_TENSOR_X_UID);
+    EXPECT_EQ(convFwd->w_tensor_uid, K_TENSOR_W_UID);
+    EXPECT_EQ(convFwd->y_tensor_uid, K_TENSOR_Y_UID);
+    EXPECT_EQ(convFwd->pre_padding, toVec(K_CONV_PRE_PADDING));
+    EXPECT_EQ(convFwd->post_padding, toVec(K_CONV_POST_PADDING));
+    EXPECT_EQ(convFwd->stride, toVec(K_CONV_STRIDE));
+    EXPECT_EQ(convFwd->dilation, toVec(K_CONV_DILATION));
+    EXPECT_EQ(convFwd->conv_mode, ConvModeSdk::CROSS_CORRELATION);
+}
+
+// Verifies that tensor UIDs auto-assigned by the frontend are preserved
+// through the lowering round-trip.
+TEST_F(IntegrationConvFpropDescriptorLowering, AutoAssignedUidsPreservedInRoundTrip)
+{
+    auto graph = std::make_shared<TestableGraph>();
+    graph->set_name("AutoUidGraph")
+        .set_io_data_type(DataType::FLOAT)
+        .set_intermediate_data_type(DataType::FLOAT)
+        .set_compute_data_type(DataType::FLOAT);
+
+    auto x = std::make_shared<TensorAttributes>();
+    x->set_name("X").set_data_type(DataType::FLOAT);
+    x->set_dim(toVec(K_AUTO_X_DIMS)).set_stride(toVec(K_AUTO_X_STRIDES));
+
+    auto w = std::make_shared<TensorAttributes>();
+    w->set_name("W").set_data_type(DataType::FLOAT);
+    w->set_dim(toVec(K_AUTO_W_DIMS)).set_stride(toVec(K_AUTO_W_STRIDES));
+
+    ConvFpropAttributes convAttrs;
+    convAttrs.set_padding(toVec(K_AUTO_PADDING));
+    convAttrs.set_stride(toVec(K_AUTO_STRIDE));
+    convAttrs.set_dilation(toVec(K_AUTO_DILATION));
+
+    auto y = graph->conv_fprop(x, w, convAttrs);
+    y->set_output(true);
+
+    auto result = graph->validate();
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    result = graph->build_operation_graph_via_descriptors(_handle);
+    ASSERT_EQ(result.code, ErrorCode::OK) << result.err_msg;
+
+    // Retrieve serialized graph
+    auto rawDesc = graph->get_raw_graph_descriptor();
+    size_t serializedSize = 0;
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(rawDesc, 0, &serializedSize, nullptr),
+              HIPDNN_STATUS_SUCCESS);
+    ASSERT_GT(serializedSize, 0u);
+
+    std::vector<uint8_t> serializedData(serializedSize);
+    ASSERT_EQ(hipdnnBackendGetSerializedBinaryGraph_ext(
+                  rawDesc, serializedSize, &serializedSize, serializedData.data()),
+              HIPDNN_STATUS_SUCCESS);
+
+    hipdnn_data_sdk::data_objects::GraphT graphT;
+    hipdnn_data_sdk::data_objects::GetGraph(serializedData.data())->UnPackTo(&graphT);
+
+    // All tensors should have been auto-assigned unique UIDs
+    // (auto-assignment starts from 0, so UID 0 is valid)
+    ASSERT_EQ(graphT.tensors.size(), 3u);
+    std::unordered_set<int64_t> uids;
+    for(const auto& t : graphT.tensors)
+    {
+        uids.insert(t->uid);
+    }
+    EXPECT_EQ(uids.size(), 3u) << "Tensor UIDs are not unique";
+
+    // The conv operation should reference the auto-assigned UIDs
+    ASSERT_EQ(graphT.nodes.size(), 1u);
+    auto* convFwd = graphT.nodes[0]->attributes.AsConvolutionFwdAttributes();
+    ASSERT_NE(convFwd, nullptr);
+
+    // Tensor UIDs in the node should match tensors in the graph
+    EXPECT_TRUE(uids.count(convFwd->x_tensor_uid) > 0)
+        << "X tensor UID " << convFwd->x_tensor_uid << " not found in graph tensors";
+    EXPECT_TRUE(uids.count(convFwd->w_tensor_uid) > 0)
+        << "W tensor UID " << convFwd->w_tensor_uid << " not found in graph tensors";
+    EXPECT_TRUE(uids.count(convFwd->y_tensor_uid) > 0)
+        << "Y tensor UID " << convFwd->y_tensor_uid << " not found in graph tensors";
+
+    // All three tensor UIDs referenced by the node should be distinct
+    std::unordered_set<int64_t> nodeUids
+        = {convFwd->x_tensor_uid, convFwd->w_tensor_uid, convFwd->y_tensor_uid};
+    EXPECT_EQ(nodeUids.size(), 3u) << "Conv node tensor UIDs are not distinct";
+}
+
+} // namespace


### PR DESCRIPTION
## Motivation

Add new C-api descriptor lowering path for Graphs in hipDNN.
This enables building graphs and lowering without using Flatbuffers in the frontend.

Part of: https://github.com/ROCm/rocm-libraries/issues/4782
Split from https://github.com/ROCm/rocm-libraries/pull/4641

## Technical Details

- Added new lowering path for GraphDescriptors that is feature flag protected
- Added support for building Graphs from lowered operations

## Test Plan

Tests added covering this functionality.
ASAN enabled tests are passing.

## Test Result

Tests passing, and ASAN passing.