### PR TITLE
[hipDNN] [ALMIOPEN-1148] KnobSettings lowering via descriptors

### DIFF
--- a/projects/hipdnn/backend/src/CMakeLists.txt
+++ b/projects/hipdnn/backend/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
     descriptors/GraphDescriptor.cpp
     descriptors/TensorDescriptor.cpp
     descriptors/ConvolutionFwdOperationDescriptor.cpp
+    descriptors/KnobSettingDescriptor.cpp
     descriptors/DescriptorAttributeUtils.cpp
     descriptors/DataTypeConversion.cpp
     descriptors/VariantDescriptor.cpp

--- a/projects/hipdnn/backend/src/descriptors/DescriptorFactory.cpp
+++ b/projects/hipdnn/backend/src/descriptors/DescriptorFactory.cpp
@@ -10,6 +10,7 @@
 #include "ExecutionPlanDescriptor.hpp"
 #include "GraphDescriptor.hpp"
 #include "HipdnnException.hpp"
+#include "KnobSettingDescriptor.hpp"
 #include "TensorDescriptor.hpp"
 #include "VariantDescriptor.hpp"
 #include "logging/Logging.hpp"
@@ -52,6 +53,9 @@ void DescriptorFactory::create(hipdnnBackendDescriptorType_t descriptorType,
         break;
     case HIPDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR:
         privateDesc = std::make_shared<ConvolutionFwdOperationDescriptor>();
+        break;
+    case HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR:
+        privateDesc = std::make_shared<KnobSettingDescriptor>();
         break;
     default:
         throw HipdnnException(HIPDNN_STATUS_NOT_SUPPORTED,

--- a/projects/hipdnn/backend/src/descriptors/EngineConfigDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/EngineConfigDescriptor.cpp
@@ -8,6 +8,7 @@
 #include "HipdnnBackendDescriptorType.h"
 #include "HipdnnBackendFlatbufferData.h"
 #include "HipdnnException.hpp"
+#include "KnobSettingDescriptor.hpp"
 #include "handle/Handle.hpp"
 
 #include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
@@ -153,8 +154,10 @@ void EngineConfigDescriptor::setAttribute(hipdnnBackendAttributeName_t attribute
     case HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT:
         setKnobChoice(attributeType, elementCount, arrayOfElements);
         break;
-    case HIPDNN_ATTR_ENGINECFG_INTERMEDIATE_INFO:
     case HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES:
+        setKnobSettingDescriptor(attributeType, elementCount, arrayOfElements);
+        break;
+    case HIPDNN_ATTR_ENGINECFG_INTERMEDIATE_INFO:
     case HIPDNN_ATTR_ENGINECFG_WORKSPACE_SIZE:
     default:
         throw HipdnnException(
@@ -273,6 +276,51 @@ void EngineConfigDescriptor::setKnobChoice(hipdnnBackendAttributeType_t attribut
         // Convert to KnobSettingT and add to the engine config data
         auto knobSettingT = wrapper.toKnobSettingT();
         _engineConfigData->knobs.push_back(std::move(knobSettingT));
+    }
+}
+
+void EngineConfigDescriptor::setKnobSettingDescriptor(hipdnnBackendAttributeType_t attributeType,
+                                                      int64_t elementCount,
+                                                      const void* arrayOfElements)
+{
+    THROW_IF_NE(attributeType,
+                HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                HIPDNN_STATUS_BAD_PARAM,
+                "EngineConfigDescriptor failed to set knob choices: Invalid attribute type.");
+
+    THROW_IF_LT(elementCount,
+                1,
+                HIPDNN_STATUS_BAD_PARAM,
+                "EngineConfigDescriptor failed to set knob choices: Element count must be > 0.");
+
+    THROW_IF_TRUE(elementCount > MAX_KNOB_CHOICES,
+                  HIPDNN_STATUS_BAD_PARAM,
+                  "EngineConfigDescriptor failed to set knob choices: "
+                  "Element count exceeds MAX_KNOB_CHOICES ("
+                      + std::to_string(MAX_KNOB_CHOICES) + ").");
+
+    THROW_IF_NULL(arrayOfElements,
+                  HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                  "EngineConfigDescriptor failed to set knob choices: Null pointer.");
+
+    auto* descriptorArray = static_cast<HipdnnBackendDescriptor* const*>(arrayOfElements);
+
+    for(int64_t i = 0; i < elementCount; ++i)
+    {
+        auto knobDesc = HipdnnBackendDescriptor::unpackDescriptor<const KnobSettingDescriptor>(
+            descriptorArray[i],
+            HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+            "EngineConfigDescriptor failed to set knob choices: "
+            "Knob setting descriptor at index "
+                + std::to_string(i) + " is null.");
+
+        THROW_IF_FALSE(knobDesc->isFinalized(),
+                       HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED,
+                       "EngineConfigDescriptor failed to set knob choices: "
+                       "Knob setting descriptor at index "
+                           + std::to_string(i) + " is not finalized.");
+
+        _engineConfigData->knobs.push_back(knobDesc->toKnobSettingT());
     }
 }
 

--- a/projects/hipdnn/backend/src/descriptors/EngineConfigDescriptor.hpp
+++ b/projects/hipdnn/backend/src/descriptors/EngineConfigDescriptor.hpp
@@ -39,9 +39,16 @@ private:
                        int64_t elementCount,
                        const void* arrayOfElements);
 
+    void setKnobSettingDescriptor(hipdnnBackendAttributeType_t attributeType,
+                                  int64_t elementCount,
+                                  const void* arrayOfElements);
+
 public:
     EngineConfigDescriptor();
     static constexpr int64_t INVALID_WORKSPACE_SIZE = -1;
+
+    /// Maximum number of knob choices that can be set on a single engine config.
+    static constexpr int64_t MAX_KNOB_CHOICES = 1024;
 
     void finalize() override;
 

--- a/projects/hipdnn/backend/src/descriptors/KnobSettingDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/KnobSettingDescriptor.cpp
@@ -100,7 +100,9 @@ void KnobSettingDescriptor::setKnobValue(hipdnnBackendAttributeType_t attributeT
             HIPDNN_STATUS_BAD_PARAM,
             "KnobSettingDescriptor::setAttribute(): elementCount must be 1 for int64 value");
         hipdnn_data_sdk::data_objects::IntValueT intVal;
-        intVal.value = *static_cast<const int64_t*>(arrayOfElements);
+        int64_t tmp;
+        std::memcpy(&tmp, arrayOfElements, sizeof(int64_t));
+        intVal.value = tmp;
         _value.Set(intVal);
         _valueSet = true;
         break;
@@ -113,17 +115,20 @@ void KnobSettingDescriptor::setKnobValue(hipdnnBackendAttributeType_t attributeT
             HIPDNN_STATUS_BAD_PARAM,
             "KnobSettingDescriptor::setAttribute(): elementCount must be 1 for double value");
         hipdnn_data_sdk::data_objects::FloatValueT floatVal;
-        floatVal.value = *static_cast<const double*>(arrayOfElements);
+        double tmp;
+        std::memcpy(&tmp, arrayOfElements, sizeof(double));
+        floatVal.value = tmp;
         _value.Set(floatVal);
         _valueSet = true;
         break;
     }
     case HIPDNN_TYPE_CHAR:
     {
-        THROW_IF_LT(elementCount,
-                    static_cast<int64_t>(0),
-                    HIPDNN_STATUS_BAD_PARAM,
-                    "KnobSettingDescriptor::setAttribute(): elementCount is negative");
+        THROW_IF_LT(
+            elementCount,
+            static_cast<int64_t>(0),
+            HIPDNN_STATUS_BAD_PARAM,
+            "KnobSettingDescriptor::setAttribute(): elementCount is negative for string value");
         THROW_IF_TRUE(elementCount > MAX_KNOB_STRING_VALUE_LENGTH,
                       HIPDNN_STATUS_BAD_PARAM,
                       "KnobSettingDescriptor::setAttribute(): "

--- a/projects/hipdnn/backend/src/descriptors/KnobSettingDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/KnobSettingDescriptor.cpp
@@ -1,0 +1,354 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "KnobSettingDescriptor.hpp"
+#include "BackendEnumStringUtils.hpp"
+#include "HipdnnBackendDescriptorType.h"
+#include "HipdnnException.hpp"
+#include <hipdnn_data_sdk/utilities/StringUtil.hpp>
+
+namespace hipdnn_backend
+{
+
+void KnobSettingDescriptor::finalize()
+{
+    THROW_IF_TRUE(isFinalized(),
+                  HIPDNN_STATUS_BAD_PARAM,
+                  "KnobSettingDescriptor::finalize() failed: Already finalized.");
+
+    THROW_IF_TRUE(_knobId.empty(),
+                  HIPDNN_STATUS_BAD_PARAM,
+                  "KnobSettingDescriptor::finalize() failed: Knob ID is not set.");
+
+    THROW_IF_FALSE(_valueSet,
+                   HIPDNN_STATUS_BAD_PARAM,
+                   "KnobSettingDescriptor::finalize() failed: Value is not set.");
+
+    HipdnnBackendDescriptorImpl<KnobSettingDescriptor>::finalize();
+}
+
+// ============================================================================
+// setAttribute
+// ============================================================================
+
+void KnobSettingDescriptor::setAttribute(hipdnnBackendAttributeName_t attributeName,
+                                         hipdnnBackendAttributeType_t attributeType,
+                                         int64_t elementCount,
+                                         const void* arrayOfElements)
+{
+    THROW_IF_TRUE(isFinalized(),
+                  HIPDNN_STATUS_NOT_INITIALIZED,
+                  "KnobSettingDescriptor::setAttribute() failed: Already finalized.");
+
+    switch(attributeName)
+    {
+    case HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE:
+        setKnobId(attributeType, elementCount, arrayOfElements);
+        break;
+    case HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE:
+        setKnobValue(attributeType, elementCount, arrayOfElements);
+        break;
+    default:
+        throw HipdnnException(
+            HIPDNN_STATUS_NOT_SUPPORTED,
+            std::string("KnobSettingDescriptor::setAttribute() is not supported for attribute ")
+                + hipdnn_backend::hipdnnGetAttributeNameString(attributeName) + ".");
+    }
+}
+
+void KnobSettingDescriptor::setKnobId(hipdnnBackendAttributeType_t attributeType,
+                                      int64_t elementCount,
+                                      const void* arrayOfElements)
+{
+    THROW_IF_FALSE(attributeType == HIPDNN_TYPE_CHAR,
+                   HIPDNN_STATUS_BAD_PARAM,
+                   "KnobSettingDescriptor::setAttribute(): "
+                   "attributeType is not HIPDNN_TYPE_CHAR");
+    THROW_IF_NULL(arrayOfElements,
+                  HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                  "KnobSettingDescriptor::setAttribute(): arrayOfElements is null");
+    THROW_IF_LT(elementCount,
+                static_cast<int64_t>(1),
+                HIPDNN_STATUS_BAD_PARAM,
+                "KnobSettingDescriptor::setAttribute(): "
+                "elementCount must be > 0 (knob ID must not be empty)");
+    THROW_IF_TRUE(elementCount > MAX_KNOB_ID_LENGTH,
+                  HIPDNN_STATUS_BAD_PARAM,
+                  "KnobSettingDescriptor::setAttribute(): "
+                  "elementCount exceeds MAX_KNOB_ID_LENGTH ("
+                      + std::to_string(MAX_KNOB_ID_LENGTH) + ")");
+
+    _knobId
+        = std::string(static_cast<const char*>(arrayOfElements), static_cast<size_t>(elementCount));
+}
+
+void KnobSettingDescriptor::setKnobValue(hipdnnBackendAttributeType_t attributeType,
+                                         int64_t elementCount,
+                                         const void* arrayOfElements)
+{
+    THROW_IF_NULL(arrayOfElements,
+                  HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                  "KnobSettingDescriptor::setAttribute(): arrayOfElements is null");
+
+    switch(attributeType)
+    {
+    case HIPDNN_TYPE_INT64:
+    {
+        THROW_IF_NE(
+            elementCount,
+            1,
+            HIPDNN_STATUS_BAD_PARAM,
+            "KnobSettingDescriptor::setAttribute(): elementCount must be 1 for int64 value");
+        hipdnn_data_sdk::data_objects::IntValueT intVal;
+        intVal.value = *static_cast<const int64_t*>(arrayOfElements);
+        _value.Set(intVal);
+        _valueSet = true;
+        break;
+    }
+    case HIPDNN_TYPE_DOUBLE:
+    {
+        THROW_IF_NE(
+            elementCount,
+            1,
+            HIPDNN_STATUS_BAD_PARAM,
+            "KnobSettingDescriptor::setAttribute(): elementCount must be 1 for double value");
+        hipdnn_data_sdk::data_objects::FloatValueT floatVal;
+        floatVal.value = *static_cast<const double*>(arrayOfElements);
+        _value.Set(floatVal);
+        _valueSet = true;
+        break;
+    }
+    case HIPDNN_TYPE_CHAR:
+    {
+        THROW_IF_LT(elementCount,
+                    static_cast<int64_t>(0),
+                    HIPDNN_STATUS_BAD_PARAM,
+                    "KnobSettingDescriptor::setAttribute(): elementCount is negative");
+        THROW_IF_TRUE(elementCount > MAX_KNOB_STRING_VALUE_LENGTH,
+                      HIPDNN_STATUS_BAD_PARAM,
+                      "KnobSettingDescriptor::setAttribute(): "
+                      "elementCount exceeds MAX_KNOB_STRING_VALUE_LENGTH ("
+                          + std::to_string(MAX_KNOB_STRING_VALUE_LENGTH) + ")");
+        hipdnn_data_sdk::data_objects::StringValueT strVal;
+        strVal.value = std::string(static_cast<const char*>(arrayOfElements),
+                                   static_cast<size_t>(elementCount));
+        _value.Set(std::move(strVal));
+        _valueSet = true;
+        break;
+    }
+    default:
+        throw HipdnnException(HIPDNN_STATUS_BAD_PARAM,
+                              std::string("KnobSettingDescriptor::setAttribute(): "
+                                          "unsupported attribute type for KNOB_CHOICE_KNOB_VALUE: ")
+                                  + hipdnn_backend::hipdnnGetAttributeTypeString(attributeType));
+    }
+}
+
+// ============================================================================
+// getAttribute
+// ============================================================================
+
+void KnobSettingDescriptor::getAttribute(hipdnnBackendAttributeName_t attributeName,
+                                         hipdnnBackendAttributeType_t attributeType,
+                                         int64_t requestedElementCount,
+                                         int64_t* elementCount,
+                                         void* arrayOfElements) const
+{
+    THROW_IF_FALSE(isFinalized(),
+                   HIPDNN_STATUS_NOT_INITIALIZED,
+                   "KnobSettingDescriptor::getAttribute() failed: Not finalized.");
+
+    switch(attributeName)
+    {
+    case HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE:
+        getKnobId(attributeType, requestedElementCount, elementCount, arrayOfElements);
+        break;
+    case HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE:
+        getKnobValue(attributeType, requestedElementCount, elementCount, arrayOfElements);
+        break;
+    default:
+        throw HipdnnException(
+            HIPDNN_STATUS_NOT_SUPPORTED,
+            std::string("KnobSettingDescriptor::getAttribute() is not supported for attribute ")
+                + hipdnn_backend::hipdnnGetAttributeNameString(attributeName) + ".");
+    }
+}
+
+void KnobSettingDescriptor::getKnobId(hipdnnBackendAttributeType_t attributeType,
+                                      int64_t requestedElementCount,
+                                      int64_t* elementCount,
+                                      void* arrayOfElements) const
+{
+    THROW_IF_FALSE(attributeType == HIPDNN_TYPE_CHAR,
+                   HIPDNN_STATUS_BAD_PARAM,
+                   "KnobSettingDescriptor::getAttribute(): attributeType is not HIPDNN_TYPE_CHAR");
+
+    THROW_IF_LT(requestedElementCount,
+                static_cast<int64_t>(0),
+                HIPDNN_STATUS_BAD_PARAM,
+                "KnobSettingDescriptor::getAttribute(): requestedElementCount is negative");
+
+    if(arrayOfElements == nullptr || requestedElementCount == 0)
+    {
+        THROW_IF_NULL(elementCount,
+                      HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                      "KnobSettingDescriptor::getAttribute(): elementCount is null");
+        *elementCount = static_cast<int64_t>(_knobId.size() + 1);
+        return;
+    }
+
+    auto maxSize = static_cast<size_t>(requestedElementCount);
+    hipdnn_data_sdk::utilities::copyMaxSizeWithNullTerminator(
+        static_cast<char*>(arrayOfElements), _knobId.c_str(), maxSize);
+
+    if(elementCount != nullptr)
+    {
+        *elementCount = static_cast<int64_t>(std::min(_knobId.size() + 1, maxSize));
+    }
+}
+
+void KnobSettingDescriptor::getKnobValue(hipdnnBackendAttributeType_t attributeType,
+                                         int64_t requestedElementCount,
+                                         int64_t* elementCount,
+                                         void* arrayOfElements) const
+{
+    switch(_value.type)
+    {
+    case hipdnn_data_sdk::data_objects::KnobValue::IntValue:
+        THROW_IF_NE(attributeType,
+                    HIPDNN_TYPE_INT64,
+                    HIPDNN_STATUS_BAD_PARAM,
+                    "KnobSettingDescriptor::getAttribute(): type mismatch, value is IntValue");
+        THROW_IF_NULL(arrayOfElements,
+                      HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                      "KnobSettingDescriptor::getAttribute(): arrayOfElements is null");
+        THROW_IF_NE(requestedElementCount,
+                    1,
+                    HIPDNN_STATUS_BAD_PARAM,
+                    "KnobSettingDescriptor::getAttribute(): requestedElementCount must be 1");
+        *static_cast<int64_t*>(arrayOfElements) = _value.AsIntValue()->value;
+        if(elementCount != nullptr)
+        {
+            *elementCount = 1;
+        }
+        break;
+    case hipdnn_data_sdk::data_objects::KnobValue::FloatValue:
+        THROW_IF_NE(attributeType,
+                    HIPDNN_TYPE_DOUBLE,
+                    HIPDNN_STATUS_BAD_PARAM,
+                    "KnobSettingDescriptor::getAttribute(): type mismatch, value is FloatValue");
+        THROW_IF_NULL(arrayOfElements,
+                      HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                      "KnobSettingDescriptor::getAttribute(): arrayOfElements is null");
+        THROW_IF_NE(requestedElementCount,
+                    1,
+                    HIPDNN_STATUS_BAD_PARAM,
+                    "KnobSettingDescriptor::getAttribute(): requestedElementCount must be 1");
+        *static_cast<double*>(arrayOfElements) = _value.AsFloatValue()->value;
+        if(elementCount != nullptr)
+        {
+            *elementCount = 1;
+        }
+        break;
+    case hipdnn_data_sdk::data_objects::KnobValue::StringValue:
+    {
+        THROW_IF_NE(attributeType,
+                    HIPDNN_TYPE_CHAR,
+                    HIPDNN_STATUS_BAD_PARAM,
+                    "KnobSettingDescriptor::getAttribute(): type mismatch, value is StringValue");
+
+        THROW_IF_LT(requestedElementCount,
+                    static_cast<int64_t>(0),
+                    HIPDNN_STATUS_BAD_PARAM,
+                    "KnobSettingDescriptor::getAttribute(): requestedElementCount is negative");
+
+        const auto& str = _value.AsStringValue()->value;
+
+        // Support the two-call pattern: first call with nullptr/0 returns required size.
+        if(arrayOfElements == nullptr || requestedElementCount == 0)
+        {
+            THROW_IF_NULL(elementCount,
+                          HIPDNN_STATUS_BAD_PARAM_NULL_POINTER,
+                          "KnobSettingDescriptor::getAttribute(): elementCount is null");
+            *elementCount = static_cast<int64_t>(str.size() + 1);
+            return;
+        }
+
+        auto maxSize = static_cast<size_t>(requestedElementCount);
+        hipdnn_data_sdk::utilities::copyMaxSizeWithNullTerminator(
+            static_cast<char*>(arrayOfElements), str.c_str(), maxSize);
+
+        if(elementCount != nullptr)
+        {
+            *elementCount = static_cast<int64_t>(std::min(str.size() + 1, maxSize));
+        }
+        break;
+    }
+    default:
+        throw HipdnnException(HIPDNN_STATUS_INTERNAL_ERROR,
+                              "KnobSettingDescriptor::getAttribute(): unknown value type ("
+                                  + std::to_string(static_cast<int>(_value.type)) + ")");
+    }
+}
+
+// ============================================================================
+// Other methods
+// ============================================================================
+
+std::unique_ptr<hipdnn_data_sdk::data_objects::KnobSettingT>
+    KnobSettingDescriptor::toKnobSettingT() const
+{
+    THROW_IF_FALSE(isFinalized(),
+                   HIPDNN_STATUS_NOT_INITIALIZED,
+                   "KnobSettingDescriptor::toKnobSettingT() failed: Not finalized.");
+
+    auto knobSetting = std::make_unique<hipdnn_data_sdk::data_objects::KnobSettingT>();
+    knobSetting->knob_id = _knobId;
+
+    // Deep-copy the KnobValueUnion
+    switch(_value.type)
+    {
+    case hipdnn_data_sdk::data_objects::KnobValue::IntValue:
+    {
+        hipdnn_data_sdk::data_objects::IntValueT intVal;
+        intVal.value = _value.AsIntValue()->value;
+        knobSetting->value.Set(intVal);
+        break;
+    }
+    case hipdnn_data_sdk::data_objects::KnobValue::FloatValue:
+    {
+        hipdnn_data_sdk::data_objects::FloatValueT floatVal;
+        floatVal.value = _value.AsFloatValue()->value;
+        knobSetting->value.Set(floatVal);
+        break;
+    }
+    case hipdnn_data_sdk::data_objects::KnobValue::StringValue:
+    {
+        hipdnn_data_sdk::data_objects::StringValueT strVal;
+        strVal.value = _value.AsStringValue()->value;
+        knobSetting->value.Set(std::move(strVal));
+        break;
+    }
+    default:
+        throw HipdnnException(HIPDNN_STATUS_INTERNAL_ERROR,
+                              "KnobSettingDescriptor::toKnobSettingT(): unknown value type ("
+                                  + std::to_string(static_cast<int>(_value.type)) + ")");
+    }
+
+    return knobSetting;
+}
+
+hipdnnBackendDescriptorType_t KnobSettingDescriptor::getStaticType()
+{
+    return HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR;
+}
+
+std::string KnobSettingDescriptor::toString() const
+{
+    std::string str = "KnobSettingDescriptor: {knobId=" + _knobId;
+    str += ", valueType=" + std::to_string(static_cast<int>(_value.type));
+    str += "}";
+    return str;
+}
+
+} // namespace hipdnn_backend

--- a/projects/hipdnn/backend/src/descriptors/KnobSettingDescriptor.hpp
+++ b/projects/hipdnn/backend/src/descriptors/KnobSettingDescriptor.hpp
@@ -1,0 +1,76 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "BackendDescriptor.hpp"
+#include <hipdnn_data_sdk/data_objects/engine_config_generated.h>
+#include <hipdnn_data_sdk/data_objects/knob_value_generated.h>
+
+namespace hipdnn_backend
+{
+
+/**
+ * @brief Backend descriptor for knob setting configuration
+ *
+ * Wraps a knob identifier and value pair as a standard backend descriptor,
+ * allowing knob settings to be passed through the C-API setAttribute/getAttribute
+ * pattern instead of manual FlatBuffer serialization.
+ *
+ * Validation limits (to catch accidental misuse):
+ * - Knob ID string: up to @ref MAX_KNOB_ID_LENGTH characters (must be non-empty)
+ * - Knob string value: up to @ref MAX_KNOB_STRING_VALUE_LENGTH characters
+ */
+class KnobSettingDescriptor : public HipdnnBackendDescriptorImpl<KnobSettingDescriptor>
+{
+public:
+    /// Maximum length of a knob ID string (characters, excluding null terminator).
+    static constexpr int64_t MAX_KNOB_ID_LENGTH = 4096;
+
+    /// Maximum length of a knob string value (characters, excluding null terminator).
+    static constexpr int64_t MAX_KNOB_STRING_VALUE_LENGTH = 65536;
+    void finalize() override;
+
+    void getAttribute(hipdnnBackendAttributeName_t attributeName,
+                      hipdnnBackendAttributeType_t attributeType,
+                      int64_t requestedElementCount,
+                      int64_t* elementCount,
+                      void* arrayOfElements) const override;
+
+    void setAttribute(hipdnnBackendAttributeName_t attributeName,
+                      hipdnnBackendAttributeType_t attributeType,
+                      int64_t elementCount,
+                      const void* arrayOfElements) override;
+
+    /// Convert to a KnobSettingT for consumption by EngineConfigDescriptor
+    std::unique_ptr<hipdnn_data_sdk::data_objects::KnobSettingT> toKnobSettingT() const;
+
+    static hipdnnBackendDescriptorType_t getStaticType();
+
+    std::string toString() const override;
+
+private:
+    std::string _knobId;
+    hipdnn_data_sdk::data_objects::KnobValueUnion _value;
+    bool _valueSet = false;
+
+    void setKnobId(hipdnnBackendAttributeType_t attributeType,
+                   int64_t elementCount,
+                   const void* arrayOfElements);
+
+    void getKnobId(hipdnnBackendAttributeType_t attributeType,
+                   int64_t requestedElementCount,
+                   int64_t* elementCount,
+                   void* arrayOfElements) const;
+
+    void setKnobValue(hipdnnBackendAttributeType_t attributeType,
+                      int64_t elementCount,
+                      const void* arrayOfElements);
+
+    void getKnobValue(hipdnnBackendAttributeType_t attributeType,
+                      int64_t requestedElementCount,
+                      int64_t* elementCount,
+                      void* arrayOfElements) const;
+};
+
+} // namespace hipdnn_backend

--- a/projects/hipdnn/backend/tests/CMakeLists.txt
+++ b/projects/hipdnn/backend/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
     descriptors/TestGraphDescriptor.cpp
     descriptors/TestTensorDescriptor.cpp
     descriptors/TestConvolutionFwdOperationDescriptor.cpp
+    descriptors/TestKnobSettingDescriptor.cpp
     descriptors/TestGraphDescriptorOps.cpp
     descriptors/TestDescriptorAttributeUtils.cpp
     descriptors/TestVariantPackDescriptor.cpp

--- a/projects/hipdnn/backend/tests/descriptors/TestDescriptorFactory.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestDescriptorFactory.cpp
@@ -9,6 +9,7 @@
 #include "descriptors/EngineDescriptor.hpp"
 #include "descriptors/ExecutionPlanDescriptor.hpp"
 #include "descriptors/GraphDescriptor.hpp"
+#include "descriptors/KnobSettingDescriptor.hpp"
 #include "descriptors/VariantDescriptor.hpp"
 #include "handle/HandleFactory.hpp"
 
@@ -177,6 +178,19 @@ TEST(TestDescriptorFactory, CreateVariantPackWithUnsupportedType)
         HIPDNN_STATUS_NOT_SUPPORTED);
 
     EXPECT_EQ(descriptor, nullptr);
+}
+
+TEST(TestDescriptorFactory, CreateKnobSettingDescriptor)
+{
+    hipdnnBackendDescriptor_t descriptor = nullptr;
+    ASSERT_NO_THROW(DescriptorFactory::create(HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR, &descriptor));
+    EXPECT_NE(descriptor, nullptr);
+
+    auto knobDesc = descriptor->asDescriptor<KnobSettingDescriptor>();
+    EXPECT_FALSE(knobDesc->isFinalized());
+    EXPECT_EQ(knobDesc->getType(), HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
+
+    ASSERT_NO_THROW(DescriptorFactory::destroy(descriptor));
 }
 
 TEST(TestDescriptorFactory, DestroyNull)

--- a/projects/hipdnn/backend/tests/descriptors/TestEngineConfigDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestEngineConfigDescriptor.cpp
@@ -7,6 +7,7 @@
 #include "descriptors/EngineConfigDescriptor.hpp"
 #include "descriptors/EngineDescriptor.hpp"
 #include "descriptors/GraphDescriptor.hpp"
+#include "descriptors/KnobSettingDescriptor.hpp"
 #include "descriptors/ScopedDescriptor.hpp"
 #include "hipdnn_backend.h"
 #include "mocks/MockDescriptor.hpp"
@@ -431,4 +432,108 @@ TEST_F(TestEngineConfigDescriptor, SetKnobChoiceOnFinalizedDescriptor)
                                    1,
                                    &knobData),
         HIPDNN_STATUS_NOT_INITIALIZED);
