### PR TITLE
rocfft: split system kernel cache into per-arch files

### DIFF
--- a/projects/rocfft/CHANGELOG.md
+++ b/projects/rocfft/CHANGELOG.md
@@ -26,6 +26,7 @@ Documentation for rocFFT is available at
 
 * Moved library to C++20 standard.
 * Removed Boost as a dependency for clients and samples.
+* Split the precompiled kernel cache file (`rocfft_kernel_cache.db`) into per-architecture files (`rocfft_kernel_cache_gfx950.db`, `rocfft_kernel_cache_gfx1201.db`, etc).
 
 ### Resolved issues
 

--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -173,6 +173,8 @@ endif()
 # tolerate comma as a value separator since the compiler does the
 # same
 string(REPLACE "," ";" GPU_TARGETS "${GPU_TARGETS}")
+# Filter out target flags as rocFFT builds generic code for each target.
+list(TRANSFORM GPU_TARGETS REPLACE ":[^;]+" "")
 rocm_check_target_ids(GPU_TARGETS TARGETS "${GPU_TARGETS}")
   
 # HIP is required - library and clients use HIP to access the device

--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -175,6 +175,7 @@ endif()
 string(REPLACE "," ";" GPU_TARGETS "${GPU_TARGETS}")
 # Filter out target flags as rocFFT builds generic code for each target.
 list(TRANSFORM GPU_TARGETS REPLACE ":[^;]+" "")
+list(REMOVE_DUPLICATES GPU_TARGETS)
 rocm_check_target_ids(GPU_TARGETS TARGETS "${GPU_TARGETS}")
   
 # HIP is required - library and clients use HIP to access the device

--- a/projects/rocfft/library/src/CMakeLists.txt
+++ b/projects/rocfft/library/src/CMakeLists.txt
@@ -524,14 +524,6 @@ endif()
 # enable a configure-time option to skip kernel cache building
 option( ROCFFT_KERNEL_CACHE_ENABLE "Enable building rocFFT kernel cache" ON)
 
-# cache file should go next to the shared object - on Windows this
-# would be the DLL, not the import library.
-if( WIN32 )
-  set( ROCFFT_KERNEL_CACHE_PATH ${CMAKE_BINARY_DIR}/staging/rocfft_kernel_cache.db )
-else()
-  set( ROCFFT_KERNEL_CACHE_PATH ${CMAKE_BINARY_DIR}/library/src/rocfft_kernel_cache.db )
-endif()
-
 # ROCFFT_BUILD_KERNEL_CACHE_PATH may be specified as a temporary file
 # to collect compiled kernels before writing them out as part of the
 # build.  any kernels that already exist in this file will be reused
@@ -558,16 +550,41 @@ if ( ROCFFT_KERNEL_CACHE_ENABLE )
   list( REMOVE_ITEM GPU_TARGETS_AOT gfx1152 )
   list( REMOVE_ITEM GPU_TARGETS_AOT gfx1153 )
   list( REMOVE_ITEM GPU_TARGETS_AOT gfx1200 )
