### PR TITLE
de-boost tensilelite: drop Boost.Program_options and Boost.Filesystem

### DIFF
--- a/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
+++ b/projects/hipblaslt/tensilelite/client/cpu_gemm_driver.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,10 +31,7 @@
 #include <random>
 #include <vector>
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/program_options.hpp>
-
+#include "ProgramOptions.hpp"
 #include "Reference.hpp"
 #include "rocisa/include/enum.hpp"
 
@@ -68,8 +65,8 @@
 
 namespace
 {
-    namespace po = boost::program_options;
     using namespace TensileLite;
+    using namespace TensileLite::Client;
 
     // Helper traits to map C++ storage types to rocisa data type enums.
     template <typename T>
@@ -276,26 +273,18 @@ int runGemm(size_t m,
 
 int main(int argc, char* argv[])
 {
-    // command line argument storage
-    size_t      m, n, k;
-    float       alpha, beta;
-    std::string typeStr;
-    bool        transA, transB, validate, tryFastPath;
-
     po::options_description desc("Allowed options");
     desc.add_options()("help,h", "Produce help message")(
-        "M", po::value<size_t>(&m)->default_value(128), "Matrix M dimension")(
-        "N", po::value<size_t>(&n)->default_value(128), "Matrix N dimension")(
-        "K", po::value<size_t>(&k)->default_value(128), "Matrix K dimension")(
-        "transA", po::value<bool>(&transA)->default_value(false), "Transpose A")(
-        "transB", po::value<bool>(&transB)->default_value(true), "Transpose B")(
-        "alpha", po::value<float>(&alpha)->default_value(1.0f), "Alpha scalar")(
-        "beta", po::value<float>(&beta)->default_value(0.0f), "Beta scalar")(
-        "type",
-        po::value<std::string>(&typeStr)->default_value("f32"),
-        "Data type (f32, f16, bf16)")(
-        "validate", po::value<bool>(&validate)->default_value(true), "Run validation against ref")(
-        "tryFastPath", po::value<bool>(&tryFastPath)->default_value(true), "Use optimized path");
+        "M", po::value<size_t>()->default_value(128), "Matrix M dimension")(
+        "N", po::value<size_t>()->default_value(128), "Matrix N dimension")(
+        "K", po::value<size_t>()->default_value(128), "Matrix K dimension")(
+        "transA", po::value<bool>()->default_value(false), "Transpose A")(
+        "transB", po::value<bool>()->default_value(true), "Transpose B")(
+        "alpha", po::value<float>()->default_value(1.0f), "Alpha scalar")(
+        "beta", po::value<float>()->default_value(0.0f), "Beta scalar")(
+        "type", po::value<std::string>()->default_value("f32"), "Data type (f32, f16, bf16)")(
+        "validate", po::value<bool>()->default_value(true), "Run validation against ref")(
+        "tryFastPath", po::value<bool>()->default_value(true), "Use optimized path");
 
     po::variables_map vm;
     try
@@ -303,7 +292,7 @@ int main(int argc, char* argv[])
         po::store(po::parse_command_line(argc, argv, desc), vm);
         po::notify(vm);
     }
-    catch(const po::error& ex)
+    catch(const std::exception& ex)
     {
         std::cerr << "Error parsing options: " << ex.what() << std::endl;
         return 1;
@@ -314,6 +303,17 @@ int main(int argc, char* argv[])
         std::cout << desc << "\n";
         return 0;
     }
+
+    size_t      m           = vm["M"].as<size_t>();
+    size_t      n           = vm["N"].as<size_t>();
+    size_t      k           = vm["K"].as<size_t>();
+    bool        transA      = vm["transA"].as<bool>();
+    bool        transB      = vm["transB"].as<bool>();
+    float       alpha       = vm["alpha"].as<float>();
+    float       beta        = vm["beta"].as<float>();
+    std::string typeStr     = vm["type"].as<std::string>();
+    bool        validate    = vm["validate"].as<bool>();
+    bool        tryFastPath = vm["tryFastPath"].as<bool>();
 
     std::cout << "Running GEMM with: M=" << m << " N=" << n << " K=" << k << " Type=" << typeStr
               << " FastPath=" << tryFastPath << std::endl;

--- a/projects/hipblaslt/tensilelite/client/include/BenchmarkTimer.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/BenchmarkTimer.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@
 #include <chrono>
 #include <cstddef>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <Tensile/ContractionProblem.hpp>
 #include <Tensile/ContractionSolution.hpp>
@@ -40,7 +40,6 @@ namespace TensileLite
 {
     namespace Client
     {
-        namespace po = boost::program_options;
 
         class BenchmarkTimer : public RunListener
         {
@@ -110,8 +109,8 @@ namespace TensileLite
 
             int m_numBenchmarksRun = 0;
 
-            Hardware const&     m_hardware;
-            ContractionProblem* m_problem;
+            Hardware const&      m_hardware;
+            ContractionProblem*  m_problem;
             ContractionSolution* m_solution;
 
             int m_numEnqueuesInSolution = 0;

--- a/projects/hipblaslt/tensilelite/client/include/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/client/include/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier:  MIT
 
 set(COMMON_CLIENT_SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/ProgramOptions.hpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/TypedId.hpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/MetaResultReporter.hpp"
         "${CMAKE_CURRENT_SOURCE_DIR}/HardwareMonitorListener.hpp"

--- a/projects/hipblaslt/tensilelite/client/include/ClientProblemFactory.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/ClientProblemFactory.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@
 #include <Tensile/KernelLanguageTypes.hpp>
 #include <Tensile/Tensile.hpp>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <cstddef>
 
@@ -39,8 +39,6 @@ namespace TensileLite
 {
     namespace Client
     {
-
-        namespace po = boost::program_options;
 
         class ClientProblemFactory
         {

--- a/projects/hipblaslt/tensilelite/client/include/DataInitialization.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/DataInitialization.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <Tensile/ContractionProblem.hpp>
 #include <Tensile/hip/HipUtils.hpp>
@@ -38,8 +38,6 @@
 #include <random>
 
 #include "RunListener.hpp"
-
-namespace po = boost::program_options;
 
 namespace TensileLite
 {

--- a/projects/hipblaslt/tensilelite/client/include/HardwareMonitorListener.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/HardwareMonitorListener.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@
 #include <cstddef>
 #include <future>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include "HardwareMonitor_fwd.hpp"
 
@@ -40,7 +40,6 @@ namespace TensileLite
 {
     namespace Client
     {
-        namespace po = boost::program_options;
 
         class HardwareMonitorListener : public RunListener
         {

--- a/projects/hipblaslt/tensilelite/client/include/LibraryUpdateReporter.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/LibraryUpdateReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@
 #include "CSVStackFile.hpp"
 #include "ResultReporter.hpp"
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <cstddef>
 
@@ -37,7 +37,6 @@ namespace TensileLite
 {
     namespace Client
     {
-        namespace po = boost::program_options;
 
         class LibraryUpdateReporter : public ResultReporter
         {

--- a/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,16 +28,12 @@
 
 #include "CSVStackFile.hpp"
 #include "ResultReporter.hpp"
-#include "TimingInstrumentation.hpp"
 
 #include <cstddef>
 #include <string>
 #include <unordered_set>
 
-#include <boost/lexical_cast.hpp>
-#include <boost/program_options.hpp>
-
-namespace po = boost::program_options;
+#include "ProgramOptions.hpp"
 
 namespace TensileLite
 {
@@ -369,7 +365,6 @@ namespace TensileLite
 
             virtual void postSolution() override
             {
-                ScopedTimer timer("post_solution_log");
                 std::unordered_map<std::string, std::string> curRow;
                 m_csvOutput.readCurrentRow(curRow);
                 bool  validation    = !(curRow[ResultKey::Validation] == "FAILED"

--- a/projects/hipblaslt/tensilelite/client/include/PerformanceReporter.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/PerformanceReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,14 +35,13 @@
 #include <limits>
 #include <string>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 #include <hip/hip_runtime.h>
 
 namespace TensileLite
 {
     namespace Client
     {
-        namespace po = boost::program_options;
 
         class PerformanceReporter : public ResultReporter
         {

--- a/projects/hipblaslt/tensilelite/client/include/ProgramOptions.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/ProgramOptions.hpp
@@ -1,0 +1,616 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Drop-in replacement for boost::program_options used by tensilelite client.
+ * Uses std::any and standard library only; no Boost dependency.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <any>
+#include <cctype>
+#include <functional>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace TensileLite
+{
+    namespace Client
+    {
+        namespace po
+        {
+
+            inline std::vector<std::string> split_string(std::string const& s,
+                                                         char const*        sep = ",;")
+            {
+                std::vector<std::string> out;
+                std::string::size_type   pos = 0;
+                for(;;)
+                {
+                    auto next = s.find_first_of(sep, pos);
+                    if(next == std::string::npos)
+                    {
+                        if(pos < s.size())
+                        {
+                            std::string part = s.substr(pos);
+                            if(!part.empty())
+                                out.push_back(std::move(part));
+                        }
+                        break;
+                    }
+                    if(next > pos)
+                        out.push_back(s.substr(pos, next - pos));
+                    pos = next + 1;
+                }
+                return out;
+            }
+
+            inline bool parse_bool_string(std::string const& s)
+            {
+                std::string lower;
+                lower.reserve(s.size());
+                for(char c : s)
+                    lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+                if(lower == "1" || lower == "true" || lower == "yes")
+                    return true;
+                if(lower == "0" || lower == "false" || lower == "no")
+                    return false;
+                throw std::runtime_error("Failed to parse bool: " + s);
+            }
+
+            inline std::string trim_opt(std::string s)
+            {
+                auto start = s.find_first_not_of(" \t");
+                if(start == std::string::npos)
+                    return {};
+                auto end = s.find_last_not_of(" \t");
+                return s.substr(start, end == std::string::npos ? end : end - start + 1);
+            }
+
+            inline std::string get_canonical_option_name(std::string const& opts)
+            {
+                auto pos = opts.find(',');
+                if(pos == std::string::npos)
+                    return trim_opt(opts);
+                return trim_opt(opts.substr(0, pos));
+            }
+
+            class variable_value
+            {
+                std::any m_value;
+
+            public:
+                variable_value() = default;
+                explicit variable_value(std::any v)
+                    : m_value(std::move(v))
+                {
+                }
+
+                bool empty() const
+                {
+                    return !m_value.has_value();
+                }
+
+                std::any& value()
+                {
+                    return m_value;
+                }
+                std::any const& value() const
+                {
+                    return m_value;
+                }
+
+                template <typename T>
+                T const& as() const
+                {
+                    if(!m_value.has_value())
+                    {
+                        // Match Boost: unset option yields default-constructed T when .as<T>() is used
+                        static T const defaultVal{};
+                        return defaultVal;
+                    }
+                    try
+                    {
+                        return std::any_cast<T const&>(m_value);
+                    }
+                    catch(std::bad_any_cast const&)
+                    {
+                        // Allow bool option stored as string (e.g. "True"/"False" from config)
+                        if constexpr(std::is_same_v<T, bool>)
+                        {
+                            if(m_value.type() == typeid(std::string))
+                            {
+                                static bool converted;
+                                converted
+                                    = parse_bool_string(std::any_cast<std::string const&>(m_value));
+                                return converted;
+                            }
+                        }
+                        throw std::runtime_error(
+                            "program_options: bad_any_cast - stored option value has a different "
+                            "type than the requested .as<T>()");
+                    }
+                }
+            };
+
+            class variables_map
+            {
+                std::map<std::string, variable_value> m_map;
+                static variable_value const           s_empty;
+
+            public:
+                using key_type       = std::string;
+                using mapped_type    = variable_value;
+                using value_type     = std::pair<const std::string, variable_value>;
+                using iterator       = std::map<std::string, variable_value>::iterator;
+                using const_iterator = std::map<std::string, variable_value>::const_iterator;
+
+                variable_value& operator[](key_type const& k)
+                {
+                    return m_map[k];
+                }
+                variable_value const& operator[](key_type const& k) const
+                {
+                    auto it = m_map.find(k);
+                    if(it != m_map.end())
+                        return it->second;
+                    return s_empty;
+                }
+
+                variable_value& at(key_type const& k)
+                {
+                    return m_map.at(k);
+                }
+                variable_value const& at(key_type const& k) const
+                {
+                    return m_map.at(k);
+                }
+
+                size_t count(key_type const& k) const
+                {
+                    return m_map.count(k);
+                }
+
+                iterator begin()
+                {
+                    return m_map.begin();
+                }
+                iterator end()
+                {
+                    return m_map.end();
+                }
+                const_iterator begin() const
+                {
+                    return m_map.begin();
+                }
+                const_iterator end() const
+                {
+                    return m_map.end();
+                }
+                const_iterator find(key_type const& k) const
+                {
+                    return m_map.find(k);
+                }
+                iterator find(key_type const& k)
+                {
+                    return m_map.find(k);
+                }
+
+                std::pair<iterator, bool> insert(value_type const& v)
+                {
+                    return m_map.insert(v);
+                }
+                void clear()
+                {
+                    m_map.clear();
+                }
+            };
+
+            struct option_value_base
+            {
+                virtual ~option_value_base()                                            = default;
+                virtual std::any                                    get_default() const = 0;
+                virtual std::function<std::any(std::string const&)> parser() const      = 0;
+                /** Parse one line from config file. Default: parser()(value). Override for Boost-compatible
+                 *  behaviour where each config line is one value (no comma split). */
+                virtual std::any parse_config_line(std::string const& value) const
+                {
+                    return parser()(value);
+                }
+                virtual bool is_multivalued() const
+                {
+                    return false;
+                }
+                virtual bool is_flag() const
+                {
+                    return false;
+                }
+                virtual bool has_explicit_default() const
+                {
+                    return false;
+                }
+                virtual bool has_implicit_value() const
+                {
+                    return false;
+                }
+                virtual std::any get_implicit_value() const
+                {
+                    return std::any();
+                }
+                virtual void merge_into(std::any& current, std::any const& new_val) const
+                {
+                    current = new_val;
+                }
+            };
+
+            template <typename T>
+            struct typed_value_holder : option_value_base
+            {
+                T    m_default{};
+                bool m_has_explicit_default = false;
+
+                typed_value_holder* default_value(T v)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(T v, std::string const&)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) {
+                        T                  t;
+                        std::istringstream ss(s);
+                        ss >> t;
+                        if(!ss && !ss.eof())
+                            throw std::runtime_error("Failed to parse option value: " + s);
+                        return std::any(t);
+                    };
+                }
+
+                bool is_flag() const override
+                {
+                    return false;
+                }
+            };
+
+            template <>
+            struct typed_value_holder<bool> : option_value_base
+            {
+                bool m_default              = false;
+                bool m_has_explicit_default = false;
+                bool m_has_implicit         = false;
+                bool m_implicit_value       = false;
+
+                typed_value_holder* default_value(bool v)
+                {
+                    m_default              = v;
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(bool v, std::string const&)
+                {
+                    m_default              = v;
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* implicit_value(bool v)
+                {
+                    m_has_implicit   = true;
+                    m_implicit_value = v;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+                bool has_implicit_value() const override
+                {
+                    return m_has_implicit;
+                }
+                std::any get_implicit_value() const override
+                {
+                    return std::any(m_implicit_value);
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) { return std::any(parse_bool_string(s)); };
+                }
+
+                bool is_flag() const override
+                {
+                    return true;
+                }
+            };
+
+            template <typename U>
+            struct typed_value_holder<std::vector<U>> : option_value_base
+            {
+                std::vector<U> m_default;
+                bool           m_has_explicit_default = false;
+
+                typed_value_holder* default_value(std::vector<U> v)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(std::vector<U> v, std::string const&)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                bool is_multivalued() const override
+                {
+                    return true;
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) {
+                        auto           parts = split_string(s);
+                        std::vector<U> out;
+                        out.reserve(parts.size());
+                        for(auto const& p : parts)
+                        {
+                            if(p.empty())
+                                continue;
+                            U                  u;
+                            std::istringstream ss(p);
+                            ss >> u;
+                            if(!ss && !ss.eof())
+                                throw std::runtime_error("Failed to parse: " + p);
+                            out.push_back(std::move(u));
+                        }
+                        return std::any(out);
+                    };
+                }
+
+                void merge_into(std::any& current, std::any const& new_val) const override
+                {
+                    auto&       c = std::any_cast<std::vector<U>&>(current);
+                    auto const& n = std::any_cast<std::vector<U> const&>(new_val);
+                    c.insert(c.end(), n.begin(), n.end());
+                }
+            };
+
+            template <>
+            struct typed_value_holder<std::vector<std::string>> : option_value_base
+            {
+                std::vector<std::string> m_default;
+                bool                     m_has_explicit_default = false;
+
+                typed_value_holder* default_value(std::vector<std::string> v)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(std::vector<std::string> v, std::string const&)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                bool is_multivalued() const override
+                {
+                    return true;
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) { return std::any(split_string(s)); };
+                }
+
+                /** Boost config file behaviour: each line is one value (no comma split). */
+                std::any parse_config_line(std::string const& value) const override
+                {
+                    std::string t = trim_opt(value);
+                    if(t.empty())
+                        return std::any(std::vector<std::string>{});
+                    return std::any(std::vector<std::string>{std::move(t)});
+                }
+
+                void merge_into(std::any& current, std::any const& new_val) const override
+                {
+                    auto&       c = std::any_cast<std::vector<std::string>&>(current);
+                    auto const& n = std::any_cast<std::vector<std::string> const&>(new_val);
+                    c.insert(c.end(), n.begin(), n.end());
+                }
+            };
+
+            template <>
+            struct typed_value_holder<std::vector<bool>> : option_value_base
+            {
+                std::vector<bool> m_default;
+                bool              m_has_explicit_default = false;
+
+                typed_value_holder* default_value(std::vector<bool> v)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(std::vector<bool> v, std::string const&)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                bool is_multivalued() const override
+                {
+                    return true;
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) {
+                        auto              parts = split_string(s);
+                        std::vector<bool> out;
+                        out.reserve(parts.size());
+                        for(auto const& p : parts)
+                        {
+                            if(p.empty())
+                                continue;
+                            out.push_back(parse_bool_string(p));
+                        }
+                        return std::any(out);
+                    };
+                }
+
+                void merge_into(std::any& current, std::any const& new_val) const override
+                {
+                    auto&       c = std::any_cast<std::vector<bool>&>(current);
+                    auto const& n = std::any_cast<std::vector<bool> const&>(new_val);
+                    c.insert(c.end(), n.begin(), n.end());
+                }
+            };
+
+            template <typename T>
+            using typed_value = typed_value_holder<T>;
+
+            template <typename T>
+            typed_value_holder<T>* value()
+            {
+                return new typed_value_holder<T>();
+            }
+
+            class options_description
+            {
+            public:
+                struct option_entry
+                {
+                    std::string                        opts; // e.g. "help,h"
+                    std::string                        description;
+                    std::unique_ptr<option_value_base> value_semantic;
+                };
+                using option_list = std::vector<option_entry>;
+
+                explicit options_description(std::string const&) {}
+
+                class add_options_helper
+                {
+                    option_list& m_list;
+
+                public:
+                    explicit add_options_helper(option_list& list)
+                        : m_list(list)
+                    {
+                    }
+
+                    add_options_helper& operator()(std::string const& opts, std::string const& desc)
+                    {
+                        auto* e = new typed_value_holder<bool>();
+                        e->default_value(false);
+                        m_list.push_back({opts, desc, std::unique_ptr<option_value_base>(e)});
+                        return *this;
+                    }
+
+                    template <typename T>
+                    add_options_helper& operator()(std::string const&     opts,
+                                                   typed_value_holder<T>* val,
+                                                   std::string const&     desc)
+                    {
+                        m_list.push_back({opts, desc, std::unique_ptr<option_value_base>(val)});
+                        return *this;
+                    }
+                };
+
+                add_options_helper add_options()
+                {
+                    return add_options_helper(m_options);
+                }
+
+                option_list const& options() const
+                {
+                    return m_options;
+                }
+
+            private:
+                option_list m_options;
+            };
+
+            variables_map parse_command_line(int                        argc,
+                                             char const* const          argv[],
+                                             options_description const& desc);
+
+            variables_map parse_config_file(std::istream& is, options_description const& desc);
+
+            inline void store(variables_map const& from, variables_map& to)
+            {
+                for(auto const& kv : from)
+                    to[kv.first].value() = kv.second.value();
+            }
+
+            inline void notify(variables_map const&) {}
+
+            std::ostream& operator<<(std::ostream& os, options_description const& desc);
+
+        } // namespace po
+    } // namespace Client
+} // namespace TensileLite

--- a/projects/hipblaslt/tensilelite/client/include/ProgressListener.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/ProgressListener.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,13 +32,12 @@
 
 #include <cstddef>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 namespace TensileLite
 {
     namespace Client
     {
-        namespace po = boost::program_options;
 
         class ProgressListener : public RunListener
         {

--- a/projects/hipblaslt/tensilelite/client/include/ReferenceValidator.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/ReferenceValidator.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,7 @@
 
 #include "RunListener.hpp"
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <Tensile/ContractionProblem.hpp>
 #include <Tensile/ContractionSolution.hpp>
@@ -41,7 +41,6 @@ namespace TensileLite
 {
     namespace Client
     {
-        namespace po = boost::program_options;
 
         class ReferenceValidator : public RunListener
         {

--- a/projects/hipblaslt/tensilelite/client/include/ResultFileReporter.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/ResultFileReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@
 #include "CSVStackFile.hpp"
 #include "ResultReporter.hpp"
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <cstddef>
 
@@ -37,7 +37,6 @@ namespace TensileLite
 {
     namespace Client
     {
-        namespace po = boost::program_options;
 
         class ResultFileReporter : public ResultReporter
         {

--- a/projects/hipblaslt/tensilelite/client/include/SolutionIterator.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/SolutionIterator.hpp
@@ -28,7 +28,7 @@
 
 #include <Tensile/MasterSolutionLibrary.hpp>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <functional>
 #include <vector>
@@ -41,8 +41,6 @@ namespace TensileLite
 {
     namespace Client
     {
-        namespace po = boost::program_options;
-
         /**
  * Not an iterator by the traditional definition but I can't think of a better
  * name

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,15 +51,16 @@
 #include "ResultFileReporter.hpp"
 #include "ResultReporter.hpp"
 
+#include "ProgramOptions.hpp"
 #include "Utility.hpp"
-
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/program_options.hpp>
 
 #include <chrono>
 #include <cstddef>
+#include <fstream>
+#include <iostream>
+#include <map>
 #include <memory>
+#include <sstream>
 
 namespace TensileLite
 {
@@ -371,6 +372,245 @@ namespace TensileLite
             return options;
         }
 
+        /** Dump parsed program options to a text file for comparison (Boost vs replacement).
+         *  Set env TENSILE_DUMP_OPTIONS=1 to enable. Writes to /tmp/tensilelite_program_options_dump.txt */
+        void DumpProgramOptionsToFile(po::variables_map const& args, char const* path)
+        {
+            std::ofstream out(path);
+            if(!out)
+            {
+                std::cerr << "TENSILE_DUMP_OPTIONS: failed to open " << path << " for write\n";
+                return;
+            }
+            out << "# program_options dump (one key=value per line; vectors as size then "
+                   "elements)\n";
+#define DUMP_OPT(K, T)                                          \
+    do                                                          \
+    {                                                           \
+        if(args.count(K))                                       \
+        {                                                       \
+            try                                                 \
+            {                                                   \
+                out << (K) << "=" << args[(K)].as<T>() << "\n"; \
+            }                                                   \
+            catch(...)                                          \
+            {                                                   \
+                out << (K) << "=(as<" #T "> failed)\n";         \
+            }                                                   \
+        }                                                       \
+    } while(0)
+#define DUMP_VEC(K, T)                                          \
+    do                                                          \
+    {                                                           \
+        if(args.count(K))                                       \
+        {                                                       \
+            try                                                 \
+            {                                                   \
+                auto const& v = args[(K)].as<std::vector<T>>(); \
+                out << (K) << ".size=" << v.size();             \
+                for(size_t i = 0; i < v.size(); ++i)            \
+                    out << " " << v[i];                         \
+                out << "\n";                                    \
+            }                                                   \
+            catch(...)                                          \
+            {                                                   \
+                out << (K) << "=(vector as failed)\n";          \
+            }                                                   \
+        }                                                       \
+    } while(0)
+#define DUMP_VECVEC(K)                                                            \
+    do                                                                            \
+    {                                                                             \
+        if(args.count(K))                                                         \
+        {                                                                         \
+            try                                                                   \
+            {                                                                     \
+                auto const& v = args[(K)].as<std::vector<std::vector<size_t>>>(); \
+                out << (K) << ".size=" << v.size() << "\n";                       \
+                for(size_t i = 0; i < v.size(); ++i)                              \
+                {                                                                 \
+                    out << (K) << "[" << i << "]=";                               \
+                    for(size_t j = 0; j < v[i].size(); ++j)                       \
+                        out << (j ? " " : "") << v[i][j];                         \
+                    out << "\n";                                                  \
+                }                                                                 \
+            }                                                                     \
+            catch(...)                                                            \
+            {                                                                     \
+                out << (K) << "=(vecvec failed)\n";                               \
+            }                                                                     \
+        }                                                                         \
+    } while(0)
+            if(args.count("config-file"))
+            {
+                try
+                {
+                    auto const& v = args["config-file"].as<std::vector<std::string>>();
+                    out << "config-file.size=" << v.size() << "\n";
+                    for(size_t i = 0; i < v.size(); ++i)
+                        out << "config-file[" << i << "]=" << v[i] << "\n";
+                }
+                catch(...)
+                {
+                    out << "config-file=(failed)\n";
+                }
+            }
+            DUMP_OPT("library-file", std::string);
+            if(args.count("code-object"))
+            {
+                try
+                {
+                    auto const& v = args["code-object"].as<std::vector<std::string>>();
+                    out << "code-object.size=" << v.size() << "\n";
+                    for(size_t i = 0; i < v.size(); ++i)
+                        out << "code-object[" << i << "]=" << v[i] << "\n";
+                }
+                catch(...)
+                {
+                    out << "code-object=(failed)\n";
+                }
+            }
+            DUMP_OPT("performance-metric", PerformanceMetric);
+            DUMP_OPT("problem-identifier", std::string);
+            DUMP_OPT("type", rocisa::DataType);
+            DUMP_OPT("a-type", rocisa::DataType);
+            DUMP_OPT("b-type", rocisa::DataType);
+            DUMP_OPT("c-type", rocisa::DataType);
+            DUMP_OPT("d-type", rocisa::DataType);
+            DUMP_OPT("e-type", rocisa::DataType);
+            DUMP_OPT("amaxD-type", rocisa::DataType);
+            DUMP_OPT("alpha-type", rocisa::DataType);
+            DUMP_OPT("beta-type", rocisa::DataType);
+            DUMP_OPT("compute-input-type", rocisa::DataType);
+            DUMP_OPT("f32-xdl-math-op", rocisa::DataType);
+            DUMP_OPT("swizzle-tensor-a", bool);
+            DUMP_OPT("swizzle-tensor-b", bool);
+            DUMP_OPT("activation-compute-type", rocisa::DataType);
+            DUMP_OPT("high-precision-accumulate", bool);
+            DUMP_OPT("sparse", int);
+            DUMP_OPT("strided-batched", bool);
+            DUMP_OPT("grouped-gemm", bool);
+            DUMP_OPT("kernel-language", KernelLanguage);
+            DUMP_OPT("deterministic-mode", bool);
+            DUMP_OPT("init-seed", unsigned int);
+            DUMP_OPT("init-a", InitMode);
+            DUMP_OPT("init-b", InitMode);
+            DUMP_OPT("init-c", InitMode);
+            DUMP_OPT("init-d", InitMode);
+            DUMP_OPT("init-e", InitMode);
+            DUMP_OPT("init-alpha", InitMode);
+            DUMP_OPT("init-beta", InitMode);
+            DUMP_OPT("init-bias", InitMode);
+            DUMP_OPT("init-scaleA", InitMode);
+            DUMP_OPT("init-scaleB", InitMode);
+            DUMP_OPT("init-scaleC", InitMode);
+            DUMP_OPT("init-scaleD", InitMode);
+            DUMP_OPT("init-scaleAlphaVec", InitMode);
+            DUMP_OPT("pristine-on-gpu", bool);
+            DUMP_OPT("c-equal-d", bool);
+            DUMP_OPT("num-elements-to-validate", int);
+            DUMP_OPT("bounds-check", BoundsCheckMode);
+            DUMP_OPT("prune-mode", PruneSparseMode);
+            DUMP_OPT("device-idx", int);
+            DUMP_OPT("use-default-stream", bool);
+            DUMP_OPT("num-warmups", int);
+            DUMP_OPT("sync-after-warmups", bool);
+            DUMP_OPT("num-benchmarks", int);
+            DUMP_OPT("num-enqueues-per-sync", int);
+            DUMP_OPT("max-enqueues-per-sync", int);
+            DUMP_OPT("num-syncs-per-benchmark", int);
+            DUMP_OPT("skip-slow-solution-ratio", float);
+            DUMP_OPT("min-flops-per-sync", size_t);
+            DUMP_OPT("use-gpu-timer", bool);
+            DUMP_OPT("sleep-percent", int);
+            DUMP_OPT("hardware-monitor", bool);
+            DUMP_OPT("perf-l2-read-hits", double);
+            DUMP_OPT("perf-l2-write-hits", double);
+            DUMP_OPT("perf-l2-read-bw-mul", double);
+            DUMP_OPT("perf-read-efficiency", double);
+            DUMP_OPT("csv-export-extra-cols", bool);
+            DUMP_OPT("csv-merge-same-problems", bool);
+            DUMP_OPT("PrintWinnersOnly", bool);
+            DUMP_VECVEC("problem-size");
+            if(args.count("prob-sol-map"))
+            {
+                try
+                {
+                    auto const& m = args["prob-sol-map"].as<std::map<int, int>>();
+                    out << "prob-sol-map.size=" << m.size() << "\n";
+                    for(auto const& p : m)
+                        out << "prob-sol-map " << p.first << "=" << p.second << "\n";
+                }
+                catch(...)
+                {
+                    out << "prob-sol-map=(failed)\n";
+                }
+            }
+            DUMP_VECVEC("a-strides");
+            DUMP_VECVEC("b-strides");
+            DUMP_VECVEC("c-strides");
+            DUMP_VECVEC("d-strides");
+            DUMP_VECVEC("e-strides");
+            DUMP_VECVEC("bias-strides");
+            DUMP_OPT("problem-start-idx", int);
+            DUMP_OPT("num-problems", int);
+            DUMP_OPT("solution-start-idx", int);
+            DUMP_OPT("num-solutions", int);
+            DUMP_OPT("best-solution", bool);
+            DUMP_OPT("results-file", std::string);
+            DUMP_OPT("log-file", std::string);
+            DUMP_OPT("log-file-append", bool);
+            DUMP_OPT("log-level", LogLevel);
+            DUMP_OPT("library-update-file", std::string);
+            DUMP_OPT("library-update-comment", bool);
+            DUMP_OPT("exit-on-error", bool);
+            DUMP_OPT("selection-only", bool);
+            DUMP_OPT("max-workspace-size", size_t);
+            DUMP_OPT("granularity-threshold", double);
+            DUMP_OPT("activation-type", ActivationType);
+            DUMP_OPT("activation-no-guard", bool);
+            if(args.count("activation-additional-args"))
+            {
+                try
+                {
+                    auto const& v
+                        = args["activation-additional-args"].as<std::vector<std::vector<double>>>();
+                    out << "activation-additional-args.size=" << v.size() << "\n";
+                    for(size_t i = 0; i < v.size(); ++i)
+                    {
+                        out << "activation-additional-args[" << i << "]=";
+                        for(size_t j = 0; j < v[i].size(); ++j)
+                            out << (j ? "," : "") << v[i][j];
+                        out << "\n";
+                    }
+                }
+                catch(...)
+                {
+                    out << "activation-additional-args=(failed)\n";
+                }
+            }
+            DUMP_VEC("activation-enum-args", ActivationType);
+            DUMP_OPT("use-bias", int);
+            DUMP_OPT("bias-source", int);
+            DUMP_OPT("use-scaleAB", std::string);
+            DUMP_OPT("use-scaleCD", bool);
+            DUMP_OPT("use-scaleAlphaVec", int);
+            DUMP_VEC("bias-type-args", rocisa::DataType);
+            DUMP_VEC("factor-dim-args", int);
+            DUMP_VEC("icache-flush-args", bool);
+            DUMP_OPT("use-e", bool);
+            DUMP_OPT("use-gradient", bool);
+            DUMP_OPT("use-user-args", bool);
+            DUMP_OPT("rotating-buffer-size", int32_t);
+            DUMP_OPT("rotating-buffer-mode", int32_t);
+            DUMP_OPT("output-amaxD", bool);
+            DUMP_OPT("timing-instrumentation", bool);
+#undef DUMP_OPT
+#undef DUMP_VEC
+#undef DUMP_VECVEC
+            std::cerr << "TENSILE_DUMP_OPTIONS: wrote " << path << "\n";
+        }
+
         std::shared_ptr<Hardware> GetHardware(po::variables_map const& args)
         {
             int deviceCount = 0;
@@ -453,18 +693,25 @@ namespace TensileLite
         }
 
         template <typename T>
+        T parse_num(std::string const& s)
+        {
+            T                  t{};
+            std::istringstream ss(s);
+            ss >> t;
+            if(!ss && !ss.eof())
+                throw std::runtime_error("Failed to parse number: " + s);
+            return t;
+        }
+
+        template <typename T>
         std::vector<T> split_nums(std::string const& value)
         {
-            std::vector<std::string> parts;
-            boost::split(parts, value, boost::algorithm::is_any_of(",;"));
-
-            std::vector<T> rv;
+            std::vector<std::string> parts = po::split_string(value);
+            std::vector<T>           rv;
             rv.reserve(parts.size());
-
             for(auto const& part : parts)
-                if(part != "")
-                    rv.push_back(boost::lexical_cast<T>(part));
-
+                if(!part.empty())
+                    rv.push_back(parse_num<T>(part));
             return rv;
         }
 
@@ -478,15 +725,13 @@ namespace TensileLite
             for(auto const& str : inValue)
                 outValue.push_back(split_nums<T>(str));
 
-            boost::any v(outValue);
-
-            args.at(name).value() = v;
+            args.at(name).value() = std::any(outValue);
         }
 
         void parse_arg_bools(po::variables_map& args, std::string const& name)
         {
             auto opts             = args[name].as<std::vector<bool>>();
-            args.at(name).value() = boost::any(opts);
+            args.at(name).value() = std::any(opts);
         }
 
         void parse_arg_ints(po::variables_map& args, std::string const& name)
@@ -502,20 +747,19 @@ namespace TensileLite
         void parse_bias_type_args(po::variables_map& args, std::string const& name)
         {
             auto type             = args[name].as<std::vector<rocisa::DataType>>();
-            args.at(name).value() = boost::any(type);
+            args.at(name).value() = std::any(type);
         }
 
         void parse_activation_enum_args(po::variables_map& args, std::string const& name)
         {
             auto type             = args[name].as<std::vector<ActivationType>>();
-            args.at(name).value() = boost::any(type);
+            args.at(name).value() = std::any(type);
         }
 
         void parse_activation_int(po::variables_map& args, std::string const& name)
         {
-            auto type = args[name].as<ActivationType>();
-
-            args.at(name).value() = boost::any(type);
+            auto type             = args[name].as<ActivationType>();
+            args.at(name).value() = std::any(type);
         }
 
         template <typename T>
@@ -530,9 +774,7 @@ namespace TensileLite
                 outValue[vec[0]] = vec[1];
             }
 
-            boost::any v(outValue);
-
-            args.at(name).value() = v;
+            args.at(name).value() = std::any(outValue);
         }
 
         void parse_arg_ints_map(po::variables_map& args, std::string const& name)
@@ -550,12 +792,12 @@ namespace TensileLite
                || type == rocisa::DataType::ComplexFloat || type == rocisa::DataType::ComplexDouble
                || type == rocisa::DataType::Int32)
             {
-                args.at("a-type").value()     = boost::any(type);
-                args.at("b-type").value()     = boost::any(type);
-                args.at("c-type").value()     = boost::any(type);
-                args.at("d-type").value()     = boost::any(type);
-                args.at("alpha-type").value() = boost::any(type);
-                args.at("beta-type").value()  = boost::any(type);
+                args.at("a-type").value()     = std::any(type);
+                args.at("b-type").value()     = std::any(type);
+                args.at("c-type").value()     = std::any(type);
+                args.at("d-type").value()     = std::any(type);
+                args.at("alpha-type").value() = std::any(type);
+                args.at("beta-type").value()  = std::any(type);
             }
         }
 

--- a/projects/hipblaslt/tensilelite/client/src/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/client/src/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(COMMON_CLIENT_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/BenchmarkTimer.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ClientProblemFactory.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ProgramOptions.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/DataInitialization.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/PerformanceReporter.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/HardwareMonitorListener.cpp"

--- a/projects/hipblaslt/tensilelite/client/src/ProgramOptions.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/ProgramOptions.cpp
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ *******************************************************************************/
+
+#include "ProgramOptions.hpp"
+
+#include <iomanip>
+#include <iostream>
+
+namespace TensileLite
+{
+    namespace Client
+    {
+        namespace po
+        {
+
+            variable_value const variables_map::s_empty;
+
+            static std::vector<std::string> get_option_names(std::string const& opts)
+            {
+                std::vector<std::string> names;
+                std::string::size_type   pos = 0;
+                for(;;)
+                {
+                    auto next = opts.find(',', pos);
+                    if(next == std::string::npos)
+                    {
+                        names.push_back(trim_opt(opts.substr(pos)));
+                        break;
+                    }
+                    names.push_back(trim_opt(opts.substr(pos, next - pos)));
+                    pos = next + 1;
+                }
+                return names;
+            }
+
+            variables_map parse_command_line(int                        argc,
+                                             char const* const          argv[],
+                                             options_description const& desc)
+            {
+                variables_map m_vm;
+                auto const&   options = desc.options();
+
+                std::map<std::string, std::pair<size_t, std::string>> arg_to_option;
+                for(size_t i = 0; i < options.size(); i++)
+                {
+                    std::string canonical = get_canonical_option_name(options[i].opts);
+                    auto        names     = get_option_names(options[i].opts);
+                    for(auto const& name : names)
+                    {
+                        if(name.empty())
+                            continue;
+                        std::string key    = (name.size() == 1 ? "-" : "--") + name;
+                        arg_to_option[key] = {i, canonical};
+                    }
+                }
+
+                for(int i = 1; i < argc; i++)
+                {
+                    std::string arg = argv[i];
+                    auto        it  = arg_to_option.find(arg);
+                    if(it == arg_to_option.end())
+                        throw std::invalid_argument("Unknown option: " + arg);
+
+                    size_t      idx       = it->second.first;
+                    std::string canonical = it->second.second;
+                    auto const& opt       = options[idx];
+
+                    if(!opt.value_semantic)
+                        continue;
+
+                    if(opt.value_semantic->is_flag())
+                    {
+                        if(opt.value_semantic->has_implicit_value())
+                        {
+                            // Optional value: --opt means implicit value; --opt false means parse value
+                            if(i + 1 < argc && argv[i + 1][0] != '-')
+                            {
+                                i++;
+                                std::any parsed = opt.value_semantic->parser()(argv[i]);
+                                m_vm[canonical].value() = std::move(parsed);
+                            }
+                            else
+                            {
+                                m_vm[canonical].value() = opt.value_semantic->get_implicit_value();
+                            }
+                        }
+                        else
+                        {
+                            m_vm[canonical].value() = std::any(true);
+                        }
+                        continue;
+                    }
+
+                    i++;
+                    if(i >= argc)
+                        throw std::invalid_argument("Missing value for option " + arg);
+                    std::string value_str = argv[i];
+                    std::any    parsed    = opt.value_semantic->parser()(value_str);
+
+                    if(opt.value_semantic->is_multivalued() && m_vm.count(canonical)
+                       && !m_vm[canonical].empty())
+                    {
+                        opt.value_semantic->merge_into(m_vm[canonical].value(), parsed);
+                    }
+                    else
+                    {
+                        m_vm[canonical].value() = std::move(parsed);
+                    }
+                }
+
+                for(size_t i = 0; i < options.size(); i++)
+                {
+                    if(!options[i].value_semantic)
+                        continue;
+                    std::string canonical = get_canonical_option_name(options[i].opts);
+                    if(canonical == "help")
+                        continue;
+                    if(!m_vm.count(canonical) || m_vm[canonical].empty())
+                        m_vm[canonical].value() = options[i].value_semantic->get_default();
+                }
+                return m_vm;
+            }
+
+            variables_map parse_config_file(std::istream& is, options_description const& desc)
+            {
+                variables_map                                         m_vm;
+                auto const&                                           options = desc.options();
+                std::map<std::string, std::pair<size_t, std::string>> name_to_option;
+                for(size_t i = 0; i < options.size(); i++)
+                {
+                    std::string canonical = get_canonical_option_name(options[i].opts);
+                    auto        names     = get_option_names(options[i].opts);
+                    for(auto const& name : names)
+                    {
+                        if(name.empty())
+                            continue;
+                        name_to_option[name] = {i, canonical};
+                    }
+                }
+
+                std::string line;
+                while(std::getline(is, line))
+                {
+                    auto hash = line.find('#');
+                    if(hash != std::string::npos)
+                        line.resize(hash);
+                    line = trim_opt(line);
+                    if(line.empty())
+                        continue;
+
+                    auto eq = line.find('=');
+                    if(eq == std::string::npos)
+                        continue;
+
+                    std::string key   = trim_opt(line.substr(0, eq));
+                    std::string value = trim_opt(line.substr(eq + 1));
+                    if(key.empty())
+                        continue;
+
+                    auto it = name_to_option.find(key);
+                    if(it == name_to_option.end())
+                        continue;
+
+                    size_t      idx       = it->second.first;
+                    std::string canonical = it->second.second;
+                    auto const& opt       = options[idx];
+
+                    if(!opt.value_semantic)
+                        continue;
+
+                    std::any parsed = opt.value_semantic->parse_config_line(value);
+                    if(opt.value_semantic->is_multivalued() && m_vm.count(canonical)
+                       && !m_vm[canonical].empty())
+                    {
+                        opt.value_semantic->merge_into(m_vm[canonical].value(), parsed);
+                    }
+                    else
+                    {
+                        m_vm[canonical].value() = std::move(parsed);
+                    }
+                }
+                return m_vm;
+            }
+
+            std::ostream& operator<<(std::ostream& os, options_description const& desc)
+            {
+                for(auto const& opt : desc.options())
+                {
+                    auto               names = get_option_names(opt.opts);
+                    std::ostringstream left;
+                    bool               first = true;
+                    for(auto const& name : names)
+                    {
+                        if(!first)
+                            left << "|";
+                        left << (name.size() == 1 ? "-" : "--") << name;
+                        first = false;
+                    }
+                    bool print_value = true;
+                    if(opt.value_semantic && opt.value_semantic->is_flag())
+                        print_value = false;
+                    if(print_value)
+                        left << " <value>";
+                    os << std::setw(34) << std::left << left.str() << " " << std::setw(82)
+                       << std::left << opt.description << "\n";
+                }
+                return os << std::flush;
+            }
+
+        } // namespace po
+    } // namespace Client
+} // namespace TensileLite

--- a/projects/hipblaslt/tensilelite/tests/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/tests/CMakeLists.txt
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier:  MIT
 
 find_package(GTest REQUIRED)
-find_package(Boost REQUIRED COMPONENTS filesystem)
 
 add_executable(tensilelite-tests)
 add_subdirectory(configs)
@@ -40,7 +39,6 @@ target_include_directories(tensilelite-tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR
 target_link_libraries(tensilelite-tests
     PUBLIC
         tensilelite::tensilelite-host
-        Boost::filesystem
     PRIVATE
         hip::device
         ${CMAKE_DL_LIBS}

--- a/projects/hipblaslt/tensilelite/tests/RangeLibrary_test.cpp
+++ b/projects/hipblaslt/tensilelite/tests/RangeLibrary_test.cpp
@@ -19,14 +19,14 @@
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  * SPDX-License-Identifier: MIT
  * ************************************************************************ */
 
 #include <gtest/gtest.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <Tensile/ContractionLibrary.hpp>
 #ifdef TENSILE_YAML
@@ -61,14 +61,14 @@ struct RangeLibraryTest
         if(library == nullptr)
         {
             std::cout << libraryPath().native() << std::endl;
-            if(!boost::filesystem::is_regular_file(libraryPath()))
+            if(!std::filesystem::is_regular_file(libraryPath()))
                 GTEST_SKIP();
             else
                 ASSERT_NE(library, nullptr);
         }
     }
 
-    boost::filesystem::path libraryPath()
+    std::filesystem::path libraryPath()
     {
         return TestData::Instance().file(filename);
     }
@@ -91,7 +91,7 @@ struct RangeLibraryTest
     {
         auto path = libraryPath();
 
-        if(boost::filesystem::is_regular_file(path))
+        if(std::filesystem::is_regular_file(path))
             return LoadLibraryFile<ContractionProblemGemm>(path.native());
 
         return nullptr;
@@ -101,14 +101,13 @@ struct RangeLibraryTest
 std::map<std::string, std::shared_ptr<SolutionLibrary<ContractionProblemGemm>>>
     RangeLibraryTest::libraryCache;
 
-
 TEST_P(RangeLibraryTest, SpecificSizes)
 {
     // Solution in Range library should be picked for
     // transposeA: true, transposeB false, datatype BFloat16,
     // M in [128, 768], N in [1024, 1408], batch_count in [-1, -1], K in [49024, 49280]
 
-    std::vector<std::tuple<size_t, size_t, size_t, size_t, bool>> MNKB = 
+    std::vector<std::tuple<size_t, size_t, size_t, size_t, bool>> MNKB =
         {{128, 1024, 1,  49024, true},
          {768, 1024, 1,  49024, true},
          {128, 1408, 1,  49024, true},
@@ -119,7 +118,6 @@ TEST_P(RangeLibraryTest, SpecificSizes)
          {128, 1409, 1,  49024, false},
          {128, 1024, 1,  16,    false},
          {128, 1024, 1,  49285, false}};
-         
 
     for(auto [M, N, B, K, in_range] : MNKB)
     {

--- a/projects/hipblaslt/tensilelite/tests/TestData.cpp
+++ b/projects/hipblaslt/tensilelite/tests/TestData.cpp
@@ -27,22 +27,14 @@
 #include "TestData.hpp"
 
 #include <glob.h>
-#include <unistd.h>
 #include <memory>
-
-#include <boost/version.hpp>
-
-#if BOOST_VERSION >= 106100
-#include <boost/dll/runtime_symbol_info.hpp>
-#else
-#define TEST_DATA_USE_PROC_EXE
-#endif
+#include <unistd.h>
 
 #include <Tensile/Utils.hpp>
 
 TestData::operator bool() const
 {
-    return boost::filesystem::is_directory(dataDir());
+    return std::filesystem::is_directory(dataDir());
 }
 
 TestData TestData::Invalid()
@@ -60,35 +52,35 @@ TestData TestData::Env(std::string const& varName)
     return TestData(var);
 }
 
-boost::filesystem::path TestData::dataDir() const
+std::filesystem::path TestData::dataDir() const
 {
     return m_dataDir;
 }
 
-boost::filesystem::path TestData::file(std::string const& filename) const
+std::filesystem::path TestData::file(std::string const& filename) const
 {
     auto simple = dataDir() / filename;
-    if(boost::filesystem::is_regular_file(simple))
+    if(std::filesystem::is_regular_file(simple))
         return simple;
 
     auto datFile = file(filename, "dat");
-    if(boost::filesystem::is_regular_file(datFile))
+    if(std::filesystem::is_regular_file(datFile))
         return datFile;
 
     auto yamlFile = file(filename, "yaml");
-    if(boost::filesystem::is_regular_file(yamlFile))
+    if(std::filesystem::is_regular_file(yamlFile))
         return yamlFile;
 
     return simple;
 }
 
-boost::filesystem::path TestData::file(std::string const& filename,
-                                       std::string const& extension) const
+std::filesystem::path TestData::file(std::string const& filename,
+                                     std::string const& extension) const
 {
     return dataDir() / (filename + "." + extension);
 }
 
-std::vector<boost::filesystem::path> TestData::glob(std::string const& pattern) const
+std::vector<std::filesystem::path> TestData::glob(std::string const& pattern) const
 {
     std::string wholePattern = (dataDir() / pattern).native();
 
@@ -105,7 +97,7 @@ std::vector<boost::filesystem::path> TestData::glob(std::string const& pattern) 
     if(err == GLOB_NOSPACE || err == GLOB_ABORTED)
         throw std::runtime_error(TensileLite::concatenate("Glob ", wholePattern, " failed."));
 
-    std::vector<boost::filesystem::path> rv(result.gl_pathc);
+    std::vector<std::filesystem::path> rv(result.gl_pathc);
 
     for(size_t i = 0; i < result.gl_pathc; i++)
         rv[i] = result.gl_pathv[i];
@@ -113,22 +105,23 @@ std::vector<boost::filesystem::path> TestData::glob(std::string const& pattern) 
     return rv;
 }
 
-boost::filesystem::path TestData::ProgramLocation()
+std::filesystem::path TestData::ProgramLocation()
 {
-#ifdef TEST_DATA_USE_PROC_EXE
-    return boost::filesystem::read_symlink("/proc/self/exe");
+#ifdef __linux__
+    return std::filesystem::read_symlink("/proc/self/exe");
 #else
-    return boost::dll::program_location();
+    // Fallback for non-Linux: not used by current CI; add platform API if needed.
+    return std::filesystem::current_path();
 #endif
 }
 
 TestData::TestData()
     : m_dataDir(ProgramLocation().parent_path() / "data")
 {
-    if(!boost::filesystem::is_directory(m_dataDir))
+    if(!std::filesystem::is_directory(m_dataDir))
     {
         auto newValue = ProgramLocation().parent_path().parent_path() / "data";
-        if(boost::filesystem::is_directory(newValue))
+        if(std::filesystem::is_directory(newValue))
             m_dataDir = newValue;
     }
 }

--- a/projects/hipblaslt/tensilelite/tests/include/TestData.hpp
+++ b/projects/hipblaslt/tensilelite/tests/include/TestData.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2019-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,9 @@
 
 #pragma once
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
+#include <string>
+#include <vector>
 
 #include <Tensile/Singleton.hpp>
 
@@ -39,23 +41,23 @@ struct TestData : public TensileLite::LazySingleton<TestData>
     static TestData Invalid();
     static TestData Env(std::string const& varName);
 
-    boost::filesystem::path dataDir() const;
+    std::filesystem::path dataDir() const;
 
-    boost::filesystem::path file(std::string const& filename) const;
-    boost::filesystem::path file(std::string const& filename, std::string const& extension) const;
+    std::filesystem::path file(std::string const& filename) const;
+    std::filesystem::path file(std::string const& filename, std::string const& extension) const;
 
-    std::vector<boost::filesystem::path> glob(std::string const& pattern) const;
+    std::vector<std::filesystem::path> glob(std::string const& pattern) const;
 
 private:
     friend Base;
 
-    boost::filesystem::path m_dataDir;
+    std::filesystem::path m_dataDir;
 
     struct invalid_data
     {
     };
 
-    static boost::filesystem::path ProgramLocation();
+    static std::filesystem::path ProgramLocation();
 
     TestData();
     TestData(std::string const& dataDir);


### PR DESCRIPTION
- Client: add ProgramOptions.hpp/cpp (std::any, no Boost); match Boost semantics for CLI/config and bool/vector options; single LogReporter (console or file) so "Log level" prints once; keep option dump for CI.
- Tests: switch TestData and RangeLibrary_test to std::filesystem; ProgramLocation via /proc/self/exe on Linux; remove Boost from tests CMake.
- Cleanup: remove dead code and duplicate trim in ProgramOptions.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
