### PR TITLE
[hipblaslt][CMS] Cleanup and standardize ValidatorInstruction hierarchy

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -134,10 +134,9 @@ MFMAS_PER_TILE_BF16 = 1   # 1 MFMA per tile pair in BF16
 VGPRS_PER_CONVERSION_GROUP = 8   # 8 VGPRs per conversion group in TF32 emulation
 
 
+@dataclass
 class ValidatorInstruction(ABC):
-    """
-    Abstract class with no method just for type hinting purposes.
-    """
+    """Abstract base for all validator instructions."""
     name: str
     issued_at: SchedulePosition
     # The minimum number of quad-cycles that this instruction takes to issue.
@@ -147,26 +146,23 @@ class ValidatorInstruction(ABC):
     def validate(self) -> Optional[str]:
         ...
 
-    @abstractmethod
     def done_idx(self) -> SchedulePosition:
+        """Position after which this instruction is done for scheduling purposes.
+
+        Default: instruction is done at its issue position.
+        Override in subclasses where completion depends on an SWaitCnt (LocalRead, GlobalRead).
         """
-        MFMA Index after which this instruction is done for the purpose of scheduling other instructions
-        which rely on something about it.
-        E.g. The done_idx of a LocalRead/GlobalRead is the index of the SWaitCnt that waits on them.
-        """
-        ...
+        return self.issued_at
 
     def min_issue_quad_cycles(self) -> int:
         return self.min_issue_quad_cycles_base
 
 @dataclass
 class LocalRead(ValidatorInstruction):
-    name: str
-    issued_at: SchedulePosition
     # The index in the list of Local Read instructions provided by a CMS schedule.
     # Needed to properly calculate must_start_after for Packs.
     issue_index: int
-    needed_by: ValidatorInstruction = field(default_factory=lambda: MFMA(POSITION_INF))
+    needed_by: ValidatorInstruction = field(default_factory=lambda: MFMA(name="MFMA", issued_at=POSITION_INF))
     guaranteed_by: SchedulePosition = field(default_factory=lambda: POSITION_INF)
 
     def done_idx(self) -> SchedulePosition:
@@ -197,12 +193,7 @@ class LocalRead(ValidatorInstruction):
 
 @dataclass
 class MFMA(ValidatorInstruction):
-    issued_at: SchedulePosition
-    name: str = "MFMA"
     mfma_finish_cycles: ClassVar[int] = QUAD_CYCLES_STANDARD_MFMA_FINISH
-
-    def done_idx(self) -> SchedulePosition:
-        return self.issued_at
 
     def validate(self) -> Optional[str]:
         return None
@@ -210,19 +201,14 @@ class MFMA(ValidatorInstruction):
 @dataclass
 class Pack(ValidatorInstruction):
     """BF16 pack instructions (v_perm). Base class for all pack types."""
-    name: str
-    issued_at: SchedulePosition
     # The index in the list of Pack instructions provided by a CMS schedule.
     # Needed to properly calculate needed_by and must_start_after.
     issue_index: int
     # Which tile/group this pack belongs to, computed at construction time.
     # Only meaningful for TF32 subclasses (CVTPack, MiddlePack, MFMAPack); None for BF16 packs.
     group_index: Optional[int] = None
-    needed_by: ValidatorInstruction = field(default_factory=lambda: MFMA(POSITION_INF))
+    needed_by: ValidatorInstruction = field(default_factory=lambda: MFMA(name="MFMA", issued_at=POSITION_INF))
     must_start_after: list[ValidatorInstruction] = field(default_factory=list)
-
-    def done_idx(self) -> SchedulePosition:
-        return self.issued_at
 
     def validate(self) -> Optional[str]:
         issued_at = self.issued_at.vmfma_index
@@ -230,7 +216,7 @@ class Pack(ValidatorInstruction):
         # Collapse must_start_after list to the single latest constraint
         effective_must_start_after = max(
             self.must_start_after, key=lambda c: c.done_idx()
-        ) if self.must_start_after else MFMA(POSITION_NEG_INF)
+        ) if self.must_start_after else MFMA(name="MFMA", issued_at=POSITION_NEG_INF)
 
         if effective_must_start_after.done_idx() < self.issued_at < self.needed_by.done_idx():
             return None
@@ -306,11 +292,6 @@ class MFMAPack(TimedPack, MFMA):
     - isinstance(x, TimedPack) is True — has quad-cycle timing constraints
     - isinstance(x, MFMA) is True — captures "this IS an MFMA" semantics
     """