-  add_custom_command(
-    OUTPUT rocfft_kernel_cache.db
-    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/rocfft_aot_helper" \"${ROCFFT_BUILD_KERNEL_CACHE_PATH}\" ${ROCFFT_KERNEL_CACHE_PATH} $<TARGET_FILE:rocfft_rtc_helper> ${GPU_TARGETS_AOT}
-    DEPENDS rocfft_aot_helper rocfft_rtc_helper
-    COMMENT "Compile kernels into shipped cache file"
-  )
-  add_custom_target( rocfft_kernel_cache_target ALL
-    DEPENDS rocfft_kernel_cache.db
-    VERBATIM
-  )
+
+  # build separate kernel cache for each target
+  foreach( arch IN ITEMS ${GPU_TARGETS_AOT} )
+    # cache file should go next to the shared object - on Windows this
+    # would be the DLL, not the import library.
+    if( WIN32 )
+      set( arch_kernel_cache_path ${CMAKE_BINARY_DIR}/staging/rocfft_kernel_cache_${arch}.db )
+    else()
+      set( arch_kernel_cache_path ${CMAKE_BINARY_DIR}/library/src/rocfft_kernel_cache_${arch}.db )
+    endif()
+
+    add_custom_command(
+      OUTPUT rocfft_kernel_cache_${arch}.db
+      COMMAND "${CMAKE_CURRENT_BINARY_DIR}/rocfft_aot_helper" \"${ROCFFT_BUILD_KERNEL_CACHE_PATH}\" ${arch_kernel_cache_path} $<TARGET_FILE:rocfft_rtc_helper> ${arch}
+      DEPENDS rocfft_aot_helper rocfft_rtc_helper
+      COMMENT "Compile ${arch} kernels into shipped cache file"
+    )
+    add_custom_target( rocfft_kernel_cache_${arch}_target ALL
+      DEPENDS rocfft_kernel_cache_${arch}.db
+      VERBATIM
+    )
+
+    # make each AOT build depend on the previous one, so that only one is
+    # running at a time.  The AOT build will itself spawn a bunch of
+    # processes to take advantage of multiple CPUs.
+    if( previous_arch )
+      add_dependencies( rocfft_kernel_cache_${arch}_target rocfft_kernel_cache_${previous_arch}_target )
+    endif()
+    set( previous_arch ${arch} )
+
+    # maintain a list of all cache files we produce for install
+    list( APPEND ROCFFT_KERNEL_CACHE_PATHS ${arch_kernel_cache_path} )
+
+  endforeach()
+
 endif()
 
 rocm_set_soversion( rocfft ${rocfft_SOVERSION} )
@@ -601,7 +618,7 @@ else()
 endif()
 
 if( NOT ENABLE_ASAN_PACKAGING AND ROCFFT_KERNEL_CACHE_ENABLE)
