### PR TITLE
[hipblaslt][CMS] Support DtlPlusLdsBuf=True in Validator

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -880,38 +880,55 @@ def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) 
                 gr.needed_by = LR_target.issued_at
 
 @applies_only_once
-def set_gr_must_start_after_from_lr0s(timeline: Timeline, swap_global_read_order: bool) -> None:
+def set_gr_must_start_after_from_lr0s(timeline: Timeline, swap_global_read_order: bool, dtl_plus_lds_buf: bool = False) -> None:
     """
-    Set the must_start_after field of the first GlobalRead based on the last LR0 of the same loop.
+    Set the must_start_after field of GlobalReads based on the last LR0 that shares their LDS block.
 
-    GRs in iteration N write (DDR->LDS) to the LDS that LR0s of iteration N read from (LDS->VGPR).
-    The first GRA must start after the last LRA0 of the same iteration is guaranteed done
-    (and vice versa for B). If SwapGlobalReadOrder is True, GRA loads B so the first GRA must
-    start after the last LRB0, and the first GRB must start after the last LRA0.
+    Standard case (dtl_plus_lds_buf=False):
+        GRs in iteration N write (DDR->LDS) to the same LDS block that LR0s of iteration N read from.
+        Each GR must start after the last same-iteration LR0 is guaranteed done.
+
+    DtlPlusLdsBuf case (dtl_plus_lds_buf=True):
+        GRs in iteration N write to a different LDS block than same-iteration LR0s read from,
+        so there is no same-iteration dependency. However, GRs in iteration N write to the LDS
+        block that LR0s from iteration N-1 were reading from, creating a cross-iteration dependency.
+        Each GR must start after the last previous-iteration LR0 is guaranteed done.
+
+    If SwapGlobalReadOrder is True, GRA loads B so the first GRA must start after the last LRB0,
+    and the first GRB must start after the last LRA0.
 
     The LR0's done_idx() is its guaranteed_by (set by apply_swaits), which is the SWaitCnt index.
 
     Args:
         timeline: The Timeline object containing the instructions.
         swap_global_read_order: Whether global read order is swapped.
+        dtl_plus_lds_buf: Whether DtlPlusLdsBuf is enabled (cross-iteration dependency).
     """
     target_names = {"GRA": "LRA0", "GRB": "LRB0"}
 
     if swap_global_read_order:
         target_names["GRA"], target_names["GRB"] = target_names["GRB"], target_names["GRA"]
 
-    for _, loop in enumerate(timeline.loops):
+    for i_loop, loop in enumerate(timeline.loops):
         for gr_name, lr0_name in target_names.items():
             grs = timeline.get_instructions(gr_name, loop)
             if not grs:
                 continue
 
-            lr0s = timeline.get_instructions(lr0_name, loop)
+            if dtl_plus_lds_buf:
+                # GRs write to a different LDS block than same-iteration LR0s.
+                # The dependency is against the previous iteration's LR0s instead.
+                if i_loop == 0:
+                    continue  # No previous iteration available (ML-1)
+                lr0s = timeline.get_instructions(lr0_name, timeline.loops[i_loop - 1])
+            else:
+                lr0s = timeline.get_instructions(lr0_name, loop)
+
             if not lr0s:
                 continue
 
-            # The last LR0 of the corresponding type in this loop.
-            _, last_lr0 = lr0s[-1]
+            # Pick the LR0 that finishes last (highest guaranteed_by)
+            last_lr0 = max((lr0 for _, lr0 in lr0s), key=lambda lr0: lr0.guaranteed_by)
             for _, gr in grs:
                 gr.must_start_after = last_lr0
 
