### PR TITLE
restore occasionally removed solver_id from stream operator

### DIFF
--- a/projects/miopen/src/solver.cpp
+++ b/projects/miopen/src/solver.cpp
@@ -96,6 +96,7 @@ void PrecompileSolutions(const Handle& h,
 
 std::ostream& operator<<(std::ostream& os, const ConvSolution& s)
 {
+    os << s.solver_id << ": ";
     std::transform(s.construction_params.begin(),
                    s.construction_params.end(),
                    std::ostream_iterator<std::string>(os, "/"),


### PR DESCRIPTION
## Motivation

Fix occasionally changed logic of stream operator in https://github.com/ROCm/rocm-libraries/pull/4143 .

## Technical Details

PR occasionally changes stream operator.
Original behavior was
```c++
std::ostream& operator<<(std::ostream& os, const ConvSolution& s)
{
  auto strings = do_some_transformation();
  os << s.solver_id << ": " << JoinStrings(strings, "/");
  return os;
}
```

## Test Plan

CI should pass

## Submission Checklist

- [ ] I have ran the tests, and they are all passing locally
- [ ] I have ran `make format` to ensure the changes have been formatted