### PR TITLE
[{roc,hip}fft-test] Avoid underflows and reserve at least half of the system's memory for host allocations on APUs

### DIFF
--- a/projects/hipfft/clients/tests/gtest_main.cpp
+++ b/projects/hipfft/clients/tests/gtest_main.cpp
@@ -634,9 +634,12 @@ int main(int argc, char* argv[])
     fftwf_plan_with_nthreads(rocfft_concurrency());
 #endif
 
-    // Set host memory limit from command-line options
-    host_memory::singleton().set_limit_gbytes(ramgb);
-    std::cout << "Host memory limit: " << ramgb << " GiB" << std::endl;
+    // Set host memory limit from command-line options (if more restrictive)
+    const auto usable_bytes = host_memory::singleton().get_usable_bytes();
+    if(ramgb * ONE_GiB < usable_bytes)
+        host_memory::singleton().set_limit_gbytes(ramgb);
+    std::cout << "Usable host memory: " << bytes_to_GiB(host_memory::singleton().get_usable_bytes())
+              << " GiB" << std::endl;
 
     if(use_fftw_wisdom)
     {

--- a/projects/hipfft/shared/sys_mem.h
+++ b/projects/hipfft/shared/sys_mem.h
@@ -171,11 +171,10 @@ private:
             // for "host" things.
             if(deviceProp.integrated)
             {
-                total_bytes -= deviceProp.totalGlobalMem;
-                if(free_bytes < deviceProp.totalGlobalMem)
-                    free_bytes = 0;
-                else
-                    free_bytes -= deviceProp.totalGlobalMem;
+                const auto dedicated_for_device_allocs
+                    = std::min(deviceProp.totalGlobalMem, std::min(free_bytes, total_bytes) / 2);
+                total_bytes -= dedicated_for_device_allocs;
+                free_bytes -= dedicated_for_device_allocs;
             }
         }
         catch(std::runtime_error&)

--- a/projects/rocfft/clients/tests/gtest_main.cpp
+++ b/projects/rocfft/clients/tests/gtest_main.cpp
@@ -648,9 +648,12 @@ int main(int argc, char* argv[])
     fftwf_plan_with_nthreads(rocfft_concurrency());
 #endif
 
-    // Set host memory limit from command-line options
-    host_memory::singleton().set_limit_gbytes(ramgb);
-    std::cout << "Host memory limit: " << ramgb << " GiB" << std::endl;
+    // Set host memory limit from command-line options (if more restrictive)
+    const auto usable_bytes = host_memory::singleton().get_usable_bytes();
+    if(ramgb * ONE_GiB < usable_bytes)
+        host_memory::singleton().set_limit_gbytes(ramgb);
+    std::cout << "Usable host memory: " << bytes_to_GiB(host_memory::singleton().get_usable_bytes())
+              << " GiB" << std::endl;
 
     if(use_fftw_wisdom)
     {

--- a/projects/rocfft/shared/sys_mem.h
+++ b/projects/rocfft/shared/sys_mem.h
@@ -171,11 +171,10 @@ private:
             // for "host" things.
             if(deviceProp.integrated)
             {
-                total_bytes -= deviceProp.totalGlobalMem;
-                if(free_bytes < deviceProp.totalGlobalMem)
-                    free_bytes = 0;
-                else
-                    free_bytes -= deviceProp.totalGlobalMem;
+                const auto dedicated_for_device_allocs
+                    = std::min(deviceProp.totalGlobalMem, std::min(free_bytes, total_bytes) / 2);
+                total_bytes -= dedicated_for_device_allocs;
+                free_bytes -= dedicated_for_device_allocs;
             }
         }
         catch(std::runtime_error&)


### PR DESCRIPTION
## Motivation

`rocfft-test` and `hipfft-test` may attempt to reserve a larger-than-expected portion of system memory for device allocations on APUs, at initialization. This may result in very small amounts of seemingly usable memory left for host allocations thereafter, and many/most tests being skipped as a result.

## Technical Details

- The suggestion caps the portion of system memory reserved for device allocations to roughly half the available system memory (at most) on APUs.
- The user-defined host memory limit is accounted for only if found more restrictive than the system's own limits.

## Test Plan

The current test base was executed on an APU system, manually.

## Test Result

Far fewer tests were skipped and tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
