### PR TITLE
[hipblaslt][tensile] Cache Kernel.cpp and similar to significantly speedup compile times

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
@@ -157,3 +157,51 @@ class TestCheckCache:
         (entry / "metadata.json").write_text("{}")
         result = _checkCache(tmp_path, "some_hash")
         assert len(result) == 1
+
+
+class TestPopulateCache:
+    def test_populates_empty_cache(self, tmp_path):
+        from Tensile.Toolchain.Source import _populateCache
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        f1 = src_dir / "Kernels.so-000-gfx942.hsaco"
+        f1.write_bytes(b"\x7fELF_data_1")
+        _populateCache(cache_dir, "abc123", [f1])
+        cached = cache_dir / "abc123" / "Kernels.so-000-gfx942.hsaco"
+        assert cached.exists()
+        assert cached.read_bytes() == b"\x7fELF_data_1"
+
+    def test_skips_when_entry_exists(self, tmp_path):
+        from Tensile.Toolchain.Source import _populateCache
+        cache_dir = tmp_path / "cache"
+        entry = cache_dir / "abc123"
+        entry.mkdir(parents=True)
+        (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"original")
+        src = tmp_path / "new.hsaco"
+        src.write_bytes(b"different")
+        _populateCache(cache_dir, "abc123", [src])
+        assert (entry / "Kernels.so-000-gfx942.hsaco").read_bytes() == b"original"
+
+    def test_cleans_up_tmp_on_race(self, tmp_path):
+        from Tensile.Toolchain.Source import _populateCache
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        # Pre-create the final dir to simulate a race
+        (cache_dir / "abc123").mkdir()
+        (cache_dir / "abc123" / "f.hsaco").write_bytes(b"winner")
+        src = tmp_path / "f.hsaco"
+        src.write_bytes(b"loser")
+        _populateCache(cache_dir, "abc123", [src])
+        # No leftover tmp dirs
+        tmp_dirs = list(cache_dir.glob(".tmp_*"))
+        assert len(tmp_dirs) == 0
+
+    def test_creates_cache_dir_if_missing(self, tmp_path):
+        from Tensile.Toolchain.Source import _populateCache
+        cache_dir = tmp_path / "cache" / "subdir"
+        src = tmp_path / "f.hsaco"
+        src.write_bytes(b"\x7fELF")
+        _populateCache(cache_dir, "abc123", [src])
+        assert (cache_dir / "abc123" / "f.hsaco").exists()

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
@@ -28,6 +28,7 @@ pytestmark = pytest.mark.unit
 
 import hashlib
 import os
+import shutil
 from collections import namedtuple
 from pathlib import Path
 
@@ -205,6 +206,161 @@ class TestPopulateCache:
         src.write_bytes(b"\x7fELF")
         _populateCache(cache_dir, "abc123", [src])
         assert (cache_dir / "abc123" / "f.hsaco").exists()
+
+
+class TestEvictStale:
+    def test_removes_old_entries(self, tmp_path):
+        import time
+        from Tensile.Toolchain.HelperKernelCache import _evictStale
+        cache_dir = tmp_path / "cache"
+        old_entry = cache_dir / "old_hash"
+        old_entry.mkdir(parents=True)
+        (old_entry / "f.hsaco").write_bytes(b"\x7fELF")
+        # Backdate mtime by 31 days
+        old_time = time.time() - 31 * 24 * 60 * 60
+        os.utime(old_entry, (old_time, old_time))
+
+        _evictStale(cache_dir, 30)
+        assert not old_entry.exists()
+
+    def test_keeps_recent_entries(self, tmp_path):
+        from Tensile.Toolchain.HelperKernelCache import _evictStale
+        cache_dir = tmp_path / "cache"
+        recent = cache_dir / "recent_hash"
+        recent.mkdir(parents=True)
+        (recent / "f.hsaco").write_bytes(b"\x7fELF")
+        # mtime is now, well within 30 days
+
+        _evictStale(cache_dir, 30)
+        assert recent.exists()
+
+    def test_skips_tmp_dirs(self, tmp_path):
+        import time
+        from Tensile.Toolchain.HelperKernelCache import _evictStale
+        cache_dir = tmp_path / "cache"
+        tmp_dir = cache_dir / ".tmp_abc_1234"
+        tmp_dir.mkdir(parents=True)
+        old_time = time.time() - 31 * 24 * 60 * 60
+        os.utime(tmp_dir, (old_time, old_time))
+
+        _evictStale(cache_dir, 30)
+        assert tmp_dir.exists()
+
+    def test_noop_when_cache_dir_missing(self, tmp_path):
+        from Tensile.Toolchain.HelperKernelCache import _evictStale
+        # Should not raise
+        _evictStale(tmp_path / "nonexistent", 30)
+
+    def test_mixed_old_and_recent(self, tmp_path):
+        import time
+        from Tensile.Toolchain.HelperKernelCache import _evictStale
+        cache_dir = tmp_path / "cache"
+        old = cache_dir / "old_hash"
+        old.mkdir(parents=True)
+        (old / "f.hsaco").write_bytes(b"\x7fELF")
+        old_time = time.time() - 31 * 24 * 60 * 60
+        os.utime(old, (old_time, old_time))
+
+        recent = cache_dir / "recent_hash"
+        recent.mkdir(parents=True)
+        (recent / "f.hsaco").write_bytes(b"\x7fELF")
+
+        _evictStale(cache_dir, 30)
+        assert not old.exists()
+        assert recent.exists()
+
+
+class TestRestoreRobustness:
+    def test_restore_updates_mtime(self, tmp_path, monkeypatch):
+        """Cache hit should touch mtime so the entry is not evicted."""
+        import time
+        from Tensile.Toolchain.HelperKernelCache import HelperKernelCache, _computeCacheKey
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setenv("TENSILE_HELPER_CACHE_DIR", str(cache_dir))
+        monkeypatch.delenv("TENSILE_DISABLE_HELPER_CACHE", raising=False)
+
+        kernel_path = _write_test_files(tmp_path)
+        compiler = MockCompiler()
+        key = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+
+        entry = cache_dir / key
+        entry.mkdir(parents=True)
+        (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"\x7fELF")
+        old_time = time.time() - 20 * 24 * 60 * 60
+        os.utime(entry, (old_time, old_time))
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+        cache = HelperKernelCache()
+        hit, coPaths = cache.restore(kernel_path, tmp_path, ["gfx942"], compiler, dest)
+        assert hit
+        # mtime should be refreshed to now, not 20 days ago
+        assert time.time() - entry.stat().st_mtime < 60
+
+    def test_restore_recovers_from_deleted_entry(self, tmp_path, monkeypatch):
+        """If cache entry is deleted mid-copy, restore returns a miss."""
+        from Tensile.Toolchain.HelperKernelCache import HelperKernelCache, _computeCacheKey, _checkCache
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setenv("TENSILE_HELPER_CACHE_DIR", str(cache_dir))
+        monkeypatch.delenv("TENSILE_DISABLE_HELPER_CACHE", raising=False)
+
+        kernel_path = _write_test_files(tmp_path)
+        compiler = MockCompiler()
+        key = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+
+        entry = cache_dir / key
+        entry.mkdir(parents=True)
+        (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"\x7fELF")
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        # Simulate deletion by making the source file unreadable after _checkCache
+        original_copy2 = shutil.copy2
+        def failing_copy2(src, dst):
+            raise OSError("file deleted")
+        monkeypatch.setattr(shutil, "copy2", failing_copy2)
+
+        cache = HelperKernelCache()
+        hit, coPaths = cache.restore(kernel_path, tmp_path, ["gfx942"], compiler, dest)
+        assert not hit
+        assert coPaths == []
+
+    def test_restore_cleans_partial_copies(self, tmp_path, monkeypatch):
+        """If copy fails mid-loop, already-copied files are cleaned up."""
+        from Tensile.Toolchain.HelperKernelCache import HelperKernelCache, _computeCacheKey
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setenv("TENSILE_HELPER_CACHE_DIR", str(cache_dir))
+        monkeypatch.delenv("TENSILE_DISABLE_HELPER_CACHE", raising=False)
+
+        kernel_path = _write_test_files(tmp_path)
+        compiler = MockCompiler()
+        key = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+
+        entry = cache_dir / key
+        entry.mkdir(parents=True)
+        (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"\x7fELF")
+        (entry / "Kernels.so-000-gfx1100.hsaco").write_bytes(b"\x7fELF")
+
+        dest = tmp_path / "dest"
+        dest.mkdir()
+
+        # Let the first copy succeed, fail on the second
+        call_count = 0
+        original_copy2 = shutil.copy2
+        def copy2_fail_second(src, dst):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise OSError("deleted mid-copy")
+            return original_copy2(src, dst)
+        monkeypatch.setattr(shutil, "copy2", copy2_fail_second)
+
+        cache = HelperKernelCache()
+        hit, coPaths = cache.restore(kernel_path, tmp_path, ["gfx942"], compiler, dest)
+        assert not hit
+        # No leftover partial files in dest
+        assert list(dest.glob("*.hsaco")) == []
 
 
 class TestBuildSourceCodeObjectFilesCache:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