-    # NOTE: Do NOT re-declare `name: str` here. Although the MRO field merge
-    # correctly resolves Pack's no-default `name` over MFMA's default,
-    # Python's _get_field uses getattr() which picks up MFMA's inherited
-    # `name = 'MFMA'` class attribute and re-introduces the default.
-
     # Override MFMA's finish cycles for 4x4 timing
     mfma_finish_cycles: ClassVar[int] = QUAD_CYCLES_MFMA_4X4_FINISH
 
@@ -324,10 +305,8 @@ class MFMAPack(TimedPack, MFMA):
 
 @dataclass
 class GlobalRead(ValidatorInstruction):
-    name: str
-    issued_at: SchedulePosition
     swap_global_read_order: bool
-    needed_by: SchedulePosition = field(default_factory=lambda: POSITION_INF)
+    needed_by: ValidatorInstruction = field(default_factory=lambda: MFMA(name="MFMA", issued_at=POSITION_INF))
     guaranteed_by: SchedulePosition = field(default_factory=lambda: POSITION_INF)
     barriered_at: list[SchedulePosition] = field(default_factory=list)
     must_start_after: list[ValidatorInstruction] = field(default_factory=list)
@@ -387,15 +366,15 @@ class GlobalRead(ValidatorInstruction):
     def _validate_needed_by(self) -> Optional[str]:
         """Validate: GR -> SWait -> SBarrier -> LR1"""
         # If needed_by is at inf, the constraint is not active (e.g. no LR1s).
-        if self.needed_by == POSITION_INF:
+        if self.needed_by.issued_at == POSITION_INF:
             return None
 
-        if self.issued_at < self.guaranteed_by < self.needed_by:
-            if any(self.guaranteed_by < barriered_at < self.needed_by for barriered_at in self.barriered_at):
+        if self.issued_at < self.guaranteed_by < self.needed_by.issued_at:
+            if any(self.guaranteed_by < barriered_at < self.needed_by.issued_at for barriered_at in self.barriered_at):
                     return None
 
         issued_at = self.issued_at.vmfma_index
-        needed_by = self.needed_by.vmfma_index
+        needed_by = self.needed_by.issued_at.vmfma_index
 
         name = self._name()
 
@@ -411,12 +390,12 @@ class GlobalRead(ValidatorInstruction):
             return f"{name} @ idx={issued_at} is not valid. There is no SBarrier acting on it."
 
         # 3. Guaranteed after needed
-        if self.guaranteed_by > self.needed_by:
-            return f"{name} @ idx={issued_at} is not valid. It is guaranteed by the SWait @ idx={guaranteed_by} which is after the first corresponding LR1 @ idx={needed_by}. Order must be {name} -> SWait -> SBarrier -> LR1."
+        if self.guaranteed_by > self.needed_by.issued_at:
+            return f"{name} @ idx={issued_at} is not valid. It is guaranteed by the SWait @ idx={guaranteed_by} which is after the first corresponding {self.needed_by.name} @ idx={needed_by}. Order must be {name} -> SWait -> SBarrier -> {self.needed_by.name}."
 
         # 4. No Barrier between SWait and LR1
