### PR TITLE
[TensileLite] Fix MX FP4 scale data initialization & argument scoping

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/Signature.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/Signature.py
@@ -221,20 +221,19 @@ class SignatureDefault(Signature):
         if kernel["ProblemType"]["UseScaleAB"]:
             signature.addArg("AddressScaleA", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
             signature.addArg("AddressScaleB", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
-        userArgumentsInfo.scaleASize += 8
-        userArgumentsInfo.scaleBSize += 8
+            userArgumentsInfo.scaleASize += 8
+            userArgumentsInfo.scaleBSize += 8
         if kernel["ProblemType"]["UseScaleCD"]:
             signature.addArg("AddressScaleC", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
             signature.addArg("AddressScaleD", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
-        userArgumentsInfo.scaleCSize += 8
-        userArgumentsInfo.scaleDSize += 8
+            userArgumentsInfo.scaleCSize += 8
+            userArgumentsInfo.scaleDSize += 8
 
         if kernel["ProblemType"]["UseScaleAlphaVec"]:
             signature.addArg("AddressScaleAlphaVec", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
             if kernel["ProblemType"]["UseScaleAlphaVec"] == 3:
                 userArgumentsInfo.factorDimSize =4
-
-        userArgumentsInfo.scaleAlphaVecSize += 8
+                userArgumentsInfo.scaleAlphaVecSize += 8
 
         if writer.states.useBias != DataDirection.NONE:
             signature.addArg("bias", SVK.SIG_GLOBALBUFFER, biasValueType, "generic")  # Note: We append the data in ws_d
@@ -243,7 +242,7 @@ class SignatureDefault(Signature):
                 signature.addArg("StrideBias",      SVK.SIG_VALUE,        "u32")
                 if kernel["ProblemType"]["UseBias"] == 3:
                     userArgumentsInfo.factorDimSize = 4
-        userArgumentsInfo.biasSize += (8 + 4 + 4)
+            userArgumentsInfo.biasSize += (8 + 4 + 4)
 
         if userArgumentsInfo.factorDimSize == 4:
             signature.addArg("factorDim", SVK.SIG_VALUE, "u32")
@@ -252,9 +251,9 @@ class SignatureDefault(Signature):
             signature.addArg(      "E", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
             for i in range(0, writer.states.e.numSgprStrides):
                 signature.addArg("StrideE%u"%i,        SVK.SIG_VALUE,        "u32")
-        userArgumentsInfo.eSize += 8
-        for i in range(0, writer.states.e.numSgprStrides):
-            userArgumentsInfo.eSize += 4
+            userArgumentsInfo.eSize += 8
+            for i in range(0, writer.states.e.numSgprStrides):
+                userArgumentsInfo.eSize += 4
 
         if ((kernel["ProblemType"]["ActivationType"] != 'none') and kernel["ActivationFused"]):
             if kernel["ProblemType"]["ActivationComputeDataType"].isHalf():

--- a/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
@@ -1709,7 +1709,10 @@ namespace TensileLite
                    or i == ContractionProblemGemm::TENSOR::METADATA)
                     continue;
 
-                if(useMXGenerator && (i == ContractionProblemGemm::TENSOR::A || i == ContractionProblemGemm::TENSOR::B))
+                if(useMXGenerator && (i == ContractionProblemGemm::TENSOR::A
+                                      || i == ContractionProblemGemm::TENSOR::B
+                                      || i == ContractionProblemGemm::TENSOR::MXSA
+                                      || i == ContractionProblemGemm::TENSOR::MXSB))
                     continue;
 
                 if(m_problemDependentData)

--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -809,8 +809,7 @@ namespace TensileLite
 
 	// NOTE: an assumption here is A & B must be both MX data types or non-MX data types.
 	//       Mixing is not supported.
-        if(!problemType.useScaleAB.empty() or
-           (problemType.mxBlockA != 0 && problemType.mxBlockB != 0)) //kernel input data
+        if(!problemType.useScaleAB.empty())
         {
             args.template append<void const*>("scaleA", inputs.scaleA);
             args.template append<void const*>("scaleB", inputs.scaleB);


### PR DESCRIPTION
## Motivation

Fix MXFP4 scale data initialization and kernel argument scoping

## Technical Details

- `DataInitialization.cpp`: Extend `initializeCPUInputs` skip guard to include `MXSA`/`MXSB` — the general tensor loop was overwriting correlated scale data from `initializeMXDataForFP4` with independent random `UE8M0` values, causing intermittent single-element validation failures from sub-ULP hardware/software dequantization differences  `UE8M0`→`float32` 
- `ContractionSolution.cpp`: Gate `scaleA`/`scaleB` argument appending on `useScaleAB` only — MX problems without `UseScaleAB` were incorrectly passing scale pointers to kernels that don't expect them
- `Signature.py`: Fix indentation of `userArgumentsInfo` size increments for `scaleA/B/C/D`, `bias`, and `E` tensor — sizes were unconditionally accumulated outside their feature if blocks, producing incorrect kernel argument layouts

## Test Plan

TBD

## Test Result

TBD

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
