### PR TITLE
[rocrand] Fix benchmark_rocrand_device_api launch parameters

### DIFF
--- a/projects/rocrand/benchmark/benchmark_occupancy_helper.hpp
+++ b/projects/rocrand/benchmark/benchmark_occupancy_helper.hpp
@@ -90,10 +90,10 @@ inline launch_params get_benchmark_launch_parameters(T           kernel,
     else
     {
         // Heuristic that picks thread count that maximizes occupancy
-        const std::vector<int> thread_options = {32, 64, 128, 256, 512, 1024};
-        for(int t : thread_options)
+        hipFuncAttributes attr;
+        HIP_CHECK(hipFuncGetAttributes(&attr, (const void*)kernel));
+        for(int t = 32; t <= attr.maxThreadsPerBlock; t *= 2)
         {
-
             if(t > params.max_threads_per_block)
                 continue;
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When running `benchmark_rocrand_device_api` on certain gpu architectures, we may get a `hipErrorLaunchFailure` due to launch params being larger than launch bounds. This PR fixes this issue.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
In the code that determines an optimal block size for launching the benchmark kernels, the kernel's `maxThreadsPerBlock` attribute was not honored. This caused the determined number of threads to exceed `maxThreadsPerBlock` on certain architectures.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Build and run  `benchmark_rocrand_device_api` on gfx1200 to confirm that the launch params are now within launch bounds.

## Test Result

<!-- Briefly summarize test outcomes. -->
The test passes.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
