### PR TITLE
[rocBLAS] fix warning in hipblaslt arg memory free and potential bug

### DIFF
--- a/projects/rocblas/library/src/hipblaslt_host.cpp
+++ b/projects/rocblas/library/src/hipblaslt_host.cpp
@@ -517,7 +517,7 @@ rocblas_status runContractionProblemHipBlasLT(const RocblasContractionProblem<Ti
             = (hipblaslt_ext::UserArguments*)((char*)(prob.handle->gsu_workspace)
                                               + (workspace_size - userArgsSize));
         RETURN_IF_HIP_ERROR(hipMemcpy(d_userArgs, userArgs, userArgsSize, hipMemcpyHostToDevice));
-        RETURN_IF_HIP_ERROR(hipFree(userArgs));
+        RETURN_IF_HIP_ERROR(hipHostFree(userArgs));
 
         if(gemm.run(d_userArgs, prob.handle->get_stream()) != HIPBLAS_STATUS_SUCCESS)
         {


### PR DESCRIPTION
## Motivation

* This pull request makes a minor update to the memory deallocation method in the HIPBLASLT contraction problem implementation. The change ensures that host memory allocated for user arguments is properly freed using the correct HIP API.

* Replaced the call to `hipFree(userArgs)` with `hipHostFree(userArgs)` in the `runContractionProblemHipBlasLT` function in `hipblaslt_host.cpp`, ensuring host-allocated memory is correctly deallocated.
