### PR TITLE
[hipblaslt][tensilelite] Significantly speed up the cache branch of LibraryIO.py::writeSolution

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -116,6 +116,10 @@ def writeMsgPack(filename, data):
     with open(filename, "wb") as f:
         msgpack.pack(data, f)
 
+def _solutionsCachePath(yamlFilename):
+    """Return path to the msgpack cache file for a solutions YAML."""
+    return yamlFilename + ".solcache.dat"
+
 def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutions, cache=False):
     """Writes solution YAML file."""
 
@@ -123,13 +127,18 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
     solutionStates = []
 
     if cache:
-        solYaml = read(filename)
-        if biasTypeArgs and activationArgs:
-            solutionStates = solYaml[4:]
-        elif biasTypeArgs or activationArgs:
-            solutionStates = solYaml[3:]
+        cachePath = _solutionsCachePath(filename)
+        if os.path.exists(cachePath):
+            with open(cachePath, "rb") as cf:
+                solutionStates = msgpack.unpack(cf, raw=False)
         else:
-            solutionStates = solYaml[2:]
+            solYaml = read(filename)
+            if biasTypeArgs and activationArgs:
+                solutionStates = solYaml[4:]
+            elif biasTypeArgs or activationArgs:
+                solutionStates = solYaml[3:]
+            else:
+                solutionStates = solYaml[2:]
     else:
         for solution in solutions:
             solutionState = solution.getAttributes()
@@ -138,6 +147,10 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
             isa = solutionState["ISA"]
             solutionState["ISA"] = [isa[0], isa[1], isa[2]]
             solutionStates.append(solutionState)
+        try:
+            writeMsgPack(_solutionsCachePath(filename), solutionStates)
+        except Exception:
+            pass  # Non-fatal: will fall back to full reload from YAML on next cached run
     # write dictionaries
     with open(filename, "w") as f:
         f.write("- MinimumRequiredVersion: {}\n".format(__version__))

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -28,6 +28,7 @@ from .CustomYamlLoader import load_yaml_stream
 from Tensile import __version__
 from Tensile.Common import printExit, printWarning, print2, \
                            versionIsCompatible, IsaInfo
+from Tensile.Common.TimingInstrumentation import timing_context
 from Tensile.Common.Architectures import gfxToIsa
 from Tensile.SolutionStructs import Solution, ProblemSizes
 from Tensile.SolutionStructs.Problem import ProblemType, problemTypeToEnum
@@ -146,22 +147,25 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
         else:
             return solYaml[2:]
 
-    if cache:
-        solutionStates = load_solution_states_from_cache(filename)
-    else:
-        solutionStates: list[dict] = []
-        for solution in solutions:
-            solutionState = solution.getAttributes()
-            solutionState["ProblemType"] = solutionState["ProblemType"].state
-            problemTypeToEnum(solutionState["ProblemType"])
-            isa = solutionState["ISA"]
-            solutionState["ISA"] = [isa[0], isa[1], isa[2]]
-            solutionStates.append(solutionState)
-        if _msgpack_available:
-            try:
-                writeMsgPack(_solutionsCacheFilename(filename), solutionStates)
-            except Exception as e:
-                printWarning("Failed to write solution cache: {}".format(e))
+    with timing_context("python_wsol_prepare"):
+        if cache:
+            with timing_context("python_wsol_prepare_cache"):
+                solutionStates = load_solution_states_from_cache(filename)
+        else:
+            with timing_context("python_wsol_prepare_nocache"):
+                solutionStates: list[dict] = []
+                for solution in solutions:
+                    solutionState = solution.getAttributes()
+                    solutionState["ProblemType"] = solutionState["ProblemType"].state
+                    problemTypeToEnum(solutionState["ProblemType"])
+                    isa = solutionState["ISA"]
+                    solutionState["ISA"] = [isa[0], isa[1], isa[2]]
+                    solutionStates.append(solutionState)
+                if _msgpack_available:
+                    try:
+                        writeMsgPack(_solutionsCacheFilename(filename), solutionStates)
+                    except Exception as e:
+                        printWarning("Failed to write solution cache: {}".format(e))
     # write dictionaries
     with open(filename, "w") as f:
         f.write("- MinimumRequiredVersion: {}\n".format(__version__))

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -129,9 +129,12 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
     if cache:
         cachePath = _solutionsCachePath(filename)
         if os.path.exists(cachePath):
-            with open(cachePath, "rb") as cf:
-                solutionStates = msgpack.unpack(cf, raw=False)
-        else:
+            try:
+                with open(cachePath, "rb") as cf:
+                    solutionStates = msgpack.unpack(cf, raw=False)
+            except Exception:
+                solutionStates = []
+        if not solutionStates:
             solYaml = read(filename)
             if biasTypeArgs and activationArgs:
                 solutionStates = solYaml[4:]

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -73,7 +73,9 @@ except ImportError:
 
 try:
     import msgpack
+    _msgpack_available = True
 except ImportError:
+    _msgpack_available = False
     print("Message pack python library not detected. Must use YAML backend instead.")
 
 
@@ -118,7 +120,8 @@ def writeMsgPack(filename, data):
 
 def _solutionsCachePath(yamlFilename):
     """Return path to the msgpack cache file for a solutions YAML."""
-    return yamlFilename + ".solcache.dat"
+    base, _ = os.path.splitext(yamlFilename)
+    return base + ".solcache.dat"
 
 def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutions, cache=False):
     """Writes solution YAML file."""
