### PR TITLE
[CI] Test: verify miopenprovider/hipblasltprovider jobs trigger correctly

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -86,8 +86,8 @@ additional_options = {
             "hipdnn",
             "hipdnn_install",
             "hipdnn-samples",
-            "miopen_plugin",
-            "hipblaslt_plugin",
+            "miopenprovider",
+            "hipblasltprovider",
         ],
         "project_to_add": "miopen",
     },
@@ -96,14 +96,14 @@ additional_options = {
             "-DTHEROCK_ENABLE_MIOPENPROVIDER=ON",
             "-DTHEROCK_ENABLE_COMPOSABLE_KERNEL=ON",
         ],
-        "projects_to_test": ["miopen_plugin"],
+        "projects_to_test": ["miopenprovider"],
         "project_to_add": "miopen",
     },
     "hipblaslt-provider": {
         "cmake_options": [
             "-DTHEROCK_ENABLE_HIPBLASLTPROVIDER=ON",
         ],
-        "projects_to_test": ["hipblaslt_plugin"],
+        "projects_to_test": ["hipblasltprovider"],
         "project_to_add": "blas",
     },
     "rocwmma": {

--- a/dnn-providers/miopen-provider/CMakeLists.txt
+++ b/dnn-providers/miopen-provider/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Copyright © Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
+# CI test: verify miopenprovider and hipblasltprovider test jobs trigger correctly.
 
 cmake_minimum_required(VERSION 3.25.2)
 message(STATUS "Building miopen provider plugin standalone")


### PR DESCRIPTION
## Purpose

Verification PR for #4987. Touches `dnn-providers/miopen-provider/CMakeLists.txt` to trigger the provider subtree detection and confirm that `miopenprovider` and `hipblasltprovider` test jobs now appear in CI (previously they were silently dropped due to key name mismatch).

## What to check

In the CI run for this PR, the TheRock CI job name should include `miopenprovider` and `hipblasltprovider` in the test matrix — not just `hipdnn`, `hipdnn_install`, and `hipdnn-samples`.

## Cleanup

To be closed/reverted once CI confirms the fix. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)