### PR TITLE
[hipblaslt][tensilelite] Replace yaml.dump with custom yaml writer

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -308,34 +308,6 @@ def writeSolutions(filename: str, problemSizes: Optional[ProblemSizes], biasType
         with timing_context("python_wsol_dump"):
             fast_yaml_dump(solutionStates, f)
 
-    # Validate custom writer against original yaml.dump
-    refFilename = filename + ".ref"
-    with open(refFilename, "w") as f:
-        f.write("- MinimumRequiredVersion: {}\n".format(__version__))
-        f.write("- ProblemSizes:\n")
-        if problemSizes:
-            for sizeRange in problemSizes.ranges:
-                f.write("  - Range: {}\n".format(sizeRange))
-            for problemExact in problemSizes.exacts:
-                f.write("  - Exact: {}\n".format(problemExact))
-        if biasTypeArgs:
-            f.write("- BiasTypeArgs: [{}]\n".format([btype.value for btype in biasTypeArgs.biasTypes]))
-        if activationArgs:
-            f.write("- ActivationArgs:\n")
-            for setting in activationArgs.settingList:
-                f.write("  - [Enum: %s]\n"%(setting.activationEnum))
-        yaml.dump(solutionStates, f, Dumper=yamlDumper, default_flow_style=None)
-
-    fastData = readYAML(filename)
-    refData = readYAML(refFilename)
-
-    if fastData != refData:
-        print("ERROR: Custom YAML writer output differs from yaml.dump for file: {}".format(filename))
-        print("Reference file kept at: {}".format(refFilename))
-        sys.exit(1)
-    else:
-        os.remove(refFilename)
-
 
 ###############################
 # Reading and parsing functions

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -184,7 +184,8 @@ def fast_yaml_dump(solutionStates, f):
     """
     for sol in solutionStates:
         first = True
-        for k, v in sol.items():
+        for k in sorted(sol.keys()):
+            v = sol[k]
             if first:
                 prefix = '- '
                 first = False
@@ -192,8 +193,8 @@ def fast_yaml_dump(solutionStates, f):
                 prefix = '  '
             if isinstance(v, dict):
                 f.write(f'{prefix}{k}:\n')
-                for k2, v2 in v.items():
-                    f.write(f'    {k2}: {_fast_yaml_scalar(v2)}\n')
+                for k2 in sorted(v.keys()):
+                    f.write(f'    {k2}: {_fast_yaml_scalar(v[k2])}\n')
             else:
                 f.write(f'{prefix}{k}: {_fast_yaml_scalar(v)}\n')
 

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -308,6 +308,34 @@ def writeSolutions(filename: str, problemSizes: Optional[ProblemSizes], biasType
         with timing_context("python_wsol_dump"):
             fast_yaml_dump(solutionStates, f)
 
+    # Validate custom writer against original yaml.dump
+    refFilename = filename + ".ref"
+    with open(refFilename, "w") as f:
+        f.write("- MinimumRequiredVersion: {}\n".format(__version__))
+        f.write("- ProblemSizes:\n")
+        if problemSizes:
+            for sizeRange in problemSizes.ranges:
+                f.write("  - Range: {}\n".format(sizeRange))
+            for problemExact in problemSizes.exacts:
+                f.write("  - Exact: {}\n".format(problemExact))
+        if biasTypeArgs:
+            f.write("- BiasTypeArgs: [{}]\n".format([btype.value for btype in biasTypeArgs.biasTypes]))
+        if activationArgs:
+            f.write("- ActivationArgs:\n")
+            for setting in activationArgs.settingList:
+                f.write("  - [Enum: %s]\n"%(setting.activationEnum))
+        yaml.dump(solutionStates, f, Dumper=yamlDumper, default_flow_style=None)
+
+    fastData = readYAML(filename)
+    refData = readYAML(refFilename)
+
+    if fastData != refData:
+        print("ERROR: Custom YAML writer output differs from yaml.dump for file: {}".format(filename))
+        print("Reference file kept at: {}".format(refFilename))
+        sys.exit(1)
+    else:
+        os.remove(refFilename)
+
 
 ###############################
 # Reading and parsing functions

--- a/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
+++ b/projects/hipblaslt/tensilelite/Tensile/LibraryIO.py
@@ -85,6 +85,118 @@ except ImportError:
 ###################
 # Writing functions
 ###################
+
+# YAML keywords that need quoting when used as string values
+_YAML_BOOL_KEYWORDS = frozenset({
+    'true', 'false', 'yes', 'no', 'on', 'off',
+    'True', 'False', 'Yes', 'No', 'On', 'Off',
+    'TRUE', 'FALSE', 'YES', 'NO', 'ON', 'OFF',
+})
+_YAML_NULL_KEYWORDS = frozenset({'null', 'Null', 'NULL', '~'})
+_YAML_SPECIAL_STARTS = frozenset('-?:,[]{}#&*!|>\'"%%@`')
+
+def _fast_yaml_scalar(v):
+    """Format a Python value as an inline YAML scalar."""
+    if v is None:
+        return 'null'
+    if isinstance(v, bool):
+        return 'true' if v else 'false'
+    if isinstance(v, int):
+        return str(v)
+    if isinstance(v, float):
+        return repr(v)
+    if isinstance(v, str):
+        return _fast_yaml_str(v)
+    if isinstance(v, list):
+        return _fast_yaml_flow_list(v)
+    return repr(v)
+
+def _fast_yaml_str(s):
+    """Format a Python string as a YAML scalar, quoting only when necessary."""
+    if not s or s in _YAML_BOOL_KEYWORDS or s in _YAML_NULL_KEYWORDS:
+        return f"'{s}'"
+    escaped = s.replace("'", "''")
+    if s[0] in _YAML_SPECIAL_STARTS or s[0] == ' ' or s[-1] == ' ':
+        return f"'{escaped}'"
+    if ': ' in s or ' #' in s or s.endswith(':') or '\n' in s:
+        return f"'{escaped}'"
+    # Check if it looks like a number
+    c = s[0]
+    if c.isdigit() or (c in '+-.' and len(s) > 1):
+        try:
+            float(s)
+            return f"'{s}'"
+        except ValueError:
+            pass
+    return s
+
+def _fast_yaml_flow_list(lst):
+    """Format a Python list as a YAML flow sequence: [a, b, c]."""
+    if not lst:
+        return '[]'
+    return f"[{', '.join(_fast_yaml_scalar(item) for item in lst)}]"
+
+def fast_yaml_dump(solutionStates, f):
+    """
+    Write a list of solution dicts as YAML, optimized for speed.
+
+    Produces output compatible with yaml.load(f, CSafeLoader).
+    Only handles the plain Python types found in solution state dicts:
+    int, bool, str, float, None, list, and dict (one level of nesting).
+
+    Limitations versus CSafeDumper:
+
+    Structural:
+      - Only one level of dict nesting. Sub-dicts whose values are themselves
+        dicts fall through to repr() via _yamlScalar.
+      - Lists of dicts are not supported. _yamlFlowList calls _yamlScalar on
+        each item, which has no dict case and falls through to repr().
+      - No block style for complex structures; everything is written
+        inline/flow.
+      - No YAML anchors/aliases. Shared references (e.g. the same ProblemType
+        dict in multiple solutions) are duplicated in the output.
+
+    Type handling:
+      - Float special values (inf, -inf, nan) are written via repr(), which
+        produces Python syntax rather than the YAML-spec forms (.inf, -.inf,
+        .nan).
+      - Tuples, sets, bytes, and datetime objects all fall through to repr(),
+        producing Python-syntax output that is not valid YAML. CSafeDumper
+        converts tuples to sequences, datetimes to timestamps, etc.
+
+    String quoting:
+      - Dict keys are never quoted. Keys that are YAML keywords (true, yes,
+        null, etc.) or contain special characters are written bare.
+      - No detection of YAML timestamp-like strings. Values such as
+        "2024-01-01" or "12:30:00" are written unquoted and may be parsed
+        back as dates or times by the loader.
+      - Octal/hex-like strings (e.g. "0x1F", "0o17") may pass through
+        unquoted and be misinterpreted as numbers by some YAML loaders.
+      - Multiline strings (containing literal newlines) are single-quoted
+        with the newline embedded directly, which can produce broken output.
+        CSafeDumper uses block scalars (|) or double-quoted strings with
+        escaped newlines.
+
+    These limitations are acceptable because this writer targets the specific
+    shape of solution state dicts (flat dicts with occasional one-level-deep
+    sub-dicts of simple scalars). The validation in writeSolutions() catches
+    any mismatch against yaml.dump output at runtime.
+    """
+    for sol in solutionStates:
+        first = True
+        for k, v in sol.items():
+            if first:
+                prefix = '- '
+                first = False
+            else:
+                prefix = '  '
+            if isinstance(v, dict):
+                f.write(f'{prefix}{k}:\n')
+                for k2, v2 in v.items():
+                    f.write(f'    {k2}: {_fast_yaml_scalar(v2)}\n')
+            else:
+                f.write(f'{prefix}{k}: {_fast_yaml_scalar(v)}\n')
+
 def write(filename_noExt, data, format="yaml"):
     """Writes data to file with specified format; extension is appended based on format."""
     if format == "yaml":
@@ -194,7 +306,7 @@ def writeSolutions(filename: str, problemSizes: Optional[ProblemSizes], biasType
         with timing_context("python_wsol_header"):
             _writeSolutionsHeader(f, problemSizes, biasTypeArgs, activationArgs)
         with timing_context("python_wsol_dump"):
-            yaml.dump(solutionStates, f, Dumper=yamlDumper, default_flow_style=None)
+            fast_yaml_dump(solutionStates, f)
 
 
 ###############################

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -71,6 +71,8 @@ TIMING_HIERARCHY = {
                 "python_wsol_prepare_cache": {},
                 "python_wsol_prepare_nocache": {},
             },
+            "python_wsol_header": {},
+            "python_wsol_dump": {},
         },
         "python_client_execution": {
             "hip_initialization": {},


### PR DESCRIPTION
## Motivation

Even after #4843, writeYAML is a major source of overhead, ~10% of total runtime, for writing out these yaml files.

Replacing yaml.dump with a custom writer. Output is not identical due to formatting for speed. E.g.
Instead of:
```
x: [[a], [b]]
```

it is:
```
x:
- [a]
- [b]
```

This is a minor representation change, the actual data is the same.

## Technical Details

Add custom yaml writer that supports only the subset of features used.

## Test Plan

Added temporary code to write a yaml with both implementations, read it in, and then assert that the resulting objects are identical. Will run through full CI with this enabled, **then remove it after review but before merging**.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