+}
+
+// Helper to create a finalized KnobSettingDescriptor
+static std::unique_ptr<HipdnnBackendDescriptor>
+    createFinalizedKnobSettingDescriptor(const std::string& knobId, int64_t value)
+{
+    auto wrapper = test_utilities::createDescriptor<KnobSettingDescriptor>();
+    auto desc = wrapper->asDescriptor<KnobSettingDescriptor>();
+    desc->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE,
+                       HIPDNN_TYPE_CHAR,
+                       static_cast<int64_t>(knobId.size()),
+                       knobId.c_str());
+    desc->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_INT64, 1, &value);
+    desc->finalize();
+    return wrapper;
+}
+
+TEST_F(TestEngineConfigDescriptor, SetKnobChoiceViaDescriptorSuccess)
+{
+    auto engineConfig = getEngineConfigDescriptor();
+
+    EXPECT_CALL(*getMockEngine(), isFinalized()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*getMockEngine(), getEngineId()).WillRepeatedly(Return(1));
+
+    ASSERT_NO_THROW(engineConfig->setAttribute(
+        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mockEngineWrapper));
+
+    auto knobWrapper = createFinalizedKnobSettingDescriptor("test_knob_100", 42);
+    auto* knobPtr = knobWrapper.get();
+
+    ASSERT_NO_THROW(engineConfig->setAttribute(
+        HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &knobPtr));
+}
+
+TEST_F(TestEngineConfigDescriptor, SetKnobChoiceViaDescriptorMultiple)
+{
+    auto engineConfig = getEngineConfigDescriptor();
+
+    EXPECT_CALL(*getMockEngine(), isFinalized()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*getMockEngine(), getEngineId()).WillRepeatedly(Return(1));
+
+    ASSERT_NO_THROW(engineConfig->setAttribute(
+        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mockEngineWrapper));
+
+    auto knobWrapper1 = createFinalizedKnobSettingDescriptor("knob_1", 10);
+    auto knobWrapper2 = createFinalizedKnobSettingDescriptor("knob_2", 20);
+    std::array<HipdnnBackendDescriptor*, 2> knobPtrs = {knobWrapper1.get(), knobWrapper2.get()};
+
+    ASSERT_NO_THROW(engineConfig->setAttribute(
+        HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, knobPtrs.data()));
+}
+
+TEST_F(TestEngineConfigDescriptor, SetKnobChoiceViaDescriptorRejectNotFinalized)
+{
+    auto engineConfig = getEngineConfigDescriptor();
+
+    EXPECT_CALL(*getMockEngine(), isFinalized()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*getMockEngine(), getEngineId()).WillRepeatedly(Return(1));
+
+    ASSERT_NO_THROW(engineConfig->setAttribute(
+        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mockEngineWrapper));
+
+    // Create a non-finalized knob descriptor
+    auto knobWrapper = test_utilities::createDescriptor<KnobSettingDescriptor>();
+    auto* knobPtr = knobWrapper.get();
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        engineConfig->setAttribute(
+            HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &knobPtr),
+        HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+}
+
+TEST_F(TestEngineConfigDescriptor, SetKnobChoiceViaDescriptorRejectWrongType)
+{
+    auto engineConfig = getEngineConfigDescriptor();
+
+    auto knobWrapper = createFinalizedKnobSettingDescriptor("test_knob", 42);
+    auto* knobPtr = knobWrapper.get();
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        engineConfig->setAttribute(
+            HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES, HIPDNN_TYPE_INT64, 1, &knobPtr),
+        HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestEngineConfigDescriptor, SetKnobChoiceViaDescriptorRejectExceedsMaxCount)
+{
+    auto engineConfig = getEngineConfigDescriptor();
+
+    EXPECT_CALL(*getMockEngine(), isFinalized()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*getMockEngine(), getEngineId()).WillRepeatedly(Return(1));
+
+    ASSERT_NO_THROW(engineConfig->setAttribute(
+        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &_mockEngineWrapper));
+
+    auto knobWrapper = createFinalizedKnobSettingDescriptor("test_knob", 42);
+    auto* knobPtr = knobWrapper.get();
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        engineConfig->setAttribute(HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES,
+                                   HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                   EngineConfigDescriptor::MAX_KNOB_CHOICES + 1,
+                                   &knobPtr),
+        HIPDNN_STATUS_BAD_PARAM);
 }

