### PR TITLE
[hipblaslt][CMS] Expand Pack validation infrastructure

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -95,6 +95,46 @@ def invert_mfma_reorder(mfma_reorder: list[int]) -> dict[int, int]:
     return {orig: new_pos for new_pos, orig in enumerate(mfma_reorder)}
 
 
+# --- Loop Names ---
+MAIN_LOOP_PREV = "ML-1"
+MAIN_LOOP = "ML"
+NO_GLOBAL_LOAD_LOOP = "NGL"
+NO_LOCAL_LOAD_LOOP = "NLL"
+
+# --- Pack Group Sizes ---
+PACK_GROUP_SIZE_TF32 = 24        # 4 CVT0 + 16 middle + 4 CVT1
+PACK_GROUP_SIZE_TF32_4X4 = 10    # 4 CVT0 + 2 MFMA + 4 CVT1
+
+# --- TF32 Pack Index Ranges (within a group) ---
+# Regular TF32 (groups of 24)
+TF32_CVT0_END = 4                # Indices 0..3 are CVT0
+TF32_MIDDLE_16_START = 4         # Indices 4..19 are middle-16
+TF32_MIDDLE_16_END = 20          # (exclusive)
+# TF32_CVT1 occupies indices 20..23
+
+# 4x4 MFMA TF32 (groups of 10)
+TF32_4X4_MFMA_START = 4          # Indices 4..5 are 4x4 MFMAs
+TF32_4X4_MFMA_END = 6            # (exclusive)
+# CVT0: 0..3, CVT1: 6..9
+
+# --- Quad-Cycle Timing (CDNA 4 ISA section 7.6) ---
+QUAD_CYCLES_CVT_BEFORE_MFMA = 2          # CVT packs need 2 quad-cycles before MFMA can use result
+QUAD_CYCLES_MFMA_4X4_BEFORE_CVT1 = 5     # 4x4 MFMA needs 5 quad-cycles before CVT1 can use result
+QUAD_CYCLES_STANDARD_MFMA_FINISH = 3      # Standard MFMA takes 3 quad-cycles to finish after issue
+QUAD_CYCLES_MFMA_4X4_FINISH = 1           # 4x4 MFMA takes 1 quad-cycle to finish after issue
+
+# --- MFMA Type-Switch Thresholds ---
+MFMA_TYPE_SWITCH_THRESHOLD_FROM_STANDARD = 5  # Min gap before type switch from standard MFMA
+MFMA_TYPE_SWITCH_THRESHOLD_FROM_4X4 = 3       # Min gap before type switch from 4x4 MFMA
+
+# --- TF32 Emulation ---
+MFMAS_PER_TILE_TF32 = 3   # 3 MFMAs per tile pair in TF32 emulation
+MFMAS_PER_TILE_BF16 = 1   # 1 MFMA per tile pair in BF16
+
+# --- VGPRs ---
+VGPRS_PER_CONVERSION_GROUP = 8   # 8 VGPRs per conversion group in TF32 emulation
+
+
 class ValidatorInstruction(ABC):
     """
     Abstract class with no method just for type hinting purposes.
@@ -160,6 +200,7 @@ class LocalRead(ValidatorInstruction):
 class MFMA(ValidatorInstruction):
     issued_at: SchedulePosition
     name: str = "MFMA"
+    __mfma_finish_cycles__ = QUAD_CYCLES_STANDARD_MFMA_FINISH
 
     def done_idx(self) -> SchedulePosition:
         return self.issued_at
@@ -235,6 +276,35 @@ class Pack(ValidatorInstruction):
             return f"{self.name} @ idx={issued_at} has too little gap between it and {self.needed_by.name} @ idx={needed_by_at}. Expected at least {self.min_quad_cycles_before_result_used} quad-cycles but only {self.estimated_quad_cycles_before_result_used} passed."
 
         return f"{self.name} at index {issued_at} is not valid."
+
+@dataclass
+class MFMAPack(Pack, MFMA):
+    """A v_mfma_f32_4x4x4_16b_bf16 instruction used in TF32 4x4 emulation pack groups.
+
+    These appear at indices TF32_4X4_MFMA_START..TF32_4X4_MFMA_END within each group
+    of PACK_GROUP_SIZE_TF32_4X4. They are real MFMA instructions but participate in
+    the pack dependency chain (CVT0 -> MFMAPack -> CVT1).
+
+    Inherits from both Pack and MFMA:
+    - isinstance(x, Pack) is True — works with pack gathering, filtering, type hints
+    - isinstance(x, MFMA) is True — captures "this IS an MFMA" semantics
+    """
+    # NOTE: Do NOT re-declare `name: str` here. Although the MRO field merge
+    # correctly resolves Pack's no-default `name` over MFMA's default,
+    # Python's _get_field uses getattr() which picks up MFMA's inherited
+    # `name = 'MFMA'` class attribute and re-introduces the default.
+
+    # Override MFMA's finish cycles for 4x4 timing
+    __mfma_finish_cycles__ = QUAD_CYCLES_MFMA_4X4_FINISH
+
+    # NOTE: min_quad_cycles_before_result_used is NOT overridden here.
+    # It keeps Pack's default (0) and is set by _handle_min_pack_quad_cycles
+    # only when the constraint is active (when local reads exist).
+    #
+    # NOTE: validate() is NOT overridden here. Pack.validate() already handles
+    # MFMAPack correctly: pair_consumer and next_scheduled_middle_16 are both
+    # None, so the pair interleaving check is naturally skipped (None is None
+    # in the happy path, and `if self.pair_consumer:` is False in the error path).
 
 
 @dataclass
@@ -399,44 +469,6 @@ class SNop(ValidatorInstruction):
     def validate(self) -> Optional[str]:
         return None
 
-MAIN_LOOP_PREV = "ML-1"
-MAIN_LOOP = "ML"
-NO_GLOBAL_LOAD_LOOP = "NGL"
-NO_LOCAL_LOAD_LOOP = "NLL"
-
-# --- Pack Group Sizes ---
-PACK_GROUP_SIZE_TF32 = 24        # 4 CVT0 + 16 middle + 4 CVT1
-PACK_GROUP_SIZE_TF32_4X4 = 10    # 4 CVT0 + 2 MFMA + 4 CVT1
-
-# --- TF32 Pack Index Ranges (within a group) ---
-# Regular TF32 (groups of 24)
-TF32_CVT0_END = 4                # Indices 0..3 are CVT0
-TF32_MIDDLE_16_START = 4         # Indices 4..19 are middle-16
-TF32_MIDDLE_16_END = 20          # (exclusive)
-# TF32_CVT1 occupies indices 20..23
-
-# 4x4 MFMA TF32 (groups of 10)
-TF32_4X4_MFMA_START = 4          # Indices 4..5 are 4x4 MFMAs
-TF32_4X4_MFMA_END = 6            # (exclusive)
-# CVT0: 0..3, CVT1: 6..9
-
-# --- Quad-Cycle Timing (CDNA 4 ISA section 7.6) ---
-QUAD_CYCLES_CVT_BEFORE_MFMA = 2          # CVT packs need 2 quad-cycles before MFMA can use result
-QUAD_CYCLES_MFMA_4X4_BEFORE_CVT1 = 5     # 4x4 MFMA needs 5 quad-cycles before CVT1 can use result
-QUAD_CYCLES_STANDARD_MFMA_FINISH = 3      # Standard MFMA takes 3 quad-cycles to finish after issue
-QUAD_CYCLES_MFMA_4X4_FINISH = 1           # 4x4 MFMA takes 1 quad-cycle to finish after issue
-
-# --- MFMA Type-Switch Thresholds ---
-MFMA_TYPE_SWITCH_THRESHOLD_FROM_STANDARD = 5  # Min gap before type switch from standard MFMA
-MFMA_TYPE_SWITCH_THRESHOLD_FROM_4X4 = 3       # Min gap before type switch from 4x4 MFMA
-
-# --- TF32 Emulation ---
-MFMAS_PER_TILE_TF32 = 3   # 3 MFMAs per tile pair in TF32 emulation
-MFMAS_PER_TILE_BF16 = 1   # 1 MFMA per tile pair in BF16
-
-# --- VGPRs ---
-VGPRS_PER_CONVERSION_GROUP = 8   # 8 VGPRs per conversion group in TF32 emulation
-
 ALL_INSTRUCTION_NAMES = [
     "LRA0", "LRB0", "LRA1", "LRB1", "LRA3", "LRB3",
     "GRA", "GRB",
@@ -527,6 +559,7 @@ class Timeline:
         assert kernel["DirectToLds"], "Only DirectToLds cases are supported by validator."
 
         swap_global_read_order = kernel["SwapGlobalReadOrder"]
+        is_4x4mfma_tf32 = kernel.get("UseMFMAF32XEmulation", False)
 
         # Explicitly add MFMAs to timeline.
         # Do at the top here so they are the first ones scheduled at each vmfma index.
@@ -587,7 +620,10 @@ class Timeline:
 
                 for idx_pack, idx_vmfma in enumerate(packs):
                     assert idx_vmfma >= -1, f"Code path {code_path}: Pack {name} at index {idx_pack} is not valid. Must be >= -1."
-                    pack = Pack(name=name, issued_at=POSITION_NEG_INF, issue_index=idx_pack)
+                    if is_4x4mfma_tf32 and idx_pack % PACK_GROUP_SIZE_TF32_4X4 in range(TF32_4X4_MFMA_START, TF32_4X4_MFMA_END):
+                        pack = MFMAPack(name=name, issued_at=POSITION_NEG_INF, issue_index=idx_pack)
+                    else:
+                        pack = Pack(name=name, issued_at=POSITION_NEG_INF, issue_index=idx_pack)
                     self._insert(idx_vmfma, pack, kernel)
             else:
                 raise NotImplementedError(f"Instruction {name} not implemented")
@@ -1092,13 +1128,11 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
                 pack.needed_by = packs[i_pack + (4 - idx_in_group)]
             elif idx_in_group in [2, 3]:
                 pack.needed_by = packs[i_pack + (5 - idx_in_group)]
-            elif idx_in_group == 4:
-                # Pack 4's result is first used by pack 8.
-                pack.needed_by = packs[i_pack + 4]
-                continue
-            elif idx_in_group == 5:
-                # Pack 5's result is first used by pack 6.
-                pack.needed_by = packs[i_pack + 1]
+            elif isinstance(pack, MFMAPack):
+                if idx_in_group == TF32_4X4_MFMA_START:        # index 4
+                    pack.needed_by = packs[i_pack + 4]
+                elif idx_in_group == TF32_4X4_MFMA_START + 1:   # index 5
+                    pack.needed_by = packs[i_pack + 1]
                 continue
             
             # Calculate pack_offset within the tile (which MFMA within the 3-MFMA group uses this pack)
@@ -1178,11 +1212,10 @@ def _handle_min_pack_quad_cycles(packs: list[Pack], is_4x4mfma: bool) -> None:
     if is_4x4mfma:
         # For TF32 4x4 MFMA: packs come in groups of 10
         # - First 4 packs (CVT0): need 2 quad-cycles before first 4x4 MFMA
-        # - Middle 2 packs: are 4x4 MFMAs themselves, no constraint
+        # - Middle 2 packs (MFMAPack): need 5 quad-cycles before CVT1 can use result
         # - Last 4 packs (CVT1): need 2 quad-cycles before "real" MFMAs that use the result
         for pack in packs:
-            idx_in_group = pack.issue_index % PACK_GROUP_SIZE_TF32_4X4
-            if TF32_4X4_MFMA_START <= idx_in_group < TF32_4X4_MFMA_END:
+            if isinstance(pack, MFMAPack):
                 # Middle 2 packs are 4x4 MFMAs, need 5 quad-cycles before the CVT1 instructions
                 pack.min_quad_cycles_before_result_used = QUAD_CYCLES_MFMA_4X4_BEFORE_CVT1
             else:
@@ -1502,64 +1535,40 @@ def hook_up_packs(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int
             
             _set_pack_needed_by(packs, pack_name, i_loop, mfma_reorder, mfma_for_linear_index, timeline.num_vmfma, kernel)
 
-def precompute_issue_times(instructions: list[ValidatorInstruction], is_4x4mfma_tf32_packs: bool) -> list[int]:
+def precompute_issue_times(instructions: list[ValidatorInstruction]) -> list[int]:
     """
     Returns a list where issue_times[i] represents the quad-cycle when instruction i starts issuing.
