### PR TITLE
[ROCFFT] Fix incorrect results when HSA_XNACK=1 on XNACK-capable GPUs

### DIFF
--- a/projects/rocfft/CHANGELOG.md
+++ b/projects/rocfft/CHANGELOG.md
@@ -46,6 +46,7 @@ Documentation for rocFFT is available at
 * Fixed functional issues for multi-device transforms involving data divisions along the slowest-varying axis (only) for some bricks but not all.
 * Fixed functional issues for multi-device transforms setting no field on input or output.
 * Fixed automatic allocation of work memory at plan execution time, when work memory is required on multiple devices.
+* Fixed incorrect results when running with `HSA_XNACK=1` on XNACK-capable GPUs (gfx90a, gfx942, gfx950).
 
 ## rocFFT 1.0.36 for ROCm 7.2.0
 

--- a/projects/rocfft/CMakeLists.txt
+++ b/projects/rocfft/CMakeLists.txt
@@ -129,9 +129,12 @@ set(DEFAULT_GPUS
   gfx900
   gfx906
   gfx908
-  gfx90a
-  gfx942
-  gfx950
+  gfx90a:xnack-
+  gfx90a:xnack+
+  gfx942:xnack-
+  gfx942:xnack+
+  gfx950:xnack-
+  gfx950:xnack+
   gfx1030
   gfx1100
   gfx1101

--- a/projects/rocfft/library/src/rtc_cache.cpp
+++ b/projects/rocfft/library/src/rtc_cache.cpp
@@ -527,7 +527,24 @@ static RTCProcessType get_rtc_process_type()
 
 static std::string gpu_arch_strip_flags(const std::string gpu_arch_with_flags)
 {
-    return gpu_arch_with_flags.substr(0, gpu_arch_with_flags.find(':'));
+    // get base architecture (e.g., "gfx942" from "gfx942:sramecc+:xnack+")
+    std::string base = gpu_arch_with_flags.substr(0, gpu_arch_with_flags.find(':'));
+
+    // XNACK flag must be preserved - XNACK+ and XNACK- code objects are
+    // not interchangeable. Stripping xnack causes incorrect behavior
+    // when HSA_XNACK=1.
+    auto xnack_pos = gpu_arch_with_flags.find(":xnack");
+    if(xnack_pos != std::string::npos)
+    {
+        // find the end of the xnack flag (either next ':' or end of string)
+        auto end_pos = gpu_arch_with_flags.find(':', xnack_pos + 1);
+        if(end_pos == std::string::npos)
+            end_pos = gpu_arch_with_flags.length();
+        return base + gpu_arch_with_flags.substr(xnack_pos, end_pos - xnack_pos);
+    }
+
+    // only strip sramecc and other non-critical flags
+    return base;
 }
 
 static std::vector<char> cached_compile_impl(const std::string&          kernel_name,
@@ -710,21 +727,12 @@ std::vector<char> RTCCache::cached_compile(const std::string&          kernel_na
                                            kernel_src_gen_t            generate_src,
                                            const std::array<char, 32>& generator_sum)
 {
-#ifdef ADDRESS_SANITIZER
-    // The address sanitizer is reported to work better when we include xnack+, so don't strip this
-    // from the architecture string when building:
-    const std::string gpu_arch = gpu_arch_with_flags;
-#else
-    // Supplied gpu arch may have extra flags on it
-    // (e.g. gfx90a:sramecc+:xnack-), Strip those from the arch name
-    // since omitting them will generate code that handles either
-    // case.
-    //
-    // As of this writing, there are no known performance benefits to
-    // including the flags.  If that changes, we may need to be more
-    // selective about which flags to strip.
-    const std::string gpu_arch = gpu_arch_strip_flags(gpu_arch_with_flags);
-#endif
+    // Supplied gpu arch may have extra flags on it (e.g. gfx90a:sramecc+:xnack+).
+    // Strip sramecc since it doesn't affect code generation, but XNACK
+    // must be preserved because XNACK+ and XNACK- code objects use different
+    // memory access instructions and are not interchangeable.
+    // Setting HSA_XNACK=1 with XNACK- code objects would cause incorrect results.
+    const std::string                     gpu_arch = gpu_arch_strip_flags(gpu_arch_with_flags);
     std::shared_future<std::vector<char>> result;
 
     const pending_key                    key{kernel_name, gpu_arch};


### PR DESCRIPTION
## Motivation

rocFFT produced incorrect FFT results when HSA_XNACK=1 was set

## Technical Details

Multiple errors were reported running `hipfft_test` with HSA_XNACK enabled, this was due to:

1. Default GPU targets only included bare architecture names (e.g., gfx942) without explicit xnack+ code objects
2. Runtime compilation stripped the :xnack+ flag from GPU architecture strings, causing kernels to be compiled for xnack- mode even when the runtime was operating in xnack+ mode.

In this PR, we modified:
- CMakeLists.txt: Update DEFAULT_GPUS to use explicit :xnack- and :xnack+ variants for XNACK-capable GPUs (gfx90a, gfx942, gfx950)
- rtc_cache.cpp: Preserve xnack flag in gpu_arch_strip_flags() instead of stripping it; only strip non-critical flags like sramecc

## Test Plan

Run whole CI to verify compilation and accuracy tests

## Test Result

CI is ongoing

## Submission Checklist

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
