### PR TITLE
[rocRoller] Fix log level of Terse not silencing info logs

### DIFF
--- a/shared/rocroller/lib/source/Logging.cpp
+++ b/shared/rocroller/lib/source/Logging.cpp
@@ -77,11 +77,10 @@ namespace rocRoller
 
             spdlog::set_default_logger(defaultLog);
 
-            LogLevel    logLevel   = settings->get(Settings::LogLvl);
-            std::string s_logLevel = toString(logLevel);
-            if(s_logLevel != "None")
+            LogLevel logLevel = settings->get(Settings::LogLvl);
+            if(logLevel != LogLevel::None)
             {
-                spdlog::cfg::helpers::load_levels(s_logLevel);
+                defaultLog->set_level(convertLogLevel(logLevel));
             }
 
             return true;


### PR DESCRIPTION
## Motivation

I was trying to silence the RNorm messages and using log level of `Terse` did not appear to do anything.

## Technical Details

Spdlog does not have the "Terse" log level, so passing that string literal silently does nothing.

Fix by using `convertLogLevel` which correctly converts from `Terse` to `warn`.

https://github.com/ROCm/rocm-libraries/blob/45f6624f77b5da1bc29e66c3af8af8291c2849a1/shared/rocroller/lib/source/Logging.cpp#L30-L34

## Test Plan

Manual.

## Test Result

Notice how the `[rr/info]` message is now silenced with `Terse` set.

Before:
```bash
ROCROLLER_LOG_LEVEL=Terse test/rocroller-tests --gtest_filter=GEMMTest/GEMMTestSuite.GPU_GEMM_DataType_FP32_Basic/0                                                                                                         16.359s (develop|?) 01:31
Running main() from /home/kerrwang/repos/rocm-libraries/develop/shared/rocroller/build_release/_deps/googletest-src/googletest/src/gtest_main.cc
Note: Google Test filter = GEMMTest/GEMMTestSuite.GPU_GEMM_DataType_FP32_Basic/0
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from GEMMTest/GEMMTestSuite
[ RUN      ] GEMMTest/GEMMTestSuite.GPU_GEMM_DataType_FP32_Basic/0
[rr/info] RNorm is 1.3247854572599279e-08 (acceptable 6.743495761743045e-06, iteration 0)
[       OK ] GEMMTest/GEMMTestSuite.GPU_GEMM_DataType_FP32_Basic/0 (615 ms)
[----------] 1 test from GEMMTest/GEMMTestSuite (615 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (615 ms total)
[  PASSED  ] 1 test.
```

Now:
```bash
ROCROLLER_LOG_LEVEL=Terse test/rocroller-tests --gtest_filter=GEMMTest/GEMMTestSuite.GPU_GEMM_DataType_FP32_Basic/0                                                                                                          1.066s (develop|?) 01:30
Running main() from /home/kerrwang/repos/rocm-libraries/develop/shared/rocroller/build_release/_deps/googletest-src/googletest/src/gtest_main.cc
Note: Google Test filter = GEMMTest/GEMMTestSuite.GPU_GEMM_DataType_FP32_Basic/0
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from GEMMTest/GEMMTestSuite
[ RUN      ] GEMMTest/GEMMTestSuite.GPU_GEMM_DataType_FP32_Basic/0
[       OK ] GEMMTest/GEMMTestSuite.GPU_GEMM_DataType_FP32_Basic/0 (632 ms)
[----------] 1 test from GEMMTest/GEMMTestSuite (632 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (632 ms total)
[  PASSED  ] 1 test.
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
