### PR TITLE
[MIOpen] Moved verify.hpp from /test to /driver

### DIFF
--- a/projects/miopen/driver/CBAInferFusion_driver.hpp
+++ b/projects/miopen/driver/CBAInferFusion_driver.hpp
@@ -36,7 +36,7 @@
 #include "util_driver.hpp"
 #include "conv_common.hpp"
 
-#include "../test/verify.hpp"
+#include "verify.hpp"
 #include "../test/cpu_conv.hpp"
 #include "../test/cpu_bias.hpp"
 

--- a/projects/miopen/driver/adam_driver.hpp
+++ b/projects/miopen/driver/adam_driver.hpp
@@ -32,7 +32,7 @@
 #include "tensor_driver.hpp"
 #include "timer.hpp"
 
-#include "../test/verify.hpp"
+#include "verify.hpp"
 
 #include <miopen/ford.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/driver/bn_driver.hpp
+++ b/projects/miopen/driver/bn_driver.hpp
@@ -35,7 +35,7 @@
 #include "util_driver.hpp"
 #include "rocrand_wrapper.hpp"
 
-#include "../test/verify.hpp"
+#include "verify.hpp"
 #include "../test/random.hpp"
 #include "../test/fusionHost.hpp"
 

--- a/projects/miopen/driver/lrn_driver.hpp
+++ b/projects/miopen/driver/lrn_driver.hpp
@@ -34,7 +34,7 @@
 #include "timer.hpp"
 #include "util_driver.hpp"
 
-#include "../test/verify.hpp"
+#include "verify.hpp"
 
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>

--- a/projects/miopen/driver/reduce_driver.hpp
+++ b/projects/miopen/driver/reduce_driver.hpp
@@ -35,7 +35,7 @@
 #include "util_driver.hpp"
 #include "util_file.hpp"
 
-#include "../test/verify.hpp"
+#include "verify.hpp"
 
 #include <miopen/miopen.h>
 #include <miopen/reduce_common.hpp>

--- a/projects/miopen/driver/transformers_adam_w_driver.hpp
+++ b/projects/miopen/driver/transformers_adam_w_driver.hpp
@@ -32,7 +32,7 @@
 #include "tensor_driver.hpp"
 #include "timer.hpp"
 
-#include "../test/verify.hpp"
+#include "verify.hpp"
 
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>

--- a/projects/miopen/driver/verify.hpp
+++ b/projects/miopen/driver/verify.hpp
@@ -37,7 +37,7 @@
 using half         = half_float::half;
 using hip_bfloat16 = bfloat16;
 #include <hip_float8.hpp>
