### PR TITLE
[TensileLite] Add build-time type validation for library logic YAMLs

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -24,6 +24,7 @@
 
 import collections
 import math
+import sys
 
 from enum import Enum
 from typing import List, Dict, Literal
@@ -39,12 +40,150 @@ from Tensile.Common import assignParameterWithDefault, IsaInfo, \
 from Tensile.Common.DataType import DataType
 from Tensile.Common.GlobalParameters import defaultSolution, \
                                             defaultInternalSupportParams
+from Tensile.Common.ValidParameters import validParameters
 from Tensile.SolutionStructs.Naming import getSolutionNameFull
 from Tensile.SolutionStructs.Problem import ProblemType
 from Tensile.Toolchain.Component import Assembler
 from Tensile.Components.CustomSchedule import hasCustomSchedule
 
 from .Utilities import reject, roundupRatio, pvar
+
+def _getExpectedTypes(validParams):
+  """Build a map from parameter name to the set of allowed Python types.
+
+  Uses the validParameters registry as the source of truth.  For each
+  parameter whose allowed-value list is not the sentinel ``-1``, we
+  collect the concrete ``type()`` of every allowed value.  Because
+  Python ``bool`` is a subclass of ``int``, we use ``type()`` (not
+  ``isinstance``) so that ``bool`` and ``int`` are kept distinct.
+
+  Returns:
+      dict[str, set[type]]: e.g. {"UseCustomMainLoopSchedule": {int},
+                                   "BufferLoad": {bool}, ...}
+  """
+  typeMap = {}
+  for name, allowedValues in validParams.items():
+    if allowedValues == -1:
+      continue
+    if isinstance(allowedValues, list) and len(allowedValues) > 0:
+      typeMap[name] = set(type(v) for v in allowedValues)
+  return typeMap
+
+# Pre-compute once at import time so the per-Solution cost is a dict lookup.
+_expectedParamTypes = _getExpectedTypes(validParameters)
+
+# Parameters to skip during type validation because YAML serialization
+# inherently produces a different type (e.g. [9, 0, 10] -> list) and the
+# conversion to the canonical type happens downstream in the pipeline.
+_skipTypeCheck = {"ISA"}
+
+
+# Module-level collector that accumulates type mismatches across all Solution
+# instances during a build.  Key is (param_name, actual_type_name,
+# expected_type_str); value is a dict with 'count', 'values' (set of unique
+# repr(value)), and 'files' (set of source file paths).
+_typeMismatchCollector = {}
+
+
+def resetTypeMismatchCollector():
+  """Clear the module-level type mismatch collector.
+
+  Call this before a new build pass or in test setUp to ensure a clean
+  slate.  Safe to call even when the collector is already empty.
+
+  Uses dict.clear() so that any existing references to
+  ``_typeMismatchCollector`` (e.g. in tests) see the same empty dict.
+  """
+  _typeMismatchCollector.clear()
+
+
+def validateParameterTypes(state, srcFile=""):
+  """Validate that every solution parameter has the correct Python type.
+
+  Compares each value in *state* against the types implied by
+  ``validParameters``.  A ``bool`` where ``int`` is expected (or vice
+  versa) is the most common error -- YAML ``false``/``true`` vs ``0``/``1``
+  are different Python types and produce different msgpack wire types,
+  which causes ``std::bad_cast`` at C++ deserialization time.
+
+  Instead of raising on the first mismatch, mismatches are collected into
+  the module-level ``_typeMismatchCollector`` dict.  Call
+  ``printTypeMismatchSummary()`` at the end of the build to emit a
+  consolidated warning.
+
+  Args:
+      state: The solution state dict (parameter name -> value).
+      srcFile: The YAML source file path, included in warning messages.
+  """
+  for key, value in state.items():
+    if key not in _expectedParamTypes or key in _skipTypeCheck:
+      continue
+    expectedTypes = _expectedParamTypes[key]
+    actualType = type(value)
+    # Use type() not isinstance() so that bool and int are distinguished
+    if actualType not in expectedTypes:
+      expectedStr = " or ".join(sorted(t.__name__ for t in expectedTypes))
+      collectorKey = (key, actualType.__name__, expectedStr)
+      if collectorKey not in _typeMismatchCollector:
+        _typeMismatchCollector[collectorKey] = {
+          "count": 0,
+          "values": set(),
+          "files": set(),
+        }
+      entry = _typeMismatchCollector[collectorKey]
+      entry["count"] += 1
+      entry["values"].add(repr(value))
+      if srcFile:
+        entry["files"].add(srcFile)
+
+
+def printTypeMismatchSummary():
+  """Print a summary of all collected type mismatches to stderr.
+
+  If no mismatches have been collected, this function prints nothing and
+  returns 0.  Otherwise it emits a WARNING block to stderr with one line
+  per unique (parameter, actual_type) combination showing the count,
+  observed values, and expected type.
+
+  Returns:
+      int: The total number of individual mismatches (0 if clean).
+  """
+  if not _typeMismatchCollector:
+    return 0
+
+  totalCount = sum(e["count"] for e in _typeMismatchCollector.values())
+  allFiles = set()
+  for e in _typeMismatchCollector.values():
+    allFiles |= e["files"]
+
+  lines = []
+  lines.append("")
+  lines.append("===========================================================")
+  lines.append(
+    f"WARNING: YAML parameter type mismatches detected "
+    f"({totalCount} total across {len(allFiles)} files):"
+  )
+  lines.append("===========================================================")
+
+  # Sort by parameter name for stable output
+  for (paramName, actualType, expectedStr), entry in sorted(
+    _typeMismatchCollector.items(), key=lambda kv: kv[0][0]
+  ):
+    valuesStr = ", ".join(sorted(entry["values"]))
+    lines.append(
+      f"  {paramName}: found {actualType} in {entry['count']} solutions "
+      f"(values: {valuesStr}) — expected {expectedStr}"
+    )
+
+  lines.append("-----------------------------------------------------------")
+  lines.append("  This will cause std::bad_cast at runtime because msgpack")
+  lines.append("  serializes bool and int as different wire types.")
+  lines.append("  Fix these to prevent future build failures.")
+  lines.append("===========================================================")
+
+  print("\n".join(lines), file=sys.stderr)
+  return totalCount
+
 
 class Fbs(Enum):
   Free=0     # Expect to be free dimension