--- a/projects/hipdnn/backend/tests/descriptors/TestKnobSettingDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestKnobSettingDescriptor.cpp
@@ -1,0 +1,536 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include "DescriptorTestUtils.hpp"
+#include "TestMacros.hpp"
+#include "descriptors/KnobSettingDescriptor.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+using namespace hipdnn_backend;
+using namespace hipdnn_backend::test_utilities;
+
+class TestKnobSettingDescriptor : public ::testing::Test
+{
+public:
+    std::shared_ptr<KnobSettingDescriptor> getDescriptor() const
+    {
+        return _wrapper->asDescriptor<KnobSettingDescriptor>();
+    }
+
+    void setKnobId(const std::string& knobId) const
+    {
+        ASSERT_NO_THROW(getDescriptor()->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE,
+                                                      HIPDNN_TYPE_CHAR,
+                                                      static_cast<int64_t>(knobId.size()),
+                                                      knobId.c_str()));
+    }
+
+    void setInt64Value(int64_t value) const
+    {
+        ASSERT_NO_THROW(getDescriptor()->setAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_INT64, 1, &value));
+    }
+
+    void setDoubleValue(double value) const
+    {
+        ASSERT_NO_THROW(getDescriptor()->setAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_DOUBLE, 1, &value));
+    }
+
+    void setStringValue(const std::string& value) const
+    {
+        ASSERT_NO_THROW(getDescriptor()->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                                      HIPDNN_TYPE_CHAR,
+                                                      static_cast<int64_t>(value.size()),
+                                                      value.c_str()));
+    }
+
+    void makeFinalized(const std::string& knobId = "test_knob", int64_t value = 42) const
+    {
+        setKnobId(knobId);
+        setInt64Value(value);
+        ASSERT_NO_THROW(getDescriptor()->finalize());
+    }
+
+protected:
+    std::unique_ptr<HipdnnBackendDescriptor> _wrapper;
+
+    void SetUp() override
+    {
+        _wrapper = createDescriptor<KnobSettingDescriptor>();
+    }
+};
+
+TEST_F(TestKnobSettingDescriptor, CreateDescriptor)
+{
+    auto desc = getDescriptor();
+    ASSERT_NE(desc, nullptr);
+    ASSERT_FALSE(desc->isFinalized());
+    ASSERT_EQ(desc->getType(), HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
+}
+
+TEST_F(TestKnobSettingDescriptor, FinalizeWithKnobIdAndInt64Value)
+{
+    setKnobId("test_knob_100");
+    setInt64Value(42);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+    ASSERT_TRUE(getDescriptor()->isFinalized());
+}
+
+TEST_F(TestKnobSettingDescriptor, FinalizeWithoutKnobIdFails)
+{
+    setInt64Value(42);
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, FinalizeWithoutValueFails)
+{
+    setKnobId("test_knob");
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, FinalizeAlreadyFinalizedFails)
+{
+    makeFinalized();
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->finalize(), HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetAttributeAfterFinalizeFails)
+{
+    makeFinalized();
+    std::string knobId = "another_knob";
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE,
+                                                             HIPDNN_TYPE_CHAR,
+                                                             static_cast<int64_t>(knobId.size()),
+                                                             knobId.c_str()),
+                               HIPDNN_STATUS_NOT_INITIALIZED);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetAttributeUnsupportedAttribute)
+{
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->setAttribute(HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_INT64, 1, nullptr),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobIdAsChar)
+{
+    std::string knobId = "test_knob_id";
+    ASSERT_NO_THROW(getDescriptor()->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE,
+                                                  HIPDNN_TYPE_CHAR,
+                                                  static_cast<int64_t>(knobId.size()),
+                                                  knobId.c_str()));
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobIdWrongTypeFails)
+{
+    int64_t val = 42;
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->setAttribute(
+                                   HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_INT64, 1, &val),
+                               HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobIdNullFails)
+{
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->setAttribute(
+                                   HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_CHAR, 5, nullptr),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+}
+
+TEST_F(TestKnobSettingDescriptor, GetKnobIdAfterFinalize)
+{
+    std::string expectedId = "test_knob_id";
+    setKnobId(expectedId);
+    setInt64Value(42);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    // Query size first
+    int64_t count = 0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_CHAR, 0, &count, nullptr));
+    ASSERT_EQ(count, static_cast<int64_t>(expectedId.size() + 1));
+
+    // Get the value
+    std::vector<char> buffer(static_cast<size_t>(count));
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_CHAR, count, nullptr, buffer.data()));
+    ASSERT_EQ(std::string(buffer.data()), expectedId);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetAndGetInt64Value)
+{
+    int64_t expectedValue = 42;
+    setKnobId("test_knob");
+    setInt64Value(expectedValue);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    int64_t actualValue = 0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_INT64, 1, nullptr, &actualValue));
+    ASSERT_EQ(actualValue, expectedValue);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetAndGetDoubleValue)
+{
+    double expectedValue = 3.14;
+    setKnobId("test_knob");
+    setDoubleValue(expectedValue);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    double actualValue = 0.0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_DOUBLE, 1, nullptr, &actualValue));
+    ASSERT_DOUBLE_EQ(actualValue, expectedValue);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetAndGetStringValue)
+{
+    std::string expectedValue = "strval";
+    setKnobId("test_knob");
+    setStringValue(expectedValue);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    // Query size first (two-call pattern)
+    int64_t count = 0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_CHAR, 0, &count, nullptr));
+    ASSERT_EQ(count, static_cast<int64_t>(expectedValue.size() + 1));
+
+    // Get the value
+    std::vector<char> buffer(static_cast<size_t>(count));
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_CHAR, count, nullptr, buffer.data()));
+    ASSERT_EQ(std::string(buffer.data()), expectedValue);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobValueWrongElementCountFailsInt64)
+{
+    int64_t val = 42;
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->setAttribute(
+                                   HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_INT64, 2, &val),
+                               HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobValueWrongElementCountFailsDouble)
+{
+    double val = 1.0;
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->setAttribute(
+                                   HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_DOUBLE, 2, &val),
+                               HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobValueNullPointerFails)
+{
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->setAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_INT64, 1, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobValueUnsupportedTypeFails)
+{
+    bool val = true;
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->setAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_BOOLEAN, 1, &val),
+        HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, GetAttributeBeforeFinalizeFails)
+{
+    setKnobId("test_knob");
+    setInt64Value(42);
+
+    int64_t val = 0;
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->getAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_INT64, 1, nullptr, &val),
+        HIPDNN_STATUS_NOT_INITIALIZED);
+}
+
+TEST_F(TestKnobSettingDescriptor, GetAttributeUnsupportedAttributeFails)
+{
+    makeFinalized();
+    int64_t val = 0;
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->getAttribute(
+            HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_INT64, 1, nullptr, &val),
+        HIPDNN_STATUS_NOT_SUPPORTED);
+}
+
+TEST_F(TestKnobSettingDescriptor, GetKnobValueTypeMismatchFails)
+{
+    makeFinalized(); // sets int64 value
+    double val = 0.0;
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->getAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_DOUBLE, 1, nullptr, &val),
+        HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, ToKnobSettingTProducesCorrectObject)
+{
+    std::string knobId = "test_knob_100";
+    int64_t value = 42;
+    setKnobId(knobId);
+    setInt64Value(value);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    auto knobSettingT = getDescriptor()->toKnobSettingT();
+    ASSERT_NE(knobSettingT, nullptr);
+    ASSERT_EQ(knobSettingT->knob_id, knobId);
+    ASSERT_EQ(knobSettingT->value.type, hipdnn_data_sdk::data_objects::KnobValue::IntValue);
+    ASSERT_EQ(knobSettingT->value.AsIntValue()->value, value);
+}
+
+TEST_F(TestKnobSettingDescriptor, ToKnobSettingTWithDoubleValue)
+{
+    std::string knobId = "double_knob";
+    double value = 2.718;
+    setKnobId(knobId);
+    setDoubleValue(value);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    auto knobSettingT = getDescriptor()->toKnobSettingT();
+    ASSERT_NE(knobSettingT, nullptr);
+    ASSERT_EQ(knobSettingT->knob_id, knobId);
+    ASSERT_EQ(knobSettingT->value.type, hipdnn_data_sdk::data_objects::KnobValue::FloatValue);
+    ASSERT_DOUBLE_EQ(knobSettingT->value.AsFloatValue()->value, value);
+}
+
+TEST_F(TestKnobSettingDescriptor, ToKnobSettingTBeforeFinalizeFails)
+{
+    setKnobId("test_knob");
+    setInt64Value(42);
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->toKnobSettingT(), HIPDNN_STATUS_NOT_INITIALIZED);
+}
+
+TEST_F(TestKnobSettingDescriptor, GetKnobIdWithElementCount)
+{
+    std::string expectedId = "my_knob";
+    makeFinalized(expectedId);
+
+    int64_t count = 0;
+    std::vector<char> buffer(64);
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_CHAR, 64, &count, buffer.data()));
+    ASSERT_EQ(count, static_cast<int64_t>(expectedId.size() + 1));
+    ASSERT_EQ(std::string(buffer.data()), expectedId);
+}
+
+TEST_F(TestKnobSettingDescriptor, GetKnobValueWithElementCount)
+{
+    int64_t expectedValue = 99;
+    makeFinalized("knob", expectedValue);
+
+    int64_t count = 0;
+    int64_t actualValue = 0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_INT64, 1, &count, &actualValue));
+    ASSERT_EQ(count, 1);
+    ASSERT_EQ(actualValue, expectedValue);
+}
+
+TEST_F(TestKnobSettingDescriptor, GetStringValueTruncatesToBufferSize)
+{
+    std::string longValue = "a_long_string_value";
+    setKnobId("test_knob");
+    setStringValue(longValue);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    // Provide a buffer smaller than the string
+    const int64_t smallBufferSize = 8;
+    std::array<char, 8> buffer = {};
+    int64_t count = 0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                                  HIPDNN_TYPE_CHAR,
+                                                  smallBufferSize,
+                                                  &count,
+                                                  buffer.data()));
+
+    // Should be truncated and null-terminated
+    ASSERT_EQ(count, smallBufferSize);
+    ASSERT_EQ(buffer.back(), '\0');
+    ASSERT_EQ(std::string(buffer.data()),
+              longValue.substr(0, static_cast<size_t>(smallBufferSize - 1)));
+}
+
+TEST_F(TestKnobSettingDescriptor, GetStringValueSizeQueryWithNullBuffer)
+{
+    std::string expectedValue = "query_size";
+    setKnobId("test_knob");
+    setStringValue(expectedValue);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    int64_t count = 0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_CHAR, 0, &count, nullptr));
+    ASSERT_EQ(count, static_cast<int64_t>(expectedValue.size() + 1));
+}
+
+TEST_F(TestKnobSettingDescriptor, GetStringValueSizeQueryNullElementCountFails)
+{
+    std::string expectedValue = "test";
+    setKnobId("test_knob");
+    setStringValue(expectedValue);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->getAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_CHAR, 0, nullptr, nullptr),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+}
+
+TEST_F(TestKnobSettingDescriptor, ToKnobSettingTWithStringValue)
+{
+    std::string knobId = "string_knob";
+    std::string value = "hello_world";
+    setKnobId(knobId);
+    setStringValue(value);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    auto knobSettingT = getDescriptor()->toKnobSettingT();
+    ASSERT_NE(knobSettingT, nullptr);
+    ASSERT_EQ(knobSettingT->knob_id, knobId);
+    ASSERT_EQ(knobSettingT->value.type, hipdnn_data_sdk::data_objects::KnobValue::StringValue);
+    ASSERT_EQ(knobSettingT->value.AsStringValue()->value, value);
+}
+
+// ============================================================================
+// Validation limit tests
+// ============================================================================
+
+TEST_F(TestKnobSettingDescriptor, SetEmptyKnobIdFails)
+{
+    std::string emptyId;
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->setAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_CHAR, 0, emptyId.c_str()),
+        HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobIdExceedsMaxLengthFails)
+{
+    std::string longId(static_cast<size_t>(KnobSettingDescriptor::MAX_KNOB_ID_LENGTH + 1), 'x');
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE,
+                                                             HIPDNN_TYPE_CHAR,
+                                                             static_cast<int64_t>(longId.size()),
+                                                             longId.c_str()),
+                               HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobIdAtMaxLengthSucceeds)
+{
+    std::string maxId(static_cast<size_t>(KnobSettingDescriptor::MAX_KNOB_ID_LENGTH), 'x');
+    ASSERT_NO_THROW(getDescriptor()->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE,
+                                                  HIPDNN_TYPE_CHAR,
+                                                  static_cast<int64_t>(maxId.size()),
+                                                  maxId.c_str()));
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobStringValueExceedsMaxLengthFails)
+{
+    std::string longValue(
+        static_cast<size_t>(KnobSettingDescriptor::MAX_KNOB_STRING_VALUE_LENGTH + 1), 'y');
+    ASSERT_THROW_HIPDNN_STATUS(getDescriptor()->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                                             HIPDNN_TYPE_CHAR,
+                                                             static_cast<int64_t>(longValue.size()),
+                                                             longValue.c_str()),
+                               HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobStringValueAtMaxLengthSucceeds)
+{
+    std::string maxValue(static_cast<size_t>(KnobSettingDescriptor::MAX_KNOB_STRING_VALUE_LENGTH),
+                         'y');
+    ASSERT_NO_THROW(getDescriptor()->setAttribute(HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                                  HIPDNN_TYPE_CHAR,
+                                                  static_cast<int64_t>(maxValue.size()),
+                                                  maxValue.c_str()));
+}
+
+TEST_F(TestKnobSettingDescriptor, SetKnobIdNegativeElementCountFails)
+{
+    std::string knobId = "test";
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->setAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_CHAR, -1, knobId.c_str()),
+        HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, GetKnobIdNegativeRequestedCountFails)
+{
+    makeFinalized();
+    std::array<char, 16> buffer{};
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->getAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_CHAR, -1, nullptr, buffer.data()),
+        HIPDNN_STATUS_BAD_PARAM);
+}
+
+TEST_F(TestKnobSettingDescriptor, GetStringValueNegativeRequestedCountFails)
+{
+    setKnobId("test_knob");
+    setStringValue("some_value");
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    std::array<char, 16> buffer{};
+    ASSERT_THROW_HIPDNN_STATUS(
+        getDescriptor()->getAttribute(
+            HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_CHAR, -1, nullptr, buffer.data()),
+        HIPDNN_STATUS_BAD_PARAM);
+}
+
+// ============================================================================
+// Overwrite behavior tests
+// ============================================================================
+
+TEST_F(TestKnobSettingDescriptor, OverwriteKnobIdBeforeFinalize)
+{
+    setKnobId("first_id");
+    setKnobId("second_id");
+    setInt64Value(42);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    // Verify the second ID took effect
+    int64_t count = 0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_CHAR, 0, &count, nullptr));
+    ASSERT_EQ(count, static_cast<int64_t>(std::string("second_id").size() + 1));
+
+    std::vector<char> buffer(static_cast<size_t>(count));
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, HIPDNN_TYPE_CHAR, count, nullptr, buffer.data()));
+    ASSERT_EQ(std::string(buffer.data()), "second_id");
+}
+
+TEST_F(TestKnobSettingDescriptor, OverwriteKnobValueBeforeFinalize)
+{
+    setKnobId("test_knob");
+    setInt64Value(10);
+    setInt64Value(99);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    // Verify the second value took effect
+    int64_t actualValue = 0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_INT64, 1, nullptr, &actualValue));
+    ASSERT_EQ(actualValue, 99);
+}
+
+TEST_F(TestKnobSettingDescriptor, OverwriteKnobValueTypeBeforeFinalize)
+{
+    setKnobId("test_knob");
+    setInt64Value(42);
+    setDoubleValue(3.14);
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    // Verify the value is now a double
+    double actualValue = 0.0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_DOUBLE, 1, nullptr, &actualValue));
+    ASSERT_DOUBLE_EQ(actualValue, 3.14);
+}

