### PR TITLE
[Origami] Move Size Validation for AutoWGM and AutoSU to Origami Layer

### DIFF
--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -970,21 +970,15 @@ namespace TensileLite
         hip::HipAMDGPU const* hipAMDGPU = dynamic_cast<hip::HipAMDGPU const*>(hardware);
 
         // Default WGM
-        int32_t  defaultWGM         = 0;
-        uint32_t defaultWGMXCC      = 0;
+        int32_t  defaultWGM         = 1;
+        uint32_t defaultWGMXCC      = 1;
         uint32_t defaultWGMXCCCHUNK = 0;
-
-        // If any of the problem sizes are less than 1, return 0 for all values
-        auto sizes = problem.problemSizes();
-        if(sizes[0] < 1 || sizes[1] < 1 || sizes[2] < 1 || sizes[3] < 1)
-        {
-            return std::make_tuple(defaultWGM, defaultWGMXCC, defaultWGMXCCCHUNK);
-        }
 
         // Dynamically pick the values
         if(sizeMapping.streamK != 0 && skgrid != 0 && sizeMapping.workGroupMapping == 0
            && sizeMapping.workGroupMappingXCC == -1)
         {
+            auto sizes = problem.problemSizes();
             // Try to find cached WGM and WGMXCC and WGMXCCCHUNK
             auto cachedWGMParams = wgmParamsCache.find(problem);
 
@@ -1087,18 +1081,11 @@ namespace TensileLite
         size_t defaultStaggerU            = 0;
         size_t defaultStaggerUStrideShift = 0;
 
-        // If any of the problem sizes are less than 1, return 0 for all values
-        auto sizes = problem.problemSizes();
-        if(sizes[0] < 1 || sizes[1] < 1 || sizes[2] < 1 || sizes[3] < 1)
-        {
-            return std::make_tuple(
-                defaultStaggerUMapping, defaultStaggerU, defaultStaggerUStrideShift);
-        }
-
         // Dynamically pick the values
         if(sizeMapping.streamK != 0 && skgrid != 0 && sizeMapping.workGroupMapping == 0
            && sizeMapping.workGroupMappingXCC == -1)
         {
+            auto sizes = problem.problemSizes();
             // Try to find cached StaggerUMapping, StaggerU and StaggerUStrideShift
             auto cachedStaggerUParams = staggerUParamsCache.find(problem);
 

--- a/shared/origami/src/origami/origami.cpp
+++ b/shared/origami/src/origami/origami.cpp
@@ -57,6 +57,12 @@ workgroup_mapping_t select_workgroup_mapping(const problem_t& problem,
   int nta = config.cache_hints_a;
   int ntb = config.cache_hints_b;
 
+  // Early Exit: problem sizes are invalid
+  if(M < 1 || N < 1 || K < 1 || batch < 1)
+  {
+    return workgroup_mapping_t{0, 0, 0};
+  }
+
   // Default values
   size_t numCUs             = hardware.N_CU;
   size_t numXCD             = hardware.NUM_XCD;
@@ -333,6 +339,12 @@ staggerU_t select_staggerU(const problem_t& problem,
 
   int nta = config.cache_hints_a;
   int ntb = config.cache_hints_b;
+
+  // Early Exit: problem sizes are invalid
+  if(M < 1 || N < 1 || K < 1 || batch < 1)
+  {
+    return staggerU_t{0, 0, 0};
+  }
 
   // Default values
   size_t numCUs       = hardware.N_CU;


### PR DESCRIPTION
## Motivation

Some failures were observed for components using hipblaslt because `problem.size()` in `ContractionSolution.cpp` can have zero valued dimensions.

## Technical Details

This PR moves the validation of the size to the Origami layer.

## Test Plan

CI and locally.

## Test Result

Performance: NA
Functionality: Passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
