### PR TITLE
[hipDNN] Fix memory leak in Knob::UnPack during EngineDescriptor::finalize

### DIFF
--- a/projects/hipdnn/backend/src/descriptors/EngineDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/EngineDescriptor.cpp
@@ -58,8 +58,9 @@ void EngineDescriptor::finalize()
             for(const auto& knobWrapper : knobWrappers)
             {
                 flatbuffers::FlatBufferBuilder builder;
-                auto knobOffset = hipdnn_data_sdk::data_objects::Knob::Pack(
-                    builder, knobWrapper->getKnob().UnPack());
+                hipdnn_data_sdk::data_objects::KnobT knobNative;
+                knobWrapper->getKnob().UnPackTo(&knobNative);
+                auto knobOffset = hipdnn_data_sdk::data_objects::Knob::Pack(builder, &knobNative);
                 builder.Finish(knobOffset);
                 _knobSerializedBuffers.push_back(builder.Release());
             }


### PR DESCRIPTION
## Summary
- Fix memory leak of 816 bytes (18 allocations) detected by AddressSanitizer in `hipdnn_backend_tests`
- Replace heap-allocated raw pointer from `Knob::UnPack()` with stack-allocated `KnobT` using `UnPackTo()`, eliminating the leak during knob re-serialization in `EngineDescriptor::finalize()`

## Details

`UnPack()` returns a raw owning `KnobT*` pointer. The old code passed this directly to `Knob::Pack()` as a temporary, so the pointer was never freed. The fix uses `UnPackTo()` to populate a stack-allocated `KnobT`, which is automatically cleaned up at end of scope.

Closes #4901

## Test plan
- [x] Build with `-DBUILD_ADDRESS_SANITIZER=ON`
- [x] All 3,613 unit tests pass across all test binaries
- [x] Zero ASAN errors (confirmed leak is eliminated)
- [x] Pre-commit checks pass (clang-format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)