--- a/projects/hipdnn/backend/tests/descriptors/TestKnobSettingDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestKnobSettingDescriptor.cpp
@@ -534,3 +534,22 @@ TEST_F(TestKnobSettingDescriptor, OverwriteKnobValueTypeBeforeFinalize)
         HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_DOUBLE, 1, nullptr, &actualValue));
     ASSERT_DOUBLE_EQ(actualValue, 3.14);
 }
+
+TEST_F(TestKnobSettingDescriptor, OverwriteIntValueWithStringBeforeFinalize)
+{
+    setKnobId("test_knob");
+    setInt64Value(42);
+    setStringValue("overwritten");
+    ASSERT_NO_THROW(getDescriptor()->finalize());
+
+    // Verify the value is now a string
+    int64_t count = 0;
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_CHAR, 0, &count, nullptr));
+    ASSERT_EQ(count, static_cast<int64_t>(std::string("overwritten").size() + 1));
+
+    std::vector<char> buffer(static_cast<size_t>(count));
+    ASSERT_NO_THROW(getDescriptor()->getAttribute(
+        HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, HIPDNN_TYPE_CHAR, count, nullptr, buffer.data()));
+    ASSERT_EQ(std::string(buffer.data()), "overwritten");
+}

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -80,6 +80,7 @@
 #include <hipdnn_frontend/attributes/PointwiseAttributes.hpp>
 #include <hipdnn_frontend/detail/BackendWrapper.hpp>
 #include <hipdnn_frontend/detail/CreateBackendDescriptor.hpp>
