### PR TITLE
[miopen] [CI] Fix nightly builds

### DIFF
--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -116,7 +116,7 @@ def runDbSyncJob(def flags, def gpu_family)
     }
 }
 
-def runBuildAndSingleGtestJob(def flags, def build_timeout_minutes=420, def gpu_family)
+def runBuildAndSingleGtestJob(Map conf=[:])
 {
     script {
         withWorkingDir {

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -464,7 +464,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx90a") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + Bf16_flags + gfx90a_flags, Build_timeout_minutes, gpu_family="gfx90X")
+                        runBuildAndSingleGtestJob(flags: Full_test + Bf16_flags + gfx90a_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx90X")
                     }
                     post {
                         always {
@@ -482,7 +482,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx90a") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + Fp16_flags + gfx90a_flags, Build_timeout_minutes, gpu_family="gfx90X")
+                        runBuildAndSingleGtestJob(flags: Full_test + Fp16_flags + gfx90a_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx90X")
                     }
                     post {
                         always {
@@ -500,7 +500,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx90a") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + gfx90a_flags, Build_timeout_minutes, gpu_family="gfx90X")
+                        runBuildAndSingleGtestJob(flags: Full_test + gfx90a_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx90X")
                     }
                     post {
                         always {
@@ -537,7 +537,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx942") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + Bf16_flags + gfx942_flags, Build_timeout_minutes, gpu_family="gfx942")
+                        runBuildAndSingleGtestJob(flags: Full_test + Bf16_flags + gfx942_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx942")
                     }
                 }               
                 stage('Fp16 Hip Install All gfx942') {
@@ -550,7 +550,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx942") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + Fp16_flags + gfx942_flags, Build_timeout_minutes, gpu_family="gfx942")
+                        runBuildAndSingleGtestJob(flags: Full_test + Fp16_flags + gfx942_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx942")
                     }
                     post {
                         always {
@@ -568,7 +568,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx942") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + gfx942_flags, Build_timeout_minutes, gpu_family="gfx942")
+                        runBuildAndSingleGtestJob(flags: Full_test + gfx942_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx942")
                     }
                     post {
                         always {
@@ -586,7 +586,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx942") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + Tf32_flags + gfx942_flags, Build_timeout_minutes, gpu_family="gfx942")
+                        runBuildAndSingleGtestJob(flags: Full_test + Tf32_flags + gfx942_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx942")
                     }
                     post {
                         always {
@@ -605,7 +605,7 @@ pipeline {
                     }
                     agent{ label rocmnode("navi32") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + Fp16_flags + gfx1101_flags, Build_timeout_minutes, gpu_family="navi")
+                        runBuildAndSingleGtestJob(flags: Full_test + Fp16_flags + gfx1101_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "navi")
                     }
                 }                
                 stage('Fp32 Hip Install All gfx1101') {
@@ -618,7 +618,7 @@ pipeline {
                     }
                     agent{ label rocmnode("navi32") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + gfx1101_flags, Build_timeout_minutes, gpu_family="navi")
+                        runBuildAndSingleGtestJob(flags: Full_test + gfx1101_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "navi")
                     }
                 }
             }
@@ -671,7 +671,7 @@ pipeline {
                     steps{
                         script {
                             withWorkingDir {
-                                utils.buildHipClangJob( build_type: 'debug', setup_flags: NOMLIR_flags + gfx90a_flags, build_cmd: NOMLIR_build_cmd, test_flags: ' --verbose ', build_install: true, gpu_family="gfx90X")
+                                utils.buildHipClangJob( build_type: 'debug', setup_flags: NOMLIR_flags + gfx90a_flags, build_cmd: NOMLIR_build_cmd, test_flags: ' --verbose ', build_install: true, gpu_family: "gfx90X")
                             }
                         }
                     }
@@ -693,7 +693,7 @@ pipeline {
                     steps{
                         script {
                             withWorkingDir {
-                                utils.buildHipClangJob( build_type: 'debug', setup_flags: "-DMIOPEN_USE_COMPOSABLEKERNEL=Off" + gfx90a_flags, make_targets: "", build_install: true, gpu_family="gfx90X")
+                                utils.buildHipClangJob( build_type: 'debug', setup_flags: "-DMIOPEN_USE_COMPOSABLEKERNEL=Off" + gfx90a_flags, make_targets: "", build_install: true, gpu_family: "gfx90X")
                             }
                         }
                     }
@@ -715,7 +715,7 @@ pipeline {
                     steps{
                         script {
                             withWorkingDir {
-                                utils.buildHipClangJob( setup_flags: "-DBUILD_SHARED_LIBS=Off" + gfx90a_flags, mlir_build: 'OFF', build_install: true, gpu_family="gfx90X")
+                                utils.buildHipClangJob( setup_flags: "-DBUILD_SHARED_LIBS=Off" + gfx90a_flags, mlir_build: 'OFF', build_install: true, gpu_family: "gfx90X")
                             }
                         }
                     }
@@ -741,7 +741,7 @@ pipeline {
                     steps{
                         script {
                             withWorkingDir {
-                                utils.buildHipClangJob(setup_flags: gfx90a_flags, make_targets: make_targets, execute_cmd: execute_cmd, find_mode: "Normal", build_install: true, gpu_family="gfx90X")
+                                utils.buildHipClangJob(setup_flags: gfx90a_flags, make_targets: make_targets, execute_cmd: execute_cmd, find_mode: "Normal", build_install: true, gpu_family: "gfx90X")
                             }
                         }
                     }
@@ -767,7 +767,7 @@ pipeline {
                     steps{
                         script {
                             withWorkingDir {
-                                utils.buildHipClangJob(setup_flags: gfx90a_flags, make_targets: make_targets, execute_cmd: execute_cmd, build_install: true, gpu_family="gfx90X")
+                                utils.buildHipClangJob(setup_flags: gfx90a_flags, make_targets: make_targets, execute_cmd: execute_cmd, build_install: true, gpu_family: "gfx90X")
                             }
                         }
                     }
@@ -789,7 +789,7 @@ pipeline {
                     steps{
                         script {
                             withWorkingDir {
-                                utils.buildHipClangJob(make_targets: Smoke_targets, setup_flags: "-DMIOPEN_USE_SQLITE_PERF_DB=On" + gfx90a_flags, build_install: true, gpu_family="gfx90X")
+                                utils.buildHipClangJob(make_targets: Smoke_targets, setup_flags: "-DMIOPEN_USE_SQLITE_PERF_DB=On" + gfx90a_flags, build_install: true, gpu_family: "gfx90X")
                             }
                         }
                     }
@@ -814,7 +814,7 @@ pipeline {
                                 utils.buildHipClangJob(setup_flags: "-DMIOPEN_ENABLE_FIN_INTERFACE=On" + gfx90a_flags,
                                                             make_targets: "test_unit_FinInterface",
                                                             execute_cmd: "bin/test_unit_FinInterface",
-                                                            gpu_family="gfx90X")
+                                                            gpu_family: "gfx90X")
                             }
                         }
                     }
@@ -836,7 +836,7 @@ pipeline {
                     steps{
                         script {
                             withWorkingDir {
-                                utils.buildHipClangJob(setup_flags: gfx90a_flags, build_type: 'debug', make_targets: Smoke_targets, build_install: true, gpu_family="gfx90X")
+                                utils.buildHipClangJob(setup_flags: gfx90a_flags, build_type: 'debug', make_targets: Smoke_targets, build_install: true, gpu_family: "gfx90X")
                             }
                         }
                     }
@@ -859,7 +859,7 @@ pipeline {
                     steps{
                         script {
                             withWorkingDir {
-                                utils.buildHipClangJob(setup_flags: gfx942_flags, build_type: 'debug', make_targets: Smoke_targets, build_install: true, gpu_family="gfx942")
+                                utils.buildHipClangJob(setup_flags: gfx942_flags, build_type: 'debug', make_targets: Smoke_targets, build_install: true, gpu_family: "gfx942")
                             }
                         }
                     }
@@ -921,7 +921,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + Bf16_flags + gfx908_flags, Build_timeout_minutes, gpu_family="gfx90X")
+                        runBuildAndSingleGtestJob(flags: Full_test + Bf16_flags + gfx908_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx90X")
                     }
                     post {
                         always {
@@ -939,7 +939,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + Fp16_flags + gfx908_flags, Build_timeout_minutes, gpu_family="gfx90X")
+                        runBuildAndSingleGtestJob(flags: Full_test + Fp16_flags + gfx908_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx90X")
                     }
                     post {
                         always {
@@ -957,7 +957,7 @@ pipeline {
                     }
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        runBuildAndSingleGtestJob(Full_test + gfx908_flags, Build_timeout_minutes, gpu_family="gfx90X")
+                        runBuildAndSingleGtestJob(flags: Full_test + gfx908_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "gfx90X")
                     }
                     post {
                         always {
@@ -977,7 +977,7 @@ pipeline {
                     steps{
                         script {
                             withWorkingDir {
-                                utils.buildHipClangJob(setup_flags: gfx908_flags, build_type: 'debug', make_targets: Smoke_targets, build_install: true, gpu_family="gfx90X")
+                                utils.buildHipClangJob(setup_flags: gfx908_flags, build_type: 'debug', make_targets: Smoke_targets, build_install: true, gpu_family: "gfx90X")
                             }
                         }
                     }
@@ -1001,7 +1001,7 @@ pipeline {
                         gfx115x_filter_flags = " -DMIOPEN_TEST_GFX115X=On "
                     }
                     steps{
-                        runBuildAndSingleGtestJob(gfx115x_filter_flags + Full_test + Bf16_flags + gfx1151_flags, Build_timeout_minutes, gpu_family: "navi")
+                        runBuildAndSingleGtestJob(flags: gfx115x_filter_flags + Full_test + Bf16_flags + gfx1151_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "navi")
                     }
                     post {
                         always {
@@ -1023,7 +1023,7 @@ pipeline {
                         build_timeout_minutes = 420
                     }
                     steps{
-                        runBuildAndSingleGtestJob(gfx115x_filter_flags + Full_test + Fp16_flags + gfx1151_flags, Build_timeout_minutes, gpu_family: "navi")
+                        runBuildAndSingleGtestJob(flags: gfx115x_filter_flags + Full_test + Fp16_flags + gfx1151_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "navi")
                     }
                     post {
                         always {
@@ -1045,7 +1045,7 @@ pipeline {
                         build_timeout_minutes = 420
                     }
                     steps{
-                        runBuildAndSingleGtestJob(gfx115x_filter_flags + Full_test + gfx1151_flags, Build_timeout_minutes, gpu_family: "navi")
+                        runBuildAndSingleGtestJob(flags: gfx115x_filter_flags + Full_test + gfx1151_flags, build_timeout_minutes: Build_timeout_minutes, gpu_family: "navi")
                     }
                     post {
                         always {

--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -118,6 +118,10 @@ def runDbSyncJob(def flags, def gpu_family)
 
 def runBuildAndSingleGtestJob(Map conf=[:])
 {
+    def flags = conf.get('flags', '')
+    def build_timeout_minutes = (conf.get('build_timeout_minutes', 420) as Integer)
+    def gpu_family = conf.get('gpu_family', null)
+
     script {
         withWorkingDir {
             def single_gtest_flags = " -DMIOPEN_TEST_DISCRETE=OFF -DGTEST_PARALLEL_LEVEL=4 "


### PR DESCRIPTION
This pull request refactors how arguments are passed to the `runBuildAndSingleGtestJob` and `utils.buildHipClangJob` functions in the `projects/miopen/Jenkinsfile`. The main improvement is switching from positional arguments to named arguments for better clarity and maintainability. Additionally, it ensures consistent quoting for string arguments.

Key refactoring changes:

**Argument Passing Improvements:**
- Updated all calls to `runBuildAndSingleGtestJob` to use named arguments (`flags`, `build_timeout_minutes`, `gpu_family`) instead of positional arguments, improving readability and reducing the risk of errors from argument order mismatches. [[1]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L467-R467) [[2]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L485-R485) [[3]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L503-R503) [[4]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L540-R540) [[5]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L553-R553) [[6]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L571-R571) [[7]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L589-R589) [[8]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L608-R608) [[9]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L621-R621) [[10]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L924-R924) [[11]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L942-R942) [[12]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L960-R960) [[13]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L1004-R1004) [[14]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L1026-R1026) [[15]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L1048-R1048)

**Consistency and Quoting:**
- Standardized the `gpu_family` argument in both `runBuildAndSingleGtestJob` and `utils.buildHipClangJob` calls to always be passed as a named argument with consistent quoting. [[1]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L674-R674) [[2]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L696-R696) [[3]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L718-R718) [[4]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L744-R744) [[5]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L770-R770) [[6]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L792-R792) [[7]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L817-R817) [[8]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L839-R839) [[9]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L862-R862) [[10]](diffhunk://#diff-631d33d84e23e32d9d0ac8c4aac704112e6237e970544e34735e83f7459ea344L980-R980)

These changes make the Jenkins pipeline script easier to read, maintain, and less error-prone.
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.