### PR TITLE
[CI] Fix provider test keys to match TheRock test_matrix

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -86,8 +86,8 @@ additional_options = {
             "hipdnn",
             "hipdnn_install",
             "hipdnn-samples",
-            "miopen_plugin",
-            "hipblaslt_plugin",
+            "miopenprovider",
+            "hipblasltprovider",
         ],
         "project_to_add": "miopen",
     },
@@ -96,14 +96,14 @@ additional_options = {
             "-DTHEROCK_ENABLE_MIOPENPROVIDER=ON",
             "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
         ],
-        "projects_to_test": ["miopen_plugin"],
+        "projects_to_test": ["miopenprovider"],
         "project_to_add": "miopen",
     },
     "hipblaslt-provider": {
         "cmake_options": [
             "-DTHEROCK_ENABLE_HIPBLASLTPROVIDER=ON",
         ],
-        "projects_to_test": ["hipblaslt_plugin"],
+        "projects_to_test": ["hipblasltprovider"],
         "project_to_add": "blas",
     },
     "rocwmma": {


### PR DESCRIPTION
## Summary

`projects_to_test` values for miopen-provider and hipblaslt-provider were using `miopen_plugin`/`hipblaslt_plugin`, but TheRock's `fetch_test_configurations.py` keys those entries as `miopenprovider` and `hipblasltprovider`. The exact-match lookup silently dropped both test jobs every time — the artifacts were built correctly but the test stage never selected them to run.

Fixes the keys in three places in `additional_options`:
- `hipdnn`: `miopen_plugin` → `miopenprovider`, `hipblaslt_plugin` → `hipblasltprovider`
- `miopen-provider`: `miopen_plugin` → `miopenprovider`
- `hipblaslt-provider`: `hipblaslt_plugin` → `hipblasltprovider`

## Test plan
- [x] Verify `miopenprovider` and `hipblasltprovider` test jobs appear in CI when `dnn-providers/miopen-provider` or `dnn-providers/hipblaslt-provider` files are changed: https://github.com/ROCm/rocm-libraries/pull/4988

🤖 Generated with [Claude Code](https://claude.com/claude-code)