### PR TITLE
[rocsparse] Fix undefined behavior in host_bsrgemm and host_csrgemm test helpers

### DIFF
--- a/projects/rocsparse/clients/common/rocsparse_host.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_host.cpp
@@ -4437,8 +4437,11 @@ void host_bsrgemm(rocsparse_direction  dir,
     std::vector<J> col(nnzb);
     std::vector<T> val(block_dim * block_dim * nnzb);
 
-    memcpy(col.data(), bsr_col_ind_C, sizeof(J) * nnzb);
-    memcpy(val.data(), bsr_val_C, sizeof(T) * block_dim * block_dim * nnzb);
+    if(nnzb > 0 && bsr_col_ind_C != nullptr && bsr_val_C != nullptr)
+    {
+        memcpy(col.data(), bsr_col_ind_C, sizeof(J) * nnzb);
+        memcpy(val.data(), bsr_val_C, sizeof(T) * block_dim * block_dim * nnzb);
+    }
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1024)
@@ -5236,8 +5239,11 @@ void host_csrgemm(J                    M,
     std::vector<J> col(nnz);
     std::vector<T> val(nnz);
 
-    memcpy(col.data(), csr_col_ind_C, sizeof(J) * nnz);
-    memcpy(val.data(), csr_val_C, sizeof(T) * nnz);
+    if(nnz > 0 && csr_col_ind_C != nullptr && csr_val_C != nullptr)
+    {
+        memcpy(col.data(), csr_col_ind_C, sizeof(J) * nnz);
+        memcpy(val.data(), csr_val_C, sizeof(T) * nnz);
+    }
 
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1024)


### PR DESCRIPTION
## Summary

Guard `memcpy()` calls with NULL pointer checks in `host_bsrgemm` and `host_csrgemm` to fix undefined behavior that causes test crashes with GCC 15/16.

## Problem

The `bsrgemm` and `csrgemm` tests crash with `SIGABRT` (heap corruption) when built with GCC 15/16 on Fedora 43/rawhide:

```
free(): invalid size
Aborted (core dumped)
```

**Affected tests:**
- `rocsparse-test --gtest_filter="*bsrgemm_extra*"`
- `rocsparse-test --gtest_filter="*csrgemm_extra*"`

## Root Cause

In `clients/common/rocsparse_host.cpp`, when the result matrix has zero non-zero elements (nnz=0), the code calls `memcpy()` with NULL source pointers:

```cpp
// host_bsrgemm (line ~4440)
std::vector<J> col(nnzb);  // size 0
std::vector<T> val(block_dim * block_dim * nnzb);
memcpy(col.data(), bsr_col_ind_C, sizeof(J) * nnzb);  // bsr_col_ind_C is NULL!
memcpy(val.data(), bsr_val_C, ...);                   // bsr_val_C is NULL!

// host_csrgemm (line ~5239) - same pattern
memcpy(col.data(), csr_col_ind_C, sizeof(J) * nnz);   // csr_col_ind_C is NULL!
memcpy(val.data(), csr_val_C, sizeof(T) * nnz);       // csr_val_C is NULL!
```

