### PR TITLE
[rocPRIM] Avoid casting away const qualifier in device_batch_memcpy

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_batch_memcpy.hpp
@@ -118,7 +118,8 @@ template<bool IsMemCpy,
          typename std::enable_if<IsMemCpy, int>::type = 0>
 ROCPRIM_DEVICE ROCPRIM_FORCE_INLINE static Alias read_item(InputIt buffer_src, Offset offset)
 {
-    return *(reinterpret_cast<Alias*>(buffer_src) + offset);
+    // Note: we must reinterpret_cast to const Alias because InputIt may be a const type.
+    return *(reinterpret_cast<const Alias*>(buffer_src) + offset);
 }
 
 template<bool IsMemCpy,


### PR DESCRIPTION
## Motivation

In some scenarios, device_batch_memcpy uses a reinterpret_cast to treat the value of an input pointer as a non-const byte-type (unsigned char). If you pass in a const pointer as the source pointer for the copy, the reinterpret cast will fail, since casting away const-ness is not allowed.

## Technical Details

This change ensures that the reinterpret_cast converts the values to const unsigned char so that it does not fail in this case.

## Test Plan

Install rocPRIM and hipCUB from the PR branch.
Create a file called test.cpp containing the following test program:
```
#include <hipcub/hipcub.hpp>

int main()
{
    // The problem: const source pointers should work but don't compile
    const int** d_srcs = nullptr;  // const source pointers
    int** d_dsts = nullptr;
    size_t* d_sizes = nullptr;

    size_t temp_bytes = 0;

    // THIS LINE FAILS TO COMPILE:
   hipError_t result = hipcub::DeviceMemcpy::Batched(
        nullptr, temp_bytes,
        d_srcs,   // const int** - FAILS template substitution
        d_dsts,
        d_sizes,
        4);

    return 0;
}
```
Build the program with `hipcc -std=c++17 -I/opt/rocm/include test.cpp -o test`
Ensure that the compilation succeeds without any errors.

## Test Result

The test program builds without any errors.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