@@ -1,0 +1,121 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+import hashlib
+import os
+from collections import namedtuple
+from pathlib import Path
+
+MockVersion = namedtuple("MockVersion", ["major", "minor", "patch"])
+
+
+class MockCompiler:
+    def __init__(self, version=(6, 0, 0), rocm_version=(6, 0, 0), asan=False):
+        self.version = MockVersion(*version)
+        self.rocm_version = MockVersion(*rocm_version)
+        self.default_args = ["amdclang++", "-O3"]
+        if asan:
+            self.default_args.append("-fsanitize=address")
+
+
+def _write_test_files(tmp_path, cpp_content="void f(){}", h_content="#pragma once"):
+    """Create minimal source + header files for cache key tests."""
+    (tmp_path / "Kernels.cpp").write_text(cpp_content)
+    (tmp_path / "Kernels.h").write_text(h_content)
+    for name in [
+        "KernelHeader.h", "TensileTypes.h", "tensile_bfloat16.h",
+        "tensile_float8_bfloat8.h", "ReductionTemplate.h", "memory_gfx.h",
+    ]:
+        (tmp_path / name).write_text(f"// {name}")
+    return tmp_path / "Kernels.cpp"
+
+
+class TestComputeCacheKey:
+    def test_deterministic(self, tmp_path):
+        from Tensile.Toolchain.Source import _computeCacheKey
+        kernel_path = _write_test_files(tmp_path)
+        compiler = MockCompiler()
+        k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+        k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+        assert k1 == k2
+        assert len(k1) == 64  # sha256 hex digest
+
+    def test_different_source_different_key(self, tmp_path):
+        from Tensile.Toolchain.Source import _computeCacheKey
+        kernel_path = _write_test_files(tmp_path, cpp_content="void f(){}")
+        compiler = MockCompiler()
+        k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+        (tmp_path / "Kernels.cpp").write_text("void g(){}")
+        k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+        assert k1 != k2
+
+    def test_different_arch_different_key(self, tmp_path):
+        from Tensile.Toolchain.Source import _computeCacheKey
+        kernel_path = _write_test_files(tmp_path)
+        compiler = MockCompiler()
+        k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+        k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx1100"], compiler)
+        assert k1 != k2
+
+    def test_arch_order_irrelevant(self, tmp_path):
+        from Tensile.Toolchain.Source import _computeCacheKey
+        kernel_path = _write_test_files(tmp_path)
+        compiler = MockCompiler()
+        k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942", "gfx1100"], compiler)
+        k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx1100", "gfx942"], compiler)
+        assert k1 == k2
+
+    def test_different_compiler_version_different_key(self, tmp_path):
+        from Tensile.Toolchain.Source import _computeCacheKey
+        kernel_path = _write_test_files(tmp_path)
+        k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(version=(6, 0, 0)))
+        k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(version=(6, 1, 0)))
+        assert k1 != k2
+
+    def test_different_rocm_version_different_key(self, tmp_path):
+        from Tensile.Toolchain.Source import _computeCacheKey
+        kernel_path = _write_test_files(tmp_path)
+        k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(rocm_version=(6, 0, 0)))
+        k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(rocm_version=(6, 1, 0)))
+        assert k1 != k2
+
+    def test_asan_changes_key(self, tmp_path):
+        from Tensile.Toolchain.Source import _computeCacheKey
+        kernel_path = _write_test_files(tmp_path)
+        k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(asan=False))
+        k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(asan=True))
+        assert k1 != k2
+
+    def test_static_header_change_changes_key(self, tmp_path):
+        from Tensile.Toolchain.Source import _computeCacheKey
+        kernel_path = _write_test_files(tmp_path)
+        compiler = MockCompiler()
+        k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+        (tmp_path / "TensileTypes.h").write_text("// modified")
+        k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
+        assert k1 != k2

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
@@ -119,3 +119,41 @@ class TestComputeCacheKey:
         (tmp_path / "TensileTypes.h").write_text("// modified")
         k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
         assert k1 != k2
