### PR TITLE
[HipDNN]: Fix missing comma in .clang-tidy and resolve some of the bugprone checks

### DIFF
--- a/projects/hipdnn/.clang-tidy
+++ b/projects/hipdnn/.clang-tidy
@@ -9,8 +9,7 @@
 # readability-math-missing-parentheses
 Checks: >
   -*,
-  bugprone-*
-  misc-*,
+  bugprone-*,
   modernize-*,
   performance-*,
   portability-*,
@@ -32,7 +31,9 @@ Checks: >
   -portability-avoid-pragma-once,
   -modernize-use-scoped-lock,
   -readability-use-concise-preprocessor-directives,
-  -readability-math-missing-parentheses
+  -readability-math-missing-parentheses,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-unchecked-optional-access
 
 WarningsAsErrors: "*"
 HeaderFileExtensions: ['h','hpp']

--- a/projects/hipdnn/backend/src/HipdnnException.hpp
+++ b/projects/hipdnn/backend/src/HipdnnException.hpp
@@ -42,7 +42,7 @@ private:
 #define THROW_IF_NE(x, y, failureStatus, message)                          \
     do                                                                     \
     {                                                                      \
-        if(x != y)                                                         \
+        if((x) != (y))                                                     \
         {                                                                  \
             throw hipdnn_backend::HipdnnException(failureStatus, message); \
         }                                                                  \
@@ -51,7 +51,7 @@ private:
 #define THROW_IF_EQ(x, y, failureStatus, message)                          \
     do                                                                     \
     {                                                                      \
-        if(x == y)                                                         \
+        if((x) == (y))                                                     \
         {                                                                  \
             throw hipdnn_backend::HipdnnException(failureStatus, message); \
         }                                                                  \
@@ -78,7 +78,7 @@ private:
 #define THROW_IF_NULL(x, failureStatus, message)                           \
     do                                                                     \
     {                                                                      \
-        if(x == nullptr)                                                   \
+        if((x) == nullptr)                                                 \
         {                                                                  \
             throw hipdnn_backend::HipdnnException(failureStatus, message); \
         }                                                                  \
@@ -87,7 +87,7 @@ private:
 #define THROW_IF_LT(x, y, failureStatus, message)                          \
     do                                                                     \
     {                                                                      \
-        if(x < y)                                                          \
+        if((x) < (y))                                                      \
         {                                                                  \
             throw hipdnn_backend::HipdnnException(failureStatus, message); \
         }                                                                  \

--- a/projects/hipdnn/backend/src/descriptors/BackendDescriptor.hpp
+++ b/projects/hipdnn/backend/src/descriptors/BackendDescriptor.hpp
@@ -50,12 +50,14 @@ private:
     bool _finalized = false;
     hipdnnBackendDescriptorType_t _type = HIPDNN_INVALID_TYPE;
 
-public:
     HipdnnBackendDescriptorImpl()
         : _type(getStaticType())
     {
     }
 
+    friend T;
+
+public:
     void finalize() override
     {
         _finalized = true;

--- a/projects/hipdnn/backend/src/descriptors/DataTypeConversion.cpp
+++ b/projects/hipdnn/backend/src/descriptors/DataTypeConversion.cpp
@@ -70,21 +70,16 @@ int64_t getDataTypeByteSize(hipdnn_data_sdk::data_objects::DataType type)
     switch(type)
     {
     case DataType::FLOAT:
+    case DataType::INT32:
         return 4;
     case DataType::DOUBLE:
         return 8;
     case DataType::HALF:
-        return 2;
     case DataType::BFLOAT16:
         return 2;
-    case DataType::INT32:
-        return 4;
     case DataType::UINT8:
-        return 1;
     case DataType::INT8:
-        return 1;
     case DataType::FP8_E4M3:
-        return 1;
     case DataType::FP8_E5M2:
         return 1;
     default:

--- a/projects/hipdnn/backend/src/descriptors/EngineHeuristicDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/EngineHeuristicDescriptor.cpp
@@ -235,14 +235,14 @@ void EngineHeuristicDescriptor::getEngineConfigs(hipdnnBackendAttributeType_t at
             engine->setAttribute(HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
                                  HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                  1,
-                                 graphDesc.getPtr());
+                                 static_cast<const void*>(graphDesc.getPtr()));
             engine->finalize();
 
             ScopedDescriptor engineDesc(HipdnnBackendDescriptor::packDescriptor(engine));
             config->setAttribute(HIPDNN_ATTR_ENGINECFG_ENGINE,
                                  HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                  1,
-                                 engineDesc.getPtr());
+                                 static_cast<const void*>(engineDesc.getPtr()));
         }
 
         *elementCount = std::min(requestedElementCount, static_cast<int64_t>(_engineIds.size()));

--- a/projects/hipdnn/backend/src/descriptors/TensorDescriptor.cpp
+++ b/projects/hipdnn/backend/src/descriptors/TensorDescriptor.cpp
@@ -279,15 +279,7 @@ void TensorDescriptor::setTensorValue(hipdnnBackendAttributeType_t attributeType
         break;
     }
     case DataType::UINT8:
-    {
-        _data.value.Set(Float8Value(bytes[0]));
-        break;
-    }
     case DataType::INT8:
-    {
-        _data.value.Set(Float8Value(bytes[0]));
-        break;
-    }
     case DataType::FP8_E4M3:
     case DataType::FP8_E5M2:
     {

--- a/projects/hipdnn/backend/src/plugin/SharedLibrary.cpp
+++ b/projects/hipdnn/backend/src/plugin/SharedLibrary.cpp
@@ -119,7 +119,7 @@ void* SharedLibrary::getSymbol(std::string_view symbolName) const
                                   + std::string(symbolName));
     }
 
-    return platform_utilities::getSymbol(_libraryHandle, symbolName.data());
+    return platform_utilities::getSymbol(_libraryHandle, std::string(symbolName).c_str());
 }
 
 const std::filesystem::path& SharedLibrary::libraryPath() const

--- a/projects/hipdnn/backend/tests/descriptors/DescriptorTestUtils.hpp
+++ b/projects/hipdnn/backend/tests/descriptors/DescriptorTestUtils.hpp
@@ -37,12 +37,18 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
     auto wrapper = createDescriptor<ConvolutionFwdOperationDescriptor>();
     auto desc = wrapper->asDescriptor<ConvolutionFwdOperationDescriptor>();
 
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &xDesc);
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &wDesc);
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &yDesc);
+    desc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(&xDesc));
+    desc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(&wDesc));
+    desc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(&yDesc));
 
     auto padding = hipdnn_tests::toVec(hipdnn_tests::constants::K_CONV_PADDING);
     auto stride = hipdnn_tests::toVec(hipdnn_tests::constants::K_CONV_STRIDE);

--- a/projects/hipdnn/backend/tests/descriptors/TestBackendDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestBackendDescriptor.cpp
@@ -39,7 +39,7 @@ TEST(TestBackendDescriptor, UnpackDescriptorFromArrayWorks)
     auto mockPtr = std::make_shared<MockDescriptor<EngineDescriptor>>();
     ScopedDescriptor packed(HipdnnBackendDescriptor::packDescriptor(mockPtr));
 
-    void* arrayOfElements = &packed.descriptor;
+    void* arrayOfElements = static_cast<void*>(&packed.descriptor);
     auto unpacked = HipdnnBackendDescriptor::unpackDescriptor<MockDescriptor<EngineDescriptor>>(
         arrayOfElements, HIPDNN_STATUS_INTERNAL_ERROR, "fail");
     ASSERT_EQ(unpacked.get(), mockPtr.get());
@@ -49,7 +49,7 @@ TEST(TestBackendDescriptor, PackDescriptorToArrayWorks)
 {
     auto mockPtr = std::make_shared<MockDescriptor<EngineDescriptor>>();
     hipdnnBackendDescriptor_t desc = nullptr;
-    void* arrayOfElements = &desc;
+    void* arrayOfElements = static_cast<void*>(&desc);
     HipdnnBackendDescriptor::packDescriptor(mockPtr, arrayOfElements);
     ScopedDescriptor scoped(desc);
 

--- a/projects/hipdnn/backend/tests/descriptors/TestConvolutionFwdOperationDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestConvolutionFwdOperationDescriptor.cpp
@@ -509,7 +509,7 @@ TEST_F(TestConvolutionFwdOperationDescriptor, GetAttributeTensorDescriptor)
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        1,
                                        &elementCount,
-                                       &retrievedX));
+                                       static_cast<void*>(&retrievedX)));
 
     ASSERT_EQ(elementCount, 1);
     ASSERT_NE(retrievedX, nullptr);

--- a/projects/hipdnn/backend/tests/descriptors/TestConvolutionWrwOperationDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestConvolutionWrwOperationDescriptor.cpp
@@ -503,7 +503,7 @@ TEST_F(TestConvolutionWrwOperationDescriptor, GetAttributeTensorDescriptor)
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        1,
                                        &elementCount,
-                                       &retrievedX));
+                                       static_cast<void*>(&retrievedX)));
 
     ASSERT_EQ(elementCount, 1);
     ASSERT_NE(retrievedX, nullptr);

--- a/projects/hipdnn/backend/tests/descriptors/TestDescriptorAttributeUtils.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestDescriptorAttributeUtils.cpp
@@ -526,8 +526,12 @@ TEST(TestDescriptorAttributeUtils, SetTensorDescriptorSuccess)
     auto wrapper = test_utilities::createFinalizedTensor(42);
     const auto* ptr = wrapper.get();
 
-    ASSERT_NO_THROW(setTensorDescriptor(
-        descTarget, uidTarget, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &ptr, "test"));
+    ASSERT_NO_THROW(setTensorDescriptor(descTarget,
+                                        uidTarget,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        static_cast<const void*>(&ptr),
+                                        "test"));
     ASSERT_NE(descTarget, nullptr);
     ASSERT_EQ(uidTarget, 42);
 }
@@ -554,8 +558,8 @@ TEST(TestDescriptorAttributeUtils, GetTensorDescriptorQueryReturnsOneOnZeroReque
     int64_t count = 0;
     HipdnnBackendDescriptor* output = nullptr;
 
-    ASSERT_NO_THROW(
-        getTensorDescriptor(source, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, &output, "test"));
+    ASSERT_NO_THROW(getTensorDescriptor(
+        source, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 0, &count, static_cast<void*>(&output), "test"));
     ASSERT_EQ(count, 1);
 }
 
@@ -604,8 +608,8 @@ TEST(TestDescriptorAttributeUtils, GetTensorDescriptorSuccess)
     int64_t count = 0;
     HipdnnBackendDescriptor* output = nullptr;
 
-    ASSERT_NO_THROW(
-        getTensorDescriptor(source, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &count, &output, "test"));
+    ASSERT_NO_THROW(getTensorDescriptor(
+        source, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &count, static_cast<void*>(&output), "test"));
     ASSERT_EQ(count, 1);
     ASSERT_NE(output, nullptr);
 }

--- a/projects/hipdnn/backend/tests/descriptors/TestEngineConfigDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestEngineConfigDescriptor.cpp
@@ -225,13 +225,19 @@ TEST_F(TestEngineConfigDescriptor, GetEngineConfigDescriptorEngine)
             HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, nullptr),
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    ASSERT_NO_THROW(engineConfig->getAttribute(
-        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, nullptr, engine.getPtr()));
+    ASSERT_NO_THROW(engineConfig->getAttribute(HIPDNN_ATTR_ENGINECFG_ENGINE,
+                                               HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                               1,
+                                               nullptr,
+                                               static_cast<void*>(engine.getPtr())));
     ASSERT_EQ(*engine.get(), *(_mockEngineWrapper.get()));
 
     int64_t count;
-    ASSERT_NO_THROW(engineConfig->getAttribute(
-        HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &count, engine2.getPtr()));
+    ASSERT_NO_THROW(engineConfig->getAttribute(HIPDNN_ATTR_ENGINECFG_ENGINE,
+                                               HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                               1,
+                                               &count,
+                                               static_cast<void*>(engine2.getPtr())));
     ASSERT_EQ(count, 1);
 }
 

--- a/projects/hipdnn/backend/tests/descriptors/TestEngineDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestEngineDescriptor.cpp
@@ -279,7 +279,7 @@ TEST_F(TestEngineDescriptor, GetEngineDescriptorGraph)
                                          HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                          1,
                                          nullptr,
-                                         graph.getPtr()));
+                                         static_cast<void*>(graph.getPtr())));
     ASSERT_EQ(*graph.get(), *(_mockGraphWrapper.get()));
 
     int64_t count;
@@ -287,7 +287,7 @@ TEST_F(TestEngineDescriptor, GetEngineDescriptorGraph)
                                          HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                          1,
                                          &count,
-                                         graph2.getPtr()));
+                                         static_cast<void*>(graph2.getPtr())));
     ASSERT_EQ(count, 1);
 }
 

--- a/projects/hipdnn/backend/tests/descriptors/TestEngineHeuristicDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestEngineHeuristicDescriptor.cpp
@@ -321,7 +321,7 @@ TEST_F(TestEngineHeuristicDescriptor, GetEngineHeuristicDescriptorGraph)
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        1,
                                        nullptr,
-                                       graph.getPtr()));
+                                       static_cast<void*>(graph.getPtr())));
     ASSERT_EQ(*graph.get(), *(_mockGraphWrapper.get()));
 
     int64_t count;
@@ -329,7 +329,7 @@ TEST_F(TestEngineHeuristicDescriptor, GetEngineHeuristicDescriptorGraph)
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        1,
                                        &count,
-                                       graph2.getPtr()));
+                                       static_cast<void*>(graph2.getPtr())));
     ASSERT_EQ(count, 1);
 }
 
@@ -375,8 +375,11 @@ TEST_F(TestEngineHeuristicDescriptor, GetEngineHeuristicDescriptorEngineConfigs)
                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     count = 0;
-    ASSERT_NO_THROW(heur->getAttribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
+    ASSERT_NO_THROW(heur->getAttribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       3,
+                                       &count,
+                                       static_cast<void*>(configs.data())));
     ASSERT_EQ(count, 3);
 
     for(auto config : configs)
@@ -389,8 +392,11 @@ TEST_F(TestEngineHeuristicDescriptor, GetEngineHeuristicDescriptorEngineConfigs)
     ScopedDescriptor singleConfig(createDescriptorPtr<EngineConfigDescriptor>());
 
     count = 0;
-    ASSERT_NO_THROW(heur->getAttribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &count, &singleConfig));
+    ASSERT_NO_THROW(heur->getAttribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       1,
+                                       &count,
+                                       static_cast<void*>(&singleConfig)));
     ASSERT_EQ(count, 1);
 }
 
@@ -446,8 +452,11 @@ TEST_F(TestEngineHeuristicDescriptor, GetEngineConfigsWithNoEngineIds)
     }
 
     int64_t count = 0;
-    ASSERT_NO_THROW(heur->getAttribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 3, &count, configs.data()));
+    ASSERT_NO_THROW(heur->getAttribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       3,
+                                       &count,
+                                       static_cast<void*>(configs.data())));
     ASSERT_EQ(count, 0);
 
     for(auto config : configs)
@@ -477,8 +486,11 @@ TEST_F(TestEngineHeuristicDescriptor, GetEngineConfigsRequestMoreThanAvailable)
     }
 
     int64_t count = 0;
-    ASSERT_NO_THROW(heur->getAttribute(
-        HIPDNN_ATTR_ENGINEHEUR_RESULTS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 5, &count, configs.data()));
+    ASSERT_NO_THROW(heur->getAttribute(HIPDNN_ATTR_ENGINEHEUR_RESULTS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       5,
+                                       &count,
+                                       static_cast<void*>(configs.data())));
     ASSERT_EQ(count, 3);
 
     for(auto config : configs)

--- a/projects/hipdnn/backend/tests/descriptors/TestExecutionPlanDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestExecutionPlanDescriptor.cpp
@@ -176,7 +176,10 @@ TEST_F(TestExecutionPlanDescriptor, SetHandle)
         HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-    plan->setAttribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+    plan->setAttribute(HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                       HIPDNN_TYPE_HANDLE,
+                       1,
+                       static_cast<const void*>(&handle));
 }
 
 TEST_F(TestExecutionPlanDescriptor, SetEngineConfig)
@@ -289,7 +292,7 @@ TEST_F(TestExecutionPlanDescriptor, GetEngineConfig)
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        1,
                                        &count,
-                                       returnedEngineConfig.getPtr()));
+                                       static_cast<void*>(returnedEngineConfig.getPtr())));
 
     ASSERT_EQ(count, 1);
     ASSERT_EQ(*returnedEngineConfig.get(), *(_mockEngineConfigWrapper.get()));
@@ -298,7 +301,7 @@ TEST_F(TestExecutionPlanDescriptor, GetEngineConfig)
                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                        1,
                                        nullptr,
-                                       nullCountEngineConfig.getPtr()));
+                                       static_cast<void*>(nullCountEngineConfig.getPtr())));
 
     ASSERT_EQ(*nullCountEngineConfig.get(), *(_mockEngineConfigWrapper.get()));
 }
@@ -308,7 +311,7 @@ TEST_F(TestExecutionPlanDescriptor, GetEngineConfigErrors)
     auto plan = getExecutionPlanDescriptor();
     hipdnnBackendDescriptor_t returnedEngineConfig = nullptr;
     int64_t count = 0;
-    void* dummy = &returnedEngineConfig;
+    void* dummy = static_cast<void*>(&returnedEngineConfig);
 
     makeExecutionPlanFinalized();
 

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptor.cpp
@@ -42,7 +42,10 @@ TEST_F(TestGraphDescriptor, SerializeDeserializeGraph)
     descriptor.deserializeGraph(serializedGraph.data(), serializedGraph.size());
 
     auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-    descriptor.setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+    descriptor.setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                            HIPDNN_TYPE_HANDLE,
+                            1,
+                            static_cast<const void*>(&handle));
     descriptor.finalize();
 
     auto output = descriptor.getSerializedGraph();
@@ -61,8 +64,10 @@ TEST_F(TestGraphDescriptor, WillCorrectlySetGraph)
     ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
 
     auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-    ASSERT_NO_THROW(
-        descriptor.setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+    ASSERT_NO_THROW(descriptor.setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                            HIPDNN_TYPE_HANDLE,
+                                            1,
+                                            static_cast<const void*>(&handle)));
     ASSERT_NO_THROW(descriptor.finalize());
 }
 
@@ -73,8 +78,10 @@ TEST_F(TestGraphDescriptor, WillCorrectlySetGraphReverseOrder)
 
     GraphDescriptor descriptor;
     auto handle = reinterpret_cast<hipdnnHandle_t>(0x12345678);
-    ASSERT_NO_THROW(
-        descriptor.setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+    ASSERT_NO_THROW(descriptor.setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                            HIPDNN_TYPE_HANDLE,
+                                            1,
+                                            static_cast<const void*>(&handle)));
 
     ASSERT_THROW_HIPDNN_STATUS(descriptor.finalize(), HIPDNN_STATUS_BAD_PARAM);
 

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorConvolutionWrw.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorConvolutionWrw.cpp
@@ -44,15 +44,15 @@ inline std::unique_ptr<HipdnnBackendDescriptor>
     desc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_BACKWARD_FILTER_X,
                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                        1,
-                       &xDesc);
+                       static_cast<const void*>(&xDesc));
     desc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_BACKWARD_FILTER_DY,
                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                        1,
