### PR TITLE
[hipBLASlt] Avoid repeated hipGetDeviceProperties in StreamK generateSingleCall (cherry-pick #4665)

### DIFF
--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -1316,10 +1316,7 @@ namespace TensileLite
             rv.numWorkGroups.z = 1;
         }
 
-        //short-term workaround
-        int             deviceId;
-        hipDeviceProp_t deviceProperties;
-
+        // Use arch from existing hardware to avoid repeated hipGetDeviceProperties (SWDEV-579719)
         auto removePrefix = [](const std::string& s) {
             size_t pos = s.find("gfx");
             if(pos != std::string::npos)
@@ -1328,11 +1325,8 @@ namespace TensileLite
             }
             return s;
         };
-
-        static_cast<void>(hipGetDevice(&deviceId));
-        static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
-        auto gpu_arch_no_prefix = removePrefix(deviceProperties.gcnArchName);
-        if(stoi(gpu_arch_no_prefix) / 100 != 12)
+        auto gpu_arch_no_prefix = removePrefix(hardware.archName());
+        if(internalArgsSupport.version >= 1)
         {
             if(internalArgsSupport.version >= 1)
             {


### PR DESCRIPTION
Cherry-pick of [#4665](https://github.com/ROCm/rocm-libraries/pull/4665) (from commit `51a0ec0` on develop) into `release/rocm-rel-7.2`.

### Summary

Removes the short-term workaround in `ContractionSolution::generateSingleCall` that called `hipGetDevice` and `hipGetDeviceProperties` every time a StreamK kernel invocation was built. The arch string is now taken from the existing `hardware.archName()` so the same logic is preserved without extra HIP device API calls.

### Rationale

On ROCm 7.2, a ~25× increase in `hipGetDevicePropertiesR0600` and `hipDeviceGetAttribute` was reported for a simple workload (e.g. 3× `torch.matmul` 1024×1024 f16 on MI300x with the hipBLASLt backend). Analysis of the codebase and a 7.0.2→7.2.0 diff showed that the only hot path doing raw device lookups in a per-invocation path is this workaround in the StreamK branch of `generateSingleCall`. In 7.2 the default solution for this case appears to be a StreamK solution, so that path is hit frequently and the repeated device calls add up. Using the already-available `Hardware const& hardware` (which carries the same device/arch info) removes those calls while keeping the existing `internalArgsSupport.version >= 1` behavior.

### References

- ROCM-2963
- Related investigation: SWDEV-579719 (Huggingface BERT slowness on MI300x CPX, ROCm 7.2)

### Test Plan

Same as #4665: run the original repro (e.g. 3× torch.matmul 1024×1024 f16 on MI300x with hipBLASLt); run hipBLASLt/StreamK tests; confirm device API call count is reduced.

### Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
