### PR TITLE
[CK] Add gfx1103 to GPU target lists

### DIFF
--- a/projects/composablekernel/CMakeLists.txt
+++ b/projects/composablekernel/CMakeLists.txt
@@ -217,18 +217,18 @@ message(STATUS "hip_version_flat=${hip_VERSION_FLAT}")
 
 message(STATUS "checking which targets are supported")
 #In order to build just the CK library (without tests and examples) for all supported GPU targets
-#use -D GPU_ARCHS="gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201"
+#use -D GPU_ARCHS="gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201"
 #the GPU_TARGETS flag will be reset in this case in order to avoid conflicts.
 #
 #In order to build CK along with all tests and examples it should be OK to set GPU_TARGETS to just 1 or 2 similar architectures.
 if(NOT ENABLE_ASAN_PACKAGING)
     if(NOT WIN32 AND ${hip_VERSION_FLAT} LESS 600300000)
         # WORKAROUND: compiler does not yet fully support gfx12 targets, need to fix version above
-        set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102")
+        set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103")
     elseif(NOT WIN32 AND ${hip_VERSION_FLAT} GREATER_EQUAL 600300000 AND ${hip_VERSION_FLAT} LESS 600400000)
-        set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
+        set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201")
     elseif(NOT WIN32 AND ${hip_VERSION_FLAT} GREATER_EQUAL 600400000 AND ${hip_VERSION_FLAT} LESS 600443483)
-        set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201;gfx950")
+        set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201;gfx950")
     elseif(NOT WIN32 AND ${hip_VERSION_FLAT} GREATER_EQUAL 600443483)
         set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx950;gfx10-3-generic;gfx11-generic;gfx12-generic")
     endif()


### PR DESCRIPTION
 Motivation

We need to fix multi-architecture CI build convergence for the gfx110X-all shard (ROCm/TheRock#3499). The gfx110X-all CI shard targets gfx1100–gfx1103, but gfx1103 is missing from CK's default CK_GPU_TARGETS lists. While CK's source code already fully supports gfx1103 (architecture enums, compiler defines, WMMA intrinsics, device detection), the CMake target lists omit it, which prevents standalone builds from including gfx1103 by default. This is a prerequisite for the corresponding TheRock change that adds gfx1100–gfx1103 to the `_ck_supported_gfx_targets` allowlist in ml-libs/CMakeLists.txt.

Technical Details

 Add gfx1103 to the default CK_GPU_TARGETS fallback lists in projects/composablekernel/CMakeLists.txt:

- Line 220: comment documenting supported GPU_ARCHS values
- Line 227: target list for HIP < 6.3 (non-Windows)
- Line 229: target list for HIP 6.3–6.4 (non-Windows)
- Line 231: target list for HIP 6.4–6.4.43483 (non-Windows)

The newest HIP version block (≥ 6.4.43483) already uses gfx11-generic, which covers all gfx11 family targets including
   gfx1103, so no change is needed there.

No source code changes are required — all architecture-specific support for gfx1103 is already in place:
  - include/ck/ck.hpp: __gfx1103__ included in __gfx11__ macro
  - include/ck_tile/core/arch/arch.hpp: GFX1103 enum and device property mappings
  - include/ck_tile/core/config.hpp: CK_TILE_ARCH_GFX1103 flag
  - include/ck/host_utility/device_prop.hpp / include/ck_tile/host/device_prop.hpp: is_gfx11_supported() includes
  gfx1103

Test Plan

  - Configure CK standalone build with -DGPU_TARGETS="gfx1103" and verify it configures without warnings and compiles
  successfully.
  - After the companion TheRock PR lands, verify the gfx110X-all CI shard builds CK and produces a CK-enabled
  libMIOpen.so matching the structure of other shards (no "gfx110X is not supported by composable kernel" warnings).

Test Result

I configured with gfx1103 and built with `ninja -j 192` on an in-memory filesystem in 49 minutes.

We will also check out Windows builds after this PR is created.