### PR TITLE
[MIOpen] cleanup -Wnrvo warnings

### DIFF
--- a/projects/miopen/cmake/EnableCompilerWarnings.cmake
+++ b/projects/miopen/cmake/EnableCompilerWarnings.cmake
@@ -102,7 +102,6 @@ set(__clang_cxx_compile_options
     -Wno-documentation
     -Wno-deprecated-builtins
     -Wno-enum-constexpr-conversion
-    -Wunused-value
     -Wno-unused-parameter
     -Wmissing-noreturn
     -Wnrvo)

--- a/projects/miopen/cmake/EnableCompilerWarnings.cmake
+++ b/projects/miopen/cmake/EnableCompilerWarnings.cmake
@@ -104,10 +104,8 @@ set(__clang_cxx_compile_options
     -Wno-enum-constexpr-conversion
     -Wunused-value
     -Wno-unused-parameter
-    -Wno-missing-noreturn
-    -Wno-tautological-constant-out-of-range-compare
-    -Wno-nrvo
-    -Wno-c++20-extensions)
+    -Wmissing-noreturn
+    -Wnrvo)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19")
     list(APPEND __clang_cxx_compile_options
         -Wno-unique-object-duplication

--- a/projects/miopen/cmake/EnableCompilerWarnings.cmake
+++ b/projects/miopen/cmake/EnableCompilerWarnings.cmake
@@ -104,7 +104,7 @@ set(__clang_cxx_compile_options
     -Wno-enum-constexpr-conversion
     -Wno-unused-parameter
     -Wmissing-noreturn
-    -Wnrvo)
+    -Wno-nrvo)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19")
     list(APPEND __clang_cxx_compile_options
         -Wno-unique-object-duplication

--- a/projects/miopen/driver/InputFlags.cpp
+++ b/projects/miopen/driver/InputFlags.cpp
@@ -257,7 +257,7 @@ TensorParameters InputFlags::GetValueTensor(const std::string& long_name) const
     if(components.empty())
         return {};
 
-    auto parse = [](auto line) {
+    auto parse = [](const std::string& line) {
         auto ret        = std::vector<int>{};
         const auto strs = miopen::SplitDelim(line, 'x');
         for(auto&& str : strs)
@@ -301,7 +301,7 @@ TensorParametersUint64 InputFlags::GetValueTensorUint64(const std::string& long_
     if(components.size() < 1)
         return {};
 
-    auto parse = [](auto line) {
+    auto parse = [](const std::string& line) {
         auto ret        = std::vector<uint64_t>{};
         const auto strs = miopen::SplitDelim(line, 'x');
         for(auto&& str : strs)
@@ -386,12 +386,12 @@ InputFlags::GetValue2dVectorInt(const std::string& long_name) const
 {
     const auto& input     = MapInputs.at(FindShortName(long_name));
     const auto components = miopen::SplitDelim(input.value.c_str(), ',');
-    auto output           = std::vector<std::vector<int32_t>>{};
+    std::vector<std::vector<int32_t>> output;
 
     if(components.size() < 1)
-        return {};
+        return output;
 
-    auto parse = [](auto line) {
+    auto parse = [](const std::string& line) {
         auto ret        = std::vector<int32_t>{};
         const auto strs = miopen::SplitDelim(line, 'x');
         for(auto&& str : strs)
@@ -421,12 +421,11 @@ InputFlags::GetValue2dVectorUint64(const std::string& long_name) const
 {
     const auto& input     = MapInputs.at(FindShortName(long_name));
     const auto components = miopen::SplitDelim(input.value.c_str(), ',');
-    auto output           = std::vector<std::vector<uint64_t>>{};
 
     if(components.size() < 1)
         return {};
 
-    auto parse = [](auto line) {
+    auto parse = [](const std::string& line) {
         auto ret        = std::vector<uint64_t>{};
         const auto strs = miopen::SplitDelim(line, 'x');
         for(auto&& str : strs)
@@ -443,6 +442,7 @@ InputFlags::GetValue2dVectorUint64(const std::string& long_name) const
         return ret;
     };
 
+    auto output = std::vector<std::vector<uint64_t>>{};
     for(auto&& component : components)
     {
         output.push_back(parse(component));

--- a/projects/miopen/driver/adam_driver.hpp
+++ b/projects/miopen/driver/adam_driver.hpp
@@ -333,11 +333,10 @@ int AdamDriver<Tgpu, Tref, Tgrad>::AddCmdLineArgs()
 template <typename Tgpu, typename Tref, typename Tgrad>
 std::vector<int> AdamDriver<Tgpu, Tref, Tgrad>::GetInputTensorLengthsFromCmdLine()
 {
-    std::vector<int> ret;
     auto tensor = inflags.GetValueTensor("dims");
     if(!tensor.lengths.empty())
         return tensor.lengths;
-    return ret;
+    return {};
 }
 
 template <typename Tgpu, typename Tref, typename Tgrad>

--- a/projects/miopen/driver/rnn_driver.hpp
+++ b/projects/miopen/driver/rnn_driver.hpp
@@ -344,7 +344,7 @@ std::vector<int> RNNDriver<Tgpu, Tref>::GetInputTensorLengthsFromCmdLine()
 
     in_n.push_back(in_h);
 
-    return std::move(in_n);
+    return in_n;
 }
 
 template <typename Tgpu, typename Tref>

--- a/projects/miopen/driver/rnn_driver.hpp
+++ b/projects/miopen/driver/rnn_driver.hpp
@@ -344,7 +344,7 @@ std::vector<int> RNNDriver<Tgpu, Tref>::GetInputTensorLengthsFromCmdLine()
 
     in_n.push_back(in_h);
 
-    return in_n;
+    return std::move(in_n);
 }
 
 template <typename Tgpu, typename Tref>

--- a/projects/miopen/driver/transformers_adam_w_driver.hpp
+++ b/projects/miopen/driver/transformers_adam_w_driver.hpp
@@ -232,11 +232,10 @@ int TransformersAdamWDriver<Tgpu, Tref, Tgrad>::AddCmdLineArgs()
 template <typename Tgpu, typename Tref, typename Tgrad>
 std::vector<int> TransformersAdamWDriver<Tgpu, Tref, Tgrad>::GetInputTensorLengthsFromCmdLine()
 {
-    std::vector<int> ret;
     auto tensor = inflags.GetValueTensor("dims");
     if(!tensor.lengths.empty())
         return tensor.lengths;
-    return ret;
+    return {};
 }
 
 template <typename Tgpu, typename Tref, typename Tgrad>

--- a/projects/miopen/driver/transformers_adam_w_driver.hpp
+++ b/projects/miopen/driver/transformers_adam_w_driver.hpp
@@ -233,9 +233,7 @@ template <typename Tgpu, typename Tref, typename Tgrad>
 std::vector<int> TransformersAdamWDriver<Tgpu, Tref, Tgrad>::GetInputTensorLengthsFromCmdLine()
 {
     auto tensor = inflags.GetValueTensor("dims");
-    if(!tensor.lengths.empty())
-        return tensor.lengths;
-    return {};
+    return tensor.lengths;
 }
 
 template <typename Tgpu, typename Tref, typename Tgrad>

--- a/projects/miopen/src/binary_cache.cpp
+++ b/projects/miopen/src/binary_cache.cpp
@@ -54,9 +54,8 @@ static fs::path ComputeSysCachePath()
 {
     auto p = miopen::ExpandUser(GetSystemDbPath());
     if(!fs::exists(p))
-        return {};
-    else
-        return p;
+        p.clear();
+    return p;
 }
 
 static fs::path ComputeUserCachePath()

--- a/projects/miopen/src/bz2.cpp
+++ b/projects/miopen/src/bz2.cpp
@@ -70,12 +70,16 @@ std::vector<char> compress(const std::vector<char>& v, bool* compressed)
     if(compressed != nullptr and e == BZ_OUTBUFF_FULL)
     {
         *compressed = false;
-        return v;
+        result      = v;
     }
-    check_bz2_error(e, "BZ2_bzBuffToBuffCompress");
-    result.resize(len);
-    if(compressed != nullptr)
-        *compressed = true;
+    else
+    {
+        check_bz2_error(e, "BZ2_bzBuffToBuffCompress");
+        result.resize(len);
+        if(compressed != nullptr)
+            *compressed = true;
+    }
+
     return result;
 }
 

--- a/projects/miopen/src/comgr.cpp
+++ b/projects/miopen/src/comgr.cpp
@@ -525,17 +525,26 @@ static std::string GetLog(const Dataset& dataset, const bool comgr_error_handlin
         /// \todo Clarify API and update implementation.
         const auto count = dataset.GetDataCount(AMD_COMGR_DATA_KIND_LOG);
         if(count < 1)
-            return {comgr_error_handling ? "comgr warning: error log not found" : ""};
+        {
+            text = comgr_error_handling ? "comgr warning: error log not found" : "";
+            return text;
+        }
 
         const auto data = dataset.GetData(AMD_COMGR_DATA_KIND_LOG, 0);
         text            = data.GetString();
         if(text.empty())
-            return {comgr_error_handling ? "comgr info: error log empty" : ""};
+        {
+            text = comgr_error_handling ? "comgr info: error log empty" : "";
+            return text;
+        }
     }
     catch(ComgrError&)
     {
         if(comgr_error_handling)
-            return {"comgr error: failed to get error log"};
+        {
+            text = "comgr error: failed to get error log";
+            return text;
+        }
         // deepcode ignore EmptyThrowOutsideCatch: false positive
         throw;
         /// \anchor catch_and_rethrow_in_getlog

--- a/projects/miopen/src/conv/heuristics/ai_heuristics.cpp
+++ b/projects/miopen/src/conv/heuristics/ai_heuristics.cpp
@@ -704,7 +704,6 @@ std::vector<uint64_t> PredictSolver(const conv::ProblemDescription& problem,
 
         cached_result =
             ProcessAndCachePredictions(problem, device, true, predictions, model->GetSolverMap());
-        return cached_result;
     }
     else
     {
@@ -720,8 +719,9 @@ std::vector<uint64_t> PredictSolver(const conv::ProblemDescription& problem,
 
         cached_result = ProcessAndCachePredictions(
             problem, device, false, predictions, model->metadata.solver_map);
-        return cached_result;
     }
+
+    return cached_result;
 }
 
 } // namespace immed_mode

--- a/projects/miopen/src/conv/heuristics/ai_heuristics.cpp
+++ b/projects/miopen/src/conv/heuristics/ai_heuristics.cpp
@@ -696,14 +696,15 @@ std::vector<uint64_t> PredictSolver(const conv::ProblemDescription& problem,
         std::unique_ptr<conv3d::Model3D> model = conv3d::Get3DModel(device);
         if(!model || !model->IsProblemSupported(problem, ctx))
         {
-            return {}; // Fallback: empty vector
+            return cached_result; // Fallback: empty vector
         }
 
         MIOPEN_LOG_I2("Evaluating 3D TunaNet");
         std::vector<float> predictions = model->Forward(problem);
 
-        return ProcessAndCachePredictions(
-            problem, device, true, predictions, model->GetSolverMap());
+        cached_result =
+            ProcessAndCachePredictions(problem, device, true, predictions, model->GetSolverMap());
+        return cached_result;
     }
     else
     {
@@ -711,14 +712,15 @@ std::vector<uint64_t> PredictSolver(const conv::ProblemDescription& problem,
         std::unique_ptr<Model> model = GetModel(device);
         if(!model || !model->IsProblemSupported(problem, ctx))
         {
-            return {}; // Fallback: empty vector
+            return cached_result; // Fallback: empty vector
         }
 
         MIOPEN_LOG_I2("Evaluating TunaNet");
         std::vector<float> predictions = model->Forward(problem);
 
-        return ProcessAndCachePredictions(
+        cached_result = ProcessAndCachePredictions(
             problem, device, false, predictions, model->metadata.solver_map);
+        return cached_result;
     }
 }
 

--- a/projects/miopen/src/conv/solver_finders.cpp
+++ b/projects/miopen/src/conv/solver_finders.cpp
@@ -227,15 +227,16 @@ std::vector<Solution> EvaluateInvokers(const Handle& handle,
                                        FindCoreResult& core_result,
                                        bool force_attach_binary)
 {
+    std::vector<Solution> ret;
+
     const auto arch = env::value(MIOPEN_DEVICE_ARCH);
     if(!arch.empty())
-        return {};
+        return ret;
 
     bool using_search_cutoff = env::value(MIOPEN_SEARCH_CUTOFF);
     auto selected            = miopen::solver::ConvSolution{miopenStatusUnknownError};
     auto best                = std::numeric_limits<float>::max();
     auto best_invoker        = Invoker{};
-    auto ret                 = std::vector<Solution>{};
     std::vector<float> samples;
 
     for(const auto& sol : solutions)
@@ -355,7 +356,10 @@ std::vector<Solution> EvaluateInvokers(const Handle& handle,
     }
 
     if(!selected.Succeeded())
-        return {};
+    {
+        ret.clear();
+        return ret;
+    }
 
     handle.RegisterInvoker(best_invoker, network_config, selected.solver_id, algorithm_name);
     MIOPEN_LOG_I("Selected: " << selected << ": " << best

--- a/projects/miopen/src/db_path.cpp.in
+++ b/projects/miopen/src/db_path.cpp.in
@@ -91,7 +91,10 @@ fs::path PrepareUserDbPath()
     /// the library to use exactly that path.
     const auto p = env::value(MIOPEN_USER_DB_PATH);
     if(!p.empty())
-        return ExpandUser(p);
+    {
+        auto result = ExpandUser(p);
+        return result;
+    }
     /// \anchor nfs-detection
     /// Otherwise, check if the user-db-path denotes a network filesystem. If this is the case, then
     /// let's assume that the library is running on a cluster system, where home directory is shared
@@ -100,14 +103,14 @@ fs::path PrepareUserDbPath()
     /// WARNING: This makes all the library's user databases non-persistent. However, for now, we
     /// assume that the performance hit associated with the usage of shared home dir is worse than
     /// the deletion of user databases.
-    const auto udb_path = ExpandUser("${MIOPEN_USER_DB_PATH}");
+    auto result = ExpandUser("${MIOPEN_USER_DB_PATH}");
 #if !MIOPEN_BUILD_DEV
-    if(GetFilesystemChecker().IsNetworkedFilesystem(udb_path))
+    if(GetFilesystemChecker().IsNetworkedFilesystem(result))
     {
-        return fs::temp_directory_path() / ".config" / "miopen";
+        result = fs::temp_directory_path() / ".config" / "miopen";
     }
 #endif
-    return udb_path;
+    return result;
 }
 } // namespace
 

--- a/projects/miopen/src/execution_context.cpp
+++ b/projects/miopen/src/execution_context.cpp
@@ -136,12 +136,12 @@ static bool CalculateIsAmdRocmOpencl(const miopen::ExecutionContext& context)
 
 static rocm_meta_version AmdRocmMetadataVersionGetEnv()
 {
-    const rocm_meta_version val{env::value(MIOPEN_DEBUG_AMD_ROCM_METADATA_ENFORCE)};
+    rocm_meta_version val{env::value(MIOPEN_DEBUG_AMD_ROCM_METADATA_ENFORCE)};
     if(!val.IsValid())
     {
         MIOPEN_LOG_W("Incorrect MIOPEN_DEBUG_AMD_ROCM_ENFORCE_MDVERSION = " << val.getValue()
                                                                             << ", using default.");
-        return rocm_meta_version::Unknown;
+        val = rocm_meta_version::Unknown;
     }
     return val;
 }

--- a/projects/miopen/src/expanduser.cpp
+++ b/projects/miopen/src/expanduser.cpp
@@ -52,7 +52,7 @@ namespace miopen {
 namespace {
 std::string GetHomeDir()
 {
-    const auto p = env::value(HOME);
+    auto p = env::value(HOME);
     if(!(p.empty() || p == std::string("/")))
     {
         return p;
@@ -61,7 +61,8 @@ std::string GetHomeDir()
     // need to figure out what is the correct thing to do here
     // in tensoflow unit tests run via bazel, $HOME is not set, so this can happen
     // setting home_dir to the /tmp for now
-    return fs::temp_directory_path().string();
+    p = fs::temp_directory_path().string();
+    return p;
 }
 } // namespace
 

--- a/projects/miopen/src/find_db.cpp
+++ b/projects/miopen/src/find_db.cpp
@@ -127,72 +127,78 @@ template <class TDb>
 fs::path FindDbRecord_t<TDb>::GetInstalledPathFile(const Handle& handle,
                                                    const std::string& path_suffix)
 {
-    const std::string ext = ".fdb.txt";
-    const auto root_path  = GetSystemDbPath();
-    const auto base_name  = handle.GetDbBasename();
-    const auto suffix = GetSystemFindDbSuffix() + (path_suffix.empty() ? "" : ('.' + path_suffix));
-    auto file_path    = root_path / (base_name + "." + suffix + ext);
-    if(fs::exists(file_path))
-    {
-        MIOPEN_LOG_I2("Found exact find database file: " << file_path);
-        return file_path;
-    }
-
-    MIOPEN_LOG_I2("inexact find database search");
-    if(!fs::is_directory(root_path))
-    {
-        MIOPEN_LOG_I("Database directory does not exist");
-        file_path = fs::path{};
-        return file_path;
-    }
-
-    MIOPEN_LOG_I2("Iterating over find db directory " << root_path);
-    std::vector<fs::path> all_files;
-    std::vector<fs::path> contents;
-    std::copy(
-        fs::directory_iterator(root_path), fs::directory_iterator(), std::back_inserter(contents));
-    for(auto const& filepath : contents)
-    {
-        if(fs::is_regular_file(filepath) && filepath.extension() == path_suffix + ".fdb.txt")
-            all_files.push_back(filepath);
-    }
-
-    const auto db_id        = handle.GetTargetProperties().DbId();
-    const int real_cu_count = handle.GetMaxComputeUnits();
-    int closest_cu          = std::numeric_limits<int>::max();
-
-    for(const auto& entry : all_files)
-    {
-        const auto fname = entry.stem().string();
-        MIOPEN_LOG_I("Checking find db file: " << fname);
-        // Check for alternate back end same ASIC
-        if(fname.starts_with(base_name))
+    static const fs::path installed_path = [&] {
+        const std::string ext = ".fdb.txt";
+        const auto root_path  = GetSystemDbPath();
+        const auto base_name  = handle.GetDbBasename();
+        const auto suffix =
+            GetSystemFindDbSuffix() + (path_suffix.empty() ? "" : ('.' + path_suffix));
+        auto file_path = root_path / (base_name + "." + suffix + ext);
+        if(fs::exists(file_path))
         {
-            file_path = entry;
+            MIOPEN_LOG_I2("Found exact find database file: " << file_path);
             return file_path;
         }
-        if(db_id.empty() || !miopen::StartsWith(db_id, "gfx") || real_cu_count == 0)
+
+        MIOPEN_LOG_I2("inexact find database search");
+        if(!fs::is_directory(root_path))
         {
+            MIOPEN_LOG_I("Database directory does not exist");
             file_path = fs::path{};
-            return file_path; // empty
+            return file_path;
         }
-        // Check for alternate ASIC any back end
-        if(fname.starts_with(db_id))
+
+        MIOPEN_LOG_I2("Iterating over find db directory " << root_path);
+        std::vector<fs::path> all_files;
+        std::vector<fs::path> contents;
+        std::copy(fs::directory_iterator(root_path),
+                  fs::directory_iterator(),
+                  std::back_inserter(contents));
+        for(auto const& filepath : contents)
         {
-            const auto pos = fname.find('_');
-            int cur_count  = -1;
-            if(pos != std::string::npos)
-                cur_count = std::stoi(fname.substr(pos + 1));
-            else
-                cur_count = std::stoi(fname.substr(db_id.length()), nullptr, 16);
-            if(abs(cur_count - real_cu_count) < (closest_cu))
+            if(fs::is_regular_file(filepath) && filepath.extension() == path_suffix + ".fdb.txt")
+                all_files.push_back(filepath);
+        }
+
+        const auto db_id        = handle.GetTargetProperties().DbId();
+        const int real_cu_count = handle.GetMaxComputeUnits();
+        int closest_cu          = std::numeric_limits<int>::max();
+
+        for(const auto& entry : all_files)
+        {
+            const auto fname = entry.stem().string();
+            MIOPEN_LOG_I("Checking find db file: " << fname);
+            // Check for alternate back end same ASIC
+            if(fname.starts_with(base_name))
             {
-                file_path  = entry;
-                closest_cu = abs(cur_count - real_cu_count);
+                file_path = entry;
+                return file_path;
+            }
+            if(db_id.empty() || !miopen::StartsWith(db_id, "gfx") || real_cu_count == 0)
+            {
+                file_path = fs::path{};
+                return file_path; // empty
+            }
+            // Check for alternate ASIC any back end
+            if(fname.starts_with(db_id))
+            {
+                const auto pos = fname.find('_');
+                int cur_count  = -1;
+                if(pos != std::string::npos)
+                    cur_count = std::stoi(fname.substr(pos + 1));
+                else
+                    cur_count = std::stoi(fname.substr(db_id.length()), nullptr, 16);
+                if(abs(cur_count - real_cu_count) < (closest_cu))
+                {
+                    file_path  = entry;
+                    closest_cu = abs(cur_count - real_cu_count);
+                }
             }
         }
-    }
-    return file_path;
+        return file_path;
+    }();
+
+    return installed_path;
 }
 #endif
 template <class TDb>

--- a/projects/miopen/src/find_db.cpp
+++ b/projects/miopen/src/find_db.cpp
@@ -127,77 +127,72 @@ template <class TDb>
 fs::path FindDbRecord_t<TDb>::GetInstalledPathFile(const Handle& handle,
                                                    const std::string& path_suffix)
 {
-    static const auto installed_path = [&] {
-        const std::string ext = ".fdb.txt";
-        const auto root_path  = GetSystemDbPath();
-        const auto base_name  = handle.GetDbBasename();
-        const auto suffix =
-            GetSystemFindDbSuffix() + (path_suffix.empty() ? "" : ('.' + path_suffix));
-        const auto file_path = root_path / (base_name + "." + suffix + ext);
-        if(fs::exists(file_path))
+    const std::string ext = ".fdb.txt";
+    const auto root_path  = GetSystemDbPath();
+    const auto base_name  = handle.GetDbBasename();
+    const auto suffix = GetSystemFindDbSuffix() + (path_suffix.empty() ? "" : ('.' + path_suffix));
+    auto file_path    = root_path / (base_name + "." + suffix + ext);
+    if(fs::exists(file_path))
+    {
+        MIOPEN_LOG_I2("Found exact find database file: " << file_path);
+        return file_path;
+    }
+
+    MIOPEN_LOG_I2("inexact find database search");
+    if(!fs::is_directory(root_path))
+    {
+        MIOPEN_LOG_I("Database directory does not exist");
+        file_path = fs::path{};
+        return file_path;
+    }
+
+    MIOPEN_LOG_I2("Iterating over find db directory " << root_path);
+    std::vector<fs::path> all_files;
+    std::vector<fs::path> contents;
+    std::copy(
+        fs::directory_iterator(root_path), fs::directory_iterator(), std::back_inserter(contents));
+    for(auto const& filepath : contents)
+    {
+        if(fs::is_regular_file(filepath) && filepath.extension() == path_suffix + ".fdb.txt")
+            all_files.push_back(filepath);
+    }
+
+    const auto db_id        = handle.GetTargetProperties().DbId();
+    const int real_cu_count = handle.GetMaxComputeUnits();
+    int closest_cu          = std::numeric_limits<int>::max();
+
+    for(const auto& entry : all_files)
+    {
+        const auto fname = entry.stem().string();
+        MIOPEN_LOG_I("Checking find db file: " << fname);
+        // Check for alternate back end same ASIC
+        if(fname.starts_with(base_name))
         {
-            MIOPEN_LOG_I2("Found exact find database file: " << file_path);
+            file_path = entry;
             return file_path;
         }
-        else
+        if(db_id.empty() || !miopen::StartsWith(db_id, "gfx") || real_cu_count == 0)
         {
-            MIOPEN_LOG_I2("inexact find database search");
-            if(fs::is_directory(root_path))
-            {
-                MIOPEN_LOG_I2("Iterating over find db directory " << root_path);
-                std::vector<fs::path> all_files;
-                std::vector<fs::path> contents;
-                std::copy(fs::directory_iterator(root_path),
-                          fs::directory_iterator(),
-                          std::back_inserter(contents));
-                for(auto const& filepath : contents)
-                {
-                    if(fs::is_regular_file(filepath) &&
-                       filepath.extension() == path_suffix + ".fdb.txt")
-                        all_files.push_back(filepath);
-                }
-
-                const auto db_id        = handle.GetTargetProperties().DbId();
-                const int real_cu_count = handle.GetMaxComputeUnits();
-                int closest_cu          = std::numeric_limits<int>::max();
-                fs::path best_path;
-                for(const auto& entry : all_files)
-                {
-                    const auto fname = entry.stem().string();
-                    MIOPEN_LOG_I("Checking find db file: " << fname);
-                    // Check for alternate back end same ASIC
-                    if(fname.starts_with(base_name))
-                    {
-                        return entry;
-                    }
-                    if(db_id.empty() || !miopen::StartsWith(db_id, "gfx") || real_cu_count == 0)
-                        return fs::path{};
-                    // Check for alternate ASIC any back end
-                    if(fname.starts_with(db_id))
-                    {
-                        const auto pos = fname.find('_');
-                        int cur_count  = -1;
-                        if(pos != std::string::npos)
-                            cur_count = std::stoi(fname.substr(pos + 1));
-                        else
-                            cur_count = std::stoi(fname.substr(db_id.length()), nullptr, 16);
-                        if(abs(cur_count - real_cu_count) < (closest_cu))
-                        {
-                            best_path  = entry;
-                            closest_cu = abs(cur_count - real_cu_count);
-                        }
-                    }
-                }
-                return best_path;
-            }
+            file_path = fs::path{};
+            return file_path; // empty
+        }
+        // Check for alternate ASIC any back end
+        if(fname.starts_with(db_id))
+        {
+            const auto pos = fname.find('_');
+            int cur_count  = -1;
+            if(pos != std::string::npos)
+                cur_count = std::stoi(fname.substr(pos + 1));
             else
+                cur_count = std::stoi(fname.substr(db_id.length()), nullptr, 16);
+            if(abs(cur_count - real_cu_count) < (closest_cu))
             {
-                MIOPEN_LOG_I("Database directory does not exist");
-                return fs::path{};
+                file_path  = entry;
+                closest_cu = abs(cur_count - real_cu_count);
             }
         }
-    }();
-    return installed_path;
+    }
+    return file_path;
 }
 #endif
 template <class TDb>

--- a/projects/miopen/src/hip/batched_transpose_sol.cpp
+++ b/projects/miopen/src/hip/batched_transpose_sol.cpp
@@ -243,19 +243,20 @@ static inline BatchedTransposeParam HeuristicGet(const ExecutionContext& ctx,
         // Early heuristic for cases that has very large width, very small height (or vice versa)
         if(hw_radio <= 48)
         {
-            return (width <= 8) ? BatchedTransposeParam{4, 64, 1, 1, 1, 1}
-                                : BatchedTransposeParam{64, 4, 1, 1, 1, 1};
+            best_kernel = (width <= 8) ? BatchedTransposeParam{4, 64, 1, 1, 1, 1}
+                                       : BatchedTransposeParam{64, 4, 1, 1, 1, 1};
         }
         else if(hw_radio <= 128)
         {
-            return (width <= 8) ? BatchedTransposeParam{4, 128, 1, 1, 1, 1}
-                                : BatchedTransposeParam{128, 4, 1, 1, 1, 1};
+            best_kernel = (width <= 8) ? BatchedTransposeParam{4, 128, 1, 1, 1, 1}
+                                       : BatchedTransposeParam{128, 4, 1, 1, 1, 1};
         }
         else
         {
-            return (width <= 8) ? BatchedTransposeParam{4, 256, 1, 1, 1, 1}
-                                : BatchedTransposeParam{256, 4, 1, 1, 1, 1};
+            best_kernel = (width <= 8) ? BatchedTransposeParam{4, 256, 1, 1, 1, 1}
+                                       : BatchedTransposeParam{256, 4, 1, 1, 1, 1};
         }
+        return best_kernel;
     }
 
     for(const auto& it : std::ranges::reverse_view(kernel_list))

--- a/projects/miopen/src/hip/general_tensor_reorder_sol.cpp
+++ b/projects/miopen/src/hip/general_tensor_reorder_sol.cpp
@@ -90,29 +90,26 @@ HeuristicGet(std::size_t data_size, uint32_t dim_0, uint32_t dim_1, uint32_t dim
     {
         if(dim_3 >= 16)
         {
-            return GeneralReorderParam{16, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
+            default_kernel = GeneralReorderParam{16, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
         }
         else if(dim_3 >= 8)
         {
-            return GeneralReorderParam{8, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
+            default_kernel = GeneralReorderParam{8, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
         }
         else if(dim_3 >= 4)
         {
-            return GeneralReorderParam{4, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
+            default_kernel = GeneralReorderParam{4, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
         }
         else if(dim_3 >= 2)
         {
-            return GeneralReorderParam{2, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
+            default_kernel = GeneralReorderParam{2, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
         }
         else
         {
-            return GeneralReorderParam{1, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
+            default_kernel = GeneralReorderParam{1, TENSOR_REORDER_BLOCK_SIZE, 1, 1, 1, 1};
         }
     }
-    else
-    {
-        return default_kernel;
-    }
+    return default_kernel;
 }
 
 } // namespace tensor_reorder

--- a/projects/miopen/src/include/miopen/batchnorm/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/batchnorm/problem_description.hpp
@@ -445,17 +445,13 @@ private:
 
     std::string GetDirectionStr() const
     {
-        std::string s;
-
         switch(direction)
         {
-        case Direction::ForwardInference: return "Inf"; ;
+        case Direction::ForwardInference: return "Inf";
         case Direction::ForwardTraining: return "Trn";
         case Direction::Backward: return "Bwd";
         default: MIOPEN_THROW(miopenStatusInvalidValue, "Wrong Batchnorm Direction provided");
         }
-
-        return s;
     }
 
     std::string GetModeStr() const

--- a/projects/miopen/src/include/miopen/db.hpp
+++ b/projects/miopen/src/include/miopen/db.hpp
@@ -342,14 +342,17 @@ private:
     template <class TFunc>
     static auto Measure(const std::string& funcName, TFunc&& func)
     {
-        if(!miopen::IsLogging(LoggingLevel::Info2))
-            return func();
-
-        const auto start = std::chrono::high_resolution_clock::now();
-        auto ret         = func();
-        const auto end   = std::chrono::high_resolution_clock::now();
-        MIOPEN_LOG_I2("Db::" << funcName << " time: " << (end - start).count() * .000001f << " ms");
-        return ret;
+        const bool logging = miopen::IsLogging(LoggingLevel::Info2);
+        const auto start   = logging ? std::chrono::high_resolution_clock::now()
+                                     : std::chrono::high_resolution_clock::time_point{};
+        auto ret           = func();
+        if(logging)
+        {
+            const auto end = std::chrono::high_resolution_clock::now();
+            MIOPEN_LOG_I2("Db::" << funcName << " time: " << (end - start).count() * .000001f
+                                 << " ms");
+        }
+        return std::move(ret); // NOLINT(clang-analyzer-cplusplus.Move)
     }
 };
 } // namespace miopen

--- a/projects/miopen/src/include/miopen/generic_search.hpp
+++ b/projects/miopen/src/include/miopen/generic_search.hpp
@@ -441,7 +441,7 @@ auto GenericSearch(const Solver s,
     const auto invoke_ctx = [invoke_ctx_]() {
         auto copy = invoke_ctx_;
         copy.SetInvokeType(InvokeType::AutoTune);
-        return copy;
+        return std::move(copy);
     }();
 
     // list of sampled solutions
@@ -712,7 +712,8 @@ auto GenericSearch(const Solver s,
     {
         MIOPEN_LOG_I(
             "Search cutoff or skipped for all kernels.  Last config returned: " << last_config);
-        return last_config;
+        best_config = std::move(last_config);
+        return best_config;
     }
 
     if(!is_passed)

--- a/projects/miopen/src/include/miopen/pooling/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/pooling/problem_description.hpp
@@ -183,16 +183,12 @@ private:
     }
     std::string GetDirectionStr() const
     {
-        std::string s;
-
         switch(direction)
         {
         case Direction::Forward: return "Fwd";
         case Direction::Backward: return "Bwd";
         default: MIOPEN_THROW(miopenStatusInvalidValue, "Wrong pooling direction provided");
         }
-
-        return s;
     }
     std::string GetModeStr() const
     {

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -307,12 +307,12 @@ struct PoolingFwdNCHWTransposingSolver
 
     inline static auto GetTransposes()
     {
-        auto ret = std::array<ProblemTensorTransposeDescriptor<Problem, InvokeParams>, 2>{{
+        return std::array<ProblemTensorTransposeDescriptor<Problem, InvokeParams>, 2>{{
             {
                 &Problem::GetXDesc,
                 &Problem::GetXDesc,
                 &InvokeParams::xDesc,
-                {&InvokeParams::x},
+                {.as_input = &InvokeParams::x},
                 "NCDHW",
                 true,
             },
@@ -320,16 +320,11 @@ struct PoolingFwdNCHWTransposingSolver
                 &Problem::GetYDesc,
                 &Problem::GetYDesc,
                 &InvokeParams::yDesc,
-                {},
+                {.as_output = &InvokeParams::y},
                 "NCDHW",
                 false,
             },
         }};
-
-        // Before C++20 you can't aggregate initialize non-first union element
-        ret[1].as_output = &InvokeParams::y;
-
-        return std::move(ret);
     }
 };
 
@@ -464,12 +459,12 @@ struct PoolingBwdNCHWTransposingSolver
 
     inline static auto GetTransposes()
     {
-        auto ret = std::array<ProblemTensorTransposeDescriptor<Problem, InvokeParams>, 2>{{
+        return std::array<ProblemTensorTransposeDescriptor<Problem, InvokeParams>, 2>{{
             {
                 &Problem::GetXDesc,
                 &Problem::GetXDesc,
                 &InvokeParams::dxDesc,
-                {},
+                {.as_output = &InvokeParams::dx},
                 "NCDHW",
                 false,
             },
@@ -477,16 +472,11 @@ struct PoolingBwdNCHWTransposingSolver
                 &Problem::GetYDesc,
                 &Problem::GetYDesc,
                 &InvokeParams::dyDesc,
-                {&InvokeParams::dy},
+                {.as_input = &InvokeParams::dy},
                 "NCDHW",
                 true,
             },
         }};
-
-        // Before C++20 you can't aggregate initialize non-first union element
-        ret[0].as_output = &InvokeParams::dx;
-
-        return std::move(ret);
     }
 };
 

--- a/projects/miopen/src/include/miopen/pooling/solvers.hpp
+++ b/projects/miopen/src/include/miopen/pooling/solvers.hpp
@@ -329,7 +329,7 @@ struct PoolingFwdNCHWTransposingSolver
         // Before C++20 you can't aggregate initialize non-first union element
         ret[1].as_output = &InvokeParams::y;
 
-        return ret;
+        return std::move(ret);
     }
 };
 
@@ -486,7 +486,7 @@ struct PoolingBwdNCHWTransposingSolver
         // Before C++20 you can't aggregate initialize non-first union element
         ret[0].as_output = &InvokeParams::dx;
 
-        return ret;
+        return std::move(ret);
     }
 };
 

--- a/projects/miopen/src/include/miopen/ramdb.hpp
+++ b/projects/miopen/src/include/miopen/ramdb.hpp
@@ -157,14 +157,17 @@ class DbTimer<RamDb>
     template <class TFunc>
     static auto Measure(const std::string& funcName, TFunc&& func)
     {
-        if(!miopen::IsLogging(LoggingLevel::Info2))
-            return func();
-
-        const auto start = std::chrono::high_resolution_clock::now();
-        auto ret         = func();
-        const auto end   = std::chrono::high_resolution_clock::now();
-        MIOPEN_LOG_I2("Db::" << funcName << " time: " << (end - start).count() * .000001f << " ms");
-        return ret;
+        const bool logging = miopen::IsLogging(LoggingLevel::Info2);
+        const auto start   = logging ? std::chrono::high_resolution_clock::now()
+                                     : std::chrono::high_resolution_clock::time_point{};
+        auto ret           = func();
+        if(logging)
+        {
+            const auto end = std::chrono::high_resolution_clock::now();
+            MIOPEN_LOG_I2("Db::" << funcName << " time: " << (end - start).count() * .000001f
+                                 << " ms");
+        }
+        return std::move(ret); // NOLINT(clang-analyzer-cplusplus.Move)
     }
 
 public:

--- a/projects/miopen/src/include/miopen/rnn/tmp_buffer_utils.hpp
+++ b/projects/miopen/src/include/miopen/rnn/tmp_buffer_utils.hpp
@@ -741,7 +741,7 @@ public:
                              std::next(strides.rbegin()),
                              std::multiplies<size_t>{});
             strides[0] *= bias_cnt;
-            return strides;
+            return std::move(strides);
         }(bias_lens, bias_mode * 2);
 
         return {input_vector_filter_sz,

--- a/projects/miopen/src/include/miopen/solver/conv_direct_naive_conv.hpp
+++ b/projects/miopen/src/include/miopen/solver/conv_direct_naive_conv.hpp
@@ -147,7 +147,7 @@ auto MakeStrideArray(V vec)
     {
         ret[i] = static_cast<StrideIndexType>(vec[i]);
     }
-    return ret;
+    return std::move(ret);
 }
 
 ::miopen::solver::ConvSolution

--- a/projects/miopen/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/projects/miopen/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -1160,7 +1160,8 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
     if(ptr_iter == conv_ptrs.end())
     {
         MIOPEN_LOG_E("PerformanceConfig kernel '" + kernel_id + "' does not exist.");
-        return {miopenStatusInvalidValue};
+        result = ConvSolution{miopenStatusInvalidValue};
+        return result;
     }
 
 #ifdef CK_EXPERIMENTAL_BUILDER
@@ -1302,6 +1303,7 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
                                     const ProblemDescriptionType& problem,
                                     const std::string& kernel_id)
 {
+    ConvSolution result;
     auto conv_ptrs             = DeviceOpType::GetInstances();
     std::optional<int> split_k = std::nullopt;
     std::string id_string      = kernel_id;
@@ -1317,10 +1319,10 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
     if(ptr_iter == conv_ptrs.end())
     {
         MIOPEN_LOG_E("PerformanceConfig kernel '" + kernel_id + "' does not exist.");
-        return {miopenStatusInvalidValue};
+        result = ConvSolution{miopenStatusInvalidValue};
+        return result;
     }
 
-    ConvSolution result;
 #ifdef CK_EXPERIMENTAL_BUILDER
     std::string description = (*ptr_iter)->describe()->detailed();
 

--- a/projects/miopen/src/include/miopen/solver/implicitgemm_static_ck_util.hpp
+++ b/projects/miopen/src/include/miopen/solver/implicitgemm_static_ck_util.hpp
@@ -186,7 +186,7 @@ inline static auto GetPerformanceConfigBase(const ExecutionContext& ctx,
     PerformanceImplicitGemm_t pp;
     pp.HeuristicInit(ctx, problem);
     MIOPEN_LOG_I(pp.ToString());
-    return pp;
+    return std::move(pp);
 }
 
 static inline bool use_amd_inline_asm(const ExecutionContext& ctx,

--- a/projects/miopen/src/ocl/convolutionocl.cpp
+++ b/projects/miopen/src/ocl/convolutionocl.cpp
@@ -1052,10 +1052,14 @@ ConvolutionDescriptor::GetSolutions(const ExecutionContext& ctx,
     {
         if(fallbackPathTaken != nullptr)
             *fallbackPathTaken = FallbackPath::None;
-        return solutions;
+    }
+    else
+    {
+        solutions =
+            GetSolutionsFallback(ctx, problem, maxSolutionCount, fallbackPathTaken, invokeParams);
     }
 
-    return GetSolutionsFallback(ctx, problem, maxSolutionCount, fallbackPathTaken, invokeParams);
+    return solutions;
 }
 
 std::size_t ConvolutionDescriptor::GetForwardSolutionWorkspaceSize(const Handle& handle,

--- a/projects/miopen/src/rnn/Solutions/Base/bw_data_modular.cpp
+++ b/projects/miopen/src/rnn/Solutions/Base/bw_data_modular.cpp
@@ -342,7 +342,7 @@ void RNNBackwardDataModularAlgo::PropDy(const Handle& handle,
 
         ws_ht_layer_size[0] = 1;
 
-        return ws_ht_layer_size;
+        return std::move(ws_ht_layer_size);
     }(workspaceInfo.hStateSizes);
 
     auto ws_dy_dst_desc = miopen::TensorDescriptor(rnn_data_type, ws_dst_size, ws_dst_strides);

--- a/projects/miopen/src/rnn/Solutions/Base/fw_data_modular.cpp
+++ b/projects/miopen/src/rnn/Solutions/Base/fw_data_modular.cpp
@@ -502,7 +502,7 @@ void RNNForwardDataModularAlgo::PropY(const Handle& handle, const runtimeArgsFwd
 
         ws_ht_layer_size[0] = 1;
 
-        return ws_ht_layer_size;
+        return std::move(ws_ht_layer_size);
     }(reservLayout.hStateSizes);
 
     auto tmp_y_desc = miopen::TensorDescriptor(rnn_data_type, tmp_y_size, tmp_y_strides);

--- a/projects/miopen/src/solution.cpp
+++ b/projects/miopen/src/solution.cpp
@@ -144,7 +144,7 @@ void Solution::RunImpl(const Handle& handle,
         auto ret = found->second;
         if(!ret.descriptor.has_value())
             ret.descriptor = problem_casted.GetTensorDescriptorChecked(name, name_str);
-        return ret;
+        return std::move(ret);
     };
 
     auto x       = get_input_checked(miopenTensorConvolutionX, "miopenTensorConvolutionX");
@@ -271,7 +271,7 @@ void Solution::RunImpl(const Handle& handle,
         auto ret = found->second;
         if(!ret.descriptor.has_value())
             ret.descriptor = problem_casted.GetTensorDescriptorChecked(name, name_str);
-        return ret;
+        return std::move(ret);
     };
 
     const mha::ProblemDescription problem_description = problem_casted.AsMha();
@@ -467,7 +467,7 @@ void Solution::RunImpl(const Handle& handle,
         auto ret = found->second;
         if(!ret.descriptor.has_value())
             ret.descriptor = problem_casted.GetTensorDescriptorChecked(name, name_str);
-        return ret;
+        return std::move(ret);
     };
 
     const softmax::ProblemDescription problem_description = problem_casted.AsSoftmax();

--- a/projects/miopen/src/solver/activ/fwd_0.cpp
+++ b/projects/miopen/src/solver/activ/fwd_0.cpp
@@ -130,7 +130,8 @@ ConvSolution ActivFwdSolver0::GetSolution(const ExecutionContext&,
         MIOPEN_LOG_E("Unsupported data types configuration: "
                      << miopen::GetDataTypeName(problem.GetXDesc().GetType()) << "x"
                      << miopen::GetDataTypeName(problem.GetYDesc().GetType()));
-        return {miopenStatusInternalError};
+        result = ConvSolution{miopenStatusInternalError};
+        return result;
     }
 
     {

--- a/projects/miopen/src/solver/conv/conv_ocl_dir2D_bwdWrW_53.cpp
+++ b/projects/miopen/src/solver/conv/conv_ocl_dir2D_bwdWrW_53.cpp
@@ -416,7 +416,8 @@ ConvSolution ConvOclBwdWrW53::GetSolution(const ExecutionContext& ctx,
                           GRP_SZ) != miopenStatusSuccess ||
        out_n_vert_reads <= 0)
     {
-        return {miopenStatusNotInitialized};
+        result = ConvSolution{miopenStatusNotInitialized};
+        return result;
     }
 
     int out_n_vert_read_loops = static_cast<int>(std::ceil(
@@ -440,12 +441,14 @@ ConvSolution ConvOclBwdWrW53::GetSolution(const ExecutionContext& ctx,
     if(out_n_horizon_read_loops > 2 && problem.GetPadW() != 0)
     {
         MIOPEN_LOG_I2("Padding where split is more than 2 ways is not supported.");
-        return {miopenStatusNotInitialized};
+        result = ConvSolution{miopenStatusNotInitialized};
+        return result;
     }
     if(out_n_horizon_read_loops > 1 && problem.GetGroupCount() > 1)
     {
         MIOPEN_LOG_I2("For large images, group support is missing.");
-        return {miopenStatusNotInitialized};
+        result = ConvSolution{miopenStatusNotInitialized};
+        return result;
     }
 
     int out_horizon_last_chunk_valid_read_units = std::ceil(

--- a/projects/miopen/src/solver/conv/conv_ocl_dir2Dfwd.cpp
+++ b/projects/miopen/src/solver/conv/conv_ocl_dir2Dfwd.cpp
@@ -319,7 +319,8 @@ ConvSolution ConvOclDirectFwd::BaseGetSolution(const ExecutionContext& ctx,
     if(result.out_pix_tile1 == 0 || result.out_pix_tile0 == 0 /* DIV/0 */)
     {
         MIOPEN_LOG_E("result.out_pix_tile1 == 0 || result.out_pix_tile0 == 0");
-        return {miopenStatusInternalError};
+        result = ConvSolution{miopenStatusInternalError};
+        return result;
     }
     result.grp_tile0 = std::max(8, (result.in_tile0 / result.out_pix_tile0));
     result.grp_tile1 = std::max(8, (result.in_tile1 / result.out_pix_tile1));
@@ -332,7 +333,8 @@ ConvSolution ConvOclDirectFwd::BaseGetSolution(const ExecutionContext& ctx,
     if(alu_tiles_sz > 256 || alu_tiles_sz == 0 /* DIV/0 */)
     {
         MIOPEN_LOG_E("need out pix size ajustments (alu_tiles_sz > 256 || alu_tiles_sz == 0)");
-        return {miopenStatusInternalError};
+        result = ConvSolution{miopenStatusInternalError};
+        return result;
     }
 
     int n_alus_total = (result.grp_tile0 * result.grp_tile1);
@@ -343,7 +345,8 @@ ConvSolution ConvOclDirectFwd::BaseGetSolution(const ExecutionContext& ctx,
     if(result.n_stacks == 0 /* DIV/0 */)
     {
         MIOPEN_LOG_E("result.n_stacks == 0");
-        return {miopenStatusInternalError};
+        result = ConvSolution{miopenStatusInternalError};
+        return result;
     }
     int n_alus_perstack = (n_alus_total + result.n_stacks - 1) / result.n_stacks;
 
@@ -464,7 +467,8 @@ ConvSolution ConvOclDirectFwd::BaseGetSolution(const ExecutionContext& ctx,
     if(n_out_tiles_perstack == 0 /* DIV/0 */)
     {
         MIOPEN_LOG_E("n_out_tiles_perstack == 0");
-        return {miopenStatusInternalError};
+        result = ConvSolution{miopenStatusInternalError};
+        return result;
     }
     size_t gbl_wk1 =
         group_counts >= 2

--- a/projects/miopen/src/target_properties.cpp
+++ b/projects/miopen/src/target_properties.cpp
@@ -55,7 +55,7 @@ static std::string GetDeviceNameFromMap(const std::string& in)
 
     const auto& dev_str = env::value(MIOPEN_DEBUG_ENFORCE_DEVICE);
     if(!dev_str.empty())
-        return std::string{dev_str};
+        return dev_str;
 
     std::string name = in.substr(0, in.find(':')); // str.substr(0, npos) returns str.
 

--- a/projects/miopen/src/target_properties.cpp
+++ b/projects/miopen/src/target_properties.cpp
@@ -55,14 +55,14 @@ static std::string GetDeviceNameFromMap(const std::string& in)
 
     const auto& dev_str = env::value(MIOPEN_DEBUG_ENFORCE_DEVICE);
     if(!dev_str.empty())
-        return dev_str;
+        return std::string{dev_str};
 
-    const auto name = in.substr(0, in.find(':')); // str.substr(0, npos) returns str.
+    std::string name = in.substr(0, in.find(':')); // str.substr(0, npos) returns str.
 
     auto match = device_name_map.find(name);
     if(match != device_name_map.end())
-        return match->second;
-    return name; // NOLINT (performance-no-automatic-move)
+        name = match->second;
+    return name;
 }
 
 // See https://github.com/llvm/llvm-project/commit/1ed4caff1d5cd49233c1ae7b9f6483a946ed5eea.

--- a/projects/miopen/src/tensor.cpp
+++ b/projects/miopen/src/tensor.cpp
@@ -892,11 +892,12 @@ std::string TensorDescriptor::ToString() const
     if(this->lens.empty())
         return result;
 
-    auto b = this->lens.begin();
-    result = std::accumulate(
-        std::next(b), this->lens.end(), std::to_string(*b), [&](std::string x, std::size_t y) {
-            return std::move(x) + ", " + std::to_string(y);
-        });
+    for(auto i : this->lens)
+    {
+        result += std::to_string(i) + ", ";
+    }
+    result = result.substr(0, result.length() - 2);
+
     return result;
 }
 

--- a/projects/miopen/src/tensor.cpp
+++ b/projects/miopen/src/tensor.cpp
@@ -891,11 +891,13 @@ std::string TensorDescriptor::ToString() const
     std::string result;
     if(this->lens.empty())
         return result;
-    for(auto i : this->lens)
-    {
-        result += std::to_string(i) + ", ";
-    }
-    return result.substr(0, result.length() - 2);
+
+    auto b = this->lens.begin();
+    result = std::accumulate(
+        std::next(b), this->lens.end(), std::to_string(*b), [&](std::string x, std::size_t y) {
+            return std::move(x) + ", " + std::to_string(y);
+        });
+    return result;
 }
 
 std::ostream& operator<<(std::ostream& stream, const TensorDescriptor& t)

--- a/projects/miopen/test/args.hpp
+++ b/projects/miopen/test/args.hpp
@@ -184,7 +184,7 @@ auto any_construct_impl(miopen::rank<1>,
 }
 
 template <class T, std::size_t... Ns, class Data>
-T any_construct_impl(miopen::rank<0>, std::index_sequence<Ns...>, const Data&)
+[[noreturn]] T any_construct_impl(miopen::rank<0>, std::index_sequence<Ns...>, const Data&)
 {
     throw std::runtime_error("Cannot construct: " + miopen::get_type_name<T>());
 }

--- a/projects/miopen/test/gtest/activ_common.hpp
+++ b/projects/miopen/test/gtest/activ_common.hpp
@@ -356,7 +356,7 @@ void CpuActivationPacked(std::size_t num_items, Ts&&... xs)
 }
 
 template <Direction direction, class A, class... Ts>
-void CpuActivationNonPacked(std::size_t num_items, Ts&&... xs)
+[[noreturn]] void CpuActivationNonPacked(std::size_t num_items, Ts&&... xs)
 {
     throw std::runtime_error("CpuActivationNonPacked is not implemented yet");
 }

--- a/projects/miopen/test/gtest/db_paths.cpp
+++ b/projects/miopen/test/gtest/db_paths.cpp
@@ -116,8 +116,7 @@ TEST_F(CPU_DbPaths_NONE, UserDbPath_NetworkFS_NoEnvVar)
 {
 #if MIOPEN_BUILD_DEV
     GTEST_SKIP() << "Network filesystem detection is disabled in MIOPEN_BUILD_DEV mode";
-#endif
-
+#else
     // Ensure environment variable is NOT set for this test
     ScopedEnvironment<std::string> unset_user_db(MIOPEN_USER_DB_PATH, "");
 
@@ -142,6 +141,7 @@ TEST_F(CPU_DbPaths_NONE, UserDbPath_NetworkFS_NoEnvVar)
         << "User DB path should contain '.config' folder";
     EXPECT_TRUE(PathContains(user_db_path, "miopen"))
         << "User DB path should contain 'miopen' folder";
+#endif
 }
 
 TEST_F(CPU_DbPaths_NONE, UserDbPath_NetworkFS_EnvVarSet)
@@ -220,8 +220,7 @@ TEST_F(CPU_DbPaths_NONE, CachePath_NetworkFS_NoEnvVar)
 {
 #if MIOPEN_BUILD_DEV
     GTEST_SKIP() << "Network filesystem detection is disabled in MIOPEN_BUILD_DEV mode";
-#endif
-
+#else
     // Ensure environment variable is NOT set for this test
     ScopedEnvironment<std::string> unset_cache(MIOPEN_CUSTOM_CACHE_DIR, "");
 
@@ -248,6 +247,7 @@ TEST_F(CPU_DbPaths_NONE, CachePath_NetworkFS_NoEnvVar)
     const std::string expected_version = GetExpectedVersionString();
     EXPECT_TRUE(PathContains(cache_path, expected_version))
         << "Cache path should contain version string '" << expected_version << "'";
+#endif
 }
 
 TEST_F(CPU_DbPaths_NONE, CachePath_NetworkFS_EnvVarSet)

--- a/projects/miopen/test/gtest/deepbench_lstm.cpp
+++ b/projects/miopen/test/gtest/deepbench_lstm.cpp
@@ -30,6 +30,14 @@ namespace {
 
 struct TestCase
 {
+    TestCase(int batch_size_, int seq_len_, int vector_len_, int hidden_size_)
+        : batch_size(batch_size_),
+          seq_len(seq_len_),
+          vector_len(vector_len_),
+          hidden_size(hidden_size_)
+    {
+    }
+
     int batch_size;
     int seq_len;
     int vector_len;

--- a/projects/miopen/test/gtest/lstm.cpp
+++ b/projects/miopen/test/gtest/lstm.cpp
@@ -29,6 +29,15 @@ namespace {
 
 struct TestCase
 {
+    TestCase(int usePadding_, int inputMode_, int biasMode_, int dirMode_, int algoMode_)
+        : usePadding(usePadding_),
+          inputMode(inputMode_),
+          biasMode(biasMode_),
+          dirMode(dirMode_),
+          algoMode(algoMode_)
+    {
+    }
+
     int usePadding;
     int inputMode;
     int biasMode;

--- a/projects/miopen/test/gtest/lstm_dropout.cpp
+++ b/projects/miopen/test/gtest/lstm_dropout.cpp
@@ -29,6 +29,8 @@ namespace {
 
 struct TestCase
 {
+    TestCase(int dirMode_, int flatBatchFill_) : dirMode(dirMode_), flatBatchFill(flatBatchFill_) {}
+
     int dirMode;
     int flatBatchFill;
 

--- a/projects/miopen/test/gtest/lstm_extra.cpp
+++ b/projects/miopen/test/gtest/lstm_extra.cpp
@@ -30,6 +30,27 @@ namespace {
 
 struct TestCase
 {
+    TestCase(int dir_mode_,
+             int no_hx_,
+             int no_dhy_,
+             int no_cx_,
+             int no_dcy_,
+             int no_hy_,
+             int no_dhx_,
+             int no_cy_,
+             int no_dcx_)
+        : dir_mode(dir_mode_),
+          no_hx(no_hx_),
+          no_dhy(no_dhy_),
+          no_cx(no_cx_),
+          no_dcy(no_dcy_),
+          no_hy(no_hy_),
+          no_dhx(no_dhx_),
+          no_cy(no_cy_),
+          no_dcx(no_dcx_)
+    {
+    }
+
     int dir_mode;
     int no_hx;
     int no_dhy;

--- a/projects/miopen/test/tensor_holder.hpp
+++ b/projects/miopen/test/tensor_holder.hpp
@@ -307,15 +307,15 @@ struct tensor
             }
         };
 
-        void operator()(any = {},
-                        any = {},
-                        any = {},
-                        any = {},
-                        any = {},
-                        any = {},
-                        any = {},
-                        any = {},
-                        any = {}) const
+        [[noreturn]] void operator()(any = {},
+                                      any = {},
+                                      any = {},
+                                      any = {},
+                                      any = {},
+                                      any = {},
+                                      any = {},
+                                      any = {},
+                                      any = {}) const
         {
             throw std::runtime_error(
                 "Arguments to for_each do not match tensor size or the function " +

--- a/projects/miopen/test/tensor_holder.hpp
+++ b/projects/miopen/test/tensor_holder.hpp
@@ -308,14 +308,14 @@ struct tensor
         };
 
         [[noreturn]] void operator()(any = {},
-                                      any = {},
-                                      any = {},
-                                      any = {},
-                                      any = {},
-                                      any = {},
-                                      any = {},
-                                      any = {},
-                                      any = {}) const
+                                     any = {},
+                                     any = {},
+                                     any = {},
+                                     any = {},
+                                     any = {},
+                                     any = {},
+                                     any = {},
+                                     any = {}) const
         {
             throw std::runtime_error(
                 "Arguments to for_each do not match tensor size or the function " +


### PR DESCRIPTION
## Motivation

Enable 
  - Wmissing-no-return
  - Wtautological-constant-out-of-range-compare

Fixed warnings
  - Wnrvo (fixed for MIOpen and MIOpenDriver targets only, option remain disabled because tests shall be fixed too)
  
Remove enabled by default
  - Wunused-value

remove non-required as we compiled with c++20
  - Wno-c++20-extensions
    
   and fix all warned places (NB: c++ HIP doesn't use c++20).
   
Part of effort to fix https://github.com/ROCm/rocm-libraries/issues/4646

## Test Plan

CI shall pass

## Submission Checklist

- [x] I have ran `make format` to ensure the changes have been formatted