-    
+
     Args:
         instructions: List of ValidatorInstruction objects in execution order.
-        is_4x4mfma_tf32_packs: True if using TF32 4x4 MFMA mode (affects Pack timing).
     """
-    class MFMAType(Enum):
-        """Used for tracking type switching penalties in quad-cycle estimation."""
-        NONE = 0      # Not an MFMA instruction
-        STANDARD = 1  # Standard MFMA instruction
-        MFMA_4X4 = 2  # 4x4 MFMA Pack instruction (indices 4-5 in groups of 10)
-
-    def get_mfma_info(instruction: ValidatorInstruction) -> tuple[MFMAType, Optional[int]]:
-        """
-        Get MFMA information for an instruction.
-        
-        Returns:
-            Tuple of (mfma_type, finish_cycles):
-            - mfma_type: The type of MFMA instruction
-            - finish_cycles: Number of quad-cycles the MFMA takes to finish, or None if not an MFMA
-        """
-        if isinstance(instruction, MFMA):
-            return (MFMAType.STANDARD, QUAD_CYCLES_STANDARD_MFMA_FINISH)
-        if isinstance(instruction, Pack) and is_4x4mfma_tf32_packs:
-            idx_in_group = instruction.issue_index % PACK_GROUP_SIZE_TF32_4X4
-            if idx_in_group in range(TF32_4X4_MFMA_START, TF32_4X4_MFMA_END):
-                return (MFMAType.MFMA_4X4, QUAD_CYCLES_MFMA_4X4_FINISH)
-        return (MFMAType.NONE, None)
-        
     mfma_free_at = 0
     current_issue = 0
-    last_mfma_type = MFMAType.NONE
+    last_mfma_class: Optional[type] = None
     last_mfma_issue = -1
-    
+
     issue_times = []
     for instruction in instructions:
-        mfma_type, finish_cycles = get_mfma_info(instruction)
-        if mfma_type != MFMAType.NONE:
+        if isinstance(instruction, MFMA):
             # MFMAs must wait for previous MFMA to finish
             current_issue = max(current_issue, mfma_free_at)
-            
+
             # MFMA type switch penalty
-            if last_mfma_type != MFMAType.NONE and last_mfma_type != mfma_type:
+            current_mfma_class = type(instruction)
+            if last_mfma_class and current_mfma_class != last_mfma_class:
                 gap = current_issue - last_mfma_issue
-                threshold = MFMA_TYPE_SWITCH_THRESHOLD_FROM_STANDARD if last_mfma_type == MFMAType.STANDARD else MFMA_TYPE_SWITCH_THRESHOLD_FROM_4X4
+                threshold = MFMA_TYPE_SWITCH_THRESHOLD_FROM_4X4 if last_mfma_class is MFMAPack else MFMA_TYPE_SWITCH_THRESHOLD_FROM_STANDARD
                 if gap < threshold:
                     current_issue += 1
-            
-            mfma_free_at = current_issue + 1 + finish_cycles  # 1 to issue + finish_cycles to complete
+
+            mfma_free_at = current_issue + 1 + instruction.__mfma_finish_cycles__  # 1 to issue + finish_cycles to complete
 
             last_mfma_issue = current_issue
-            last_mfma_type = mfma_type
-        
+            last_mfma_class = current_mfma_class
+
         issue_times.append(current_issue)
         current_issue = current_issue + instruction.min_issue_quad_cycles()
-    
+
     return issue_times
 
 def estimate_quad_cycles_precomputed(i_start: int, i_end: int, issue_times: list[int]) -> int:
@@ -1622,7 +1631,7 @@ def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
     index_for_inst_id = {id(inst): i for i, inst in enumerate(timeline.combined_timeline)}
 
     # Precompute issue times
-    issue_times = precompute_issue_times(timeline.combined_timeline, kernel.get("UseMFMAF32XEmulation", False))
+    issue_times = precompute_issue_times(timeline.combined_timeline)
         
     # Estimate number of quad-cycles between being issued and result being used
     for i_instruction, instruction in enumerate(timeline.combined_timeline):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1385,16 +1385,17 @@ def _hook_up_packs_f32(packs: list[Pack], all_middle_16_packs: list['MiddlePack'
     # For the middle-16 packs, hook up the consumer Pack to the producer Pack to handle temporary register re-use.
     # The middle 16 packs are scheduled sequentially in pairs, and no other middle-16 pack
     # (even from other groups) can be scheduled between a pair.
-    for i, pack in enumerate(packs):
-        if isinstance(pack, MiddlePack) and pack.issue_index % 2 == 0:
-            pack.pair_consumer = packs[i + 1]
+    for group_idx in sorted(pack_groups.keys()):
+        middle_packs = [p for p in pack_groups[group_idx] if isinstance(p, MiddlePack)]
+        for i in range(0, len(middle_packs), 2):
+            middle_packs[i].pair_consumer = middle_packs[i + 1]
 
     # Hook up the producer Pack in each pair to the middle-16 Pack scheduled immediately after it.
     # Only modify the packs that were passed in, rather than all packs in all_middle_16_packs.
     for pack in packs:
         if not isinstance(pack, MiddlePack):
             continue
-        if pack.issue_index % 2 != 0:  # Not a producer
+        if pack.pair_consumer is None:  # Not a producer (pair_consumer set above)
             continue
         pack.next_scheduled_middle_16 = all_middle_16_packs[all_middle_16_packs.index(pack) + 1]
 

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -225,7 +225,7 @@ class Pack(ValidatorInstruction):
     def done_idx(self) -> SchedulePosition:
         return self.issued_at
 
-    def validate(self) -> str | None:
+    def validate(self) -> Optional[str]:
         issued_at = self.issued_at.vmfma_index
 
         if self.must_start_after.done_idx() < self.issued_at < self.needed_by.done_idx():
@@ -258,7 +258,7 @@ class TimedPack(Pack):
     # This is a lower bound estimate (does not account for most stalls and such).
     estimated_quad_cycles_before_result_used: int = 0
 
-    def validate(self) -> str | None:
+    def validate(self) -> Optional[str]:
         error = super().validate()
         if error:
             return error
@@ -279,7 +279,7 @@ class MiddlePack(Pack):
     pair_consumer: Optional['MiddlePack'] = None
     next_scheduled_middle_16: Optional['MiddlePack'] = None
 
-    def validate(self) -> str | None:
+    def validate(self) -> Optional[str]:
         error = super().validate()
         if error:
             return error

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -1630,8 +1630,8 @@ def estimate_quad_cycles_precomputed(i_start: int, i_end: int, issue_times: list
 @applies_only_once
 def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
     """
