### PR TITLE
[rocthrust] Fix unqualified swap calls in contiguous_storage.inl

### DIFF
--- a/projects/rocthrust/thrust/detail/contiguous_storage.inl
+++ b/projects/rocthrust/thrust/detail/contiguous_storage.inl
@@ -1,6 +1,6 @@
 /*
  *  Copyright 2008-2018 NVIDIA Corporation
- *  Modifications Copyright© 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *  Modifications Copyright© 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/projects/rocthrust/thrust/detail/contiguous_storage.inl
+++ b/projects/rocthrust/thrust/detail/contiguous_storage.inl
@@ -39,7 +39,6 @@
 #endif
 
 #include <stdexcept> // for std::runtime_error
-#include <utility> // for use of std::swap in the WAR below
 
 THRUST_NAMESPACE_BEGIN
 
@@ -199,16 +198,21 @@ THRUST_HOST_DEVICE void contiguous_storage<T, Alloc>::swap(contiguous_storage& x
 {
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
   using _THRUST_STD::swap;
-#else
-  using thrust::swap;
-#endif
   swap(m_begin, x.m_begin);
   swap(m_size, x.m_size);
+#else
+  thrust::swap(m_begin, x.m_begin);
+  thrust::swap(m_size, x.m_size);
+#endif
 
   // FIXME(bgruber): swap_allocators already swaps m_allocator, so we are swapping twice here !!
   swap_allocators(integral_constant<bool, allocator_traits<Alloc>::propagate_on_container_swap::value>(),
                   x.m_allocator);
+#if _THRUST_HAS_DEVICE_SYSTEM_STD
   swap(m_allocator, x.m_allocator);
+#else
+  thrust::swap(m_allocator, x.m_allocator);
+#endif
 } // end contiguous_storage::swap()
 
 template <typename T, typename Alloc>
@@ -357,10 +361,10 @@ THRUST_HOST_DEVICE void contiguous_storage<T, Alloc>::swap_allocators(false_type
                (if (is_allocator_not_equal(other)) { throw allocator_mismatch_on_swap(); }));
 #if _THRUST_HAS_DEVICE_SYSTEM_STD
   using _THRUST_STD::swap;
-#else
-  using thrust::swap;
-#endif
   swap(m_allocator, other);
+#else
+  thrust::swap(m_allocator, other);
+#endif
 } // end contiguous_storage::swap_allocators()
 
 template <typename T, typename Alloc>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR fixes a couple of unqualified swap calls caused ADL ambiguity with libhipcxx 3.0.2.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Unqualified swap() calls in thrust/detail/contiguous_storage.inl cause compilation failures when used with cuda::std namespace types due to ADL ambiguity between thrust::swap and cuda::std::swap. The ambiguity is removed by explicit calls to thrust::swap when _THRUST_HAS_DEVICE_SYSTEM_STD is not defined. When _THRUST_HAS_DEVICE_SYSTEM_STD is defined, std::swap provides a fallback while allowing customized swap implementation via ADL - this is to be consistent with CCCL.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Build a reproducer that uses cuda::std namespace types in host_vector.

## Test Result

<!-- Briefly summarize test outcomes. -->
The compilation is successful.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
