### PR TITLE
Expand hipblaslt smoke test coverage

### DIFF
--- a/projects/hipblaslt/clients/tests/data/smoke_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/smoke_gtest.yaml
@@ -401,4 +401,281 @@ Tests:
   activation_type: [relu, sigmoid]
   unit_check: 1
   gpu_arch: '1[1-2]\d{2}'
+
+###################################
+# Additional Coverage Tests       #
+###################################
+
+# Swish activation
+- name: matmul_bias_swish_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 0
+  activation_type: swish
+  bias_vector: [0, 1]
+  unit_check: 0
+  norm_check: 1
+
+# Clamp activation
+- name: matmul_bias_clamp_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 0
+  activation_type: clamp
+  activation_arg1: -1.5
+  activation_arg2: 1.5
+  bias_vector: [0, 1]
+  unit_check: 0
+  norm_check: 1
+
+# Auxiliary output with GELU
+- name: matmul_gelu_aux_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 0
+  use_e: 1
+  activation_type: gelu
+  unit_check: 0
+  norm_check: 1
+
+# DGELU gradient
+- name: matmul_dgelu_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 0
+  use_e: 1
+  gradient: 1
+  activation_type: gelu
+  unit_check: 1
+  gpu_arch_exclude: '1[1-2]\d{2}'
+
+# Bias gradient (bgradb)
+- name: matmul_bgradb_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 0
+  gradient: 1
+  bias_vector: 1
+  bias_type: f32_r
+  bias_source: b
+  unit_check: 1
+  gpu_arch_exclude: '1[1-2]\d{2}'
+
+# Grouped GEMM
+- name: matmul_grouped_gemm_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  grouped_gemm: 2
+  alpha: 1
+  beta: 0
+  unit_check: 1
+  algo_method: 2
+  gpu_arch_exclude: '1[1-2]\d{2}'
+
+# Extended API
+- name: matmul_ext_api_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 0
+  use_ext: 1
+  use_ext_setproblem: 1
+  algo_method: 2
+  unit_check: 1
+
+# Algorithm method variants
+- name: matmul_algo_method_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 0
+  algo_method: [0, 1, 2]
+  unit_check: 1
+
+# FP16 with FP32 output
+- name: matmul_fp16_fp32dst_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_fp32dst_precision
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: 0
+  unit_check: 1
+
+# BF16 with FP32 output
+- name: matmul_bf16_fp32dst_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_bf16_fp32dst_precision
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: 0
+  unit_check: 1
+
+# AMAX D output scaling
+- name: matmul_amaxD_smoke
+  category: smoke
+  function:
+    matmul: *f8_fnuz_precision_dst_f8_fnuz
+  matrix_size: *smoke_matrix_size_range
+  transA: T
+  transB: N
+  alpha: 1
+  beta: 0
+  scaleA: 1
+  scaleB: 1
+  scaleD: 1
+  amaxD: 1
+  unit_check: 1
+  gpu_arch: '942'
+
+# Mixed precisions (FP8+FP16)
+- name: matmul_mix_fp8_fp16_smoke
+  category: smoke
+  function:
+    matmul: *fp8fp16_fnuz_precision_dst_fp16
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 0
+  unit_check: 1
+  gpu_arch: '942'
+
+# Batched operations
+- name: matmul_batched_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: 1
+  batch_count: 2
+  unit_check: 1
+
+# C equals D optimization
+- name: matmul_c_equal_d_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 1
+  c_equal_d: true
+  unit_check: 1
+
+# HMM (unified memory)
+- name: matmul_hmm_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  matrix_size: *smoke_matrix_size_range
+  transA: N
+  transB: N
+  alpha: 1
+  beta: 0
+  HMM: true
+  unit_check: 1
+
+###################################
+# Edge Cases                      #
+###################################
+
+# K=0 case
+- name: matmul_k0_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  M: 8
+  N: 8
+  K: 0
+  alpha: 1
+  beta: 1
+  transA: N
+  transB: N
+  unit_check: 1
+
+# M=1 case (vector-matrix)
+- name: matmul_m1_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  M: 1
+  N: 32
+  K: 32
+  alpha: 1
+  beta: 0
+  transA: N
+  transB: N
+  unit_check: 1
+
+# N=1 case (matrix-vector)
+- name: matmul_n1_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  M: 32
+  N: 1
+  K: 32
+  alpha: 1
+  beta: 0
+  transA: N
+  transB: N
+  unit_check: 1
+
+# Non-aligned sizes
+- name: matmul_non_aligned_smoke
+  category: smoke
+  function:
+    matmul: *hpa_half_precision
+  M: 17
+  N: 19
+  K: 23
+  alpha: 1
+  beta: 0
+  transA_transB: *transA_transB_range
+  unit_check: 1
+
 ...


### PR DESCRIPTION
This PR expands the `smoke_gtest.yaml` test configuration to provide comprehensive minimum coverage for hipblaslt matmul functionality. The additional tests enable first-pass validation on new architectures and FFM/emulators.

### Changes

Added 19 new test cases to `hipblaslt/clients/tests/data/smoke_gtest.yaml`:

__Activation Functions:__

- `matmul_bias_swish_smoke` - Swish activation
- `matmul_bias_clamp_smoke` - Clamp activation with configurable bounds

__Auxiliary & Gradient Operations:__

- `matmul_gelu_aux_smoke` - GELU with auxiliary output (use_e)
- `matmul_dgelu_smoke` - DGELU gradient computation
- `matmul_bgradb_smoke` - Bias gradient backpropagation

__API & Algorithm Coverage:__

- `matmul_grouped_gemm_smoke` - Grouped GEMM operations
- `matmul_ext_api_smoke` - Extended API (use_ext, use_ext_setproblem)
- `matmul_algo_method_smoke` - Algorithm method variants (0, 1, 2)

__Precision Variants:__

- `matmul_fp16_fp32dst_smoke` - FP16 input with FP32 output
- `matmul_bf16_fp32dst_smoke` - BF16 input with FP32 output
- `matmul_amaxD_smoke` - AMAX D output scaling (GFX942)
- `matmul_mix_fp8_fp16_smoke` - Mixed FP8+FP16 precisions (GFX942)

__Operational Modes:__

- `matmul_batched_smoke` - Batched operations (batch_count=2)
- `matmul_c_equal_d_smoke` - C equals D in-place optimization
- `matmul_hmm_smoke` - HMM unified memory

__Edge Cases:__

- `matmul_k0_smoke` - K=0 dimension
- `matmul_m1_smoke` - M=1 (vector-matrix multiplication)
- `matmul_n1_smoke` - N=1 (matrix-vector multiplication)
- `matmul_non_aligned_smoke` - Non-aligned matrix sizes (17x19x23)