-    Perform a rough estimate on the number of quad-cycles that pass between when a instruction is issued and when its result is used.
-    Needed to ensure the restrictions laied out in section 7.6 of the CDNA 4 ISA are met. Failing to meet these restrictions will result in deterministic errors.
+    Perform a rough estimate on the number of quad-cycles that pass between when an instruction is issued and when its result is used.
+    Needed to ensure the restrictions laid out in section 7.6 of the CDNA 4 ISA are met. Failing to meet these restrictions will result in deterministic errors.
     
     E.g. for the 4x4 MFMA TF32 route the 6th and 7th pack instructions map to:
     v_mfma_f32_4x4x4_16b_bf16 v[0:3], ..., ..., ...

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -210,29 +210,16 @@ class MFMA(ValidatorInstruction):
 
 @dataclass
 class Pack(ValidatorInstruction):
+    """BF16 pack instructions (v_perm). Base class for all pack types."""
     name: str
     issued_at: SchedulePosition
     # The index in the list of Pack instructions provided by a CMS schedule.
     # Needed to properly calculate needed_by and must_start_after.
     issue_index: int
+    # Which tile/group this pack belongs to, computed at construction time.
+    group_index: int = 0
     needed_by: ValidatorInstruction = field(default_factory=lambda: MFMA(POSITION_INF))
     must_start_after: ValidatorInstruction = field(default_factory=lambda: MFMA(POSITION_NEG_INF))
-
-    # TF32 middle-16 pair constraint fields
-    # Regular TF32 case involves 24 Pack instructions per 8 VGPR in 4 logical groups: [first 4], [middle 16], [last 4]
-    # The middle-16 packs are issued in pairs: [produce result in temp VGPR, consume result from temp VGPR].
-    # All instances of the middle-16 packs used the SAME temp VGPR, thus we cannot schedule another middle-16 pack between
-    # the producer and consumer packs in any given pair.
-    pair_consumer: Optional['Pack'] = None  # The pack that should be the next one scheduled 
-    next_scheduled_middle_16: Optional['Pack'] = None  # Next middle-16 pack scheduled after this one
-
-    # The minimum number of quad-cycles that must pass before the result of this pack is used.
-    # Measure from the point that this Pack is finished being issued.
-    # See section 7.6 of the CDNA 4 ISA
-    min_quad_cycles_before_result_used: int = 0
-    # The estimated number of quad-cycles that passed between the pack being issued and the result being used.
-    # This is a lower bound estimate (does not account for most stalls and such).
-    estimated_quad_cycles_before_result_used: int = 0
 
     def done_idx(self) -> SchedulePosition:
         return self.issued_at
@@ -240,15 +227,11 @@ class Pack(ValidatorInstruction):
     def validate(self) -> str | None:
         issued_at = self.issued_at.vmfma_index
 
-        if (
-            (self.must_start_after.done_idx() < self.issued_at < self.needed_by.done_idx()) 
-            and (self.pair_consumer is self.next_scheduled_middle_16)
-            and (self.min_quad_cycles_before_result_used <= self.estimated_quad_cycles_before_result_used)
-        ):
+        if self.must_start_after.done_idx() < self.issued_at < self.needed_by.done_idx():
             return None
-        
+
         # TODO: Add info about the issue index of the instruction that failed when printing the error message.
-        
+
         # Issued too early
         if self.issued_at < self.must_start_after.done_idx():
             # NOTE: Don't have to check equality case, since only 1 instruction can be issued at any point in time.
@@ -261,32 +244,64 @@ class Pack(ValidatorInstruction):
             needed_by_at = self.needed_by.issued_at.vmfma_index
             return f"{self.name} @ idx={issued_at} issued too late, must be issued before {self.needed_by.name} @ idx={needed_by_at}."
 
-        # TF32 pair constraint validation
-        if self.pair_consumer:
-            assert self.next_scheduled_middle_16, "Pair leader must have a next_middle_16_in_schedule."
-
-            if not (self.next_scheduled_middle_16 is self.pair_consumer):
-                next_issued_at = self.next_scheduled_middle_16.issued_at.vmfma_index
-                pair_issued_at = self.pair_consumer.issued_at.vmfma_index
-                return f"{self.name} @ idx={issued_at} has wrong interleaving. Should have been followed by {self.pair_consumer.name} @ idx={pair_issued_at} but was followed by {self.next_scheduled_middle_16.name} @ idx={next_issued_at}."
-
-        # Not enough time before result was used
-        if self.estimated_quad_cycles_before_result_used < self.min_quad_cycles_before_result_used:
-            needed_by_at = self.needed_by.issued_at.vmfma_index
-            return f"{self.name} @ idx={issued_at} has too little gap between it and {self.needed_by.name} @ idx={needed_by_at}. Expected at least {self.min_quad_cycles_before_result_used} quad-cycles but only {self.estimated_quad_cycles_before_result_used} passed."
-
         return f"{self.name} at index {issued_at} is not valid."
 
 @dataclass
-class MFMAPack(Pack, MFMA):
+class TimedPack(Pack):
+    """Pack with quad-cycle timing constraints (TF32 CVT and MFMA packs)."""
+    # The minimum number of quad-cycles that must pass before the result of this pack is used.
+    # Measure from the point that this Pack is finished being issued.
+    # See section 7.6 of the CDNA 4 ISA
+    min_quad_cycles_before_result_used: int = 0
+    # The estimated number of quad-cycles that passed between the pack being issued and the result being used.
+    # This is a lower bound estimate (does not account for most stalls and such).
+    estimated_quad_cycles_before_result_used: int = 0
+
+    def validate(self) -> str | None:
+        error = super().validate()
+        if error:
+            return error
+        if self.estimated_quad_cycles_before_result_used < self.min_quad_cycles_before_result_used:
+            issued_at = self.issued_at.vmfma_index
+            needed_by_at = self.needed_by.issued_at.vmfma_index
+            return f"{self.name} @ idx={issued_at} has too little gap between it and {self.needed_by.name} @ idx={needed_by_at}. Expected at least {self.min_quad_cycles_before_result_used} quad-cycles but only {self.estimated_quad_cycles_before_result_used} passed."
+        return None
+
+@dataclass
+class CVTPack(TimedPack):
+    """TF32 CVT0/CVT1 packs (v_cvt_pk_bf16_f32). Type marker for isinstance dispatch."""
+    pass
+
+@dataclass
+class MiddlePack(Pack):
+    """Middle-16 packs in TF32 groups of 24. Have pair constraints for shared temp VGPR."""
+    pair_consumer: Optional['MiddlePack'] = None
+    next_scheduled_middle_16: Optional['MiddlePack'] = None
+
+    def validate(self) -> str | None:
+        error = super().validate()
+        if error:
+            return error
+        if self.pair_consumer:
+            assert self.next_scheduled_middle_16, "Pair leader must have a next_middle_16_in_schedule."
+            if not (self.next_scheduled_middle_16 is self.pair_consumer):
+                issued_at = self.issued_at.vmfma_index
+                next_issued_at = self.next_scheduled_middle_16.issued_at.vmfma_index
+                pair_issued_at = self.pair_consumer.issued_at.vmfma_index
+                return f"{self.name} @ idx={issued_at} has wrong interleaving. Should have been followed by {self.pair_consumer.name} @ idx={pair_issued_at} but was followed by {self.next_scheduled_middle_16.name} @ idx={next_issued_at}."
+        return None
+
+@dataclass
+class MFMAPack(TimedPack, MFMA):
     """A v_mfma_f32_4x4x4_16b_bf16 instruction used in TF32 4x4 emulation pack groups.
 
     These appear at indices TF32_4X4_MFMA_START..TF32_4X4_MFMA_END within each group
     of PACK_GROUP_SIZE_TF32_4X4. They are real MFMA instructions but participate in
     the pack dependency chain (CVT0 -> MFMAPack -> CVT1).
 
-    Inherits from both Pack and MFMA:
+    Inherits from both TimedPack and MFMA:
     - isinstance(x, Pack) is True — works with pack gathering, filtering, type hints
+    - isinstance(x, TimedPack) is True — has quad-cycle timing constraints
     - isinstance(x, MFMA) is True — captures "this IS an MFMA" semantics
     """
     # NOTE: Do NOT re-declare `name: str` here. Although the MRO field merge
@@ -559,6 +574,7 @@ class Timeline:
         assert kernel["DirectToLds"], "Only DirectToLds cases are supported by validator."
 
         swap_global_read_order = kernel["SwapGlobalReadOrder"]
+        is_tf32_emulation = kernel.get("UseF32XEmulation", False)
         is_4x4mfma_tf32 = kernel.get("UseMFMAF32XEmulation", False)
 
         # Explicitly add MFMAs to timeline.
@@ -620,8 +636,22 @@ class Timeline:
 
                 for idx_pack, idx_vmfma in enumerate(packs):
                     assert idx_vmfma >= -1, f"Code path {code_path}: Pack {name} at index {idx_pack} is not valid. Must be >= -1."
-                    if is_4x4mfma_tf32 and idx_pack % PACK_GROUP_SIZE_TF32_4X4 in range(TF32_4X4_MFMA_START, TF32_4X4_MFMA_END):
-                        pack = MFMAPack(name=name, issued_at=POSITION_NEG_INF, issue_index=idx_pack)
+                    if is_4x4mfma_tf32:
+                        # Construction-time constants: PACK_GROUP_SIZE_TF32_4X4, TF32_4X4_MFMA_START/END
+                        idx_in_group = idx_pack % PACK_GROUP_SIZE_TF32_4X4
+                        group_idx = idx_pack // PACK_GROUP_SIZE_TF32_4X4
+                        if TF32_4X4_MFMA_START <= idx_in_group < TF32_4X4_MFMA_END:
+                            pack = MFMAPack(name=name, issued_at=POSITION_NEG_INF, issue_index=idx_pack, group_index=group_idx)
+                        else:
+                            pack = CVTPack(name=name, issued_at=POSITION_NEG_INF, issue_index=idx_pack, group_index=group_idx)
+                    elif is_tf32_emulation:
+                        # Construction-time constants: PACK_GROUP_SIZE_TF32, TF32_MIDDLE_16_START/END
+                        idx_in_group = idx_pack % PACK_GROUP_SIZE_TF32
+                        group_idx = idx_pack // PACK_GROUP_SIZE_TF32
+                        if TF32_MIDDLE_16_START <= idx_in_group < TF32_MIDDLE_16_END:
+                            pack = MiddlePack(name=name, issued_at=POSITION_NEG_INF, issue_index=idx_pack, group_index=group_idx)
+                        else:
+                            pack = CVTPack(name=name, issued_at=POSITION_NEG_INF, issue_index=idx_pack, group_index=group_idx)
                     else:
                         pack = Pack(name=name, issued_at=POSITION_NEG_INF, issue_index=idx_pack)
                     self._insert(idx_vmfma, pack, kernel)