@@ -128,13 +131,16 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
 
     if cache:
         cachePath = _solutionsCachePath(filename)
-        if os.path.exists(cachePath):
-            try:
-                with open(cachePath, "rb") as cf:
-                    solutionStates = msgpack.unpack(cf, raw=False)
-            except Exception:
-                solutionStates = []
-        if not solutionStates:
+        loaded = False
+        if _msgpack_available and os.path.exists(cachePath):
+            if os.path.getmtime(cachePath) >= os.path.getmtime(filename):
+                try:
+                    with open(cachePath, "rb") as cf:
+                        solutionStates = msgpack.unpack(cf, raw=False)
+                    loaded = True
+                except Exception:
+                    pass  # Corrupt cache; fall back to YAML
+        if not loaded:
             solYaml = read(filename)
             if biasTypeArgs and activationArgs:
                 solutionStates = solYaml[4:]
@@ -150,10 +156,11 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
             isa = solutionState["ISA"]
             solutionState["ISA"] = [isa[0], isa[1], isa[2]]
             solutionStates.append(solutionState)
-        try:
-            writeMsgPack(_solutionsCachePath(filename), solutionStates)
-        except Exception:
-            pass  # Non-fatal: will fall back to full reload from YAML on next cached run
+        if _msgpack_available:
+            try:
+                writeMsgPack(_solutionsCachePath(filename), solutionStates)
+            except Exception as e:
+                printWarning("Failed to write solution cache: {}".format(e))
     # write dictionaries
     with open(filename, "w") as f:
         f.write("- MinimumRequiredVersion: {}\n".format(__version__))

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -118,37 +118,38 @@ def writeMsgPack(filename, data):
     with open(filename, "wb") as f:
         msgpack.pack(data, f)
 
-def _solutionsCachePath(yamlFilename):
+def _solutionsCacheFilename(yamlFilename):
     """Return path to the msgpack cache file for a solutions YAML."""
     base, _ = os.path.splitext(yamlFilename)
     return base + ".solcache.dat"
 
 def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutions, cache=False):
     """Writes solution YAML file."""
-
-    # convert objects to nested dictionaries
-    solutionStates = []
-
-    if cache:
-        cachePath = _solutionsCachePath(filename)
-        loaded = False
+    def load_solution_states_from_cache(filename) -> list[dict]:
+        """Try loading from msgpack cache, falling back to YAML."""
+        cachePath = _solutionsCacheFilename(filename)
+        # Try msgpack cache if available and the cache file exists
         if _msgpack_available and os.path.exists(cachePath):
+            # If the YAML is newer than the cache, don't use the cache; assume it's stale
             if os.path.getmtime(cachePath) >= os.path.getmtime(filename):
                 try:
                     with open(cachePath, "rb") as cf:
-                        solutionStates = msgpack.unpack(cf, raw=False)
-                    loaded = True
-                except Exception:
-                    pass  # Corrupt cache; fall back to YAML
-        if not loaded:
-            solYaml = read(filename)
-            if biasTypeArgs and activationArgs:
-                solutionStates = solYaml[4:]
-            elif biasTypeArgs or activationArgs:
-                solutionStates = solYaml[3:]
-            else:
-                solutionStates = solYaml[2:]
+                        return msgpack.unpack(cf, raw=False)
+                except Exception as e:
+                    printWarning("Failed to load solution cache: {}".format(e))
+        # Fall back to YAML
+        solYaml = read(filename)
+        if biasTypeArgs and activationArgs:
+            return solYaml[4:]
+        elif biasTypeArgs or activationArgs:
+            return solYaml[3:]
+        else:
+            return solYaml[2:]
+
+    if cache:
+        solutionStates = load_solution_states_from_cache(filename)
     else:
+        solutionStates: list[dict] = []
         for solution in solutions:
             solutionState = solution.getAttributes()
             solutionState["ProblemType"] = solutionState["ProblemType"].state
@@ -158,7 +159,7 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
             solutionStates.append(solutionState)
         if _msgpack_available:
             try:
-                writeMsgPack(_solutionsCachePath(filename), solutionStates)
+                writeMsgPack(_solutionsCacheFilename(filename), solutionStates)
             except Exception as e:
                 printWarning("Failed to write solution cache: {}".format(e))
     # write dictionaries

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -66,7 +66,12 @@ TIMING_HIERARCHY = {
         },
         "python_write_cache": {},
         "python_solution_indexing": {},
-        "python_write_solutions": {},
+        "python_write_solutions": {
+            "python_wsol_prepare": {
+                "python_wsol_prepare_cache": {},
+                "python_wsol_prepare_nocache": {},
+            },
+        },
         "python_client_execution": {
             "hip_initialization": {},
             "library_loading": {},


### PR DESCRIPTION
## Motivation

The cache branch of LibraryIO.py::writeSolution (from running Tensile with `--use-cache`) is substantially slower than the non-cached branch. It adds as much as 30% overhead on certain yamls (e.g. tail_small_size.yaml) because it's reading and parsing large yaml files in order to get a small subset of the data.

## Technical Details

Adds a msgpack sidecar cache (.solcache.dat) alongside the solutions YAML file. On non-cached runs, solution states are saved to msgpack after being built. On cached runs, the msgpack file is read instead of parsing the full YAML, avoiding expensive YAML deserialization. Falls back to YAML if the cache file doesn't exist.

## Test Plan

Run existing tests.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
