### PR TITLE
[rocBLAS] improve rocblas-bench usability related to large arguments that require ILP64 API

### DIFF
--- a/projects/rocblas/clients/benchmarks/client.cpp
+++ b/projects/rocblas/clients/benchmarks/client.cpp
@@ -1201,15 +1201,6 @@ void gpu_thread_run_bench(int id, const Arguments& arg, const std::string& filte
     run_bench_test(false, a, filter, name_filter, any_stride, false);
 }
 
-void gpu_thread_init_device_and_run_bench(int                id,
-                                          const Arguments&   arg,
-                                          const std::string& filter,
-                                          bool               any_stride)
-{
-    gpu_thread_init_device(id, arg, filter, any_stride);
-    gpu_thread_run_bench(id, arg, filter, any_stride);
-}
-
 void run_bench_gpu_test(int                parallel_devices,
                         Arguments&         arg,
                         const std::string& filter,
@@ -1229,7 +1220,6 @@ void run_bench_gpu_test(int                parallel_devices,
 
     for(int id = 0; id < parallel_devices; ++id)
         thread_init[id] = std::thread(::gpu_thread_init_device, id, arg, filter, any_stride);
-    //thread_init[id] = std::thread(::gpu_thread_init_device_and_run_bench, id, arg, filter, any_stride);
 
     for(int id = 0; id < parallel_devices; ++id)
         thread_init[id].join();
@@ -1242,9 +1232,6 @@ void run_bench_gpu_test(int                parallel_devices,
 
     for(int id = 0; id < parallel_devices; ++id)
         thread[id].join();
-
-    //for(int id = 0; id < parallel_devices; ++id)
-    //    thread_init[id].join();
 }
 
 // Replace --batch with --batch_count for backward compatibility

--- a/projects/rocblas/clients/benchmarks/client.cpp
+++ b/projects/rocblas/clients/benchmarks/client.cpp
@@ -927,6 +927,42 @@ struct perf_syrk_ex<
 // unit check override
 int8_t g_unit_check = 0;
 
+inline bool int32_api_invalid(const int64_t& val)
+{
+    return ((int32_t)val != val);
+}
+
+bool api_arg_check(Arguments& arg, bool any_stride)
+{
+    // check if 64 bit arguments were passed to 32bit APIs
+    if(arg.api & c_API_64) // bitmask
+        return true;
+
+    auto invalid = [](const char* var) {
+        rocblas_cout << "rocblas-bench INFO: argument int32 overflow: " << var
+                     << ", did you indend to use --api 1 ?" << std::endl;
+        return false;
+    };
+
+    if(int32_api_invalid(arg.batch_count))
+    {
+        return invalid("batch_count");
+    }
+    if(int32_api_invalid(arg.M))
+    {
+        return invalid("m");
+    }
+    if(int32_api_invalid(arg.N))
+    {
+        return invalid("n");
+    }
+    if(int32_api_invalid(arg.K))
+    {
+        return invalid("k");
+    }
+    return true;
+}
+
 void gemm_arg_adjust(Arguments& arg, bool any_stride)
 {
     // adjust dimension for GEMM routines
@@ -1043,14 +1079,11 @@ int run_bench_test(bool               init,
             return 0;
     }
 
-    // argument modifications
-    if(!strcmp(function, "gemm") || !strcmp(function, "gemm_batched")
-       || !strcmp(function, "gemm_strided_batched"))
-    {
-        gemm_arg_adjust(arg, any_stride);
-    }
+    if(!api_arg_check(arg, any_stride))
+        return 0;
 
-    // dispatch
+    // argument modifications and dispatch
+
     if(!strcmp(function, "gemm_ex") || !strcmp(function, "gemm_batched_ex"))
     {
         gemm_arg_adjust(arg, any_stride);
@@ -1065,6 +1098,12 @@ int run_bench_test(bool               init,
     }
     else
     {
+        if(!strcmp(function, "gemm") || !strcmp(function, "gemm_batched")
+           || !strcmp(function, "gemm_strided_batched"))
+        {
+            gemm_arg_adjust(arg, any_stride);
+        }
+
         if(!strcmp(function, "scal") || !strcmp(function, "scal_batched")
            || !strcmp(function, "scal_strided_batched"))
             rocblas_blas1_dispatch<perf_blas_scal>(arg);
@@ -1162,6 +1201,15 @@ void gpu_thread_run_bench(int id, const Arguments& arg, const std::string& filte
     run_bench_test(false, a, filter, name_filter, any_stride, false);
 }
 
+void gpu_thread_init_device_and_run_bench(int                id,
+                                          const Arguments&   arg,
+                                          const std::string& filter,
+                                          bool               any_stride)
+{
+    gpu_thread_init_device(id, arg, filter, any_stride);
+    gpu_thread_run_bench(id, arg, filter, any_stride);
+}
+
 void run_bench_gpu_test(int                parallel_devices,
                         Arguments&         arg,
                         const std::string& filter,
@@ -1181,6 +1229,7 @@ void run_bench_gpu_test(int                parallel_devices,
 
     for(int id = 0; id < parallel_devices; ++id)
         thread_init[id] = std::thread(::gpu_thread_init_device, id, arg, filter, any_stride);
+    //thread_init[id] = std::thread(::gpu_thread_init_device_and_run_bench, id, arg, filter, any_stride);
 
     for(int id = 0; id < parallel_devices; ++id)
         thread_init[id].join();
@@ -1193,6 +1242,9 @@ void run_bench_gpu_test(int                parallel_devices,
 
     for(int id = 0; id < parallel_devices; ++id)
         thread[id].join();
+
+    //for(int id = 0; id < parallel_devices; ++id)
+    //    thread_init[id].join();
 }
 
 // Replace --batch with --batch_count for backward compatibility
@@ -1466,7 +1518,7 @@ try
 
         ("api",
          value<int32_t>(&api)->default_value(0),
-         "Use API, supercedes fortran flag (0==C, 1==C_64, ...)")
+         "Use API, supercedes fortran flag (0==C, 1==C_64 ILP64, ...)")
 
         ("workspace",
          value<size_t>(&arg.user_allocated_workspace)->default_value(0),

--- a/projects/rocblas/docs/how-to/Programmers_Guide.rst
+++ b/projects/rocblas/docs/how-to/Programmers_Guide.rst
@@ -1464,6 +1464,12 @@ For example, the performance of SGEMM using rocblas-bench on an AMD vega20 machi
    transA,transB,M,N,K,alpha,lda,ldb,beta,ldc,rocblas-Gflops,us
    N,N,4096,4096,4096,1,4096,4096,0,4096,11941.5,11509.4
 
+Logging affects performance, so only use it to log the command under evaluation,
+then run the command without logging to measure performance.
+
+Use of logging to advise on rocblas-bench arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 A useful way of finding the parameters that can be used with ``./rocblas-bench -f gemm`` is to turn on logging
 by setting the environment variable ``ROCBLAS_LAYER=2``. For example, if the user runs:
 
@@ -1483,15 +1489,18 @@ The user can copy and change the above command. For example, to change the datat
 
    ./rocblas-bench -f gemm -r f64_r --transposeA N --transposeB N -m 2048 -n 2048 -k 2048 --alpha 1 --lda 2048 --ldb 2048 --beta 0 --ldc 2048
 
+
+Benchmarking ILP64 APIs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 To measure performance on the ILP64 API functions, when they exist, add the argument ``--api 1`` rather
 than changing the function name set in ``-f``.
-Logging affects performance, so only use it to log the command under evaluation,
-then run the command without logging to measure performance.
 
 
 .. note::
 
-   rocblas-bench also has the flag ``-v 1`` for correctness checks.
+   rocblas-bench has the flag ``-v 1`` for norm based correctness checks against CPU reference.
+   rocblas-bench has the flag ``-t 1`` for equality and tolerance based correctness checks against CPU reference.
 
 Benchmarking special case gemv_batched and gemv_strided_batched functions using rocblas-bench
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This pull request introduces argument validation for 32-bit and 64-bit API usage in `rocblas-bench`, clarifies documentation around API selection and benchmarking, and refactors argument adjustment and threading logic in the benchmark client. The main goal is to prevent accidental overflow when using 32-bit APIs and to improve user guidance for API selection and correctness checking.

### API validation and argument handling

* Added `api_arg_check` and `int32_api_invalid` functions to detect and warn users when 64-bit sized arguments are passed to 32-bit APIs, preventing silent overflow and guiding users to use the correct API flag (`--api 1`).
* Refactored the order of argument adjustment and dispatch in `run_bench_test` to ensure argument validation occurs before any modifications or function dispatch. 
* Clarified the `api` argument description to specify `1==C_64 ILP64` for improved user understanding.

### Documentation improvements

* Updated the programmer's guide to emphasize the impact of logging on performance, provide clearer instructions for benchmarking ILP64 APIs, and clarify correctness checking flags for `rocblas-bench`. 

ROCM-3837