-  rocm_install(FILES ${ROCFFT_KERNEL_CACHE_PATH}
+  rocm_install(FILES ${ROCFFT_KERNEL_CACHE_PATHS}
     DESTINATION "${ROCFFT_KERNEL_CACHE_INSTALL_DIR}"
     COMPONENT runtime
   )

--- a/projects/rocfft/library/src/include/rtc_cache.h
+++ b/projects/rocfft/library/src/include/rtc_cache.h
@@ -119,13 +119,51 @@ struct RTCCache
     static std::unique_ptr<RTCCache> single;
 
 private:
-    sqlite3_ptr connect_db(const std::filesystem::path& path, bool readonly);
+    // encapsulate a connection to a database file
+    struct db_file
+    {
+        db_file() = default;
+        // Attempt to fetch code object from the cache.  Returns empty
+        // vector if the query was run successfully but no object was
+        // found.
+        std::vector<char> get_code_object(const std::string&          kernel_name,
+                                          const std::string&          gpu_arch,
+                                          const std::array<char, 32>& generator_sum);
 
-    // database handles to system- and user-level caches.  either or
-    // both may be a null pointer, if that particular cache could not
-    // be located.
-    sqlite3_ptr db_sys;
-    sqlite3_ptr db_user;
+        // Store the code object into the cache.
+        void store_code_object(const std::string&          kernel_name,
+                               const std::string&          gpu_arch,
+                               const std::array<char, 32>& generator_sum,
+                               const std::vector<char>&    code);
+
+        bool is_connected() const
+        {
+            return db.get() != nullptr;
+        }
+
+        void connect_db(const std::filesystem::path& path, bool readonly);
+
+        // For convenience, allow passing these directly to sqlite APIs
+        operator sqlite3*()
+        {
+            return db.get();
+        }
+
+        sqlite3_ptr db;
+
+        sqlite3_stmt_ptr get_stmt;
+        std::mutex       get_mutex;
+        sqlite3_stmt_ptr store_stmt;
+        std::mutex       store_mutex;
+    };
+
+    // Database handles to system- and user-level caches.  System
+    // databases are mapped from a GPU arch name, since each arch is
+    // in a separate file.  Any of the db files may return
+    // connected() == false, if that particular cache could not be
+    // opened.
+    std::map<std::string, db_file> db_sys;
+    db_file                        db_user;
 
     // query handles, with mutexes to prevent concurrent queries that
     // might stomp on one another's bound values

--- a/projects/rocfft/library/src/rtc_cache.cpp
+++ b/projects/rocfft/library/src/rtc_cache.cpp
@@ -30,6 +30,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <hip/hip_runtime_api.h>
 #include <hip/hip_version.h>
 #include <hip/hiprtc.h>
 #include <mutex>

--- a/projects/rocfft/library/src/rtc_cache.cpp
+++ b/projects/rocfft/library/src/rtc_cache.cpp
@@ -152,7 +152,8 @@ static std::set<std::string> get_visible_gpu_arches()
     std::set<std::string> arches;
     int                   deviceCount = 0;
     if(hipGetDeviceCount(&deviceCount) != hipSuccess)
-        throw std::runtime_error("hipGetDeviceCount failed");
+        // this can mean no devices are visible
+        return arches;
 
     for(int device = 0; device < deviceCount; ++device)
     {

--- a/projects/rocfft/library/src/rtc_cache.cpp
+++ b/projects/rocfft/library/src/rtc_cache.cpp
@@ -35,12 +35,14 @@
 #include <mutex>
 #include <optional>
 #include <semaphore>
+#include <set>
 
 namespace fs = std::filesystem;
 
 std::unique_ptr<RTCCache> RTCCache::single;
 
-static const char* default_cache_filename = "rocfft_kernel_cache.db";
+static const char* default_cache_filename_prefix = "rocfft_kernel_cache_";
+static const char* default_cache_filename_suffix = ".db";
 
 // Lock for in-process compilation - due to limits in ROCclr, we
 // can do at most one compilation in a process before we have to
@@ -117,7 +119,7 @@ static unsigned int get_max_subprocesses()
 }
 
 // Get paths to system RTC cache, in decreasing order of preference.
-static std::vector<fs::path> rtccache_db_sys_paths()
+static std::vector<fs::path> rtccache_db_sys_paths(const std::string& gpu_arch)
 {
     // if env var is set, use that directly
     std::vector<fs::path> paths;
@@ -133,12 +135,32 @@ static std::vector<fs::path> rtccache_db_sys_paths()
         if(!lib_path.empty())
         {
             // try next to the library, and in rocfft subdir
+            auto cache_filename = std::string(default_cache_filename_prefix) + gpu_arch
+                                  + default_cache_filename_suffix;
             fs::path library_parent_path = lib_path.parent_path();
-            paths.push_back(library_parent_path / default_cache_filename);
-            paths.push_back(library_parent_path / "rocfft" / default_cache_filename);
+            paths.push_back(library_parent_path / cache_filename);
+            paths.push_back(library_parent_path / "rocfft" / cache_filename);
         }
     }
     return paths;
+}
+
+// get the GPU arches that are present on the devices that are visible
+static std::set<std::string> get_visible_gpu_arches()
+{
+    std::set<std::string> arches;
+    int                   deviceCount = 0;
+    if(hipGetDeviceCount(&deviceCount) != hipSuccess)
+        throw std::runtime_error("hipGetDeviceCount failed");
+
+    for(int device = 0; device < deviceCount; ++device)
+    {
+        hipDeviceProp_t prop;
+        if(hipGetDeviceProperties(&prop, device) != hipSuccess)
+            throw std::runtime_error("hipGetDeviceProperties failed");
+        arches.insert(prop.gcnArchName);
+    }
+    return arches;
 }
 
 // Get list of candidate paths to RTC user cache DB, in decreasing
@@ -157,16 +179,18 @@ static std::vector<fs::path> rtccache_db_user_paths()
     return paths;
 }
 
