### PR TITLE
[rocsparse] Fix csrsm kernel that was missing syncthreads

### DIFF
--- a/projects/rocsparse/library/src/level3/csrsm_device.h
+++ b/projects/rocsparse/library/src/level3/csrsm_device.h
@@ -98,7 +98,7 @@ namespace rocsparse
                                                    : -1;
                 scsr_val[hipThreadIdx_x]
                     = (hipThreadIdx_x < row_end - j) ? csr_val[hipThreadIdx_x + j] : -1;
-                
+
                 // Wait for preload to finish
                 __syncthreads();
             }

--- a/projects/rocsparse/library/src/level3/csrsm_device.h
+++ b/projects/rocsparse/library/src/level3/csrsm_device.h
@@ -91,15 +91,17 @@ namespace rocsparse
             // This happens only once for each chunk of BLOCKSIZE elements
             if(k == 0)
             {
+                __syncthreads();
+
                 scsr_col_ind[hipThreadIdx_x] = (hipThreadIdx_x < row_end - j)
                                                    ? csr_col_ind[hipThreadIdx_x + j] - idx_base
                                                    : -1;
                 scsr_val[hipThreadIdx_x]
                     = (hipThreadIdx_x < row_end - j) ? csr_val[hipThreadIdx_x + j] : -1;
+                
+                // Wait for preload to finish
+                __syncthreads();
             }
-
-            // Wait for preload to finish
-            __syncthreads();
 
             // Current column this lane operates on
             const J local_col = scsr_col_ind[k];


### PR DESCRIPTION
## Motivation

Add missing syncthreads in csrsm kernel

## Technical Details

When the fill mode is `rocsparse_fill_mode_upper`, all threads in a block may hit the `continue` at either https://github.com/ROCm/rocm-libraries/blob/8cdf8ca81c1ddc52c36e3933077cfaeca37d6cfa/projects/rocsparse/library/src/level3/csrsm_device.h#L132 or https://github.com/ROCm/rocm-libraries/blob/8cdf8ca81c1ddc52c36e3933077cfaeca37d6cfa/projects/rocsparse/library/src/level3/csrsm_device.h#L145. If this happens, we jump back to the top of the `for` loop. Here if the iteration of the `for` loop necessitates loading another `BLOCKSIZE` columns and values into shared memory, some of the threads may do this before other threads have loaded their previous values at line https://github.com/ROCm/rocm-libraries/blob/8cdf8ca81c1ddc52c36e3933077cfaeca37d6cfa/projects/rocsparse/library/src/level3/csrsm_device.h#L105 and https://github.com/ROCm/rocm-libraries/blob/8cdf8ca81c1ddc52c36e3933077cfaeca37d6cfa/projects/rocsparse/library/src/level3/csrsm_device.h#L108.

Adding a `__syncthreads()` prior to the loading and of the data into shared memory ensures that the threads will access the correct data. Moving the `__syncthreads()` into the if statement https://github.com/ROCm/rocm-libraries/blob/8cdf8ca81c1ddc52c36e3933077cfaeca37d6cfa/projects/rocsparse/library/src/level3/csrsm_device.h#L92 results in slightly better performance for fill mode `rocsparse_fill_mode_upper` as shown in these plots:

[scsrsm_gfx1201_upper_bmwcra_1.pdf](https://github.com/user-attachments/files/25727684/scsrsm_gfx1201_upper_bmwcra_1.pdf)
[scsrsm_gfx1201_lower_bmwcra_1.pdf](https://github.com/user-attachments/files/25727685/scsrsm_gfx1201_lower_bmwcra_1.pdf)
[scsrsm_gfx1201_upper_20_100_bmwcra_1.pdf](https://github.com/user-attachments/files/25727686/scsrsm_gfx1201_upper_20_100_bmwcra_1.pdf)
[scsrsm_gfx1201_lower_20_100_bmwcra_1.pdf](https://github.com/user-attachments/files/25727687/scsrsm_gfx1201_lower_20_100_bmwcra_1.pdf)

## Test Plan

Ensure all CI tests pass
