### PR TITLE
fix(rocprim): check if wave size is supported in warp_sort benchmark

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -28,10 +28,6 @@ Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projec
 * Removed unused `equality`, `inequality`, `sum`, `max`, `min` from thread_operator.hpp.
 * Removed duplicate `inequality_operator` from binary_op_warpper.hpp
 
-### Known issues
-
-* benchmark_warp_sort may hang on Navi GPUs on Windows when running logical warp sizes > hardware warp size.
-
 ## rocPRIM 4.2.0 for ROCm 7.2
 
 ### Added

--- a/projects/rocprim/benchmark/benchmark_warp_sort.cpp
+++ b/projects/rocprim/benchmark/benchmark_warp_sort.cpp
@@ -24,13 +24,18 @@
 
 #include "primbench.hpp"
 
-#define CREATE_SORT_BENCHMARK(K, BS, WS, IPT) executor.queue<warp_sort_benchmark<K, BS, WS, IPT>>();
+#define CREATE_SORT_BENCHMARK(K, BS, WS, IPT)                  \
+    if(is_warp_size_supported(WS, device_id))                  \
+    {                                                          \
+        executor.queue<warp_sort_benchmark<K, BS, WS, IPT>>(); \
+    }
 
-#define CREATE_SORTBYKEY_BENCHMARK(K, V, BS, WS, IPT) \
-    executor.queue<warp_sort_benchmark<K, BS, WS, IPT, V>>();
+#define CREATE_SORTBYKEY_BENCHMARK(K, V, BS, WS, IPT)             \
+    if(is_warp_size_supported(WS, device_id))                     \
+    {                                                             \
+        executor.queue<warp_sort_benchmark<K, BS, WS, IPT, V>>(); \
+    }
 
-// clang-format off
-#ifndef ROCPRIM_NAVI					    
 #define BENCHMARK_TYPE(type)                \
     CREATE_SORT_BENCHMARK(type, 64, 64, 1)  \
     CREATE_SORT_BENCHMARK(type, 64, 64, 2)  \
@@ -46,35 +51,14 @@
     CREATE_SORT_BENCHMARK(type, 64, 16, 1)  \
     CREATE_SORT_BENCHMARK(type, 64, 16, 2)  \
     CREATE_SORT_BENCHMARK(type, 64, 16, 4)
-#elif defined(_WIN32) // Currently, running a logical warpSize > hardware warpSize on Windows on Navi cards leads to a hang.
-#define BENCHMARK_TYPE(type)                \
-    CREATE_SORT_BENCHMARK(type, 64, 32, 1)  \
-    CREATE_SORT_BENCHMARK(type, 64, 32, 1)  \
-    CREATE_SORT_BENCHMARK(type, 64, 16, 2)  \
-    CREATE_SORT_BENCHMARK(type, 64, 16, 2)  \
-    CREATE_SORT_BENCHMARK(type, 64, 16, 4)	
-#endif
-// clang-format on
 
-// clang-format off
-#ifndef ROCPRIM_NAVI					    			
 #define BENCHMARK_KEY_TYPE(type, value)                 \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 64, 1)  \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 64, 2)  \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 64, 4)  \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 64, 1) \
     CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 64, 2) \
-    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 64, 4) 
-#elif defined(_WIN32) // Currently, running a logical warpSize > hardware warpSize on Windows on Navi cards leads to a hang.											    
-#define BENCHMARK_KEY_TYPE(type, value)                 \
-    CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 32, 1)  \
-    CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 32, 2)  \
-    CREATE_SORTBYKEY_BENCHMARK(type, value, 64, 32, 4)  \
-    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 32, 1) \
-    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 32, 2) \
-    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 32, 4) 
-#endif
-// clang-format on
+    CREATE_SORTBYKEY_BENCHMARK(type, value, 256, 64, 4)
 
 int main(int argc, char* argv[])
 {
@@ -82,6 +66,9 @@ int main(int argc, char* argv[])
     settings.size                    = 128 * primbench::MiB;
     settings.noise_tolerance_percent = 2;
     primbench::executor executor(argc, argv, settings);
+
+    int device_id;
+    HIP_CHECK(hipGetDevice(&device_id));
 
     BENCHMARK_TYPE(int32_t)
     BENCHMARK_TYPE(float)


### PR DESCRIPTION
## Motivation

rocPRIM its `benchmark_warp_sort.cpp` had compilation and runtime errors, which have now been fixed.

## Technical Details

Sinus Rollins from Stream HPC had originally fixed the runtime error in a GitLab merge request, but since he has been sick for the past couple of days, I have created this pull request for him and updated his commit.

PR [Temporarily disable benchmark_warp_sort cases](https://github.com/ROCm/rocm-libraries/pull/4779) was merged yesterday, and it accidentally introduced the compilation error when attempting to fix the very same runtime error. Its fix was Windows-specific, so failed to compile on Linux.

## Test Plan

I first reproduced the Linux compilation and runtime error on our Navi GPU (RX 9070 XT, so gfx1201):
```sh
ninja benchmark_warp_sort && benchmark/benchmark_warp_sort
```

## Test Result

I confirmed that the compilation and runtime error is fixed by this PR on the same Navi GPU. All 40/40 benchmark specializations run without any runtime errors.

On our non-Navi GPU (MI210, so gfx90a), all 184/184 benchmark specializations run without any runtime errors.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