-                       &dyDesc);
+                       static_cast<const void*>(&dyDesc));
     desc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_BACKWARD_FILTER_DW,
                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                        1,
-                       &dwDesc);
+                       static_cast<const void*>(&dwDesc));
 
     std::vector<int64_t> prePadding = {1, 1};
     desc->setAttribute(
@@ -89,7 +89,10 @@ public:
     {
         auto desc = getDescriptor();
         hipdnnHandle_t handle = &_mockHandle;
-        desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+        desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                           HIPDNN_TYPE_HANDLE,
+                           1,
+                           static_cast<const void*>(&handle));
     }
 
 protected:
@@ -118,8 +121,10 @@ TEST_F(TestGraphDescriptorConvolutionWrw, BuildFromSingleOperation)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {opDesc.get()};
-    ASSERT_NO_THROW(desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()));
+    ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       1,
+                                       static_cast<const void*>(ops.data())));
     ASSERT_NO_THROW(desc->finalize());
 
     // Verify the built graph
@@ -160,8 +165,10 @@ TEST_F(TestGraphDescriptorConvolutionWrw, ComputeDataTypePreserved)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {opDesc.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     auto serialized = desc->getSerializedGraph();

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorOps.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorOps.cpp
@@ -145,7 +145,10 @@ public:
     {
         auto desc = getDescriptor();
         hipdnnHandle_t handle = &_mockHandle;
-        desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+        desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                           HIPDNN_TYPE_HANDLE,
+                           1,
+                           static_cast<const void*>(&handle));
     }
 
 protected:
@@ -175,8 +178,10 @@ TEST_F(TestGraphDescriptorOps, BuildFromSingleOperation)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    ASSERT_NO_THROW(desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()));
+    ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       1,
+                                       static_cast<const void*>(ops.data())));
     ASSERT_NO_THROW(desc->finalize());
 
     // Verify the built graph
@@ -240,8 +245,10 @@ TEST_F(TestGraphDescriptorOps, BuildFromMultipleOperations)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 2> ops = {conv1.convOp.get(), convOp2.get()};
-    ASSERT_NO_THROW(desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, ops.data()));
+    ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       2,
+                                       static_cast<const void*>(ops.data())));
     ASSERT_NO_THROW(desc->finalize());
 
     auto serialized = desc->getSerializedGraph();
@@ -325,8 +332,10 @@ TEST_F(TestGraphDescriptorOps, TensorDeduplication)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 2> ops = {conv1.convOp.get(), convOp2.get()};
-    ASSERT_NO_THROW(desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, ops.data()));
+    ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       2,
+                                       static_cast<const void*>(ops.data())));
     ASSERT_NO_THROW(desc->finalize());
 
     auto serialized = desc->getSerializedGraph();
@@ -403,8 +412,10 @@ TEST_F(TestGraphDescriptorOps, ComputeDataTypePreserved)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     auto serialized = desc->getSerializedGraph();
@@ -455,12 +466,18 @@ TEST_F(TestGraphDescriptorOps, ConvolutionAttributesPreserved)
     HipdnnBackendDescriptor* w = conv.wDesc.get();
     HipdnnBackendDescriptor* y = conv.yDesc.get();
 
-    convDesc->setAttribute(
-        HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &x);
-    convDesc->setAttribute(
-        HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &w);
-    convDesc->setAttribute(
-        HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &y);
+    convDesc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X,
+                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                           1,
+                           static_cast<const void*>(&x));
+    convDesc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W,
+                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                           1,
+                           static_cast<const void*>(&w));
+    convDesc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y,
+                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                           1,
+                           static_cast<const void*>(&y));
 
     const std::vector<int64_t> kCustomPrePadding = {2, 3};
     const std::vector<int64_t> kCustomPostPadding = {4, 5};
@@ -488,8 +505,10 @@ TEST_F(TestGraphDescriptorOps, ConvolutionAttributesPreserved)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {wrapper.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     auto serialized = desc->getSerializedGraph();
@@ -542,12 +561,16 @@ TEST_F(TestGraphDescriptorOps, SetOperationsAndHandleAnyOrder)
         auto conv = createDefaultConvOp();
 
         std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-        ASSERT_NO_THROW(desc->setAttribute(
-            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()));
+        ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                           1,
+                                           static_cast<const void*>(ops.data())));
 
         hipdnnHandle_t handle = &_mockHandle;
-        ASSERT_NO_THROW(
-            desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+        ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                           HIPDNN_TYPE_HANDLE,
+                                           1,
+                                           static_cast<const void*>(&handle)));
 
         ASSERT_NO_THROW(desc->finalize());
 
@@ -595,12 +618,16 @@ TEST_F(TestGraphDescriptorOps, SetOperationsAndHandleAnyOrder)
         auto convOp = createFinalizedConvOp(xDesc.get(), wDesc.get(), yDesc.get());
 
         hipdnnHandle_t handle = &_mockHandle;
-        ASSERT_NO_THROW(
-            desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle));
+        ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                           HIPDNN_TYPE_HANDLE,
+                                           1,
+                                           static_cast<const void*>(&handle)));
 
         std::array<HipdnnBackendDescriptor*, 1> ops = {convOp.get()};
-        ASSERT_NO_THROW(desc->setAttribute(
-            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()));
+        ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                           HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                           1,
+                                           static_cast<const void*>(ops.data())));
 
         ASSERT_NO_THROW(desc->finalize());
 
@@ -653,8 +680,10 @@ TEST_F(TestGraphDescriptorOps, SetOperationsMultipleBatches)
 
     // Set multiple operations in a single setAttribute call
     std::array<HipdnnBackendDescriptor*, 2> ops = {conv1.convOp.get(), convOp2.get()};
-    ASSERT_NO_THROW(desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, ops.data()));
+    ASSERT_NO_THROW(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                       2,
+                                       static_cast<const void*>(ops.data())));
 
     ASSERT_NO_THROW(desc->finalize());
 
@@ -733,10 +762,11 @@ TEST_F(TestGraphDescriptorOps, SetOperationsFailsUnfinalized)
     auto unfinalizedOp = createDescriptor<ConvolutionFwdOperationDescriptor>();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {unfinalizedOp.get()};
-    ASSERT_THROW_HIPDNN_STATUS(
-        desc->setAttribute(
-            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()),
-        HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
+    ASSERT_THROW_HIPDNN_STATUS(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                                  HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                  1,
+                                                  static_cast<const void*>(ops.data())),
+                               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
 }
 
 TEST_F(TestGraphDescriptorOps, SetOperationsFailsNullDescriptor)
@@ -744,10 +774,11 @@ TEST_F(TestGraphDescriptorOps, SetOperationsFailsNullDescriptor)
     auto desc = getDescriptor();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {nullptr};
-    ASSERT_THROW_HIPDNN_STATUS(
-        desc->setAttribute(
-            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()),
-        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                                  HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                  1,
+                                                  static_cast<const void*>(ops.data())),
+                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
 TEST_F(TestGraphDescriptorOps, SetOperationsFailsWrongType)
@@ -758,10 +789,11 @@ TEST_F(TestGraphDescriptorOps, SetOperationsFailsWrongType)
     auto tensorDesc = createFinalizedTensor(K_TENSOR_X_UID);
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {tensorDesc.get()};
-    ASSERT_THROW_HIPDNN_STATUS(
-        desc->setAttribute(
-            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()),
-        HIPDNN_STATUS_NOT_SUPPORTED);
+    ASSERT_THROW_HIPDNN_STATUS(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                                  HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                  1,
+                                                  static_cast<const void*>(ops.data())),
+                               HIPDNN_STATUS_NOT_SUPPORTED);
 }
 
 TEST_F(TestGraphDescriptorOps, SetOperationsFailsAfterFinalize)
@@ -772,15 +804,18 @@ TEST_F(TestGraphDescriptorOps, SetOperationsFailsAfterFinalize)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     // Try to set operations after finalize
-    ASSERT_THROW_HIPDNN_STATUS(
-        desc->setAttribute(
-            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data()),
-        HIPDNN_STATUS_NOT_INITIALIZED);
+    ASSERT_THROW_HIPDNN_STATUS(desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                                  HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                  1,
+                                                  static_cast<const void*>(ops.data())),
+                               HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
 TEST_F(TestGraphDescriptorOps, FinalizeFailsWithoutHandle)
@@ -791,8 +826,10 @@ TEST_F(TestGraphDescriptorOps, FinalizeFailsWithoutHandle)
     // Don't set handle
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
 
     ASSERT_THROW_HIPDNN_STATUS(desc->finalize(), HIPDNN_STATUS_BAD_PARAM);
 }
@@ -818,8 +855,10 @@ TEST_F(TestGraphDescriptorOps, SerializedGraphVerifiable)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     auto serialized = desc->getSerializedGraph();
@@ -851,8 +890,10 @@ TEST_F(TestGraphDescriptorOps, SerializedGraphUnpackable)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     auto serialized = desc->getSerializedGraph();
@@ -902,8 +943,10 @@ TEST_F(TestGraphDescriptorOps, GetSerializedGraphMultipleCalls)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     // Call getSerializedGraph multiple times
@@ -949,8 +992,10 @@ TEST_F(TestGraphDescriptorOps, GraphHasCorrectNodeCount)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     auto serialized = desc->getSerializedGraph();
@@ -979,8 +1024,10 @@ TEST_F(TestGraphDescriptorOps, GraphHasCorrectTensorCount)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
     desc->finalize();
 
     auto serialized = desc->getSerializedGraph();
@@ -1106,12 +1153,18 @@ public:
         HipdnnBackendDescriptor* w = wDesc.get();
         HipdnnBackendDescriptor* y = yDesc.get();
 
-        convDesc->setAttribute(
-            HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &x);
-        convDesc->setAttribute(
-            HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &w);
-        convDesc->setAttribute(
-            HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &y);
+        convDesc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X,
+                               HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                               1,
+                               static_cast<const void*>(&x));
+        convDesc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W,
+                               HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                               1,
+                               static_cast<const void*>(&w));
+        convDesc->setAttribute(HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y,
+                               HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                               1,
+                               static_cast<const void*>(&y));
         convDesc->setAttribute(HIPDNN_ATTR_CONVOLUTION_PRE_PADDINGS,
                                HIPDNN_TYPE_INT64,
                                static_cast<int64_t>(prePadding.size()),
@@ -1140,11 +1193,16 @@ public:
         auto graphDesc = graphWrapper->asDescriptor<GraphDescriptor>();
 
         hipdnnHandle_t handle = &_mockHandle;
-        graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+        graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                HIPDNN_TYPE_HANDLE,
+                                1,
+                                static_cast<const void*>(&handle));
 
         std::array<HipdnnBackendDescriptor*, 1> ops = {convWrapper.get()};
-        graphDesc->setAttribute(
-            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+        graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                1,
+                                static_cast<const void*>(ops.data()));
         graphDesc->finalize();
 
         auto serialized = graphDesc->getSerializedGraph();
@@ -1331,8 +1389,10 @@ TEST_F(TestGraphDescriptorOps, GraphLevelDataTypesPreserved)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
 
     // Set graph-level data types before finalize
     auto computeDt = HIPDNN_DATA_HALF;
@@ -1367,8 +1427,10 @@ TEST_F(TestGraphDescriptorOps, PreferredEngineIdPreserved)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
 
     int64_t engineId = 42;
     desc->setAttribute(
@@ -1390,8 +1452,10 @@ TEST_F(TestGraphDescriptorOps, GraphLevelDataTypesDefaultToUnset)
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 1> ops = {conv.convOp.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       1,
+                       static_cast<const void*>(ops.data()));
 
     // Finalize without setting any graph-level data types
     desc->finalize();
@@ -1411,7 +1475,10 @@ TEST_F(TestGraphDescriptorOps, SharedTensorDifferentPositions)
     auto graphDesc = graphWrapper->asDescriptor<GraphDescriptor>();
 
     auto handle = reinterpret_cast<hipdnnHandle_t>(&_mockHandle);
-    graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+    graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                            HIPDNN_TYPE_HANDLE,
+                            1,
+                            static_cast<const void*>(&handle));
 
     // Create tensors (Y tensor shared between ops)
     auto xDesc1 = createFinalizedTensor(K_TENSOR_X_UID);
@@ -1430,8 +1497,10 @@ TEST_F(TestGraphDescriptorOps, SharedTensorDifferentPositions)
     auto op2 = createFinalizedConvOp(sharedTensor.get(), wDesc2.get(), yDesc2.get());
 
     std::array<HipdnnBackendDescriptor*, 2> opDescs = {op1.get(), op2.get()};
-    graphDesc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, opDescs.data());
+    graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                            HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                            2,
+                            static_cast<const void*>(opDescs.data()));
 
     graphDesc->finalize();
 
@@ -1518,8 +1587,10 @@ TEST_F(TestGraphDescriptorOps, FinalizeFailsDuplicateTensorUidDifferentDescripto
     setHandle();
 
     std::array<HipdnnBackendDescriptor*, 2> ops = {op1.get(), op2.get()};
-    desc->setAttribute(
-        HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 2, ops.data());
+    desc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                       2,
+                       static_cast<const void*>(ops.data()));
 
     ASSERT_THROW_HIPDNN_STATUS(desc->finalize(), HIPDNN_STATUS_BAD_PARAM);
 }
@@ -1531,15 +1602,19 @@ TEST_F(TestGraphDescriptorOps, SetOperationsRejectsNonOperationDescriptor)
 
     // Set handle first
     auto handle = reinterpret_cast<hipdnnHandle_t>(&_mockHandle);
-    graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+    graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                            HIPDNN_TYPE_HANDLE,
+                            1,
+                            static_cast<const void*>(&handle));
 
     // Create a tensor descriptor (does NOT implement IGraphOperation)
     auto tensorWrapper = createFinalizedTensor(99);
     HipdnnBackendDescriptor* tensorDescPtr = tensorWrapper.get();
 
     // Attempting to set a non-operation descriptor as an operation should throw
-    ASSERT_THROW_HIPDNN_STATUS(
-        graphDesc->setAttribute(
-            HIPDNN_ATTR_OPERATIONGRAPH_OPS, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &tensorDescPtr),
-        HIPDNN_STATUS_NOT_SUPPORTED);
+    ASSERT_THROW_HIPDNN_STATUS(graphDesc->setAttribute(HIPDNN_ATTR_OPERATIONGRAPH_OPS,
+                                                       HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                       1,
+                                                       static_cast<const void*>(&tensorDescPtr)),
+                               HIPDNN_STATUS_NOT_SUPPORTED);
 }

--- a/projects/hipdnn/backend/tests/descriptors/TestVariantPackDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestVariantPackDescriptor.cpp
@@ -31,13 +31,17 @@ TEST_F(TestVariantPackDescriptorWhenInitialized, ValidSetAttributes)
     _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                              HIPDNN_TYPE_VOID_PTR,
                              devPtrs.size(),
-                             devPtrs.data());
+                             static_cast<const void*>(devPtrs.data()));
 
-    _descriptor.setAttribute(
-        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
+    _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+                             HIPDNN_TYPE_INT64,
+                             uids.size(),
+                             static_cast<const void*>(uids.data()));
 
-    _descriptor.setAttribute(
-        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
+    _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                             HIPDNN_TYPE_VOID_PTR,
+                             1,
+                             static_cast<const void*>(&workspace));
 
     ASSERT_NO_THROW(_descriptor.finalize());
     EXPECT_TRUE(_descriptor.isFinalized());
@@ -54,23 +58,28 @@ TEST_F(TestVariantPackDescriptorWhenInitialized, ValidSetAndGetBeforeFinalAttrib
     _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                              HIPDNN_TYPE_VOID_PTR,
                              devPtrs.size(),
-                             devPtrs.data());
+                             static_cast<const void*>(devPtrs.data()));
 
-    _descriptor.setAttribute(
-        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
+    _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+                             HIPDNN_TYPE_INT64,
+                             uids.size(),
+                             static_cast<const void*>(uids.data()));
 
-    _descriptor.setAttribute(
-        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
+    _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                             HIPDNN_TYPE_VOID_PTR,
+                             1,
+                             static_cast<const void*>(&workspace));
     // getting before finalized
     std::array<void*, 3> retrievedDevPtrs;
     int64_t elementCount = 0;
 
-    ASSERT_THROW_HIPDNN_STATUS(_descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        retrievedDevPtrs.size(),
-                                                        &elementCount,
-                                                        retrievedDevPtrs.data()),
-                               HIPDNN_STATUS_NOT_INITIALIZED);
+    ASSERT_THROW_HIPDNN_STATUS(
+        _descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                 HIPDNN_TYPE_VOID_PTR,
+                                 retrievedDevPtrs.size(),
+                                 &elementCount,
+                                 static_cast<void*>(retrievedDevPtrs.data())),
+        HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
 TEST_F(TestVariantPackDescriptorWhenInitialized, InvalidSetAttributes)
@@ -114,13 +123,17 @@ TEST_F(TestVariantPackDescriptorWhenInitialized, InvalidFinalizeCounts)
     _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                              HIPDNN_TYPE_VOID_PTR,
                              devPtrs.size(),
-                             devPtrs.data());
+                             static_cast<const void*>(devPtrs.data()));
 
-    _descriptor.setAttribute(
-        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, uids.size(), uids.data());
+    _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+                             HIPDNN_TYPE_INT64,
+                             uids.size(),
+                             static_cast<const void*>(uids.data()));
 
-    _descriptor.setAttribute(
-        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace);
+    _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                             HIPDNN_TYPE_VOID_PTR,
+                             1,
+                             static_cast<const void*>(&workspace));
 
     ASSERT_THROW(_descriptor.finalize(), HipdnnException);
     EXPECT_FALSE(_descriptor.isFinalized());
@@ -137,12 +150,13 @@ TEST_F(TestVariantPackDescriptorWhenInitialized, InvalidGetAttributeNotFinalized
     std::array<void*, 3> retrievedDevPtrs;
     int64_t elementCount = 0;
 
-    ASSERT_THROW_HIPDNN_STATUS(_descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        retrievedDevPtrs.size(),
-                                                        &elementCount,
-                                                        retrievedDevPtrs.data()),
-                               HIPDNN_STATUS_NOT_INITIALIZED);
+    ASSERT_THROW_HIPDNN_STATUS(
+        _descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                 HIPDNN_TYPE_VOID_PTR,
+                                 retrievedDevPtrs.size(),
+                                 &elementCount,
+                                 static_cast<void*>(retrievedDevPtrs.data())),
+        HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
 class TestVariantPackDescriptorWhenFinalized : public ::testing::Test
@@ -160,15 +174,17 @@ protected:
         _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                  HIPDNN_TYPE_VOID_PTR,
                                  static_cast<int64_t>(_devPtrs.size()),
-                                 _devPtrs.data());
+                                 static_cast<const void*>(_devPtrs.data()));
 
         _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                  HIPDNN_TYPE_INT64,
                                  static_cast<int64_t>(_uids.size()),
-                                 _uids.data());
+                                 static_cast<const void*>(_uids.data()));
 
-        _descriptor.setAttribute(
-            HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &_workspace);
+        _descriptor.setAttribute(HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                                 HIPDNN_TYPE_VOID_PTR,
+                                 1,
+                                 static_cast<const void*>(&_workspace));
 
         ASSERT_NO_THROW(_descriptor.finalize());
         EXPECT_TRUE(_descriptor.isFinalized());