-static sqlite3_stmt_ptr prepare_stmt(sqlite3_ptr& db, const char* sql)
+static sqlite3_stmt_ptr prepare_stmt(sqlite3* db, const char* sql)
 {
     sqlite3_stmt* stmt = nullptr;
-    if(sqlite3_prepare_v2(db.get(), sql, -1, &stmt, nullptr) == SQLITE_OK)
+    if(sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) == SQLITE_OK)
         return sqlite3_stmt_ptr(stmt);
-    throw std::runtime_error(std::string("sqlite_prepare_v2 failed: ") + sqlite3_errmsg(db.get()));
+    throw std::runtime_error(std::string("sqlite_prepare_v2 failed: ") + sqlite3_errmsg(db));
 }
 
-sqlite3_ptr RTCCache::connect_db(const fs::path& path, bool readonly)
+void RTCCache::db_file::connect_db(const fs::path& path, bool readonly)
 {
+    db.reset();
+
     sqlite3* db_raw = nullptr;
     int      flags  = SQLITE_OPEN_FULLMUTEX;
     if(readonly)
@@ -181,21 +205,21 @@ sqlite3_ptr RTCCache::connect_db(const fs::path& path, bool readonly)
     if(sqlite3_open_v2(path.string().c_str(), &db_raw, flags, nullptr) != SQLITE_OK)
     {
         sqlite3_close(db_raw);
-        return nullptr;
+        return;
     }
 
-    sqlite3_ptr db(db_raw);
+    db.reset(db_raw);
 
     // we can potentially want to write a bunch of kernels in
     // parallel (when doing mass compilation).  set a bigger busy
     // timeout (5s) so that concurrent modifications will wait for one
     // another
-    sqlite3_busy_timeout(db_raw, 5000);
+    sqlite3_busy_timeout(db.get(), 5000);
 
+    // create the default table
     if(!readonly)
     {
-        // create the default table
-        auto create = prepare_stmt(db,
+        auto create = prepare_stmt(db.get(),
                                    "CREATE TABLE IF NOT EXISTS cache_v1 ("
                                    "  kernel_name TEXT NOT NULL,"
                                    "  arch TEXT NOT NULL,"
@@ -207,28 +231,7 @@ sqlite3_ptr RTCCache::connect_db(const fs::path& path, bool readonly)
                                    "      kernel_name, arch, hip_version, generator_sum"
                                    "      ))");
         if(sqlite3_step(create.get()) != SQLITE_DONE)
-            return nullptr;
-    }
-
-    return db;
-}
-
-RTCCache::RTCCache()
-{
-    auto sys_paths = rtccache_db_sys_paths();
-    for(const auto& p : sys_paths)
-    {
-        db_sys = connect_db(p, true);
-        if(db_sys)
-            break;
-    }
-
-    auto paths = rtccache_db_user_paths();
-    for(const auto& p : paths)
-    {
-        db_user = connect_db(p, false);
-        if(db_user)
-            break;
+            throw std::runtime_error(sqlite3_errmsg(db.get()));
     }
 
     static const char* get_stmt_text = "SELECT code "
@@ -239,56 +242,82 @@ RTCCache::RTCCache()
                                        "  AND hip_version = :hip_version "
                                        "  AND generator_sum = :generator_sum ";
 
-    static const char* store_stmt_text = "INSERT OR REPLACE INTO cache_v1 ("
-                                         "    kernel_name,"
-                                         "    arch,"
-                                         "    hip_version,"
-                                         "    generator_sum,"
-                                         "    code,"
-                                         "    timestamp"
-                                         ")"
-                                         "VALUES ("
-                                         "    :kernel_name,"
-                                         "    :arch,"
-                                         "    :hip_version,"
-                                         "    :generator_sum,"
-                                         "    :code,"
-                                         "    CAST(STRFTIME('%s','now') AS INTEGER)"
-                                         ")";
-
-    // prepare get/store statements once so they can be called many
-    // times
-    if(db_sys)
+    try
     {
-        // it's possible that the sys cache exists but is not usable.
-        // so if we are unable to talk to it, just stop using it
+        get_stmt = prepare_stmt(db.get(), get_stmt_text);
+    }
+    catch(std::exception&)
+    {
+        // connection is not usable
+        db.reset();
+        return;
+    }
+
+    if(!readonly)
+    {
+        static const char* store_stmt_text = "INSERT OR REPLACE INTO cache_v1 ("
+                                             "    kernel_name,"
+                                             "    arch,"
+                                             "    hip_version,"
+                                             "    generator_sum,"
+                                             "    code,"
+                                             "    timestamp"
+                                             ")"
+                                             "VALUES ("
+                                             "    :kernel_name,"
+                                             "    :arch,"
+                                             "    :hip_version,"
+                                             "    :generator_sum,"
+                                             "    :code,"
+                                             "    CAST(STRFTIME('%s','now') AS INTEGER)"
+                                             ")";
         try
         {
-            get_stmt_sys = prepare_stmt(db_sys, get_stmt_text);
+            store_stmt = prepare_stmt(db.get(), store_stmt_text);
         }
         catch(std::exception&)
         {
-            db_sys.reset();
+            // connection might still be usable for getting kernels,
+            // but store_stmt will be null.  store operations will be
+            // a no-op.
         }
-    }
-    if(db_user)
-    {
-        get_stmt_user   = prepare_stmt(db_user, get_stmt_text);
-        store_stmt_user = prepare_stmt(db_user, store_stmt_text);
     }
 }
 
-static std::vector<char> get_code_object_impl(const std::string&          kernel_name,
-                                              const std::string&          gpu_arch,
-                                              const std::array<char, 32>& generator_sum,
-                                              sqlite3_ptr&                db,
-                                              sqlite3_stmt_ptr&           get_stmt,
-                                              std::mutex&                 get_mutex)
+RTCCache::RTCCache()
+{
+    for(const auto& arch : get_visible_gpu_arches())
+    {
+        auto sys_paths = rtccache_db_sys_paths(arch);
+        // create an entry in the map for this arch
+        auto iter = db_sys.try_emplace(arch).first;
+        // try connecting to the available paths until one succeeds
+        for(const auto& p : sys_paths)
+        {
+            iter->second.connect_db(p, true);
+            if(iter->second.is_connected())
+                break;
+        }
+    }
+
+    auto paths = rtccache_db_user_paths();
+    // try connecting to the available paths until one succeeds
+    for(const auto& p : paths)
+    {
+        db_user.connect_db(p, false);
+        if(db_user.is_connected())
+            break;
+    }
+}
+
+std::vector<char> RTCCache::db_file::get_code_object(const std::string&          kernel_name,
+                                                     const std::string&          gpu_arch,
+                                                     const std::array<char, 32>& generator_sum)
 {
     std::vector<char> code;
 
     // allow env variable to disable reads
-    if(!rocfft_getenv("ROCFFT_RTC_CACHE_READ_DISABLE").empty())
+    if(!rocfft_getenv("ROCFFT_RTC_CACHE_READ_DISABLE").empty() || !db || !get_stmt)
         return code;
 
     std::lock_guard<std::mutex> lock(get_mutex);
@@ -323,28 +352,30 @@ std::vector<char> RTCCache::get_code_object(const std::string&          kernel_n
 {
     std::vector<char> code;
     // try user cache first
-    if(get_stmt_user)
-        code = get_code_object_impl(
-            kernel_name, gpu_arch, generator_sum, db_user, get_stmt_user, get_mutex_user);
+    if(db_user.is_connected())
+        code = db_user.get_code_object(kernel_name, gpu_arch, generator_sum);
     // fall back to system cache
-    if(code.empty() && get_stmt_sys)
-        code = get_code_object_impl(
-            kernel_name, gpu_arch, generator_sum, db_sys, get_stmt_sys, get_mutex_sys);
+    if(code.empty())
+    {
+        auto sys = db_sys.find(gpu_arch);
+        if(sys != db_sys.end() && sys->second.is_connected())
+            code = sys->second.get_code_object(kernel_name, gpu_arch, generator_sum);
+    }
     return code;
 }
 
-void RTCCache::store_code_object(const std::string&          kernel_name,
-                                 const std::string&          gpu_arch,
-                                 const std::array<char, 32>& generator_sum,
-                                 const std::vector<char>&    code)
+void RTCCache::db_file::store_code_object(const std::string&          kernel_name,
+                                          const std::string&          gpu_arch,
+                                          const std::array<char, 32>& generator_sum,
+                                          const std::vector<char>&    code)
 {
     // allow env variable to disable writes
-    if(!rocfft_getenv("ROCFFT_RTC_CACHE_WRITE_DISABLE").empty())
+    if(!rocfft_getenv("ROCFFT_RTC_CACHE_WRITE_DISABLE").empty() || !db || !store_stmt)
         return;
 
-    std::lock_guard<std::mutex> lock(store_mutex_user);
+    std::lock_guard<std::mutex> lock(store_mutex);
 
-    auto s = store_stmt_user.get();
+    auto s = store_stmt.get();
     sqlite3_reset(s);
 
     // bind arguments to the query and execute
@@ -357,25 +388,34 @@ void RTCCache::store_code_object(const std::string&          kernel_name,
        || sqlite3_bind_blob(s, 5, code.data(), code.size(), SQLITE_TRANSIENT))
     {
         throw std::runtime_error(std::string("store_code_object bind: ")
-                                 + sqlite3_errmsg(db_user.get()));
+                                 + sqlite3_errmsg(db.get()));
     }
     if(sqlite3_step(s) != SQLITE_DONE)
     {
         std::cerr << "Error: failed to store code object for " << kernel_name << ": "
-                  << sqlite3_errmsg(db_user.get()) << std::endl;
+                  << sqlite3_errmsg(db.get()) << std::endl;
         // some kind of problem storing the row?  log it
         if(LOG_RTC_ENABLED())
             (*LogSingleton::GetInstance().GetRTCOS())
                 << "Error: failed to store code object for " << kernel_name << ": "
-                << sqlite3_errmsg(db_user.get()) << std::flush;
+                << sqlite3_errmsg(db.get()) << std::flush;
     }
     sqlite3_reset(s);
+}
+
+void RTCCache::store_code_object(const std::string&          kernel_name,
+                                 const std::string&          gpu_arch,
+                                 const std::array<char, 32>& generator_sum,
+                                 const std::vector<char>&    code)
+{
+    if(db_user.is_connected())
+        db_user.store_code_object(kernel_name, gpu_arch, generator_sum, code);
 }
 
 rocfft_status RTCCache::serialize(void** buffer, size_t* buffer_len_bytes)
 {
     sqlite3_int64 db_size = 0;
-    auto          ptr     = sqlite3_serialize(db_user.get(), "main", &db_size, 0);
+    auto          ptr     = sqlite3_serialize(db_user, "main", &db_size, 0);
     if(ptr)
     {
         *buffer           = ptr;
@@ -395,8 +435,7 @@ rocfft_status RTCCache::deserialize(const void* buffer, size_t buffer_len_bytes)
     std::lock_guard<std::mutex> lock(deserialize_mutex);
 
     // attach an empty database named "deserialized"
-    sqlite3_exec(
-        db_user.get(), "ATTACH DATABASE ':memory:' AS deserialized", nullptr, nullptr, nullptr);
+    sqlite3_exec(db_user, "ATTACH DATABASE ':memory:' AS deserialized", nullptr, nullptr, nullptr);
     // the attach might fail if somehow this is our second
     // deserialize and the db already existed.  later steps will
     // notice this, so we can skip this error check
@@ -405,7 +444,7 @@ rocfft_status RTCCache::deserialize(const void* buffer, size_t buffer_len_bytes)
     // it to be read-only
     auto buffer_mut = const_cast<unsigned char*>(static_cast<const unsigned char*>(buffer));
 
-    int sql_err = sqlite3_deserialize(db_user.get(),
+    int sql_err = sqlite3_deserialize(db_user,
                                       "deserialized",
                                       buffer_mut,
                                       buffer_len_bytes,
@@ -416,7 +455,7 @@ rocfft_status RTCCache::deserialize(const void* buffer, size_t buffer_len_bytes)
 
     // now the deserialized db is in memory.  run an additive query to
     // update the real db with the temp contents.
-    sql_err           = sqlite3_exec(db_user.get(),
+    sql_err           = sqlite3_exec(db_user,
                            "INSERT OR REPLACE INTO cache_v1 ("
                            "    kernel_name,"
                            "    arch,"
@@ -439,7 +478,7 @@ rocfft_status RTCCache::deserialize(const void* buffer, size_t buffer_len_bytes)
     rocfft_status ret = sql_err == SQLITE_OK ? rocfft_status_success : rocfft_status_failure;
 
     // detach the temp db
-    sqlite3_exec(db_user.get(), "DETACH DATABASE deserialized", nullptr, nullptr, nullptr);
+    sqlite3_exec(db_user, "DETACH DATABASE deserialized", nullptr, nullptr, nullptr);
 
     return ret;
 }
@@ -725,7 +764,7 @@ void RTCCache::enable_write_mostly()
 {
     // increase sqlite timeout as many processes may be contending over
     // this database
-    sqlite3_busy_timeout(db_user.get(), 30000);
+    sqlite3_busy_timeout(db_user, 30000);
 
     // set the cache file to WAL mode, which allows for faster writes
     // that don't block with reads
@@ -744,10 +783,13 @@ void RTCCache::write_aot_cache(const std::string&              output_path,
     if(fs::exists(output_path))
         fs::remove(output_path);
 
-    // connect to the output path but discard the returned pointer -
+    // connect to the output db but discard it immediately -
     // this will create the cache tables but close the connection so
     // we can reopen it from inside our existing db handle.
-    connect_db(output_path, false);
+    {
+        db_file out_db;
+        out_db.connect_db(output_path, false);
+    }
 
     auto attach_stmt = prepare_stmt(db_user, "ATTACH DATABASE :db AS out_db");
     sqlite3_reset(attach_stmt.get());
@@ -755,10 +797,10 @@ void RTCCache::write_aot_cache(const std::string&              output_path,
            attach_stmt.get(), 1, output_path.c_str(), output_path.size(), SQLITE_TRANSIENT)
        != SQLITE_OK)
         throw std::runtime_error(std::string("write_aot_cache attach bind: ")
-                                 + sqlite3_errmsg(db_user.get()));
+                                 + sqlite3_errmsg(db_user));
     if(sqlite3_step(attach_stmt.get()) != SQLITE_DONE)
         throw std::runtime_error(std::string("write_aot_cache attach step: ")
-                                 + sqlite3_errmsg(db_user.get()));
+                                 + sqlite3_errmsg(db_user));
     sqlite3_reset(attach_stmt.get());
 
     // copy only the required arches, in case more are present in the
@@ -768,7 +810,7 @@ void RTCCache::write_aot_cache(const std::string&              output_path,
                                          "  arch TEXT NOT NULL )");
     if(sqlite3_step(create_temp_stmt.get()) != SQLITE_DONE)
         throw std::runtime_error(std::string("write_aot_cache create temp table: ")
-                                 + sqlite3_errmsg(db_user.get()));
+                                 + sqlite3_errmsg(db_user));
 
     auto insert_temp_stmt = prepare_stmt(db_user, "INSERT INTO temp.aot_arch VALUES ( ? )");
     for(const auto& gpu_arch_with_flags : gpu_archs)
@@ -779,10 +821,10 @@ void RTCCache::write_aot_cache(const std::string&              output_path,
                insert_temp_stmt.get(), 1, gpu_arch.c_str(), gpu_arch.size(), SQLITE_TRANSIENT)
            != SQLITE_OK)
             throw std::runtime_error(std::string("write_aot_cache temp bind: ")
-                                     + sqlite3_errmsg(db_user.get()));
+                                     + sqlite3_errmsg(db_user));
         if(sqlite3_step(insert_temp_stmt.get()) != SQLITE_DONE)
             throw std::runtime_error(std::string("write_aot_cache temp step: ")
-                                     + sqlite3_errmsg(db_user.get()));
+                                     + sqlite3_errmsg(db_user));
         sqlite3_reset(insert_temp_stmt.get());
     }
 
@@ -810,11 +852,11 @@ void RTCCache::write_aot_cache(const std::string&              output_path,
            != SQLITE_OK
        || sqlite3_bind_int64(copy_stmt.get(), 2, HIP_VERSION) != SQLITE_OK)
         throw std::runtime_error(std::string("write_aot_cache copy bind: ")
-                                 + sqlite3_errmsg(db_user.get()));
+                                 + sqlite3_errmsg(db_user));
 
     if(sqlite3_step(copy_stmt.get()) != SQLITE_DONE)
         throw std::runtime_error(std::string("write_aot_cache copy step: ")
-                                 + sqlite3_errmsg(db_user.get()));
+                                 + sqlite3_errmsg(db_user));
     sqlite3_reset(copy_stmt.get());
 }
 