+#include <hipdnn_frontend/detail/DescriptorHelpers.hpp>
 #include <hipdnn_frontend/detail/EngineOverrideUtils.hpp>
 #include <hipdnn_frontend/detail/GraphDetail.hpp>
 #include <hipdnn_frontend/detail/GraphPacker.hpp>
@@ -144,6 +145,66 @@ private:
             return engineId;
         }();
         return s_defaultId;
+    }
+
+    // TODO: Remove this feature flag once all operation types support descriptor-based
+    // lowering and the flatbuffer path is no longer needed.
+    static bool useDescriptorApi()
+    {
+        static const bool s_useDescriptorApi
+            = hipdnn_data_sdk::utilities::getEnv("HIPDNN_USE_DESCRIPTOR_API") == "1";
+        return s_useDescriptorApi;
+    }
+
+    /// Apply validated knob settings to the engine config descriptor, using
+    /// either the descriptor-based or FlatBuffer serialization path depending
+    /// on the HIPDNN_USE_DESCRIPTOR_API feature flag.
+    Error applyKnobSettingsToEngineConfig(const std::vector<KnobSetting>& validatedSettings)
+    {
+        if(validatedSettings.empty())
+        {
+            return {ErrorCode::OK, ""};
+        }
+
+        if(useDescriptorApi())
+        {
+            HIPDNN_FE_LOG_INFO("Using descriptor-based API for knob settings");
+            return detail::applyKnobSettingsViaDescriptors(_engineConfigDesc->get(),
+                                                           validatedSettings);
+        }
+
+        // FlatBuffer serialization path (existing default)
+        std::vector<flatbuffers::DetachedBuffer> knobBuffers;
+        knobBuffers.reserve(validatedSettings.size());
+
+        for(const auto& setting : validatedSettings)
+        {
+            flatbuffers::FlatBufferBuilder builder;
+            auto knobSettingOffset = setting.packKnobSetting(builder);
+            builder.Finish(knobSettingOffset);
+            knobBuffers.push_back(builder.Release());
+        }
+
+        std::vector<hipdnnBackendFlatbufferData_t> flatbufferDataArray;
+        flatbufferDataArray.reserve(knobBuffers.size());
+
+        for(const auto& buffer : knobBuffers)
+        {
+            hipdnnBackendFlatbufferData_t fbData;
+            fbData.ptr = buffer.data();
+            fbData.size = buffer.size();
+            flatbufferDataArray.push_back(fbData);
+        }
+
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(detail::hipdnnBackend()->backendSetAttribute(
+                                             _engineConfigDesc->get(),
+                                             HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
+                                             HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
+                                             static_cast<int64_t>(flatbufferDataArray.size()),
+                                             flatbufferDataArray.data()),
+                                         "Failed to set knob settings on engine config.");
+
+        return {ErrorCode::OK, ""};
     }
 
     void assignUnsetTensorUids()