-        if not any(self.guaranteed_by < barriered_at < self.needed_by for barriered_at in self.barriered_at):
-            return f"{name} @ idx={issued_at} is not valid. No SBarrier between SWait @ idx={guaranteed_by} and LR1 @ idx={needed_by}. Order must be {name} -> SWait -> SBarrier -> LR1."
+        if not any(self.guaranteed_by < barriered_at < self.needed_by.issued_at for barriered_at in self.barriered_at):
+            return f"{name} @ idx={issued_at} is not valid. No SBarrier between SWait @ idx={guaranteed_by} and {self.needed_by.name} @ idx={needed_by}. Order must be {name} -> SWait -> SBarrier -> {self.needed_by.name}."
 
         # TODO: Did we miss a case and will we ever end up here?
         return f"{name} @ idx={issued_at} is not valid. issued @ idx={issued_at}, guaranteed @ idx={guaranteed_by}, barriered @ idx={[b.vmfma_index for b in self.barriered_at]}, needed @ idx={needed_by} is not valid."
@@ -435,15 +414,10 @@ class GlobalRead(ValidatorInstruction):
 
 @dataclass
 class SWait(ValidatorInstruction):
-    issued_at: SchedulePosition
     dscnt: int
     vlcnt: int
     vscnt: int
     comment: str
-    name: str = "SWaitCnt"
-
-    def done_idx(self) -> SchedulePosition:
-        return self.issued_at
 
     def _is_valid(self) -> bool:
         return self.dscnt >= -1 and self.vlcnt >= -1 and self.vscnt >= -1 and self.issued_at.vmfma_index >= -1
@@ -455,28 +429,18 @@ class SWait(ValidatorInstruction):
 
 @dataclass
 class Barrier(ValidatorInstruction):
-    issued_at: SchedulePosition
     comment: str
-    name: str = "SBarrier"
-
-    def done_idx(self) -> SchedulePosition:
-        return self.issued_at
 
     def validate(self) -> Optional[str]:
         return f"Barrier at index {self.issued_at.vmfma_index} is not valid. Must be >= -1." if self.issued_at.vmfma_index < -1 else None
 
 @dataclass
 class SNop(ValidatorInstruction):
-    issued_at: SchedulePosition
     wait_state: int
-    name: str = "SNop"
 
     def min_issue_quad_cycles(self) -> int:
         # Base instruction quad-cycles plus wait_state additional cycles
         return self.min_issue_quad_cycles_base + self.wait_state
-
-    def done_idx(self) -> SchedulePosition:
-        return self.issued_at
 
     def validate(self) -> Optional[str]:
         return None
@@ -485,11 +449,6 @@ class SNop(ValidatorInstruction):
 class GRInc(ValidatorInstruction):
     """Scalar pointer-increment instructions (GRIncA/GRIncB) that advance the
     global memory address before the next buffer_load."""
-    name: str
-    issued_at: SchedulePosition
-
-    def done_idx(self) -> SchedulePosition:
-        return self.issued_at
 
     def validate(self) -> Optional[str]:
         return None
@@ -608,9 +567,9 @@ class Timeline:
                     assert idx_vmfma >= -1, f"Code path {code_path}: SWaitCnt at index {idx_sync} is not valid. Must be >= -1."
                     
                     if isinstance(sync, SWaitCnt):
-                        sync_instruction = SWait(issued_at=POSITION_NEG_INF, dscnt=sync.dscnt, vlcnt=sync.vlcnt, vscnt=sync.vscnt, comment=sync.comment)
+                        sync_instruction = SWait(name="SWaitCnt", issued_at=POSITION_NEG_INF, dscnt=sync.dscnt, vlcnt=sync.vlcnt, vscnt=sync.vscnt, comment=sync.comment)
                     elif isinstance(sync, SBarrier):
-                        sync_instruction = Barrier(issued_at=POSITION_NEG_INF, comment=sync.comment)
+                        sync_instruction = Barrier(name="SBarrier", issued_at=POSITION_NEG_INF, comment=sync.comment)
                     else:
                         raise ValueError(f"Unexpected sync instruction type: {type(sync)}")
                     
