### PR TITLE
Refresh README.md headings, CI badges, and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # ROCm Libraries
 
-Welcome to the ROCm Libraries superrepo. This repository consolidates multiple ROCm-related libraries and shared components into a single repository to streamline development, CI, and integration.
+Welcome to the ROCm Libraries super-repo. This repository consolidates multiple ROCm-related libraries and shared components into a single repository to streamline development, CI, and integration.
 
-## Superrepo Goals
+## Super-repo Goals
 
 - Enable unified build and test workflows across ROCm libraries.
 - Facilitate shared tooling, CI, and contributor experience.
 - Improve integration, visibility, and collaboration across ROCm library teams.
 
-## Superrepo Project Status
+## Super-repo Project Status
 
 ### TheRock CI Status
 
@@ -21,8 +21,8 @@ TheRock CI performs multi-component testing on top of builds leveraging [TheRock
 This table provides the current status of the migration of specific components as well as a pointer to the health of their legacy CI systems.
 
 **Key:**
-- **Completed**: Fully migrated and integrated. This superrepo should be considered the source of truth for this project. The old repo may still be used for certain release activities.
-- **In Progress**: Ongoing migration, tests, or integration. Please refrain from submitting new pull requests on the individual repo of the project, and develop on the superrepo.
+- **Completed**: Fully migrated and integrated. This super-repo should be considered the source of truth for this project. The old repo may still be used for certain release activities.
+- **In Progress**: Ongoing migration, tests, or integration. Please refrain from submitting new pull requests on the individual repo of the project, and develop on the super-repo.
 - **Pending**: Not yet started or in the early planning stages. The individual repo should be considered the source of truth for this project.
 
 | Component           | Migration Status | Azure CI Status                       | Math CI Status                        |
@@ -99,7 +99,7 @@ To begin contributing or building, see the [CONTRIBUTING.md](./CONTRIBUTING.md) 
 
 ## License
 
-This superrepo contains multiple subprojects, each of which retains the license under which it was originally published.
+This super-repo contains multiple subprojects, each of which retains the license under which it was originally published.
 
 - 📁 Refer to the `LICENSE`, `LICENSE.md`, or `LICENSE.txt` file within each `projects/` or `shared/` directory for specific license terms.
 - 📄 Refer to the header notice in individual files outside `projects/` or `shared/` folders for their specific license terms.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
 # ROCm Libraries
 
-Welcome to the ROCm Libraries monorepo. This repository consolidates multiple ROCm-related libraries and shared components into a single repository to streamline development, CI, and integration. The first set of libraries focuses on components required for building PyTorch.
+Welcome to the ROCm Libraries superrepo. This repository consolidates multiple ROCm-related libraries and shared components into a single repository to streamline development, CI, and integration.
 
-# Monorepo Status and CI Health
+## Superrepo Goals
 
-This table provides the current status of the migration of specific ROCm libraries as well as a pointer to their current CI health.
+- Enable unified build and test workflows across ROCm libraries.
+- Facilitate shared tooling, CI, and contributor experience.
+- Improve integration, visibility, and collaboration across ROCm library teams.
+
+## Superrepo Project Status
+
+### TheRock CI Status
+
+TheRock CI performs multi-component testing on top of builds leveraging [TheRock](https://github.com/ROCm/TheRock) build system.
+
+[![TheRock CI](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci.yml/badge.svg?branch=develop&event=push)](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci.yml?query=branch%3Adevelop+event%3Apush) [![TheRock CI Nightly](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci-nightly.yml/badge.svg?branch=develop)](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci-nightly.yml?query=branch%3Adevelop)
+
+### Component Migration and Legacy CI Status
+
+This table provides the current status of the migration of specific components as well as a pointer to the health of their legacy CI systems.
 
 **Key:**
-- **Completed**: Fully migrated and integrated. This monorepo should be considered the source of truth for this project. The old repo may still be used for release activities.
-- **In Progress**: Ongoing migration, tests, or integration. Please refrain from submitting new pull requests on the individual repo of the project, and develop on the monorepo.
+- **Completed**: Fully migrated and integrated. This superrepo should be considered the source of truth for this project. The old repo may still be used for certain release activities.
+- **In Progress**: Ongoing migration, tests, or integration. Please refrain from submitting new pull requests on the individual repo of the project, and develop on the superrepo.
 - **Pending**: Not yet started or in the early planning stages. The individual repo should be considered the source of truth for this project.
 
 | Component           | Migration Status | Azure CI Status                       | Math CI Status                        |
@@ -37,14 +51,6 @@ This table provides the current status of the migration of specific ROCm librari
 | `tensile`           | Completed   | [![Azure CI](https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/status%2Fmonorepo%2FTensile?repoName=ROCm%2Frocm-libraries&branchName=develop)](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/latest?definitionId=305&repoName=ROCm%2Frocm-libraries&branchName=develop) |[![Math-CI](https://pcue-math-rocm-ci-apim.azure-api.net/buildstatus?job=/rocm-libraries/precheckin/tensile/develop&subject=MathCI)](http://math-ci.amd.com/job/rocm-libraries/job/precheckin/job/tensile/job/develop/lastBuild/) |
 | `rocwmma`           | Completed   | [![Azure CI](https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/status%2Fmonorepo%2Frocwmma?repoName=ROCm%2Frocm-libraries&branchName=develop)](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/latest?definitionId=370&repoName=ROCm%2Frocm-libraries&branchName=develop) |[![Math-CI](https://pcue-math-rocm-ci-apim.azure-api.net/buildstatus?job=/rocm-libraries/precheckin/rocwmma/develop&subject=MathCI)](http://math-ci.amd.com/job/rocm-libraries/job/precheckin/job/rocwmma/job/develop/lastBuild/) |
 | `hiptensor`           | Completed  | [![Azure CI](https://dev.azure.com/ROCm-CI/ROCm-CI/_apis/build/status%2Fmonorepo%2Fhiptensor?repoName=ROCm%2Frocm-libraries&branchName=develop)](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/latest?definitionId=374&repoName=ROCm%2Frocm-libraries&branchName=develop) |[![Math-CI](https://pcue-math-rocm-ci-apim.azure-api.net/buildstatus?job=/rocm-libraries/precheckin/hiptensor/develop&subject=MathCI)](http://math-ci.amd.com/job/rocm-libraries/job/precheckin/job/hiptensor/job/develop/lastBuild/) |
-
-# TheRock CI Status
-
-Note TheRock CI performs multi-component testing on top of builds leveraging [TheRock](https://github.com/ROCm/TheRock) build system.
-
-[![TheRock CI Nightly](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci-nightly.yml/badge.svg)](https://github.com/ROCm/rocm-libraries/actions/workflows/therock-ci-nightly.yml)
-
----
 
 ## Nomenclature
 
@@ -87,24 +93,19 @@ shared/
 - Each folder under `projects/` corresponds to a ROCm library that was previously maintained in a standalone GitHub repository and released as distinct packages.
 - Each folder under `shared/` contains code that existed in its own repository and is used as a dependency by multiple libraries, but does not produce its own distinct packages in previous ROCm releases.
 
-## Goals
-
-- Enable unified build and test workflows across ROCm libraries.
-- Facilitate shared tooling, CI, and contributor experience.
-- Improve integration, visibility, and collaboration across ROCm library teams.
-
 ## Getting Started
 
 To begin contributing or building, see the [CONTRIBUTING.md](./CONTRIBUTING.md) guide. It includes setup instructions, sparse-checkout configuration, development workflow, and pull request guidelines.
 
 ## License
 
-This monorepo contains multiple subprojects, each of which retains the license under which it was originally published.
+This superrepo contains multiple subprojects, each of which retains the license under which it was originally published.
 
-📁 Refer to the `LICENSE`, `LICENSE.md`, or `LICENSE.txt` file within each `projects/` or `shared/` directory for specific license terms.
-📄 Refer to the header notice in individual files outside `projects/` or `shared/` folders for their specific license terms.
+- 📁 Refer to the `LICENSE`, `LICENSE.md`, or `LICENSE.txt` file within each `projects/` or `shared/` directory for specific license terms.
+- 📄 Refer to the header notice in individual files outside `projects/` or `shared/` folders for their specific license terms.
 
-> **Note**: The root of this repository does not define a unified license across all components.
+> [!NOTE]
+> The root of this repository does not yet define a unified license across all components.
 
 ## Questions or Feedback?
 


### PR DESCRIPTION
## Motivation

I at least want to add a CI status badge for "TheRock CI", not just "TheRock CI Nightly". While I was making that change I noticed a few other parts of the README that could be updated. Happy to walk some of those back to keep this change more focused if people want.

## Technical Details

* Switch from "monorepo" to "super-repo" (in alignment with the readme in https://github.com/ROCm/rocm-systems)
* Move "Goals" section near the top, where the repository purpose is explained
* Add status badge for TheRock CI and filter status badges to the `develop` branch
* Mark Azure CI and Math CI as "Legacy CI" and move TheRock CI status badges ahead of them
* Minor formatting improvements to the "License" section

If these changes look good, we could make similar changes to the readme in rocm-systems.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