@@ -807,12 +868,7 @@ public:
      */
     Error build_operation_graph(hipdnnHandle_t handle) // NOLINT(readability-identifier-naming)
     {
-        // TODO: Remove this feature flag once all operation types support descriptor-based
-        // lowering and the flatbuffer path is no longer needed.
-        static const bool s_useDescriptorApi
-            = hipdnn_data_sdk::utilities::getEnv("HIPDNN_USE_DESCRIPTOR_API") == "1";
-
-        if(s_useDescriptorApi)
+        if(useDescriptorApi())
         {
             return build_operation_graph_via_descriptors(handle);
         }
@@ -1070,38 +1126,7 @@ public:
             validatedSettings.emplace_back(setting);
         }
 
-        if(!validatedSettings.empty())
-        {
-            std::vector<flatbuffers::DetachedBuffer> knobBuffers;
-            knobBuffers.reserve(validatedSettings.size());
-
-            for(const auto& setting : validatedSettings)
-            {
-                flatbuffers::FlatBufferBuilder builder;
-                auto knobSettingOffset = setting.packKnobSetting(builder);
-                builder.Finish(knobSettingOffset);
-                knobBuffers.push_back(builder.Release());
-            }
-
-            std::vector<hipdnnBackendFlatbufferData_t> flatbufferDataArray;
-            flatbufferDataArray.reserve(knobBuffers.size());
-
-            for(const auto& buffer : knobBuffers)
-            {
-                hipdnnBackendFlatbufferData_t fbData;
-                fbData.ptr = buffer.data();
-                fbData.size = buffer.size();
-                flatbufferDataArray.push_back(fbData);
-            }
-
-            HIPDNN_RETURN_ON_BACKEND_FAILURE(detail::hipdnnBackend()->backendSetAttribute(
-                                                 _engineConfigDesc->get(),
-                                                 HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
-                                                 HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
-                                                 static_cast<int64_t>(flatbufferDataArray.size()),
-                                                 flatbufferDataArray.data()),
-                                             "Failed to set knob settings on engine config.");
-        }
+        HIPDNN_CHECK_ERROR(applyKnobSettingsToEngineConfig(validatedSettings));
 
         // Finalize engine config after knobs have been set
         HIPDNN_RETURN_ON_BACKEND_FAILURE(

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -80,10 +80,10 @@
 #include <hipdnn_frontend/attributes/PointwiseAttributes.hpp>
 #include <hipdnn_frontend/detail/BackendWrapper.hpp>
 #include <hipdnn_frontend/detail/CreateBackendDescriptor.hpp>
-#include <hipdnn_frontend/detail/DescriptorHelpers.hpp>
 #include <hipdnn_frontend/detail/EngineOverrideUtils.hpp>
 #include <hipdnn_frontend/detail/GraphDetail.hpp>
 #include <hipdnn_frontend/detail/GraphPacker.hpp>
+#include <hipdnn_frontend/detail/KnobPacker.hpp>
 #include <hipdnn_frontend/detail/ScopedHipdnnBackendDescriptor.hpp>
 #include <hipdnn_frontend/knob/Knob.hpp>
 #include <hipdnn_frontend/node/BatchnormBackwardNode.hpp>
@@ -1077,7 +1077,7 @@ public:
     /**
      * @brief Create an execution plan with specific engine and knob settings
      * @param engineId The engine ID to use
-     * @param settings Vector of KnobSetting objects to configure the engine
+     * @param settings Vector of KnobSetting objects to configure the engine (max 1024)
      * @return Error indicating success or failure
      *
      * This method allows fine-grained control over engine selection and

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorHelpers.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorHelpers.hpp
@@ -9,7 +9,6 @@
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 #include <hipdnn_frontend/detail/BackendWrapper.hpp>
 #include <hipdnn_frontend/detail/ScopedHipdnnBackendDescriptor.hpp>
-#include <hipdnn_frontend/knob/KnobSetting.hpp>
 #include <string>
 #include <unordered_map>
 #include <variant>
@@ -220,114 +219,6 @@ inline Error
 {
     HIPDNN_CHECK_ERROR(createOrFindTensorDesc(tensorDescs, tensor));
     return setDescriptorAttrTensorRef(desc, attrName, tensor->get_uid(), tensorDescs, errorContext);
-}
-
-/// Result type for createKnobSettingDescriptor.
-struct KnobSettingDescriptorResult
-{
-    Error error;
-    ScopedHipdnnBackendDescriptor descriptor;
-};
-
-/// Creates a finalized HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR from a KnobSetting.
-/// The descriptor is ready to be passed to EngineConfigDescriptor via
-/// HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES.
-inline KnobSettingDescriptorResult
-    createKnobSettingDescriptor(const hipdnn_frontend::KnobSetting& setting)
-{
-    ScopedHipdnnBackendDescriptor desc(HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
-    if(!desc.valid())
-    {
-        return {{ErrorCode::HIPDNN_BACKEND_ERROR,
-                 "Failed to create knob setting descriptor for " + setting.knobId()},
-                {}};
-    }
-
-    // Set knob ID
-    auto idErr = setDescriptorAttrString(
-        desc.get(), HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, setting.knobId(), "knob ID");
-    if(idErr.is_bad())
-    {
-        return {idErr, {}};
-    }
-
-    // Set knob value, dispatching on the variant type
-    auto valueErr = std::visit(
-        [&](auto&& val) -> Error {
-            using T = std::decay_t<decltype(val)>;
-            if constexpr(std::is_same_v<T, int64_t>)
-            {
-                return setDescriptorAttrScalar(desc.get(),
-                                               HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
-                                               HIPDNN_TYPE_INT64,
-                                               val,
-                                               "knob value (int64)");
-            }
-            else if constexpr(std::is_same_v<T, double>)
-            {
-                return setDescriptorAttrScalar(desc.get(),
-                                               HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
-                                               HIPDNN_TYPE_DOUBLE,
-                                               val,
-                                               "knob value (double)");
-            }
-            else if constexpr(std::is_same_v<T, std::string>)
-            {
-                return setDescriptorAttrString(
-                    desc.get(), HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, val, "knob value (string)");
-            }
-            else
-            {
-                return {ErrorCode::INVALID_VALUE, "Unsupported knob value type"};
-            }
-        },
-        setting.value());
-
-    if(valueErr.is_bad())
-    {
-        return {valueErr, {}};
-    }
-
-    auto finalizeErr = finalizeDescriptor(desc.get(), "knob setting descriptor");
-    if(finalizeErr.is_bad())
-    {
-        return {finalizeErr, {}};
-    }
-
-    return {{}, std::move(desc)};
-}
-
-/// Applies knob settings to an engine config descriptor using the descriptor-based
-/// C API path. Creates a KnobSettingDescriptor per setting and passes them to
-/// the engine config via HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES.
-inline Error
-    applyKnobSettingsViaDescriptors(hipdnnBackendDescriptor_t engineConfigDesc,
-                                    const std::vector<hipdnn_frontend::KnobSetting>& settings)
-{
-    std::vector<ScopedHipdnnBackendDescriptor> knobDescs;
-    knobDescs.reserve(settings.size());
-    std::vector<hipdnnBackendDescriptor_t> knobDescPtrs;
-    knobDescPtrs.reserve(settings.size());
-
-    for(const auto& setting : settings)
-    {
-        auto result = createKnobSettingDescriptor(setting);
-        if(result.error.is_bad())
-        {
-            return result.error;
-        }
-        knobDescs.push_back(std::move(result.descriptor));
-        knobDescPtrs.push_back(knobDescs.back().get());
-    }
-
-    HIPDNN_RETURN_ON_BACKEND_FAILURE(
-        hipdnnBackend()->backendSetAttribute(engineConfigDesc,
-                                             HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES,
-                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                             static_cast<int64_t>(knobDescPtrs.size()),
-                                             knobDescPtrs.data()),
-        "Failed to set knob settings on engine config via descriptors.");
-    return {};
 }
 
 } // namespace hipdnn_frontend::detail

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorHelpers.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorHelpers.hpp
@@ -9,8 +9,10 @@
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 #include <hipdnn_frontend/detail/BackendWrapper.hpp>
 #include <hipdnn_frontend/detail/ScopedHipdnnBackendDescriptor.hpp>
+#include <hipdnn_frontend/knob/KnobSetting.hpp>
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 namespace hipdnn_frontend::detail
@@ -218,6 +220,114 @@ inline Error
 {
     HIPDNN_CHECK_ERROR(createOrFindTensorDesc(tensorDescs, tensor));
     return setDescriptorAttrTensorRef(desc, attrName, tensor->get_uid(), tensorDescs, errorContext);
+}
+
+/// Result type for createKnobSettingDescriptor.
+struct KnobSettingDescriptorResult
+{
+    Error error;
+    ScopedHipdnnBackendDescriptor descriptor;
+};
+
+/// Creates a finalized HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR from a KnobSetting.
+/// The descriptor is ready to be passed to EngineConfigDescriptor via
+/// HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES.
+inline KnobSettingDescriptorResult
+    createKnobSettingDescriptor(const hipdnn_frontend::KnobSetting& setting)
+{
+    ScopedHipdnnBackendDescriptor desc(HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
+    if(!desc.valid())
+    {
+        return {{ErrorCode::HIPDNN_BACKEND_ERROR,
+                 "Failed to create knob setting descriptor for " + setting.knobId()},
+                {}};
+    }
+
+    // Set knob ID
+    auto idErr = setDescriptorAttrString(
+        desc.get(), HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, setting.knobId(), "knob ID");
+    if(idErr.is_bad())
+    {
+        return {idErr, {}};
+    }
+
+    // Set knob value, dispatching on the variant type
+    auto valueErr = std::visit(
+        [&](auto&& val) -> Error {
+            using T = std::decay_t<decltype(val)>;
+            if constexpr(std::is_same_v<T, int64_t>)
+            {
+                return setDescriptorAttrScalar(desc.get(),
+                                               HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                               HIPDNN_TYPE_INT64,
+                                               val,
+                                               "knob value (int64)");
+            }
+            else if constexpr(std::is_same_v<T, double>)
+            {
+                return setDescriptorAttrScalar(desc.get(),
+                                               HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                               HIPDNN_TYPE_DOUBLE,
+                                               val,
+                                               "knob value (double)");
+            }
+            else if constexpr(std::is_same_v<T, std::string>)
+            {
+                return setDescriptorAttrString(
+                    desc.get(), HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, val, "knob value (string)");
+            }
+            else
+            {
+                return {ErrorCode::INVALID_VALUE, "Unsupported knob value type"};
+            }
+        },
+        setting.value());
+
+    if(valueErr.is_bad())
+    {
+        return {valueErr, {}};
+    }
+
+    auto finalizeErr = finalizeDescriptor(desc.get(), "knob setting descriptor");
+    if(finalizeErr.is_bad())
+    {
+        return {finalizeErr, {}};
+    }
+
+    return {{}, std::move(desc)};
+}
+
+/// Applies knob settings to an engine config descriptor using the descriptor-based
+/// C API path. Creates a KnobSettingDescriptor per setting and passes them to
+/// the engine config via HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES.
+inline Error
+    applyKnobSettingsViaDescriptors(hipdnnBackendDescriptor_t engineConfigDesc,
+                                    const std::vector<hipdnn_frontend::KnobSetting>& settings)
+{
+    std::vector<ScopedHipdnnBackendDescriptor> knobDescs;
+    knobDescs.reserve(settings.size());
+    std::vector<hipdnnBackendDescriptor_t> knobDescPtrs;
+    knobDescPtrs.reserve(settings.size());
+
+    for(const auto& setting : settings)
+    {
+        auto result = createKnobSettingDescriptor(setting);
+        if(result.error.is_bad())
+        {
+            return result.error;
+        }
+        knobDescs.push_back(std::move(result.descriptor));
+        knobDescPtrs.push_back(knobDescs.back().get());
+    }
+
+    HIPDNN_RETURN_ON_BACKEND_FAILURE(
+        hipdnnBackend()->backendSetAttribute(engineConfigDesc,
+                                             HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES,
+                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                             static_cast<int64_t>(knobDescPtrs.size()),
+                                             knobDescPtrs.data()),
+        "Failed to set knob settings on engine config via descriptors.");
+    return {};
 }
 
 } // namespace hipdnn_frontend::detail

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/KnobPacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/KnobPacker.hpp
@@ -1,0 +1,106 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
+#pragma once
+
+#include <hipdnn_frontend/Error.hpp>
+#include <hipdnn_frontend/detail/BackendWrapper.hpp>
+#include <hipdnn_frontend/detail/DescriptorHelpers.hpp>
+#include <hipdnn_frontend/detail/ScopedHipdnnBackendDescriptor.hpp>
+#include <hipdnn_frontend/knob/KnobSetting.hpp>
+#include <vector>
+
+namespace hipdnn_frontend::detail
+{
+
+/// Creates a finalized HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR from a KnobSetting.
+/// The descriptor is ready to be passed to EngineConfigDescriptor via
+/// HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES.
+inline Error createKnobSettingDescriptor(const hipdnn_frontend::KnobSetting& setting,
+                                         ScopedHipdnnBackendDescriptor& outDesc)
+{
+    ScopedHipdnnBackendDescriptor desc(HIPDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
+    if(!desc.valid())
+    {
+        return {ErrorCode::HIPDNN_BACKEND_ERROR,
+                "Failed to create knob setting descriptor for " + setting.knobId()};
+    }
+
+    // Set knob ID
+    HIPDNN_CHECK_ERROR(setDescriptorAttrString(
+        desc.get(), HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE, setting.knobId(), "knob ID"));
+
+    // Set knob value, dispatching on the variant type
+    HIPDNN_CHECK_ERROR(std::visit(
+        [&](auto&& val) -> Error {
+            using T = std::decay_t<decltype(val)>;
+            if constexpr(std::is_same_v<T, int64_t>)
+            {
+                return setDescriptorAttrScalar(desc.get(),
+                                               HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                               HIPDNN_TYPE_INT64,
+                                               val,
+                                               "knob value (int64)");
+            }
+            else if constexpr(std::is_same_v<T, double>)
+            {
+                return setDescriptorAttrScalar(desc.get(),
+                                               HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                               HIPDNN_TYPE_DOUBLE,
+                                               val,
+                                               "knob value (double)");
+            }
+            else if constexpr(std::is_same_v<T, std::string>)
+            {
+                return setDescriptorAttrString(
+                    desc.get(), HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE, val, "knob value (string)");
+            }
+            else
+            {
+                return {ErrorCode::INVALID_VALUE, "Unsupported knob value type"};
+            }
+        },
+        setting.value()));
+
+    HIPDNN_CHECK_ERROR(finalizeDescriptor(desc.get(), "knob setting descriptor"));
+
+    outDesc = std::move(desc);
+    return {};
+}
+
+/// Applies knob settings to an engine config descriptor using the descriptor-based
+/// C API path. Creates a KnobSettingDescriptor per setting and passes them to
+/// the engine config via HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES.
+inline Error
+    applyKnobSettingsViaDescriptors(hipdnnBackendDescriptor_t engineConfigDesc,
+                                    const std::vector<hipdnn_frontend::KnobSetting>& settings)
+{
+    if(settings.empty())
+    {
+        return {};
+    }
+
+    std::vector<ScopedHipdnnBackendDescriptor> knobDescs;
+    knobDescs.reserve(settings.size());
+    std::vector<hipdnnBackendDescriptor_t> knobDescPtrs;
+    knobDescPtrs.reserve(settings.size());
+
+    for(const auto& setting : settings)
+    {
+        ScopedHipdnnBackendDescriptor knobDesc;
+        HIPDNN_CHECK_ERROR(createKnobSettingDescriptor(setting, knobDesc));
+        knobDescs.push_back(std::move(knobDesc));
+        knobDescPtrs.push_back(knobDescs.back().get());
+    }
+
+    HIPDNN_RETURN_ON_BACKEND_FAILURE(
+        hipdnnBackend()->backendSetAttribute(engineConfigDesc,
+                                             HIPDNN_ATTR_ENGINECFG_KNOB_CHOICES,
+                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                             static_cast<int64_t>(knobDescPtrs.size()),
+                                             knobDescPtrs.data()),
+        "Failed to set knob settings on engine config via descriptors.");
+    return {};
+}
+
+} // namespace hipdnn_frontend::detail

--- a/projects/hipdnn/frontend/tests/TestDescriptorHelpers.cpp
+++ b/projects/hipdnn/frontend/tests/TestDescriptorHelpers.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_frontend/detail/DescriptorHelpers.hpp>
+#include <hipdnn_frontend/detail/KnobPacker.hpp>
 #include <hipdnn_frontend/knob/KnobSetting.hpp>
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
 
@@ -660,9 +661,10 @@ TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorInt64)
     EXPECT_CALL(*_mockBackend, backendFinalize(_)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
     hipdnn_frontend::KnobSetting setting("test_knob", int64_t{42});
-    auto result = createKnobSettingDescriptor(setting);
-    EXPECT_TRUE(result.error.is_good()) << result.error.err_msg;
-    EXPECT_TRUE(result.descriptor.valid());
+    ScopedHipdnnBackendDescriptor desc;
+    auto err = createKnobSettingDescriptor(setting, desc);
+    EXPECT_TRUE(err.is_good()) << err.err_msg;
+    EXPECT_TRUE(desc.valid());
 }
 
 TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorDouble)
@@ -688,9 +690,10 @@ TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorDouble)
     EXPECT_CALL(*_mockBackend, backendFinalize(_)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
     hipdnn_frontend::KnobSetting setting("double_knob", 3.14);
-    auto result = createKnobSettingDescriptor(setting);
-    EXPECT_TRUE(result.error.is_good()) << result.error.err_msg;
-    EXPECT_TRUE(result.descriptor.valid());
+    ScopedHipdnnBackendDescriptor desc;
+    auto err = createKnobSettingDescriptor(setting, desc);
+    EXPECT_TRUE(err.is_good()) << err.err_msg;
+    EXPECT_TRUE(desc.valid());
 }
 
 TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorString)
@@ -716,9 +719,10 @@ TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorString)
     EXPECT_CALL(*_mockBackend, backendFinalize(_)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
 
     hipdnn_frontend::KnobSetting setting("str_knob", std::string("my_value"));
-    auto result = createKnobSettingDescriptor(setting);
-    EXPECT_TRUE(result.error.is_good()) << result.error.err_msg;
-    EXPECT_TRUE(result.descriptor.valid());
+    ScopedHipdnnBackendDescriptor desc;
+    auto err = createKnobSettingDescriptor(setting, desc);
+    EXPECT_TRUE(err.is_good()) << err.err_msg;
+    EXPECT_TRUE(desc.valid());
 }
 
 TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorFailsOnCreate)
@@ -728,9 +732,10 @@ TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorFailsOnCreate)
     EXPECT_CALL(*_mockBackend, getLastErrorString(_, _)).Times(AnyNumber());
 
     hipdnn_frontend::KnobSetting setting("test_knob", int64_t{42});
-    auto result = createKnobSettingDescriptor(setting);
-    EXPECT_TRUE(result.error.is_bad());
-    EXPECT_EQ(result.error.code, ErrorCode::HIPDNN_BACKEND_ERROR);
+    ScopedHipdnnBackendDescriptor desc;
+    auto err = createKnobSettingDescriptor(setting, desc);
+    EXPECT_TRUE(err.is_bad());
+    EXPECT_EQ(err.code, ErrorCode::HIPDNN_BACKEND_ERROR);
 }
 
 TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorFailsOnSetAttribute)
@@ -742,9 +747,10 @@ TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorFailsOnSetAttribute)
         .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
 
     hipdnn_frontend::KnobSetting setting("test_knob", int64_t{42});
-    auto result = createKnobSettingDescriptor(setting);
-    EXPECT_TRUE(result.error.is_bad());
-    EXPECT_EQ(result.error.code, ErrorCode::HIPDNN_BACKEND_ERROR);
+    ScopedHipdnnBackendDescriptor desc;
+    auto err = createKnobSettingDescriptor(setting, desc);
+    EXPECT_TRUE(err.is_bad());
+    EXPECT_EQ(err.code, ErrorCode::HIPDNN_BACKEND_ERROR);
 }
 
 TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorFailsOnFinalize)
@@ -757,7 +763,8 @@ TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorFailsOnFinalize)
     EXPECT_CALL(*_mockBackend, backendFinalize(_)).WillOnce(Return(HIPDNN_STATUS_INTERNAL_ERROR));
 
     hipdnn_frontend::KnobSetting setting("test_knob", int64_t{42});
-    auto result = createKnobSettingDescriptor(setting);
-    EXPECT_TRUE(result.error.is_bad());
-    EXPECT_EQ(result.error.code, ErrorCode::HIPDNN_BACKEND_ERROR);
+    ScopedHipdnnBackendDescriptor desc;
+    auto err = createKnobSettingDescriptor(setting, desc);
+    EXPECT_TRUE(err.is_bad());
+    EXPECT_EQ(err.code, ErrorCode::HIPDNN_BACKEND_ERROR);
 }

--- a/projects/hipdnn/frontend/tests/TestDescriptorHelpers.cpp
+++ b/projects/hipdnn/frontend/tests/TestDescriptorHelpers.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_frontend/detail/DescriptorHelpers.hpp>
+#include <hipdnn_frontend/knob/KnobSetting.hpp>
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
 
 #include "fake_backend/BackendTestMatchers.hpp"
@@ -629,4 +630,134 @@ TEST_F(TestDescriptorHelpers, EnsureTensorDescSetsPassByValueInt32)
     auto err = createOrFindTensorDesc(tensorDescs, tensor);
     EXPECT_TRUE(err.is_good()) << err.err_msg;
     EXPECT_EQ(tensorDescs.size(), 1u);
+}
+
+// ============================================================================
+// createKnobSettingDescriptor tests
+// ============================================================================
+
+TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorInt64)
+{
+    expectCreateAndDestroyDescriptor();
+
+    // Expect: set knob ID (CHAR), set knob value (INT64), finalize
+    EXPECT_CALL(*_mockBackend,
+                backendSetAttribute(_,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE,
+                                    HIPDNN_TYPE_CHAR,
+                                    static_cast<int64_t>(std::string("test_knob").size()),
+                                    pointsToString("test_knob")))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    EXPECT_CALL(*_mockBackend,
+                backendSetAttribute(_,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                    HIPDNN_TYPE_INT64,
+                                    1,
+                                    pointsToScalar<int64_t>(42)))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    EXPECT_CALL(*_mockBackend, backendFinalize(_)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    hipdnn_frontend::KnobSetting setting("test_knob", int64_t{42});
+    auto result = createKnobSettingDescriptor(setting);
+    EXPECT_TRUE(result.error.is_good()) << result.error.err_msg;
+    EXPECT_TRUE(result.descriptor.valid());
+}
+
+TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorDouble)
+{
+    expectCreateAndDestroyDescriptor();
+
+    EXPECT_CALL(*_mockBackend,
+                backendSetAttribute(_,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE,
+                                    HIPDNN_TYPE_CHAR,
+                                    static_cast<int64_t>(std::string("double_knob").size()),
+                                    pointsToString("double_knob")))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    EXPECT_CALL(*_mockBackend,
+                backendSetAttribute(_,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                    HIPDNN_TYPE_DOUBLE,
+                                    1,
+                                    pointsToScalar<double>(3.14)))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    EXPECT_CALL(*_mockBackend, backendFinalize(_)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    hipdnn_frontend::KnobSetting setting("double_knob", 3.14);
+    auto result = createKnobSettingDescriptor(setting);
+    EXPECT_TRUE(result.error.is_good()) << result.error.err_msg;
+    EXPECT_TRUE(result.descriptor.valid());
+}
+
+TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorString)
+{
+    expectCreateAndDestroyDescriptor();
+
+    EXPECT_CALL(*_mockBackend,
+                backendSetAttribute(_,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_TYPE,
+                                    HIPDNN_TYPE_CHAR,
+                                    static_cast<int64_t>(std::string("str_knob").size()),
+                                    pointsToString("str_knob")))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    EXPECT_CALL(*_mockBackend,
+                backendSetAttribute(_,
+                                    HIPDNN_ATTR_KNOB_CHOICE_KNOB_VALUE,
+                                    HIPDNN_TYPE_CHAR,
+                                    static_cast<int64_t>(std::string("my_value").size()),
+                                    pointsToString("my_value")))
+        .WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    EXPECT_CALL(*_mockBackend, backendFinalize(_)).WillOnce(Return(HIPDNN_STATUS_SUCCESS));
+
+    hipdnn_frontend::KnobSetting setting("str_knob", std::string("my_value"));
+    auto result = createKnobSettingDescriptor(setting);
+    EXPECT_TRUE(result.error.is_good()) << result.error.err_msg;
+    EXPECT_TRUE(result.descriptor.valid());
+}
+
+TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorFailsOnCreate)
+{
+    EXPECT_CALL(*_mockBackend, backendCreateDescriptor(_, _))
+        .WillOnce(Return(HIPDNN_STATUS_INTERNAL_ERROR));
+    EXPECT_CALL(*_mockBackend, getLastErrorString(_, _)).Times(AnyNumber());
+
+    hipdnn_frontend::KnobSetting setting("test_knob", int64_t{42});
+    auto result = createKnobSettingDescriptor(setting);
+    EXPECT_TRUE(result.error.is_bad());
+    EXPECT_EQ(result.error.code, ErrorCode::HIPDNN_BACKEND_ERROR);
+}
+
+TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorFailsOnSetAttribute)
+{
+    expectCreateAndDestroyDescriptor();
+
+    // First setAttribute (knob ID) fails
+    EXPECT_CALL(*_mockBackend, backendSetAttribute(_, _, _, _, _))
+        .WillOnce(Return(HIPDNN_STATUS_BAD_PARAM));
+
+    hipdnn_frontend::KnobSetting setting("test_knob", int64_t{42});
+    auto result = createKnobSettingDescriptor(setting);
+    EXPECT_TRUE(result.error.is_bad());
+    EXPECT_EQ(result.error.code, ErrorCode::HIPDNN_BACKEND_ERROR);
+}
+
+TEST_F(TestDescriptorHelpers, CreateKnobSettingDescriptorFailsOnFinalize)
+{
+    expectCreateAndDestroyDescriptor();
+
+    // setAttribute calls succeed, but finalize fails
+    EXPECT_CALL(*_mockBackend, backendSetAttribute(_, _, _, _, _))
+        .WillRepeatedly(Return(HIPDNN_STATUS_SUCCESS));
+    EXPECT_CALL(*_mockBackend, backendFinalize(_)).WillOnce(Return(HIPDNN_STATUS_INTERNAL_ERROR));
+
+    hipdnn_frontend::KnobSetting setting("test_knob", int64_t{42});
+    auto result = createKnobSettingDescriptor(setting);
+    EXPECT_TRUE(result.error.is_bad());
+    EXPECT_EQ(result.error.code, ErrorCode::HIPDNN_BACKEND_ERROR);
 }


### PR DESCRIPTION
## Motivation
We're removing flatbuffers as a frontend dependency.  This PR will allow us to use a C-API to lower frontend KnobSettings to the backend.

## Technical Details
- Added a KnobSettingsDescriptor and tests
- Added backend factory methods and tests
- Added frontend utility methods and tests
- Wired up backend KnobSettingsDescriptors to flatbuffer KnobSettingsT for delivery to the plugins

## Test Plan
- Ran all applicable unit tests with the feature flag enabled
- CI will not run on this until all work is completed and the feature flag can be removed

## Test Result
- [x] Backend unit tests (KnobSetting + EngineConfig): 64/64 passed - all new and existing tests pass
- [x] Frontend DescriptorHelpers: 30/30 passed - including new CreateKnobSettingDescriptorFailsOnFinalize
- [x] Conv forward propagation (descriptor API on): 6/6 passed - IntegrationConvFpropDescriptorLowering + IntegrationConvolutionForwardFp32
- [x] Knob integration tests (FlatBuffer path): 15/15 passed - these use Pointwise nodes, which the descriptor path doesn't support yet
- [x] MIOpen plugin smoke tests: 1135/1137 passed - 2 ConvFwdBiasActiv failures are pre-existing (confirmed on main branch)
- [x] Sample integration tests: 14/14 passed

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