@@ -620,7 +579,7 @@ class Timeline:
                     assert idx_vmfma >= -1, f"Code path {code_path}: SNop at index {idx_snop} is not valid. Must be >= -1."
                     # The waitState is stored as the first parameter in the rocisa SNop instruction
                     wait_state = snop.getParams()[0]
-                    snop_instruction = SNop(issued_at=POSITION_NEG_INF, wait_state=wait_state)
+                    snop_instruction = SNop(name="SNop", issued_at=POSITION_NEG_INF, wait_state=wait_state)
                     self._insert(idx_vmfma, snop_instruction, kernel)
             elif name.startswith("LRA") or name.startswith("LRB"):
                 for idx_LR, idx_vmfma in enumerate(schedule_get(name, code_path, schedule_info)):
@@ -803,7 +762,7 @@ def apply_barriers(timeline: Timeline) -> None:
             instruction = timeline.combined_timeline[i_inst]
             if not isinstance(instruction, GlobalRead):
                 continue
-            if instruction.barriered_at and barrier.issued_at >= instruction.needed_by:
+            if instruction.barriered_at and barrier.issued_at >= instruction.needed_by.issued_at:
                 # Note: Cannot break since we can't say anything about the relationship 
                 #       of `GR.needed_by` between GRs based on the order they're encountered.
                 continue
@@ -966,7 +925,7 @@ def set_gr_needed_by_from_lrs(timeline: Timeline, swap_global_read_order: bool) 
             
             _, LR_target = target[0]
             for _, gr in grs:
-                gr.needed_by = LR_target.issued_at
+                gr.needed_by = LR_target
 
 @applies_only_once
 def set_gr_must_start_after_from_lr0s(timeline: Timeline, swap_global_read_order: bool, dtl_plus_lds_buf: bool = False) -> None:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
@@ -65,13 +65,13 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         Validates that when multiple MFMA instructions are issued back-to-back,
         the estimated quad-cycles account for the execution latency and stalling.
         """
-        target_mfma = MFMA(issued_at=_pos(3, 0))
+        target_mfma = MFMA(name="MFMA", issued_at=_pos(3, 0))
         pack0 = Pack(name="Pack0", issue_index=0, issued_at=_pos(-1, 0), needed_by=target_mfma)
         all_instructions = [
             pack0,
-            MFMA(issued_at=_pos(0, 0)),
-            MFMA(issued_at=_pos(1, 0)),
-            MFMA(issued_at=_pos(2, 0)),
+            MFMA(name="MFMA", issued_at=_pos(0, 0)),
+            MFMA(name="MFMA", issued_at=_pos(1, 0)),
+            MFMA(name="MFMA", issued_at=_pos(2, 0)),
             target_mfma,
         ]
         # +4x3 for the 3 MFMAs to issue + finish
@@ -82,12 +82,12 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         """
         Test that consecutive non-MFMA instructions are estimated correctly.
         """
-        target_snop = SNop(issued_at=_pos(-1, 3), wait_state=0)
+        target_snop = SNop(name="SNop", issued_at=_pos(-1, 3), wait_state=0)
         pack0 = Pack(name="Pack0", issue_index=0, issued_at=_pos(-1, 0), needed_by=target_snop)
         all_instructions = [
             pack0,
-            SNop(issued_at=_pos(-1, 1), wait_state=0),
-            SNop(issued_at=_pos(-1, 2), wait_state=0),
+            SNop(name="SNop", issued_at=_pos(-1, 1), wait_state=0),
+            SNop(name="SNop", issued_at=_pos(-1, 2), wait_state=0),
             target_snop,
         ]
         # +1 for 1st SNop
@@ -102,14 +102,14 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         the cycle estimation reflects parallel execution on different execution units,
         with no unnecessary stalls between these independent instruction types.
         """