@@ -1106,131 +1136,136 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
 
     if is_4x4mfma_tf32:
         # TF32 4x4 MFMA: Packs come in groups of 10
-        # First 4 packs (CVT0) feed into indices 4-5 (4x4 MFMAs)
-        # Middle 2 packs are 4x4 MFMAs.
-        # Last 4 packs (CVT1) feed into the actual MFMAs starting at base_offset
-        
+        # CVT0 packs feed into MFMAPacks, MFMAPacks feed into CVT1 packs
+        # CVT0 and CVT1 packs also feed into external MFMAs
+
         # Half tile count since each quarter uses half of the A tiles and half of the B tiles.
         n_tiles_a //= 2
         n_tiles_b //= 2
 
         packs = sorted(packs, key=lambda x: x.issue_index)
-        for i_pack, pack in enumerate(packs):
-            idx_in_group = pack.issue_index % PACK_GROUP_SIZE_TF32_4X4
-            # Which group of 10 packs (which tile) does this pack belong to?
-            group_index = pack.issue_index // PACK_GROUP_SIZE_TF32_4X4
+        # Group packs by group_index (computed at construction time)
+        groups: dict[int, list[Pack]] = defaultdict(list)
+        for pack in packs:
+            groups[pack.group_index].append(pack)
 
-            # The first 4 packs have both a needed_by for MFMAs, and a needed_by for the next packs
-            # First 4 CVT0 packs (indices 0-3) feed into 4x4 MFMAs (indices 4-5)
-            # Packs 0 and 1 are needed by Pack 4 (first 4x4 MFMA)
-            # Packs 2 and 3 are needed by Pack 5 (second 4x4 MFMA)
-            if idx_in_group in [0, 1]:
-                pack.needed_by = packs[i_pack + (4 - idx_in_group)]
-            elif idx_in_group in [2, 3]:
-                pack.needed_by = packs[i_pack + (5 - idx_in_group)]
-            elif isinstance(pack, MFMAPack):
-                if idx_in_group == TF32_4X4_MFMA_START:        # index 4
-                    pack.needed_by = packs[i_pack + 4]
-                elif idx_in_group == TF32_4X4_MFMA_START + 1:   # index 5
-                    pack.needed_by = packs[i_pack + 1]
-                continue
-            
-            # Calculate pack_offset within the tile (which MFMA within the 3-MFMA group uses this pack)
-            if idx_in_group < TF32_CVT0_END:
-                # First 4 CVT0 packs: feed into the 1st MFMA of each tile (bf16*bf16)
-                pack_offset = 0
-            else:
-                # Last 4 CVT1 packs (indices 6-9): produce error terms used by 2nd/3rd MFMAs
-                # A_error is used in mfma 2/3 (offset 1)
-                # B_error is used in mfma 3/3 (offset 2)
+        for group_index, group_packs in sorted(groups.items()):
+            # Separate by type within each group
+            cvt_packs = [p for p in group_packs if isinstance(p, CVTPack)]
+            mfma_packs = [p for p in group_packs if isinstance(p, MFMAPack)]
+            # First 4 CVTPacks are CVT0 (before MFMAPacks by construction order)
+            cvt0 = cvt_packs[:4]
+            # Last 4 CVTPacks are CVT1 (after MFMAPacks by construction order)
+            cvt1 = cvt_packs[4:]
+
+            # CVT0 → MFMAPack inter-pack dependencies
+            # Packs 0 and 1 are needed by first 4x4 MFMA
+            # Packs 2 and 3 are needed by second 4x4 MFMA
+            cvt0[0].needed_by = mfma_packs[0]
+            cvt0[1].needed_by = mfma_packs[0]
+            cvt0[2].needed_by = mfma_packs[1]
+            cvt0[3].needed_by = mfma_packs[1]
+
+            # MFMAPack → CVT1 inter-pack dependencies
+            mfma_packs[0].needed_by = cvt1[2]
+            mfma_packs[1].needed_by = cvt1[0]
+
+            # External MFMA needed_by for CVT0 packs
+            for pack in cvt0:
+                earliest_execution = find_earliest_mfma_execution(
+                    is_pack_B=is_pack_B,
+                    tile_index=group_index,
+                    mfma_in_tile=0,  # CVT0 feeds into 1st MFMA (bf16*bf16)
+                    base_offset=base_offset,
+                    n_a_tiles=n_tiles_a,
+                    n_b_tiles=n_tiles_b,
+                    mfma_reorder=mfma_reorder,
+                )
+                mfma_needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
+                # CVT0 packs have both inter-pack and MFMA needed_by; take the earlier one
+                if pack.needed_by.issued_at > mfma_needed_by.issued_at:
+                    pack.needed_by = mfma_needed_by
+
+            # External MFMA needed_by for CVT1 packs
+            for pack in cvt1:
                 pack_offset = 2 if is_pack_B else 1
-            
-            earliest_execution = find_earliest_mfma_execution(
-                is_pack_B=is_pack_B,
-                tile_index=group_index,
-                mfma_in_tile=pack_offset,
-                base_offset=base_offset,
-                n_a_tiles=n_tiles_a,
-                n_b_tiles=n_tiles_b,
-                mfma_reorder=mfma_reorder,
-            )
-            
-            # Add iteration offset to get final position
-            mfma_needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
-            # Packs 0-3 have multiple needed_by. But since both have the same min quad-cycle wait,
-            # We can pick the one that occurs sooner as it's the active constraint.
-            if pack.needed_by.issued_at > mfma_needed_by.issued_at:
-                pack.needed_by = mfma_needed_by
+                earliest_execution = find_earliest_mfma_execution(
+                    is_pack_B=is_pack_B,
+                    tile_index=group_index,
+                    mfma_in_tile=pack_offset,
+                    base_offset=base_offset,
+                    n_a_tiles=n_tiles_a,
+                    n_b_tiles=n_tiles_b,
+                    mfma_reorder=mfma_reorder,
+                )
+                mfma_needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
+                if pack.needed_by.issued_at > mfma_needed_by.issued_at:
+                    pack.needed_by = mfma_needed_by
     else:
         # Regular TF32: Packs come in groups of 24
         # Half tile count since each quarter uses half of the A tiles and half of the B tiles.
         n_tiles_a //= 2
         n_tiles_b //= 2
+
+        # Group packs by group_index (computed at construction time)
+        groups: dict[int, list[Pack]] = defaultdict(list)
         for pack in packs:
-            idx_in_group = pack.issue_index % PACK_GROUP_SIZE_TF32
-            # Which group of 24 packs (which tile) does this pack belong to?
-            group_index = pack.issue_index // PACK_GROUP_SIZE_TF32
+            groups[pack.group_index].append(pack)
 
-            # Middle 16 packs (4-19) don't need needed_by set
-            # They are depended on by the last 4 packs and are handled implicitly.
-            if TF32_MIDDLE_16_START <= idx_in_group < TF32_MIDDLE_16_END:
-                continue
+        for group_index, group_packs in sorted(groups.items()):
+            # MiddlePacks don't need needed_by set (handled implicitly)
+            cvt_packs = [p for p in group_packs if isinstance(p, CVTPack)]
+            assert len(cvt_packs) == 8, f"Expected 8 CVT packs per group, got {len(cvt_packs)}"
+            # First 4 CVTPacks are CVT0, last 4 are CVT1 (by construction order)
+            cvt0 = cvt_packs[:4]
+            cvt1 = cvt_packs[4:]
 
-            # Determine which MFMA within the 3-MFMA tile group uses this pack
-            if idx_in_group < TF32_CVT0_END:
+            for pack in cvt0:
                 # CVT0 packs (bf16 approximations) are used by MFMA 0 (bf16*bf16)
-                mfma_in_tile = 0
-            else:
+                earliest_execution = find_earliest_mfma_execution(
+                    is_pack_B=is_pack_B,
+                    tile_index=group_index,
+                    mfma_in_tile=0,
+                    base_offset=base_offset,
+                    n_a_tiles=n_tiles_a,
+                    n_b_tiles=n_tiles_b,
+                    mfma_reorder=mfma_reorder,
+                )
+                pack.needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
+
+            for pack in cvt1:
                 # CVT1 packs (error terms): A_error -> 2nd MFMA, B_error -> 3rd MFMA
                 mfma_in_tile = 2 if is_pack_B else 1
