### PR TITLE
Scope clang-tidy CI to hipDNN only

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -6,9 +6,10 @@ on:
       - 'projects/hipdnn/**/*.[ch]p?p?'
       - 'projects/hipdnn/cmake/ClangTidy.cmake'
       - 'projects/hipdnn/.clang-tidy'
-      - 'dnn-providers/miopen-provider/**/*.[ch]p?p?'
-      - 'dnn-providers/miopen-provider/cmake/ClangTidy.cmake'
-      - 'dnn-providers/miopen-provider/.clang-tidy'
+      # Disabled: see https://github.com/ROCm/rocm-libraries/issues/5067
+      # - 'dnn-providers/miopen-provider/**/*.[ch]p?p?'
+      # - 'dnn-providers/miopen-provider/cmake/ClangTidy.cmake'
+      # - 'dnn-providers/miopen-provider/.clang-tidy'
       - '.github/workflows/clang-tidy.yml'
   workflow_dispatch:
 
@@ -26,8 +27,9 @@ jobs:
           filters: |
             hipdnn:
               - 'projects/hipdnn/**'
-            miopen-provider:
-              - 'dnn-providers/miopen-provider/**'
+            # Disabled: see https://github.com/ROCm/rocm-libraries/issues/5067
+            # miopen-provider:
+            #   - 'dnn-providers/miopen-provider/**'
 
       - name: Checkout TheRock
         uses: actions/checkout@v4
@@ -78,16 +80,17 @@ jobs:
             -DHIP_PLATFORM=amd
           ninja -C build-hipdnn tidy
 
-      - name: Run clang-tidy (miopen-provider)
-        if: steps.changes.outputs.miopen-provider == 'true' || github.event_name == 'workflow_dispatch'
-        run: |
-          . .venv/bin/activate
-          export PATH=/opt/rocm/bin:/opt/rocm/llvm/bin:$PATH
-          export CXX=/opt/rocm/llvm/bin/clang++
-          cmake -S dnn-providers/miopen-provider -B build-miopen-provider -G Ninja \
-            -DENABLE_CLANG_TIDY=ON \
-            -DROCM_PATH=/opt/rocm \
-            -DCMAKE_PREFIX_PATH=/opt/rocm \
-            -DENABLE_CLANG_FORMAT=OFF \
-            -DHIP_PLATFORM=amd
-          ninja -C build-miopen-provider tidy
+      # Disabled: see https://github.com/ROCm/rocm-libraries/issues/5067
+      # - name: Run clang-tidy (miopen-provider)
+      #   if: steps.changes.outputs.miopen-provider == 'true' || github.event_name == 'workflow_dispatch'
+      #   run: |
+      #     . .venv/bin/activate
+      #     export PATH=/opt/rocm/bin:/opt/rocm/llvm/bin:$PATH
+      #     export CXX=/opt/rocm/llvm/bin/clang++
+      #     cmake -S dnn-providers/miopen-provider -B build-miopen-provider -G Ninja \
+      #       -DENABLE_CLANG_TIDY=ON \
+      #       -DROCM_PATH=/opt/rocm \
+      #       -DCMAKE_PREFIX_PATH=/opt/rocm \
+      #       -DENABLE_CLANG_FORMAT=OFF \
+      #       -DHIP_PLATFORM=amd
+      #     ninja -C build-miopen-provider tidy


### PR DESCRIPTION
## Summary

Clang tidy action was prone to flakiness because for any cross-project change, it would use the headers from TheRock for checking the symbols as opposed to the changes in the dependency project. e.g. if hipDNN had new API introduced and the MIOpen provider were changed to use this new API simultaneously, clang-tidy would fail since it relied on this API being available in TheRock install.

We are disabling clang-tidy on the MIOpen provider until we can determine a better approach.

- Comments out miopen-provider trigger paths, change detection filter, and build step from the clang-tidy workflow
- hipDNN clang-tidy continues to run as before
- Provider config is preserved as comments for easy re-enablement later

🤖 Generated with [Claude Code](https://claude.com/claude-code)