### PR TITLE
Upgrade tensilelite and rocisa minimum Python version to 3.10

### DIFF
--- a/projects/hipblaslt/tensilelite/rocisa/setup.py
+++ b/projects/hipblaslt/tensilelite/rocisa/setup.py
@@ -64,5 +64,5 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.10',
 )

--- a/projects/hipblaslt/tensilelite/rocisa/tox.ini
+++ b/projects/hipblaslt/tensilelite/rocisa/tox.ini
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 [tox]
-envlist = py38, py39, py310
+envlist = py310, py311, py312, py313
 
 [testenv]
 skip_install = true  # disable pip install . to ignore setup.py in rocisa

--- a/projects/hipblaslt/tensilelite/setup.py
+++ b/projects/hipblaslt/tensilelite/setup.py
@@ -48,7 +48,7 @@ setup(
   author="Advanced Micro Devices",
   license="MIT",
   install_requires=read_requirements_from_txt(),
-  python_requires='>=3.9',
+  python_requires='>=3.10',
   packages=["Tensile", "rocisa"],
   package_data={ "Tensile": ["Tensile/cmake/*"] },
   data_files=[ ("cmake", ["Tensile/cmake/TensileConfig.cmake", "Tensile/cmake/TensileConfigVersion.cmake"]) ],


### PR DESCRIPTION
- tensilelite/setup.py: python_requires >=3.9 → >=3.10
- rocisa/setup.py: python_requires >=3.8 → >=3.10
- rocisa/tox.ini: envlist py38,py39,py310 → py310,py311,py312,py313

## Motivation

This completes the transition mapped out in https://github.com/ROCm/rocm-libraries/issues/3448


## Test Plan

CI

