### PR TITLE
[CK][rdna] Skip AI heuristics

### DIFF
--- a/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/projects/miopen/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <optional>
 #include <miopen/env.hpp>
+#include <miopen/stringutils.hpp>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS)
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS_IDX_OVERRIDE);
@@ -656,8 +657,13 @@ void PerformanceConfigHipImplicitGemm3DGroupFwdXdlops::HeuristicInit(
 
     // 3. AI heuristics (if enabled)
 #if MIOPEN_ENABLE_AI_KERNEL_TUNING
+    // Skip AI heuristics for RDNA architectures (gfx11x, gfx12x) - models not available
+    const std::string& device_name = ctx.GetStream().GetDeviceName();
+    const bool is_rdna =
+        miopen::StartsWith(device_name, "gfx11") || miopen::StartsWith(device_name, "gfx12");
+
     if(&ctx != &GetDummyCtx() &&
-       !env::disabled(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS_AI_HEUR))
+       !env::disabled(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS_AI_HEUR) && !is_rdna)
     {
         MIOPEN_LOG_I2(
             "Step 3: Attempting AI heuristics for data type: " << problem.GetInDataType());
@@ -734,6 +740,11 @@ void PerformanceConfigHipImplicitGemm3DGroupFwdXdlops::HeuristicInit(
             MIOPEN_LOG_I2("Step 3: AI heuristics failed, proceeding to default initialization");
             // Continue to default initialization
         }
+    }
+    else if(is_rdna)
+    {
+        MIOPEN_LOG_I2("Step 3: AI heuristics skipped (not supported for RDNA architecture: "
+                      << device_name << ")");
     }
     else
     {


### PR DESCRIPTION
Skip AI heuristics for RDNA (gfx11xx/gfx12xx)

## Motivation

Avoid warnings at attempt to run AI heuristics for kernel selection on RDNA where no support of this feature
```
....
MIOpen(HIP): Error [/__w/TheRock/TheRock/rocm-libraries/projects/miopen/src/conv/heuristics/ai_candidate_selection.cpp:63] Could not open metadata file: /root/test_therock/therock_venv/lib/python3.12/site-packages/_rocm_sdk_libraries_gfx120X_all/share/miopen/db/gfx1201_ConvHipImplicitGemm3DGroupFwdXdlops_metadata.tn.model
Buffered 128 messages to file: RSB-RORLAB-17-L:/tmp/miopen_error_3409251.log
MIOpen(HIP): Error [/__w/TheRock/TheRock/rocm-libraries/projects/miopen/src/conv/heuristics/ai_candidate_selection.cpp:400] Failed to construct CandidateSelectionModel for arch: gfx1201, solver: ConvHipImplicitGemm3DGroupFwdXdlops. Exception: RSB-RORLAB-17-L:/__w/TheRock/TheRock/rocm-libraries/projects/miopen/src/conv/heuristics/ai_candidate_selection.cpp:63: Could not open metadata file: /root/test_therock/therock_venv/lib/python3.12/site-packages/_rocm_sdk_libraries_gfx120X_all/share/miopen/db/gfx1201_ConvHipImplicitGemm3DGroupFwdXdlops_metadata.tn.model
Buffered 128 messages to file: RSB-RORLAB-17-L:/tmp/miopen_error_3409251.log
MIOpen(HIP): Error [/__w/TheRock/TheRock/rocm-libraries/projects/miopen/src/conv/heuristics/ai_candidate_selection.cpp:63] Could not open metadata file: /root/test_therock/therock_venv/lib/python3.12/site-packages/_rocm_sdk_libraries_gfx120X_all/share/miopen/db/gfx1201_ConvHipImplicitGemm3DGroupFwdXdlops_metadata.tn.model
Buffered 128 messages to file: RSB-RORLAB-17-L:/tmp/miopen_error_3409251.log
MIOpen(HIP): Error [/__w/TheRock/TheRock/rocm-libraries/projects/miopen/src/conv/heuristics/ai_candidate_selection.cpp:400] Failed to construct CandidateSelectionModel for arch: gfx1201, solver: ConvHipImplicitGemm3DGroupFwdXdlops. Exception: RSB-RORLAB-17-L:/__w/TheRock/TheRock/rocm-libraries/projects/miopen/src/conv/heuristics/ai_candidate_selection.cpp:63: Could not open metadata file: /root/test_therock/therock_venv/lib/python3.12/site-packages/_rocm_sdk_libraries_gfx120X_all/share/miopen/db/gfx1201_ConvHipImplicitGemm3DGroupFwdXdlops_metadata.tn.model
Buffered 128 messages to file: RSB-RORLAB-17-L:/tmp/miopen_error_3409251.log
MIOpen(HIP): Error [/__w/TheRock/TheRock/rocm-libraries/projects/miopen/src/conv/heuristics/ai_candidate_selection.cpp:63] Could not open metadata file: /root/test_therock/therock_venv/lib/python3.12/site-packages/_rocm_sdk_libraries_gfx120X_all/share/miopen/db/gfx1201_ConvHipImplicitGemm3DGroupFwdXdlops_metadata.tn.model
Buffered 128 messages to file: RSB-RORLAB-17-L:/tmp/miopen_error_3409251.log
MIOpen(HIP): Error [/__w/TheRock/TheRock/rocm-libraries/projects/miopen/src/conv/heuristics/ai_candidate_selection.cpp:400] Failed to construct CandidateSelectionModel for arch: gfx1201, solver: ConvHipImplicitGemm3DGroupFwdXdlops. Exception: RSB-RORLAB-17-L:/__w/TheRock/TheRock/rocm-libraries/projects/miopen/src/conv/heuristics/ai_candidate_selection.cpp:63: Could not open metadata file: /root/test_therock/therock_venv/lib/python3.12/site-packages/_rocm_sdk_libraries_gfx120X_all/share/miopen/db/gfx1201_ConvHipImplicitGemm3DGroupFwdXdlops_metadata.tn.model
Buffered 128 messages to file: RSB-RORLAB-17-L:/tmp/miopen_error_3409251.log
....
```                                                                            

## Technical Details

Add condition to skip based on device name

## Test Plan

Run on RDNA platform and check that no warnings

## Test Result

No warings

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Fixes https://github.com/ROCm/rocm-libraries/issues/4790