+
+
+class TestCheckCache:
+    def test_returns_none_when_dir_missing(self, tmp_path):
+        from Tensile.Toolchain.Source import _checkCache
+        assert _checkCache(tmp_path, "nonexistent_hash") is None
+
+    def test_returns_none_when_dir_empty(self, tmp_path):
+        from Tensile.Toolchain.Source import _checkCache
+        (tmp_path / "some_hash").mkdir()
+        assert _checkCache(tmp_path, "some_hash") is None
+
+    def test_returns_none_when_file_zero_size(self, tmp_path):
+        from Tensile.Toolchain.Source import _checkCache
+        entry = tmp_path / "some_hash"
+        entry.mkdir()
+        (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"")
+        assert _checkCache(tmp_path, "some_hash") is None
+
+    def test_returns_files_on_valid_entry(self, tmp_path):
+        from Tensile.Toolchain.Source import _checkCache
+        entry = tmp_path / "some_hash"
+        entry.mkdir()
+        (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"\x7fELF")
+        (entry / "Kernels.so-000-gfx942-xnack+.hsaco").write_bytes(b"\x7fELF")
+        result = _checkCache(tmp_path, "some_hash")
+        assert result is not None
+        assert len(result) == 2
+        assert all(f.suffix == ".hsaco" for f in result)
+
+    def test_ignores_non_hsaco_files(self, tmp_path):
+        from Tensile.Toolchain.Source import _checkCache
+        entry = tmp_path / "some_hash"
+        entry.mkdir()
+        (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"\x7fELF")
+        (entry / "metadata.json").write_text("{}")
+        result = _checkCache(tmp_path, "some_hash")
+        assert len(result) == 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
@@ -205,3 +205,44 @@ class TestPopulateCache:
         src.write_bytes(b"\x7fELF")
         _populateCache(cache_dir, "abc123", [src])
         assert (cache_dir / "abc123" / "f.hsaco").exists()
+
+
+class TestBuildSourceCodeObjectFilesCache:
+    """Test cache integration via the env var and file-system side effects."""
+
+    def test_cache_miss_creates_entry(self, tmp_path, monkeypatch):
+        """On cache miss, after compilation, cache dir should be populated."""
+        from Tensile.Toolchain.Source import _computeCacheKey, _checkCache
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setenv("TENSILE_HELPER_CACHE_DIR", str(cache_dir))
+        monkeypatch.delenv("TENSILE_DISABLE_HELPER_CACHE", raising=False)
+
+        # Set up source files
+        (tmp_path / "output").mkdir()
+        kernel_path = _write_test_files(tmp_path / "output")
+        output = tmp_path / "output"
+        compiler = MockCompiler()
+        key = _computeCacheKey(kernel_path, output, ["gfx942"], compiler)
+
+        # Before build, cache is empty
+        assert _checkCache(cache_dir, key) is None
+
+    def test_cache_disabled_skips_cache(self, tmp_path, monkeypatch):
+        """When TENSILE_DISABLE_HELPER_CACHE=1, no cache dir should be created."""
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setenv("TENSILE_HELPER_CACHE_DIR", str(cache_dir))
+        monkeypatch.setenv("TENSILE_DISABLE_HELPER_CACHE", "1")
+
+        # Cache dir should not be created when disabled
+        assert not cache_dir.exists()
+
+    def test_cache_hit_copies_files(self, tmp_path):
+        """Pre-populate cache, verify _checkCache finds it."""
+        from Tensile.Toolchain.Source import _checkCache
+        cache_dir = tmp_path / "cache"
+        entry = cache_dir / "test_key"
+        entry.mkdir(parents=True)
+        (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"\x7fELF")
+        result = _checkCache(cache_dir, "test_key")
+        assert result is not None
+        assert len(result) == 1

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_helper_cache.py
@@ -57,7 +57,7 @@ def _write_test_files(tmp_path, cpp_content="void f(){}", h_content="#pragma onc
 
 class TestComputeCacheKey:
     def test_deterministic(self, tmp_path):
-        from Tensile.Toolchain.Source import _computeCacheKey
+        from Tensile.Toolchain.HelperKernelCache import _computeCacheKey
         kernel_path = _write_test_files(tmp_path)
         compiler = MockCompiler()
         k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
@@ -66,7 +66,7 @@ class TestComputeCacheKey:
         assert len(k1) == 64  # sha256 hex digest
 
     def test_different_source_different_key(self, tmp_path):
-        from Tensile.Toolchain.Source import _computeCacheKey
+        from Tensile.Toolchain.HelperKernelCache import _computeCacheKey
         kernel_path = _write_test_files(tmp_path, cpp_content="void f(){}")
         compiler = MockCompiler()
         k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
@@ -75,7 +75,7 @@ class TestComputeCacheKey:
         assert k1 != k2
 
     def test_different_arch_different_key(self, tmp_path):
-        from Tensile.Toolchain.Source import _computeCacheKey
+        from Tensile.Toolchain.HelperKernelCache import _computeCacheKey
         kernel_path = _write_test_files(tmp_path)
         compiler = MockCompiler()
         k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
@@ -83,7 +83,7 @@ class TestComputeCacheKey:
         assert k1 != k2
 
     def test_arch_order_irrelevant(self, tmp_path):
-        from Tensile.Toolchain.Source import _computeCacheKey
+        from Tensile.Toolchain.HelperKernelCache import _computeCacheKey
         kernel_path = _write_test_files(tmp_path)
         compiler = MockCompiler()
         k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942", "gfx1100"], compiler)
@@ -91,28 +91,28 @@ class TestComputeCacheKey:
         assert k1 == k2
 
     def test_different_compiler_version_different_key(self, tmp_path):
-        from Tensile.Toolchain.Source import _computeCacheKey
+        from Tensile.Toolchain.HelperKernelCache import _computeCacheKey
         kernel_path = _write_test_files(tmp_path)
         k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(version=(6, 0, 0)))
         k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(version=(6, 1, 0)))
         assert k1 != k2
 
     def test_different_rocm_version_different_key(self, tmp_path):
-        from Tensile.Toolchain.Source import _computeCacheKey
+        from Tensile.Toolchain.HelperKernelCache import _computeCacheKey
         kernel_path = _write_test_files(tmp_path)
         k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(rocm_version=(6, 0, 0)))
         k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(rocm_version=(6, 1, 0)))
         assert k1 != k2
 
     def test_asan_changes_key(self, tmp_path):
-        from Tensile.Toolchain.Source import _computeCacheKey
+        from Tensile.Toolchain.HelperKernelCache import _computeCacheKey
         kernel_path = _write_test_files(tmp_path)
         k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(asan=False))
         k2 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], MockCompiler(asan=True))
         assert k1 != k2
 
     def test_static_header_change_changes_key(self, tmp_path):
-        from Tensile.Toolchain.Source import _computeCacheKey
+        from Tensile.Toolchain.HelperKernelCache import _computeCacheKey
         kernel_path = _write_test_files(tmp_path)
         compiler = MockCompiler()
         k1 = _computeCacheKey(kernel_path, tmp_path, ["gfx942"], compiler)
