### PR TITLE
[Hipblaslt] Reuse existing ProblemType object if available in _getName

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Naming.py
@@ -120,7 +120,11 @@ def _getName(state, requiredParameters: frozenset, splitGSU: bool, ignoreInterna
                                                            "StaggerUMapping",
                                                            "GlobalSplitUCoalesced",
                                                            "GlobalSplitUWorkGroupMappingRoundRobin"])
-  components = [f'{str(ProblemType(state["ProblemType"],printIndexAssignmentInfo=False))}']
+  pt = state["ProblemType"]
+  if isinstance(pt, ProblemType):
+    components = [str(pt)]
+  else:
+    components = [str(ProblemType(pt, printIndexAssignmentInfo=False))]
 
   if "MacroTile0" in state \
       and "MacroTile1" in state \


### PR DESCRIPTION
## Motivation

`state["ProblemType"]` is almost always already a ProblemType object (TensileMergeLibrary.py being the exception). Recreating it each time adds unnecessary overhead to runs.

## Technical Details

Check and use existing object if available.

## Test Plan

Existing tests.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