@@ -2033,17 +2050,27 @@ def add_gr_not_too_early_constraints(timeline: Timeline, ctx: ValidatorPassConte
     """
     Ensure that GlobalReads are not issued before the corresponding LR0s are guaranteed complete.
 
-    Required ordering per operand:
-        last LR0 -> SWaitCnt (ensures LR0 done for wave) -> SBarrier (ensures LR0 done for workgroup) -> first GR
+    Standard case (DtlPlusLdsBuf=False):
+        Same-iteration dependency. GRs write to the same LDS block that LR0s read from.
+        Required ordering per operand:
+            last LR0 -> SWaitCnt -> SBarrier -> first GR (within same iteration)
+
+    DtlPlusLdsBuf case (DtlPlusLdsBuf=True):
+        Cross-iteration dependency. GRs write to a different LDS block than same-iteration LR0s,
+        but to the same block that previous-iteration LR0s were reading from.
+        Required ordering per operand:
+            last LR0 (iter N-1) -> SWaitCnt -> SBarrier -> first GR (iter N)
 
     GRA writes (DDR->LDS) to the LDS that LRA0 reads from (LDS->VGPR).
     We conservatively assume GRA always writes everywhere that a thread in the workgroup is reading from in LRA0.
     Thus we must ensure that every thread in every wave in the workgroup has finished all of its LRA0 instructions
     before GRA is issued. Same logic applies for B. No cross-operand constraints (LRA0 vs GRB are independent).
     """
+    dtl_plus_lds_buf = ctx.kernel.get("DtlPlusLdsBuf", False)
+
     # apply_swaits must run first so that LR0.guaranteed_by (done_idx) is set before must_start_after hookup.
     apply_swaits(timeline)
-    set_gr_must_start_after_from_lr0s(timeline, ctx.swap_global_read_order)
+    set_gr_must_start_after_from_lr0s(timeline, ctx.swap_global_read_order, dtl_plus_lds_buf)
     apply_must_start_after_barriers(timeline)
 
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
@@ -307,6 +307,7 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         GRB loads A -> must start after LRA0.
         """
         assert self.num_vmfma == 8
+        self.kernel["SwapGlobalReadOrder"] = True
         optSchedule = {
             "SYNC": [[1, 2, 5, 6]],
             "GRA": [[6, 7]],
@@ -320,7 +321,6 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
             SBarrier(comment=""),
         ]
-        self.kernel["SwapGlobalReadOrder"] = True
         self.validate(optSchedule, syncCode, 1, None, None, 0, None)
 
     def test_negative_swap_global_read_order(self):
@@ -330,6 +330,7 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
         GRA load at 3 is before LRB0 is guaranteed done (done at 5).
         """
         assert self.num_vmfma == 8
+        self.kernel["SwapGlobalReadOrder"] = True
         optSchedule = {
             "SYNC": [[1, 2, 5, 6]],
             "GRA": [[3, 3]],
@@ -343,7 +344,6 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
             SBarrier(comment=""),
         ]
-        self.kernel["SwapGlobalReadOrder"] = True
         self.validate(
             optSchedule, syncCode, 1, None, None, 0,
             "GRA (Swapped, loading B) @ idx=3 is issued too early. "
@@ -716,4 +716,174 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
             optSchedule, syncCode, 1, None, None, 0,
             "GRB @ idx=3 is issued too early. "
             "Must be issued after idx=-1 (of next iteration), which is when LRB0 is guaranteed done."
+        )
+
+
+class TestValidateGlobalReadsNotTooEarlyDtlPlusLdsBuf(CMSValidationTestBase):
+    """
+    Tests for DtlPlusLdsBuf=True support in add_gr_not_too_early_constraints.
+
+    With DtlPlusLdsBuf=True, GRs in iteration N write to a different LDS block than
+    same-iteration LR0s, so there is no same-iteration dependency. Instead, GRs depend
+    on the *previous* iteration's LR0s (cross-iteration dependency).
+    """
+    validator_passes = [add_gr_not_too_early_constraints]
+
+    def setUp(self):
+        super().setUp()
+        self.kernel["DtlPlusLdsBuf"] = True
+
+    def test_basic(self):
+        """
+        Same schedule as the standard test_basic. Should pass.
+        """
+        assert self.num_vmfma == 8
+        optSchedule = {
+            "LRA0": [[0]],
+            "LRB0": [[1]],
+            "SYNC": [[3, 3]],
+            "GRA": [[5, 5]],
+            "GRB": [[6, 6]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SBarrier(comment="")
+        ]
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+
+    def test_gr_before_same_iter_sync_safe(self):
+        """
+        GRA load at 2 is before the SWaitCnt at 3 in the same iteration.
+        Without DtlPlusLdsBuf this would fail (same-iteration LRA0's guaranteed_by=3 > GRA=2).
+        With DtlPlusLdsBuf, GRA depends on ML-1's LRA0, which is guaranteed by ML-1's
+        SWaitCnt at (loop=0, vmfma=3). GRA at (loop=1, vmfma=2) > (loop=0, vmfma=3).
+        ML-1's SBarrier at (loop=0, vmfma=4) provides the required barrier.
+        
+        Should pass.
+        """
+        assert self.num_vmfma == 8
+        optSchedule = {
+            "LRA0": [[0]],
+            "LRB0": [[1]],
+            "GRA": [[1, 2]],
+            "SYNC": [[3, 4]],
+            "GRB": [[6, 6]],
+        }
+        syncCode = [SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""), SBarrier(comment="")]
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+
+    def test_negative_prev_iter_lr0_not_guaranteed(self):
+        """
+        ML-1's LRA0 is at index 5, AFTER ML-1's SWaitCnt(dscnt=0) at index 3.
+        So ML-1's LRA0 is NOT guaranteed within ML-1. It's guaranteed by ML's SWaitCnt
+        at (loop=1, vmfma=3). ML's GRA at (loop=1, vmfma=2) < (loop=1, vmfma=3) -> too early.
+        """
+        assert self.num_vmfma == 8
+        optSchedule = {
+            "SYNC": [[3, 4]],
+            "LRA0": [[5]],
+            "LRB0": [[1]],
+            "GRA": [[2, 2]],
+            "GRB": [[6, 6]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SBarrier(comment="")
+        ]
+        self.validate(
+            optSchedule, syncCode, 1, None, None, 0,
+            "GRA @ idx=2 is issued too early. "
+            "Must be issued after idx=3, which is when LRA0 is guaranteed done."
+        )
+
+    def test_swap_global_read_order(self):
+        """
+        SwapGlobalReadOrder + DtlPlusLdsBuf: GRA depends on prev LRB0, GRB depends on prev LRA0.
+        Both are guaranteed within ML-1. Should pass.
+        """
+        assert self.num_vmfma == 8
+        self.kernel["SwapGlobalReadOrder"] = True
+        optSchedule = {
+            "SYNC": [[1,2, 5, 6]],
+            "GRA": [[6, 7]],
+            "LRA0": [[0]],
+            "GRB": [[2, 3]],
+            "LRB0": [[4]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SBarrier(comment=""),
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SBarrier(comment=""),
+        ]
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+
+    def test_negative_swap_global_read_order(self):
+        """
+        SwapGlobalReadOrder + DtlPlusLdsBuf: GRA depends on prev LRB0 (swapped).
+        ML-1's LRB0 is at index 5, AFTER ML-1's SWaitCnt at 3. So ML-1's LRB0
+        is guaranteed by ML's SWaitCnt at (loop=1, vmfma=3).
+        GRA at (loop=1, vmfma=2) < (loop=1, vmfma=3) -> too early.
+        """
+        assert self.num_vmfma == 8
+        self.kernel["SwapGlobalReadOrder"] = True
+        optSchedule = {
+            "LRA0": [[0]],
+            "LRB0": [[5]],
+            "SYNC": [[3, 4]],
+            "GRA": [[2, 2]],
+            "GRB": [[7, 7]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SBarrier(comment="")
+        ]
+        self.validate(
+            optSchedule, syncCode, 1, None, None, 0,
+            "GRA (Swapped, loading B) @ idx=2 is issued too early. "
+            "Must be issued after idx=3, which is when LRB0 is guaranteed done."
+        )
+
+    def test_multiple_lr0s(self):
+        """
+        Multiple LRA0s in previous iteration, all guaranteed by ML-1's SWaitCnt(dscnt=0).
+        max(guaranteed_by) selects the LR0 with the highest guaranteed_by. Both are at (0,3).
+        GRA at (1,5) > (0,3). Should pass.
+        """
+        assert self.num_vmfma == 8
+        optSchedule = {
+            "LRA0": [[0, 2]],
+            "LRB0": [[1]],
+            "SYNC": [[3, 4]],
+            "GRA": [[5, 5]],
+            "GRB": [[6, 6]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SBarrier(comment="")
+        ]
+        self.validate(optSchedule, syncCode, 1, None, None, 0, None)
+
+    def test_negative_multiple_lr0s_one_not_guaranteed(self):
+        """
+        Two LRA0s in previous iteration: one at 0 (guaranteed by ML-1's SWaitCnt at 3)
+        and one at 5 (NOT guaranteed within ML-1, guaranteed by ML's SWaitCnt at 3).
+        max(guaranteed_by) = (loop=1, vmfma=3). GRA at (1,2) < (1,3) -> too early.
+        """
+        assert self.num_vmfma == 8
+        optSchedule = {
+            "SYNC": [[3, 4]],
+            "LRA0": [[0, 5]],
+            "LRB0": [[1]],
+            "GRA": [[2, 2]],
+            "GRB": [[6, 6]],
+        }
+        syncCode = [
+            SWaitCnt(dscnt=0, vlcnt=-1, vscnt=-1, comment=""),
+            SBarrier(comment="")
+        ]
+        self.validate(
+            optSchedule, syncCode, 1, None, None, 0,
+            "GRA @ idx=2 is issued too early. "
+            "Must be issued after idx=3, which is when LRA0 is guaranteed done."
         )


### PR DESCRIPTION
## Motivation

Add support for running with new `DtlPlusLdsBuf` flag.

## Technical Details

There is no longer a dependency between the LR0 of this iteration the the GR of this iteration. Instead it is between the GR of this iteration and the LR0 of the previous iteration.

## Test Plan

Run existing tests.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
