### PR TITLE
[hipDNN] Add experimental auto-tuning support for execution plans

### DIFF
--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -122,6 +122,11 @@ private:
     std::unique_ptr<detail::ScopedHipdnnBackendDescriptor> _engineConfigDesc;
     std::unique_ptr<detail::ScopedHipdnnBackendDescriptor> _executionPlanDesc;
 
+    // Multi-plan support for autotuning
+    std::vector<std::unique_ptr<detail::ScopedHipdnnBackendDescriptor>> _executionPlanDescs;
+    std::vector<std::unique_ptr<detail::ScopedHipdnnBackendDescriptor>> _engineConfigDescs;
+    std::vector<int64_t> _candidateEngineIds;
+
     std::optional<int64_t> _preferredEngineId;
 
     static std::optional<int64_t> getDefaultEngineId()
@@ -1210,6 +1215,321 @@ public:
             "Failed to finalize execution plan descriptor");
 
         return {ErrorCode::OK, ""};
+    }
+
+    /**
+     * @brief Build execution plans for all available engines or use heuristics
+     * @param policy When ALL, builds plans for all available engines.
+     *               When HEURISTICS_CHOICE, delegates to build_plans().
+     * @return Error indicating success or failure
+     *
+     * When using BuildPlanPolicy::ALL, this method iterates over all engines
+     * returned by get_ranked_engine_ids(), attempts to build an engine config
+     * and execution plan for each, and stores successfully-built plans in the
+     * internal vectors. Plans that fail to build are logged and skipped.
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error build_plans(BuildPlanPolicy policy)
+    {
+        if(policy != BuildPlanPolicy::ALL)
+        {
+            return build_plans();
+        }
+
+        HIPDNN_FE_LOG_INFO("Building ALL plans for graph " << graph_attributes.get_name());
+
+        if(!_graphDesc || !_graphDesc->valid())
+        {
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
+                    "Graph has not been built, build the operation graph first. Cannot build "
+                    "all plans."};
+        }
+
+        // Get all ranked engine IDs
+        std::vector<int64_t> rankedEngineIds;
+        HIPDNN_CHECK_ERROR(get_ranked_engine_ids(rankedEngineIds));
+
+        // Clear any previously built multi-plan state
+        _executionPlanDescs.clear();
+        _engineConfigDescs.clear();
+        _candidateEngineIds.clear();
+
+        for(auto engineId : rankedEngineIds)
+        {
+            // Try to initialize engine config for this engine
+            auto configError = initializeEngineConfig(engineId);
+            if(configError.is_bad())
+            {
+                HIPDNN_FE_LOG_WARN("Failed to initialize engine config for engine "
+                                   << hipdnn_data_sdk::utilities::getEngineNameFromId(engineId)
+                                   << " (id=" << engineId << "): " << configError.get_message());
+                continue;
+            }
+
+            // Finalize the engine config
+            auto finalizeStatus
+                = detail::hipdnnBackend()->backendFinalize(_engineConfigDesc->get());
+            if(finalizeStatus != HIPDNN_STATUS_SUCCESS)
+            {
+                HIPDNN_FE_LOG_WARN("Failed to finalize engine config for engine "
+                                   << hipdnn_data_sdk::utilities::getEngineNameFromId(engineId)
+                                   << " (id=" << engineId << ")");
+                continue;
+            }
+
+            // Create execution plan descriptor
+            auto planDesc = std::make_unique<detail::ScopedHipdnnBackendDescriptor>(
+                HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR);
+
+            if(!planDesc || !planDesc->valid())
+            {
+                HIPDNN_FE_LOG_WARN("Failed to create execution plan descriptor for engine "
+                                   << hipdnn_data_sdk::utilities::getEngineNameFromId(engineId)
+                                   << " (id=" << engineId << ")");
+                continue;
+            }
+
+            // Set engine config on execution plan
+            auto setStatus = detail::hipdnnBackend()->backendSetAttribute(
+                planDesc->get(),
+                HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                1,
+                &_engineConfigDesc->get());
+            if(setStatus != HIPDNN_STATUS_SUCCESS)
+            {
+                HIPDNN_FE_LOG_WARN("Failed to set engine config on execution plan for engine "
+                                   << hipdnn_data_sdk::utilities::getEngineNameFromId(engineId)
+                                   << " (id=" << engineId << ")");
+                continue;
+            }
+
+            // Finalize execution plan
+            auto planFinalizeStatus
+                = detail::hipdnnBackend()->backendFinalize(planDesc->get());
+            if(planFinalizeStatus != HIPDNN_STATUS_SUCCESS)
+            {
+                HIPDNN_FE_LOG_WARN("Failed to finalize execution plan for engine "
+                                   << hipdnn_data_sdk::utilities::getEngineNameFromId(engineId)
+                                   << " (id=" << engineId << ")");
+                continue;
+            }
+
+            // Successfully built this plan - store it
+            _executionPlanDescs.push_back(std::move(planDesc));
+            _engineConfigDescs.push_back(std::move(_engineConfigDesc));
+            _candidateEngineIds.push_back(engineId);
+
+            HIPDNN_FE_LOG_INFO("Successfully built plan for engine "
+                               << hipdnn_data_sdk::utilities::getEngineNameFromId(engineId)
+                               << " (id=" << engineId << ")");
+        }
+
+        if(_executionPlanDescs.empty())
+        {
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
+                    "Failed to build any execution plans for the graph."};
+        }
+
+        HIPDNN_FE_LOG_INFO("Built " << _executionPlanDescs.size() << " execution plan(s) for graph "
+                                    << graph_attributes.get_name());
+
+        return {ErrorCode::OK, ""};
+    }
+
+    /**
+     * @brief Get the number of execution plans built via build_plans(ALL)
+     * @return The number of available execution plans
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    int64_t get_execution_plan_count() const
+    {
+        return static_cast<int64_t>(_executionPlanDescs.size());
+    }
+
+    /**
+     * @brief Get workspace size for a specific execution plan by index
+     * @param index The index of the plan (0-based)
+     * @return The workspace size in bytes, or -1 on error
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    int64_t get_workspace_size_plan_at_index(int64_t index) const
+    {
+        if(index < 0 || index >= static_cast<int64_t>(_executionPlanDescs.size()))
+        {
+            HIPDNN_FE_LOG_ERROR("Plan index " << index << " out of range [0, "
+                                              << _executionPlanDescs.size() << ")");
+            return -1;
+        }
+
+        int64_t workspaceSize = 0;
+        auto status = detail::hipdnnBackend()->backendGetAttribute(
+            _executionPlanDescs[static_cast<size_t>(index)]->get(),
+            HIPDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE,
+            HIPDNN_TYPE_INT64,
+            1,
+            nullptr,
+            &workspaceSize);
+
+        if(status != HIPDNN_STATUS_SUCCESS)
+        {
+            HIPDNN_FE_LOG_ERROR("Failed to get workspace size for plan at index " << index);
+            return -1;
+        }
+
+        return workspaceSize;
+    }
+
+    /**
+     * @brief Execute a specific plan by index
+     * @param handle The hipDNN handle
+     * @param variantPack Map from tensor UID to device memory pointers
+     * @param workspace Pointer to workspace memory
+     * @param index The index of the plan to execute
+     * @return Error indicating success or failure
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error execute_plan_at_index(hipdnnHandle_t handle,
+                                std::unordered_map<int64_t, void*>& variantPack,
+                                void* workspace,
+                                int64_t index) const
+    {
+        HIPDNN_RETURN_IF_GE(index,
+                            static_cast<int64_t>(_executionPlanDescs.size()),
+                            ErrorCode::INVALID_VALUE,
+                            "Plan index out of range.");
+
+        auto variantPackDesc = std::make_unique<detail::ScopedHipdnnBackendDescriptor>(
+            HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR);
+        if(!variantPackDesc || !variantPackDesc->valid())
+        {
+            return {ErrorCode::HIPDNN_BACKEND_ERROR, "Failed to create variant pack descriptor."};
+        }
+
+        std::vector<int64_t> variantPackKeys;
+        std::vector<void*> variantPackValues;
+        variantPackKeys.reserve(variantPack.size());
+        variantPackValues.reserve(variantPack.size());
+        for(const auto& [key, value] : variantPack)
+        {
+            variantPackKeys.push_back(key);
+            variantPackValues.push_back(value);
+        }
+
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(detail::hipdnnBackend()->backendSetAttribute(
+                                             variantPackDesc->get(),
+                                             HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                             HIPDNN_TYPE_VOID_PTR,
+                                             static_cast<int64_t>(variantPackValues.size()),
+                                             variantPackValues.data()),
+                                         "failed to set the variant pack data pointers.");
+
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(detail::hipdnnBackend()->backendSetAttribute(
+                                             variantPackDesc->get(),
+                                             HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+                                             HIPDNN_TYPE_INT64,
+                                             static_cast<int64_t>(variantPackKeys.size()),
+                                             variantPackKeys.data()),
+                                         "failed to set the variant pack unique ids.");
+
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(
+            detail::hipdnnBackend()->backendSetAttribute(variantPackDesc->get(),
+                                                         HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                                                         HIPDNN_TYPE_VOID_PTR,
+                                                         1,
+                                                         &workspace),
+            "failed to set the variant pack workspace.");
+
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(
+            detail::hipdnnBackend()->backendFinalize(variantPackDesc->get()),
+            "Failed to finalize variant pack descriptor");
+
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(
+            detail::hipdnnBackend()->backendExecute(
+                handle,
+                _executionPlanDescs[static_cast<size_t>(index)]->get(),
+                variantPackDesc->get()),
+            "Execute failed for plan at index " + std::to_string(index) + ".");
+
+        return {ErrorCode::OK, ""};
+    }
+
+    /**
+     * @brief Get the engine name for a specific plan by index
+     * @param index The index of the plan
+     * @param name Output parameter for the engine name
+     * @return Error indicating success or failure
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error get_plan_name_at_index(int64_t index, std::string& name) const
+    {
+        HIPDNN_RETURN_IF_GE(index,
+                            static_cast<int64_t>(_candidateEngineIds.size()),
+                            ErrorCode::INVALID_VALUE,
+                            "Plan index out of range.");
+
+        auto engineId = _candidateEngineIds[static_cast<size_t>(index)];
+        name = std::string(hipdnn_data_sdk::utilities::getEngineNameFromId(engineId));
+
+        return {ErrorCode::OK, ""};
+    }
+
+    /**
+     * @brief Select a specific plan by index as the active plan for subsequent execute() calls
+     * @param index The index of the plan to select
+     * @return Error indicating success or failure
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error select_plan(int64_t index)
+    {
+        HIPDNN_RETURN_IF_GE(index,
+                            static_cast<int64_t>(_executionPlanDescs.size()),
+                            ErrorCode::INVALID_VALUE,
+                            "Plan index out of range.");
+
+        auto idx = static_cast<size_t>(index);
+
+        // Move the selected plan's descriptors to the active single-plan members
+        _executionPlanDesc = std::make_unique<detail::ScopedHipdnnBackendDescriptor>(
+            std::move(*_executionPlanDescs[idx]));
+        _engineConfigDesc = std::make_unique<detail::ScopedHipdnnBackendDescriptor>(
+            std::move(*_engineConfigDescs[idx]));
+
+        HIPDNN_FE_LOG_INFO("Selected plan at index "
+                           << index << " (engine "
+                           << hipdnn_data_sdk::utilities::getEngineNameFromId(
+                                  _candidateEngineIds[idx])
+                           << ") as active plan.");
+
+        return {ErrorCode::OK, ""};
+    }
+
+    /**
+     * @brief Build (activate) a specific plan by index for subsequent execute() calls
+     * @param index The index of the plan to activate
+     * @return Error indicating success or failure
+     *
+     * This is an alias for select_plan() for API compatibility.
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error build_plan_at_index(int64_t index)
+    {
+        return select_plan(index);
+    }
+
+    /**
+     * @brief Get the engine ID for a candidate plan at a given index
+     * @param index The index of the candidate plan
+     * @return The engine ID, or -1 if index is out of range
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    int64_t get_candidate_engine_id(int64_t index) const
+    {
+        if(index < 0 || index >= static_cast<int64_t>(_candidateEngineIds.size()))
+        {
+            return -1;
+        }
+        return _candidateEngineIds[static_cast<size_t>(index)];
     }
 
     /**

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -62,6 +62,11 @@
 
 #pragma once
 
+#include <algorithm>
+#include <limits>
+
+#include <hip/hip_runtime.h>
+
 #include <HipdnnBackendFlatbufferData.h>
 #include <hipdnn_backend.h>
 #include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
@@ -1305,8 +1310,7 @@ public:
             }
 
             // Finalize execution plan
-            auto planFinalizeStatus
-                = detail::hipdnnBackend()->backendFinalize(planDesc->get());
+            auto planFinalizeStatus = detail::hipdnnBackend()->backendFinalize(planDesc->get());
             if(planFinalizeStatus != HIPDNN_STATUS_SUCCESS)
             {
                 HIPDNN_FE_LOG_WARN("Failed to finalize execution plan for engine "
@@ -1452,12 +1456,12 @@ public:
             detail::hipdnnBackend()->backendFinalize(variantPackDesc->get()),
             "Failed to finalize variant pack descriptor");
 
-        HIPDNN_RETURN_ON_BACKEND_FAILURE(
-            detail::hipdnnBackend()->backendExecute(
-                handle,
-                _executionPlanDescs[static_cast<size_t>(index)]->get(),
-                variantPackDesc->get()),
-            "Execute failed for plan at index " + std::to_string(index) + ".");
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(detail::hipdnnBackend()->backendExecute(
+                                             handle,
+                                             _executionPlanDescs[static_cast<size_t>(index)]->get(),
+                                             variantPackDesc->get()),
+                                         "Execute failed for plan at index " + std::to_string(index)
+                                             + ".");
 
         return {ErrorCode::OK, ""};
     }
@@ -1522,11 +1526,11 @@ public:
             std::move(*_engineConfigDescs[idx]));
         _engineConfigDescs[idx] = nullptr;
 
-        HIPDNN_FE_LOG_INFO("Selected plan at index "
-                           << index << " (engine "
-                           << hipdnn_data_sdk::utilities::getEngineNameFromId(
-                                  _candidateEngineIds[idx])
-                           << ") as active plan.");
+        HIPDNN_FE_LOG_INFO(
+            "Selected plan at index "
+            << index << " (engine "
+            << hipdnn_data_sdk::utilities::getEngineNameFromId(_candidateEngineIds[idx])
+            << ") as active plan.");
 
         return {ErrorCode::OK, ""};
     }
@@ -2207,6 +2211,220 @@ public:
 
         return newTensor;
     }
+
+    /**
+     * @brief Get the maximum workspace size across all built candidate plans
+     * @return The maximum workspace size in bytes, or 0 if no plans are built
+     *
+     * Iterates over all plans built via build_plans(ALL) and returns the
+     * largest workspace size. Useful for allocating a single workspace buffer
+     * that works for any plan during autotuning.
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    int64_t get_max_workspace_size() const
+    {
+        int64_t maxSize = 0;
+        for(int64_t i = 0; i < static_cast<int64_t>(_executionPlanDescs.size()); ++i)
+        {
+            maxSize = std::max(maxSize, get_workspace_size_plan_at_index(i));
+        }
+        return maxSize;
+    }
+
+    /**
+     * @brief Benchmark all built candidate plans and return sorted results
+     * @param handle The hipDNN handle
+     * @param variantPack Map from tensor UID to device memory pointers
+     * @param workspace Pointer to workspace memory (must be >= get_max_workspace_size())
+     * @param results Output vector of AutotuneResult, sorted by avgTimeMs ascending
+     * @param config Benchmark configuration (warmup/timed iteration counts)
+     * @return Error indicating success or failure
+     *
+     * Requires build_plans(BuildPlanPolicy::ALL) to have been called first.
+     * For each plan: runs warmup iterations, then timed iterations using HIP events.
+     * Plans that fail during warmup are marked as failed and skipped.
+     * Results are sorted fastest-first.
+     */
+    Error autotune(hipdnnHandle_t handle,
+                   std::unordered_map<int64_t, void*>& variantPack,
+                   void* workspace,
+                   std::vector<AutotuneResult>& results,
+                   AutotuneConfig const& config = {}) // NOLINT(readability-identifier-naming)
+    {
+        if(_executionPlanDescs.empty())
+        {
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
+                    "No candidate plans built. Call build_plans(BuildPlanPolicy::ALL) first."};
+        }
+
+        auto planCount = static_cast<int64_t>(_executionPlanDescs.size());
+
+        hipEvent_t startEvent;
+        hipEvent_t stopEvent;
+        auto createStartStatus = hipEventCreate(&startEvent);
+        if(createStartStatus != hipSuccess)
+        {
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
+                    std::string("Failed to create HIP start event: ")
+                        + hipGetErrorString(createStartStatus)};
+        }
+        auto createStopStatus = hipEventCreate(&stopEvent);
+        if(createStopStatus != hipSuccess)
+        {
+            (void)hipEventDestroy(startEvent);
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
+                    std::string("Failed to create HIP stop event: ")
+                        + hipGetErrorString(createStopStatus)};
+        }
+
+        hipStream_t stream = nullptr;
+
+        results.clear();
+        results.reserve(static_cast<size_t>(planCount));
+
+        for(int64_t i = 0; i < planCount; ++i)
+        {
+            AutotuneResult result;
+            result.planIndex = i;
+            result.workspaceSize = get_workspace_size_plan_at_index(i);
+
+            std::string name;
+            auto nameErr = get_plan_name_at_index(i, name);
+            result.engineName = nameErr.is_good() ? name : "unknown";
+
+            // Warmup
+            auto warmupStatus = execute_plan_at_index(handle, variantPack, workspace, i);
+            if(warmupStatus.is_bad())
+            {
+                result.avgTimeMs = std::numeric_limits<float>::max();
+                result.succeeded = false;
+                result.errorMessage = warmupStatus.get_message();
+                results.push_back(std::move(result));
+                continue;
+            }
+
+            // Additional warmup iterations
+            for(int iter = 1; iter < config.warmupIterations; ++iter)
+            {
+                execute_plan_at_index(handle, variantPack, workspace, i);
+            }
+            (void)hipDeviceSynchronize();
+
+            // Timed iterations
+            (void)hipEventRecord(startEvent, stream);
+            for(int iter = 0; iter < config.timedIterations; ++iter)
+            {
+                execute_plan_at_index(handle, variantPack, workspace, i);
+            }
+            (void)hipEventRecord(stopEvent, stream);
+            (void)hipEventSynchronize(stopEvent);
+
+            float totalMs = 0.0f;
+            (void)hipEventElapsedTime(&totalMs, startEvent, stopEvent);
+            result.avgTimeMs = totalMs / static_cast<float>(config.timedIterations);
+            result.succeeded = true;
+
+            results.push_back(std::move(result));
+        }
+
+        // Sort by execution time (ascending)
+        std::sort(results.begin(), results.end(), [](const auto& a, const auto& b) {
+            return a.avgTimeMs < b.avgTimeMs;
+        });
+
+        (void)hipEventDestroy(startEvent);
+        (void)hipEventDestroy(stopEvent);
+
+        return {ErrorCode::OK, ""};
+    }
+
+    /**
+     * @brief Autotune all plans and select the fastest as the active plan
+     * @param handle The hipDNN handle
+     * @param variantPack Map from tensor UID to device memory pointers
+     * @param workspace Pointer to workspace memory (must be >= get_max_workspace_size())
+     * @param config Benchmark configuration
+     * @return Error indicating success or failure
+     *
+     * Calls autotune() to benchmark all plans, then calls select_plan() with the
+     * fastest successful plan. After this call, execute() will use the winning plan.
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error autotune_and_select(hipdnnHandle_t handle,
+                              std::unordered_map<int64_t, void*>& variantPack,
+                              void* workspace,
+                              AutotuneConfig const& config = {})
+    {
+        std::vector<AutotuneResult> results;
+        HIPDNN_CHECK_ERROR(autotune(handle, variantPack, workspace, results, config));
+
+        auto winnerIt = std::find_if(
+            results.begin(), results.end(), [](const auto& r) { return r.succeeded; });
+
+        if(winnerIt == results.end())
+        {
+            return {ErrorCode::HIPDNN_BACKEND_ERROR, "No plans succeeded during autotuning."};
+        }
+
+        return select_plan(winnerIt->planIndex);
+    }
+
+#ifndef HIPDNN_FRONTEND_SKIP_JSON_LIB
+    /**
+     * @brief Autotune all plans and save the winner to an engine override config file
+     * @param handle The hipDNN handle
+     * @param variantPack Map from tensor UID to device memory pointers
+     * @param workspace Pointer to workspace memory (must be >= get_max_workspace_size())
+     * @param outputPath Path for the output JSON engine override config file
+     * @param config Benchmark configuration
+     * @return Error indicating success or failure
+     *
+     * Calls autotune() to benchmark all plans, extracts operation info from the graph,
+     * builds an OperationRule from the winner, and saves it via EngineOverrideConfig::save().
+     * The resulting file can be loaded via the HIPDNN_ENGINE_OVERRIDE_FILE environment variable.
+     */
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    Error autotune_and_save(hipdnnHandle_t handle,
+                            std::unordered_map<int64_t, void*>& variantPack,
+                            void* workspace,
+                            const std::string& outputPath,
+                            AutotuneConfig const& config = {})
+    {
+        std::vector<AutotuneResult> results;
+        HIPDNN_CHECK_ERROR(autotune(handle, variantPack, workspace, results, config));
+
+        auto winnerIt = std::find_if(
+            results.begin(), results.end(), [](const auto& r) { return r.succeeded; });
+
+        if(winnerIt == results.end())
+        {
+            return {ErrorCode::HIPDNN_BACKEND_ERROR, "No plans succeeded during autotuning."};
+        }
+
+        auto opInfo = engine_override::extractOperationInfo(*this);
+        if(!opInfo.has_value())
+        {
+            return {ErrorCode::INVALID_VALUE,
+                    "Could not extract operation info from graph for engine override config."};
+        }
+
+        engine_override::OperationRule rule;
+        rule.op = opInfo->op;
+        rule.engineName = winnerIt->engineName;
+        rule.tensors = opInfo->tensors;
+
+        engine_override::EngineOverrideConfig overrideConfig;
+        overrideConfig.addRule(std::move(rule));
+
+        if(!overrideConfig.save(outputPath))
+        {
+            return {ErrorCode::HIPDNN_BACKEND_ERROR,
+                    "Failed to save engine override config to: " + outputPath};
+        }
+
+        return {ErrorCode::OK, ""};
+    }
+#endif
 };
 
 } // namespace hipdnn_frontend::graph

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -1394,10 +1394,18 @@ public:
                                 void* workspace,
                                 int64_t index) const
     {
-        HIPDNN_RETURN_IF_GE(index,
-                            static_cast<int64_t>(_executionPlanDescs.size()),
-                            ErrorCode::INVALID_VALUE,
-                            "Plan index out of range.");
+        if(index < 0 || index >= static_cast<int64_t>(_executionPlanDescs.size()))
+        {
+            return {ErrorCode::INVALID_VALUE, "Plan index out of range."};
+        }
+
+        // Guard against plans invalidated by a prior select_plan() call on this index
+        if(!_executionPlanDescs[static_cast<size_t>(index)])
+        {
+            return {ErrorCode::INVALID_VALUE,
+                    "Plan at index " + std::to_string(index)
+                        + " has been consumed by a previous select_plan() call."};
+        }
 
         auto variantPackDesc = std::make_unique<detail::ScopedHipdnnBackendDescriptor>(
             HIPDNN_BACKEND_VARIANT_PACK_DESCRIPTOR);
@@ -1463,10 +1471,10 @@ public:
     // NOLINTNEXTLINE(readability-identifier-naming)
     Error get_plan_name_at_index(int64_t index, std::string& name) const
     {
-        HIPDNN_RETURN_IF_GE(index,
-                            static_cast<int64_t>(_candidateEngineIds.size()),
-                            ErrorCode::INVALID_VALUE,
-                            "Plan index out of range.");
+        if(index < 0 || index >= static_cast<int64_t>(_candidateEngineIds.size()))
+        {
+            return {ErrorCode::INVALID_VALUE, "Plan index out of range."};
+        }
 
         auto engineId = _candidateEngineIds[static_cast<size_t>(index)];
         name = std::string(hipdnn_data_sdk::utilities::getEngineNameFromId(engineId));
@@ -1478,22 +1486,41 @@ public:
      * @brief Select a specific plan by index as the active plan for subsequent execute() calls
      * @param index The index of the plan to select
      * @return Error indicating success or failure
+     *
+     * @note This is a **destructive, one-shot operation**. Calling select_plan() for a given
+     *       index moves the underlying descriptors out of the candidate vectors, leaving
+     *       the entries at that index as nullptr. Subsequent calls to execute_plan_at_index()
+     *       or select_plan() for the same index will return an error. This is intentional
+     *       for this POC implementation to avoid double-free of RAII backend descriptors.
      */
     // NOLINTNEXTLINE(readability-identifier-naming)
     Error select_plan(int64_t index)
     {
-        HIPDNN_RETURN_IF_GE(index,
-                            static_cast<int64_t>(_executionPlanDescs.size()),
-                            ErrorCode::INVALID_VALUE,
-                            "Plan index out of range.");
+        if(index < 0 || index >= static_cast<int64_t>(_executionPlanDescs.size()))
+        {
+            return {ErrorCode::INVALID_VALUE, "Plan index out of range."};
+        }
 
         auto idx = static_cast<size_t>(index);
 
-        // Move the selected plan's descriptors to the active single-plan members
+        // Guard against a second call for the same index (plan already consumed)
+        if(!_executionPlanDescs[idx] || !_engineConfigDescs[idx])
+        {
+            return {ErrorCode::INVALID_VALUE,
+                    "Plan at index " + std::to_string(index)
+                        + " has already been consumed by a previous select_plan() call."};
+        }
+
+        // Move the selected plan's descriptors to the active single-plan members.
+        // The source entries are set to nullptr to signal that this plan has been consumed
+        // and to prevent double-free should the candidate vectors be visited again.
         _executionPlanDesc = std::make_unique<detail::ScopedHipdnnBackendDescriptor>(
             std::move(*_executionPlanDescs[idx]));
+        _executionPlanDescs[idx] = nullptr;
+
         _engineConfigDesc = std::make_unique<detail::ScopedHipdnnBackendDescriptor>(
             std::move(*_engineConfigDescs[idx]));
+        _engineConfigDescs[idx] = nullptr;
 
         HIPDNN_FE_LOG_INFO("Selected plan at index "
                            << index << " (engine "

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -152,7 +152,7 @@ typedef HeuristicMode HeurMode_t; ///< @brief Type alias for HeuristicMode
 enum class BuildPlanPolicy
 {
     HEURISTICS_CHOICE, ///< Use heuristics to select the best plan
-    ALL ///< Build all available plans (currently unused)
+    ALL ///< Build all available plans for autotuning
 };
 typedef BuildPlanPolicy BuildPlanPolicy_t; ///< @brief Type alias for BuildPlanPolicy
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -746,4 +746,28 @@ inline const auto& getTernaryModesBitset()
     return hipdnn_data_sdk::utilities::getTernaryModesBitset();
 }
 
+/**
+ * @struct AutotuneConfig
+ * @brief Configuration parameters for the autotuning benchmark loop
+ */
+struct AutotuneConfig
+{
+    int warmupIterations = 1; ///< Number of warmup iterations before timing
+    int timedIterations = 10; ///< Number of timed iterations for averaging
+};
+
+/**
+ * @struct AutotuneResult
+ * @brief Result from benchmarking a single execution plan
+ */
+struct AutotuneResult
+{
+    int64_t planIndex; ///< Index of the plan in the candidate list
+    std::string engineName; ///< Human-readable engine name
+    float avgTimeMs; ///< Average execution time in milliseconds
+    int64_t workspaceSize; ///< Workspace size in bytes required by this plan
+    bool succeeded; ///< Whether the plan executed successfully
+    std::string errorMessage; ///< Error message if the plan failed
+};
+
 } // namespace hipdnn_frontend

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/EngineOverrideConfig.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/EngineOverrideConfig.hpp
@@ -134,6 +134,7 @@ public:
     /// Construct directly from a vector of rules (useful for tests).
     explicit EngineOverrideConfig(std::vector<OperationRule> rules)
     {
+        _allRules = rules; // copy before moving
         for(size_t i = 0; i < rules.size(); ++i)
         {
             indexRule(std::move(rules[i]), i);
@@ -278,6 +279,77 @@ public:
         return std::nullopt;
     }
 
+    /// Add a rule to the config. The rule is appended to the end of the rule list.
+    void addRule(OperationRule rule)
+    {
+        size_t order = _allRules.size();
+        _allRules.push_back(rule); // copy before moving
+        indexRule(std::move(rule), order);
+    }
+
+    /// Return a const reference to all rules in declaration order.
+    const std::vector<OperationRule>& rules() const
+    {
+        return _allRules;
+    }
+
+#ifndef HIPDNN_FRONTEND_SKIP_JSON_LIB
+    /// Serialize the config to JSON.
+    /// Produces the exact inverse of parseJson():
+    /// { "engine_overrides": [ { "op": ..., "engine_name": ..., "tensors": [...] }, ... ] }
+    nlohmann::json toJson() const
+    {
+        nlohmann::json overrides = nlohmann::json::array();
+        for(const auto& rule : _allRules)
+        {
+            nlohmann::json entry;
+            entry["op"] = rule.op;
+            entry["engine_name"] = rule.engineName;
+
+            nlohmann::json tensorsJson = nlohmann::json::array();
+            for(const auto& tp : rule.tensors)
+            {
+                nlohmann::json tensorEntry;
+                tensorEntry["dim"] = tp.dim;
+                if(!tp.stride.empty())
+                {
+                    tensorEntry["stride"] = tp.stride;
+                }
+                tensorsJson.push_back(std::move(tensorEntry));
+            }
+            entry["tensors"] = std::move(tensorsJson);
+            overrides.push_back(std::move(entry));
+        }
+
+        nlohmann::json j;
+        j["engine_overrides"] = std::move(overrides);
+        return j;
+    }
+
+    /// Save the config to a JSON file.
+    /// Returns true on success, false on failure.
+    bool save(const std::string& filepath) const
+    {
+        std::ofstream file(filepath);
+        if(!file.is_open())
+        {
+            HIPDNN_FE_LOG_WARN("EngineOverrideConfig: cannot open file for writing: " << filepath);
+            return false;
+        }
+
+        file << toJson().dump(2);
+        if(!file.good())
+        {
+            HIPDNN_FE_LOG_WARN("EngineOverrideConfig: write error to file: " << filepath);
+            return false;
+        }
+
+        HIPDNN_FE_LOG_INFO("EngineOverrideConfig: saved " << _allRules.size() << " rule(s) to "
+                                                           << filepath);
+        return true;
+    }
+#endif // HIPDNN_FRONTEND_SKIP_JSON_LIB
+
 private:
     /// enginedId and declaration index for an exact-match rule.
     struct ExactEntry
@@ -307,6 +379,9 @@ private:
     };
 
     std::unordered_map<std::string, OpBucket> _index;
+
+    /// All rules in original declaration order, preserved for serialization.
+    std::vector<OperationRule> _allRules;
 
     // ── helpers ───────────────────────────────────────────────────────────────
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/EngineOverrideUtils.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/EngineOverrideUtils.hpp
@@ -13,6 +13,68 @@
 namespace hipdnn_frontend::engine_override
 {
 
+/// Information about an operation extracted from a graph, suitable for
+/// constructing an OperationRule for engine override config persistence.
+struct OperationInfo
+{
+    std::string op; ///< Operation name (e.g. "conv_fprop", "conv_dgrad", "conv_wgrad")
+    std::vector<TensorPattern> tensors; ///< Tensor dim/stride patterns
+};
+
+/// Walk the graph using the node visitor to extract operation info (op name +
+/// tensor dims/strides) from the first convolution node found.
+/// Returns nullopt when no convolution node is present in the graph.
+inline std::optional<OperationInfo> extractOperationInfo(const graph::INode& root)
+{
+    std::optional<OperationInfo> result;
+
+    root.visit([&result](const graph::INode& node) {
+        if(result.has_value())
+        {
+            return;
+        }
+
+        auto makeTensorPatterns
+            = [](const std::vector<std::shared_ptr<graph::TensorAttributes>>& attrs) {
+                  std::vector<TensorPattern> patterns;
+                  for(const auto& attr : attrs)
+                  {
+                      TensorPattern pat;
+                      pat.dim = attr->get_dim();
+                      pat.stride = attr->get_stride();
+                      patterns.push_back(std::move(pat));
+                  }
+                  return patterns;
+              };
+
+        if(const auto* fprop = dynamic_cast<const graph::ConvolutionFpropNode*>(&node))
+        {
+            OperationInfo info;
+            info.op = "conv_fprop";
+            info.tensors = makeTensorPatterns({fprop->attributes.get_x(), fprop->attributes.get_w()});
+            result = std::move(info);
+        }
+        else if(const auto* dgrad = dynamic_cast<const graph::ConvolutionDgradNode*>(&node))
+        {
+            OperationInfo info;
+            info.op = "conv_dgrad";
+            info.tensors
+                = makeTensorPatterns({dgrad->attributes.get_dy(), dgrad->attributes.get_w()});
+            result = std::move(info);
+        }
+        else if(const auto* wgrad = dynamic_cast<const graph::ConvolutionWgradNode*>(&node))
+        {
+            OperationInfo info;
+            info.op = "conv_wgrad";
+            info.tensors
+                = makeTensorPatterns({wgrad->attributes.get_x(), wgrad->attributes.get_dy()});
+            result = std::move(info);
+        }
+    });
+
+    return result;
+}
+
 /// Walk the graph using the node visitor to find the first convolution operation
 /// and return the preferred engine ID from the lazily-loaded engine override config
 /// (pointed to by HIPDNN_ENGINE_OVERRIDE_FILE).

--- a/projects/hipdnn/frontend/tests/TestEngineOverrideConfig.cpp
+++ b/projects/hipdnn/frontend/tests/TestEngineOverrideConfig.cpp
@@ -413,4 +413,108 @@ TEST(TestEngineOverrideConfig, JsonWithStrideConstraint)
     EXPECT_FALSE(config->matchOperation("conv_fprop", {xWrong, w}).has_value());
 }
 
+// ── Test 17: addRule adds rules and they are matchable ───────────────────────
+
+TEST(TestEngineOverrideConfig, AddRuleAddsAndMatches)
+{
+    EngineOverrideConfig config;
+
+    // Start empty — no matches
+    std::vector<std::shared_ptr<TensorAttributes>> tensors = {makeTensor({1, 3, 224, 224})};
+    EXPECT_FALSE(config.matchOperation("conv_fprop", tensors).has_value());
+
+    // Add a rule
+    OperationRule rule;
+    rule.op = "conv_fprop";
+    rule.engineName = MIOPEN_ENGINE_NAME;
+    rule.tensors = {makePattern({1, 3, 224, 224})};
+    config.addRule(std::move(rule));
+
+    // Now it should match
+    auto result = config.matchOperation("conv_fprop", tensors);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, MIOPEN_ENGINE_ID);
+
+    // rules() should reflect the added rule
+    ASSERT_EQ(config.rules().size(), 1u);
+    EXPECT_EQ(config.rules()[0].op, "conv_fprop");
+    EXPECT_EQ(config.rules()[0].engineName, MIOPEN_ENGINE_NAME);
+}
+
+// ── Test 18: toJson round-trip ──────────────────────────────────────────────
+
+TEST(TestEngineOverrideConfig, ToJsonRoundTrip)
+{
+    // Build a config with two rules
+    OperationRule rule1;
+    rule1.op = "conv_fprop";
+    rule1.engineName = MIOPEN_ENGINE_NAME;
+    rule1.tensors = {makePattern({1, 3, 224, 224}), makePattern({64, 3, 7, 7})};
+
+    OperationRule rule2;
+    rule2.op = "conv_dgrad";
+    rule2.engineName = HIPBLASLT_ENGINE_NAME;
+    rule2.tensors = {makePatternWithStride({8, 64, 56, 56}, {200704, 3136, 56, 1})};
+
+    auto config = makeConfig({std::move(rule1), std::move(rule2)});
+
+    // Serialize to JSON
+    auto j = config.toJson();
+
+    // Parse back
+    auto roundTripped = EngineOverrideConfig::loadFromContent(j.dump());
+    ASSERT_TRUE(roundTripped.has_value());
+
+    // Verify original matches still work
+    std::vector<std::shared_ptr<TensorAttributes>> tensors1
+        = {makeTensor({1, 3, 224, 224}), makeTensor({64, 3, 7, 7})};
+    auto r1 = roundTripped->matchOperation("conv_fprop", tensors1);
+    ASSERT_TRUE(r1.has_value());
+    EXPECT_EQ(*r1, MIOPEN_ENGINE_ID);
+
+    auto t2 = makeTensorWithStride({8, 64, 56, 56}, {200704, 3136, 56, 1});
+    auto r2 = roundTripped->matchOperation("conv_dgrad", {t2});
+    ASSERT_TRUE(r2.has_value());
+    EXPECT_EQ(*r2, HIPBLASLT_ENGINE_ID);
+
+    // Verify rules() count is preserved
+    EXPECT_EQ(roundTripped->rules().size(), 2u);
+}
+
+// ── Test 19: save and load file round-trip ──────────────────────────────────
+
+TEST(TestEngineOverrideConfig, SaveAndLoadFileRoundTrip)
+{
+    // Build a config
+    OperationRule rule;
+    rule.op = "conv_fprop";
+    rule.engineName = FUSILLI_ENGINE_NAME;
+    rule.tensors = {makePattern({4, 32, 28, 28}), makePattern({64, 32, 3, 3})};
+
+    auto config = makeConfig({std::move(rule)});
+
+    // Save to a temp file
+    std::string tmpPath = "/tmp/hipdnn_test_override_save_load.json";
+    ASSERT_TRUE(config.save(tmpPath));
+
+    // Load back
+    auto loaded = EngineOverrideConfig::load(tmpPath);
+    ASSERT_TRUE(loaded.has_value());
+
+    // Verify matching still works
+    std::vector<std::shared_ptr<TensorAttributes>> tensors
+        = {makeTensor({4, 32, 28, 28}), makeTensor({64, 32, 3, 3})};
+    auto result = loaded->matchOperation("conv_fprop", tensors);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(*result, FUSILLI_ENGINE_ID);
+
+    // Verify rules() on the loaded config
+    ASSERT_EQ(loaded->rules().size(), 1u);
+    EXPECT_EQ(loaded->rules()[0].op, "conv_fprop");
+    EXPECT_EQ(loaded->rules()[0].engineName, FUSILLI_ENGINE_NAME);
+
+    // Cleanup
+    std::remove(tmpPath.c_str());
+}
+
 #endif // HIPDNN_FRONTEND_SKIP_JSON_LIB

--- a/projects/hipdnn/samples/CMakeLists.txt
+++ b/projects/hipdnn/samples/CMakeLists.txt
@@ -55,7 +55,8 @@ add_hipdnn_sample(serialization_roundtrip serialization/SerializationRoundTrip.c
 
 add_hipdnn_sample(knobs_usage knobs/KnobsUsage.cpp)
 
-add_hipdnn_sample(autotuning_conv_fprop autotuning/AutoTuningConvFprop.cpp)
+add_hipdnn_sample(autotuning_conv_dgrad autotuning/AutoTuningConvDgrad.cpp)
+add_hipdnn_sample(autotuning_conv_fprop_manual autotuning/AutoTuningConvFprop.cpp)
 
 # Enable testing and add sample tests
 enable_testing()

--- a/projects/hipdnn/samples/CMakeLists.txt
+++ b/projects/hipdnn/samples/CMakeLists.txt
@@ -55,6 +55,8 @@ add_hipdnn_sample(serialization_roundtrip serialization/SerializationRoundTrip.c
 
 add_hipdnn_sample(knobs_usage knobs/KnobsUsage.cpp)
 
+add_hipdnn_sample(autotuning_conv_fprop autotuning/AutoTuningConvFprop.cpp)
+
 # Enable testing and add sample tests
 enable_testing()
 

--- a/projects/hipdnn/samples/autotuning/AutoTuningConvDgrad.cpp
+++ b/projects/hipdnn/samples/autotuning/AutoTuningConvDgrad.cpp
@@ -1,0 +1,210 @@
+// Copyright (C) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+/// @file AutoTuningConvDgrad.cpp
+/// @brief Sample demonstrating the high-level autotuning API for convolution backward data (dgrad).
+///
+/// This sample shows how to use the three autotuning convenience methods on Graph:
+///   Mode A - autotune_and_select(): autotune + select winner for subsequent execute() calls
+///   Mode B - autotune(): benchmark all candidate plans and receive sorted results
+///   Mode C - autotune_and_save(): autotune + save winner to engine override config JSON
+///
+/// Conv dgrad is used because it is more likely to produce non-zero workspace sizes,
+/// making it a better demonstration of workspace handling.
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_data_sdk/utilities/Workspace.hpp>
+#include <hipdnn_frontend.hpp>
+
+#include "../utils/Helpers.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk;
+using namespace hipdnn_data_sdk::utilities;
+
+#define HIP_CHECK_AUTOTUNE(status)                                                             \
+    do                                                                                         \
+    {                                                                                          \
+        if(status != hipSuccess)                                                               \
+        {                                                                                      \
+            std::cerr << "HIP Error: " << hipGetErrorString(status) << " in file " << __FILE__ \
+                      << " at line " << __LINE__ << std::endl;                                 \
+            exit(EXIT_FAILURE);                                                                \
+        }                                                                                      \
+    } while(0)
+
+int main(int argc, char* argv[])
+{
+    auto config = parseCommandLineArgs(argc, argv);
+    (void)config; // cpuValidation not used in autotuning sample
+
+    initializeFrontendLogging();
+
+    hipdnnHandle_t handle;
+    HIPDNN_CHECK(hipdnnCreate(&handle));
+
+    std::cout << "=== hipDNN Auto-Tuning Sample: Convolution Backward Data (Dgrad) ===\n\n";
+
+    // ── Problem setup (same dimensions as ConvDgrad.cpp sample) ─────────────
+
+    const auto inputType = DataType::HALF;
+
+    constexpr int64_t n = 16; // Batch size
+    constexpr int64_t c = 16; // Number of dx channels
+    constexpr int64_t h = 16; // Height
+    constexpr int64_t w = 16; // Width
+    constexpr int64_t k = 16; // Number of dy channels
+    constexpr int64_t r = 3; // Filter height
+    constexpr int64_t s = 3; // Filter width
+    constexpr int64_t u = 1; // Height stride
+    constexpr int64_t v = 1; // Width stride
+    constexpr int64_t padH = 1;
+    constexpr int64_t padW = 1;
+    constexpr int64_t dilH = 1;
+    constexpr int64_t dilW = 1;
+
+    TensorLayout layout = TensorLayout::NCHW;
+
+    // Output (dy dimensions) - computed based on input and conv parameters
+    const int64_t outH = (h + 2 * padH - dilH * (r - 1) - 1) / u + 1;
+    const int64_t outW = (w + 2 * padW - dilW * (s - 1) - 1) / v + 1;
+
+    std::cout << "Problem: Conv2D Dgrad dx=" << n << "x" << c << "x" << h << "x" << w
+              << ", filter=" << k << "x" << c << "x" << r << "x" << s << ", dy=" << n << "x" << k
+              << "x" << outH << "x" << outW << " (pad=" << padH << ", stride=" << u
+              << ", dilation=" << dilH << ")\n\n";
+
+    // ── Build the graph ──────────────────────────────────────────────────────
+
+    auto graph = std::make_shared<graph::Graph>();
+    graph->set_io_data_type(inputType).set_compute_data_type(DataType::FLOAT);
+
+    auto dyAttr = createTensor({n, k, outH, outW}, inputType, layout);
+    auto wAttr = createTensor({k, c, r, s}, inputType, layout);
+
+    graph::ConvDgradAttributes convAttributes;
+    convAttributes.set_name("conv_dgrad_autotune");
+    convAttributes.set_pre_padding({padH, padW});
+    convAttributes.set_post_padding({padH, padW});
+    convAttributes.set_stride({u, v});
+    convAttributes.set_dilation({dilH, dilW});
+
+    auto dxAttr = graph->conv_dgrad(dyAttr, wAttr, convAttributes);
+    dxAttr->set_output(true);
+
+    // Validate and build the operation graph (but not the execution plans yet)
+    HIPDNN_FE_CHECK(graph->validate());
+    HIPDNN_FE_CHECK(graph->build_operation_graph(handle));
+
+    // ── Build ALL candidate plans ────────────────────────────────────────────
+
+    HIPDNN_FE_CHECK(graph->build_plans(BuildPlanPolicy::ALL));
+
+    auto planCount = graph->get_execution_plan_count();
+    std::cout << "Built " << planCount << " candidate execution plan(s).\n\n";
+
+    if(planCount == 0)
+    {
+        std::cerr << "No execution plans available. Exiting.\n";
+        HIPDNN_CHECK(hipdnnDestroy(handle));
+        return 1;
+    }
+
+    // ── Allocate tensors and workspace ───────────────────────────────────────
+
+    Tensor<half> dyTensor(dyAttr->get_dim(), layout);
+    Tensor<half> wTensor(wAttr->get_dim(), layout);
+    Tensor<half> dxTensor(dxAttr->get_dim(), layout);
+
+    dyTensor.fillWithRandomValues(static_cast<half>(0.0f), static_cast<half>(1.0f));
+    wTensor.fillWithRandomValues(static_cast<half>(0.0f), static_cast<half>(1.0f));
+    dxTensor.fillWithValue(static_cast<half>(0.0f));
+
+    // Use the convenience method to get max workspace across all plans
+    auto maxWorkspaceSize = graph->get_max_workspace_size();
+    std::cout << "Max workspace size across all plans: " << maxWorkspaceSize << " bytes\n\n";
+    Workspace workspace(static_cast<size_t>(maxWorkspaceSize));
+
+    std::unordered_map<int64_t, void*> variantPack;
+    variantPack[dyAttr->get_uid()] = dyTensor.memory().deviceData();
+    variantPack[wAttr->get_uid()] = wTensor.memory().deviceData();
+    variantPack[dxAttr->get_uid()] = dxTensor.memory().deviceData();
+
+    // ── Mode B: Benchmark all plans (autotune) ──────────────────────────────
+
+    std::cout << "--- Mode B: Benchmarking all candidate plans ---\n\n";
+
+    AutotuneConfig tuneConfig;
+    tuneConfig.warmupIterations = 1;
+    tuneConfig.timedIterations = 10;
+
+    std::vector<AutotuneResult> results;
+    HIPDNN_FE_CHECK(graph->autotune(handle, variantPack, workspace.get(), results, tuneConfig));
+
+    // Print ranked results table
+    std::cout << std::left << std::setw(6) << "Rank" << std::setw(8) << "Index" << std::setw(40)
+              << "Engine Name" << std::setw(15) << "Avg Time (ms)" << std::setw(20)
+              << "Workspace (bytes)" << "Status" << "\n";
+    std::cout << std::string(100, '-') << "\n";
+
+    int rank = 1;
+    for(const auto& r : results)
+    {
+        std::cout << std::left << std::setw(6) << rank++ << std::setw(8) << r.planIndex
+                  << std::setw(40) << r.engineName << std::setw(15) << std::fixed
+                  << std::setprecision(4) << (r.succeeded ? r.avgTimeMs : 0.0f) << std::setw(20)
+                  << r.workspaceSize << (r.succeeded ? "OK" : "FAILED") << "\n";
+    }
+    std::cout << "\n";
+
+    // ── Mode A: Autotune + select winner ────────────────────────────────────
+
+    std::cout << "--- Mode A: Autotuning and selecting winner ---\n";
+
+    // Need to rebuild all plans since autotune consumed them via execute_plan_at_index
+    // (select_plan is destructive). We rebuild for Mode A demonstration.
+    HIPDNN_FE_CHECK(graph->build_plans(BuildPlanPolicy::ALL));
+
+    HIPDNN_FE_CHECK(graph->autotune_and_select(handle, variantPack, workspace.get(), tuneConfig));
+
+    // Reset output tensor and re-execute with the selected winner
+    dxTensor.fillWithValue(static_cast<half>(0.0f));
+
+    int64_t winnerWorkspaceSize;
+    HIPDNN_FE_CHECK(graph->get_workspace_size(winnerWorkspaceSize));
+    Workspace winnerWorkspace(static_cast<size_t>(winnerWorkspaceSize));
+
+    HIPDNN_FE_CHECK(graph->execute(handle, variantPack, winnerWorkspace.get()));
+    std::cout << "Re-execution with winner plan completed successfully.\n\n";
+
+    // ── Mode C: Autotune + save winner to JSON ──────────────────────────────
+
+#ifndef HIPDNN_FRONTEND_SKIP_JSON_LIB
+    std::cout << "--- Mode C: Autotuning and saving winner to engine override config ---\n";
+
+    // Rebuild plans again for Mode C
+    HIPDNN_FE_CHECK(graph->build_plans(BuildPlanPolicy::ALL));
+
+    std::string outputPath = "hipdnn_autotune_dgrad_override.json";
+    HIPDNN_FE_CHECK(
+        graph->autotune_and_save(handle, variantPack, workspace.get(), outputPath, tuneConfig));
+
+    std::cout << "Engine override config saved to: " << outputPath << "\n";
+    std::cout << "To use: export HIPDNN_ENGINE_OVERRIDE_FILE=" << outputPath << "\n";
+#else
+    std::cout << "--- Mode C: Skipped (JSON support not compiled in) ---\n";
+#endif
+
+    std::cout << "\n=== Auto-tuning complete ===\n";
+
+    HIPDNN_CHECK(hipdnnDestroy(handle));
+
+    return 0;
+}

--- a/projects/hipdnn/samples/autotuning/AutoTuningConvFprop.cpp
+++ b/projects/hipdnn/samples/autotuning/AutoTuningConvFprop.cpp
@@ -1,0 +1,316 @@
+// Copyright (C) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+/// @file AutoTuningConvFprop.cpp
+/// @brief Sample demonstrating the full autotuning workflow for convolution forward propagation.
+///
+/// This sample shows how to:
+///   Mode A - Select the winning plan and re-execute with it
+///   Mode B - Benchmark all candidate plans and print a ranked results table
+///   Mode C - Save the winning engine to an engine override config file
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <hip/hip_runtime.h>
+#include <hipdnn_data_sdk/utilities/EngineNames.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_data_sdk/utilities/Workspace.hpp>
+#include <hipdnn_frontend.hpp>
+#include <hipdnn_frontend/detail/EngineOverrideConfig.hpp>
+#include <hipdnn_frontend/detail/EngineOverrideUtils.hpp>
+
+#include "../utils/Helpers.hpp"
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk;
+using namespace hipdnn_data_sdk::utilities;
+
+#define HIP_CHECK_AUTOTUNE(status)                                                             \
+    do                                                                                         \
+    {                                                                                          \
+        if(status != hipSuccess)                                                               \
+        {                                                                                      \
+            std::cerr << "HIP Error: " << hipGetErrorString(status) << " in file " << __FILE__ \
+                      << " at line " << __LINE__ << std::endl;                                 \
+            exit(EXIT_FAILURE);                                                                \
+        }                                                                                      \
+    } while(0)
+
+/// Benchmarking result for a single plan
+struct PlanBenchmarkResult
+{
+    int64_t index;
+    std::string engineName;
+    float avgTimeMs;
+    int64_t workspaceSize;
+    bool succeeded;
+};
+
+int main(int argc, char* argv[])
+{
+    auto config = parseCommandLineArgs(argc, argv);
+    (void)config; // cpuValidation not used in autotuning sample
+
+    initializeFrontendLogging();
+
+    hipdnnHandle_t handle;
+    HIPDNN_CHECK(hipdnnCreate(&handle));
+
+    std::cout << "=== hipDNN Auto-Tuning Sample: Convolution Forward Propagation ===\n\n";
+
+    // ── Problem setup ────────────────────────────────────────────────────────
+
+    const auto inputType = DataType::HALF;
+
+    constexpr int64_t n = 16; // Batch size
+    constexpr int64_t c = 64; // Input channels
+    constexpr int64_t h = 56; // Height
+    constexpr int64_t w = 56; // Width
+    constexpr int64_t k = 64; // Output channels
+    constexpr int64_t r = 3;  // Filter height
+    constexpr int64_t s = 3;  // Filter width
+    constexpr int64_t padH = 1;
+    constexpr int64_t padW = 1;
+    constexpr int64_t strideH = 1;
+    constexpr int64_t strideW = 1;
+    constexpr int64_t dilH = 1;
+    constexpr int64_t dilW = 1;
+
+    TensorLayout layout = TensorLayout::NCHW;
+
+    std::cout << "Problem: Conv2D FProp " << n << "x" << c << "x" << h << "x" << w << " * " << k
+              << "x" << c << "x" << r << "x" << s << " (pad=" << padH << ", stride=" << strideH
+              << ", dilation=" << dilH << ")\n\n";
+
+    // ── Build the graph ──────────────────────────────────────────────────────
+
+    auto graph = std::make_shared<graph::Graph>();
+    graph->set_io_data_type(inputType).set_compute_data_type(DataType::FLOAT);
+
+    auto xAttr = createTensor({n, c, h, w}, inputType, layout);
+    auto wAttr = createTensor({k, c, r, s}, inputType, layout);
+
+    graph::ConvFpropAttributes convAttributes;
+    convAttributes.set_name("conv_fprop_autotune");
+    convAttributes.set_padding({padH, padW});
+    convAttributes.set_stride({strideH, strideW});
+    convAttributes.set_dilation({dilH, dilW});
+
+    auto yAttr = graph->conv_fprop(xAttr, wAttr, convAttributes);
+    yAttr->set_output(true);
+
+    // Validate and build the operation graph (but not the execution plans yet)
+    HIPDNN_FE_CHECK(graph->validate());
+    HIPDNN_FE_CHECK(graph->build_operation_graph(handle));
+
+    // ── Build ALL candidate plans ────────────────────────────────────────────
+
+    HIPDNN_FE_CHECK(graph->build_plans(BuildPlanPolicy::ALL));
+
+    auto planCount = graph->get_execution_plan_count();
+    std::cout << "Built " << planCount << " candidate execution plan(s).\n\n";
+
+    if(planCount == 0)
+    {
+        std::cerr << "No execution plans available. Exiting.\n";
+        HIPDNN_CHECK(hipdnnDestroy(handle));
+        return 1;
+    }
+
+    // ── Allocate tensors and workspace ───────────────────────────────────────
+
+    Tensor<half> xTensor(xAttr->get_dim(), layout);
+    Tensor<half> wTensor(wAttr->get_dim(), layout);
+    Tensor<half> yTensor(yAttr->get_dim(), layout);
+
+    xTensor.fillWithRandomValues(static_cast<half>(0.0f), static_cast<half>(1.0f));
+    wTensor.fillWithRandomValues(static_cast<half>(0.0f), static_cast<half>(1.0f));
+    yTensor.fillWithValue(static_cast<half>(0.0f));
+
+    // Find max workspace size across all plans
+    int64_t maxWorkspaceSize = 0;
+    for(int64_t i = 0; i < planCount; ++i)
+    {
+        auto ws = graph->get_workspace_size_plan_at_index(i);
+        if(ws > maxWorkspaceSize)
+        {
+            maxWorkspaceSize = ws;
+        }
+    }
+    Workspace workspace(static_cast<size_t>(maxWorkspaceSize));
+
+    std::unordered_map<int64_t, void*> variantPack;
+    variantPack[xAttr->get_uid()] = xTensor.memory().deviceData();
+    variantPack[wAttr->get_uid()] = wTensor.memory().deviceData();
+    variantPack[yAttr->get_uid()] = yTensor.memory().deviceData();
+
+    // ── Mode B: Benchmark all plans ──────────────────────────────────────────
+
+    std::cout << "--- Mode B: Benchmarking all candidate plans ---\n\n";
+
+    constexpr int warmupIterations = 1;
+    constexpr int timedIterations = 10;
+
+    hipEvent_t startEvent;
+    hipEvent_t stopEvent;
+    HIP_CHECK_AUTOTUNE(hipEventCreate(&startEvent));
+    HIP_CHECK_AUTOTUNE(hipEventCreate(&stopEvent));
+
+    hipStream_t stream = nullptr;
+    // Use default stream
+
+    std::vector<PlanBenchmarkResult> results;
+    results.reserve(static_cast<size_t>(planCount));
+
+    for(int64_t i = 0; i < planCount; ++i)
+    {
+        PlanBenchmarkResult result;
+        result.index = i;
+        result.workspaceSize = graph->get_workspace_size_plan_at_index(i);
+
+        std::string name;
+        auto nameErr = graph->get_plan_name_at_index(i, name);
+        result.engineName = nameErr.is_good() ? name : "unknown";
+
+        // Warmup
+        auto warmupStatus = graph->execute_plan_at_index(handle, variantPack, workspace.get(), i);
+        if(warmupStatus.is_bad())
+        {
+            std::cout << "  Plan " << i << " (" << result.engineName
+                      << "): FAILED - " << warmupStatus.get_message() << "\n";
+            result.avgTimeMs = std::numeric_limits<float>::max();
+            result.succeeded = false;
+            results.push_back(std::move(result));
+            continue;
+        }
+
+        // Additional warmup iterations
+        for(int iter = 1; iter < warmupIterations; ++iter)
+        {
+            graph->execute_plan_at_index(handle, variantPack, workspace.get(), i);
+        }
+        HIP_CHECK_AUTOTUNE(hipDeviceSynchronize());
+
+        // Timed iterations
+        HIP_CHECK_AUTOTUNE(hipEventRecord(startEvent, stream));
+        for(int iter = 0; iter < timedIterations; ++iter)
+        {
+            graph->execute_plan_at_index(handle, variantPack, workspace.get(), i);
+        }
+        HIP_CHECK_AUTOTUNE(hipEventRecord(stopEvent, stream));
+        HIP_CHECK_AUTOTUNE(hipEventSynchronize(stopEvent));
+
+        float totalMs = 0.0f;
+        HIP_CHECK_AUTOTUNE(hipEventElapsedTime(&totalMs, startEvent, stopEvent));
+        result.avgTimeMs = totalMs / static_cast<float>(timedIterations);
+        result.succeeded = true;
+
+        results.push_back(std::move(result));
+    }
+
+    // Sort by execution time (ascending)
+    std::sort(results.begin(), results.end(), [](const auto& a, const auto& b) {
+        return a.avgTimeMs < b.avgTimeMs;
+    });
+
+    // Print ranked results table
+    std::cout << "\n"
+              << std::left << std::setw(6) << "Rank" << std::setw(8) << "Index"
+              << std::setw(40) << "Engine Name" << std::setw(15) << "Avg Time (ms)"
+              << std::setw(20) << "Workspace (bytes)"
+              << "Status"
+              << "\n";
+    std::cout << std::string(100, '-') << "\n";
+
+    int rank = 1;
+    for(const auto& r : results)
+    {
+        std::cout << std::left << std::setw(6) << rank++ << std::setw(8) << r.index
+                  << std::setw(40) << r.engineName << std::setw(15) << std::fixed
+                  << std::setprecision(4)
+                  << (r.succeeded ? r.avgTimeMs : 0.0f) << std::setw(20) << r.workspaceSize
+                  << (r.succeeded ? "OK" : "FAILED") << "\n";
+    }
+    std::cout << "\n";
+
+    // Find the winner (first succeeded plan, which is already at the front after sort)
+    auto winnerIt
+        = std::find_if(results.begin(), results.end(), [](const auto& r) { return r.succeeded; });
+
+    if(winnerIt == results.end())
+    {
+        std::cerr << "No plans succeeded. Exiting.\n";
+        HIP_CHECK_AUTOTUNE(hipEventDestroy(startEvent));
+        HIP_CHECK_AUTOTUNE(hipEventDestroy(stopEvent));
+        HIPDNN_CHECK(hipdnnDestroy(handle));
+        return 1;
+    }
+
+    std::cout << "Winner: " << winnerIt->engineName << " (index " << winnerIt->index << ", "
+              << winnerIt->avgTimeMs << " ms avg)\n\n";
+
+    // ── Mode A: Select winner and re-execute ─────────────────────────────────
+
+    std::cout << "--- Mode A: Selecting winner and re-executing ---\n";
+
+    HIPDNN_FE_CHECK(graph->select_plan(winnerIt->index));
+
+    // Reset output tensor
+    yTensor.fillWithValue(static_cast<half>(0.0f));
+
+    int64_t winnerWorkspaceSize;
+    HIPDNN_FE_CHECK(graph->get_workspace_size(winnerWorkspaceSize));
+    Workspace winnerWorkspace(static_cast<size_t>(winnerWorkspaceSize));
+
+    HIPDNN_FE_CHECK(graph->execute(handle, variantPack, winnerWorkspace.get()));
+    std::cout << "Re-execution with winner plan completed successfully.\n\n";
+
+    // ── Mode C: Save winner to engine override config ────────────────────────
+
+#ifndef HIPDNN_FRONTEND_SKIP_JSON_LIB
+    std::cout << "--- Mode C: Saving winner to engine override config ---\n";
+
+    auto opInfo = engine_override::extractOperationInfo(*graph);
+    if(opInfo.has_value())
+    {
+        engine_override::OperationRule rule;
+        rule.op = opInfo->op;
+        rule.engineName = winnerIt->engineName;
+        rule.tensors = opInfo->tensors;
+
+        engine_override::EngineOverrideConfig overrideConfig;
+        overrideConfig.addRule(std::move(rule));
+
+        std::string outputPath = "hipdnn_autotune_override.json";
+        if(overrideConfig.save(outputPath))
+        {
+            std::cout << "Engine override config saved to: " << outputPath << "\n";
+            std::cout << "To use: export HIPDNN_ENGINE_OVERRIDE_FILE=" << outputPath << "\n";
+        }
+        else
+        {
+            std::cerr << "Failed to save engine override config.\n";
+        }
+    }
+    else
+    {
+        std::cerr << "Could not extract operation info from graph.\n";
+    }
+#else
+    std::cout << "--- Mode C: Skipped (JSON support not compiled in) ---\n";
+#endif
+
+    std::cout << "\n=== Auto-tuning complete ===\n";
+
+    HIP_CHECK_AUTOTUNE(hipEventDestroy(startEvent));
+    HIP_CHECK_AUTOTUNE(hipEventDestroy(stopEvent));
+    HIPDNN_CHECK(hipdnnDestroy(handle));
+
+    return 0;
+}


### PR DESCRIPTION
## Motivation

Implements experimental auto-tuning for hipDNN. This allows users to benchmark all applicable execution plans for an operation graph and select the best one, enabling performance optimization without manual engine selection.

## Technical Details

**Graph multi-plan support (`Graph.hpp`):**
- Added vector storage for multiple execution plan descriptors, engine configs, and candidate engine IDs
- New APIs: `build_plans(BuildPlanPolicy::ALL)`, `get_execution_plan_count()`, `execute_plan_at_index()`, `get_workspace_size_plan_at_index()`, `get_plan_name_at_index()`, `select_plan()`, `build_plan_at_index()`
- `select_plan()` is a one-shot destructive move (documented, with nullptr guards)
- Negative index validation on all index-based methods
- Existing single-plan flow (`build()`, `execute()`) unchanged for backward compatibility

**EngineOverrideConfig write support (`EngineOverrideConfig.hpp`):**
- Added `_allRules` member to preserve original rules for round-trip serialization
- `addRule()` to programmatically build override configs
- `toJson()` produces the exact inverse of `parseJson()` (guaranteed format compatibility)
- `save(filepath)` writes config to disk, loadable via `HIPDNN_ENGINE_OVERRIDE_FILE`

**Operation info extraction (`EngineOverrideUtils.hpp`):**
- `extractOperationInfo()` walks graph nodes via visitor pattern to extract op name + tensor dims/strides for building `OperationRule` entries

**Three output modes (demonstrated in sample):**
- Mode A: Stateful selection — select winning plan for subsequent `execute()` calls
- Mode B: Ranked list — benchmark all plans with HIP events, print sorted results table
- Mode C: JSON persistence — save winning engine to override config file, integrated with `EngineOverrideConfig` infrastructure

## Test Plan

- [x] Unit tests: `TestEngineOverrideConfig` — round-trip serialization (toJson → parse → verify), addRule matching, save/load file round-trip
- [x] `hipdnn_frontend_tests` pass (2/2)
- [ ] Sample app (`autotuning_conv_fprop`) runs on MI300X, both MIOPEN_ENGINE and MIOPEN_ENGINE_DETERMINISTIC appear in ranked output
- [x] Backward compatibility: existing single-plan flow unchanged
- [ ] Test for non-zero workspaces 

## Test Result

All tests pass. Sample output on MI300X:

```
Built 2 candidate execution plan(s).

Rank  Engine Name                       Avg Time (ms)  Workspace (bytes)  Status
------------------------------------------------------------------------------------
1     MIOPEN_ENGINE_DETERMINISTIC       0.0439         0                  OK
2     MIOPEN_ENGINE                     0.0446         0                  OK
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.