@@ -848,10 +890,10 @@ void RTCCache::cleanup_cache(sqlite3_int64 target_size_bytes)
                                     "    ) ");
     if(sqlite3_bind_int64(delete_stmt.get(), 1, target_size_bytes) != SQLITE_OK)
         throw std::runtime_error(std::string("cleanup_cache delete bind: ")
-                                 + sqlite3_errmsg(db_user.get()));
+                                 + sqlite3_errmsg(db_user));
     if(sqlite3_step(delete_stmt.get()) != SQLITE_DONE)
         throw std::runtime_error(std::string("cleanup_cache delete step: ")
-                                 + sqlite3_errmsg(db_user.get()));
+                                 + sqlite3_errmsg(db_user));
     delete_stmt.reset();
 
     // check if we can reclaim 20% or more of the file's space by vacuuming
@@ -872,6 +914,6 @@ void RTCCache::cleanup_cache(sqlite3_int64 target_size_bytes)
         auto vacuum_stmt = prepare_stmt(db_user, "VACUUM");
         if(sqlite3_step(vacuum_stmt.get()) != SQLITE_DONE)
             throw std::runtime_error(std::string("cleanup_cache vacuum step: ")
-                                     + sqlite3_errmsg(db_user.get()));
+                                     + sqlite3_errmsg(db_user));
     }
 }

