### PR TITLE
[formocast][origami] Refine accuracy of math clocks

### DIFF
--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/pass/cycle.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/pass/cycle.cpp
@@ -915,7 +915,7 @@ namespace rocisa
                     if (soffsetStr.find("s") != std::string::npos) {
                         hasSgprOffset = true;
                     }
-                    cycles = formocast.getGlobalReadQueueFullStallCycles(currCycles, hwGRFIFO, bpr, numWaves, (rocIsa::getInstance().getKernel().isaVersion[0] == 9), false);
+                    cycles = formocast.getGlobalReadQueueFullStallCycles(currCycles, hwGRFIFO, bpr, numWaves, (rocIsa::getInstance().getKernel().isaVersion[0] == 9), hasSgprOffset);
                 }
                 if(auto wInst = std::dynamic_pointer_cast<DSStoreB128>(item))
                 {

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/pass/cycle.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/pass/cycle.cpp
@@ -1214,7 +1214,7 @@ namespace rocisa
         }
         else {
             // not supported
-            formocast.setHardware(origami::hardware_t::architecture_t::gfx950);
+            return 0;
         }
         // Calculate local read bytes
         auto localReadBytes = _calculateLocalReadBytes(module, numWaves);

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/pass/cycle.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/pass/cycle.cpp
@@ -783,7 +783,7 @@ namespace rocisa
         int previousLW = 0;
         std::queue<int> hwLRFIFO;
         std::queue<int> lgkmLRFIFO;
-        std::queue<int> hwGRFIFO;
+        std::deque<int> hwGRFIFO;
         bool isEndOfLoop  = false;
         int numPreviousLRs = 0;
         bool isPreviousMFMA = false;
@@ -909,7 +909,13 @@ namespace rocisa
                     } else if (auto gr64 = std::dynamic_pointer_cast<BufferLoadB64>(grInst)) {
                         bpr = 8;
                     }
-                    cycles = formocast.getGlobalReadQueueFullStallCycles(currCycles, hwGRFIFO, bpr, numWaves, rocIsa::getInstance().getKernel().isaVersion == std::array<int, 3>{9, 5, 0});
+
+                    bool hasSgprOffset = false;
+                    auto soffsetStr = InstructionInputToString(grInst->soffset);
+                    if (soffsetStr.find("s") != std::string::npos) {
+                        hasSgprOffset = true;
+                    }
+                    cycles = formocast.getGlobalReadQueueFullStallCycles(currCycles, hwGRFIFO, bpr, numWaves, (rocIsa::getInstance().getKernel().isaVersion[0] == 9), false);
                 }
                 if(auto wInst = std::dynamic_pointer_cast<DSStoreB128>(item))
                 {

--- a/projects/hipblaslt/tensilelite/rocisa/rocisa/src/pass/cycle.cpp
+++ b/projects/hipblaslt/tensilelite/rocisa/rocisa/src/pass/cycle.cpp
@@ -909,7 +909,7 @@ namespace rocisa
                     } else if (auto gr64 = std::dynamic_pointer_cast<BufferLoadB64>(grInst)) {
                         bpr = 8;
                     }