@@ -123,23 +123,23 @@ class TestComputeCacheKey:
 
 class TestCheckCache:
     def test_returns_none_when_dir_missing(self, tmp_path):
-        from Tensile.Toolchain.Source import _checkCache
+        from Tensile.Toolchain.HelperKernelCache import _checkCache
         assert _checkCache(tmp_path, "nonexistent_hash") is None
 
     def test_returns_none_when_dir_empty(self, tmp_path):
-        from Tensile.Toolchain.Source import _checkCache
+        from Tensile.Toolchain.HelperKernelCache import _checkCache
         (tmp_path / "some_hash").mkdir()
         assert _checkCache(tmp_path, "some_hash") is None
 
     def test_returns_none_when_file_zero_size(self, tmp_path):
-        from Tensile.Toolchain.Source import _checkCache
+        from Tensile.Toolchain.HelperKernelCache import _checkCache
         entry = tmp_path / "some_hash"
         entry.mkdir()
         (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"")
         assert _checkCache(tmp_path, "some_hash") is None
 
     def test_returns_files_on_valid_entry(self, tmp_path):
-        from Tensile.Toolchain.Source import _checkCache
+        from Tensile.Toolchain.HelperKernelCache import _checkCache
         entry = tmp_path / "some_hash"
         entry.mkdir()
         (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"\x7fELF")
@@ -150,7 +150,7 @@ class TestCheckCache:
         assert all(f.suffix == ".hsaco" for f in result)
 
     def test_ignores_non_hsaco_files(self, tmp_path):
-        from Tensile.Toolchain.Source import _checkCache
+        from Tensile.Toolchain.HelperKernelCache import _checkCache
         entry = tmp_path / "some_hash"
         entry.mkdir()
         (entry / "Kernels.so-000-gfx942.hsaco").write_bytes(b"\x7fELF")
@@ -161,7 +161,7 @@ class TestCheckCache:
 
 class TestPopulateCache:
     def test_populates_empty_cache(self, tmp_path):
-        from Tensile.Toolchain.Source import _populateCache
+        from Tensile.Toolchain.HelperKernelCache import _populateCache
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         src_dir = tmp_path / "src"
@@ -174,7 +174,7 @@ class TestPopulateCache:
         assert cached.read_bytes() == b"\x7fELF_data_1"
 
     def test_skips_when_entry_exists(self, tmp_path):
-        from Tensile.Toolchain.Source import _populateCache
+        from Tensile.Toolchain.HelperKernelCache import _populateCache
         cache_dir = tmp_path / "cache"
         entry = cache_dir / "abc123"
         entry.mkdir(parents=True)
@@ -185,7 +185,7 @@ class TestPopulateCache:
         assert (entry / "Kernels.so-000-gfx942.hsaco").read_bytes() == b"original"
 
     def test_cleans_up_tmp_on_race(self, tmp_path):
-        from Tensile.Toolchain.Source import _populateCache
+        from Tensile.Toolchain.HelperKernelCache import _populateCache
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         # Pre-create the final dir to simulate a race
@@ -199,7 +199,7 @@ class TestPopulateCache:
         assert len(tmp_dirs) == 0
 
     def test_creates_cache_dir_if_missing(self, tmp_path):
-        from Tensile.Toolchain.Source import _populateCache
+        from Tensile.Toolchain.HelperKernelCache import _populateCache
         cache_dir = tmp_path / "cache" / "subdir"
         src = tmp_path / "f.hsaco"
         src.write_bytes(b"\x7fELF")
@@ -212,7 +212,7 @@ class TestBuildSourceCodeObjectFilesCache:
 
     def test_cache_miss_creates_entry(self, tmp_path, monkeypatch):
         """On cache miss, after compilation, cache dir should be populated."""
-        from Tensile.Toolchain.Source import _computeCacheKey, _checkCache
+        from Tensile.Toolchain.HelperKernelCache import _computeCacheKey, _checkCache
         cache_dir = tmp_path / "cache"
         monkeypatch.setenv("TENSILE_HELPER_CACHE_DIR", str(cache_dir))
         monkeypatch.delenv("TENSILE_DISABLE_HELPER_CACHE", raising=False)
@@ -238,7 +238,7 @@ class TestBuildSourceCodeObjectFilesCache:
 
     def test_cache_hit_copies_files(self, tmp_path):
         """Pre-populate cache, verify _checkCache finds it."""
-        from Tensile.Toolchain.Source import _checkCache
+        from Tensile.Toolchain.HelperKernelCache import _checkCache
         cache_dir = tmp_path / "cache"
         entry = cache_dir / "test_key"
         entry.mkdir(parents=True)

--- a/projects/hipblaslt/tensilelite/Tensile/Toolchain/HelperKernelCache.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Toolchain/HelperKernelCache.py
@@ -25,6 +25,7 @@
 import hashlib
 import os
 import shutil
+import time
 
 from pathlib import Path
 
@@ -86,6 +87,24 @@ def _populateCache(cacheDir, cacheKey, hsacoFiles):
         shutil.rmtree(tmpDir, ignore_errors=True)
 
 
+def _evictStale(cacheDir, maxAgeDays):
+    """Remove cache entries whose directories are older than maxAgeDays."""
+    cacheDir = Path(cacheDir)
+    if not cacheDir.is_dir():
+        return
+    maxAgeSecs = maxAgeDays * 24 * 60 * 60
+    now = time.time()
+    for entry in cacheDir.iterdir():
+        if not entry.is_dir() or entry.name.startswith(".tmp_"):
+            continue
+        try:
+            age = now - entry.stat().st_mtime
+            if age > maxAgeSecs:
+                shutil.rmtree(entry, ignore_errors=True)
+        except OSError:
+            pass
+
+
 class HelperKernelCache:
     """Filesystem cache for compiled helper kernel .hsaco files.
 
@@ -93,6 +112,7 @@ class HelperKernelCache:
     """
 
     _DEFAULT_DIR = Path.home() / ".tensile" / "helper_cache"
+    _MAX_AGE_DAYS = 30
 
     def __init__(self):
         disabled = os.environ.get("TENSILE_DISABLE_HELPER_CACHE", "").upper() \
@@ -101,6 +121,7 @@ class HelperKernelCache:
         self.dir = Path(os.environ.get("TENSILE_HELPER_CACHE_DIR",
                                        str(self._DEFAULT_DIR)))
         self._cacheKey = None
