### PR TITLE
[ci] Adding rocwmma as a part of blas build in TheRock CI

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -59,10 +59,6 @@ project_map = {
         "cmake_options": ["-DTHEROCK_ENABLE_FFT=ON", "-DTHEROCK_ENABLE_RAND=ON"],
         "projects_to_test": ["hipfft", "rocfft"],
     },
-    "rocwmma": {
-        "cmake_options": ["-DTHEROCK_ENABLE_ROCWMMA=ON"],
-        "projects_to_test": ["rocwmma"],
-    },
 }
 
 # For certain math components, they are optional during building and testing.
@@ -113,6 +109,11 @@ additional_options = {
             "-DTHEROCK_ENABLE_HIPBLASLTPROVIDER=ON",
         ],
         "projects_to_test": ["hipblaslt_plugin"],
+        "project_to_add": "blas",
+    },
+    "rocwmma": {
+        "cmake_options": ["-DTHEROCK_ENABLE_ROCWMMA=ON"],
+        "projects_to_test": ["rocwmma"],
         "project_to_add": "blas",
     },
 }


### PR DESCRIPTION
rocwmma builds part of BLAS, so to save resources, rocwmma will build a part of BLAS or separately if rocwmma-only files are updated

PR checks below will test this functionality