-
-            earliest_execution = find_earliest_mfma_execution(
-                is_pack_B=is_pack_B,
-                tile_index=group_index,
-                mfma_in_tile=mfma_in_tile,
-                base_offset=base_offset,
-                n_a_tiles=n_tiles_a,
-                n_b_tiles=n_tiles_b,
-                mfma_reorder=mfma_reorder,
-            )
-
-            # Add iteration offset to get final position
-            pack.needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
+                earliest_execution = find_earliest_mfma_execution(
+                    is_pack_B=is_pack_B,
+                    tile_index=group_index,
+                    mfma_in_tile=mfma_in_tile,
+                    base_offset=base_offset,
+                    n_a_tiles=n_tiles_a,
+                    n_b_tiles=n_tiles_b,
+                    mfma_reorder=mfma_reorder,
+                )
+                pack.needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
        
 
-def _handle_min_pack_quad_cycles(packs: list[Pack], is_4x4mfma: bool) -> None:
+def _handle_min_pack_quad_cycles(packs: list[Pack]) -> None:
     """
-    Set the min_quad_cycles_before_result_used field for Pack instructions.
+    Set the min_quad_cycles_before_result_used field for TimedPack instructions.
     This is used to enforce timing constraints for TF32 emulation modes.
-    
+    Only TimedPack subclasses (CVTPack, MFMAPack) have timing fields;
+    MiddlePack and plain Pack are skipped.
+
     Args:
         packs: List of Pack instructions to set minimum quad-cycles for.
-        is_4x4mfma: True if using TF32 4x4 MFMA mode (groups of 10), 
-                    False for main TF32 mode (groups of 24).
     """
-    
-    if is_4x4mfma:
-        # For TF32 4x4 MFMA: packs come in groups of 10
-        # - First 4 packs (CVT0): need 2 quad-cycles before first 4x4 MFMA
-        # - Middle 2 packs (MFMAPack): need 5 quad-cycles before CVT1 can use result
-        # - Last 4 packs (CVT1): need 2 quad-cycles before "real" MFMAs that use the result
-        for pack in packs:
-            if isinstance(pack, MFMAPack):
-                # Middle 2 packs are 4x4 MFMAs, need 5 quad-cycles before the CVT1 instructions
-                pack.min_quad_cycles_before_result_used = QUAD_CYCLES_MFMA_4X4_BEFORE_CVT1
-            else:
-                # First 4 and last 4 packs (CVT instructions) need 2 quad-cycles before MFMAs can use their results.
-                pack.min_quad_cycles_before_result_used = QUAD_CYCLES_CVT_BEFORE_MFMA
-
-    else:
-        # For main TF32 mode: packs come in groups of 24
-        # - First 4 packs (indices 0-3): CVT0, need 2 quad-cycles before MFMA
-        # - Middle 16 packs (indices 4-19): v_cvt_f32_bf16 + v_sub_f32 pairs, no constraint
-        # - Last 4 packs (indices 20-23): CVT1, need 2 quad-cycles before MFMA
-        for pack in packs:
-            if not (TF32_MIDDLE_16_START <= pack.issue_index % PACK_GROUP_SIZE_TF32 < TF32_MIDDLE_16_END):
-                # First 4 and last 4 packs (CVT instructions) need 2 quad-cycles before MFMAs can use their results.
-                pack.min_quad_cycles_before_result_used = QUAD_CYCLES_CVT_BEFORE_MFMA
+    for pack in packs:
+        if isinstance(pack, MFMAPack):
+            # 4x4 MFMAs need 5 quad-cycles before CVT1 can use result
+            pack.min_quad_cycles_before_result_used = QUAD_CYCLES_MFMA_4X4_BEFORE_CVT1
+        elif isinstance(pack, CVTPack):
+            # CVT packs need 2 quad-cycles before MFMAs can use their results
+            pack.min_quad_cycles_before_result_used = QUAD_CYCLES_CVT_BEFORE_MFMA
+        # All other packs have no timing constraints
 
 def _hook_up_packs_bf16(packs: list[Pack], local_reads: list[LocalRead]) -> None:
     """
@@ -1265,7 +1300,7 @@ def _hook_up_packs_bf16(packs: list[Pack], local_reads: list[LocalRead]) -> None
         if latest_lr.guaranteed_by > pack.must_start_after.done_idx():
             pack.must_start_after = latest_lr
 
-def _hook_up_packs_f32(packs: list[Pack], all_middle_16_packs: list[Pack], local_reads: list[LocalRead]) -> None:
+def _hook_up_packs_f32(packs: list[Pack], all_middle_16_packs: list['MiddlePack'], local_reads: list[LocalRead]) -> None:
     """
     For TF32 emulation, data is loaded as fp32 and converted into pairs of bf16 values.
     Each fp32 value is converted into a bf16 approximation and an error term.