-        target_mfma = MFMA(issued_at=_pos(1, 0))
+        target_mfma = MFMA(name="MFMA", issued_at=_pos(1, 0))
         pack0 = Pack(name="Pack0", issue_index=0, issued_at=_pos(-1, 0), needed_by=target_mfma)
         all_instructions = [
             pack0,
-            MFMA(issued_at=_pos(0, 0)),
-            SNop(issued_at=_pos(0, 1), wait_state=0),
-            SNop(issued_at=_pos(0, 2), wait_state=0),
-            SNop(issued_at=_pos(0, 3), wait_state=0),
+            MFMA(name="MFMA", issued_at=_pos(0, 0)),
+            SNop(name="SNop", issued_at=_pos(0, 1), wait_state=0),
+            SNop(name="SNop", issued_at=_pos(0, 2), wait_state=0),
+            SNop(name="SNop", issued_at=_pos(0, 3), wait_state=0),
             target_mfma
         ]
         # +1 for MFMA to issue
@@ -124,15 +124,15 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         an MFMA immediately before the window boundary does not cause stalls for the
         first instruction, as they execute on different hardware units.
         """
-        target_mfma = MFMA(issued_at=_pos(1, 0))
+        target_mfma = MFMA(name="MFMA", issued_at=_pos(1, 0))
         pack0 = Pack(name="Pack0", issue_index=0, issued_at=_pos(0, 1), needed_by=target_mfma)
         all_instructions = [
-            MFMA(issued_at=_pos(0, 0)),
+            MFMA(name="MFMA", issued_at=_pos(0, 0)),
             # Window starts with Pack
             pack0,
-            SNop(issued_at=_pos(0, 2), wait_state=0),
-            SNop(issued_at=_pos(0, 3), wait_state=0),
-            SNop(issued_at=_pos(0, 4), wait_state=0),
+            SNop(name="SNop", issued_at=_pos(0, 2), wait_state=0),
+            SNop(name="SNop", issued_at=_pos(0, 3), wait_state=0),
+            SNop(name="SNop", issued_at=_pos(0, 4), wait_state=0),
             target_mfma
         ]
         self.validate(pack0, 3, all_instructions)
@@ -147,14 +147,14 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         MFMA instruction. This tests the propagation of stall effects across instruction
         types.
         """
-        target_snop = SNop(issued_at=_pos(1, 2), wait_state=0)
+        target_snop = SNop(name="SNop", issued_at=_pos(1, 2), wait_state=0)
         pack0 = Pack(name="Pack0", issue_index=0, issued_at=_pos(0, 1), needed_by=target_snop)
         all_instructions = [
-            MFMA(issued_at=_pos(0, 0)),
+            MFMA(name="MFMA", issued_at=_pos(0, 0)),
             # Window starts with Pack
             pack0,
-            MFMA(issued_at=_pos(1, 0)),  # +2 qs of stall
-            SNop(issued_at=_pos(1, 1), wait_state=0),
+            MFMA(name="MFMA", issued_at=_pos(1, 0)),  # +2 qs of stall
+            SNop(name="SNop", issued_at=_pos(1, 1), wait_state=0),
             target_snop
         ]
         # +3 quad-cycles for MFMA before window to finish.
@@ -169,16 +169,16 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         The effect of this is that the issuing of the MFMA is stalled,
         but the number of quad-cycles in the window is smaller than in the tests above.
         """
-        target_snop = SNop(issued_at=_pos(2, 2), wait_state=0)
+        target_snop = SNop(name="SNop", issued_at=_pos(2, 2), wait_state=0)
         pack0 = Pack(name="Pack0", issue_index=0, issued_at=_pos(0, 1), needed_by=target_snop)
         all_instructions = [
-            MFMA(issued_at=_pos(0, 0)),
+            MFMA(name="MFMA", issued_at=_pos(0, 0)),
             # Window starts with Pack
             pack0,
-            MFMA(issued_at=_pos(1, 0)),
-            SNop(issued_at=_pos(1, 1), wait_state=0),
-            MFMA(issued_at=_pos(2, 0)),  # +2 qs of stall
-            SNop(issued_at=_pos(2, 1), wait_state=0),
+            MFMA(name="MFMA", issued_at=_pos(1, 0)),
+            SNop(name="SNop", issued_at=_pos(1, 1), wait_state=0),
+            MFMA(name="MFMA", issued_at=_pos(2, 0)),  # +2 qs of stall
+            SNop(name="SNop", issued_at=_pos(2, 1), wait_state=0),
             target_snop
         ]
         # +1 for Pack to issue
@@ -192,11 +192,11 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         The 5th and 6th Pack for 4x4MFMA are MFMAs which take 1 cycle to finish.
         Ensure that we can issue things in parallel with them.
         """
