### PR TITLE
 [Tensilelite] Fix UserArgs struct stride mismatch in grouped GEMM

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/Signature.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/Signature.py
@@ -221,19 +221,19 @@ class SignatureDefault(Signature):
         if kernel["ProblemType"]["UseScaleAB"]:
             signature.addArg("AddressScaleA", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
             signature.addArg("AddressScaleB", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
-            userArgumentsInfo.scaleASize += 8
-            userArgumentsInfo.scaleBSize += 8
+        userArgumentsInfo.scaleASize += 8
+        userArgumentsInfo.scaleBSize += 8
         if kernel["ProblemType"]["UseScaleCD"]:
             signature.addArg("AddressScaleC", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
             signature.addArg("AddressScaleD", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
-            userArgumentsInfo.scaleCSize += 8
-            userArgumentsInfo.scaleDSize += 8
+        userArgumentsInfo.scaleCSize += 8
+        userArgumentsInfo.scaleDSize += 8
 
         if kernel["ProblemType"]["UseScaleAlphaVec"]:
             signature.addArg("AddressScaleAlphaVec", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
             if kernel["ProblemType"]["UseScaleAlphaVec"] == 3:
                 userArgumentsInfo.factorDimSize =4
-                userArgumentsInfo.scaleAlphaVecSize += 8
+        userArgumentsInfo.scaleAlphaVecSize += 8
 
         if writer.states.useBias != DataDirection.NONE:
             signature.addArg("bias", SVK.SIG_GLOBALBUFFER, biasValueType, "generic")  # Note: We append the data in ws_d
@@ -242,7 +242,7 @@ class SignatureDefault(Signature):
                 signature.addArg("StrideBias",      SVK.SIG_VALUE,        "u32")
                 if kernel["ProblemType"]["UseBias"] == 3:
                     userArgumentsInfo.factorDimSize = 4
-            userArgumentsInfo.biasSize += (8 + 4 + 4)
+        userArgumentsInfo.biasSize += (8 + 4 + 4)
 
         if userArgumentsInfo.factorDimSize == 4:
             signature.addArg("factorDim", SVK.SIG_VALUE, "u32")
@@ -251,9 +251,9 @@ class SignatureDefault(Signature):
             signature.addArg(      "E", SVK.SIG_GLOBALBUFFER, cptValueType, "generic")
             for i in range(0, writer.states.e.numSgprStrides):
                 signature.addArg("StrideE%u"%i,        SVK.SIG_VALUE,        "u32")
-            userArgumentsInfo.eSize += 8
-            for i in range(0, writer.states.e.numSgprStrides):
-                userArgumentsInfo.eSize += 4
+        userArgumentsInfo.eSize += 8
+        for i in range(0, writer.states.e.numSgprStrides):
+            userArgumentsInfo.eSize += 4
 
         if ((kernel["ProblemType"]["ActivationType"] != 'none') and kernel["ActivationFused"]):
             if kernel["ProblemType"]["ActivationComputeDataType"].isHalf():


### PR DESCRIPTION
## Motivation

Grouped GEMM with `UseUserArgs: True` crashes with `hipErrorIllegalAddress` because the kernel's `userArgsInfo.totalSize` doesn't match `sizeof(DeviceUserArguments)`.

## Technical Details

`DeviceUserArguments` is a fixed 196-byte packed struct, but `userArgsInfo` field sizes in `Signature.py` were only set inside feature-gated blocks, leaving them at 0 when features were disabled. 

This made `totalSize` (stride between per-problem entries) and `extArgOffset` (epilogue field offsets) smaller than the struct, causing the kernel to read from wrong offsets for multi-problem grouped GEMMs. 

Fix: move size assignments outside conditional blocks to always match the struct layout.

## Test Plan

Existing test: `grouped_gemm_userargs.yaml` — validates grouped GEMM with `UseUserArgs: True` across ScaleAlphaVec, Bias+Activation, and plain configurations.

## Test Result

- [x] Test passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

AIHPBLAS-1220