### PR TITLE
CI Skip Testing Fix

### DIFF
--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -290,6 +290,8 @@ def shouldRunCICheck() {
                     git log --name-only --pretty=format: origin/$CHANGE_TARGET..HEAD -- projects/composablekernel/ | sort -u | grep -v '^$'
                 else
                     # For feature branch builds, compare against merge-base with base branch
+                    # Ensure we have the base branch fetched for shallow clones
+                    git fetch origin $BASE_BRANCH --depth=50 2>/dev/null || true
                     MERGE_BASE=$(git merge-base HEAD origin/$BASE_BRANCH 2>/dev/null || echo "HEAD~1")
                     echo "Branch build detected, checking all touched files since merge-base: $MERGE_BASE" >&2
                     git log --name-only --pretty=format: $MERGE_BASE..HEAD -- projects/composablekernel/ | sort -u | grep -v '^$'

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -287,14 +287,12 @@ def shouldRunCICheck() {
                 if [ "$CHANGE_ID" != "" ]; then
                     # For PR builds, get all files touched in any commit
                     echo "PR build detected, checking all touched files against origin/$CHANGE_TARGET" >&2
-                    git log --name-only --pretty=format: origin/$CHANGE_TARGET..HEAD -- projects/composablekernel/ | sort -u | grep -v '^$'
+                    git log --name-only --pretty=format: origin/$CHANGE_TARGET..HEAD -- projects/composablekernel/ | sort -u | grep -v '^$' || true
                 else
                     # For feature branch builds, compare against merge-base with base branch
-                    # Ensure we have the base branch fetched for shallow clones
-                    git fetch origin $BASE_BRANCH --depth=50 2>/dev/null || true
                     MERGE_BASE=$(git merge-base HEAD origin/$BASE_BRANCH 2>/dev/null || echo "HEAD~1")
                     echo "Branch build detected, checking all touched files since merge-base: $MERGE_BASE" >&2
-                    git log --name-only --pretty=format: $MERGE_BASE..HEAD -- projects/composablekernel/ | sort -u | grep -v '^$'
+                    git log --name-only --pretty=format: $MERGE_BASE..HEAD -- projects/composablekernel/ | sort -u | grep -v '^$' || true
                 fi
             '''
         ).trim().split('\n')

--- a/projects/composablekernel/README.md
+++ b/projects/composablekernel/README.md
@@ -1,5 +1,4 @@
 # Composable Kernel
-# Test
 
 > [!NOTE]
 > The published documentation is available at [Composable Kernel](https://rocm.docs.amd.com/projects/composable_kernel/en/latest/) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the `docs` folder of this repository. As with all ROCm projects, the documentation is open source. For more information on contributing to the documentation, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).

--- a/projects/composablekernel/README.md
+++ b/projects/composablekernel/README.md
@@ -1,4 +1,5 @@
 # Composable Kernel
+# Test
 
 > [!NOTE]
 > The published documentation is available at [Composable Kernel](https://rocm.docs.amd.com/projects/composable_kernel/en/latest/) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the `docs` folder of this repository. As with all ROCm projects, the documentation is open source. For more information on contributing to the documentation, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).


### PR DESCRIPTION
## Motivation

While testing the Skip CI functionality, it revealed a minor issue where the CI skip check fails when a branch is built at the exact commit where it diverged from develop. CI is still run by default if a failure is detected.

When git log <merge-base>..HEAD returns no files (because HEAD equals merge-base), the command grep -v '^$' exits with error code 1, causing the skip check to fail.

## Technical Details

Added || true to the grep commands so empty output is handled gracefully instead of causing a script failure.

## Test Plan

- Simulate the failures and ensure the grep failure is handled gracefully.

## Test Result

- Simulated grep failures using an empty string. The script handles the error correctly.
- Verified the CI skip functionality skips CI when non-relevant file changes are made.
- Verified the CI skip functionality does not skip CI when relevant file changes are made.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