@@ -195,16 +211,18 @@ TEST_F(TestVariantPackDescriptorWhenFinalized, ValidGetAttributes)
                              HIPDNN_TYPE_VOID_PTR,
                              retrievedDevPtrs.size(),
                              &elementCount,
-                             retrievedDevPtrs.data());
+                             static_cast<void*>(retrievedDevPtrs.data()));
     EXPECT_EQ(elementCount, _devPtrs.size());
-    EXPECT_EQ(
-        std::memcmp(retrievedDevPtrs.data(), _devPtrs.data(), _devPtrs.size() * sizeof(void*)), 0);
+    EXPECT_EQ(std::memcmp(static_cast<const void*>(retrievedDevPtrs.data()),
+                          static_cast<const void*>(_devPtrs.data()),
+                          _devPtrs.size() * sizeof(void*)),
+              0);
 
     _descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                              HIPDNN_TYPE_INT64,
                              retrievedUids.size(),
                              &elementCount,
-                             retrievedUids.data());
+                             static_cast<void*>(retrievedUids.data()));
     EXPECT_EQ(elementCount, _uids.size());
     EXPECT_EQ(std::memcmp(retrievedUids.data(), _uids.data(), _uids.size() * sizeof(int64_t)), 0);
 
@@ -212,7 +230,7 @@ TEST_F(TestVariantPackDescriptorWhenFinalized, ValidGetAttributes)
                              HIPDNN_TYPE_VOID_PTR,
                              1,
                              &elementCount,
-                             &retrievedWorkspace);
+                             static_cast<void*>(&retrievedWorkspace));
     EXPECT_EQ(elementCount, 1);
     EXPECT_EQ(retrievedWorkspace, _workspace);
 }
@@ -224,12 +242,13 @@ TEST_F(TestVariantPackDescriptorWhenFinalized, InvalidGetAttributes)
     void* retrievedWorkspace = nullptr;
     int64_t elementCount = 0;
 
-    ASSERT_THROW_HIPDNN_STATUS(_descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_INT64,
-                                                        retrievedDevPtrs.size(),
-                                                        &elementCount,
-                                                        retrievedDevPtrs.data()),
-                               HIPDNN_STATUS_BAD_PARAM);
+    ASSERT_THROW_HIPDNN_STATUS(
+        _descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                 HIPDNN_TYPE_INT64,
+                                 retrievedDevPtrs.size(),
+                                 &elementCount,
+                                 static_cast<void*>(retrievedDevPtrs.data())),
+        HIPDNN_STATUS_BAD_PARAM);
 
     ASSERT_THROW_HIPDNN_STATUS(_descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                                         HIPDNN_TYPE_VOID_PTR,
@@ -252,12 +271,13 @@ TEST_F(TestVariantPackDescriptorWhenFinalized, InvalidGetAttributes)
                                                         nullptr),
                                HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    ASSERT_THROW_HIPDNN_STATUS(_descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
-                                                        HIPDNN_TYPE_VOID_PTR,
-                                                        retrievedDevPtrs.size(),
-                                                        nullptr,
-                                                        retrievedDevPtrs.data()),
-                               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
+    ASSERT_THROW_HIPDNN_STATUS(
+        _descriptor.getAttribute(HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                 HIPDNN_TYPE_VOID_PTR,
+                                 retrievedDevPtrs.size(),
+                                 nullptr,
+                                 static_cast<void*>(retrievedDevPtrs.data())),
+        HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
 } // namespace hipdnn_backend

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/logging/Logger.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/logging/Logger.hpp
@@ -134,41 +134,43 @@ inline constexpr const char* K_COMPONENT_NAME = "hipdnn_sdk";
 // Usage:
 //   HIPDNN_SDK_LOG_INFO_WITH_COMPONENT("my_component", "Message " << value);
 
-#define HIPDNN_SDK_LOG_INFO_WITH_COMPONENT(component, msg)                                    \
-    do                                                                                        \
-    {                                                                                         \
-        if(::hipdnn_data_sdk::logging::isLogLevelEnabled(HIPDNN_SEV_INFO))                    \
-        {                                                                                     \
-            ::hipdnn_data_sdk::logging::detail::LogStream(HIPDNN_SEV_INFO, component) << msg; \
-        }                                                                                     \
+// NOLINTBEGIN(bugprone-macro-parentheses) - msg is a stream expression, cannot be parenthesized
+#define HIPDNN_SDK_LOG_INFO_WITH_COMPONENT(component, msg)                                      \
+    do                                                                                          \
+    {                                                                                           \
+        if(::hipdnn_data_sdk::logging::isLogLevelEnabled(HIPDNN_SEV_INFO))                      \
+        {                                                                                       \
+            ::hipdnn_data_sdk::logging::detail::LogStream(HIPDNN_SEV_INFO, (component)) << msg; \
+        }                                                                                       \
     } while(0)
 
-#define HIPDNN_SDK_LOG_WARN_WITH_COMPONENT(component, msg)                                    \
-    do                                                                                        \
-    {                                                                                         \
-        if(::hipdnn_data_sdk::logging::isLogLevelEnabled(HIPDNN_SEV_WARN))                    \
-        {                                                                                     \
-            ::hipdnn_data_sdk::logging::detail::LogStream(HIPDNN_SEV_WARN, component) << msg; \
-        }                                                                                     \
+#define HIPDNN_SDK_LOG_WARN_WITH_COMPONENT(component, msg)                                      \
+    do                                                                                          \
+    {                                                                                           \
+        if(::hipdnn_data_sdk::logging::isLogLevelEnabled(HIPDNN_SEV_WARN))                      \
+        {                                                                                       \
+            ::hipdnn_data_sdk::logging::detail::LogStream(HIPDNN_SEV_WARN, (component)) << msg; \
+        }                                                                                       \
     } while(0)
 
-#define HIPDNN_SDK_LOG_ERROR_WITH_COMPONENT(component, msg)                                    \
-    do                                                                                         \
-    {                                                                                          \
-        if(::hipdnn_data_sdk::logging::isLogLevelEnabled(HIPDNN_SEV_ERROR))                    \
-        {                                                                                      \
-            ::hipdnn_data_sdk::logging::detail::LogStream(HIPDNN_SEV_ERROR, component) << msg; \
-        }                                                                                      \
+#define HIPDNN_SDK_LOG_ERROR_WITH_COMPONENT(component, msg)                                      \
+    do                                                                                           \
+    {                                                                                            \
+        if(::hipdnn_data_sdk::logging::isLogLevelEnabled(HIPDNN_SEV_ERROR))                      \
+        {                                                                                        \
+            ::hipdnn_data_sdk::logging::detail::LogStream(HIPDNN_SEV_ERROR, (component)) << msg; \
+        }                                                                                        \
     } while(0)
 
-#define HIPDNN_SDK_LOG_FATAL_WITH_COMPONENT(component, msg)                                    \
-    do                                                                                         \
-    {                                                                                          \
-        if(::hipdnn_data_sdk::logging::isLogLevelEnabled(HIPDNN_SEV_FATAL))                    \
-        {                                                                                      \
-            ::hipdnn_data_sdk::logging::detail::LogStream(HIPDNN_SEV_FATAL, component) << msg; \
-        }                                                                                      \
+#define HIPDNN_SDK_LOG_FATAL_WITH_COMPONENT(component, msg)                                      \
+    do                                                                                           \
+    {                                                                                            \
+        if(::hipdnn_data_sdk::logging::isLogLevelEnabled(HIPDNN_SEV_FATAL))                      \
+        {                                                                                        \
+            ::hipdnn_data_sdk::logging::detail::LogStream(HIPDNN_SEV_FATAL, (component)) << msg; \
+        }                                                                                        \
     } while(0)
+// NOLINTEND(bugprone-macro-parentheses)
 
 // ============================================================================
 // SDK Logging Macros (HIPDNN_SDK_LOG_*)
@@ -182,6 +184,7 @@ inline constexpr const char* K_COMPONENT_NAME = "hipdnn_sdk";
 //   HIPDNN_SDK_LOG_WARN("Warning: " << someValue);
 //   HIPDNN_SDK_LOG_ERROR("Error in " << functionName);
 
+// NOLINTBEGIN(bugprone-macro-parentheses) - msg is a stream expression
 #define HIPDNN_SDK_LOG_INFO(msg) \
     HIPDNN_SDK_LOG_INFO_WITH_COMPONENT(::hipdnn_data_sdk::logging::K_COMPONENT_NAME, msg)
 
@@ -193,3 +196,4 @@ inline constexpr const char* K_COMPONENT_NAME = "hipdnn_sdk";
 
 #define HIPDNN_SDK_LOG_FATAL(msg) \
     HIPDNN_SDK_LOG_FATAL_WITH_COMPONENT(::hipdnn_data_sdk::logging::K_COMPONENT_NAME, msg)
+// NOLINTEND(bugprone-macro-parentheses)

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/types/Fp8E4M3.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/types/Fp8E4M3.hpp
@@ -114,7 +114,8 @@ inline uint8_t float_to_fp8_e4m3_bits(float f, bool saturate = true) noexcept
     std::memcpy(&bits, &f, sizeof(float));
 
     uint32_t sign = (bits >> 24) & 0x80; // Extract sign to bit 7
-    int32_t exp = ((bits >> 23) & 0xFF) - 127 + 7; // Rebias from float (127) to E4M3 (7)
+    int32_t exp = static_cast<int32_t>(((bits >> 23) & 0xFF) - 127
+                                       + 7); // Rebias from float (127) to E4M3 (7)
     uint32_t mant = bits & 0x007FFFFF;
 
     // Handle overflow

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/types/Fp8E5M2.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/types/Fp8E5M2.hpp
@@ -122,7 +122,8 @@ inline uint8_t float_to_fp8_e5m2_bits(float f, bool saturate = true) noexcept
     std::memcpy(&bits, &f, sizeof(float));
 
     uint32_t sign = (bits >> 24) & 0x80; // Extract sign to bit 7
-    int32_t exp = ((bits >> 23) & 0xFF) - 127 + 15; // Rebias from float (127) to E5M2 (15)
+    int32_t exp = static_cast<int32_t>(((bits >> 23) & 0xFF) - 127
+                                       + 15); // Rebias from float (127) to E5M2 (15)
     uint32_t mant = bits & 0x007FFFFF;
 
     // Handle overflow

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp
@@ -106,7 +106,7 @@ struct EngineRegistrar
     EngineRegistrar(std::string_view name)
     {
         detail::getMutableEngineNames().insert(name);
-        auto id = engineNameToId(name.data());
+        auto id = engineNameToId(std::string(name));
         detail::getMutableEngineIdToNameMap()[id] = name;
 
         // Check for collisions

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
@@ -342,8 +342,15 @@ public:
                                         + std::to_string(strides().size()) + ")");
         }
 
-        return throwIfOutOfBounds(
-            std::inner_product(indices.begin(), indices.end(), strides().begin(), int64_t{0}));
+        return throwIfOutOfBounds(std::inner_product(indices.begin(),
+                                                     indices.end(),
+                                                     strides().begin(),
+                                                     int64_t{0},
+                                                     std::plus<int64_t>{},
+                                                     [](const auto& idx, const auto& stride) {
+                                                         return static_cast<int64_t>(idx)
+                                                                * static_cast<int64_t>(stride);
+                                                     }));
     }
 
     virtual ITensorIterator<false> begin() = 0;
@@ -520,7 +527,7 @@ protected:
             std::inner_product(dims.begin(),
                                dims.end(),
                                strides.begin(),
-                               1,
+                               size_t{1},
                                std::plus<>(),
                                [](size_t len, size_t stride) { return (len - 1) * stride; }));
     }
