### PR TITLE
Reject case of WGMXCC and SKXCC being used together

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1255,6 +1255,10 @@ class Solution(collections.abc.Mapping):
     state["LocalWriteUseSgprB"] = False
     state["StoreSwapAddr"] = False
 
+    if state["WorkGroupMappingXCC"] != 0 and state["StreamKXCCMapping"] != 0:
+      reject(state, printRejectionReason, "Cannot use WorkGroupMappingXCC and StreamKXCCMapping together.")
+      return False
+
     if state["WorkGroupMappingXCC"] == -1:
       if state["StreamK"] == 0:
         reject(state, printRejectionReason, "Can only use auto WGMXCC with StreamK.")

--- a/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/projects/hipblaslt/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1255,7 +1255,7 @@ class Solution(collections.abc.Mapping):
     state["LocalWriteUseSgprB"] = False
     state["StoreSwapAddr"] = False
 
-    if state["WorkGroupMappingXCC"] != 0 and state["StreamKXCCMapping"] != 0:
+    if state["WorkGroupMappingXCC"] != 1 and state["StreamKXCCMapping"] != 0:
       reject(state, printRejectionReason, "Cannot use WorkGroupMappingXCC and StreamKXCCMapping together.")
       return False
 


### PR DESCRIPTION
## Motivation

WGMXCC and SKXCC mapping should not be used at the same time.

## Technical Details

These two parameters accomplish the same thing and work is in progress to combine them.

## Test Plan

Waiting on CI tests.