@@ -1280,7 +1315,7 @@ def _hook_up_packs_f32(packs: list[Pack], all_middle_16_packs: list[Pack], local
     - 4 `v_cvt_pk_bf16_f32` to calculate and pack the bf16 approximations.
     - 8 pairs of (`v_cvt_f32_bf16`, `v_sub_f32`) to calculate the error terms.
     - 4 `v_cvt_pk_bf16_f32` to pack the error terms into final registers.
-    
+
     This function sets the must_start_after field based on LR and inter-pack dependencies,
     and handles pair constraints for middle-16 packs.
     The needed_by field is set separately by _set_pack_needed_by.
@@ -1289,8 +1324,11 @@ def _hook_up_packs_f32(packs: list[Pack], all_middle_16_packs: list[Pack], local
     # This is necessary to handle inter-pack dependencies.
     packs = sorted(packs, key=lambda x: x.issue_index)
 
-    assert len(packs) % PACK_GROUP_SIZE_TF32 == 0, "Each Pack must be a multiple of 24 instructions in TF32 emulation mode."
-    n_pack_groups = len(packs) // PACK_GROUP_SIZE_TF32
+    # Group packs by group_index (computed at construction time)
+    pack_groups: dict[int, list[Pack]] = defaultdict(list)
+    for pack in packs:
+        pack_groups[pack.group_index].append(pack)
+    n_pack_groups = len(pack_groups)
 
     assert len(local_reads) % n_pack_groups == 0, "Case not supported: Different number of LRs for each Pack group."
     n_lrs_per_group = len(local_reads) // n_pack_groups
@@ -1300,9 +1338,9 @@ def _hook_up_packs_f32(packs: list[Pack], all_middle_16_packs: list[Pack], local
 
     # Partial Pack->Pack dependency graph within a group of 24.
     # Key: pack index (0-23), Value: list of pack indices it depends on.
-    # Empty list means it has no dependencies on other packs.
+    # Empty list means it depends on local reads only (CVT0 packs).
     # NOTE: This is only a partial graph. It does not account for use of the temporary register by the middle 16 packs.
-    #       That interaction is handled seperately at the end of this function.
+    #       That interaction is handled separately at the end of this function.
     pack_dependencies: dict[int, list[int]] = {
         # First 4 packs (v_cvt_pk_bf16_f32) depend on local reads only, and are not included
         0: [], 1: [], 2: [], 3: [],
@@ -1318,19 +1356,18 @@ def _hook_up_packs_f32(packs: list[Pack], all_middle_16_packs: list[Pack], local
         23: [ 5,  7, 22],
     }
 
-    for group_idx in range(n_pack_groups):
+    for group_idx in sorted(pack_groups.keys()):
         start = group_idx * n_lrs_per_group
         end = start + n_lrs_per_group
         local_reads_for_group = local_reads[start:end]
 
-        start = group_idx * PACK_GROUP_SIZE_TF32
-        end = start + PACK_GROUP_SIZE_TF32
-        pack_group = packs[start:end]
+        pack_group = pack_groups[group_idx]
 
         # Set must_start_after
         for leader_idx, pack in enumerate(pack_group):
-            if leader_idx < TF32_CVT0_END:
-                # First 4 packs depend only on local reads.
+            dependencies = pack_dependencies[leader_idx]
+            if not dependencies:
+                # CVT0 packs: depend only on local reads.
                 first_lr = (leader_idx * 2) // vgprs_per_local_read
                 last_lr = (leader_idx * 2 + 1) // vgprs_per_local_read
                 pack_lrs = local_reads_for_group[first_lr:last_lr + 1]
@@ -1338,26 +1375,22 @@ def _hook_up_packs_f32(packs: list[Pack], all_middle_16_packs: list[Pack], local
                 if latest_lr.guaranteed_by > pack.must_start_after.done_idx():
                     pack.must_start_after = latest_lr
             else:
-                # Packs 4-23 depend on other packs (via pack_dependencies).
-                dependencies = pack_dependencies[leader_idx]
+                # MiddlePack and CVT1: depend on other packs (via pack_dependencies).
                 latest_dep = max((pack_group[d] for d in dependencies), key=lambda p: p.done_idx())
                 if latest_dep.done_idx() > pack.must_start_after.done_idx():
                     pack.must_start_after = latest_dep
 
     # For the middle-16 packs, hook up the consumer Pack to the producer Pack to handle temporary register re-use.
-    # Hook up the consumer Pack 
-    # Set up pair constraints for middle-16 packs (indices 4-19) to 
     # The middle 16 packs are scheduled sequentially in pairs, and no other middle-16 pack
     # (even from other groups) can be scheduled between a pair.
     for i, pack in enumerate(packs):
-        idx_in_group = pack.issue_index % PACK_GROUP_SIZE_TF32
-        if TF32_MIDDLE_16_START <= idx_in_group < TF32_MIDDLE_16_END and idx_in_group % 2 == 0:
+        if isinstance(pack, MiddlePack) and pack.issue_index % 2 == 0:
             pack.pair_consumer = packs[i + 1]
-    
+
     # Hook up the producer Pack in each pair to the middle-16 Pack scheduled immediately after it.
     # Only modify the packs that were passed in, rather than all packs in all_middle_16_packs.
     for pack in packs:
-        if not (TF32_MIDDLE_16_START <= (pack.issue_index % PACK_GROUP_SIZE_TF32) < TF32_MIDDLE_16_END):  # Not a middle-16 pack
+        if not isinstance(pack, MiddlePack):
             continue
         if pack.issue_index % 2 != 0:  # Not a producer
             continue
@@ -1383,8 +1416,11 @@ def _hook_up_packs_f32_mfma(packs: list[Pack], local_reads: list[LocalRead]) -> 
     # This is necessary to handle inter-pack dependencies.
     packs = sorted(packs, key=lambda x: x.issue_index)
 
-    assert len(packs) % PACK_GROUP_SIZE_TF32_4X4 == 0, "Packs must be issued in groups of 10."
-    n_pack_groups = len(packs) // PACK_GROUP_SIZE_TF32_4X4
+    # Group packs by group_index (computed at construction time)
+    pack_groups_map: dict[int, list[Pack]] = defaultdict(list)
+    for pack in packs:
+        pack_groups_map[pack.group_index].append(pack)
+    n_pack_groups = len(pack_groups_map)
 
     assert len(local_reads) % n_pack_groups == 0, "Case not supported: Different number of LRs for each Pack group."
     n_lrs_per_group = len(local_reads) // n_pack_groups
@@ -1394,7 +1430,7 @@ def _hook_up_packs_f32_mfma(packs: list[Pack], local_reads: list[LocalRead]) -> 
 
     # Partial Pack->Pack dependency graph within a group of 10.
     # Key: pack index (0-9), Value: list of pack indices it depends on.
-    # Empty list means it has no dependencies on other packs.
+    # Empty list means it depends on local reads only (CVT0 packs).
     # NOTE: Does not handle the quad-cycle spacing dependencies between packs and MFMAs.
     pack_dependencies: dict[int, list[int]] = {
         # First 4 packs only depend on local reads.
@@ -1409,29 +1445,27 @@ def _hook_up_packs_f32_mfma(packs: list[Pack], local_reads: list[LocalRead]) -> 
         9: [4, 8],
     }
 
-    for group_idx in range(n_pack_groups):
+    for group_idx in sorted(pack_groups_map.keys()):
         start = group_idx * n_lrs_per_group
         end = start + n_lrs_per_group
         local_reads_for_group = local_reads[start:end]
 
-        start = group_idx * PACK_GROUP_SIZE_TF32_4X4
-        end = start + PACK_GROUP_SIZE_TF32_4X4
-        pack_group = packs[start:end]
+        pack_group = pack_groups_map[group_idx]
 
         # Set must_start_after
         for pack_idx, pack in enumerate(pack_group):
-            if pack_idx < TF32_CVT0_END:
-                # First 4 packs depend only on local reads.
+            dependencies = pack_dependencies[pack_idx]
+            if not dependencies:
+                # CVT0 packs: depend only on local reads.
                 first_lr = (pack_idx * 2) // vgprs_per_local_read
                 last_lr = (pack_idx * 2 + 1) // vgprs_per_local_read
                 pack_lrs = local_reads_for_group[first_lr:last_lr + 1]
                 latest_lr = max(pack_lrs, key=lambda lr: lr.done_idx())
-                
+
                 if latest_lr.guaranteed_by > pack.must_start_after.done_idx():
                     pack.must_start_after = latest_lr
             else:
-                # Packs 4-9 depend on other packs (via pack_dependencies).
-                dependencies = pack_dependencies[pack_idx]
+                # MFMAPack and CVT1: depend on other packs (via pack_dependencies).
                 latest_dep = max((pack_group[d] for d in dependencies), key=lambda p: p.done_idx())
                 if latest_dep.done_idx() > pack.must_start_after.done_idx():
                     pack.must_start_after = latest_dep
@@ -1514,7 +1548,7 @@ def hook_up_packs(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int
             all_middle_16_packs = []
             for packs in packs_by_name.values():
                 for pack in packs:
-                    if TF32_MIDDLE_16_START <= (pack.issue_index % PACK_GROUP_SIZE_TF32) < TF32_MIDDLE_16_END:
+                    if isinstance(pack, MiddlePack):
                         all_middle_16_packs.append(pack)
             all_middle_16_packs.sort(key=lambda p: p.issued_at)
 
@@ -1529,7 +1563,7 @@ def hook_up_packs(timeline: Timeline, kernel: 'Solution', mfma_reorder: list[int
                     _hook_up_packs_f32_mfma(packs, local_reads)
                 else:
                     _hook_up_packs_f32(packs, all_middle_16_packs, local_reads)
-                _handle_min_pack_quad_cycles(packs, is_4x4mfma_tf32)
+                _handle_min_pack_quad_cycles(packs)
             else:
                 _hook_up_packs_bf16(packs, local_reads)
             
@@ -1635,20 +1669,17 @@ def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
         
     # Estimate number of quad-cycles between being issued and result being used
     for i_instruction, instruction in enumerate(timeline.combined_timeline):
-        if not hasattr(instruction, "min_quad_cycles_before_result_used") or instruction.min_quad_cycles_before_result_used == 0:
-            continue
-
-        if not hasattr(instruction, "needed_by") or instruction.needed_by is None:
-            continue
-        # needed_by can be a ValidatorInstruction or a SchedulePosition (e.g. GlobalRead.needed_by)
-        needed_by_obj = instruction.needed_by
-        if not isinstance(needed_by_obj, ValidatorInstruction):
-            continue
-        if needed_by_obj.issued_at == POSITION_INF:
+        if not isinstance(instruction, TimedPack) or instruction.min_quad_cycles_before_result_used == 0:
             continue
 
         needed_by = instruction.needed_by
-        
+        if needed_by is None:
+            continue
+        if not isinstance(needed_by, ValidatorInstruction):
+            continue
+        if needed_by.issued_at == POSITION_INF:
+            continue
+
         i_needed_by = index_for_inst_id.get(id(needed_by))
         estimate = estimate_quad_cycles_precomputed(i_instruction, i_needed_by, issue_times)
         instruction.estimated_quad_cycles_before_result_used = estimate

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -142,7 +142,7 @@ class ValidatorInstruction(ABC):
     name: str
     issued_at: SchedulePosition
     # The minimum number of quad-cycles that this instruction takes to issue.
-    __min_issue_quad_cycles__: int = 1
+    min_issue_quad_cycles_base: int = 1
 
     @abstractmethod
     def validate(self) -> Optional[str]:
@@ -158,7 +158,7 @@ class ValidatorInstruction(ABC):
         ...
 
     def min_issue_quad_cycles(self) -> int:
-        return self.__min_issue_quad_cycles__
+        return self.min_issue_quad_cycles_base
 
 @dataclass
 class LocalRead(ValidatorInstruction):
@@ -200,7 +200,7 @@ class LocalRead(ValidatorInstruction):
 class MFMA(ValidatorInstruction):
     issued_at: SchedulePosition
     name: str = "MFMA"
-    __mfma_finish_cycles__ = QUAD_CYCLES_STANDARD_MFMA_FINISH
+    mfma_finish_cycles = QUAD_CYCLES_STANDARD_MFMA_FINISH
 
     def done_idx(self) -> SchedulePosition:
         return self.issued_at
@@ -217,7 +217,8 @@ class Pack(ValidatorInstruction):
     # Needed to properly calculate needed_by and must_start_after.
     issue_index: int
     # Which tile/group this pack belongs to, computed at construction time.
-    group_index: int = 0
+    # Only meaningful for TF32 subclasses (CVTPack, MiddlePack, MFMAPack); None for BF16 packs.
+    group_index: Optional[int] = None
     needed_by: ValidatorInstruction = field(default_factory=lambda: MFMA(POSITION_INF))
     must_start_after: ValidatorInstruction = field(default_factory=lambda: MFMA(POSITION_NEG_INF))
 
@@ -310,16 +311,14 @@ class MFMAPack(TimedPack, MFMA):
     # `name = 'MFMA'` class attribute and re-introduces the default.
 
     # Override MFMA's finish cycles for 4x4 timing
-    __mfma_finish_cycles__ = QUAD_CYCLES_MFMA_4X4_FINISH
+    mfma_finish_cycles = QUAD_CYCLES_MFMA_4X4_FINISH
 
     # NOTE: min_quad_cycles_before_result_used is NOT overridden here.
-    # It keeps Pack's default (0) and is set by _handle_min_pack_quad_cycles
+    # It keeps TimedPack's default (0) and is set by _handle_min_pack_quad_cycles
     # only when the constraint is active (when local reads exist).
     #
-    # NOTE: validate() is NOT overridden here. Pack.validate() already handles
-    # MFMAPack correctly: pair_consumer and next_scheduled_middle_16 are both
-    # None, so the pair interleaving check is naturally skipped (None is None
-    # in the happy path, and `if self.pair_consumer:` is False in the error path).
+    # NOTE: validate() is NOT overridden here. The MRO chain
+    # (TimedPack.validate → Pack.validate) handles MFMAPack correctly.
 
 
 @dataclass
@@ -476,7 +475,7 @@ class SNop(ValidatorInstruction):
 
     def min_issue_quad_cycles(self) -> int:
         # Base instruction quad-cycles plus wait_state additional cycles
-        return self.__min_issue_quad_cycles__ + self.wait_state
+        return self.min_issue_quad_cycles_base + self.wait_state
 
     def done_idx(self) -> SchedulePosition:
         return self.issued_at
@@ -1153,10 +1152,12 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
             # Separate by type within each group
             cvt_packs = [p for p in group_packs if isinstance(p, CVTPack)]
             mfma_packs = [p for p in group_packs if isinstance(p, MFMAPack)]
-            # First 4 CVTPacks are CVT0 (before MFMAPacks by construction order)
+            assert len(cvt_packs) == 8, f"Expected 8 CVT packs per group, got {len(cvt_packs)}"
+            assert len(mfma_packs) == 2, f"Expected 2 MFMA packs per group, got {len(mfma_packs)}"
+            # CVT0 come before CVT1 by construction order (sorted by issue_index)
             cvt0 = cvt_packs[:4]
-            # Last 4 CVTPacks are CVT1 (after MFMAPacks by construction order)
             cvt1 = cvt_packs[4:]
+            assert cvt0[-1].issue_index < cvt1[0].issue_index, "CVT0 packs must have lower issue_index than CVT1 packs"
 
             # CVT0 → MFMAPack inter-pack dependencies
             # Packs 0 and 1 are needed by first 4x4 MFMA
@@ -1170,37 +1171,36 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
             mfma_packs[0].needed_by = cvt1[2]
             mfma_packs[1].needed_by = cvt1[0]
 
-            # External MFMA needed_by for CVT0 packs
+            # External MFMA needed_by for CVT0 packs (all share the same MFMA target)
+            cvt0_earliest = find_earliest_mfma_execution(
+                is_pack_B=is_pack_B,
+                tile_index=group_index,
+                mfma_in_tile=0,  # CVT0 feeds into 1st MFMA (bf16*bf16)
+                base_offset=base_offset,
+                n_a_tiles=n_tiles_a,
+                n_b_tiles=n_tiles_b,
+                mfma_reorder=mfma_reorder,
+            )
+            cvt0_mfma_needed_by = mfma_for_linear_index[iteration_offset + cvt0_earliest]
             for pack in cvt0:
-                earliest_execution = find_earliest_mfma_execution(
-                    is_pack_B=is_pack_B,
-                    tile_index=group_index,
-                    mfma_in_tile=0,  # CVT0 feeds into 1st MFMA (bf16*bf16)
-                    base_offset=base_offset,
-                    n_a_tiles=n_tiles_a,
-                    n_b_tiles=n_tiles_b,
-                    mfma_reorder=mfma_reorder,
-                )
-                mfma_needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
                 # CVT0 packs have both inter-pack and MFMA needed_by; take the earlier one
-                if pack.needed_by.issued_at > mfma_needed_by.issued_at:
-                    pack.needed_by = mfma_needed_by
+                if pack.needed_by.issued_at > cvt0_mfma_needed_by.issued_at:
+                    pack.needed_by = cvt0_mfma_needed_by
 
-            # External MFMA needed_by for CVT1 packs
+            # External MFMA needed_by for CVT1 packs (all share the same MFMA target)
+            cvt1_earliest = find_earliest_mfma_execution(
+                is_pack_B=is_pack_B,
+                tile_index=group_index,
+                mfma_in_tile=2 if is_pack_B else 1,
+                base_offset=base_offset,
+                n_a_tiles=n_tiles_a,
+                n_b_tiles=n_tiles_b,
+                mfma_reorder=mfma_reorder,
+            )
+            cvt1_mfma_needed_by = mfma_for_linear_index[iteration_offset + cvt1_earliest]
             for pack in cvt1:
-                pack_offset = 2 if is_pack_B else 1
-                earliest_execution = find_earliest_mfma_execution(
-                    is_pack_B=is_pack_B,
-                    tile_index=group_index,
-                    mfma_in_tile=pack_offset,
-                    base_offset=base_offset,
-                    n_a_tiles=n_tiles_a,
-                    n_b_tiles=n_tiles_b,
-                    mfma_reorder=mfma_reorder,
-                )
-                mfma_needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
-                if pack.needed_by.issued_at > mfma_needed_by.issued_at:
-                    pack.needed_by = mfma_needed_by
+                if pack.needed_by.issued_at > cvt1_mfma_needed_by.issued_at:
+                    pack.needed_by = cvt1_mfma_needed_by
     else:
         # Regular TF32: Packs come in groups of 24
         # Half tile count since each quarter uses half of the A tiles and half of the B tiles.
@@ -1216,36 +1216,38 @@ def _set_pack_needed_by(packs: list[Pack], pack_name: str, i_loop: int, mfma_reo
             # MiddlePacks don't need needed_by set (handled implicitly)
             cvt_packs = [p for p in group_packs if isinstance(p, CVTPack)]
             assert len(cvt_packs) == 8, f"Expected 8 CVT packs per group, got {len(cvt_packs)}"
-            # First 4 CVTPacks are CVT0, last 4 are CVT1 (by construction order)
+            # CVT0 come before CVT1 by construction order (sorted by issue_index)
             cvt0 = cvt_packs[:4]
             cvt1 = cvt_packs[4:]
+            assert cvt0[-1].issue_index < cvt1[0].issue_index, "CVT0 packs must have lower issue_index than CVT1 packs"
 
+            # CVT0 packs (bf16 approximations) are used by MFMA 0 (bf16*bf16)
+            cvt0_earliest = find_earliest_mfma_execution(
+                is_pack_B=is_pack_B,
+                tile_index=group_index,
+                mfma_in_tile=0,
+                base_offset=base_offset,
+                n_a_tiles=n_tiles_a,
+                n_b_tiles=n_tiles_b,
+                mfma_reorder=mfma_reorder,
+            )
+            cvt0_needed_by = mfma_for_linear_index[iteration_offset + cvt0_earliest]
             for pack in cvt0:
-                # CVT0 packs (bf16 approximations) are used by MFMA 0 (bf16*bf16)
-                earliest_execution = find_earliest_mfma_execution(
-                    is_pack_B=is_pack_B,
-                    tile_index=group_index,
-                    mfma_in_tile=0,
-                    base_offset=base_offset,
-                    n_a_tiles=n_tiles_a,
-                    n_b_tiles=n_tiles_b,
-                    mfma_reorder=mfma_reorder,
-                )
-                pack.needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
+                pack.needed_by = cvt0_needed_by
 
+            # CVT1 packs (error terms): A_error -> 2nd MFMA, B_error -> 3rd MFMA
+            cvt1_earliest = find_earliest_mfma_execution(
+                is_pack_B=is_pack_B,
+                tile_index=group_index,
+                mfma_in_tile=2 if is_pack_B else 1,
+                base_offset=base_offset,
+                n_a_tiles=n_tiles_a,
+                n_b_tiles=n_tiles_b,
+                mfma_reorder=mfma_reorder,
+            )
+            cvt1_needed_by = mfma_for_linear_index[iteration_offset + cvt1_earliest]
             for pack in cvt1:
-                # CVT1 packs (error terms): A_error -> 2nd MFMA, B_error -> 3rd MFMA
-                mfma_in_tile = 2 if is_pack_B else 1
-                earliest_execution = find_earliest_mfma_execution(
-                    is_pack_B=is_pack_B,
-                    tile_index=group_index,
-                    mfma_in_tile=mfma_in_tile,
-                    base_offset=base_offset,
-                    n_a_tiles=n_tiles_a,
-                    n_b_tiles=n_tiles_b,
-                    mfma_reorder=mfma_reorder,
-                )
-                pack.needed_by = mfma_for_linear_index[iteration_offset + earliest_execution]
+                pack.needed_by = cvt1_needed_by
        
 
 def _handle_min_pack_quad_cycles(packs: list[Pack]) -> None:
@@ -1595,7 +1597,7 @@ def precompute_issue_times(instructions: list[ValidatorInstruction]) -> list[int
                 if gap < threshold:
                     current_issue += 1
 
-            mfma_free_at = current_issue + 1 + instruction.__mfma_finish_cycles__  # 1 to issue + finish_cycles to complete
+            mfma_free_at = current_issue + 1 + instruction.mfma_finish_cycles  # 1 to issue + finish_cycles to complete
 
             last_mfma_issue = current_issue
             last_mfma_class = current_mfma_class
@@ -1652,7 +1654,7 @@ def estimate_quad_cycles(timeline: Timeline, kernel: 'Solution') -> int:
     During the finish cycles of an MFMA we can issue other instructions.
     E.g.: MFMA, SNop(2)
     There will have an execution time of 4 quad-cycles.
-    The SNop(2) which takes 3 quad-cycles (1 issue + 2 finish) will be executed in parallel with the MFMA finishing and fit intirely behind the 3 cycles the mfma takes to finish.
+    The SNop(2) which takes 3 quad-cycles (1 issue + 2 finish) will be executed in parallel with the MFMA finishing and fit entirely behind the 3 cycles the mfma takes to finish.
     """
     if not kernel.get("UseF32XEmulation", False):
         # Only F32 emulation issues instructions (Packs) which need estimation of quad-cycles for correctness.

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass, field
 from collections import defaultdict
 from copy import deepcopy
 from enum import Enum, auto
-from typing import Optional
+from typing import ClassVar, Optional
 
 from rocisa.instruction import SWaitCnt, SBarrier
 from Tensile.Common.Utilities import printWarning
@@ -142,7 +142,7 @@ class ValidatorInstruction(ABC):
     name: str
     issued_at: SchedulePosition
     # The minimum number of quad-cycles that this instruction takes to issue.
-    min_issue_quad_cycles_base: int = 1
+    min_issue_quad_cycles_base: ClassVar[int] = 1
 
     @abstractmethod
     def validate(self) -> Optional[str]:
@@ -200,7 +200,7 @@ class LocalRead(ValidatorInstruction):
 class MFMA(ValidatorInstruction):
     issued_at: SchedulePosition
     name: str = "MFMA"
-    mfma_finish_cycles = QUAD_CYCLES_STANDARD_MFMA_FINISH
+    mfma_finish_cycles: ClassVar[int] = QUAD_CYCLES_STANDARD_MFMA_FINISH
 
     def done_idx(self) -> SchedulePosition:
         return self.issued_at
@@ -311,7 +311,7 @@ class MFMAPack(TimedPack, MFMA):
     # `name = 'MFMA'` class attribute and re-introduces the default.
 
     # Override MFMA's finish cycles for 4x4 timing
-    mfma_finish_cycles = QUAD_CYCLES_MFMA_4X4_FINISH
+    mfma_finish_cycles: ClassVar[int] = QUAD_CYCLES_MFMA_4X4_FINISH
 
     # NOTE: min_quad_cycles_before_result_used is NOT overridden here.
     # It keeps TimedPack's default (0) and is set by _handle_min_pack_quad_cycles

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
@@ -25,7 +25,7 @@
 
 import unittest
 
-from Tensile.Components.CMSValidator import estimate_quad_cycles_precomputed, MFMA, MFMAPack, Pack, TimedPack, CVTPack, MiddlePack, precompute_issue_times, SchedulePosition, SNop, ValidatorInstruction
+from Tensile.Components.CMSValidator import estimate_quad_cycles_precomputed, MFMA, MFMAPack, Pack, precompute_issue_times, SchedulePosition, SNop, ValidatorInstruction
 
 
 def _pos(vmfma_index: int, sub_index: int) -> SchedulePosition:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
@@ -25,7 +25,7 @@
 
 import unittest
 
-from Tensile.Components.CMSValidator import estimate_quad_cycles_precomputed, MFMA, Pack, precompute_issue_times, SchedulePosition, SNop, ValidatorInstruction
+from Tensile.Components.CMSValidator import estimate_quad_cycles_precomputed, MFMA, MFMAPack, Pack, TimedPack, CVTPack, MiddlePack, precompute_issue_times, SchedulePosition, SNop, ValidatorInstruction
 
 
 def _pos(vmfma_index: int, sub_index: int) -> SchedulePosition:
@@ -33,7 +33,7 @@ def _pos(vmfma_index: int, sub_index: int) -> SchedulePosition:
 
 
 class TestEstimateQuadCyclesValidator(unittest.TestCase):
-    def validate(self, instruction: ValidatorInstruction, expected_quad_cycles: int, all_instructions: list[ValidatorInstruction], is_4x4mfma_tf32_packs: bool):
+    def validate(self, instruction: ValidatorInstruction, expected_quad_cycles: int, all_instructions: list[ValidatorInstruction]):
         """
         Helper method to validate quad-cycle estimation.
 
@@ -42,7 +42,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         2. Only the starting instruction has estimated_quad_cycles_before_result_used set to expected value
         3. All other instructions have estimated_quad_cycles_before_result_used set to 0
         """
-        issue_times = precompute_issue_times(all_instructions, is_4x4mfma_tf32_packs)
+        issue_times = precompute_issue_times(all_instructions)
         i_instruction = all_instructions.index(instruction)
         i_needed_by = all_instructions.index(instruction.needed_by)
 
@@ -75,7 +75,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
             target_mfma,
         ]
         # +4x3 for the 3 MFMAs to issue + finish
-        self.validate(pack0, 12, all_instructions, False)
+        self.validate(pack0, 12, all_instructions)
 
 
     def test_back_to_back_scalar(self):
@@ -92,7 +92,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         ]
         # +1 for 1st SNop
         # +1 for 2nd SNop
-        self.validate(pack0, 2, all_instructions, False)
+        self.validate(pack0, 2, all_instructions)
 
     def test_parallel_mfma_snop(self):
         """
@@ -114,7 +114,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         ]
         # +1 for MFMA to issue
         # +3 for MFMA to finish (3 SNops hidden in this latency)
-        self.validate(pack0, 4, all_instructions, False)
+        self.validate(pack0, 4, all_instructions)
 
     def test_mfma_before_start_non_mfma_instruction(self):
         """
@@ -135,7 +135,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
             SNop(issued_at=_pos(0, 4), wait_state=0),
             target_mfma
         ]
-        self.validate(pack0, 3, all_instructions, False)
+        self.validate(pack0, 3, all_instructions)
 
     def test_mfma_before_start_non_mfma_instruction_2(self):
         """
@@ -160,7 +160,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         # +3 quad-cycles for MFMA before window to finish.
         # +1 quad-cycle for MFMA in window to issue
         # (last SNop issues in parallel with MFMA finish)
-        self.validate(pack0, 4, all_instructions, False)
+        self.validate(pack0, 4, all_instructions)
 
     def test_mfma_before_start_mfma_instruction(self):
         """
@@ -185,7 +185,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         # +3 for first MFMA in window to finish (1 SNop issues in parallel)
         # +3 for second MFMA to finish (1 SNop issues in parallel)
         # +1 for final SNop to issue
-        self.validate(pack0, 8, all_instructions, False)
+        self.validate(pack0, 8, all_instructions)
 
     def test_4x4mfma_pack_parallel(self):
         """
@@ -193,7 +193,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         Ensure that we can issue things in parallel with them.
         """
         target_snop = SNop(issued_at=_pos(-1, 2), wait_state=0)
-        pack0 = Pack(name="PackA0", issue_index=5, issued_at=_pos(-1, 0), needed_by=target_snop)
+        pack0 = MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(-1, 0), needed_by=target_snop)
         all_instructions = [
             pack0,
             SNop(issued_at=_pos(-1, 1), wait_state=1),
@@ -201,14 +201,14 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         ]
         # +1 for Pack to finish (SNop issues in parallel)
         # +1 for SNop to finish
-        self.validate(pack0, 2, all_instructions, True)
+        self.validate(pack0, 2, all_instructions)
 
     def test_4x4mfma_to_mfma_extra_stall(self):
         """
         Extra 4 quad-cycle latency associated with switching MFMA type.
         """
         target_snop = SNop(issued_at=_pos(0, 1), wait_state=0)
-        pack0 = Pack(name="PackA0", issue_index=5, issued_at=_pos(-1, 0), needed_by=target_snop)
+        pack0 = MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(-1, 0), needed_by=target_snop)
         all_instructions = [
             pack0,
             MFMA(issued_at=_pos(0, 0)),
@@ -217,14 +217,14 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         # +1 for Pack to finish (MFMA stalls)
         # +1 extra since switching MFMA type
         # +1 for MFMA to issue
-        self.validate(pack0, 3, all_instructions, True)
+        self.validate(pack0, 3, all_instructions)
 
     def test_4x4mfma_to_mfma_extra_stall_missing(self):
         """
         4x4 -> 16x16 has extra 4 quad-cycle latency only when issuing in the first 3 quad-cycles after the MFMA.
         """
         target_snop = SNop(issued_at=_pos(0, 1), wait_state=0)
-        pack0 = Pack(name="PackA0", issue_index=5, issued_at=_pos(-1, 0), needed_by=target_snop)
+        pack0 = MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(-1, 0), needed_by=target_snop)
         all_instructions = [
             pack0,
             SNop(issued_at=_pos(-1, 1), wait_state=1),
@@ -234,7 +234,7 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         # +1 for Pack to finish (Snop issue hidden)
         # +1 for SNop finish
         # +1 for MFMA to issue
-        self.validate(pack0, 3, all_instructions, True)
+        self.validate(pack0, 3, all_instructions)
 
     def test_mfma_to_4x4mfma_extra_stall(self):
         """
@@ -245,14 +245,14 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         all_instructions = [
             pack0,
             MFMA(issued_at=_pos(0, 0)),
-            Pack(name="PackA0", issue_index=5, issued_at=_pos(0, 1)),
+            MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(0, 1)),
             target_snop,
         ]
         # +1 for MFMA to issue
         # +3 for MFMA to finish (PackA0 stalls)
         # +1 extra since switching MFMA type
         # +1 for PackA0 to issue
-        self.validate(pack0, 6, all_instructions, True)
+        self.validate(pack0, 6, all_instructions)
 
     def test_mfma_to_4x4mfma_extra_stall_missing(self):
         """
@@ -264,11 +264,11 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
             pack0,
             MFMA(issued_at=_pos(0, 0)),
             SNop(issued_at=_pos(0, 1), wait_state=3),
-            Pack(name="PackA0", issue_index=5, issued_at=_pos(0, 2)),
+            MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(0, 2)),
             target_snop,
         ]
         # +1 for MFMA to issue
         # +3 for MFMA to finish (SNop issue + 2 wait hidden)
         # +1 for SNop to finish (3rd of 3 wait_state)
         # +1 for PackA0 to issue
-        self.validate(pack0, 6, all_instructions, True)
+        self.validate(pack0, 6, all_instructions)


### PR DESCRIPTION
## Motivation

The Pack category for CMS is used as a grab bag of instructions which change type and rules depending on kernel type and flags. They require more structure and classes to handled than the other instructions which stay much more consistent between kernels and flags.

This PR adds in several subclasses and refactors the pack handling code to be less brittle and make it easier to add support for more flags and future pack types.

## Technical Details

- Introduced `CVTPack`, `MiddlePack`, and `MFMAPack` subclasses of `Pack` to replace index-based conditional logic (`issue_index % group_size`) with `isinstance` checks and subclass-specific fields.
- Extracted magic numbers (group sizes, quad-cycle timings, index ranges) into module-level named constants.
- Moved pair-constraint fields (`pair_consumer`, `next_scheduled_middle_16`) from the base `Pack` class into `MiddlePack` where they belong.
- Moved timing field (`min_quad_cycles_before_result_used`) into a `TimedPack` intermediate class shared by `CVTPack` and `MFMAPack`.
- Simplified `_handle_min_pack_quad_cycles` and `_set_pack_needed_by` — the per-type logic is now handled by the class hierarchy rather than modular-arithmetic on indices.
- Used `ClassVar` for class-level constants (`min_issue_quad_cycles_base`, `mfma_finish_cycles`).
- Updated tests to use relative position checks instead of brittle absolute-position assertions.

## Test Plan

Run existing test.

## Test Result

All tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.