@@ -533,7 +540,7 @@ protected:
         }
 
         return static_cast<size_t>(
-            std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>()));
+            std::accumulate(dims.begin(), dims.end(), int64_t{1}, std::multiplies<>()));
     }
 };
 

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/TensorView.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/TensorView.hpp
@@ -78,6 +78,7 @@ public:
 
     iterator begin()
     {
+        // NOLINTNEXTLINE(bugprone-branch-clone) - Different constness requires separate branches
         if constexpr(IsConst)
         {
             return iterator(_tensor.cbegin());
@@ -90,6 +91,7 @@ public:
 
     iterator end()
     {
+        // NOLINTNEXTLINE(bugprone-branch-clone) - Different constness requires separate branches
         if constexpr(IsConst)
         {
             return iterator(_tensor.cend());

--- a/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestEngineNames.cpp
@@ -35,7 +35,7 @@ TEST_F(TestEngineNames, EngineIdToNameMappingConsistent)
     // Verify each mapping is consistent
     for(const auto& [id, name] : idToName)
     {
-        auto calculatedId = engineNameToId(name.data());
+        auto calculatedId = engineNameToId(std::string(name));
         EXPECT_EQ(id, calculatedId)
             << "ID mismatch for engine: " << name << " (stored: 0x" << std::hex << id
             << ", calculated: 0x" << calculatedId << std::dec << ")";
@@ -79,7 +79,7 @@ TEST_F(TestEngineNames, EngineCountMatches)
     // Also verify all names in one are in the other
     for(const auto& name : allEngines)
     {
-        auto id = engineNameToId(name.data());
+        auto id = engineNameToId(std::string(name));
         EXPECT_NE(idToName.find(id), idToName.end())
             << "Engine '" << name << "' is in getAllEngineNames but not in getEngineIdToNameMap";
     }

--- a/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestMigratableMemory.cpp
@@ -69,7 +69,9 @@ TEST(TestMigratableMemory, MoveConstructor)
 
     MigratableMemory<float> memory2(std::move(memory1));
 
-    EXPECT_TRUE(memory1.empty());
+    EXPECT_TRUE(
+        memory1
+            .empty()); // NOLINT(bugprone-use-after-move) - Intentionally testing moved-from object state
     EXPECT_EQ(memory1.count(), 0);
     EXPECT_EQ(memory1.location(), MemoryLocation::NONE);
     EXPECT_EQ(memory1.hostData(), nullptr);
@@ -89,7 +91,9 @@ TEST(TestMigratableMemory, MoveAssignment)
     MigratableMemory<float> memory2;
     memory2 = std::move(memory1);
 
-    EXPECT_TRUE(memory1.empty());
+    EXPECT_TRUE(
+        memory1
+            .empty()); // NOLINT(bugprone-use-after-move) - Intentionally testing moved-from object state
     EXPECT_EQ(memory1.count(), 0);
     EXPECT_EQ(memory1.location(), MemoryLocation::NONE);
     EXPECT_EQ(memory1.hostData(), nullptr);

--- a/projects/hipdnn/data_sdk/tests/utilities/TestScopedResource.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestScopedResource.cpp
@@ -37,7 +37,8 @@ TEST(TestScopedResource, CheckMove)
         utilities::ScopedResource sr1(&r, [](auto r) { r->released = true; });
 
         utilities::ScopedResource sr2(std::move(sr1));
-        ASSERT_TRUE(sr1.isEmpty());
+        ASSERT_TRUE(
+            sr1.isEmpty()); // NOLINT(bugprone-use-after-move) - Intentionally testing moved-from object state
         ASSERT_FALSE(sr2.isEmpty());
         ASSERT_FALSE(r.released);
     }
@@ -59,7 +60,8 @@ TEST(TestScopedResource, CheckMoveAssign)
         ASSERT_FALSE(r1.released);
         ASSERT_TRUE(r2.released);
 
-        ASSERT_TRUE(sr1.isEmpty());
+        ASSERT_TRUE(
+            sr1.isEmpty()); // NOLINT(bugprone-use-after-move) - Intentionally testing moved-from object state
         ASSERT_FALSE(sr2.isEmpty());
     }
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Error.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Error.hpp
@@ -171,7 +171,7 @@ typedef Error error_t; ///< @brief Type alias for Error
 #define HIPDNN_RETURN_IF_NE(x, y, error_status, message) \
     do                                                   \
     {                                                    \
-        if(x != y)                                       \
+        if((x) != (y))                                   \
         {                                                \
             return {error_status, message};              \
         }                                                \
@@ -180,7 +180,7 @@ typedef Error error_t; ///< @brief Type alias for Error
 #define HIPDNN_RETURN_IF_EQ(x, y, error_status, message) \
     do                                                   \
     {                                                    \
-        if(x == y)                                       \
+        if((x) == (y))                                   \
         {                                                \
             return {error_status, message};              \
         }                                                \
@@ -207,7 +207,7 @@ typedef Error error_t; ///< @brief Type alias for Error
 #define HIPDNN_RETURN_IF_NULL(x, error_status, message) \
     do                                                  \
     {                                                   \
-        if(x == nullptr)                                \
+        if((x) == nullptr)                              \
         {                                               \
             return {error_status, message};             \
         }                                               \
@@ -216,7 +216,7 @@ typedef Error error_t; ///< @brief Type alias for Error
 #define HIPDNN_RETURN_IF_LT(x, y, error_status, message) \
     do                                                   \
     {                                                    \
-        if(x < y)                                        \
+        if((x) < (y))                                    \
         {                                                \
             return {error_status, message};              \
         }                                                \
@@ -225,7 +225,7 @@ typedef Error error_t; ///< @brief Type alias for Error
 #define HIPDNN_RETURN_IF_GE(x, y, error_status, message) \
     do                                                   \
     {                                                    \
-        if(x >= y)                                       \
+        if((x) >= (y))                                   \
         {                                                \
             return {error_status, message};              \
         }                                                \
@@ -234,7 +234,7 @@ typedef Error error_t; ///< @brief Type alias for Error
 #define HIPDNN_RETURN_IF_LE(x, y, error_status, message) \
     do                                                   \
     {                                                    \
-        if(x <= y)                                       \
+        if((x) <= (y))                                   \
         {                                                \
             return {error_status, message};              \
         }                                                \

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -239,12 +239,13 @@ private:
         auto engineConfigDesc = std::make_unique<detail::ScopedHipdnnBackendDescriptor>(
             HIPDNN_BACKEND_ENGINECFG_DESCRIPTOR);
 
+        auto engineDescPtr = engineDesc.get();
         HIPDNN_RETURN_ON_BACKEND_FAILURE(
             detail::hipdnnBackend()->backendSetAttribute(engineConfigDesc->get(),
                                                          HIPDNN_ATTR_ENGINECFG_ENGINE,
                                                          HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                                          1,
-                                                         &engineDesc.get()),
+                                                         static_cast<void*>(&engineDescPtr)),
             "Failed to set engine on the engine config descriptor.");
 
         _engineConfigDesc = std::move(engineConfigDesc);
@@ -489,7 +490,7 @@ private:
 
         if(fbGraph->preferred_engine_id().has_value())
         {
-            _preferredEngineId = fbGraph->preferred_engine_id().value();
+            _preferredEngineId = fbGraph->preferred_engine_id();
         }
 
         // Build tensorMap from FlatBuffer tensors
@@ -873,7 +874,7 @@ public:
                                                          HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
                                                          HIPDNN_TYPE_HANDLE,
                                                          1,
-                                                         &handle),
+                                                         static_cast<const void*>(&handle)),
             "Failed to set handle on the graph.");
 
         HIPDNN_RETURN_ON_BACKEND_FAILURE(
@@ -1322,13 +1323,14 @@ public:
     {
         HIPDNN_FE_LOG_INFO("Building plans for graph " << graph_attributes.get_name());
 
-        HIPDNN_RETURN_ON_BACKEND_FAILURE(
-            detail::hipdnnBackend()->backendSetAttribute(_executionPlanDesc->get(),
-                                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
-                                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
-                                                         1,
-                                                         &_engineConfigDesc->get()),
-            "Failed to set the engine config on execution plan.");
+        auto engineConfigDescPtr = _engineConfigDesc->get();
+        HIPDNN_RETURN_ON_BACKEND_FAILURE(detail::hipdnnBackend()->backendSetAttribute(
+                                             _executionPlanDesc->get(),
+                                             HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                             1,
+                                             static_cast<const void*>(&engineConfigDescPtr)),
+                                         "Failed to set the engine config on execution plan.");
 
         HIPDNN_RETURN_ON_BACKEND_FAILURE(
             detail::hipdnnBackend()->backendFinalize(_executionPlanDesc->get()),
@@ -1485,7 +1487,7 @@ public:
                                              HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                              HIPDNN_TYPE_VOID_PTR,
                                              static_cast<int64_t>(variantPackValues.size()),
-                                             variantPackValues.data()),
+                                             static_cast<void*>(variantPackValues.data())),
                                          "failed to set the variant pack data pointers.");
 
         HIPDNN_RETURN_ON_BACKEND_FAILURE(detail::hipdnnBackend()->backendSetAttribute(
@@ -1493,7 +1495,7 @@ public:
                                              HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                              HIPDNN_TYPE_INT64,
                                              static_cast<int64_t>(variantPackKeys.size()),
-                                             variantPackKeys.data()),
+                                             static_cast<void*>(variantPackKeys.data())),
                                          "failed to set the variant pack unique ids.");
 
         HIPDNN_RETURN_ON_BACKEND_FAILURE(
@@ -1501,7 +1503,7 @@ public:
                                                          HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
                                                          HIPDNN_TYPE_VOID_PTR,
                                                          1,
-                                                         &workspace),
+                                                         static_cast<void*>(&workspace)),
             "failed to set the variant pack unique ids.");
 
         HIPDNN_RETURN_ON_BACKEND_FAILURE(

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -666,7 +666,6 @@ inline hipdnnBackendHeurMode_t toBackendType(const HeuristicMode& type)
     switch(type)
     {
     case HeuristicMode::FALLBACK:
-        return hipdnnBackendHeurMode_t::HIPDNN_HEUR_MODE_FALLBACK;
     default:
         return hipdnnBackendHeurMode_t::HIPDNN_HEUR_MODE_FALLBACK;
     }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/Attributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/Attributes.hpp
@@ -52,6 +52,13 @@ template <typename DerivedT>
 class Attributes
 {
 private:
+    Attributes() = default;
+
+    friend DerivedT;
+
+    template <typename>
+    friend class Attributes;
+
     /**
      * @brief Get mutable reference to derived class
      * @return Reference to *this cast to DerivedT&

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/SdpaAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/SdpaAttributes.hpp
@@ -633,21 +633,21 @@ public:
             optUid(get_rng_dump()),
             optUid(get_amax_s()),
             optUid(get_amax_o()),
-            generate_stats.has_value() ? flatbuffers::Optional<bool>(*generate_stats)
+            generate_stats.has_value() ? flatbuffers::Optional<bool>(generate_stats)
                                        : flatbuffers::nullopt,
             alibi_mask,
             padding_mask,
             causal_mask,
             causal_mask_bottom_right,
-            dropout_probability.has_value() ? flatbuffers::Optional<float>(*dropout_probability)
+            dropout_probability.has_value() ? flatbuffers::Optional<float>(dropout_probability)
                                             : flatbuffers::nullopt,
-            attn_scale_value.has_value() ? flatbuffers::Optional<float>(*attn_scale_value)
+            attn_scale_value.has_value() ? flatbuffers::Optional<float>(attn_scale_value)
                                          : flatbuffers::nullopt,
-            left_bound.has_value() ? flatbuffers::Optional<int64_t>(*left_bound)
+            left_bound.has_value() ? flatbuffers::Optional<int64_t>(left_bound)
                                    : flatbuffers::nullopt,
-            right_bound.has_value() ? flatbuffers::Optional<int64_t>(*right_bound)
+            right_bound.has_value() ? flatbuffers::Optional<int64_t>(right_bound)
                                     : flatbuffers::nullopt,
-            max_seq_len_kv.has_value() ? flatbuffers::Optional<int32_t>(*max_seq_len_kv)
+            max_seq_len_kv.has_value() ? flatbuffers::Optional<int32_t>(max_seq_len_kv)
                                        : flatbuffers::nullopt,
             toSdkType(diagonal_alignment),
             toSdkType(mma_core_mode),
@@ -764,7 +764,7 @@ public:
 
         if(fb->generate_stats().has_value())
         {
-            attr.generate_stats = fb->generate_stats().value();
+            attr.generate_stats = fb->generate_stats();
         }
         attr.alibi_mask = fb->alibi_mask();
         attr.padding_mask = fb->padding_mask();
@@ -773,23 +773,23 @@ public:
 
         if(fb->dropout_probability().has_value())
         {
-            attr.dropout_probability = fb->dropout_probability().value();
+            attr.dropout_probability = fb->dropout_probability();
         }
         if(fb->attn_scale_value().has_value())
         {
-            attr.attn_scale_value = fb->attn_scale_value().value();
+            attr.attn_scale_value = fb->attn_scale_value();
         }
         if(fb->left_bound().has_value())
         {
-            attr.left_bound = fb->left_bound().value();
+            attr.left_bound = fb->left_bound();
         }
         if(fb->right_bound().has_value())
         {
-            attr.right_bound = fb->right_bound().value();
+            attr.right_bound = fb->right_bound();
         }
         if(fb->max_seq_len_kv().has_value())
         {
-            attr.max_seq_len_kv = fb->max_seq_len_kv().value();
+            attr.max_seq_len_kv = fb->max_seq_len_kv();
         }
 
         attr.diagonal_alignment = fromSdkType(fb->diagonal_alignment());

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/CreateBackendDescriptor.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/CreateBackendDescriptor.hpp
@@ -19,7 +19,7 @@ inline Error createEngineDescriptorForGraph(ScopedHipdnnBackendDescriptor& engin
                                              HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
                                              HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                              1,
-                                             &graphDesc),
+                                             static_cast<const void*>(&graphDesc)),
         "Failed to set operation graph on the engine descriptor.");
 
     HIPDNN_RETURN_ON_BACKEND_FAILURE(
@@ -45,7 +45,7 @@ inline Error
                                              HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                              HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                              1,
-                                             &graphDesc),
+                                             static_cast<const void*>(&graphDesc)),
         "Failed to set operation graph on the engine heuristic descriptor.");
 
     // TODO

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorHelpers.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/DescriptorHelpers.hpp
@@ -124,7 +124,7 @@ inline Error setDescriptorAttrTensorRef(
     auto descPtr = it->second.get();
     HIPDNN_RETURN_ON_BACKEND_FAILURE(
         hipdnnBackend()->backendSetAttribute(
-            desc, attrName, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, &descPtr),
+            desc, attrName, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, static_cast<const void*>(&descPtr)),
         "Failed to set " + errorContext);
     return {};
 }

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/GraphDetail.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/GraphDetail.hpp
@@ -60,7 +60,7 @@ inline Error
                                              HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                              static_cast<int64_t>(engineConfigsShallow.size()),
                                              &count,
-                                             engineConfigsShallow.data()),
+                                             static_cast<void*>(engineConfigsShallow.data())),
         "Failed to get engine configurations from the heuristic descriptor.");
 
     if(count == 0)
@@ -84,7 +84,7 @@ inline Error
                                                  HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                                  1,
                                                  nullptr,
-                                                 &engineDesc),
+                                                 static_cast<void*>(&engineDesc)),
             "Failed to get engine from engine configuration descriptor.");
 
         // Clean-up engineDesc once we no longer need it within this scope.

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/detail/GraphPacker.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/detail/GraphPacker.hpp
@@ -36,8 +36,11 @@ inline Error assembleGraphDescriptor(const std::vector<ScopedHipdnnBackendDescri
 
     // Set handle on graph
     HIPDNN_RETURN_ON_BACKEND_FAILURE(
-        hipdnnBackend()->backendSetAttribute(
-            graphDesc.get(), HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+        hipdnnBackend()->backendSetAttribute(graphDesc.get(),
+                                             HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                             HIPDNN_TYPE_HANDLE,
+                                             1,
+                                             static_cast<const void*>(&handle)),
         "Failed to set handle on GraphDescriptor");
 
     // Set operations on graph
@@ -52,7 +55,7 @@ inline Error assembleGraphDescriptor(const std::vector<ScopedHipdnnBackendDescri
                                              HIPDNN_ATTR_OPERATIONGRAPH_OPS,
                                              HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                              static_cast<int64_t>(opDescPtrs.size()),
-                                             opDescPtrs.data()),
+                                             static_cast<const void*>(opDescPtrs.data())),
         "Failed to set operations on GraphDescriptor");
 
     // Set graph-level data types

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/Node.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/Node.hpp
@@ -155,6 +155,13 @@ template <typename DerivedT>
 class BaseNode : public INode
 {
 private:
+    BaseNode() = default;
+
+    friend DerivedT;
+
+    template <typename>
+    friend class BaseNode;
+
     DerivedT& self()
     {
         return static_cast<DerivedT&>(*this);

--- a/projects/hipdnn/frontend/tests/TestBatchnormBackwardNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestBatchnormBackwardNode.cpp
@@ -45,7 +45,9 @@ TEST(TestBatchnormBackwardNode, PreValidateNodeMissingValues)
     auto error = node.pre_validate_node();
     EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
-    batchnormAttributes.set_dy(std::make_shared<TensorAttributes>());
+    batchnormAttributes.set_dy(
+        std::make_shared<
+            TensorAttributes>()); // NOLINT(bugprone-use-after-move) - Testing incremental attribute setting
     auto batchnormAttributesCopy = batchnormAttributes;
     BatchnormBackwardNode nodeWithDy(std::move(batchnormAttributesCopy), graphAttributes);
 

--- a/projects/hipdnn/frontend/tests/TestBatchnormInferenceNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestBatchnormInferenceNode.cpp
@@ -93,7 +93,9 @@ TEST(TestBatchnormInferenceNode, PreValidateNodeMissingValues)
     auto error = node.pre_validate_node();
     EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
-    batchnormAttributes.set_x(std::make_shared<TensorAttributes>());
+    batchnormAttributes.set_x(
+        std::make_shared<
+            TensorAttributes>()); // NOLINT(bugprone-use-after-move) - Testing incremental attribute setting
     auto batchnormAttributesCopy = batchnormAttributes;
     BatchnormInferenceNode nodeWithX(std::move(batchnormAttributesCopy), graphAttributes);
 

--- a/projects/hipdnn/frontend/tests/TestBatchnormInferenceNodeVarianceExt.cpp
+++ b/projects/hipdnn/frontend/tests/TestBatchnormInferenceNodeVarianceExt.cpp
@@ -97,7 +97,9 @@ TEST(TestBatchnormInferenceNodeVarianceExt, PreValidateNodeMissingValues)
     auto error = node.pre_validate_node();
     EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
-    batchnormAttributes.set_x(std::make_shared<TensorAttributes>());
+    batchnormAttributes.set_x(
+        std::make_shared<
+            TensorAttributes>()); // NOLINT(bugprone-use-after-move) - Testing incremental attribute setting
     auto batchnormAttributesCopy = batchnormAttributes;
     BatchnormInferenceNodeVarianceExt nodeWithX(std::move(batchnormAttributesCopy),
                                                 graphAttributes);

--- a/projects/hipdnn/frontend/tests/TestBatchnormNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestBatchnormNode.cpp
@@ -47,7 +47,9 @@ TEST(TestBatchnormNode, PreValidateNodeMissingValues)
     auto error = node.pre_validate_node();
     EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
-    batchnormAttributes.set_x(std::make_shared<TensorAttributes>());
+    batchnormAttributes.set_x(
+        std::make_shared<
+            TensorAttributes>()); // NOLINT(bugprone-use-after-move) - Testing incremental attribute setting
     auto batchnormAttributesCopy = batchnormAttributes;
     BatchnormNode nodeWithX(std::move(batchnormAttributesCopy), graphAttributes);
 

--- a/projects/hipdnn/frontend/tests/TestEngineOverrideConfig.cpp
+++ b/projects/hipdnn/frontend/tests/TestEngineOverrideConfig.cpp
@@ -263,7 +263,9 @@ TEST(TestEngineOverrideConfig, ExactStrideMatchSelectsEngine)
     EXPECT_EQ(*result, MIOPEN_ENGINE_ID);
 
     // Different stride must not match
-    auto wrongStride = makeTensorWithStride({1, 3, 224, 224}, {1, 224, 224 * 3, 224 * 3 * 224});
+    auto wrongStride = makeTensorWithStride(
+        {1, 3, 224, 224},
+        {1, 224, static_cast<int64_t>(224) * 3, static_cast<int64_t>(224) * 3 * 224});
     EXPECT_FALSE(config.matchOperation("conv_fprop", {wrongStride}).has_value());
 }
 
@@ -409,7 +411,9 @@ TEST(TestEngineOverrideConfig, JsonWithStrideConstraint)
     EXPECT_EQ(*r1, MIOPEN_ENGINE_ID);
 
     // Wrong stride must not match
-    auto xWrong = makeTensorWithStride({1, 3, 224, 224}, {1, 224, 224 * 3, 224 * 3 * 224});
+    auto xWrong = makeTensorWithStride(
+        {1, 3, 224, 224},
+        {1, 224, static_cast<int64_t>(224) * 3, static_cast<int64_t>(224) * 3 * 224});
     EXPECT_FALSE(config->matchOperation("conv_fprop", {xWrong, w}).has_value());
 }
 

--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -5927,7 +5927,7 @@ TEST_F(TestGraph, SetPreferredEngineIdByName)
     // Verify it was converted to the correct ID
     auto expectedId = hipdnn_data_sdk::utilities::engineNameToId(testEngineName);
     EXPECT_TRUE(graph.get_preferred_engine_id_ext().has_value());
-    EXPECT_EQ(graph.get_preferred_engine_id_ext().value(), expectedId);
+    EXPECT_EQ(*graph.get_preferred_engine_id_ext(), expectedId);
 }
 
 TEST_F(TestGraph, SetPreferredEngineIdByEmptyStringClearsPreference)
@@ -5962,7 +5962,7 @@ TEST_F(TestGraph, SetPreferredEngineIdByNameThenById)
 
     // Verify the ID overload took precedence
     EXPECT_TRUE(graph.get_preferred_engine_id_ext().has_value());
-    EXPECT_EQ(graph.get_preferred_engine_id_ext().value(), overrideId);
+    EXPECT_EQ(*graph.get_preferred_engine_id_ext(), overrideId);
 }
 
 TEST_F(TestGraph, SetPreferredEngineIdByIdThenByName)
@@ -5980,7 +5980,7 @@ TEST_F(TestGraph, SetPreferredEngineIdByIdThenByName)
 
     // Verify the name overload took precedence
     EXPECT_TRUE(graph.get_preferred_engine_id_ext().has_value());
-    EXPECT_EQ(graph.get_preferred_engine_id_ext().value(), expectedId);
+    EXPECT_EQ(*graph.get_preferred_engine_id_ext(), expectedId);
 }
 
 TEST_F(TestGraph, MethodChaining)
@@ -6010,13 +6010,13 @@ TEST_F(TestGraph, MethodChaining)
     EXPECT_EQ(graph.get_intermediate_data_type(), DataType::HALF);
     EXPECT_EQ(graph.get_io_data_type(), DataType::BFLOAT16);
     EXPECT_TRUE(graph.get_preferred_engine_id_ext().has_value());
-    EXPECT_EQ(graph.get_preferred_engine_id_ext().value(), 12345);
+    EXPECT_EQ(*graph.get_preferred_engine_id_ext(), 12345);
 
     // Test chaining with string overload
     auto& ref6 = graph.set_preferred_engine_id_ext(testEngineName);
     EXPECT_EQ(&graph, &ref6);
     EXPECT_TRUE(graph.get_preferred_engine_id_ext().has_value());
-    EXPECT_EQ(graph.get_preferred_engine_id_ext().value(), expectedEngineId);
+    EXPECT_EQ(*graph.get_preferred_engine_id_ext(), expectedEngineId);
 }
 
 // Test that create_execution_plan_ext handles deprecated knobs correctly.
@@ -6252,8 +6252,10 @@ TEST_F(TestGraph, MoveConstruction)
     EXPECT_EQ(movedGraph.get_compute_data_type(), DataType::FLOAT);
     EXPECT_EQ(movedGraph.get_intermediate_data_type(), DataType::HALF);
     EXPECT_EQ(movedGraph.get_io_data_type(), DataType::FLOAT);
-    EXPECT_EQ(originalGraph.get_name(), "");
-    EXPECT_TRUE(originalGraph.getTensorsByName().empty());
+    EXPECT_EQ(originalGraph.get_name(),
+              ""); // NOLINT(bugprone-use-after-move) - Testing move semantics
+    EXPECT_TRUE(originalGraph.getTensorsByName()
+                    .empty()); // NOLINT(bugprone-use-after-move) - Testing move semantics
 }
 
 TEST_F(TestGraph, MoveAssignment)
@@ -6344,14 +6346,14 @@ TEST_F(TestGraph, MoveConstructionWithPreferredEngineId)
         .set_preferred_engine_id_ext(42);
 
     EXPECT_TRUE(originalGraph.get_preferred_engine_id_ext().has_value());
-    EXPECT_EQ(originalGraph.get_preferred_engine_id_ext().value(), 42);
+    EXPECT_EQ(*originalGraph.get_preferred_engine_id_ext(), 42);
 
     // Move construct
     Graph movedGraph(std::move(originalGraph));
 
     // Verify preferred engine id was moved
     EXPECT_TRUE(movedGraph.get_preferred_engine_id_ext().has_value());
-    EXPECT_EQ(movedGraph.get_preferred_engine_id_ext().value(), 42);
+    EXPECT_EQ(*movedGraph.get_preferred_engine_id_ext(), 42);
 }
 
 TEST_F(TestGraph, MoveAssignmentToEmptyGraph)
@@ -6419,7 +6421,7 @@ TEST_F(TestGraph, EngineOverrideDoesNotReplaceExplicitlySetEngineId)
     EXPECT_TRUE(graph.build_operation_graph(_handle).is_good());
 
     ASSERT_TRUE(graph.get_preferred_engine_id_ext().has_value());
-    EXPECT_EQ(graph.get_preferred_engine_id_ext().value(), EXPLICIT_ENGINE_ID);
+    EXPECT_EQ(*graph.get_preferred_engine_id_ext(), EXPLICIT_ENGINE_ID);
 }
 
 // Test 2: EngineOverrideConfig::matchOperation identifies conv_fprop tensors
@@ -6692,7 +6694,7 @@ TEST_F(TestGraph, BuildAndSerializeSdpaFpropGraphWithStats)
     EXPECT_EQ(deserializedSdpaAttributes->v_tensor_uid, v->get_uid());
     EXPECT_EQ(deserializedSdpaAttributes->o_tensor_uid, o->get_uid());
     ASSERT_TRUE(deserializedSdpaAttributes->stats_tensor_uid.has_value());
-    EXPECT_EQ(deserializedSdpaAttributes->stats_tensor_uid.value(), stats->get_uid());
+    EXPECT_EQ(*deserializedSdpaAttributes->stats_tensor_uid, stats->get_uid());
     ASSERT_TRUE(deserializedSdpaAttributes->generate_stats.has_value());
-    EXPECT_TRUE(deserializedSdpaAttributes->generate_stats.value());
+    EXPECT_TRUE(*deserializedSdpaAttributes->generate_stats);
 }

--- a/projects/hipdnn/frontend/tests/TestPointwiseAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestPointwiseAttributes.cpp
@@ -54,19 +54,19 @@ TEST(TestPointwiseAttributes, CreatePointwiseAttributes)
 
     EXPECT_EQ(pointwiseAttributes.get_mode(), PointwiseMode::RELU_FWD);
     EXPECT_TRUE(pointwiseAttributes.get_relu_lower_clip().has_value());
-    EXPECT_EQ(pointwiseAttributes.get_relu_lower_clip().value(), 0.1f);
+    EXPECT_EQ(*pointwiseAttributes.get_relu_lower_clip(), 0.1f);
     EXPECT_TRUE(pointwiseAttributes.get_relu_upper_clip().has_value());
-    EXPECT_EQ(pointwiseAttributes.get_relu_upper_clip().value(), 6.0f);
+    EXPECT_EQ(*pointwiseAttributes.get_relu_upper_clip(), 6.0f);
     EXPECT_TRUE(pointwiseAttributes.get_relu_lower_clip_slope().has_value());
-    EXPECT_EQ(pointwiseAttributes.get_relu_lower_clip_slope().value(), 0.01f);
+    EXPECT_EQ(*pointwiseAttributes.get_relu_lower_clip_slope(), 0.01f);
     EXPECT_TRUE(pointwiseAttributes.get_axis().has_value());
-    EXPECT_EQ(pointwiseAttributes.get_axis().value(), 1);
+    EXPECT_EQ(*pointwiseAttributes.get_axis(), 1);
     EXPECT_TRUE(pointwiseAttributes.get_swish_beta().has_value());
-    EXPECT_EQ(pointwiseAttributes.get_swish_beta().value(), 1.5f);
+    EXPECT_EQ(*pointwiseAttributes.get_swish_beta(), 1.5f);
     EXPECT_TRUE(pointwiseAttributes.get_elu_alpha().has_value());
-    EXPECT_EQ(pointwiseAttributes.get_elu_alpha().value(), 0.9f);
+    EXPECT_EQ(*pointwiseAttributes.get_elu_alpha(), 0.9f);
     EXPECT_TRUE(pointwiseAttributes.get_softplus_beta().has_value());
-    EXPECT_EQ(pointwiseAttributes.get_softplus_beta().value(), 2.0f);
+    EXPECT_EQ(*pointwiseAttributes.get_softplus_beta(), 2.0f);
 }
 
 TEST(TestPointwiseAttributes, CreatePointwiseAttributesWithTwoInputs)

--- a/projects/hipdnn/frontend/tests/TestRMSNormNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestRMSNormNode.cpp
@@ -80,8 +80,12 @@ TEST(TestRMSNormNode, PreValidateNodeMissingValues)
     auto error = node.pre_validate_node();
     EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 
-    rmsnormAttributes.set_x(std::make_shared<TensorAttributes>());
-    rmsnormAttributes.set_forward_phase(NormFwdPhase::TRAINING);
+    rmsnormAttributes.set_x(
+        std::make_shared<
+            TensorAttributes>()); // NOLINT(bugprone-use-after-move) - Testing incremental attribute setting
+    rmsnormAttributes.set_forward_phase(
+        NormFwdPhase::
+            TRAINING); // NOLINT(bugprone-use-after-move) - Testing incremental attribute setting
     auto rmsnormAttributesCopy = rmsnormAttributes;
     RMSNormNode nodeWithX(std::move(rmsnormAttributesCopy), graphAttributes);
 
@@ -396,7 +400,7 @@ TEST(TestRMSNormNode, PackNodeWithBias)
 
     ASSERT_NE(packedAttributes, nullptr);
     EXPECT_TRUE(packedAttributes->bias_tensor_uid().has_value());
-    EXPECT_EQ(packedAttributes->bias_tensor_uid().value(), biasTensor->get_uid());
+    EXPECT_EQ(*packedAttributes->bias_tensor_uid(), biasTensor->get_uid());
 }
 
 TEST(TestRMSNormNode, GatherHipdnnTensors)

--- a/projects/hipdnn/frontend/tests/TestScopedHipdnnBackendDescriptor.cpp
+++ b/projects/hipdnn/frontend/tests/TestScopedHipdnnBackendDescriptor.cpp
@@ -168,8 +168,8 @@ TEST_F(TestScopedHipdnnBackendDescriptor, MoveConstructorTransfersOwnership)
     auto desc2 = ScopedHipdnnBackendDescriptor(std::move(desc1));
     EXPECT_TRUE(desc2.valid());
     EXPECT_EQ(desc2.get(), raw);
-    EXPECT_FALSE(desc1.valid());
-    EXPECT_EQ(desc1.get(), nullptr);
+    EXPECT_FALSE(desc1.valid()); // NOLINT(bugprone-use-after-move) - Testing move semantics
+    EXPECT_EQ(desc1.get(), nullptr); // NOLINT(bugprone-use-after-move) - Testing move semantics
 }
 
 TEST_F(TestScopedHipdnnBackendDescriptor, MoveAssignmentTransfersOwnership)
@@ -199,8 +199,8 @@ TEST_F(TestScopedHipdnnBackendDescriptor, MoveAssignmentTransfersOwnership)
 
     EXPECT_TRUE(desc2.valid());
     EXPECT_EQ(desc2.get(), fakeDesc1);
-    EXPECT_FALSE(desc1.valid());
-    EXPECT_EQ(desc1.get(), nullptr);
+    EXPECT_FALSE(desc1.valid()); // NOLINT(bugprone-use-after-move) - Testing move semantics
+    EXPECT_EQ(desc1.get(), nullptr); // NOLINT(bugprone-use-after-move) - Testing move semantics
 }
 
 TEST_F(TestScopedHipdnnBackendDescriptor, MoveFromInvalidDescriptor)

--- a/projects/hipdnn/frontend/tests/TestTensorValueAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestTensorValueAttributes.cpp
@@ -28,7 +28,7 @@ TEST(TestTensorValueAttributes, SetGetClearFloat)
 
     auto opt = tensor.get_pass_by_value<float>();
     ASSERT_TRUE(opt.has_value());
-    EXPECT_FLOAT_EQ(opt.value(), TEST_VALUE);
+    EXPECT_FLOAT_EQ(*opt, TEST_VALUE);
 
     tensor.clear_value();
     EXPECT_FALSE(tensor.get_pass_by_value());
@@ -42,7 +42,7 @@ TEST(TestTensorValueAttributes, ConstructorValues)
 
     auto opt = tensor.get_pass_by_value<float>();
     ASSERT_TRUE(opt.has_value());
-    EXPECT_EQ(opt.value(), TEST_VALUE);
+    EXPECT_EQ(*opt, TEST_VALUE);
 }
 
 TEST(TestTensorValueAttributes, PackUnpackFloatValue)
@@ -269,7 +269,7 @@ TEST(TestTensorValueAttributes, TypeSafety)
 
     auto floatOpt = tensor.get_pass_by_value<float>();
     ASSERT_TRUE(floatOpt.has_value());
-    EXPECT_FLOAT_EQ(floatOpt.value(), 42.0f);
+    EXPECT_FLOAT_EQ(*floatOpt, 42.0f);
 
     EXPECT_FALSE(tensor.get_pass_by_value<half>().has_value());
     EXPECT_FALSE(tensor.get_pass_by_value<bfloat16>().has_value());
@@ -283,7 +283,7 @@ TEST(TestTensorValueAttributes, TypeSafety)
 
     auto intOpt = tensor.get_pass_by_value<int32_t>();
     ASSERT_TRUE(intOpt.has_value());
-    EXPECT_EQ(intOpt.value(), 123);
+    EXPECT_EQ(*intOpt, 123);
 }
 
 TEST(TestTensorValueAttributes, NumericLimits)
@@ -293,17 +293,17 @@ TEST(TestTensorValueAttributes, NumericLimits)
     tensor.set_value(std::numeric_limits<float>::max());
     auto floatOpt = tensor.get_pass_by_value<float>();
     ASSERT_TRUE(floatOpt.has_value());
-    EXPECT_FLOAT_EQ(floatOpt.value(), std::numeric_limits<float>::max());
+    EXPECT_FLOAT_EQ(*floatOpt, std::numeric_limits<float>::max());
 
     tensor.set_value(std::numeric_limits<int32_t>::min());
     auto intOpt = tensor.get_pass_by_value<int32_t>();
     ASSERT_TRUE(intOpt.has_value());
-    EXPECT_EQ(intOpt.value(), std::numeric_limits<int32_t>::min());
+    EXPECT_EQ(*intOpt, std::numeric_limits<int32_t>::min());
 
     tensor.set_value(std::numeric_limits<uint8_t>::max());
     auto uint8Opt = tensor.get_pass_by_value<uint8_t>();
     ASSERT_TRUE(uint8Opt.has_value());
-    EXPECT_EQ(uint8Opt.value(), std::numeric_limits<uint8_t>::max());
+    EXPECT_EQ(*uint8Opt, std::numeric_limits<uint8_t>::max());
 
     tensor.set_value(std::numeric_limits<double>::infinity());
 

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/PluginException.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/PluginException.hpp
@@ -45,7 +45,7 @@ private:
 #define PLUGIN_THROW_IF_NE(x, y, failureStatus, message)                            \
     do                                                                              \
     {                                                                               \
-        if(x != y)                                                                  \
+        if((x) != (y))                                                              \
         {                                                                           \
             throw hipdnn_plugin_sdk::HipdnnPluginException(failureStatus, message); \
         }                                                                           \
@@ -54,7 +54,7 @@ private:
 #define PLUGIN_THROW_IF_EQ(x, y, failureStatus, message)                            \
     do                                                                              \
     {                                                                               \
-        if(x == y)                                                                  \
+        if((x) == (y))                                                              \
         {                                                                           \
             throw hipdnn_plugin_sdk::HipdnnPluginException(failureStatus, message); \
         }                                                                           \
@@ -81,7 +81,7 @@ private:
 #define PLUGIN_THROW_IF_NULL(x, failureStatus, message)                             \
     do                                                                              \
     {                                                                               \
-        if(x == nullptr)                                                            \
+        if((x) == nullptr)                                                          \
         {                                                                           \
             throw hipdnn_plugin_sdk::HipdnnPluginException(failureStatus, message); \
         }                                                                           \
@@ -90,7 +90,7 @@ private:
 #define PLUGIN_THROW_IF_LT(x, y, failureStatus, message)                            \
     do                                                                              \
     {                                                                               \
-        if(x < y)                                                                   \
+        if((x) < (y))                                                               \
         {                                                                           \
             throw hipdnn_plugin_sdk::HipdnnPluginException(failureStatus, message); \
         }                                                                           \

--- a/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/PluginHelpers.hpp
+++ b/projects/hipdnn/plugin_sdk/include/hipdnn_plugin_sdk/PluginHelpers.hpp
@@ -9,10 +9,12 @@
 
 #include <iostream>
 
+// NOLINTBEGIN(bugprone-macro-parentheses) - msg is a stream expression, cannot be parenthesized
 // Logging macros for plugin API entry/exit (stream-style)
 #define LOG_API_ENTRY(msg) HIPDNN_PLUGIN_LOG_INFO("API called: [" << __func__ << "] " << msg)
 #define LOG_API_SUCCESS(func_name, msg) \
-    HIPDNN_PLUGIN_LOG_INFO("API success: [" << func_name << "] " << msg)
+    HIPDNN_PLUGIN_LOG_INFO("API success: [" << (func_name) << "] " << msg)
+// NOLINTEND(bugprone-macro-parentheses)
 
 namespace hipdnn_plugin_sdk
 {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
@@ -79,11 +79,7 @@ constexpr float getToleranceTraining()
     {
         return 1e-7f; // this needs to be changed when double is supported
     }
-    else if constexpr(std::is_same_v<T, float>)
-    {
-        return 4e-3f;
-    }
-    else if constexpr(std::is_same_v<T, half>)
+    else if constexpr(std::is_same_v<T, float> || std::is_same_v<T, half>)
     {
         return 4e-3f;
     }
@@ -127,15 +123,7 @@ constexpr float getRmsToleranceTraining()
 {
     // RMS tolerance values for use with CpuFpReferenceMiopenRmsValidation
     // These match MIOpen's relative RMS error tolerance (typically 0.4% = 4e-3)
-    if constexpr(std::is_same_v<T, double>)
-    {
-        return 4e-3f; // 0.4% relative RMS error
-    }
-    else if constexpr(std::is_same_v<T, float>)
-    {
-        return 4e-3f; // 0.4% relative RMS error
-    }
-    else if constexpr(std::is_same_v<T, half>)
+    if constexpr(std::is_same_v<T, double> || std::is_same_v<T, float> || std::is_same_v<T, half>)
     {
         return 4e-3f; // 0.4% relative RMS error
     }
@@ -161,11 +149,7 @@ constexpr float getToleranceFwd()
     {
         return 1e-5f;
     }
-    else if constexpr(std::is_same_v<T, half>)
-    {
-        return 1e-2f;
-    }
-    else if constexpr(std::is_same_v<T, bfloat16>)
+    else if constexpr(std::is_same_v<T, half> || std::is_same_v<T, bfloat16>)
     {
         return 1e-2f;
     }
@@ -189,11 +173,7 @@ constexpr float getToleranceBwd()
     {
         return 8.5e-6f;
     }
-    else if constexpr(std::is_same_v<T, half>)
-    {
-        return 2e-2f;
-    }
-    else if constexpr(std::is_same_v<T, bfloat16>)
+    else if constexpr(std::is_same_v<T, half> || std::is_same_v<T, bfloat16>)
     {
         return 2e-2f;
     }
@@ -216,11 +196,7 @@ constexpr float getToleranceWrw()
     {
         return 2e-4f;
     }
-    else if constexpr(std::is_same_v<T, half>)
-    {
-        return 2e-1f;
-    }
-    else if constexpr(std::is_same_v<T, bfloat16>)
+    else if constexpr(std::is_same_v<T, half> || std::is_same_v<T, bfloat16>)
     {
         return 2e-1f;
     }
@@ -242,11 +218,7 @@ constexpr float getTolerance()
     {
         return 1e-5f;
     }
-    else if constexpr(std::is_same_v<T, half>)
-    {
-        return 1e-2f;
-    }
-    else if constexpr(std::is_same_v<T, bfloat16>)
+    else if constexpr(std::is_same_v<T, half> || std::is_same_v<T, bfloat16>)
     {
         return 1e-2f;
     }

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormBwdSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormBwdSignatureKey.hpp
@@ -73,9 +73,8 @@ struct BatchnormBwdSignatureKey
         if(nodeAttributes->mean_tensor_uid().has_value()
            && nodeAttributes->inv_variance_tensor_uid().has_value())
         {
-            auto meanTensorAttr = tensorMap.at(nodeAttributes->mean_tensor_uid().value());
-            auto invVarianceTensorAttr
-                = tensorMap.at(nodeAttributes->inv_variance_tensor_uid().value());
+            auto meanTensorAttr = tensorMap.at(*nodeAttributes->mean_tensor_uid());
+            auto invVarianceTensorAttr = tensorMap.at(*nodeAttributes->inv_variance_tensor_uid());
 
             if(meanTensorAttr->data_type() != invVarianceTensorAttr->data_type())
             {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainPlan.hpp
@@ -124,15 +124,14 @@ public:
         if(_params.meanTensor.has_value())
         {
             mean = createShallowTensor<MeanVarianceDataType>(
-                _params.meanTensor.value(), variantPack.at(_params.meanTensor.value().uid));
+                *_params.meanTensor, variantPack.at(_params.meanTensor->uid));
             meanPtr = mean.get();
         }
 
         if(_params.invVarianceTensor.has_value())
         {
             invVariance = createShallowTensor<MeanVarianceDataType>(
-                _params.invVarianceTensor.value(),
-                variantPack.at(_params.invVarianceTensor.value().uid));
+                *_params.invVarianceTensor, variantPack.at(_params.invVarianceTensor->uid));
             invVariancePtr = invVariance.get();
         }
 
@@ -157,35 +156,33 @@ public:
         if(_params.momentumTensor.has_value())
         {
             momentumValue = hipdnn_data_sdk::utilities::extractDoubleFromTensorValue(
-                _params.momentumTensor.value(), "Momentum");
+                *_params.momentumTensor, "Momentum");
         }
 
         if(_params.prevRunningMeanTensor.has_value())
         {
             prevRunningMean = createShallowTensor<MeanVarianceDataType>(
-                _params.prevRunningMeanTensor.value(),
-                variantPack.at(_params.prevRunningMeanTensor.value().uid));
+                *_params.prevRunningMeanTensor, variantPack.at(_params.prevRunningMeanTensor->uid));
             prevRunningMeanPtr = prevRunningMean.get();
         }
         if(_params.prevRunningVarianceTensor.has_value())
         {
             prevRunningVariance = createShallowTensor<MeanVarianceDataType>(
-                _params.prevRunningVarianceTensor.value(),
-                variantPack.at(_params.prevRunningVarianceTensor.value().uid));
+                *_params.prevRunningVarianceTensor,
+                variantPack.at(_params.prevRunningVarianceTensor->uid));
             prevRunningVariancePtr = prevRunningVariance.get();
         }
         if(_params.nextRunningMeanTensor.has_value())
         {
             nextRunningMean = createShallowTensor<MeanVarianceDataType>(
-                _params.nextRunningMeanTensor.value(),
-                variantPack.at(_params.nextRunningMeanTensor.value().uid));
+                *_params.nextRunningMeanTensor, variantPack.at(_params.nextRunningMeanTensor->uid));
             nextRunningMeanPtr = nextRunningMean.get();
         }
         if(_params.nextRunningVarianceTensor.has_value())
         {
             nextRunningVariance = createShallowTensor<MeanVarianceDataType>(
-                _params.nextRunningVarianceTensor.value(),
-                variantPack.at(_params.nextRunningVarianceTensor.value().uid));
+                *_params.nextRunningVarianceTensor,
+                variantPack.at(_params.nextRunningVarianceTensor->uid));
             nextRunningVariancePtr = nextRunningVariance.get();
         }
 
@@ -330,17 +327,17 @@ public:
 
         if(nodeAttributes->mean_tensor_uid().has_value())
         {
-            mean = tensorMap.at(nodeAttributes->mean_tensor_uid().value());
+            mean = tensorMap.at(*nodeAttributes->mean_tensor_uid());
         }
 
         if(nodeAttributes->inv_variance_tensor_uid().has_value())
         {
-            invVariance = tensorMap.at(nodeAttributes->inv_variance_tensor_uid().value());
+            invVariance = tensorMap.at(*nodeAttributes->inv_variance_tensor_uid());
         }
 
         if(nodeAttributes->momentum_tensor_uid())
         {
-            momentum = tensorMap.at(nodeAttributes->momentum_tensor_uid().value());
+            momentum = tensorMap.at(*nodeAttributes->momentum_tensor_uid());
         }
 
         if(nodeAttributes->prev_running_mean_tensor_uid()
@@ -348,12 +345,10 @@ public:
            && nodeAttributes->next_running_mean_tensor_uid()
            && nodeAttributes->next_running_variance_tensor_uid())
         {
-            prevRunningMean = tensorMap.at(nodeAttributes->prev_running_mean_tensor_uid().value());
-            prevRunningVariance
-                = tensorMap.at(nodeAttributes->prev_running_variance_tensor_uid().value());
-            nextRunningMean = tensorMap.at(nodeAttributes->next_running_mean_tensor_uid().value());
-            nextRunningVariance
-                = tensorMap.at(nodeAttributes->next_running_variance_tensor_uid().value());
+            prevRunningMean = tensorMap.at(*nodeAttributes->prev_running_mean_tensor_uid());
+            prevRunningVariance = tensorMap.at(*nodeAttributes->prev_running_variance_tensor_uid());
+            nextRunningMean = tensorMap.at(*nodeAttributes->next_running_mean_tensor_uid());
+            nextRunningVariance = tensorMap.at(*nodeAttributes->next_running_variance_tensor_uid());
         }
 
         BatchnormTrainParams<MeanVarianceDataType> params(

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainSignatureKey.hpp
@@ -49,7 +49,7 @@ struct BatchnormTrainSignatureKey
         }
 
         auto xTensorAttr = tensorMap.at(nodeAttributes->x_tensor_uid());
-        auto meanTensorAttr = tensorMap.at(nodeAttributes->mean_tensor_uid().value());
+        auto meanTensorAttr = tensorMap.at(*nodeAttributes->mean_tensor_uid());
         auto scaleTensorAttr = tensorMap.at(nodeAttributes->scale_tensor_uid());
         auto yTensorAttr = tensorMap.at(nodeAttributes->y_tensor_uid());
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanRegistrySignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanRegistrySignatureKey.hpp
@@ -45,7 +45,14 @@ struct PlanRegistrySignatureKeyHash
 {
     std::size_t operator()(const PlanRegistrySignatureKey& k) const noexcept
     {
-        return std::visit([](auto const& x) { return x.hashSelf(); }, k);
+        try
+        {
+            return std::visit([](auto const& x) { return x.hashSelf(); }, k);
+        }
+        catch(...)
+        {
+            return 0;
+        }
     }
 };
 
@@ -67,7 +74,14 @@ struct PlanRegistrySignatureKeyEqual
     bool operator()(const PlanRegistrySignatureKey& a,
                     const PlanRegistrySignatureKey& b) const noexcept
     {
-        return std::visit(*this, a, b);
+        try
+        {
+            return std::visit(*this, a, b);
+        }
+        catch(...)
+        {
+            return false;
+        }
     }
 };
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanUtils.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanUtils.hpp
@@ -26,7 +26,7 @@
 #define CHECK_OPTIONAL_TENSOR_EXISTS(tensor_map, optional_tensor_uid) \
     do                                                                \
     {                                                                 \
-        if(!optional_tensor_uid.has_value())                          \
+        if(!(optional_tensor_uid).has_value())                        \
         {                                                             \
             return false;                                             \
         }                                                             \

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PointwisePlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PointwisePlan.hpp
@@ -74,6 +74,7 @@ public:
 
     void execute(const std::unordered_map<int64_t, void*>& variantPack) override
     {
+        // NOLINTNEXTLINE(bugprone-branch-clone) - Different parameter presence requires different code paths
         if(_params.reluLowerClip.has_value() || _params.reluUpperClip.has_value()
            || _params.reluLowerClipSlope.has_value() || _params.swishBeta.has_value())
         {
@@ -107,7 +108,7 @@ private:
             }
 
             auto shallowIn1Tensor = createShallowTensor<Input1Type>(
-                _params.in1Tensor.value(), variantPack.at(_params.in1Tensor.value().uid));
+                *_params.in1Tensor, variantPack.at(_params.in1Tensor->uid));
 
             utilities::CpuReferencePointwiseImpl<OutputType, Input0Type, Input1Type>::
                 pointwiseCompute(
@@ -152,7 +153,7 @@ private:
             }
 
             auto shallowIn1Tensor = createShallowTensor<Input1Type>(
-                _params.in1Tensor.value(), variantPack.at(_params.in1Tensor.value().uid));
+                *_params.in1Tensor, variantPack.at(_params.in1Tensor->uid));
 
             utilities::CpuReferencePointwiseImpl<OutputType, Input0Type, Input1Type>::
                 pointwiseCompute(_params.mode,

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp
@@ -38,16 +38,10 @@ constexpr bool IS_VALID_TENSOR_TYPE_V
 template <typename TargetType, typename SourceType>
 inline TargetType safeConvert(const SourceType& value)
 {
-    if constexpr(std::is_same_v<TargetType, bfloat16>)
+    if constexpr(std::is_same_v<TargetType, bfloat16> || std::is_same_v<TargetType, half>)
     {
-        // For bfloat16, explicitly convert through float to avoid precision warnings
-        // bfloat16 lacks direct constructor from double, only from float
-        return static_cast<TargetType>(static_cast<float>(value));
-    }
-    else if constexpr(std::is_same_v<TargetType, half>)
-    {
-        // For half, explicitly convert through float to avoid precision warnings
-        // half lacks direct constructor from double, only from float
+        // For bfloat16 and half, explicitly convert through float to avoid precision warnings
+        // Both types lack direct constructor from double, only from float
         return static_cast<TargetType>(static_cast<float>(value));
     }
     else

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/ReferencePointwiseBase.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/ReferencePointwiseBase.hpp
@@ -104,6 +104,7 @@ private:
     {
         DeviceExecutor policy;
 
+        // NOLINTBEGIN(bugprone-branch-clone) - Branches appear identical but use different functor types
         switch(operation)
         {
         case hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD:
@@ -137,6 +138,7 @@ private:
             throw std::runtime_error("Unsupported unary pointwise operation: "
                                      + std::to_string(static_cast<int>(operation)));
         }
+        // NOLINTEND(bugprone-branch-clone)
 
         policy.markOutputModified(output);
     }
@@ -153,6 +155,7 @@ private:
     {
         DeviceExecutor policy;
 
+        // NOLINTBEGIN(bugprone-branch-clone) - Branches appear identical but use different functor types
         switch(operation)
         {
         case hipdnn_data_sdk::data_objects::PointwiseMode::RELU_FWD:
@@ -173,6 +176,7 @@ private:
             throw std::runtime_error("Unsupported parameterized pointwise operation: "
                                      + std::to_string(static_cast<int>(operation)));
         }
+        // NOLINTEND(bugprone-branch-clone)
 
         policy.markOutputModified(output);
     }
@@ -197,6 +201,7 @@ private:
         case hipdnn_data_sdk::data_objects::PointwiseMode::MUL:
             policy.executeBinaryBroadcast(input1, input2, output, pointwise::Multiply{});
             break;
+        // NOLINTBEGIN(bugprone-branch-clone) - different functor types
         case hipdnn_data_sdk::data_objects::PointwiseMode::RELU_BWD:
             policy.executeBinaryBroadcast(
                 input1, input2, output, pointwise::ReluBackward<ComputeType>{});
@@ -209,6 +214,7 @@ private:
             policy.executeBinaryBroadcast(
                 input1, input2, output, pointwise::TanhBackward<ComputeType>{});
             break;
+        // NOLINTEND(bugprone-branch-clone)
         default:
             throw std::runtime_error("Unsupported binary pointwise operation: "
                                      + std::to_string(static_cast<int>(operation)));

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceMatmul.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceMatmul.cpp
@@ -355,7 +355,7 @@ TYPED_TEST(CpuFpReferenceMatmulBasic, MatmulBatch3D)
     for(int i = 0; i < tensorAElementCount; ++i)
     {
         tensorA.memory().hostData()[i] = static_cast<typename TypeParam::ADataType>(
-            static_cast<float>(i - tensorAElementCount / 2));
+            static_cast<float>(i - static_cast<double>(tensorAElementCount) / 2));
     }
     for(int i = 0; i < tensorBElementCount; ++i)
     {
@@ -393,12 +393,12 @@ TYPED_TEST(CpuFpReferenceMatmulBasic, Matmul3DBroadcast)
     for(int i = 0; i < tensorAElementCount; ++i)
     {
         tensorA.memory().hostData()[i] = static_cast<typename TypeParam::ADataType>(
-            static_cast<float>(i - tensorAElementCount / 2));
+            static_cast<float>(i - static_cast<double>(tensorAElementCount) / 2));
     }
     for(int i = 0; i < tensorBElementCount; ++i)
     {
         tensorB.memory().hostData()[i] = static_cast<typename TypeParam::BDataType>(
-            static_cast<float>(i + tensorAElementCount / 2));
+            static_cast<float>(i + static_cast<double>(tensorAElementCount) / 2));
     }
 
     hipdnn_test_sdk::utilities::CpuFpReferenceMatmul::matmul<typename TypeParam::ADataType,
@@ -464,12 +464,12 @@ TYPED_TEST(CpuFpReferenceMatmulBasic, Matmul4DBroadcast)
     for(int i = 0; i < tensorAElementCount; ++i)
     {
         tensorA.memory().hostData()[i] = static_cast<typename TypeParam::ADataType>(
-            static_cast<float>(i - tensorAElementCount / 2));
+            static_cast<float>(i - static_cast<double>(tensorAElementCount) / 2));
     }
     for(int i = 0; i < tensorBElementCount; ++i)
     {
         tensorB.memory().hostData()[i] = static_cast<typename TypeParam::BDataType>(
-            static_cast<float>(i + tensorAElementCount / 2));
+            static_cast<float>(i + static_cast<double>(tensorAElementCount) / 2));
     }
 
     hipdnn_test_sdk::utilities::CpuFpReferenceMatmul::matmul<typename TypeParam::ADataType,

--- a/projects/hipdnn/test_sdk/tests/utilities/TestLoggingUtils.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestLoggingUtils.cpp
@@ -84,35 +84,45 @@ TEST(TestStringToSeverity, ValidOffReturnsOptionalWithOff)
 {
     auto result = detail::stringToSeverity("off");
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), HIPDNN_SEV_OFF);
+    EXPECT_EQ(
+        *result,
+        HIPDNN_SEV_OFF); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 }
 
 TEST(TestStringToSeverity, ValidInfoReturnsOptionalWithInfo)
 {
     auto result = detail::stringToSeverity("info");
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), HIPDNN_SEV_INFO);
+    EXPECT_EQ(
+        *result,
+        HIPDNN_SEV_INFO); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 }
 
 TEST(TestStringToSeverity, ValidWarnReturnsOptionalWithWarn)
 {
     auto result = detail::stringToSeverity("warn");
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), HIPDNN_SEV_WARN);
+    EXPECT_EQ(
+        *result,
+        HIPDNN_SEV_WARN); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 }
 
 TEST(TestStringToSeverity, ValidErrorReturnsOptionalWithError)
 {
     auto result = detail::stringToSeverity("error");
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), HIPDNN_SEV_ERROR);
+    EXPECT_EQ(
+        *result,
+        HIPDNN_SEV_ERROR); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 }
 
 TEST(TestStringToSeverity, ValidFatalReturnsOptionalWithFatal)
 {
     auto result = detail::stringToSeverity("fatal");
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result.value(), HIPDNN_SEV_FATAL);
+    EXPECT_EQ(
+        *result,
+        HIPDNN_SEV_FATAL); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 }
 
 TEST(TestStringToSeverity, InvalidStringReturnsNullopt)
@@ -133,45 +143,67 @@ TEST(TestStringToSeverity, CaseInsensitiveMatching)
 {
     // Uppercase
     ASSERT_TRUE(detail::stringToSeverity("OFF").has_value());
-    EXPECT_EQ(detail::stringToSeverity("OFF").value(), HIPDNN_SEV_OFF);
+    EXPECT_EQ(
+        *detail::stringToSeverity("OFF"),
+        HIPDNN_SEV_OFF); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     ASSERT_TRUE(detail::stringToSeverity("INFO").has_value());
-    EXPECT_EQ(detail::stringToSeverity("INFO").value(), HIPDNN_SEV_INFO);
+    EXPECT_EQ(
+        *detail::stringToSeverity("INFO"),
+        HIPDNN_SEV_INFO); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     ASSERT_TRUE(detail::stringToSeverity("WARN").has_value());
-    EXPECT_EQ(detail::stringToSeverity("WARN").value(), HIPDNN_SEV_WARN);
+    EXPECT_EQ(
+        *detail::stringToSeverity("WARN"),
+        HIPDNN_SEV_WARN); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     ASSERT_TRUE(detail::stringToSeverity("ERROR").has_value());
-    EXPECT_EQ(detail::stringToSeverity("ERROR").value(), HIPDNN_SEV_ERROR);
+    EXPECT_EQ(
+        *detail::stringToSeverity("ERROR"),
+        HIPDNN_SEV_ERROR); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     ASSERT_TRUE(detail::stringToSeverity("FATAL").has_value());
-    EXPECT_EQ(detail::stringToSeverity("FATAL").value(), HIPDNN_SEV_FATAL);
+    EXPECT_EQ(
+        *detail::stringToSeverity("FATAL"),
+        HIPDNN_SEV_FATAL); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     // Mixed case
     ASSERT_TRUE(detail::stringToSeverity("Info").has_value());
-    EXPECT_EQ(detail::stringToSeverity("Info").value(), HIPDNN_SEV_INFO);
+    EXPECT_EQ(
+        *detail::stringToSeverity("Info"),
+        HIPDNN_SEV_INFO); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     ASSERT_TRUE(detail::stringToSeverity("WaRn").has_value());
-    EXPECT_EQ(detail::stringToSeverity("WaRn").value(), HIPDNN_SEV_WARN);
+    EXPECT_EQ(
+        *detail::stringToSeverity("WaRn"),
+        HIPDNN_SEV_WARN); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 }
 
 TEST(TestStringToSeverity, TrimsWhitespace)
 {
     // Leading whitespace
     ASSERT_TRUE(detail::stringToSeverity("  info").has_value());
-    EXPECT_EQ(detail::stringToSeverity("  info").value(), HIPDNN_SEV_INFO);
+    EXPECT_EQ(
+        *detail::stringToSeverity("  info"),
+        HIPDNN_SEV_INFO); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     // Trailing whitespace
     ASSERT_TRUE(detail::stringToSeverity("warn  ").has_value());
-    EXPECT_EQ(detail::stringToSeverity("warn  ").value(), HIPDNN_SEV_WARN);
+    EXPECT_EQ(
+        *detail::stringToSeverity("warn  "),
+        HIPDNN_SEV_WARN); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     // Both ends
     ASSERT_TRUE(detail::stringToSeverity("  error  ").has_value());
-    EXPECT_EQ(detail::stringToSeverity("  error  ").value(), HIPDNN_SEV_ERROR);
+    EXPECT_EQ(
+        *detail::stringToSeverity("  error  "),
+        HIPDNN_SEV_ERROR); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     // Tabs and newlines
     ASSERT_TRUE(detail::stringToSeverity("\tfatal\n").has_value());
-    EXPECT_EQ(detail::stringToSeverity("\tfatal\n").value(), HIPDNN_SEV_FATAL);
+    EXPECT_EQ(
+        *detail::stringToSeverity("\tfatal\n"),
+        HIPDNN_SEV_FATAL); // NOLINT(bugprone-unchecked-optional-access) - checked by ASSERT_TRUE
 
     // Whitespace-only still invalid
     EXPECT_FALSE(detail::stringToSeverity("   ").has_value());

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BatchnormGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BatchnormGraphUtils.hpp
@@ -76,7 +76,7 @@ static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
         auto prevRunningMeanAttr = hipdnn_frontend::graph::makeTensorAttributes(
             "prev_running_mean",
             hipdnn_frontend::fromSdkType(meanVarianceDataType),
-            tensorBundle.prevRunningMeanTensor.value());
+            *tensorBundle.prevRunningMeanTensor);
         prevRunningMeanAttr.set_uid(uid++);
         prevRunningMeanTensorAttr = std::make_shared<hipdnn_frontend::graph::TensorAttributes>(
             std::move(prevRunningMeanAttr));
@@ -84,7 +84,7 @@ static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
         auto prevRunningVarianceAttr = hipdnn_frontend::graph::makeTensorAttributes(
             "prev_running_variance",
             hipdnn_frontend::fromSdkType(meanVarianceDataType),
-            tensorBundle.prevRunningVarianceTensor.value());
+            *tensorBundle.prevRunningVarianceTensor);
         prevRunningVarianceAttr.set_uid(uid++);
         prevRunningVarianceTensorAttr = std::make_shared<hipdnn_frontend::graph::TensorAttributes>(
             std::move(prevRunningVarianceAttr));

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BatchnormTensorBundles.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BatchnormTensorBundles.hpp
@@ -143,31 +143,31 @@ struct BatchnormTrainTensorBundle
         //optionals
         if(momentumTensorAttr != nullptr)
         {
-            variantPack[momentumTensorAttr->get_uid()] = momentumTensor.value().memory().hostData();
+            variantPack[momentumTensorAttr->get_uid()] = momentumTensor->memory().hostData();
         }
 
         if(prevRunningMeanTensorAttr != nullptr)
         {
             variantPack[prevRunningMeanTensorAttr->get_uid()]
-                = prevRunningMeanTensor.value().memory().hostData();
+                = prevRunningMeanTensor->memory().hostData();
         }
 
         if(prevRunningVarianceTensorAttr != nullptr)
         {
             variantPack[prevRunningVarianceTensorAttr->get_uid()]
-                = prevRunningVarianceTensor.value().memory().hostData();
+                = prevRunningVarianceTensor->memory().hostData();
         }
 
         if(nextRunningMeanTensorAttr != nullptr)
         {
             variantPack[nextRunningMeanTensorAttr->get_uid()]
-                = nextRunningMeanTensor.value().memory().hostData();
+                = nextRunningMeanTensor->memory().hostData();
         }
 
         if(nextRunningVarianceTensorAttr != nullptr)
         {
             variantPack[nextRunningVarianceTensorAttr->get_uid()]
-                = nextRunningVarianceTensor.value().memory().hostData();
+                = nextRunningVarianceTensor->memory().hostData();
         }
 
         return variantPack;

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/PointwiseTensorBundles.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/PointwiseTensorBundles.hpp
@@ -43,7 +43,7 @@ struct PointwiseBinaryTensorBundle : public hipdnn_test_sdk::utilities::GraphTen
             = node.attributesAs<hipdnn_data_sdk::data_objects::PointwiseAttributes>();
 
         randomizeTensor(attributes.in_0_tensor_uid(), -1.0f, 1.0f, seed);
-        randomizeTensor(attributes.in_1_tensor_uid().value(), -1.0f, 1.0f, seed + 1);
+        randomizeTensor(*attributes.in_1_tensor_uid(), -1.0f, 1.0f, seed + 1);
         // Output tensor not randomized - computed by operation
     }
 };

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPointwiseOperationsCpuGraphExecutor.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestPointwiseOperationsCpuGraphExecutor.cpp
@@ -113,7 +113,7 @@ public:
 
         tensorBundle.tensors[attributes.in_0_tensor_uid()]->fillTensorWithValue(
             params.in0TensorValue);
-        tensorBundle.tensors[attributes.in_1_tensor_uid().value()]->fillTensorWithValue(
+        tensorBundle.tensors[*attributes.in_1_tensor_uid()]->fillTensorWithValue(
             params.in1TensorValue);
 
         CpuReferenceGraphExecutor().execute(
@@ -132,6 +132,7 @@ public:
         input0.fillTensorWithValue(params.in0TensorValue);
         Tensor<InputType> output(params.outputDims);
 
+        // NOLINTNEXTLINE(bugprone-branch-clone) - branches have different arg counts
         if(params.reluLowerClip.has_value() || params.reluUpperClip.has_value()
            || params.reluLowerClipSlope.has_value())
         {
@@ -139,10 +140,10 @@ public:
                 PointwiseMode::RELU_FWD,
                 output,
                 input0,
-                params.reluLowerClip.has_value() ? params.reluLowerClip.value() : 0.0f,
-                params.reluUpperClip.has_value() ? params.reluUpperClip.value()
+                params.reluLowerClip.has_value() ? *params.reluLowerClip : 0.0f,
+                params.reluUpperClip.has_value() ? *params.reluUpperClip
                                                  : std::numeric_limits<float>::max(),
-                params.reluLowerClipSlope.has_value() ? params.reluLowerClipSlope.value() : 0.0f);
+                params.reluLowerClipSlope.has_value() ? *params.reluLowerClipSlope : 0.0f);
         }
         else
         {
@@ -164,6 +165,7 @@ public:
 
         Tensor<InputType> output(params.outputDims);
 
+        // NOLINTNEXTLINE(bugprone-branch-clone) - branches have different arg counts
         if(params.reluLowerClip.has_value() || params.reluUpperClip.has_value()
            || params.reluLowerClipSlope.has_value())
         {
@@ -172,10 +174,10 @@ public:
                 output,
                 input0,
                 input1,
-                params.reluLowerClip.has_value() ? params.reluLowerClip.value() : 0.0f,
-                params.reluUpperClip.has_value() ? params.reluUpperClip.value()
+                params.reluLowerClip.has_value() ? *params.reluLowerClip : 0.0f,
+                params.reluUpperClip.has_value() ? *params.reluUpperClip
                                                  : std::numeric_limits<float>::max(),
-                params.reluLowerClipSlope.has_value() ? params.reluLowerClipSlope.value() : 0.0f);
+                params.reluLowerClipSlope.has_value() ? *params.reluLowerClipSlope : 0.0f);
         }
         else
         {

--- a/projects/hipdnn/tests/backend/IntegrationConvOperationDescriptorApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationConvOperationDescriptorApi.cpp
@@ -67,19 +67,19 @@ TEST_F(IntegrationConvOperationDescriptorApi, CreateAndFinalizeConvOperation)
                                         HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &xDesc),
+                                        static_cast<const void*>(&xDesc)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendSetAttribute(opDesc,
                                         HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &wDesc),
+                                        static_cast<const void*>(&wDesc)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendSetAttribute(opDesc,
                                         HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &yDesc),
+                                        static_cast<const void*>(&yDesc)),
               HIPDNN_STATUS_SUCCESS);
 
     // Set convolution parameters
@@ -147,19 +147,19 @@ TEST_F(IntegrationConvOperationDescriptorApi, GetAfterSetVerifiesAllAttributes)
                                         HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &xDesc),
+                                        static_cast<const void*>(&xDesc)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendSetAttribute(opDesc,
                                         HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &wDesc),
+                                        static_cast<const void*>(&wDesc)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendSetAttribute(opDesc,
                                         HIPDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_Y,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &yDesc),
+                                        static_cast<const void*>(&yDesc)),
               HIPDNN_STATUS_SUCCESS);
 
     // Set convolution parameters
@@ -215,7 +215,7 @@ TEST_F(IntegrationConvOperationDescriptorApi, GetAfterSetVerifiesAllAttributes)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         &elementCount,
-                                        &retrievedDesc),
+                                        static_cast<void*>(&retrievedDesc)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(elementCount, 1);
     EXPECT_NE(retrievedDesc, nullptr);
@@ -228,7 +228,7 @@ TEST_F(IntegrationConvOperationDescriptorApi, GetAfterSetVerifiesAllAttributes)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         &elementCount,
-                                        &retrievedDesc),
+                                        static_cast<void*>(&retrievedDesc)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(elementCount, 1);
     EXPECT_NE(retrievedDesc, nullptr);
@@ -241,7 +241,7 @@ TEST_F(IntegrationConvOperationDescriptorApi, GetAfterSetVerifiesAllAttributes)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         &elementCount,
-                                        &retrievedDesc),
+                                        static_cast<void*>(&retrievedDesc)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(elementCount, 1);
     EXPECT_NE(retrievedDesc, nullptr);

--- a/projects/hipdnn/tests/backend/IntegrationEngineApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationEngineApi.cpp
@@ -50,7 +50,7 @@ TEST_F(IntegrationEngineApi, SetEngineOperationGraph)
                                         HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_graph),
+                                        static_cast<const void*>(&_graph)),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     test_util::createTestGraph(&_graph, _handle);
@@ -59,7 +59,7 @@ TEST_F(IntegrationEngineApi, SetEngineOperationGraph)
                                         HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_graph),
+                                        static_cast<const void*>(&_graph)),
               HIPDNN_STATUS_SUCCESS);
 }
 
@@ -113,7 +113,7 @@ TEST_F(IntegrationEngineApi, GetEngineOperationGraph)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         nullptr,
-                                        &graph),
+                                        static_cast<void*>(&graph)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_NE(graph, nullptr);
 

--- a/projects/hipdnn/tests/backend/IntegrationEngineConfigApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationEngineConfigApi.cpp
@@ -57,7 +57,7 @@ TEST_F(IntegrationEngineConfigApi, SetEngineConfigEngine)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine),
+                                        static_cast<const void*>(&_engine)),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     test_util::createTestEngine(&_engine, &_graph, _handle, gidx, true);
@@ -65,7 +65,7 @@ TEST_F(IntegrationEngineConfigApi, SetEngineConfigEngine)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine),
+                                        static_cast<const void*>(&_engine)),
               HIPDNN_STATUS_SUCCESS);
 }
 
@@ -179,7 +179,7 @@ TEST_F(IntegrationEngineConfigApi, SetAttributeAfterFinalization)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &newEngine),
+                                        static_cast<const void*>(&newEngine)),
               HIPDNN_STATUS_NOT_INITIALIZED);
 
     if(newEngine != nullptr)

--- a/projects/hipdnn/tests/backend/IntegrationEngineHeuristicApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationEngineHeuristicApi.cpp
@@ -72,7 +72,7 @@ protected:
                                             HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                             1,
-                                            &_graph),
+                                            static_cast<const void*>(&_graph)),
                   HIPDNN_STATUS_SUCCESS);
     }
 
@@ -95,7 +95,7 @@ TEST_F(IntegrationEngineHeuristicApi, SetEngineHeuristicOperationGraph)
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &nullGraph),
+                                        static_cast<const void*>(&nullGraph)),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     test_util::createTestGraph(&_graph, _handle);
@@ -104,7 +104,7 @@ TEST_F(IntegrationEngineHeuristicApi, SetEngineHeuristicOperationGraph)
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_graph),
+                                        static_cast<const void*>(&_graph)),
               HIPDNN_STATUS_SUCCESS);
 }
 
@@ -186,7 +186,7 @@ TEST_F(IntegrationEngineHeuristicApi, GetAttributeOnUnfinalizedDescriptor)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         nullptr,
-                                        &dummyGraph),
+                                        static_cast<void*>(&dummyGraph)),
               HIPDNN_STATUS_BAD_PARAM_NOT_FINALIZED);
 }
 
@@ -202,7 +202,7 @@ TEST_F(IntegrationEngineHeuristicApi, GetEngineHeuristicOperationGraph)
                                         HIPDNN_TYPE_INT64,
                                         1,
                                         nullptr,
-                                        &retrievedGraph),
+                                        static_cast<void*>(&retrievedGraph)),
               HIPDNN_STATUS_BAD_PARAM);
 
     EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
@@ -210,7 +210,7 @@ TEST_F(IntegrationEngineHeuristicApi, GetEngineHeuristicOperationGraph)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         2,
                                         nullptr,
-                                        &retrievedGraph),
+                                        static_cast<void*>(&retrievedGraph)),
               HIPDNN_STATUS_BAD_PARAM);
 
     EXPECT_EQ(hipdnnBackendGetAttribute(_engineHeuristic,
@@ -226,7 +226,7 @@ TEST_F(IntegrationEngineHeuristicApi, GetEngineHeuristicOperationGraph)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         nullptr,
-                                        &retrievedGraph),
+                                        static_cast<void*>(&retrievedGraph)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_NE(retrievedGraph, nullptr);
 
@@ -239,7 +239,7 @@ TEST_F(IntegrationEngineHeuristicApi, GetEngineHeuristicOperationGraph)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         &count,
-                                        &retrievedGraph2),
+                                        static_cast<void*>(&retrievedGraph2)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(count, 1);
 
@@ -342,7 +342,7 @@ TEST_F(IntegrationEngineHeuristicApi, GetEngineConfigs)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         3,
                                         nullptr,
-                                        configs.data()),
+                                        static_cast<void*>(configs.data())),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
     int64_t count = 0;
@@ -375,7 +375,7 @@ TEST_F(IntegrationEngineHeuristicApi, GetEngineConfigs)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         3, // Ask for 3, but only one engine avaliable.
                                         &count,
-                                        configs.data()),
+                                        static_cast<void*>(configs.data())),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(count, 1); // Only one returned since there isn't more than that.
 
@@ -387,7 +387,7 @@ TEST_F(IntegrationEngineHeuristicApi, GetEngineConfigs)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
                                         nullptr,
-                                        &engine),
+                                        static_cast<void*>(&engine)),
               HIPDNN_STATUS_SUCCESS);
     ASSERT_NE(engine, nullptr);
 
@@ -427,7 +427,7 @@ TEST_F(IntegrationEngineHeuristicApi, GetEngineConfigsRequestMoreThanAvailable)
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         5,
                                         &count,
-                                        configs.data()),
+                                        static_cast<void*>(configs.data())),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(count, 1);
 

--- a/projects/hipdnn/tests/backend/IntegrationExecutionPlanApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationExecutionPlanApi.cpp
@@ -66,8 +66,11 @@ TEST_F(IntegrationExecutionPlanApi, SetExecutionPlanHandle)
                   _plan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, nullptr),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 
-    EXPECT_EQ(hipdnnBackendSetAttribute(
-                  _plan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+    EXPECT_EQ(hipdnnBackendSetAttribute(_plan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
               HIPDNN_STATUS_SUCCESS);
 }
 
@@ -86,7 +89,7 @@ TEST_F(IntegrationExecutionPlanApi, SetExecutionPlanEngineConfig)
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 }
 
@@ -118,8 +121,11 @@ TEST_F(IntegrationExecutionPlanApi, Finalize)
 {
     EXPECT_EQ(hipdnnBackendFinalize(_plan), HIPDNN_STATUS_BAD_PARAM);
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(
-                  _plan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
+    ASSERT_EQ(hipdnnBackendSetAttribute(_plan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendFinalize(_plan), HIPDNN_STATUS_BAD_PARAM);
 

--- a/projects/hipdnn/tests/backend/IntegrationGraphDescriptorApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationGraphDescriptorApi.cpp
@@ -68,8 +68,11 @@ TEST_F(IntegrationGraphDescriptorApi, SetOperationGraph)
     status = hipdnnCreate(&handle);
     EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
 
-    status = hipdnnBackendSetAttribute(
-        descriptor, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+    status = hipdnnBackendSetAttribute(descriptor,
+                                       HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                       HIPDNN_TYPE_HANDLE,
+                                       1,
+                                       static_cast<const void*>(&handle));
     EXPECT_EQ(status, HIPDNN_STATUS_SUCCESS);
 
     status = hipdnnBackendFinalize(descriptor);
@@ -150,8 +153,11 @@ TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphSizeQueryMatchesCopySize
     hipdnnHandle_t handle = nullptr;
     ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(
-                  desc, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+    ASSERT_EQ(hipdnnBackendSetAttribute(desc,
+                                        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&handle)),
               HIPDNN_STATUS_SUCCESS);
     ASSERT_EQ(hipdnnBackendFinalize(desc), HIPDNN_STATUS_SUCCESS);
 
@@ -203,8 +209,11 @@ TEST_F(IntegrationGraphDescriptorApi, SerializedGraphRoundTripPreservesGraphProp
     hipdnnHandle_t handle = nullptr;
     ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(
-                  desc, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+    ASSERT_EQ(hipdnnBackendSetAttribute(desc,
+                                        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&handle)),
               HIPDNN_STATUS_SUCCESS);
     ASSERT_EQ(hipdnnBackendFinalize(desc), HIPDNN_STATUS_SUCCESS);
 
@@ -259,8 +268,11 @@ TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphFailsWithInsufficientBuf
     hipdnnHandle_t handle = nullptr;
     ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(
-                  desc, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+    ASSERT_EQ(hipdnnBackendSetAttribute(desc,
+                                        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&handle)),
               HIPDNN_STATUS_SUCCESS);
     ASSERT_EQ(hipdnnBackendFinalize(desc), HIPDNN_STATUS_SUCCESS);
 
@@ -304,8 +316,11 @@ TEST_F(IntegrationGraphDescriptorApi, GetSerializedGraphSucceedsWithOversizedBuf
     hipdnnHandle_t handle = nullptr;
     ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(
-                  desc, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+    ASSERT_EQ(hipdnnBackendSetAttribute(desc,
+                                        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&handle)),
               HIPDNN_STATUS_SUCCESS);
     ASSERT_EQ(hipdnnBackendFinalize(desc), HIPDNN_STATUS_SUCCESS);
 

--- a/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationKnobsApi.cpp
@@ -373,7 +373,7 @@ TEST_F(IntegrationKnobsApi, GetKnobInfoNotFinalizedEngine)
                                         HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_graph),
+                                        static_cast<const void*>(&_graph)),
               HIPDNN_STATUS_SUCCESS);
     ASSERT_EQ(hipdnnBackendSetAttribute(
                   _engine, HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx),
@@ -408,7 +408,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceIntValue)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine),
+                                        static_cast<const void*>(&_engine)),
               HIPDNN_STATUS_SUCCESS);
 
     // Set an integer knob value
@@ -419,7 +419,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceIntValue)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     // Finalize should succeed
@@ -438,7 +438,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceFloatValue)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine),
+                                        static_cast<const void*>(&_engine)),
               HIPDNN_STATUS_SUCCESS);
 
     // Set a float knob value
@@ -449,7 +449,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceFloatValue)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     // Finalize should succeed
@@ -468,7 +468,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceStringValue)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine),
+                                        static_cast<const void*>(&_engine)),
               HIPDNN_STATUS_SUCCESS);
 
     // Set a string knob value
@@ -479,7 +479,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceStringValue)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     // Finalize should succeed
@@ -498,7 +498,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceMultipleKnobs)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine),
+                                        static_cast<const void*>(&_engine)),
               HIPDNN_STATUS_SUCCESS);
 
     // Create multiple knob settings
@@ -516,7 +516,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceMultipleKnobs)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         3,
-                                        knobDataArray.data()),
+                                        static_cast<const void*>(knobDataArray.data())),
               HIPDNN_STATUS_SUCCESS);
 
     // Finalize should succeed
@@ -544,7 +544,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceNullPointer)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine),
+                                        static_cast<const void*>(&_engine)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_engineConfig,
@@ -567,7 +567,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceInvalidType)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine),
+                                        static_cast<const void*>(&_engine)),
               HIPDNN_STATUS_SUCCESS);
 
     auto knobBuffer = KnobSettingFactory::createIntKnobSetting("test.int_knob", 50);
@@ -578,7 +578,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceInvalidType)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_INT64,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_BAD_PARAM);
 }
 
@@ -594,7 +594,7 @@ TEST_F(IntegrationKnobsApi, SetKnobChoiceOnFinalizedConfig)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
@@ -610,7 +610,7 @@ TEST_F(IntegrationKnobsApi, GetMaxWorkspaceSizeWithKnobs)
                                         HIPDNN_ATTR_ENGINECFG_ENGINE,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engine),
+                                        static_cast<const void*>(&_engine)),
               HIPDNN_STATUS_SUCCESS);
 
     // Set a knob before finalizing
@@ -621,7 +621,7 @@ TEST_F(IntegrationKnobsApi, GetMaxWorkspaceSizeWithKnobs)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -693,7 +693,7 @@ protected:
                                             HIPDNN_ATTR_ENGINECFG_ENGINE,
                                             HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                             1,
-                                            &_engine),
+                                            static_cast<const void*>(&_engine)),
                   HIPDNN_STATUS_SUCCESS);
     }
 };
@@ -710,7 +710,7 @@ TEST_F(IntegrationConstraintValidationApi, IntValueToFloatConstraint)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -720,16 +720,18 @@ TEST_F(IntegrationConstraintValidationApi, IntValueToFloatConstraint)
         hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
@@ -752,7 +754,7 @@ TEST_F(IntegrationConstraintValidationApi, FloatValueToIntConstraint)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -762,16 +764,18 @@ TEST_F(IntegrationConstraintValidationApi, FloatValueToIntConstraint)
         hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
@@ -794,7 +798,7 @@ TEST_F(IntegrationConstraintValidationApi, StringValueToIntConstraint)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -804,16 +808,18 @@ TEST_F(IntegrationConstraintValidationApi, StringValueToIntConstraint)
         hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
@@ -836,7 +842,7 @@ TEST_F(IntegrationConstraintValidationApi, IntValueToStringConstraint)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -846,16 +852,18 @@ TEST_F(IntegrationConstraintValidationApi, IntValueToStringConstraint)
         hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
@@ -878,7 +886,7 @@ TEST_F(IntegrationConstraintValidationApi, FloatValueToStringConstraint)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -888,16 +896,18 @@ TEST_F(IntegrationConstraintValidationApi, FloatValueToStringConstraint)
         hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
@@ -920,7 +930,7 @@ TEST_F(IntegrationConstraintValidationApi, StringValueToFloatConstraint)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -930,16 +940,18 @@ TEST_F(IntegrationConstraintValidationApi, StringValueToFloatConstraint)
         hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);
@@ -970,7 +982,7 @@ TEST_F(IntegrationConstraintValidationApi, CorrectTypesSucceed)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         3,
-                                        knobDataArray.data()),
+                                        static_cast<const void*>(knobDataArray.data())),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -980,16 +992,18 @@ TEST_F(IntegrationConstraintValidationApi, CorrectTypesSucceed)
         hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_SUCCESS);
@@ -1012,7 +1026,7 @@ TEST_F(IntegrationConstraintValidationApi, UnknownKnobIsIgnored)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         1,
-                                        &knobData),
+                                        static_cast<const void*>(&knobData)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -1022,16 +1036,18 @@ TEST_F(IntegrationConstraintValidationApi, UnknownKnobIsIgnored)
         hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_SUCCESS);
@@ -1059,7 +1075,7 @@ TEST_F(IntegrationConstraintValidationApi, MixedValidAndInvalidKnobs)
                                         HIPDNN_ATTR_KNOB_CHOICE_SERIALIZED_VALUE_EXT,
                                         HIPDNN_TYPE_FLATBUFFER_DATA_STRUCT_EXT,
                                         2,
-                                        knobDataArray.data()),
+                                        static_cast<const void*>(knobDataArray.data())),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_engineConfig), HIPDNN_STATUS_SUCCESS);
@@ -1069,16 +1085,18 @@ TEST_F(IntegrationConstraintValidationApi, MixedValidAndInvalidKnobs)
         hipdnnBackendCreateDescriptor(HIPDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR, &executionPlan),
         HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &_handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&_handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &_engineConfig),
+                                        static_cast<const void*>(&_engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(executionPlan), HIPDNN_STATUS_PLUGIN_ERROR);

--- a/projects/hipdnn/tests/backend/IntegrationLoggingPipeline.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationLoggingPipeline.cpp
@@ -131,8 +131,11 @@ TEST_F(IntegrationGpuLoggingPipeline, EnumFormatting)
     hipdnnHandle_t handle = nullptr;
     ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
 
-    status = hipdnnBackendSetAttribute(
-        descriptor, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle);
+    status = hipdnnBackendSetAttribute(descriptor,
+                                       HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                       HIPDNN_TYPE_HANDLE,
+                                       1,
+                                       static_cast<const void*>(&handle));
     ASSERT_EQ(status, HIPDNN_STATUS_SUCCESS);
 
     // Note: GraphDescriptor::getAttribute is not supported - it returns NOT_SUPPORTED for all attributes.
@@ -198,7 +201,7 @@ TEST_F(IntegrationGpuLoggingPipeline, FullWorkflowLogging)
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        &graph),
+                                        static_cast<const void*>(&graph)),
               HIPDNN_STATUS_SUCCESS);
 
     auto mode = HIPDNN_HEUR_MODE_FALLBACK;

--- a/projects/hipdnn/tests/backend/IntegrationPluginLoading.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationPluginLoading.cpp
@@ -78,7 +78,7 @@ void createHeuristicDescriptor(hipdnnBackendDescriptor_t* heuristicDescriptor,
                                         HIPDNN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        graph),
+                                        static_cast<const void*>(graph)),
               HIPDNN_STATUS_SUCCESS);
 
     auto backendModes = HIPDNN_HEUR_MODE_FALLBACK;

--- a/projects/hipdnn/tests/backend/IntegrationVariantPackApi.cpp
+++ b/projects/hipdnn/tests/backend/IntegrationVariantPackApi.cpp
@@ -35,15 +35,17 @@ TEST_F(IntegrationVariantPackDescriptorApi, ValidSetAttributesAndFinalize)
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
-                                        devPtrs.data()),
+                                        static_cast<const void*>(devPtrs.data())),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendSetAttribute(
                   _varpack, HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, 3, uids.data()),
               HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(
-        hipdnnBackendSetAttribute(
-            _varpack, HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace),
-        HIPDNN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
+                                        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                                        HIPDNN_TYPE_VOID_PTR,
+                                        1,
+                                        static_cast<const void*>(&workspace)),
+              HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendFinalize(_varpack), HIPDNN_STATUS_SUCCESS);
 }
 
@@ -59,15 +61,17 @@ TEST_F(IntegrationVariantPackDescriptorApi, ValidSetAttributesAndGetAttributesBe
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
-                                        devPtrs.data()),
+                                        static_cast<const void*>(devPtrs.data())),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(hipdnnBackendSetAttribute(
                   _varpack, HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_INT64, 3, uids.data()),
               HIPDNN_STATUS_SUCCESS);
-    EXPECT_EQ(
-        hipdnnBackendSetAttribute(
-            _varpack, HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &workspace),
-        HIPDNN_STATUS_SUCCESS);
+    EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
+                                        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                                        HIPDNN_TYPE_VOID_PTR,
+                                        1,
+                                        static_cast<const void*>(&workspace)),
+              HIPDNN_STATUS_SUCCESS);
 
     std::array<void*, 3> retrievedDevPtrs;
     int64_t elementCount = 0;
@@ -77,7 +81,7 @@ TEST_F(IntegrationVariantPackDescriptorApi, ValidSetAttributesAndGetAttributesBe
                                         HIPDNN_TYPE_INT64,
                                         3,
                                         &elementCount,
-                                        retrievedDevPtrs.data()),
+                                        static_cast<void*>(retrievedDevPtrs.data())),
               HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
@@ -90,22 +94,28 @@ TEST_F(IntegrationVariantPackDescriptorApi, InvalidSetAttributes)
     void* workspace = reinterpret_cast<void*>(0xdeadbeef);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS expects HIPDNN_TYPE_VOID_PTR
-    EXPECT_EQ(
-        hipdnnBackendSetAttribute(
-            _varpack, HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS, HIPDNN_TYPE_INT64, 3, devPtrs.data()),
-        HIPDNN_STATUS_BAD_PARAM);
+    EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
+                                        HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
+                                        HIPDNN_TYPE_INT64,
+                                        3,
+                                        static_cast<const void*>(devPtrs.data())),
+              HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS expects HIPDNN_TYPE_INT64
-    EXPECT_EQ(
-        hipdnnBackendSetAttribute(
-            _varpack, HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS, HIPDNN_TYPE_VOID_PTR, 3, uids.data()),
-        HIPDNN_STATUS_BAD_PARAM);
+    EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
+                                        HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
+                                        HIPDNN_TYPE_VOID_PTR,
+                                        3,
+                                        static_cast<const void*>(uids.data())),
+              HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_WORKSPACE expects HIPDNN_TYPE_VOID_PTR
-    EXPECT_EQ(
-        hipdnnBackendSetAttribute(
-            _varpack, HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 2, &workspace),
-        HIPDNN_STATUS_BAD_PARAM);
+    EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
+                                        HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                                        HIPDNN_TYPE_VOID_PTR,
+                                        2,
+                                        static_cast<const void*>(&workspace)),
+              HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since null ptr passed
     EXPECT_EQ(
@@ -124,7 +134,7 @@ TEST_F(IntegrationVariantPackDescriptorApi, InvalidGetAttributes)
                                         HIPDNN_TYPE_INT64,
                                         3,
                                         &elementCount,
-                                        retrievedDevPtrs.data()),
+                                        static_cast<void*>(retrievedDevPtrs.data())),
               HIPDNN_STATUS_NOT_INITIALIZED);
 }
 
@@ -146,14 +156,14 @@ TEST_F(IntegrationVariantPackDescriptorApi, InvalidFinalizeParams)
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         devPtrs.size(),
-                                        devPtrs.data()),
+                                        static_cast<const void*>(devPtrs.data())),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                         HIPDNN_TYPE_INT64,
                                         uids.size(),
-                                        uids.data()),
+                                        static_cast<const void*>(uids.data())),
               HIPDNN_STATUS_SUCCESS);
 
     EXPECT_EQ(hipdnnBackendFinalize(_varpack), HIPDNN_STATUS_BAD_PARAM);
@@ -198,18 +208,20 @@ protected:
                                             HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                             HIPDNN_TYPE_VOID_PTR,
                                             static_cast<int64_t>(_devPtrs.size()),
-                                            _devPtrs.data()),
+                                            static_cast<const void*>(_devPtrs.data())),
                   HIPDNN_STATUS_SUCCESS);
         EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
                                             HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                             HIPDNN_TYPE_INT64,
                                             static_cast<int64_t>(_uids.size()),
-                                            _uids.data()),
+                                            static_cast<const void*>(_uids.data())),
                   HIPDNN_STATUS_SUCCESS);
-        EXPECT_EQ(
-            hipdnnBackendSetAttribute(
-                _varpack, HIPDNN_ATTR_VARIANT_PACK_WORKSPACE, HIPDNN_TYPE_VOID_PTR, 1, &_workspace),
-            HIPDNN_STATUS_SUCCESS);
+        EXPECT_EQ(hipdnnBackendSetAttribute(_varpack,
+                                            HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
+                                            HIPDNN_TYPE_VOID_PTR,
+                                            1,
+                                            static_cast<const void*>(&_workspace)),
+                  HIPDNN_STATUS_SUCCESS);
         EXPECT_EQ(hipdnnBackendFinalize(_varpack), HIPDNN_STATUS_SUCCESS);
     }
 
@@ -231,18 +243,20 @@ TEST_F(IntegrationVariantPackDescriptorApiFinalized, ValidGetAttributes)
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
                                         &elementCount,
-                                        retrievedDevPtrs.data()),
+                                        static_cast<void*>(retrievedDevPtrs.data())),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(elementCount, 3);
-    EXPECT_EQ(
-        std::memcmp(retrievedDevPtrs.data(), _devPtrs.data(), _devPtrs.size() * sizeof(void*)), 0);
+    EXPECT_EQ(std::memcmp(static_cast<const void*>(retrievedDevPtrs.data()),
+                          static_cast<const void*>(_devPtrs.data()),
+                          _devPtrs.size() * sizeof(void*)),
+              0);
 
     EXPECT_EQ(hipdnnBackendGetAttribute(_varpack,
                                         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                         HIPDNN_TYPE_INT64,
                                         3,
                                         &elementCount,
-                                        retrievedUids.data()),
+                                        static_cast<void*>(retrievedUids.data())),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(elementCount, 3);
     EXPECT_EQ(std::memcmp(retrievedUids.data(), _uids.data(), _uids.size() * sizeof(int64_t)), 0);
@@ -252,7 +266,7 @@ TEST_F(IntegrationVariantPackDescriptorApiFinalized, ValidGetAttributes)
                                         HIPDNN_TYPE_VOID_PTR,
                                         1,
                                         &elementCount,
-                                        &retrievedWorkspace),
+                                        static_cast<void*>(&retrievedWorkspace)),
               HIPDNN_STATUS_SUCCESS);
     EXPECT_EQ(elementCount, 1);
     EXPECT_EQ(retrievedWorkspace, _workspace);
@@ -271,7 +285,7 @@ TEST_F(IntegrationVariantPackDescriptorApiFinalized, InvalidGetAttributes)
                                         HIPDNN_TYPE_INT64,
                                         3,
                                         &elementCount,
-                                        retrievedDevPtrs.data()),
+                                        static_cast<void*>(retrievedDevPtrs.data())),
               HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS expects HIPDNN_TYPE_INT64
@@ -280,7 +294,7 @@ TEST_F(IntegrationVariantPackDescriptorApiFinalized, InvalidGetAttributes)
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
                                         &elementCount,
-                                        retrievedUids.data()),
+                                        static_cast<void*>(retrievedUids.data())),
               HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since HIPDNN_ATTR_VARIANT_PACK_WORKSPACE expects HIPDNN_TYPE_VOID_PTR
@@ -290,7 +304,7 @@ TEST_F(IntegrationVariantPackDescriptorApiFinalized, InvalidGetAttributes)
                                         HIPDNN_TYPE_VOID_PTR,
                                         2,
                                         &elementCount,
-                                        &retrievedWorkspace),
+                                        static_cast<void*>(&retrievedWorkspace)),
               HIPDNN_STATUS_BAD_PARAM);
 
     // HIPDNN_STATUS_BAD_PARAM since arrayOfElements cannot be nullptr
@@ -308,7 +322,7 @@ TEST_F(IntegrationVariantPackDescriptorApiFinalized, InvalidGetAttributes)
                                         HIPDNN_TYPE_VOID_PTR,
                                         3,
                                         nullptr,
-                                        retrievedDevPtrs.data()),
+                                        static_cast<void*>(retrievedDevPtrs.data())),
               HIPDNN_STATUS_BAD_PARAM_NULL_POINTER);
 }
 
@@ -318,6 +332,6 @@ TEST_F(IntegrationVariantPackDescriptorApiFinalized, InvalidSetAttributes)
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         static_cast<int64_t>(_devPtrs.size()),
-                                        _devPtrs.data()),
+                                        static_cast<const void*>(_devPtrs.data())),
               HIPDNN_STATUS_NOT_INITIALIZED);
 }

--- a/projects/hipdnn/tests/backend/TestUtil.cpp
+++ b/projects/hipdnn/tests/backend/TestUtil.cpp
@@ -43,8 +43,11 @@ void createTestGraph(hipdnnBackendDescriptor_t* descriptor, hipdnnHandle_t handl
                   descriptor, serializedGraph.data(), serializedGraph.size()),
               HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(hipdnnBackendSetAttribute(
-                  *descriptor, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
+    ASSERT_EQ(hipdnnBackendSetAttribute(*descriptor,
+                                        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&handle)),
               HIPDNN_STATUS_SUCCESS);
 }
 
@@ -60,10 +63,12 @@ void populateTestEngine(hipdnnBackendDescriptor_t engine,
     }
 
     ASSERT_EQ(hipdnnBackendFinalize(*graph), HIPDNN_STATUS_SUCCESS);
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            engine, HIPDNN_ATTR_ENGINE_OPERATION_GRAPH, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, graph),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(engine,
+                                        HIPDNN_ATTR_ENGINE_OPERATION_GRAPH,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        static_cast<const void*>(graph)),
+              HIPDNN_STATUS_SUCCESS);
     ASSERT_EQ(hipdnnBackendSetAttribute(
                   engine, HIPDNN_ATTR_ENGINE_GLOBAL_INDEX, HIPDNN_TYPE_INT64, 1, &gidx),
               HIPDNN_STATUS_SUCCESS);
@@ -97,10 +102,12 @@ void populateTestEngineConfig(hipdnnBackendDescriptor_t* engineConfig,
         createTestEngine(engine, graph, handle, gidx, true);
     }
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            *engineConfig, HIPDNN_ATTR_ENGINECFG_ENGINE, HIPDNN_TYPE_BACKEND_DESCRIPTOR, 1, engine),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(*engineConfig,
+                                        HIPDNN_ATTR_ENGINECFG_ENGINE,
+                                        HIPDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        static_cast<const void*>(engine)),
+              HIPDNN_STATUS_SUCCESS);
 
     if(finalize)
     {
@@ -128,10 +135,12 @@ void populateTestExecutionPlan(hipdnnBackendDescriptor_t* executionPlan,
                                int64_t gidx,
                                bool finalize)
 {
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            *executionPlan, HIPDNN_ATTR_EXECUTION_PLAN_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(*executionPlan,
+                                        HIPDNN_ATTR_EXECUTION_PLAN_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     if(*engineConfig == nullptr)
     {
@@ -142,7 +151,7 @@ void populateTestExecutionPlan(hipdnnBackendDescriptor_t* executionPlan,
                                         HIPDNN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
                                         HIPDNN_TYPE_BACKEND_DESCRIPTOR,
                                         1,
-                                        engineConfig),
+                                        static_cast<const void*>(engineConfig)),
               HIPDNN_STATUS_SUCCESS);
 
     if(finalize)
@@ -178,14 +187,14 @@ void setTensorMappingsInVariantPack(hipdnnBackendDescriptor_t variantPack,
                                         HIPDNN_ATTR_VARIANT_PACK_UNIQUE_IDS,
                                         HIPDNN_TYPE_INT64,
                                         static_cast<int64_t>(tensorIds.size()),
-                                        tensorIds.data()),
+                                        static_cast<const void*>(tensorIds.data())),
               HIPDNN_STATUS_SUCCESS);
 
     ASSERT_EQ(hipdnnBackendSetAttribute(variantPack,
                                         HIPDNN_ATTR_VARIANT_PACK_DATA_POINTERS,
                                         HIPDNN_TYPE_VOID_PTR,
                                         static_cast<int64_t>(dataPtrs.size()),
-                                        dataPtrs.data()),
+                                        static_cast<const void*>(dataPtrs.data())),
               HIPDNN_STATUS_SUCCESS);
 }
 
@@ -197,7 +206,7 @@ void setWorkspaceInVariantPack(hipdnnBackendDescriptor_t variantPack, void* work
                                             HIPDNN_ATTR_VARIANT_PACK_WORKSPACE,
                                             HIPDNN_TYPE_VOID_PTR,
                                             1,
-                                            &workspace),
+                                            static_cast<const void*>(&workspace)),
                   HIPDNN_STATUS_SUCCESS);
     }
 }
@@ -245,10 +254,12 @@ void createAndInitializeBackendDescriptor(hipdnnBackendDescriptor_t* backendDesc
         backendDescriptor, serializedGraph.data(), serializedGraph.size());
     ASSERT_EQ(status, HIPDNN_STATUS_SUCCESS);
 
-    ASSERT_EQ(
-        hipdnnBackendSetAttribute(
-            *backendDescriptor, HIPDNN_ATTR_OPERATIONGRAPH_HANDLE, HIPDNN_TYPE_HANDLE, 1, &handle),
-        HIPDNN_STATUS_SUCCESS);
+    ASSERT_EQ(hipdnnBackendSetAttribute(*backendDescriptor,
+                                        HIPDNN_ATTR_OPERATIONGRAPH_HANDLE,
+                                        HIPDNN_TYPE_HANDLE,
+                                        1,
+                                        static_cast<const void*>(&handle)),
+              HIPDNN_STATUS_SUCCESS);
 
     status = hipdnnBackendFinalize(*backendDescriptor);
     ASSERT_EQ(status, HIPDNN_STATUS_SUCCESS);

--- a/projects/hipdnn/tests/test_plugins/TestPluginEngineIdMap.hpp
+++ b/projects/hipdnn/tests/test_plugins/TestPluginEngineIdMap.hpp
@@ -11,6 +11,7 @@ template <class T>
 constexpr int64_t engineId() = delete;
 } // namespace hipdnn_tests::plugin_constants
 
+// NOLINTBEGIN(bugprone-macro-parentheses) - ClassName is a type name, id is used as a value
 #define HIPDNN_MAP_TO_ID(ClassName, id)      \
     class ClassName;                         \
     namespace hipdnn_tests::plugin_constants \
@@ -18,9 +19,10 @@ constexpr int64_t engineId() = delete;
     template <>                              \
     constexpr int64_t engineId<ClassName>()  \
     {                                        \
-        return id;                           \
+        return (id);                         \
     };                                       \
     }
+// NOLINTEND(bugprone-macro-parentheses)
 
 HIPDNN_MAP_TO_ID(GoodPlugin, -2);
 HIPDNN_MAP_TO_ID(GoodDefaultPlugin, -3);


### PR DESCRIPTION

## Motivation
Have all clang-tidy checks working eventually. 

## Technical Details

The .clang-tidy Checks field uses a YAML folded scalar (>), which joins lines with spaces. A missing comma after `bugprone-*` caused it to concatenate with the next line into the invalid token `bugprone-* misc-*`, silently disabling both check groups.

This commit adds the missing comma to properly enable `bugprone-*` checks, and fixes all resulting warnings across 78 files. The `misc-*` checks are intentionally removed for now (to be addressed separately).

Changes:
- Fix missing comma after bugprone-* in .clang-tidy
- Remove misc-* from enabled checks (deferred to separate PR)
- Disable bugprone-easily-swappable-parameters (not fixable without API changes)
- Disable bugprone-unchecked-optional-access (false positives with ASSERT_TRUE guards)
- Fix bugprone-macro-parentheses: wrap macro args in parens where safe, use NOLINTBEGIN/END for stream-expression macros (Logger.hpp, PluginHelpers.hpp)
- Fix bugprone-narrowing-conversions with explicit static_cast
- Fix bugprone-multi-level-implicit-pointer-conversion with static_cast<void*>
- Fix bugprone-branch-clone by combining duplicate switch cases
- Fix bugprone-fold-init-type with correct accumulator types
- Fix bugprone-string-constructor and bugprone-stringview-nullptr issues
- Fix readability-redundant-access-specifiers in Attributes.hpp and Node.hpp



<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
