### PR TITLE
[Tensile] Skip warmup iteration in elapsed time calculation

### DIFF
--- a/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
@@ -235,9 +235,11 @@ namespace TensileLite
 
             double_millis totalTime(0.0);
 
+            // Skip the first warmup event (cold start) when multiple warmups are available
+            size_t warmupStartIdx = startEvents->size() == 1 ? 0 : 1;
             float enqTime = 0.0f;
             HIP_CHECK_EXC(hipEventSynchronize(stopEvents->back().back()));
-            for(size_t i = 0; i < startEvents->size(); i++)
+            for(size_t i = warmupStartIdx; i < startEvents->size(); i++)
             {
                 HIP_CHECK_EXC(hipEventElapsedTime(
                     &enqTime, startEvents->at(i).front(), stopEvents->at(i).back()));


### PR DESCRIPTION
- Start loop from index 1 instead of 0 to exclude warmup iteration from the elapsed time calculation

## Motivation

### Summary

When the `skip-slow-solution` feature compares warmup elapsed times between solutions, the first warmup iteration (cold start) is included in the total elapsed time. This cold-start overhead is **orders of magnitude** larger than subsequent iterations and is **common to all solutions**, masking the actual kernel performance differences. This PR excludes the first warmup iteration from the elapsed time calculation to improve the accuracy of the skip-slow-solution decision.

### Problem

In `BenchmarkTimer::postWarmup()`, the elapsed time is calculated by summing all warmup events starting from index 0. The first warmup iteration suffers from GPU cold-start overhead (HIP runtime initialization, memory allocation, cache population, etc.), which makes its execution time **1,000x – 27,000x** slower than steady-state iterations.

This causes two issues:
1. **Warmup total time is dominated by cold start**: The first iteration contributes >98% of the total elapsed time, completely masking actual kernel performance differences between solutions.
2. **Skip-slow-solution ratio comparison becomes ineffective**: Since all solutions share similar cold-start overhead, their warmup times converge to nearly the same value regardless of actual kernel performance.

### Data Analysis

#### 1. Cold-Start Overhead (Iter 1 vs Iter 2)

Experiment: 100 independent runs per GEMM shape, measuring per-iteration execution time (µs). 20 warmup iterations per run.

| GEMM Shape | Iter 1 Mean (µs) | Iter 2 Mean (µs) | Slowdown Ratio |
|---|---|---|---|
| m100\_n309657\_b1\_k2048 | 1,599,559.68 | 1,577.85 | **1,014×** |
| m112\_n86016\_b1\_k2048 | 1,605,440.67 | 468.52 | **3,426×** |
| m168\_n57344\_b1\_k1024 | 1,621,365.99 | 224.82 | **7,212×** |
| m201\_n103219\_b1\_k256 | 1,632,564.39 | 423.82 | **3,852×** |
| m39936\_n64\_b1\_k256 | 1,656,028.82 | 61.75 | **26,818×** |
| m403\_n77414\_b1\_k1024 | 1,618,361.60 | 706.26 | **2,292×** |
| m43008\_n224\_b1\_k1024 | 1,627,920.74 | 312.96 | **5,201×** |
| m448\_n86016\_b1\_k1024 | 1,599,925.01 | 608.20 | **2,630×** |
| m604\_n51609\_b1\_k256 | 1,646,109.49 | 310.57 | **5,300×** |
| m77414\_n403\_b1\_k256 | 1,619,083.72 | 323.27 | **5,011×** |

The first warmup iteration is consistently ~1.6 seconds (GPU cold start overhead), while actual kernel execution times range from 27 µs to 1,578 µs.

#### 2. Impact on Warmup Total Elapsed Time

Taking **m403\_n77414\_b1\_k1024** as an example (20 warmup iterations):

| Metric | With Iter 1 | Without Iter 1 |
|---|---|---|
| Total elapsed time | 1,618,361 + 19 × 687 ≈ **1,631,414 µs** | 19 × 687 ≈ **13,053 µs** |
| Iter 1 contribution | **99.2%** | 0% |

Suppose two solutions have a **2× actual performance difference** (Solution A: 687 µs/iter, Solution B: 1,374 µs/iter):

| Comparison | With Iter 1 | Without Iter 1 |
|---|---|---|
| Total A | 1,631,414 µs | 13,053 µs |
| Total B | 1,644,467 µs | 26,106 µs |
| **Observed ratio (B/A)** | **1.008** (0.8% difference) | **2.0** (correct 2× difference) |

**Including iter 1 completely masks the actual 2× performance gap**, reducing it to a negligible 0.8% — well below any practical `skip-slow-solution-ratio` threshold.

#### 3. Coefficient of Variation (CV) Stability

CV (%) across 100 independent runs — lower values indicate more stable/reproducible measurements:

| GEMM Shape | Iter 1 CV (%) | Iter 2 CV (%) | Avg CV Iter 2–20 (%) |
|---|---|---|---|
| m100\_n309657\_b1\_k2048 | 1.73 | 0.23 | 0.20 |
| m112\_n86016\_b1\_k2048 | 3.83 | 0.22 | 1.36 |
| m403\_n77414\_b1\_k1024 | 1.49 | 0.14 | 0.55 |
| m448\_n86016\_b1\_k1024 | 3.09 | 0.18 | 0.78 |
| m77414\_n403\_b1\_k256 | 1.58 | 0.10 | 1.58 |

Iter 1 consistently shows higher CV than subsequent iterations, indicating that cold-start timing is less stable and introduces additional noise into the comparison.

