### PR TITLE
[TensileLite] Fix wrong-type literals in assignDerivedParameters

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
@@ -401,7 +401,7 @@ defaultBenchmarkCommonParameters = [
     {"GlobalSplitUAlgorithm": ["MultipleBuffer"]},
     {"GlobalSplitUCoalesced": [False]},
     {"GlobalSplitUWorkGroupMappingRoundRobin": [False]},
-    {"Use64bShadowLimit": [1]},
+    {"Use64bShadowLimit": [True]},
     {"NumLoadsCoalescedA": [1]},
     {"NumLoadsCoalescedB": [1]},
     {"WorkGroup": [[16, 16, 1]]},

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -654,7 +654,7 @@ class Solution(collections.abc.Mapping):
     if state["DirectToVgprA"] and state["DirectToVgprB"]:
       # change the following parameter values
       state["PrefetchGlobalRead"] = 1
-      state["ExpandPointerSwap"] = 0
+      state["ExpandPointerSwap"] = False
       state["1LDSBuffer"] = 0
       state["PrefetchLocalRead"] = 0
       # So far, DTVA + DTVB does not perform well (waitcnt is not ideal).
@@ -768,7 +768,7 @@ class Solution(collections.abc.Mapping):
     # does not work with PGR>=2 + EPS
     if state["PrefetchGlobalRead"] >= 2 and state["ExpandPointerSwap"]:
       # force EPS=0 and continue
-      state["ExpandPointerSwap"] = 0
+      state["ExpandPointerSwap"] = False
 
     # does not work with Sparse
     if state["ProblemType"]["Sparse"]:
@@ -1322,7 +1322,7 @@ class Solution(collections.abc.Mapping):
 
     bufferLoad = state["BufferLoad"] and state["KernelLanguage"] == "Assembly"
     if not bufferLoad:
-      state["DirectToLds"] = False
+      state["DirectToLds"] = 0
       state["DirectToLdsA"] = False
       state["DirectToLdsB"] = False
       state["_UseSgprForGRO"] = False
@@ -1337,9 +1337,9 @@ class Solution(collections.abc.Mapping):
     #These modes only work under certain conditions, apply them here:
     #  - The "NoLoad" loop is only generated if PrefetchGlobalRead>0
     #  - And Suppress does not work if GSU>1 for some reason
-    if state["SuppressNoLoadLoop"] == 1:
+    if state["SuppressNoLoadLoop"]:
       if not (bufferLoad and state["PrefetchGlobalRead"] == 1 and (state["GlobalSplitU"]==1 or state["GlobalSplitU"]==-1)):
-        state["SuppressNoLoadLoop"] = 0
+        state["SuppressNoLoadLoop"] = False
 
     #print("PackedC0IdxChars", state["PackedC0IdxChars"])
     #print("PackedC1IdxChars", state["PackedC1IdxChars"])
@@ -1404,10 +1404,10 @@ class Solution(collections.abc.Mapping):
       state["VectorWidthB"] = 1
 
     if state["ScheduleIterAlg"] == 2:
-      state["ExpandPointerSwap"] = 1
+      state["ExpandPointerSwap"] = True
       print2("\nSet SIA=2, force ExpandPointerSwap=1")
 
-    if state["ExpandPointerSwap"] == 1:
+    if state["ExpandPointerSwap"]:
       # Pointer swap only used if PGR==1 or (PGR>1 and double/double complex) - so set ExpandPointerSwap=0 here
       # So far, EPS=1 and PGR>1 works only with double/double complex.
       #if not (bufferLoad and state["PrefetchGlobalRead"] == 1):
@@ -1415,7 +1415,7 @@ class Solution(collections.abc.Mapping):
               or (state["PrefetchGlobalRead"] > 1 and \
                   (state["ProblemType"]["DataType"].isDouble() or state["ProblemType"]["DataType"].isDoubleComplex()))
               or (state["ProblemType"]["Sparse"] and state["PrefetchGlobalRead"] > 0))):
-        state["ExpandPointerSwap"] = 0
+        state["ExpandPointerSwap"] = False
 
     #################################################################
     # ForceUnrollSubIter requirements
@@ -1512,7 +1512,7 @@ class Solution(collections.abc.Mapping):
       if not state["DirectToVgprSparseMetadata"]:
         state["VectorWidthMetadata"] = state["VectorWidthA"] if state["ProblemType"]["Sparse"] == 1 else state["VectorWidthB"]
       # ON/OFF the sourceswap according to the sparse type automatically
-      state["SourceSwap"] = 0 if state["ProblemType"]["Sparse"] == 1 else 1
+      state["SourceSwap"] = False if state["ProblemType"]["Sparse"] == 1 else True
 
     # if state["EnableMatrixInstruction"] and not state["SourceSwap"] and (state["VectorWidthA"] > 1 or state["VectorWidthB"] > 1):
     #   reject(state, printRejectionReason, "not implement VectorWidth without SourceSwap")
@@ -1608,8 +1608,8 @@ class Solution(collections.abc.Mapping):
     # Check if CMS is available for this solution
     if state["UseCustomMainLoopSchedule"] in [-1, 1]:
       # initialize CMS related config parameters (for CMS only)
-      state["SwapGlobalReadOrder"] = False
-      state["UsePLRPack"] = False
+      state["SwapGlobalReadOrder"] = 0
+      state["UsePLRPack"] = 0
 
       hasCMS,_ = hasCustomSchedule(state)
       if state["UseCustomMainLoopSchedule"] == 1 and not hasCMS:
@@ -1627,25 +1627,25 @@ class Solution(collections.abc.Mapping):
       # usePLRPack check
       # adjust setting only for non CMS (keep original setting for CMS)
       if backup_UsePLRPack:
-        state["UsePLRPack"] = True
+        state["UsePLRPack"] = 1
         # MatrixInstruction only
         if not state["EnableMatrixInstruction"]:
-          state["UsePLRPack"] = False
+          state["UsePLRPack"] = 0
         # F32X emulation only
         if not state["UseF32XEmulation"]:
-          state["UsePLRPack"] = False
+          state["UsePLRPack"] = 0
         # SIA3 only
         if state["ScheduleIterAlg"] != 3:
-          state["UsePLRPack"] = False
+          state["UsePLRPack"] = 0
         # enable UsePLRPack for SubIter only
         if not state["ForceUnrollSubIter"]:
           state["UsePLRPack"] = 0
         # DirectToLds (both A and B) only
         if state["DirectToLds"] != 1:
-          state["UsePLRPack"] = False
+          state["UsePLRPack"] = 0
         # PGR and PLR should be non 0
         if state["PrefetchGlobalRead"] == 0 or state["PrefetchLocalRead"] == 0:
-          state["UsePLRPack"] = False
+          state["UsePLRPack"] = 0
 
     # disable SwapGlobalReadOrder if grmode(normal/DTL/DTV) is different between A and B
     # GRA and GRB need to be equivalent to swap the order
@@ -1659,10 +1659,10 @@ class Solution(collections.abc.Mapping):
       return grmode
     if state["UseCustomMainLoopSchedule"] == 0:
       if getGrMode("A") != getGrMode("B"):
-        state["SwapGlobalReadOrder"] = False
+        state["SwapGlobalReadOrder"] = 0
       # SwapGlobalReadOrder does not work with UnrollLoopSwapGlobalReadOrder
       if state["UnrollLoopSwapGlobalReadOrder"]:
-        state["SwapGlobalReadOrder"] = False
+        state["SwapGlobalReadOrder"] = 0
 
     # 0: Normal mode. Hardware applies all of the normal data dependency checks
     # 1: Full expert mode (not suppoeted yet). Disable hardware checks against: VA_VDST, VA_SDST, VA_SSRC, VA_VCC, VM_VSRC and SA_SDST.
@@ -3195,9 +3195,9 @@ class Solution(collections.abc.Mapping):
       if ldsNumBytes > 32768 or \
           state["ProblemType"]["ComputeDataType"].numBytes() * state["MacroTile0"] * state["MacroTile1"] > 32768*4:
         state["NumElementsPerBatchStore"] = 0
-        state["StorePriorityOpt"] = 0
+        state["StorePriorityOpt"] = False
         state["StoreSyncOpt"] = 0
-        state["GroupLoadStore"] = 0
+        state["GroupLoadStore"] = False
       else:
         state["NumElementsPerBatchStore"] = 16 if not state["ProblemType"]["DataType"].numBytes() == 8 else 1
 
@@ -3781,7 +3781,7 @@ class Solution(collections.abc.Mapping):
       if (rocmVersion.major < 6 or (rocmVersion.major == 6 and rocmVersion.patch < 32650)) or \
           not (isa == (9, 0, 10) or isa[:2] == (9, 4) or isa == (9, 5, 0)):
         #print("Force to Disable PreloadKernArgs since this hipcc version doesn't support",)
-        state["PreloadKernArgs"] = 0
+        state["PreloadKernArgs"] = False
 
     # change negative ExtraLatencyForLR to 0 for non DirectToVgpr
     if state["ExtraLatencyForLR"] < 0 and not (state["DirectToVgprA"] or state["DirectToVgprB"]):


### PR DESCRIPTION
## Summary

`assignDerivedParameters()` was assigning values with incorrect Python
types to several parameters. Since Python `bool` is a subclass of `int`,
these assignments are silently accepted but produce different msgpack
wire types when serialized — `bool(False)` becomes msgpack BOOLEAN `0xc2`
while `int(0)` becomes msgpack POSITIVE_INTEGER `0x00`. The C++ msgpack
deserializer then throws `std::bad_cast` when it encounters the wrong
wire type.

## Changes

### Bool-expecting params that were incorrectly assigned int literals:
- **ExpandPointerSwap**: assigned `0`/`1` at lines 801, 915, 1551, 1562 → Fixed: `0` -> `False`, `1` -> `True`
- **SuppressNoLoadLoop**: compared `== 1` and assigned `0` at lines 1484, 1486 → Fixed: comparison changed to truthiness check, `0` -> `False`
- **SourceSwap**: assigned `0`/`1` via ternary at line 1659 → Fixed: `0` -> `False`, `1` -> `True`
- **StorePriorityOpt**: assigned `0` at line 3342 → Fixed: `0` -> `False`
- **GroupLoadStore**: assigned `0` at line 3344 → Fixed: `0` -> `False`
- **PreloadKernArgs**: assigned `0` at line 3928 → Fixed: `0` -> `False`

### Int-expecting params that were incorrectly assigned bool literals:
- **DirectToLds**: assigned `False` at line 1469 → Fixed: `False` -> `0`
- **SwapGlobalReadOrder**: assigned `False` at lines 1755, 1806, 1809 → Fixed: `False` -> `0`
- **UsePLRPack**: assigned `True`/`False` at lines 1756, 1774, 1777, 1780, 1783, 1789, 1792 → Fixed: `True` -> `1`, `False` -> `0`

### Wrong default in GlobalParameters.py:
- **Use64bShadowLimit**: default was `[1]` (int) but `validParameters` declares it as `[True, False]` (bool) → Fixed: `[1]` -> `[True]`

## Test plan
- [x] Changes are purely mechanical literal substitutions (no logic changes)
- [x] `bool(False) == int(0)` and `bool(True) == int(1)` in Python, so all comparisons and branching behavior is preserved
- [x] Verified via automated scan: zero wrong-type assignments remain after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AIGECORE-189