-                    cycles = formocast.getGlobalReadQueueFullStallCycles(currCycles, hwGRFIFO, bpr, numWaves, false);
+                    cycles = formocast.getGlobalReadQueueFullStallCycles(currCycles, hwGRFIFO, bpr, numWaves, rocIsa::getInstance().getKernel().isaVersion == std::array<int, 3>{9, 5, 0});
                 }
                 if(auto wInst = std::dynamic_pointer_cast<DSStoreB128>(item))
                 {

--- a/shared/origami/include/origami/simulator/tensilelite/formocast.hpp
+++ b/shared/origami/include/origami/simulator/tensilelite/formocast.hpp
@@ -278,9 +278,10 @@ namespace origami
          * @param bpRead Bytes per read operation
          * @param numWaves Number of waves
          * @param isStall Whether the pipeline is stalled
+         * @param isSgprOffset Whether the SGPR offset is used
          * @return Stall cycles if FIFO is full, currentCycle otherwise
          */
-        int getGlobalReadQueueFullStallCycles(int currentCycle, std::queue<int>& fifo, int bpRead, int numWaves, bool isStall);
+        int getGlobalReadQueueFullStallCycles(int currentCycle, std::deque<int>& fifo, int bpRead, int numWaves, bool isStall, bool isSgprOffset);
         
         /**
          * @brief Get the cycle when local read operations complete

--- a/shared/origami/include/origami/simulator/tensilelite/formocast_simulator.hpp
+++ b/shared/origami/include/origami/simulator/tensilelite/formocast_simulator.hpp
@@ -660,9 +660,10 @@ namespace origami
          * @param bpRead Bytes per read operation
          * @param numWaves Number of waves
          * @param isStall Whether pipeline is stalled
+         * @param isSgprOffset Whether the SGPR offset is used
          * @return Stall cycles if FIFO is full, 0 otherwise
          */
-        int getGlobalReadQueueFullStallCycles(int currentCycle, std::queue<int>& fifo, int bpRead, int numWaves, bool isStall) const;
+        int getGlobalReadQueueFullStallCycles(int currentCycle, std::deque<int>& fifo, int bpRead, int numWaves, bool isStall, bool isSgprOffset) const;
         
         /**
          * @brief Push a local read-write operation into FIFO

--- a/shared/origami/src/simulator/tensilelite/formocast.cpp
+++ b/shared/origami/src/simulator/tensilelite/formocast.cpp
@@ -804,6 +804,11 @@ namespace origami
             if (bpRead <= 4) {
                 grStallCycles = 1;
             }
+            // Theoretically, the maximum number of entries that can be retained is max of readStalledLength.
+            const int maxRetainedEntries = (grFIFOLength - 4) * numWaves;
+            while (fifo.size() > maxRetainedEntries) {
+                fifo.pop_front();
+            }
             // pop finished GRs
             if (fifo.size() < grFIFOLength) {
                 // if FIFO is not empty, set finalCycle to the last cycle + 1. Only 1 GR can be issued in each cycle.

--- a/shared/origami/src/simulator/tensilelite/formocast.cpp
+++ b/shared/origami/src/simulator/tensilelite/formocast.cpp
@@ -788,10 +788,14 @@ namespace origami
         }
 
 
-        int getGlobalReadQueueFullStallCycles(int currentCycle, std::queue<int>& fifo, int bpRead, int numWaves, bool isStall)
+        int getGlobalReadQueueFullStallCycles(int currentCycle, std::deque<int>& fifo, int bpRead, int numWaves, bool isStall, bool isSgprOffset)
         {
+            int extraIssueCycles = 0;
+            if (isSgprOffset) {
+                extraIssueCycles = 1;
+            }
             if (!isStall) {
-                return currentCycle;
+                return currentCycle + extraIssueCycles;
             }
             int finalCycle = currentCycle;
             // GR FIFO length is 16, stall cycles is 16 cycles.
@@ -800,39 +804,41 @@ namespace origami
             if (bpRead <= 4) {
                 grStallCycles = 1;
             }
+            // pop finished GRs
             if (fifo.size() < grFIFOLength) {
                 // if FIFO is not empty, set finalCycle to the last cycle + 1. Only 1 GR can be issued in each cycle.
                 if (fifo.size() > 0) {
-                    finalCycle = std::max(finalCycle, fifo.back() + 1);
+                    finalCycle = std::max(finalCycle + extraIssueCycles, fifo.back() + extraIssueCycles + 1);
                 }
                 // push all GRs of all waves
-                for(auto wave = 0; wave < numWaves; wave += 2) {
-                    fifo.push(finalCycle + (wave / 2));
-                    fifo.push(finalCycle + (wave / 2));
+                for(auto wave = 0; wave < numWaves; wave += 1) {
+                    fifo.push_back(finalCycle + wave * (1 + extraIssueCycles));
                 }
             } else {
-                while(fifo.size() > 0) {
-                    if (fifo.front() + grStallCycles * grFIFOLength < currentCycle) {
-                        fifo.pop();
-                    } else {
-                        break;
-                    }
-                }
                 // FIFO is full
-                // push all GRs of all waves
-                if(fifo.size() < grFIFOLength) {
+                // the index of GR which stall happens is relative with the interval of each GRs.
+                int intervalOfGRs = (currentCycle - fifo[fifo.size() - numWaves]);
+                int readStalledLength = grFIFOLength;
+                if (intervalOfGRs > 4)
+                {
+                    readStalledLength += (intervalOfGRs - 4) * numWaves;
+                }
+                if(fifo.size() < readStalledLength)
+                {
+                    // stall is delayed
+                    finalCycle = std::max(finalCycle + extraIssueCycles, fifo.back() + extraIssueCycles + 1);
+                    // push all GRs of all waves
+                    for(auto wave = 0; wave < numWaves; wave += 1) {
+                        fifo.push_back(finalCycle + wave * (1 + extraIssueCycles));
+                    }
+                }
+                else{
+                    // push all GRs of all waves
+                    finalCycle = std::max(finalCycle + extraIssueCycles, fifo.back() + grStallCycles);
                     for(auto wave = 0; wave < numWaves; wave++) {
-                        fifo.push(finalCycle + wave);
+                        fifo.push_back(finalCycle + wave * grStallCycles);
                     }
                 }
-                else {
-                    finalCycle = std::max(finalCycle, fifo.back() + grStallCycles);
-                    for(auto wave = 0; wave < numWaves; wave++) {    
-                        fifo.pop();
-                        fifo.push(finalCycle + wave * grStallCycles);
-                    }
-                }
-                
             }
             return finalCycle;
         }

--- a/shared/origami/src/simulator/tensilelite/formocast.cpp
+++ b/shared/origami/src/simulator/tensilelite/formocast.cpp
@@ -790,31 +790,49 @@ namespace origami
 
         int getGlobalReadQueueFullStallCycles(int currentCycle, std::queue<int>& fifo, int bpRead, int numWaves, bool isStall)
         {
-            int finalCycle = currentCycle;
-            int grStallLatencyBuffer;
-
             if (!isStall) {
-                grStallLatencyBuffer = 1; //no stall
-            } else if (bpRead == 16) {
-                grStallLatencyBuffer = 160;
-            } else if (bpRead == 8) {
-                grStallLatencyBuffer = 80;
-            } else {
-                grStallLatencyBuffer = 40;
+                return currentCycle;
             }
-
-            if (fifo.size() < (16 / numWaves)) {
-                fifo.push(currentCycle);
-            } else {
-                int oldCycle = fifo.front();
-                if ((currentCycle - oldCycle) >= grStallLatencyBuffer) {
-                    fifo.pop();
-                    fifo.push(currentCycle);
-                } else {
-                    finalCycle = oldCycle + grStallLatencyBuffer;
-                    fifo.pop();
-                    fifo.push(finalCycle);
+            int finalCycle = currentCycle;
+            // GR FIFO length is 16, stall cycles is 16 cycles.
+            const int grFIFOLength = 16;
+            int grStallCycles = 4;
+            if (bpRead <= 4) {
+                grStallCycles = 1;
+            }
+            if (fifo.size() < grFIFOLength) {
+                // if FIFO is not empty, set finalCycle to the last cycle + 1. Only 1 GR can be issued in each cycle.
+                if (fifo.size() > 0) {
+                    finalCycle = std::max(finalCycle, fifo.back() + 1);
                 }
+                // push all GRs of all waves
+                for(auto wave = 0; wave < numWaves; wave += 2) {
+                    fifo.push(finalCycle + (wave / 2));
+                    fifo.push(finalCycle + (wave / 2));
+                }
+            } else {
+                while(fifo.size() > 0) {
+                    if (fifo.front() + grStallCycles * grFIFOLength < currentCycle) {
+                        fifo.pop();
+                    } else {
+                        break;
+                    }
+                }
+                // FIFO is full
+                // push all GRs of all waves
+                if(fifo.size() < grFIFOLength) {
+                    for(auto wave = 0; wave < numWaves; wave++) {
+                        fifo.push(finalCycle + wave);
+                    }
+                }
+                else {
+                    finalCycle = std::max(finalCycle, fifo.back() + grStallCycles);
+                    for(auto wave = 0; wave < numWaves; wave++) {    
+                        fifo.pop();
+                        fifo.push(finalCycle + wave * grStallCycles);
+                    }
+                }
+                
             }
             return finalCycle;
         }

--- a/shared/origami/src/simulator/tensilelite/formocast_simulator.cpp
+++ b/shared/origami/src/simulator/tensilelite/formocast_simulator.cpp
@@ -715,9 +715,9 @@ namespace origami
         hw_consts = getHardwareConstants(hw);
     }
 
-    int Formocast::getGlobalReadQueueFullStallCycles(int currentCycle, std::queue<int>& fifo, int bpRead, int numWaves, bool isStall) const
+    int Formocast::getGlobalReadQueueFullStallCycles(int currentCycle, std::deque<int>& fifo, int bpRead, int numWaves, bool isStall, bool isSgprOffset) const
     {
-        return simulator::getGlobalReadQueueFullStallCycles(currentCycle, fifo, bpRead, numWaves, isStall);
+        return simulator::getGlobalReadQueueFullStallCycles(currentCycle, fifo, bpRead, numWaves, isStall, isSgprOffset);
     }
 
     int Formocast::getLocalReadCompletionCycle(int currentCycle, std::queue<int>& fifo, int numLR) const
@@ -746,11 +746,15 @@ namespace origami
         int issuePenality = 0;
         if(numWaves == 4)
         {
+            // only 2 simds can be issued at the same time. if 4 simds, need 1 extra issue cycle.
             issuePenality = issueCycles;
-            if(bpWrite == 16)
-                issuePenality += 3;
         }
-        return std::max(previousLW + issueCycles + issuePenality, currentCycle + issueCycles);
+        if(currentCycle - previousLW >= issueCycles)
+        {
+            // if the space is enough, no stall.
+            return currentCycle + issueCycles;
+        }
+        return currentCycle + issueCycles + issuePenality;
     }
 
     void Formocast::pushLocalReadWrite(int currentCycle, std::queue<int>& fifo, int bpr, double bankConflict, bool isLocalRead, int numPreviousLRs)

--- a/shared/origami/tests/test_formocast.cpp
+++ b/shared/origami/tests/test_formocast.cpp
@@ -425,38 +425,36 @@ TEST_CASE("Formocast: FIFO queue operations", "[formocast]") {
     simulator.setHardware(hardware_t::architecture_t::gfx950);
     
     SECTION("Check global read FIFO full - no stall") {
-        std::queue<int> fifo;
-        int result = simulator.getGlobalReadQueueFullStallCycles(100, fifo, 8, 4, false);
+        std::deque<int> fifo;
+        int result = simulator.getGlobalReadQueueFullStallCycles(100, fifo, 8, 4, false, false);
         REQUIRE(result == 100);
-        REQUIRE(fifo.size() == 1);
-        REQUIRE(fifo.back() == 100);
+        REQUIRE(fifo.size() == 0);
     }
     
     SECTION("Check global read FIFO full - with stall") {
-        std::queue<int> fifo;
-        fifo.push(10);
-        fifo.push(20);
-        fifo.push(30);
-        fifo.push(40);
-        // no stall
-        int result = simulator.getGlobalReadQueueFullStallCycles(100, fifo, 8, 4, true);
-        REQUIRE(result == 100);
-        REQUIRE(fifo.size() == 4);
+        std::deque<int> fifo;
+        fifo.push_back(10);
+        fifo.push_back(11);
+        fifo.push_back(12);
+        fifo.push_back(13);
+        fifo.push_back(15);
+        fifo.push_back(16);
+        fifo.push_back(17);
+        fifo.push_back(18);
+        fifo.push_back(20);
+        fifo.push_back(21);
+        fifo.push_back(22);
+        fifo.push_back(23);
+        fifo.push_back(25);
+        fifo.push_back(26);
+        fifo.push_back(27);
+        fifo.push_back(28);
+        // stall
+        int result = simulator.getGlobalReadQueueFullStallCycles(29, fifo, 8, 4, true, false);
+        REQUIRE(result == 32);
+        REQUIRE(fifo.size() == 20);
     }
-    
-    SECTION("Check global read FIFO full - causes stall") {
-        std::queue<int> fifo;
-        fifo.push(50);
-        fifo.push(60);
-        fifo.push(70);
-        fifo.push(80);
-        // stall to 130
-        int result = simulator.getGlobalReadQueueFullStallCycles(100, fifo, 8, 4, true);
-        REQUIRE(result == 130);
-        REQUIRE(fifo.size() == 4);
-        REQUIRE(fifo.back() == 130);
-    }
-    
+
     SECTION("Check local read FIFO full - no stall") {
         std::queue<int> fifo;
         // no stall
@@ -588,50 +586,34 @@ TEST_CASE("Formocast: FIFO queue operations", "[formocast]") {
     
     SECTION("Get local write queue full stall cycles - numWaves != 4") {
         // When numWaves != 4, no penalty is applied
-        // result = max(previousLW + issueCycles, currentCycle + issueCycles)
-        // Test case 1: currentCycle dominates
-        int result1 = simulator.getLocalWriteQueueFullStallCycles(100, 50, 10, 8, 2);
-        REQUIRE(result1 == 110); // max(50 + 10, 100 + 10) = 110
-        
-        // Test case 2: previousLW dominates
-        int result2 = simulator.getLocalWriteQueueFullStallCycles(100, 150, 10, 8, 2);
-        REQUIRE(result2 == 160); // max(150 + 10, 100 + 10) = 160
+        // Test case 1: no penalty
+        int result1 = simulator.getLocalWriteQueueFullStallCycles(100, 50, 3, 8, 2);
+        REQUIRE(result1 == 103);
+
+        // Test case 2: previousLW dominates without penalty
+        int result2 = simulator.getLocalWriteQueueFullStallCycles(100, 70, 3, 8, 2);
+        REQUIRE(result2 == 103);
+
+        // Test case 3: closer previousLW dominates without penalty
+        int result3 = simulator.getLocalWriteQueueFullStallCycles(100, 99, 3, 8, 2);
+        REQUIRE(result3 == 103);
     }
-    
-    SECTION("Get local write queue full stall cycles - numWaves == 4, bpWrite != 16") {
-        // When numWaves == 4 and bpWrite != 16, penalty = issueCycles
-        // result = max(previousLW + issueCycles + issueCycles, currentCycle + issueCycles)
-        // Test case 1: currentCycle dominates
-        int result1 = simulator.getLocalWriteQueueFullStallCycles(100, 50, 10, 8, 4);
-        REQUIRE(result1 == 110); // max(50 + 10 + 10, 100 + 10) = max(70, 110) = 110
-        
-        // Test case 2: previousLW + penalty dominates
-        int result2 = simulator.getLocalWriteQueueFullStallCycles(100, 120, 10, 8, 4);
-        REQUIRE(result2 == 140); // max(120 + 10 + 10, 100 + 10) = max(140, 110) = 140
-    }
-    
+
     SECTION("Get local write queue full stall cycles - numWaves == 4, bpWrite == 16") {
-        // When numWaves == 4 and bpWrite == 16, penalty = issueCycles + 3
-        // result = max(previousLW + issueCycles + issueCycles + 3, currentCycle + issueCycles)
+        // When numWaves == 4 and bpWrite == 16, penalty = issueCycles
         // Test case 1: currentCycle dominates
-        int result1 = simulator.getLocalWriteQueueFullStallCycles(100, 50, 10, 16, 4);
-        REQUIRE(result1 == 110); // max(50 + 10 + 10 + 3, 100 + 10) = max(73, 110) = 110
+        int result1 = simulator.getLocalWriteQueueFullStallCycles(100, 50, 5, 16, 4);
+        REQUIRE(result1 == 105);
         
         // Test case 2: previousLW + penalty dominates
-        int result2 = simulator.getLocalWriteQueueFullStallCycles(100, 120, 10, 16, 4);
-        REQUIRE(result2 == 143); // max(120 + 10 + 10 + 3, 100 + 10) = max(143, 110) = 143
+        int result2 = simulator.getLocalWriteQueueFullStallCycles(100, 99, 5, 16, 4);
+        REQUIRE(result2 == 110);
     }
     
     SECTION("Get local write queue full stall cycles - edge cases") {
         // Edge case: previousLW == currentCycle
         int result1 = simulator.getLocalWriteQueueFullStallCycles(100, 100, 10, 8, 2);
-        REQUIRE(result1 == 110); // max(100 + 10, 100 + 10) = 110
-        
-        // Edge case: numWaves == 4, bpWrite == 16, previousLW much larger
-        // penalty = issueCycles + 3 = 5 + 3 = 8
-        // result = max(200 + 5 + 8, 50 + 5) = max(213, 55) = 213
-        int result2 = simulator.getLocalWriteQueueFullStallCycles(50, 200, 5, 16, 4);
-        REQUIRE(result2 == 213);
+        REQUIRE(result1 == 110);
     }
 }
 


### PR DESCRIPTION
## Motivation

1. Refine Local write instruction accuracy.
2. Support Global read instruction FIFO stall behavior. Note that the stall is not related with the memory latency. It is the HW behavior to queue the instruction in TCP_TCC stage.

## Technical Details

Simulate the FIFO behavior.

## Test Plan

Run BBSTN 257 kernels with different MTs. Remove the global incremental code to make L2 always hit (so that very less memory latency included.) Compare the buffer_load issue cycles between formocast and rocprofv3.

## Test Result

before patch
average difference per instruction: +12 cylces
after patch 
average difference per instruction: +3 cylces

Refine origami test for local write and global read to approach the real cases.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
