### PR TITLE
[MIOpen] Fix response file path handling in addkernels (#4182)

### DIFF
--- a/projects/miopen/addkernels/addkernels.cpp
+++ b/projects/miopen/addkernels/addkernels.cpp
@@ -1,28 +1,6 @@
-/*******************************************************************************
- *
- * MIT License
- *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- *******************************************************************************/
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
+
 #include "include_inliner.hpp"
 #include "miopen/filesystem.hpp"
 #include <algorithm>
@@ -316,7 +294,27 @@ int main(int argc, char* argv[])
         std::string arg(argv[i]);
         std::transform(arg.begin(), arg.end(), arg.begin(), ::tolower);
 
-        if(arg == "-s" || arg == "-source")
+        // Handle response file (starts with @)
+        if(arg.starts_with('@'))
+        {
+            std::string response_file = std::string(argv[i]).substr(1);
+            std::ifstream file(response_file);
+            if(!file.is_open())
+            {
+                std::cerr << "Error: Cannot open response file: " << response_file << std::endl;
+                return 1;
+            }
+
+            std::string line;
+            while(std::getline(file, line))
+            {
+                if(!line.empty() && !line.starts_with('#'))
+                {
+                    sourceFiles.emplace_back(line);
+                }
+            }
+        }
+        else if(arg == "-s" || arg == "-source")
         {
             while(++i < argc && *argv[i] != '-')
                 sourceFiles.emplace_back(argv[i]);

--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -813,12 +813,19 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
                 set(KERNEL_SRC_ASM_PATH ${PROJECT_BINARY_DIR}/inlined_kernels/batch_${KERNELS_BATCH_ID}.S)
                 set(KERNEL_SRC_BIN_PATH ${PROJECT_BINARY_DIR}/inlined_kernels/batch_${KERNELS_BATCH_ID}.bin)
 
+                # Generate response file for this batch to avoid command line length limits
+                set(KERNEL_RESPONSE_FILE ${PROJECT_BINARY_DIR}/inlined_kernels/batch_${KERNELS_BATCH_ID}_files.txt)
+                file(WRITE ${KERNEL_RESPONSE_FILE} "")
+                foreach(kernel_file ${KERNELS_BATCH})
+                    file(APPEND ${KERNEL_RESPONSE_FILE} "${kernel_file}\n")
+                endforeach()
+
                 if(MIOPEN_INCBIN)
                     add_custom_command(
                         OUTPUT ${KERNEL_SRC_HPP_PATH} ${KERNEL_SRC_ASM_PATH} ${KERNEL_SRC_BIN_PATH}
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                        DEPENDS addkernels ${KERNELS_BATCH} ${KERNEL_INCLUDES}
-                        COMMAND $<TARGET_FILE:addkernels> -asm ${KERNEL_SRC_ASM_PATH} ${KERNEL_SRC_BIN_PATH} -target ${KERNEL_SRC_HPP_PATH} -extern ${EXTRA_OPTIONS} -source ${KERNELS_BATCH}
+                        DEPENDS addkernels ${KERNELS_BATCH} ${KERNEL_INCLUDES} ${KERNEL_RESPONSE_FILE}
+                        COMMAND $<TARGET_FILE:addkernels> -asm ${KERNEL_SRC_ASM_PATH} ${KERNEL_SRC_BIN_PATH} -target ${KERNEL_SRC_HPP_PATH} -extern ${EXTRA_OPTIONS} @${KERNEL_RESPONSE_FILE}
                         COMMENT "Inlining kernels batch #${KERNELS_BATCH_ID}${MESSAGE_SUFFIX}"
                         )
                     list(APPEND MIOpen_Source ${KERNEL_SRC_HPP_PATH} ${KERNEL_SRC_ASM_PATH})
@@ -826,8 +833,8 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
                     add_custom_command(
                         OUTPUT ${KERNEL_SRC_HPP_PATH}
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                        DEPENDS addkernels ${KERNELS_BATCH} ${KERNEL_INCLUDES}
-                        COMMAND $<TARGET_FILE:addkernels> -target ${KERNEL_SRC_HPP_PATH} -extern ${EXTRA_OPTIONS} -source ${KERNELS_BATCH}
+                        DEPENDS addkernels ${KERNELS_BATCH} ${KERNEL_INCLUDES} ${KERNEL_RESPONSE_FILE}
+                        COMMAND $<TARGET_FILE:addkernels> -target ${KERNEL_SRC_HPP_PATH} -extern ${EXTRA_OPTIONS} @${KERNEL_RESPONSE_FILE}
                         COMMENT "Inlining kernels batch #${KERNELS_BATCH_ID}${MESSAGE_SUFFIX}"
                         )
                     configure_file(kernels/kernels_batch.cpp.in ${KERNEL_SRC_CPP_PATH})


### PR DESCRIPTION
## Motivation

Windows has a ~8191 character command line limit. MIOpen's `addkernels` tool receives hundreds of kernel assembly files as command-line arguments, which exceeds this limit and causes build failures on Windows.
This PR implements response file support (`@file.txt` syntax) to work around command line length limits by reading file lists from a text file instead of passing them as direct arguments. Fixes #4182

## Technical Details

**Changes to `addkernels.cpp`:**
- Added response file parsing for `@file.txt` syntax 
- Reads kernel file paths from text file instead of command line
- Supports comments (`#`) and empty lines
- Preserves original path case when opening response files 

**Changes to `src/CMakeLists.txt`:**
- Generate `batch_N_files.txt` response files for each kernel batch
- Replace `-source ${KERNELS_BATCH}` with `@${KERNEL_RESPONSE_FILE}`
- Add response files to build dependencies
This avoids Windows command line length limits while maintaining backward compatibility with the `-source` option.

## Test Plan

1. Implemented response file support in `addkernels.cpp`
2. Manually tested `addkernels` with `@response_file.txt` syntax
3. Verified response file parsing handles comments and empty lines correctly
4. Rebuilt `addkernels` tool successfully
5. Modified `CMakeLists.txt` to generate and use response files
6. Built full MIOpen with response file feature enabled

## Test Result

All 933 MIOpen build targets completed successfully.  Response files generated correctly in `build/inlined_kernels/batch_*_files.txt`. Backward compatibility with `-source` option maintained.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