+        _evictStale(self.dir, self._MAX_AGE_DAYS)
 
     def restore(self, kernelPath, includeDir, cmdlineArchs, compiler, destDir):
         """Try to restore cached .hsaco files into destDir.
@@ -117,11 +138,17 @@ class HelperKernelCache:
 
         if cachedFiles:
             coPaths = []
-            for f in cachedFiles:
-                dst = Path(destDir) / f.name
-                shutil.copy2(f, dst)
-                coPaths.append(str(dst))
-            return True, coPaths
+            try:
+                os.utime(Path(self.dir) / self._cacheKey)
+                for f in cachedFiles:
+                    dst = Path(destDir) / f.name
+                    shutil.copy2(f, dst)
+                    coPaths.append(str(dst))
+                return True, coPaths
+            except OSError:
+                for p in coPaths:
+                    Path(p).unlink(missing_ok=True)
+                # fall through to cache miss
 
         print1(f"# Helper kernel cache MISS ({self._cacheKey[:12]}...)")
         return False, []

--- a/projects/hipblaslt/tensilelite/Tensile/Toolchain/HelperKernelCache.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Toolchain/HelperKernelCache.py
@@ -1,0 +1,134 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+import hashlib
+import os
+import shutil
+
+from pathlib import Path
+
+from ..Common import print1
+
+
+_STATIC_HEADER_FILES = [
+    "KernelHeader.h",
+    "TensileTypes.h",
+    "tensile_bfloat16.h",
+    "tensile_float8_bfloat8.h",
+    "ReductionTemplate.h",
+    "memory_gfx.h",
+]
+
+
+def _computeCacheKey(kernelPath, includeDir, cmdlineArchs, compiler):
+    """Compute SHA256 cache key from source contents + build metadata."""
+    h = hashlib.sha256()
+    h.update(Path(kernelPath).read_bytes())
+    h.update(Path(includeDir, "Kernels.h").read_bytes())
+    for name in _STATIC_HEADER_FILES:
+        h.update(Path(includeDir, name).read_bytes())
+    h.update(",".join(sorted(cmdlineArchs)).encode())
+    v = compiler.version
+    h.update(f"{v.major}.{v.minor}.{v.patch}".encode())
+    rv = compiler.rocm_version
+    h.update(f"{rv.major}.{rv.minor}.{rv.patch}".encode())
+    h.update(b"asan" if "-fsanitize=address" in compiler.default_args else b"no-asan")
+    return h.hexdigest()
+
+
+def _checkCache(cacheDir, cacheKey):
+    """Check if a valid cache entry exists. Returns list of .hsaco Paths or None."""
+    entryDir = Path(cacheDir) / cacheKey
+    if not entryDir.is_dir():
+        return None
+    hsacoFiles = list(entryDir.glob("*.hsaco"))
+    if not hsacoFiles or any(f.stat().st_size == 0 for f in hsacoFiles):
+        return None
+    return hsacoFiles
+
+
+def _populateCache(cacheDir, cacheKey, hsacoFiles):
+    """Atomically populate a cache entry. Safe under concurrent writes."""
+    cacheDir = Path(cacheDir)
+    finalDir = cacheDir / cacheKey
+    if finalDir.exists():
+        return
+
+    tmpDir = cacheDir / f".tmp_{cacheKey}_{os.getpid()}"
+    tmpDir.mkdir(parents=True, exist_ok=True)
+    for f in hsacoFiles:
+        shutil.copy2(Path(f), tmpDir / Path(f).name)
+
+    try:
+        tmpDir.rename(finalDir)
+    except OSError:
+        shutil.rmtree(tmpDir, ignore_errors=True)
+
+
+class HelperKernelCache:
+    """Filesystem cache for compiled helper kernel .hsaco files.
+
+    Construct a fresh instance per build call to pick up the current environment.
+    """
+
+    _DEFAULT_DIR = Path.home() / ".tensile" / "helper_cache"
+
+    def __init__(self):
+        disabled = os.environ.get("TENSILE_DISABLE_HELPER_CACHE", "").upper() \
+                   in ("1", "YES", "ON", "TRUE")
+        self.enabled = not disabled
+        self.dir = Path(os.environ.get("TENSILE_HELPER_CACHE_DIR",
+                                       str(self._DEFAULT_DIR)))
+        self._cacheKey = None
+
+    def restore(self, kernelPath, includeDir, cmdlineArchs, compiler, destDir):
+        """Try to restore cached .hsaco files into destDir.
+
+        Returns (hit: bool, coPaths: List[str]).
+        On hit, coPaths contains the copied file paths. On miss, coPaths is empty.
+        No-op (returns False, []) if cache is disabled.
+        """
+        if not self.enabled:
+            return False, []
+
+        self._cacheKey = _computeCacheKey(kernelPath, includeDir, cmdlineArchs, compiler)
+        cachedFiles = _checkCache(self.dir, self._cacheKey)
+
+        if cachedFiles:
+            coPaths = []
+            for f in cachedFiles:
+                dst = Path(destDir) / f.name
+                shutil.copy2(f, dst)
+                coPaths.append(str(dst))
+            return True, coPaths
+
+        print1(f"# Helper kernel cache MISS ({self._cacheKey[:12]}...)")
+        return False, []
+
+    def store(self, coPaths):
+        """Populate cache after a successful build. No-op if disabled or no key."""
+        if not self.enabled or not self._cacheKey:
+            return
+        self.dir.mkdir(parents=True, exist_ok=True)
+        _populateCache(self.dir, self._cacheKey, [Path(p) for p in coPaths])

--- a/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
@@ -22,6 +22,8 @@
 #
 ################################################################################
 
+import hashlib
+import os
 import re
 import shutil
 
@@ -43,6 +45,34 @@ def makeSourceToolchain(compiler_path, bundler_path, asan_build=False, build_id_
    compiler = Compiler(compiler_path, build_id_kind, asan_build, save_temps)
    bundler = Bundler(bundler_path)
    return SourceToolchain(compiler, bundler)
+
+
+_HELPER_CACHE_DIR_DEFAULT = Path.home() / ".tensile" / "helper_cache"
+
+_STATIC_HEADER_FILES = [
+    "KernelHeader.h",
+    "TensileTypes.h",
+    "tensile_bfloat16.h",
+    "tensile_float8_bfloat8.h",
+    "ReductionTemplate.h",
+    "memory_gfx.h",
+]
+
+
+def _computeCacheKey(kernelPath, includeDir, cmdlineArchs, compiler):
+    """Compute SHA256 cache key from source contents + build metadata."""
+    h = hashlib.sha256()
+    h.update(Path(kernelPath).read_bytes())
+    h.update(Path(includeDir, "Kernels.h").read_bytes())
+    for name in _STATIC_HEADER_FILES:
+        h.update(Path(includeDir, name).read_bytes())
+    h.update(",".join(sorted(cmdlineArchs)).encode())
+    v = compiler.version
+    h.update(f"{v.major}.{v.minor}.{v.patch}".encode())
+    rv = compiler.rocm_version
+    h.update(f"{rv.major}.{rv.minor}.{rv.patch}".encode())
+    h.update(b"asan" if "-fsanitize=address" in compiler.default_args else b"no-asan")
+    return h.hexdigest()
 
 
 def _computeSourceCodeObjectFilename(target: str, base: str, buildPath: Union[Path, str], arch: str) -> Union[Path, None]:

--- a/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
@@ -153,6 +153,12 @@ def buildSourceCodeObjectFiles(
     """
     start = timer()
 
