### PR TITLE
[hipblas-common] Fix rmake.py help message

### DIFF
--- a/projects/hipblas-common/rmake.py
+++ b/projects/hipblas-common/rmake.py
@@ -1,23 +1,6 @@
 #!/usr/bin/python3
-"""Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
-   ies of the Software, and to permit persons to whom the Software is furnished
-   to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in all
-   copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
-   PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-   FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-   COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
-   CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-"""
+# Copyright Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
 
 import os
 import platform
@@ -41,7 +24,7 @@ def parse_args():
                         help='Specify path to configure & build process output directory.(optional, default: ./build)')
 
     general_opts.add_argument('-i', '--install', required=False, default=False, dest='install', action='store_true',
-                        help='Generate and install library package after build. Windows only. Linux use install.sh (optional, default: False)')
+                        help='Generate and install library package after build. (optional, default: False)')
 
     return parser.parse_args()
 # yapf: enable


### PR DESCRIPTION
## Motivation

The rmake.py help message erroneously indicates that the `--install` option is for windows only and that linux should use install.sh. There is no install.sh in the hipblas-common project and the `--install` option does in fact work on linux.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