-        target_snop = SNop(issued_at=_pos(-1, 2), wait_state=0)
+        target_snop = SNop(name="SNop", issued_at=_pos(-1, 2), wait_state=0)
         pack0 = MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(-1, 0), needed_by=target_snop)
         all_instructions = [
             pack0,
-            SNop(issued_at=_pos(-1, 1), wait_state=1),
+            SNop(name="SNop", issued_at=_pos(-1, 1), wait_state=1),
             target_snop,
         ]
         # +1 for Pack to finish (SNop issues in parallel)
@@ -207,11 +207,11 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         """
         Extra 4 quad-cycle latency associated with switching MFMA type.
         """
-        target_snop = SNop(issued_at=_pos(0, 1), wait_state=0)
+        target_snop = SNop(name="SNop", issued_at=_pos(0, 1), wait_state=0)
         pack0 = MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(-1, 0), needed_by=target_snop)
         all_instructions = [
             pack0,
-            MFMA(issued_at=_pos(0, 0)),
+            MFMA(name="MFMA", issued_at=_pos(0, 0)),
             target_snop,
         ]
         # +1 for Pack to finish (MFMA stalls)
@@ -223,12 +223,12 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         """
         4x4 -> 16x16 has extra 4 quad-cycle latency only when issuing in the first 3 quad-cycles after the MFMA.
         """
-        target_snop = SNop(issued_at=_pos(0, 1), wait_state=0)
+        target_snop = SNop(name="SNop", issued_at=_pos(0, 1), wait_state=0)
         pack0 = MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(-1, 0), needed_by=target_snop)
         all_instructions = [
             pack0,
-            SNop(issued_at=_pos(-1, 1), wait_state=1),
-            MFMA(issued_at=_pos(0, 0)),
+            SNop(name="SNop", issued_at=_pos(-1, 1), wait_state=1),
+            MFMA(name="MFMA", issued_at=_pos(0, 0)),
             target_snop,
         ]
         # +1 for Pack to finish (Snop issue hidden)
@@ -240,11 +240,11 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         """
         Extra 4 quad-cycle latency associated with switching MFMA type.
         """
-        target_snop = SNop(issued_at=_pos(0, 2), wait_state=0)
+        target_snop = SNop(name="SNop", issued_at=_pos(0, 2), wait_state=0)
         pack0 = Pack(name="Pack0", issue_index=0, issued_at=_pos(-1, 0), needed_by=target_snop)
         all_instructions = [
             pack0,
-            MFMA(issued_at=_pos(0, 0)),
+            MFMA(name="MFMA", issued_at=_pos(0, 0)),
             MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(0, 1)),
             target_snop,
         ]
@@ -258,12 +258,12 @@ class TestEstimateQuadCyclesValidator(unittest.TestCase):
         """
         16x16 -> 4x4 has extra 4 quad-cycle latency only when issuing in the first 4 quad-cycles after the MFMA.
         """