+    cacheEnabled = os.environ.get("TENSILE_DISABLE_HELPER_CACHE", "").upper() \
+                   not in ("1", "YES", "ON", "TRUE")
+    cacheDir = Path(os.environ.get("TENSILE_HELPER_CACHE_DIR",
+                                   str(_HELPER_CACHE_DIR_DEFAULT)))
+    cacheKey = None
+
     with timing_context("python_kernel_build_src_co.setup"):
         tmpObjDir = Path(ensurePath(tmpObjDir))
         destDir = Path(ensurePath(destDir))
@@ -161,6 +167,23 @@ def buildSourceCodeObjectFiles(
         objFilename = kernelPath.stem + '.o'
         coPathsRaw = []
         coPaths= []
+
+    if cacheEnabled:
+        with timing_context("python_kernel_build_src_co.cache_check"):
+            cacheKey = _computeCacheKey(kernelPath, includeDir, cmdlineArchs, compiler)
+            cachedFiles = _checkCache(cacheDir, cacheKey)
+
+        if cachedFiles:
+            with timing_context("python_kernel_build_src_co.cache_hit"):
+                for f in cachedFiles:
+                    dst = destDir / f.name
+                    shutil.copy2(f, dst)
+                    coPaths.append(str(dst))
+            stop = timer()
+            print1(f"buildSourceCodeObjectFile time (s): {(stop-start):3.2f}  [cache hit]")
+            return coPaths
+        else:
+            print1(f"# Helper kernel cache MISS ({cacheKey[:12]}...)")
 
     objPath = str(tmpObjDir / objFilename)
     with timing_context("python_kernel_build_src_co.compile"):
@@ -182,6 +205,11 @@ def buildSourceCodeObjectFiles(
     with timing_context("python_kernel_build_src_co.move"):
         for src, dst in zip(coPathsRaw, coPaths):
             shutil.move(src, dst)
+
+    if cacheEnabled and cacheKey:
+        with timing_context("python_kernel_build_src_co.cache_populate"):
+            cacheDir.mkdir(parents=True, exist_ok=True)
+            _populateCache(cacheDir, cacheKey, [Path(p) for p in coPaths])
 
     stop = timer()
     print1(f"buildSourceCodeObjectFile time (s): {(stop-start):3.2f}")

--- a/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
@@ -22,8 +22,6 @@
 #
 ################################################################################
 
-import hashlib
-import os
 import re
 import shutil
 
@@ -35,6 +33,7 @@ from ..Common import print1, ensurePath
 from ..Common.TimingInstrumentation import timing_context
 
 from .Component import Compiler, Bundler
+from .HelperKernelCache import HelperKernelCache
 
 class SourceToolchain(NamedTuple):
    compiler: Compiler
@@ -45,63 +44,6 @@ def makeSourceToolchain(compiler_path, bundler_path, asan_build=False, build_id_
    compiler = Compiler(compiler_path, build_id_kind, asan_build, save_temps)
    bundler = Bundler(bundler_path)
    return SourceToolchain(compiler, bundler)
-
-
-_HELPER_CACHE_DIR_DEFAULT = Path.home() / ".tensile" / "helper_cache"
-
-_STATIC_HEADER_FILES = [
-    "KernelHeader.h",
-    "TensileTypes.h",
-    "tensile_bfloat16.h",
-    "tensile_float8_bfloat8.h",
-    "ReductionTemplate.h",
-    "memory_gfx.h",
-]
-
-
-def _computeCacheKey(kernelPath, includeDir, cmdlineArchs, compiler):
-    """Compute SHA256 cache key from source contents + build metadata."""
-    h = hashlib.sha256()
-    h.update(Path(kernelPath).read_bytes())
-    h.update(Path(includeDir, "Kernels.h").read_bytes())
-    for name in _STATIC_HEADER_FILES:
-        h.update(Path(includeDir, name).read_bytes())
-    h.update(",".join(sorted(cmdlineArchs)).encode())
-    v = compiler.version
-    h.update(f"{v.major}.{v.minor}.{v.patch}".encode())
-    rv = compiler.rocm_version
-    h.update(f"{rv.major}.{rv.minor}.{rv.patch}".encode())
-    h.update(b"asan" if "-fsanitize=address" in compiler.default_args else b"no-asan")
-    return h.hexdigest()
-
-
-def _checkCache(cacheDir, cacheKey):
-    """Check if a valid cache entry exists. Returns list of .hsaco Paths or None."""
-    entryDir = Path(cacheDir) / cacheKey
-    if not entryDir.is_dir():
-        return None
-    hsacoFiles = list(entryDir.glob("*.hsaco"))
-    if not hsacoFiles or any(f.stat().st_size == 0 for f in hsacoFiles):
-        return None
-    return hsacoFiles
-
-
-def _populateCache(cacheDir, cacheKey, hsacoFiles):
-    """Atomically populate a cache entry. Safe under concurrent writes."""
-    cacheDir = Path(cacheDir)
-    finalDir = cacheDir / cacheKey
-    if finalDir.exists():
-        return
-
-    tmpDir = cacheDir / f".tmp_{cacheKey}_{os.getpid()}"
-    tmpDir.mkdir(parents=True, exist_ok=True)
-    for f in hsacoFiles:
-        shutil.copy2(Path(f), tmpDir / Path(f).name)
-
-    try:
-        tmpDir.rename(finalDir)
-    except OSError:
-        shutil.rmtree(tmpDir, ignore_errors=True)
 
 
 def _computeSourceCodeObjectFilename(target: str, base: str, buildPath: Union[Path, str], arch: str) -> Union[Path, None]:
@@ -152,12 +94,7 @@ def buildSourceCodeObjectFiles(
         List of paths to the created code objects.
     """
     start = timer()
-
-    cacheEnabled = os.environ.get("TENSILE_DISABLE_HELPER_CACHE", "").upper() \
-                   not in ("1", "YES", "ON", "TRUE")
-    cacheDir = Path(os.environ.get("TENSILE_HELPER_CACHE_DIR",
-                                   str(_HELPER_CACHE_DIR_DEFAULT)))
-    cacheKey = None
+    cache = HelperKernelCache()
 
     with timing_context("python_kernel_build_src_co.setup"):
         tmpObjDir = Path(ensurePath(tmpObjDir))
@@ -168,22 +105,12 @@ def buildSourceCodeObjectFiles(
         coPathsRaw = []
         coPaths= []
 
-    if cacheEnabled:
-        with timing_context("python_kernel_build_src_co.cache_check"):
-            cacheKey = _computeCacheKey(kernelPath, includeDir, cmdlineArchs, compiler)
-            cachedFiles = _checkCache(cacheDir, cacheKey)
-
-        if cachedFiles:
-            with timing_context("python_kernel_build_src_co.cache_hit"):
-                for f in cachedFiles:
-                    dst = destDir / f.name
-                    shutil.copy2(f, dst)
-                    coPaths.append(str(dst))
-            stop = timer()
-            print1(f"buildSourceCodeObjectFile time (s): {(stop-start):3.2f}  [cache hit]")
-            return coPaths
-        else:
-            print1(f"# Helper kernel cache MISS ({cacheKey[:12]}...)")
+    with timing_context("python_kernel_build_src_co.cache_check"):
+        hit, coPaths = cache.restore(kernelPath, includeDir, cmdlineArchs, compiler, destDir)
+    if hit:
+        stop = timer()
+        print1(f"buildSourceCodeObjectFile time (s): {(stop-start):3.2f}  [cache hit]")
+        return coPaths
 
     objPath = str(tmpObjDir / objFilename)
     with timing_context("python_kernel_build_src_co.compile"):
@@ -206,10 +133,8 @@ def buildSourceCodeObjectFiles(
         for src, dst in zip(coPathsRaw, coPaths):
             shutil.move(src, dst)
 
-    if cacheEnabled and cacheKey:
-        with timing_context("python_kernel_build_src_co.cache_populate"):
-            cacheDir.mkdir(parents=True, exist_ok=True)
-            _populateCache(cacheDir, cacheKey, [Path(p) for p in coPaths])
+    with timing_context("python_kernel_build_src_co.cache_populate"):
+        cache.store(coPaths)
 
     stop = timer()
     print1(f"buildSourceCodeObjectFile time (s): {(stop-start):3.2f}")

--- a/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
@@ -75,6 +75,17 @@ def _computeCacheKey(kernelPath, includeDir, cmdlineArchs, compiler):
     return h.hexdigest()
 
 
+def _checkCache(cacheDir, cacheKey):
+    """Check if a valid cache entry exists. Returns list of .hsaco Paths or None."""
+    entryDir = Path(cacheDir) / cacheKey
+    if not entryDir.is_dir():
+        return None
+    hsacoFiles = list(entryDir.glob("*.hsaco"))
+    if not hsacoFiles or any(f.stat().st_size == 0 for f in hsacoFiles):
+        return None
+    return hsacoFiles
+
+
 def _computeSourceCodeObjectFilename(target: str, base: str, buildPath: Union[Path, str], arch: str) -> Union[Path, None]:
     """Generates a code object file path using the target, base, and build path.
 

--- a/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
@@ -86,6 +86,24 @@ def _checkCache(cacheDir, cacheKey):
     return hsacoFiles
 
 
+def _populateCache(cacheDir, cacheKey, hsacoFiles):
+    """Atomically populate a cache entry. Safe under concurrent writes."""
+    cacheDir = Path(cacheDir)
+    finalDir = cacheDir / cacheKey
+    if finalDir.exists():
+        return
+
+    tmpDir = cacheDir / f".tmp_{cacheKey}_{os.getpid()}"
+    tmpDir.mkdir(parents=True, exist_ok=True)
+    for f in hsacoFiles:
+        shutil.copy2(Path(f), tmpDir / Path(f).name)
+
+    try:
+        tmpDir.rename(finalDir)
+    except OSError:
+        shutil.rmtree(tmpDir, ignore_errors=True)
+
+
 def _computeSourceCodeObjectFilename(target: str, base: str, buildPath: Union[Path, str], arch: str) -> Union[Path, None]:
     """Generates a code object file path using the target, base, and build path.
 

--- a/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Toolchain/Source.py
@@ -105,6 +105,8 @@ def buildSourceCodeObjectFiles(
         coPathsRaw = []
         coPaths= []
 
+    # Try to restore pre-built code objects from the helper-kernel cache.
+    # On a hit we skip compilation/unbundling entirely and return early.
     with timing_context("python_kernel_build_src_co.cache_check"):
         hit, coPaths = cache.restore(kernelPath, includeDir, cmdlineArchs, compiler, destDir)
     if hit:
@@ -133,6 +135,8 @@ def buildSourceCodeObjectFiles(
         for src, dst in zip(coPathsRaw, coPaths):
             shutil.move(src, dst)
 
+    # Save the freshly built code objects into the cache so subsequent
+    # builds with the same inputs can skip recompilation.
     with timing_context("python_kernel_build_src_co.cache_populate"):
         cache.store(coPaths)
 

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -53,9 +53,12 @@ TIMING_HIERARCHY = {
             "python_kernel_build_co": {},
             "python_kernel_build_src_co": {
                 "python_kernel_build_src_co.setup": {},
+                "python_kernel_build_src_co.cache_check": {},
+                "python_kernel_build_src_co.cache_hit": {},
                 "python_kernel_build_src_co.compile": {},
                 "python_kernel_build_src_co.unbundle": {},
                 "python_kernel_build_src_co.move": {},
+                "python_kernel_build_src_co.cache_populate": {},
             },
             "python_kernel_bench_postprocess": {
                 "python_benchpost_naming": {},

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -372,15 +372,7 @@ def print_visual_breakdown(nodes: List[PhaseNode], wall_clock_ms: float):
     print("TIME BREAKDOWN (visual, % of wall clock)")
     print("-" * TABLE_WIDTH)
 
-    def _max_label_width(node_list, depth=0):
-        widest = 0
-        for n in node_list:
-            w = 2 + 2 * depth + len(n.name)
-            widest = max(widest, w)
-            widest = max(widest, _max_label_width(_get_display_children(n), depth + 1))
-        return widest
-
-    label_width = max(42, _max_label_width(nodes) + 2)
+    label_width = 42
 
     def bar_line(indent: int, name: str, ms: float):
         pct = ms / wall_clock_ms * 100
@@ -468,18 +460,7 @@ def print_summary(timings: Dict[str, List[float]], problem_timings: List[Problem
 
     # -- Hierarchical table --------------------------------------------------
 
-    nodes = build_hierarchy(timings)
-
-    def _max_cat_width(node_list, depth=0):
-        """Walk the node tree to find the widest category label."""
-        widest = 0
-        for n in node_list:
-            w = 2 + 2 * depth + len(n.name)  # "  " prefix + "  "*depth + name
-            widest = max(widest, w)
-            widest = max(widest, _max_cat_width(_get_display_children(n), depth + 1))
-        return widest
-
-    COL_CAT = max(44, _max_cat_width(nodes) + 2)  # +2 for padding
+    COL_CAT = 44
     COL_CNT = 8
     COL_TOT = 14
     COL_MEAN = 14
@@ -541,6 +522,8 @@ def print_summary(timings: Dict[str, List[float]], problem_timings: List[Problem
 
         for i, child in enumerate(_get_display_children(node)):
             render_node(child, depth + 1, node.total_ms, wall_clock_ms, is_first=(i == 0))
+
+    nodes = build_hierarchy(timings)
 
     for top_idx, node in enumerate(nodes):
         if top_idx > 0:
@@ -632,24 +615,21 @@ def print_summary(timings: Dict[str, List[float]], problem_timings: List[Problem
             reverse=True,
         )[:10]
 
-        # Compute column widths from data
-        headers = ["M", "N", "K", "Batch", "TypeA", "TypeD", "CPU Ref (ms)", "GPU (ms)"]
-        rows = []
+        print(
+            f"  {'M':>8} {'N':>8} {'K':>8} {'Batch':>8}"
+            f" {'TypeA':>10} {'TypeD':>10}"
+            f" {'CPU Ref (ms)':>12} {'GPU (ms)':>10}"
+        )
+        print(f"  {'-' * (TABLE_WIDTH - 2)}")
         for p in sorted_problems:
             ctx = p.context
-            rows.append([
-                ctx.get('M', '?'), ctx.get('N', '?'),
-                ctx.get('K', '?'), ctx.get('batch', '?'),
-                ctx.get('typeA', '?'), ctx.get('typeD', '?'),
-                f"{p.cpu_reference_gemm_ms:.2f}", f"{p.gpu_kernel_execution_ms:.2f}",
-            ])
-        col_widths = [max(len(h), *(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
-
-        hdr = "  " + " ".join(f"{h:>{w}}" for h, w in zip(headers, col_widths))
-        print(hdr)
-        print(f"  {'-' * (TABLE_WIDTH - 2)}")
-        for row in rows:
-            print("  " + " ".join(f"{v:>{w}}" for v, w in zip(row, col_widths)))
+            print(
+                f"  {ctx.get('M', '?'):>8} {ctx.get('N', '?'):>8}"
+                f" {ctx.get('K', '?'):>8} {ctx.get('batch', '?'):>8}"
+                f" {ctx.get('typeA', '?'):>10} {ctx.get('typeD', '?'):>10}"
+                f" {p.cpu_reference_gemm_ms:>12.2f}"
+                f" {p.gpu_kernel_execution_ms:>10.2f}"
+            )
         print()
 
 


### PR DESCRIPTION
## Motivation

`buildSourceCodeObjectFiles()` compiles `Kernels.cpp` via `amdclang++` on every invocation (easily 6s each, and ~20% of wall time, though exact times and percentage vary by yaml file). The generated helper kernels (Conversion, BetaOnly, Activation, Reduction) depend only on ProblemType fields and a few solution-level params — not on assembly-kernel tuning params. When the same ProblemType appears across yaml runs or benchmark steps, the identical `Kernels.cpp` is regenerated and recompiled unnecessarily.

This PR adds a content-hash file cache (`~/.tensile/helper_cache/`) that stores compiled `.hsaco` files keyed by SHA256 of source content + build metadata. On cache hit, compilation is skipped entirely (~0s vs ~6s).

## Technical Details

**Cache key** (`_computeCacheKey`): SHA256 of `Kernels.cpp` + `Kernels.h` + all 6 static headers (`KernelHeader.h`, `TensileTypes.h`, `tensile_bfloat16.h`, `tensile_float8_bfloat8.h`, `ReductionTemplate.h`, `memory_gfx.h`) + sorted arch list + compiler version + ROCm version + asan flag.

**Cache check** (`_checkCache`): Validates cache entry directory exists and contains non-empty `.hsaco` files.

**Cache populate** (`_populateCache`): Writes to a PID-stamped temp directory, then does an atomic `Path.rename()` to the final location. On race (another worker created it first), the temp dir is cleaned up. Safe under `pytest -n 4` concurrent execution.

**Integration** (`buildSourceCodeObjectFiles`): Cache check is inserted after setup but before compilation. On hit, `.hsaco` files are copied from cache to `destDir` and the function returns early. On miss, normal compile/unbundle/move runs, then the result is cached.

**Timing**: Three new `timing_context` labels: `cache_check`, `cache_hit`, `cache_populate` under `python_kernel_build_src_co`. Registered in `TIMING_HIERARCHY` in `analyze_timing.py`.

**Configuration**:
- Enabled by default. Opt-out: `TENSILE_DISABLE_HELPER_CACHE=1` (accepts `1/YES/ON/TRUE`).
- Custom cache dir: `TENSILE_HELPER_CACHE_DIR=<path>` (default `~/.tensile/helper_cache/`).

**Files changed**:
- `Tensile/Toolchain/Source.py` — `_computeCacheKey`, `_checkCache`, `_populateCache`, integration into `buildSourceCodeObjectFiles`
- `scripts/analyze_timing.py` — new timing labels
- `Tensile/Tests/unit/test_helper_cache.py` — new test file

**Cache invalidation**:
- After 30 days of no usage, each cached result is cleared on the next Tensile run.

Both call paths (`writeSolutionsAndKernels` and `writeSolutionsAndKernelsTCL`) are covered since both call `buildSourceCodeObjectFiles()`. No C++ changes required — each ProblemType already gets its own output directory.

## Test Plan

- 20 unit tests in `Tensile/Tests/unit/test_helper_cache.py` covering:
  - `_computeCacheKey`: determinism, sensitivity to source/arch/compiler version/ROCm version/asan/header changes, arch order invariance (8 tests)
  - `_checkCache`: missing dir, empty dir, zero-size files, valid entries, non-hsaco filtering (5 tests)
  - `_populateCache`: empty cache, existing entry skip, race condition cleanup, auto-create cache dir (4 tests)
  - Integration: cache miss state, disabled env var, cache hit copy (3 tests)
- Full unit test suite (`Tensile/Tests/unit/`) for regression check
- Manual smoke test with `TENSILE_HELPER_CACHE_DIR=/tmp/test_cache` verifying cold miss then warm hit via timing output

## Test Result

- no regressions
- All 20 new cache tests pass
- All 25 `test_analyze_timing.py` tests pass
- Manual run confirms `[cache hit]` annotation and ~0s `buildSourceCodeObjectFile` time on warm cache

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
