### PR TITLE
show timer summary in gtest

### DIFF
--- a/shared/rocroller/test/unit/GEMMBasicTest.cpp
+++ b/shared/rocroller/test/unit/GEMMBasicTest.cpp
@@ -8,6 +8,7 @@
 
 #include "GEMMTestBase.hpp"
 #include <rocRoller/GPUArchitecture/GPUCapability.hpp>
+#include <rocRoller/Utilities/Timer.hpp>
 
 namespace GEMMTests
 {
@@ -20,7 +21,7 @@ namespace GEMMTests
 
     /**
      * GEMMBasicTestGPU: Consolidated basic tests for smoke tests.
-     * 
+     *
      * These tests exercise core GEMM features with minimal
      * parameterization (only GPU architecture).
      */
@@ -66,6 +67,7 @@ namespace GEMMTests
         gemm.macN  = 256;
         gemm.macK  = 128;
         basicGEMM<FP8, FP8, float>(gemm);
+        std::cout << rocRoller::TimerPool::summary() << std::endl;
     }
 
     TEST_P(GEMMBasicTestSuite, GPU_BasicGEMM_StreamK)


### PR DESCRIPTION
```bash
./test/rocroller-tests --gtest_filter=GEMMBasicTest/GEMMBasicTestSuite.GPU_BasicGEMM_FP8/0                                                                                                                                 (base) (develop|💩?) 15:29
Running main() from /home/kerrwang/repos/rocm-libraries/develop/shared/rocroller/build_release/_deps/googletest-src/googletest/src/gtest_main.cc
Note: Google Test filter = GEMMBasicTest/GEMMBasicTestSuite.GPU_BasicGEMM_FP8/0
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from GEMMBasicTest/GEMMBasicTestSuite
[ RUN      ] GEMMBasicTest/GEMMBasicTestSuite.GPU_BasicGEMM_FP8/0
[rr/info] RNorm is 5.191042283569143e-06 (acceptable 4.3832722451329795e-05, iteration 0)
AddDeallocate::simplifyDependencies                                 1ms
AddLDSBarriers::apply                                          251019ms
Assembler::assembleMachineCode                                     36ms
CommandKernel::generateKernel                                  869792ms
CommandKernel::generateKernelGraph                             867377ms
CommandKernel::generateKernelSource                              2414ms
CommandKernel::getKernelArguments                                   0ms
CommandKernel::getKernelInvocation                                  0ms
CommandKernel::launchKernel                                        37ms
CommandKernel::loadKernel                                          37ms
Constraint::AcceptablePrefetchNodes                                15ms
Constraint::NoAmbiguousNodes                                     7026ms
Constraint::NoBadBodyEdges                                        348ms
Constraint::NoConstructDestructMT                                   1ms
Constraint::NoDanglingJammedNumbers                                 0ms
Constraint::NoDanglingMappings                                     90ms
Constraint::NoLDSTiles                                              6ms
Constraint::NoRedundantSetCoordinates                              64ms
Constraint::SingleControlRoot                                      28ms
Constraint::VerifyLDSBarriers                                  590906ms
Constraint::WalkableControlGraph                                  750ms
ControlFlowArgumentTracer                                         257ms
ControlFlowRWTracer                                               611ms
ControlGraph::lookupOrder                                          87ms
GPUArchitectureLibrary::LoadLibrary                                10ms
GPUArchitectureLibrary::getAllSupportedISAs                         0ms
GPUArchitectureLibrary::getCDNAISAs                                 0ms
GPUArchitectureLibrary::getMFMASupportedISAs                        0ms
KernelGraph::AddLDSPadding                                          0ms
KernelGraph::Transformation::AddConvert                           310ms
KernelGraph::Transformation::AddDeallocateArguments               953ms
KernelGraph::Transformation::AddDeallocateDataFlow                581ms
KernelGraph::Transformation::AddDirect2LDS                         28ms
KernelGraph::Transformation::AddF6LDSPadding                       82ms
KernelGraph::Transformation::AddLDS                                 0ms
KernelGraph::Transformation::AddLDSBarriers                    251019ms
KernelGraph::Transformation::AddLDSPadding                          0ms
KernelGraph::Transformation::AddPRNG                               29ms
KernelGraph::Transformation::AddPrefetch                          112ms
KernelGraph::Transformation::AliasDataFlowTags                    112ms
KernelGraph::Transformation::AssignIndexExpressions               828ms
KernelGraph::Transformation::CleanArguments                       803ms
KernelGraph::Transformation::CleanLoops                           102ms
KernelGraph::Transformation::ConnectWorkgroups                      0ms
KernelGraph::Transformation::ConstantPropagation                    0ms
KernelGraph::Transformation::FuseExpressions                        0ms
KernelGraph::Transformation::FuseLoops                            492ms
KernelGraph::Transformation::IdentifyParallelDimensions             0ms
KernelGraph::Transformation::InlineIncrements                     364ms
KernelGraph::Transformation::InlineInits                          365ms
KernelGraph::Transformation::LoadPacked                           405ms
KernelGraph::Transformation::LowerLinear                            0ms
KernelGraph::Transformation::LowerTensorContraction                 0ms
KernelGraph::Transformation::LowerTile                              0ms
KernelGraph::Transformation::MergeAdjacentDeallocates             807ms
KernelGraph::Transformation::NopExtraScopes                       147ms
KernelGraph::Transformation::OrderEpilogueBlocks                  383ms
KernelGraph::Transformation::OrderExchangeNodes                    92ms
KernelGraph::Transformation::OrderMemory                            0ms
KernelGraph::Transformation::OrderMultiplyNodes                   427ms
KernelGraph::Transformation::RemoveDuplicates                     690ms
KernelGraph::Transformation::SetWorkitemCount                     144ms
KernelGraph::Transformation::Simplify                            1236ms
KernelGraph::Transformation::SortArguments                        246ms
KernelGraph::Transformation::SwizzleScale                          80ms
KernelGraph::Transformation::UnrollLoops                          179ms
KernelGraph::Transformation::UpdateParameters                       0ms
KernelGraph::Transformation::UpdateWavefrontParameters             38ms
KernelGraph::Transformation::WorkgroupRemapXCC                      0ms
KernelGraph::translate                                              0ms
LowerFromKernelGraph::generate                                   1768ms
addArgumentDeallocates::add nodes                                   0ms
controlStack                                                      168ms
duplicateMacroTile                                                  0ms
getTopSetCoordinate                                                 3ms
lastRWLocations                                                    42ms
populateOrderCache                                             122043ms
removeRedundantBodyEdges                                           54ms
removeRedundantSequenceEdges                                      633ms

[       OK ] GEMMBasicTest/GEMMBasicTestSuite.GPU_BasicGEMM_FP8/0 (870193 ms)
[----------] 1 test from GEMMBasicTest/GEMMBasicTestSuite (870193 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (870193 ms total)
[  PASSED  ] 1 test.
```