--- a/projects/rocfft/library/src/rtc_cache.cpp
+++ b/projects/rocfft/library/src/rtc_cache.cpp
@@ -159,7 +159,14 @@ static std::set<std::string> get_visible_gpu_arches()
         hipDeviceProp_t prop;
         if(hipGetDeviceProperties(&prop, device) != hipSuccess)
             throw std::runtime_error("hipGetDeviceProperties failed");
-        arches.insert(prop.gcnArchName);
+
+        std::string arch = prop.gcnArchName;
+        // strip flags, as rocFFT deals with generic code for each
+        // arch
+        auto colonIdx = arch.find(':');
+        if(colonIdx != std::string::npos)
+            arch.resize(colonIdx);
+        arches.insert(arch);
     }
     return arches;
 }


### PR DESCRIPTION
## Motivation

Split the rocfft_kernel_cache.db file into separate files for each GPU architecture.

## Technical Details

Multiple devices of different architectures might be present at runtime, so we need to maintain a map of arch -> db files for the read-only system caches.  We still just have one read-write user-cache, so it can mix architectures if necessary.

## Test Plan

Built rocFFT with:
* kernel cache disabled
* cache enabled for multiple architectures that are present at build time
* cache enabled for multiple architectures that are not present at build time

Ran smoke tests and confirmed in debugger that the correct per-arch cache is consulted.

## Test Result

Builds and tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