-        target_snop = SNop(issued_at=_pos(0, 3), wait_state=0)
+        target_snop = SNop(name="SNop", issued_at=_pos(0, 3), wait_state=0)
         pack0 = Pack(name="Pack0", issue_index=0, issued_at=_pos(-1, 0), needed_by=target_snop)
         all_instructions = [
             pack0,
-            MFMA(issued_at=_pos(0, 0)),
-            SNop(issued_at=_pos(0, 1), wait_state=3),
+            MFMA(name="MFMA", issued_at=_pos(0, 0)),
+            SNop(name="SNop", issued_at=_pos(0, 1), wait_state=3),
             MFMAPack(name="PackA0", issue_index=5, issued_at=_pos(0, 2)),
             target_snop,
         ]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGRsCompleteBeforeLr1s.py
@@ -131,7 +131,7 @@ class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, 2, 2, 0,
-            "GRA @ idx=0 is not valid. No SBarrier between SWait @ idx=3 and LR1 @ idx=6. Order must be GRA -> SWait -> SBarrier -> LR1."
+            "GRA @ idx=0 is not valid. No SBarrier between SWait @ idx=3 and LRA1 @ idx=6. Order must be GRA -> SWait -> SBarrier -> LRA1."
         )
 
     def test_guaranteed_after_first_lr1(self):
@@ -159,7 +159,7 @@ class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
 
         self.validate(
             optSchedule, syncCode, 1, 4, 4, 0,
-            "GRA @ idx=0 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=3. Order must be GRA -> SWait -> SBarrier -> LR1."
+            "GRA @ idx=0 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LRA1 @ idx=3. Order must be GRA -> SWait -> SBarrier -> LRA1."
         )
 
     def test_less_than_1_full_iteration_to_complete(self):
@@ -362,7 +362,7 @@ class TestValidateGRsCompleteBeforeLr1s(CMSValidationTestBase):
         ]
         self.validate(
             optSchedule, syncCode, 1, 2, 2, 0,
-            "GRB (Swapped, loading A) @ idx=3 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LR1 @ idx=2. Order must be GRB (Swapped, loading A) -> SWait -> SBarrier -> LR1."
+            "GRB (Swapped, loading A) @ idx=3 is not valid. It is guaranteed by the SWait @ idx=4 which is after the first corresponding LRA1 @ idx=2. Order must be GRB (Swapped, loading A) -> SWait -> SBarrier -> LRA1."
         )
 
     def test_fail_with_odd_number_of_grs(self):


### PR DESCRIPTION
## Motivation

Reduce redundancy in the `ValidatorInstruction` class hierarchy by leveraging proper Python dataclass inheritance, and unify the type of `GlobalRead.needed_by` with the rest of the hierarchy.

## Technical Details

Depends on #5021

- Made `ValidatorInstruction` a `@dataclass` so `name` and `issued_at` are declared once on the base class and inherited by all subclasses, removing duplicate field declarations from `LocalRead`, `MFMA`, `Pack`, `GlobalRead`, `SWait`, `Barrier`, `SNop`, and `GRInc`.
- Converted `done_idx()` from an abstract method to a concrete method with a default implementation (`return self.issued_at`), eliminating 6 identical one-line overrides in subclasses where the instruction is "done" at its issue position. `LocalRead` and `GlobalRead` still override it (they return `self.guaranteed_by`).
- Changed `GlobalRead.needed_by` from `SchedulePosition` to `ValidatorInstruction`, matching `LocalRead.needed_by` and `Pack.needed_by`. All comparisons and accesses updated accordingly.
- Error messages in `GlobalRead._validate_needed_by()` now use `self.needed_by.name` instead of hardcoded `"LR1"`, producing more specific diagnostics (e.g., `LRA1`).

## Test Plan

- Updated `test_EstimateQuadCyclesForValidator.py` to pass explicit `name=` and `issued_at=` to `MFMA()` and `SNop()` constructors.
- Updated expected error messages in `test_ValidateGRsCompleteBeforeLr1s.py` to expect specific instruction names (e.g., `LRA1`) instead of generic `LR1`.

## Test Result

All 38 unit tests pass across the 3 affected test files.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
