### PR TITLE
[rocBLAS] turn off expected deprecated warnings in solver example

### DIFF
--- a/projects/rocblas/clients/samples/CMakeLists.txt
+++ b/projects/rocblas/clients/samples/CMakeLists.txt
@@ -43,6 +43,9 @@ add_executable( rocblas-example-hip-complex-her2 example_hip_complex_her2.cpp )
 add_executable( rocblas-example-gemv-graph-capture example_gemv_graph_capture.cpp )
 add_executable( rocblas-example-header-check example_header_check.cpp)
 
+# test deprecated API without warnings until they are removed. Then this entire example can be deleted TODO
+target_compile_options( rocblas-example-solver PRIVATE -Wno-deprecated )
+
 set( sample_list_base rocblas-example-sscal rocblas-example-scal-template rocblas-example-scal-multiple-strided-batch rocblas-example-solver rocblas-example-hip-complex-her2 rocblas-example-gemv-graph-capture rocblas-example-header-check)
 
 

--- a/projects/rocblas/next-cmake/clients/samples/example_solver_rocblas/CMakeLists.txt
+++ b/projects/rocblas/next-cmake/clients/samples/example_solver_rocblas/CMakeLists.txt
@@ -12,6 +12,10 @@ target_include_directories(
   rocblas-example-solver
   PRIVATE ${TEMP_CLIENT_SAMPLES_DIR}/../../library/src/include)
 
+# test deprecated API without warnings until they are removed.  Then this entire example can be deleted TODO
+target_compile_options(
+  rocblas-example-solver PRIVATE -Wno-deprecated)
+
 set_target_properties(
   rocblas-example-solver PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                     ${PROJECT_BINARY_DIR}/staging)


### PR DESCRIPTION
## Technical Details

This pull request introduces a temporary change to the build configuration for the `rocblas-example-solver` sample to suppress compiler warnings about deprecated APIs. This allows developers to continue testing deprecated functionality without interruption, until those APIs are removed and the example is deleted.

Build configuration updates:

* Added the `-Wno-deprecated` compile option to the `rocblas-example-solver` target in both `projects/rocblas/clients/samples/CMakeLists.txt` and `projects/rocblas/next-cmake/clients/samples/example_solver_rocblas/CMakeLists.txt`, with a TODO comment noting this is a temporary measure.