@@ -187,6 +326,11 @@ class Solution(collections.abc.Mapping):
     # Assign solution state from config, filling missing from the defaultSolution
     for key in defaultSolution:
       assignParameterWithDefault(self._state, key, config, defaultSolution)
+
+    # Validate parameter types against the validParameters registry.
+    # Catches bool-vs-int mismatches (YAML false vs 0) that would cause
+    # std::bad_cast at C++ msgpack deserialization time.
+    validateParameterTypes(self._state, srcFile=srcName)
 
     if 'ISA' not in self._state:
       if 'ISA' in config:

--- a/projects/hipblaslt/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/projects/hipblaslt/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -68,6 +68,7 @@ from Tensile.KernelWriterBase import (
 )
 from Tensile.SolutionLibrary import MasterSolutionLibrary
 from Tensile.SolutionStructs import Solution
+from Tensile.SolutionStructs.Solution import printTypeMismatchSummary
 from Tensile.Toolchain.Assembly import makeAssemblyToolchain, buildAssemblyCodeObjectFiles
 from Tensile.Toolchain.Source import makeSourceToolchain, buildSourceCodeObjectFiles
 from Tensile.Toolchain.Validators import (
@@ -650,6 +651,10 @@ def generateLogicDataAndSolutions(logicFiles, args, assembler: Assembler, isaInf
         else:
             masterLibraries[architectureName] = newLibrary
             masterLibraries[architectureName].version = args["CodeObjectVersion"]
+
+    # After all YAML files have been parsed and Solution objects created,
+    # print a summary of any type mismatches that were collected.
+    printTypeMismatchSummary()
 
     # Sort masterLibraries to make global soln index values deterministic
     solnReIndex = 0

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_validateParameterTypes.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_validateParameterTypes.py
@@ -1,0 +1,358 @@
+################################################################################
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+import pytest
+
+from Tensile.SolutionStructs.Solution import (
+    validateParameterTypes,
+    _getExpectedTypes,
+    _expectedParamTypes,
+    _skipTypeCheck,
+    _typeMismatchCollector,
+    resetTypeMismatchCollector,
+    printTypeMismatchSummary,
+)
+from Tensile.Common.ValidParameters import validParameters
+
+
+class TestGetExpectedTypes:
+    """Tests for the _getExpectedTypes helper."""
+
+    def test_returns_dict(self):
+        result = _getExpectedTypes(validParameters)
+        assert isinstance(result, dict)
+
+    def test_int_param_has_int_type(self):
+        """UseCustomMainLoopSchedule: [-1, 0, 1] should expect {int}."""
+        result = _getExpectedTypes(validParameters)
+        assert "UseCustomMainLoopSchedule" in result
+        assert result["UseCustomMainLoopSchedule"] == {int}
+
+    def test_bool_param_has_bool_type(self):
+        """BufferLoad: [False, True] should expect {bool}."""
+        result = _getExpectedTypes(validParameters)
+        assert "BufferLoad" in result
+        assert result["BufferLoad"] == {bool}
+
+    def test_sentinel_minus_one_skipped(self):
+        """Parameters with validParams[name] == -1 should be skipped."""
+        result = _getExpectedTypes({"Foo": -1, "Bar": [0, 1]})
+        assert "Foo" not in result
+        assert "Bar" in result
+
+    def test_precomputed_matches_fresh(self):
+        """The module-level _expectedParamTypes should match a fresh computation."""
+        fresh = _getExpectedTypes(validParameters)
+        assert _expectedParamTypes == fresh
+
+
+class TestValidateParameterTypes:
+    """Tests for the validateParameterTypes function (warning-collection mode)."""
+
+    def setup_method(self):
+        """Reset the collector before each test."""
+        resetTypeMismatchCollector()
+
+    # --- Passing cases (no mismatches collected) ---
+
+    def test_int_param_with_int_value_passes(self):
+        """int value for an int param should not collect a mismatch."""
+        state = {"UseCustomMainLoopSchedule": 0}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_int_param_with_negative_int_passes(self):
+        state = {"UseCustomMainLoopSchedule": -1}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_bool_param_with_bool_value_passes(self):
+        """bool value for a bool param should not collect a mismatch."""
+        state = {"BufferLoad": True}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_bool_param_with_false_passes(self):
+        state = {"BufferLoad": False}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_unknown_param_ignored(self):
+        """Parameters not in validParameters should be silently skipped."""
+        state = {"SomeUnknownParameter": "whatever"}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    def test_empty_state_passes(self):
+        validateParameterTypes({})
+        assert len(_typeMismatchCollector) == 0
+
+    def test_multiple_valid_params_pass(self):
+        state = {
+            "UseCustomMainLoopSchedule": 0,
+            "BufferLoad": True,
+            "BufferStore": False,
+            "PrefetchGlobalRead": 1,
+        }
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+    # --- Mismatch collection cases ---
+
+    def test_bool_where_int_expected_collects(self):
+        """bool(False) for an int param should be collected, not raise."""
+        state = {"UseCustomMainLoopSchedule": False}
+        validateParameterTypes(state)  # should NOT raise
+        assert len(_typeMismatchCollector) == 1
+        key = ("UseCustomMainLoopSchedule", "bool", "int")
+        assert key in _typeMismatchCollector
+        assert _typeMismatchCollector[key]["count"] == 1
+
+    def test_bool_true_where_int_expected_collects(self):
+        """bool(True) for an int param should be collected."""
+        state = {"UseCustomMainLoopSchedule": True}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("UseCustomMainLoopSchedule", "bool", "int")
+        assert key in _typeMismatchCollector
+        assert _typeMismatchCollector[key]["count"] == 1
+
+    def test_int_where_bool_expected_collects(self):
+        """int(0) for a bool param like BufferLoad should be collected."""
+        state = {"BufferLoad": 0}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("BufferLoad", "int", "bool")
+        assert key in _typeMismatchCollector
+
+    def test_int_one_where_bool_expected_collects(self):
+        """int(1) for a bool param like BufferLoad should be collected."""
+        state = {"BufferLoad": 1}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("BufferLoad", "int", "bool")
+        assert key in _typeMismatchCollector
+
+    def test_string_where_int_expected_collects(self):
+        state = {"UseCustomMainLoopSchedule": "0"}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("UseCustomMainLoopSchedule", "str", "int")
+        assert key in _typeMismatchCollector
+
+    def test_float_where_int_expected_collects(self):
+        state = {"UseCustomMainLoopSchedule": 0.0}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("UseCustomMainLoopSchedule", "float", "int")
+        assert key in _typeMismatchCollector
+
+    # --- Collected entry details ---
+
+    def test_collector_records_param_name(self):
+        state = {"UseCustomMainLoopSchedule": False}
+        validateParameterTypes(state)
+        keys = list(_typeMismatchCollector.keys())
+        assert keys[0][0] == "UseCustomMainLoopSchedule"
+
+    def test_collector_records_value(self):
+        state = {"UseCustomMainLoopSchedule": False}
+        validateParameterTypes(state)
+        key = ("UseCustomMainLoopSchedule", "bool", "int")
+        assert "False" in _typeMismatchCollector[key]["values"]
+
+    def test_collector_records_actual_type(self):
+        state = {"UseCustomMainLoopSchedule": False}
+        validateParameterTypes(state)
+        keys = list(_typeMismatchCollector.keys())
+        assert keys[0][1] == "bool"
+
+    def test_collector_records_expected_type(self):
+        state = {"UseCustomMainLoopSchedule": False}
+        validateParameterTypes(state)
+        keys = list(_typeMismatchCollector.keys())
+        assert keys[0][2] == "int"
+
+    def test_collector_records_source_file(self):
+        state = {"UseCustomMainLoopSchedule": False}
+        validateParameterTypes(state, srcFile="my_file.yaml")
+        key = ("UseCustomMainLoopSchedule", "bool", "int")
+        assert "my_file.yaml" in _typeMismatchCollector[key]["files"]
+
+    def test_collector_empty_srcfile_not_recorded(self):
+        """When srcFile is empty string, files set should remain empty."""
+        state = {"UseCustomMainLoopSchedule": False}
+        validateParameterTypes(state, srcFile="")
+        key = ("UseCustomMainLoopSchedule", "bool", "int")
+        assert len(_typeMismatchCollector[key]["files"]) == 0
+
+    # --- Accumulation across multiple calls ---
+
+    def test_multiple_mismatches_all_collected(self):
+        """All mismatches in a single state dict should be collected."""
+        state = {
+            "PrefetchGlobalRead": 1,              # valid int
+            "UseCustomMainLoopSchedule": False,    # BAD: bool for int
+            "BufferLoad": True,                    # valid bool
+        }
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 1
+        key = ("UseCustomMainLoopSchedule", "bool", "int")
+        assert key in _typeMismatchCollector
+
+    def test_accumulates_across_calls(self):
+        """Multiple validateParameterTypes calls accumulate into the collector."""
+        validateParameterTypes({"UseCustomMainLoopSchedule": False}, srcFile="a.yaml")
+        validateParameterTypes({"UseCustomMainLoopSchedule": True}, srcFile="b.yaml")
+        key = ("UseCustomMainLoopSchedule", "bool", "int")
+        assert _typeMismatchCollector[key]["count"] == 2
+        assert _typeMismatchCollector[key]["values"] == {"False", "True"}
+        assert _typeMismatchCollector[key]["files"] == {"a.yaml", "b.yaml"}
+
+    def test_different_params_get_separate_entries(self):
+        """Mismatches on different params create separate collector entries."""
+        validateParameterTypes({"UseCustomMainLoopSchedule": False})
+        validateParameterTypes({"BufferLoad": 0})
+        assert len(_typeMismatchCollector) == 2
+
+    # --- Skip list ---
+
+    def test_isa_in_skip_list(self):
+        """ISA should be in _skipTypeCheck (YAML deserializes as list, not tuple)."""
+        assert "ISA" in _skipTypeCheck
+
+    def test_skipped_param_does_not_collect(self):
+        """A param in _skipTypeCheck should not trigger collection."""
+        # ISA expects tuple/SemanticVersion but YAML gives list
+        state = {"ISA": [9, 0, 10]}
+        validateParameterTypes(state)
+        assert len(_typeMismatchCollector) == 0
+
+
+class TestResetTypeMismatchCollector:
+    """Tests for resetTypeMismatchCollector()."""
+
+    def test_reset_clears_collector(self):
+        """After reset, the collector should be empty."""
+        resetTypeMismatchCollector()
+        validateParameterTypes({"UseCustomMainLoopSchedule": False})
+        assert len(_typeMismatchCollector) > 0
+        resetTypeMismatchCollector()
+        assert len(_typeMismatchCollector) == 0
+
+    def test_reset_on_empty_is_safe(self):
+        """Calling reset when already empty should not raise."""
+        resetTypeMismatchCollector()
+        resetTypeMismatchCollector()
+        assert len(_typeMismatchCollector) == 0
+
+    def test_reset_allows_fresh_collection(self):
+        """After reset, new mismatches start from count=0."""
+        resetTypeMismatchCollector()
+        validateParameterTypes({"UseCustomMainLoopSchedule": False})
+        resetTypeMismatchCollector()
+        validateParameterTypes({"UseCustomMainLoopSchedule": True})
+        key = ("UseCustomMainLoopSchedule", "bool", "int")
+        assert _typeMismatchCollector[key]["count"] == 1
+        assert _typeMismatchCollector[key]["values"] == {"True"}
+
+
+class TestPrintTypeMismatchSummary:
+    """Tests for printTypeMismatchSummary()."""
+
+    def setup_method(self):
+        resetTypeMismatchCollector()
+
+    def test_returns_zero_when_clean(self):
+        """No mismatches -> returns 0 and prints nothing."""
+        result = printTypeMismatchSummary()
+        assert result == 0
+
+    def test_returns_total_count(self):
+        """Should return the total number of individual mismatches."""
+        validateParameterTypes({"UseCustomMainLoopSchedule": False}, srcFile="a.yaml")
+        validateParameterTypes({"UseCustomMainLoopSchedule": True}, srcFile="b.yaml")
+        validateParameterTypes({"BufferLoad": 0}, srcFile="c.yaml")
+        result = printTypeMismatchSummary()
+        assert result == 3
+
+    def test_outputs_warning_to_stderr(self, capsys):
+        """Summary should be printed to stderr, not stdout."""
+        validateParameterTypes({"UseCustomMainLoopSchedule": False}, srcFile="test.yaml")
+        printTypeMismatchSummary()
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "WARNING" in captured.err
+
+    def test_output_contains_param_name(self, capsys):
+        validateParameterTypes({"UseCustomMainLoopSchedule": False})
+        printTypeMismatchSummary()
+        captured = capsys.readouterr()
+        assert "UseCustomMainLoopSchedule" in captured.err
+
+    def test_output_contains_actual_type(self, capsys):
+        validateParameterTypes({"UseCustomMainLoopSchedule": False})
+        printTypeMismatchSummary()
+        captured = capsys.readouterr()
+        assert "bool" in captured.err
+
+    def test_output_contains_expected_type(self, capsys):
+        validateParameterTypes({"UseCustomMainLoopSchedule": False})
+        printTypeMismatchSummary()
+        captured = capsys.readouterr()
+        assert "int" in captured.err
+
+    def test_output_contains_solution_count(self, capsys):
+        validateParameterTypes({"UseCustomMainLoopSchedule": False}, srcFile="a.yaml")
+        validateParameterTypes({"UseCustomMainLoopSchedule": True}, srcFile="b.yaml")
+        printTypeMismatchSummary()
+        captured = capsys.readouterr()
+        assert "2 solutions" in captured.err
+
+    def test_output_contains_file_count(self, capsys):
+        validateParameterTypes({"UseCustomMainLoopSchedule": False}, srcFile="a.yaml")
+        validateParameterTypes({"UseCustomMainLoopSchedule": True}, srcFile="b.yaml")
+        printTypeMismatchSummary()
+        captured = capsys.readouterr()
+        assert "2 files" in captured.err
+
+    def test_output_contains_fix_message(self, capsys):
+        validateParameterTypes({"UseCustomMainLoopSchedule": False})
+        printTypeMismatchSummary()
+        captured = capsys.readouterr()
+        assert "Fix these to prevent future build failures" in captured.err
+
+    def test_no_output_when_clean(self, capsys):
+        """When there are no mismatches, nothing should be printed."""
+        printTypeMismatchSummary()
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_multiple_param_types_in_output(self, capsys):
+        """Multiple different mismatched params should all appear in output."""
+        validateParameterTypes({"UseCustomMainLoopSchedule": False})
+        validateParameterTypes({"BufferLoad": 0})
+        printTypeMismatchSummary()
+        captured = capsys.readouterr()
+        assert "UseCustomMainLoopSchedule" in captured.err
+        assert "BufferLoad" in captured.err

--- a/projects/hipblaslt/utilities/fix_yaml_types.py
+++ b/projects/hipblaslt/utilities/fix_yaml_types.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Fix YAML parameter type mismatches in library logic files.
+
+Usage:
+    python3 fix_yaml_types.py <directory>
+
+Recursively finds all *.yaml files under <directory> and applies targeted
+regex substitutions to correct bool/int/float type mismatches.  These
+mismatches cause std::bad_cast at C++ msgpack deserialization time because
+msgpack serializes bool and int as different wire types.
+
+Idempotent — safe to run multiple times.
+"""
+
+import os
+import re
+import sys
+import glob
+
+
+# ── Known mismatch patterns ──────────────────────────────────────────────────
+#
+# Derived from Tensile.Common.ValidParameters.validParameters.  Each group
+# lists parameters whose YAML values have the wrong Python type after
+# yaml.safe_load().
+
+# Group A: Bool -> Int
+# validParameters declares these as int (e.g. [-1, 0, 1]) but YAMLs have
+# false/true which yaml.safe_load() returns as Python bool.
+BOOL_TO_INT_PARAMS = [
+    "ClusterLocalRead",
+    "DirectToLds",
+    "SwapGlobalReadOrder",
+    "TransposeLDS",
+    "TransposeLDSMetadata",
+    "UseCustomMainLoopSchedule",
+    "UsePLRPack",
+]
+
+# Group B: Int -> Bool
+# validParameters declares these as bool (e.g. [False, True]) but YAMLs have
+# 0/1 which yaml.safe_load() returns as Python int.
+INT_TO_BOOL_PARAMS = [
+    "ActivationFuncCall",
+    "ConvertAfterDS",
+    "DirectToVgprA",
+    "DirectToVgprB",
+    "ExpandPointerSwap",
+    "ForceDisableShadowInit",
+    "GroupLoadStore",
+    "LDSTrInst",
+    "MIArchVgpr",
+    "NoReject",
+    "PreloadKernArgs",
+    "SourceSwap",
+    "StorePriorityOpt",
+    "SuppressNoLoadLoop",
+    "TailloopInNll",
+    "Use64bShadowLimit",
+    "WaveSplitK",
+]
+
+# Group C: Int -> Float
+# validParameters declares these as float but YAMLs have bare integers.
+INT_TO_FLOAT_PARAMS = [
+    "GlobalReadPerMfma",
+]
+
+
+def _build_patterns():
+    """Build compiled regex patterns and their replacements.
+
+    Returns a list of (compiled_regex, replacement_string) tuples.
+    Each regex matches a full line with the parameter at end-of-line.
+    """
+    patterns = []
+
+    # Group A: false -> 0, true -> 1
+    for param in BOOL_TO_INT_PARAMS:
+        patterns.append((
+            re.compile(rf"^(\s*{param}: )false$", re.MULTILINE),
+            rf"\g<1>0",
+        ))
+        patterns.append((
+            re.compile(rf"^(\s*{param}: )true$", re.MULTILINE),
+            rf"\g<1>1",
+        ))
+
+    # Group B: 0 -> false, 1 -> true
+    for param in INT_TO_BOOL_PARAMS:
+        patterns.append((
+            re.compile(rf"^(\s*{param}: )0$", re.MULTILINE),
+            rf"\g<1>false",
+        ))
+        patterns.append((
+            re.compile(rf"^(\s*{param}: )1$", re.MULTILINE),
+            rf"\g<1>true",
+        ))
+
+    # Group C: 1 -> 1.0
+    for param in INT_TO_FLOAT_PARAMS:
+        patterns.append((
+            re.compile(rf"^(\s*{param}: )1$", re.MULTILINE),
+            rf"\g<1>1.0",
+        ))
+
+    return patterns
+
+
+PATTERNS = _build_patterns()
+
+
+def count_mismatches(content):
+    """Count how many lines in content match any mismatch pattern.
+
+    Returns (group_a_count, group_b_count, group_c_count).
+    """
+    counts = [0, 0, 0]
+
+    for param in BOOL_TO_INT_PARAMS:
+        counts[0] += len(re.findall(
+            rf"^\s*{param}: (?:false|true)$", content, re.MULTILINE))
+
+    for param in INT_TO_BOOL_PARAMS:
+        counts[1] += len(re.findall(
+            rf"^\s*{param}: [01]$", content, re.MULTILINE))
+
+    for param in INT_TO_FLOAT_PARAMS:
+        counts[2] += len(re.findall(
+            rf"^\s*{param}: 1$", content, re.MULTILINE))
+
+    return tuple(counts)
+
+
+def fix_content(content):
+    """Apply all type-fix patterns to content string.  Returns new content."""
+    for pattern, replacement in PATTERNS:
+        content = pattern.sub(replacement, content)
+    return content
+
+
+def fix_file(filepath):
+    """Fix a single YAML file in-place.  Returns True if file was modified."""
+    with open(filepath, "r") as f:
+        original = f.read()
+
+    fixed = fix_content(original)
+
+    if fixed != original:
+        with open(filepath, "w") as f:
+            f.write(fixed)
+        return True
+    return False
+
+
+def find_yaml_files(directory):
+    """Recursively find all *.yaml files under directory."""
+    return sorted(glob.glob(os.path.join(directory, "**/*.yaml"), recursive=True))
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <directory>")
+        print("  Recursively fixes YAML parameter type mismatches under <directory>")
+        return 1
+
+    target_dir = sys.argv[1]
+
+    if not os.path.isdir(target_dir):
+        print(f"Error: '{target_dir}' is not a directory")
+        return 1
+
+    yaml_files = find_yaml_files(target_dir)
+    print(f"=== fix_yaml_types.py ===")
+    print(f"Target directory: {target_dir}")
+    print(f"YAML files found: {len(yaml_files)}")
+    print()
+
+    # Count mismatches before
+    before = [0, 0, 0]
+    for filepath in yaml_files:
+        with open(filepath, "r") as f:
+            content = f.read()
+        a, b, c = count_mismatches(content)
+        before[0] += a
+        before[1] += b
+        before[2] += c
+
+    before_total = sum(before)
+
+    print("--- Mismatches found BEFORE fix ---")
+    print(f"  Group A (bool->int):   {before[0]}")
+    print(f"  Group B (int->bool):   {before[1]}")
+    print(f"  Group C (int->float):  {before[2]}")
+    print(f"  Total:                 {before_total}")
+    print()
+
+    if before_total == 0:
+        print("No mismatches to fix. All parameters have correct types.")
+        return 0
+
+    # Apply fixes
+    print("Applying fixes...")
+    files_modified = 0
+    for filepath in yaml_files:
+        if fix_file(filepath):
+            files_modified += 1
+    print(f"Done. Modified {files_modified} files.")
+    print()
+
+    # Count mismatches after (verification)
+    after = [0, 0, 0]
+    for filepath in yaml_files:
+        with open(filepath, "r") as f:
+            content = f.read()
+        a, b, c = count_mismatches(content)
+        after[0] += a
+        after[1] += b
+        after[2] += c
+
+    after_total = sum(after)
+
+    print("--- Mismatches found AFTER fix ---")
+    print(f"  Group A (bool->int):   {after[0]}")
+    print(f"  Group B (int->bool):   {after[1]}")
+    print(f"  Group C (int->float):  {after[2]}")
+    print(f"  Total:                 {after_total}")
+    print()
+
+    if after_total == 0:
+        print("SUCCESS: All mismatches fixed.")
+        return 0
+    else:
+        print(f"WARNING: {after_total} mismatches remain after fix. "
+              "Manual inspection needed.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/hipblaslt/utilities/test_fix_yaml_types.py
+++ b/projects/hipblaslt/utilities/test_fix_yaml_types.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Tests for fix_yaml_types.py."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+import pytest
+
+from fix_yaml_types import (
+    BOOL_TO_INT_PARAMS,
+    INT_TO_BOOL_PARAMS,
+    INT_TO_FLOAT_PARAMS,
+    count_mismatches,
+    fix_content,
+    fix_file,
+    find_yaml_files,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def make_yaml(tmpdir, filename, content):
+    """Write a YAML file in tmpdir and return its path."""
+    path = os.path.join(tmpdir, filename)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(textwrap.dedent(content))
+    return path
+
+
+# ── Tests for fix_content ────────────────────────────────────────────────────
+
+class TestFixContentGroupA:
+    """Group A: Bool -> Int (false->0, true->1)."""
+
+    @pytest.mark.parametrize("param", BOOL_TO_INT_PARAMS)
+    def test_false_to_zero(self, param):
+        content = f"    {param}: false\n"
+        result = fix_content(content)
+        assert result == f"    {param}: 0\n"
+
+    @pytest.mark.parametrize("param", BOOL_TO_INT_PARAMS)
+    def test_true_to_one(self, param):
+        content = f"    {param}: true\n"
+        result = fix_content(content)
+        assert result == f"    {param}: 1\n"
+
+    @pytest.mark.parametrize("param", BOOL_TO_INT_PARAMS)
+    def test_int_value_unchanged(self, param):
+        """Already-correct int values should not be modified."""
+        content = f"    {param}: 0\n"
+        assert fix_content(content) == content
+        content = f"    {param}: 1\n"
+        assert fix_content(content) == content
+
+    def test_unrelated_param_unchanged(self):
+        content = "    SomeOtherParam: false\n"
+        assert fix_content(content) == content
+
+
+class TestFixContentGroupB:
+    """Group B: Int -> Bool (0->false, 1->true)."""
+
+    @pytest.mark.parametrize("param", INT_TO_BOOL_PARAMS)
+    def test_zero_to_false(self, param):
+        content = f"    {param}: 0\n"
+        result = fix_content(content)
+        assert result == f"    {param}: false\n"
+
+    @pytest.mark.parametrize("param", INT_TO_BOOL_PARAMS)
+    def test_one_to_true(self, param):
+        content = f"    {param}: 1\n"
+        result = fix_content(content)
+        assert result == f"    {param}: true\n"
+
+    @pytest.mark.parametrize("param", INT_TO_BOOL_PARAMS)
+    def test_bool_value_unchanged(self, param):
+        """Already-correct bool values should not be modified."""
+        content = f"    {param}: false\n"
+        assert fix_content(content) == content
+        content = f"    {param}: true\n"
+        assert fix_content(content) == content
+
+    def test_unrelated_int_param_unchanged(self):
+        content = "    DepthU: 1\n"
+        assert fix_content(content) == content
+
+
+class TestFixContentGroupC:
+    """Group C: Int -> Float (1 -> 1.0)."""
+
+    def test_int_to_float(self):
+        content = "    GlobalReadPerMfma: 1\n"
+        result = fix_content(content)
+        assert result == "    GlobalReadPerMfma: 1.0\n"
+
+    def test_already_float_unchanged(self):
+        content = "    GlobalReadPerMfma: 1.0\n"
+        assert fix_content(content) == content
+
+    def test_other_int_unchanged(self):
+        """Only value 1 should be converted, not other ints."""
+        content = "    GlobalReadPerMfma: 2\n"
+        assert fix_content(content) == content
+
+    def test_unrelated_param_unchanged(self):
+        content = "    OtherFloat: 1\n"
+        assert fix_content(content) == content
+
+
+# ── Tests for idempotency ────────────────────────────────────────────────────
+
+class TestIdempotency:
+    """Running fix_content twice should produce the same result."""
+
+    def test_all_groups_idempotent(self):
+        content = textwrap.dedent("""\
+            UseCustomMainLoopSchedule: false
+            DirectToLds: true
+            ExpandPointerSwap: 0
+            SourceSwap: 1
+            GlobalReadPerMfma: 1
+        """)
+        first = fix_content(content)
+        second = fix_content(first)
+        assert first == second
+
+    def test_already_correct_idempotent(self):
+        content = textwrap.dedent("""\
+            UseCustomMainLoopSchedule: 0
+            ExpandPointerSwap: true
+            GlobalReadPerMfma: 1.0
+        """)
+        assert fix_content(content) == content
+
+
+# ── Tests for end-of-line anchoring ──────────────────────────────────────────
+
+class TestEndOfLineAnchoring:
+    """Values not at end-of-line should not be touched."""
+
+    def test_value_in_list_not_touched(self):
+        content = "    SomeList: [DirectToLds: false, Other: 1]\n"
+        assert fix_content(content) == content
+
+    def test_value_in_comment_not_touched(self):
+        content = '    Comment: "DirectToLds: false means disabled"\n'
+        assert fix_content(content) == content
+
+    def test_bare_eol_value_is_fixed(self):
+        content = "    DirectToLds: false\n"
+        result = fix_content(content)
+        assert result == "    DirectToLds: 0\n"
+
+    def test_multi_digit_int_not_matched(self):
+        """ExpandPointerSwap: 10 should NOT become ExpandPointerSwap: true0."""
+        content = "    ExpandPointerSwap: 10\n"
+        assert fix_content(content) == content
+
+
+# ── Tests for count_mismatches ───────────────────────────────────────────────
+
+class TestCountMismatches:
+
+    def test_no_mismatches(self):
+        content = "    UseCustomMainLoopSchedule: 0\n    ExpandPointerSwap: true\n"
+        assert count_mismatches(content) == (0, 0, 0)
+
+    def test_group_a_counts(self):
+        content = "    DirectToLds: false\n    DirectToLds: true\n"
+        a, b, c = count_mismatches(content)
+        assert a == 2
+        assert b == 0
+        assert c == 0
+
+    def test_group_b_counts(self):
+        content = "    ExpandPointerSwap: 0\n    SourceSwap: 1\n"
+        a, b, c = count_mismatches(content)
+        assert a == 0
+        assert b == 2
+        assert c == 0
+
+    def test_group_c_counts(self):
+        content = "    GlobalReadPerMfma: 1\n"
+        a, b, c = count_mismatches(content)
+        assert a == 0
+        assert b == 0
+        assert c == 1
+
+    def test_mixed_groups(self):
+        content = textwrap.dedent("""\
+            DirectToLds: false
+            ExpandPointerSwap: 0
+            GlobalReadPerMfma: 1
+        """)
+        assert count_mismatches(content) == (1, 1, 1)
+
+
+# ── Tests for fix_file ───────────────────────────────────────────────────────
+
+class TestFixFile:
+
+    def test_modifies_file_in_place(self, tmp_path):
+        yaml_file = tmp_path / "test.yaml"
+        yaml_file.write_text("    DirectToLds: false\n")
+        assert fix_file(str(yaml_file)) is True
+        assert yaml_file.read_text() == "    DirectToLds: 0\n"
+
+    def test_returns_false_when_no_changes(self, tmp_path):
+        yaml_file = tmp_path / "test.yaml"
+        yaml_file.write_text("    DirectToLds: 0\n")
+        assert fix_file(str(yaml_file)) is False
+
+    def test_preserves_unrelated_content(self, tmp_path):
+        yaml_file = tmp_path / "test.yaml"
+        original = "    DepthU: 32\n    DirectToLds: false\n    ThreadTile: [4, 4]\n"
+        yaml_file.write_text(original)
+        fix_file(str(yaml_file))
+        result = yaml_file.read_text()
+        assert "DepthU: 32" in result
+        assert "ThreadTile: [4, 4]" in result
+        assert "DirectToLds: 0" in result
+
+
+# ── Tests for find_yaml_files ────────────────────────────────────────────────
+
+class TestFindYamlFiles:
+
+    def test_finds_nested_yaml(self, tmp_path):
+        subdir = tmp_path / "arch" / "Equality"
+        subdir.mkdir(parents=True)
+        (subdir / "test.yaml").write_text("content\n")
+        (tmp_path / "top.yaml").write_text("content\n")
+        result = find_yaml_files(str(tmp_path))
+        assert len(result) == 2
+
+    def test_ignores_non_yaml(self, tmp_path):
+        (tmp_path / "test.txt").write_text("content\n")
+        (tmp_path / "test.yaml").write_text("content\n")
+        result = find_yaml_files(str(tmp_path))
+        assert len(result) == 1
+
+    def test_empty_directory(self, tmp_path):
+        result = find_yaml_files(str(tmp_path))
+        assert result == []
+
+
+# ── Tests for mixed correct/incorrect values ─────────────────────────────────
+
+class TestMixedContent:
+
+    def test_mixed_correct_and_incorrect(self):
+        content = textwrap.dedent("""\
+            - solution1:
+                UseCustomMainLoopSchedule: 0
+                DirectToLds: false
+                ExpandPointerSwap: true
+                SourceSwap: 1
+            - solution2:
+                UseCustomMainLoopSchedule: true
+                DirectToLds: 1
+                ExpandPointerSwap: 0
+                SourceSwap: false
+        """)
+        result = fix_content(content)
+        # Fixed
+        assert "DirectToLds: false" not in result
+        assert "SourceSwap: 1\n" not in result
+        assert "UseCustomMainLoopSchedule: true" not in result
+        assert "ExpandPointerSwap: 0\n" not in result
+        # Already correct — preserved
+        assert "UseCustomMainLoopSchedule: 0" in result
+        assert "DirectToLds: 1" in result
+        assert "ExpandPointerSwap: true" in result
+        assert "SourceSwap: false" in result
+
+
+# ── Tests for CLI ────────────────────────────────────────────────────────────
+
+class TestCLI:
+    """Test the script as a command-line tool."""
+
+    SCRIPT = os.path.join(os.path.dirname(__file__), "fix_yaml_types.py")
+
+    def test_no_args_exits_nonzero(self):
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT],
+            capture_output=True, text=True)
+        assert result.returncode == 1
+        assert "Usage" in result.stdout
+
+    def test_nonexistent_dir_exits_nonzero(self):
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT, "/nonexistent/path"],
+            capture_output=True, text=True)
+        assert result.returncode == 1
+        assert "not a directory" in result.stdout
+
+    def test_clean_dir_exits_zero(self, tmp_path):
+        subdir = tmp_path / "arch"
+        subdir.mkdir()
+        (subdir / "test.yaml").write_text("    DirectToLds: 0\n")
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT, str(tmp_path)],
+            capture_output=True, text=True)
+        assert result.returncode == 0
+        assert "No mismatches to fix" in result.stdout
+
+    def test_fixes_and_reports_success(self, tmp_path):
+        subdir = tmp_path / "arch"
+        subdir.mkdir()
+        (subdir / "test.yaml").write_text("    DirectToLds: false\n")
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT, str(tmp_path)],
+            capture_output=True, text=True)
+        assert result.returncode == 0
+        assert "SUCCESS" in result.stdout
+        assert (subdir / "test.yaml").read_text() == "    DirectToLds: 0\n"
+
+    def test_reports_counts(self, tmp_path):
+        subdir = tmp_path / "arch"
+        subdir.mkdir()
+        (subdir / "test.yaml").write_text(
+            "    DirectToLds: false\n    ExpandPointerSwap: 0\n    GlobalReadPerMfma: 1\n")
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT, str(tmp_path)],
+            capture_output=True, text=True)
+        assert "Group A (bool->int):   1" in result.stdout
+        assert "Group B (int->bool):   1" in result.stdout
+        assert "Group C (int->float):  1" in result.stdout


### PR DESCRIPTION
> **Depends on #5001** — that PR must be merged first (both modify `Solution.py`).

## Summary

- Add `validateParameterTypes()` to `Solution.__init__()` that checks every
  YAML parameter's type against `validParameters` at build time
- Mismatches (e.g. YAML `false` where `int 0` is expected) are collected and
  printed as a WARNING summary at the end of `TensileCreateLibrary`
- Add `fix_yaml_types.py` script to batch-fix all known mismatch patterns
- 43 + 101 unit tests

## Motivation

YAML `false`/`true` vs `0`/`1` produce different msgpack wire types, causing
`std::bad_cast` at C++ deserialization time. There are currently ~2246 library
logic YAML files with type mismatches across all 14 architectures and 25
distinct parameters. This PR adds the detection infrastructure; follow-up PRs
will fix the existing YAML files and then flip the warnings to build errors.

## Changes

### `tensilelite/Tensile/SolutionStructs/Solution.py`:
- `_getExpectedTypes(validParams)` — builds a map from param name to set of allowed Python types
- `_expectedParamTypes` — pre-computed at import time
- `_skipTypeCheck = {"ISA"}` — exempts params where YAML type differs structurally
- `_typeMismatchCollector` — module-level dict accumulating mismatches across all Solution instances
- `validateParameterTypes(state, srcFile="")` — collects mismatches (warning mode)
- `printTypeMismatchSummary()` — prints grouped summary to stderr
- `resetTypeMismatchCollector()` — for test isolation

### `tensilelite/Tensile/TensileCreateLibrary/Run.py`:
- Calls `printTypeMismatchSummary()` after YAML parsing loop

### `fix_yaml_types.py`:
- Standalone script: recursively fixes 25 known parameter type mismatches
  (7 bool→int, 17 int→bool, 1 int→float)
- Reports before/after counts, idempotent, pure regex

### Tests:
- `test_validateParameterTypes.py` — 43 tests
- `test_fix_yaml_types.py` — 101 tests

## Test plan
- [x] `pytest tensilelite/Tensile/Tests/unit/test_validateParameterTypes.py` (43 pass)
- [x] `pytest test_fix_yaml_types.py` (101 pass)
- [x] `fix_yaml_types.py` verified against full YAML directory (0 mismatches after fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AIGECORE-189