### PR TITLE
Add TF32 nightly all solution tests

### DIFF
--- a/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
+++ b/projects/hipblaslt/clients/tests/data/matmul_gtest.yaml
@@ -2275,6 +2275,36 @@ Tests:
   requested_solution_num: -1
   unit_check: 1
 
+- name: matmul_heuristic_all_solutions_xf32
+  category: nightly
+  function:
+    matmul: *xf32_precision
+  matrix_size:
+    - { M:  128,   N:  128,    K:  2048 }
+    - { M:  127,   N:  127,    K:  2047 }
+  algo_method: [0,1]
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [0,1]
+  requested_solution_num: -1
+  unit_check: 1
+  gpu_arch: '9(42|50)'
+
+- name: matmul_heuristic_all_solutions_f32_fast_bf16
+  category: nightly
+  function:
+    matmul: *single_precision_bf16computeIn_precision
+  matrix_size:
+    - { M:  128,   N:  128,    K:  2048 }
+    - { M:  127,   N:  127,    K:  2047 }
+  algo_method: [0,1]
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [0,1]
+  requested_solution_num: -1
+  unit_check: 1
+  gpu_arch: '950'
+
 - name: matmul_heuristic_all_solutions_real_1byte_fnuz
   category: nightly
   function:


### PR DESCRIPTION
## Motivation

Adding nightly test for TF32x3 (XF32/F32X/S_MX) and TF32x1 (SS_BSS)

## Technical Details

Solution all (algomethod all) tests to test all existing kernels in logic for TF32x3 and TF32x1 on gfx942 and gfx950.

## Test Plan

Nightlies

## Test Result

TBD ... 