-#include "tensor_holder.hpp"
+#include "../test/tensor_holder.hpp"
 
 namespace miopen {
 

--- a/projects/miopen/test/bn_3d_peract_test.cpp
+++ b/projects/miopen/test/bn_3d_peract_test.cpp
@@ -41,7 +41,7 @@
 #include "driver.hpp"
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 #include <cmath>
 #include <ctime>

--- a/projects/miopen/test/bn_spatial_test.cpp
+++ b/projects/miopen/test/bn_spatial_test.cpp
@@ -28,7 +28,7 @@
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
 #include "test.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "random.hpp"
 #include <array>
 #include <cmath>

--- a/projects/miopen/test/conv_common.hpp
+++ b/projects/miopen/test/conv_common.hpp
@@ -48,7 +48,7 @@
 #include "driver.hpp"
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <miopen/stringutils.hpp>
 #include "tensor_util.hpp"
 #include <miopen/algorithm.hpp>

--- a/projects/miopen/test/driver.hpp
+++ b/projects/miopen/test/driver.hpp
@@ -33,7 +33,7 @@
 #include "serialize.hpp"
 #include "tensor_holder.hpp"
 #include "test.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 #include <functional>
 #include <deque>

--- a/projects/miopen/test/fusionHost.hpp
+++ b/projects/miopen/test/fusionHost.hpp
@@ -38,7 +38,7 @@
 #include <miopen/fusion_plan.hpp>
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 template <class T>
 void convHostForward(const tensor<T>& input,

--- a/projects/miopen/test/gru_common.hpp
+++ b/projects/miopen/test/gru_common.hpp
@@ -33,7 +33,7 @@
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
 #include "test.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "rnn_util.hpp"
 #include "random.hpp"
 #include "workspace.hpp"

--- a/projects/miopen/test/gtest/adam.hpp
+++ b/projects/miopen/test/gtest/adam.hpp
@@ -29,7 +29,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/adam.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/addlayernorm.hpp
+++ b/projects/miopen/test/gtest/addlayernorm.hpp
@@ -28,7 +28,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/addlayernorm.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/binary_tensor_ops.cpp
+++ b/projects/miopen/test/gtest/binary_tensor_ops.cpp
@@ -32,7 +32,7 @@
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
 #include "tensor_util.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 namespace {
 using BinaryTensorOpsCase = std::tuple<std::vector<size_t>, std::vector<int>, float, bool>;

--- a/projects/miopen/test/gtest/bn_peract_test.cpp
+++ b/projects/miopen/test/gtest/bn_peract_test.cpp
@@ -49,7 +49,7 @@
 #include "tensor_holder.hpp"
 #include "test.hpp"
 #include "test_parameter_name_generator.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 // Run CPU emulations in hierarchical reduction mode.
 // #define MIO_HEIRARCH_SEL 0

--- a/projects/miopen/test/gtest/cat.hpp
+++ b/projects/miopen/test/gtest/cat.hpp
@@ -29,7 +29,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/cat.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/compare_helper.hpp
+++ b/projects/miopen/test/gtest/compare_helper.hpp
@@ -32,7 +32,7 @@
 
 #include <iostream>
 
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "../tensor_holder.hpp"
 
 namespace test_helpers {

--- a/projects/miopen/test/gtest/cpu_multi_head_attention.hpp
+++ b/projects/miopen/test/gtest/cpu_multi_head_attention.hpp
@@ -27,7 +27,7 @@
 
 #include "mha_helper.hpp"
 #include "attention_golden.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 namespace test {
 namespace cpu {

--- a/projects/miopen/test/gtest/f8_cast_util.hpp
+++ b/projects/miopen/test/gtest/f8_cast_util.hpp
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <hip_float8.hpp>
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 using float8_fnuz  = miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>;
 using bfloat8_fnuz = miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>;
 

--- a/projects/miopen/test/gtest/getitem.hpp
+++ b/projects/miopen/test/gtest/getitem.hpp
@@ -28,7 +28,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/getitem.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/glu.hpp
+++ b/projects/miopen/test/gtest/glu.hpp
@@ -30,7 +30,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 #include <algorithm>
 #include <cstdint>

--- a/projects/miopen/test/gtest/gpu_mha_backward.cpp
+++ b/projects/miopen/test/gtest/gpu_mha_backward.cpp
@@ -28,7 +28,7 @@
 #include "get_handle.hpp"
 #include "mha_helper.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "gtest_common.hpp"
 #include "../workspace.hpp"
 #include "../tensor_util.hpp"

--- a/projects/miopen/test/gtest/gpu_mha_forward.cpp
+++ b/projects/miopen/test/gtest/gpu_mha_forward.cpp
@@ -28,7 +28,7 @@
 #include "get_handle.hpp"
 #include "mha_helper.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "gtest_common.hpp"
 #include "../workspace.hpp"
 

--- a/projects/miopen/test/gtest/graphapi_capi_mha_common.hpp
+++ b/projects/miopen/test/gtest/graphapi_capi_mha_common.hpp
@@ -36,7 +36,7 @@
 #include "gtest_common.hpp"
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "../workspace.hpp"
 #include "gtest/mha_helper.hpp"
 

--- a/projects/miopen/test/gtest/groupnorm.hpp
+++ b/projects/miopen/test/gtest/groupnorm.hpp
@@ -32,7 +32,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "../driver/tensor_driver.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <random>
 
 struct GroupNormTestCase

--- a/projects/miopen/test/gtest/gtest_activation.cpp
+++ b/projects/miopen/test/gtest/gtest_activation.cpp
@@ -35,7 +35,7 @@
 #include <miopen/tensor.hpp>
 #include <utility>
 #include <fusionHost.hpp>
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "gtest/gtest.h"
 #include <half/half.hpp>
 

--- a/projects/miopen/test/gtest/kthvalue.hpp
+++ b/projects/miopen/test/gtest/kthvalue.hpp
@@ -29,7 +29,7 @@
 
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 #include <gtest/gtest.h>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/layernorm.hpp
+++ b/projects/miopen/test/gtest/layernorm.hpp
@@ -27,7 +27,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/layernorm.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/mha_find20.cpp
+++ b/projects/miopen/test/gtest/mha_find20.cpp
@@ -27,7 +27,7 @@
 #include "test.hpp"
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "../workspace.hpp"
 
 #include <miopen/mha/mha_descriptor.hpp>

--- a/projects/miopen/test/gtest/multimarginloss.hpp
+++ b/projects/miopen/test/gtest/multimarginloss.hpp
@@ -27,7 +27,7 @@
 #include "cpu_multimarginloss.hpp"
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/miopen.h>
 #include <miopen/multimarginloss.hpp>

--- a/projects/miopen/test/gtest/prelu.hpp
+++ b/projects/miopen/test/gtest/prelu.hpp
@@ -28,7 +28,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 #include <gtest/gtest.h>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/reducecalculation.hpp
+++ b/projects/miopen/test/gtest/reducecalculation.hpp
@@ -29,7 +29,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/miopen.h>
 #include <miopen/reducecalculation.hpp>

--- a/projects/miopen/test/gtest/reduceextreme.hpp
+++ b/projects/miopen/test/gtest/reduceextreme.hpp
@@ -29,7 +29,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/reduceextreme.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/rope.hpp
+++ b/projects/miopen/test/gtest/rope.hpp
@@ -28,7 +28,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/rope.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/soft_max.cpp
+++ b/projects/miopen/test/gtest/soft_max.cpp
@@ -3,7 +3,7 @@
 
 #include "get_handle.hpp"
 #include "miopen/miopen.h"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/softmax.hpp>
 

--- a/projects/miopen/test/gtest/softmarginloss.hpp
+++ b/projects/miopen/test/gtest/softmarginloss.hpp
@@ -27,7 +27,7 @@
 #include "cpu_softmarginloss.hpp"
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/miopen.h>
 #include <miopen/softmarginloss.hpp>

--- a/projects/miopen/test/gtest/softmax_find20.cpp
+++ b/projects/miopen/test/gtest/softmax_find20.cpp
@@ -29,7 +29,7 @@
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
 #include "../driver/mloSoftmaxHost.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 #include <miopen/softmax.hpp>
 

--- a/projects/miopen/test/gtest/solver_f8.hpp
+++ b/projects/miopen/test/gtest/solver_f8.hpp
@@ -33,7 +33,7 @@
 #include <miopen/conv/data_invoke_params.hpp>
 #include "conv_common.hpp"
 #include "hip_float8.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "../random.hpp"
 
 #include "conv_test_base.hpp"

--- a/projects/miopen/test/gtest/t5layernorm.hpp
+++ b/projects/miopen/test/gtest/t5layernorm.hpp
@@ -28,7 +28,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/t5layernorm.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/tensor_2d_lite_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_2d_lite_ocl_hip.cpp
@@ -27,7 +27,7 @@
 #include <gtest/gtest.h>
 
 #include "get_handle.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 #define PERF_ENABLE 0
 #if PERF_ENABLE

--- a/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_4d_generic_ocl_hip.cpp
@@ -27,7 +27,7 @@
 #include "perf_helper.hpp"
 
 #include <miopen/datatype.hpp>
-#include <verify.hpp>
+#include "../driver/verify.hpp"
 
 #include <gtest/gtest.h>
 

--- a/projects/miopen/test/gtest/tensor_fwd_bias_generic_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_fwd_bias_generic_ocl_hip.cpp
@@ -28,7 +28,7 @@
 
 #include "get_handle.hpp"
 #include "tensor_util.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 #define PERF_ENABLE 0
 #if PERF_ENABLE

--- a/projects/miopen/test/gtest/tensor_fwd_bias_ocl_hip.cpp
+++ b/projects/miopen/test/gtest/tensor_fwd_bias_ocl_hip.cpp
@@ -28,7 +28,7 @@
 
 #include "get_handle.hpp"
 #include "tensor_util.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 #define PERF_ENABLE 0
 #if PERF_ENABLE

--- a/projects/miopen/test/gtest/transformers_adam_w.hpp
+++ b/projects/miopen/test/gtest/transformers_adam_w.hpp
@@ -29,7 +29,7 @@
 #include "get_handle.hpp"
 #include "random.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/adam.hpp>
 #include <miopen/miopen.h>

--- a/projects/miopen/test/gtest/unary_tensor_ops.cpp
+++ b/projects/miopen/test/gtest/unary_tensor_ops.cpp
@@ -32,7 +32,7 @@
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
 #include "tensor_util.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 namespace {
 using UnaryTensorOpsCase = std::tuple<std::vector<size_t>, int>;

--- a/projects/miopen/test/gtest/vec_add.cpp
+++ b/projects/miopen/test/gtest/vec_add.cpp
@@ -26,7 +26,7 @@
 
 #include "get_handle.hpp"
 #include "random.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include <gtest/gtest.h>
 #include <miopen/miopen.h>
 #include <miopen/kernel_build_params.hpp>

--- a/projects/miopen/test/gtest/w_supertensor.cpp
+++ b/projects/miopen/test/gtest/w_supertensor.cpp
@@ -32,7 +32,7 @@
 
 #include "gtest_common.hpp"
 #include "test_parameter_name_generator.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 namespace {
 

--- a/projects/miopen/test/lstm_common.hpp
+++ b/projects/miopen/test/lstm_common.hpp
@@ -33,7 +33,7 @@
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
 #include "test.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "rnn_util.hpp"
 #include "random.hpp"
 #include "cpu_rnn.hpp"

--- a/projects/miopen/test/pooling_common.hpp
+++ b/projects/miopen/test/pooling_common.hpp
@@ -47,7 +47,7 @@
 #include "driver.hpp"
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 #include "cpu_conv.hpp"
 #include "workspace.hpp"
 

--- a/projects/miopen/test/tensor_vec.cpp
+++ b/projects/miopen/test/tensor_vec.cpp
@@ -38,7 +38,7 @@
 #include "driver.hpp"
 #include "get_handle.hpp"
 #include "tensor_holder.hpp"
-#include "verify.hpp"
+#include "../driver/verify.hpp"
 
 template <class T>
 void tensor_vec_forward(


### PR DESCRIPTION
## Technical Details

I have moved verify.hpp because is used in MIOpenDriver and it was present in the test directory.

## Test Plan

CI shall be passed.

## Submission Checklist

- [ ] I have ran the tests, and they are all passing locally
- [ ] I have ran `make format` to ensure the changes have been formatted