### PR TITLE
[hipSOLVER] Add trtri for testing

### DIFF
--- a/projects/hipsolver/CHANGELOG.md
+++ b/projects/hipsolver/CHANGELOG.md
@@ -6,6 +6,12 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ## (Unreleased) hipSOLVER
 
 ### Added
+
+* Added compatibility-only functions:
+  * trtri
+    * hipsolverDnXtrtri_bufferSize
+    * hipsolverDnXtrtri
+
 ### Changed
 ### Removed
 ### Optimized

--- a/projects/hipsolver/clients/common/hipsolver_datatype2string.cpp
+++ b/projects/hipsolver/clients/common/hipsolver_datatype2string.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,6 +49,19 @@ char hipsolver2char_fill(hipsolverFillMode_t value)
         return 'U';
     case HIPSOLVER_FILL_MODE_LOWER:
         return 'L';
+    default:
+        throw std::invalid_argument("Invalid enum");
+    }
+}
+
+char hipsolver2char_diag(hipsolverDiagType_t value)
+{
+    switch(value)
+    {
+    case HIPSOLVER_DIAG_NON_UNIT:
+        return 'N';
+    case HIPSOLVER_DIAG_UNIT:
+        return 'U';
     default:
         throw std::invalid_argument("Invalid enum");
     }
@@ -158,6 +171,21 @@ hipsolverFillMode_t char2hipsolver_fill(char value)
     case 'l':
     case 'L':
         return HIPSOLVER_FILL_MODE_LOWER;
+    default:
+        throw std::invalid_argument("Invalid character");
+    }
+}
+
+hipsolverDiagType_t char2hipsolver_diag(char value)
+{
+    switch(value)
+    {
+    case 'n':
+    case 'N':
+        return HIPSOLVER_DIAG_NON_UNIT;
+    case 'u':
+    case 'U':
+        return HIPSOLVER_DIAG_UNIT;
     default:
         throw std::invalid_argument("Invalid character");
     }

--- a/projects/hipsolver/clients/common/lapack_host_reference.cpp
+++ b/projects/hipsolver/clients/common/lapack_host_reference.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -825,6 +825,11 @@ void zpotrs_(char*                   uplo,
              hipsolverDoubleComplex* B,
              int*                    ldb,
              int*                    info);
+
+void strtri_(char* uplo, char* diag, int* n, float* A, int* lda, int* info);
+void dtrtri_(char* uplo, char* diag, int* n, double* A, int* lda, int* info);
+void ctrtri_(char* uplo, char* diag, int* n, hipsolverComplex* A, int* lda, int* info);
+void ztrtri_(char* uplo, char* diag, int* n, hipsolverDoubleComplex* A, int* lda, int* info);
 
 void ssyevd_(char*  evect,
              char*  uplo,
@@ -2676,6 +2681,51 @@ void cpu_potrs(hipsolverFillMode_t     uplo,
 {
     char uploC = hipsolver2char_fill(uplo);
     zpotrs_(&uploC, &n, &nrhs, A, &lda, B, &ldb, info);
+}
+
+// trtri
+template <>
+void cpu_trtri(
+    hipsolverFillMode_t uplo, hipsolverDiagType_t diag, int n, float* A, int lda, int* info)
+{
+    char uploC = hipsolver2char_fill(uplo);
+    char diagC = hipsolver2char_diag(diag);
+    strtri_(&uploC, &diagC, &n, A, &lda, info);
+}
+
+template <>
+void cpu_trtri(
+    hipsolverFillMode_t uplo, hipsolverDiagType_t diag, int n, double* A, int lda, int* info)
+{
+    char uploC = hipsolver2char_fill(uplo);
+    char diagC = hipsolver2char_diag(diag);
+    dtrtri_(&uploC, &diagC, &n, A, &lda, info);
+}
+
+template <>
+void cpu_trtri(hipsolverFillMode_t uplo,
+               hipsolverDiagType_t diag,
+               int                 n,
+               hipsolverComplex*   A,
+               int                 lda,
+               int*                info)
+{
+    char uploC = hipsolver2char_fill(uplo);
+    char diagC = hipsolver2char_diag(diag);
+    ctrtri_(&uploC, &diagC, &n, A, &lda, info);
+}
+
+template <>
+void cpu_trtri(hipsolverFillMode_t     uplo,
+               hipsolverDiagType_t     diag,
+               int                     n,
+               hipsolverDoubleComplex* A,
+               int                     lda,
+               int*                    info)
+{
+    char uploC = hipsolver2char_fill(uplo);
+    char diagC = hipsolver2char_diag(diag);
+    ztrtri_(&uploC, &diagC, &n, A, &lda, info);
 }
 
 // syevd & heevd

--- a/projects/hipsolver/clients/gtest/CMakeLists.txt
+++ b/projects/hipsolver/clients/gtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -58,6 +58,7 @@ set(hipsolverDn_test_source
   potrf_gtest.cpp
   potri_gtest.cpp
   potrs_gtest.cpp
+  trtri_gtest.cpp
   syevd_heevd_gtest.cpp
   syevj_heevj_gtest.cpp
   sygvd_hegvd_gtest.cpp

--- a/projects/hipsolver/clients/gtest/trtri_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/trtri_gtest.cpp
@@ -1,0 +1,152 @@
+/* ************************************************************************
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING IN ANY WAY OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#include "testing_trtri.hpp"
+
+using ::testing::Combine;
+using ::testing::TestWithParam;
+using ::testing::Values;
+using ::testing::ValuesIn;
+using namespace std;
+
+typedef std::tuple<vector<int>, char> trtri_tuple;
+
+// each matrix_size_range vector is a {n, lda, singular/diag}
+// if singular = 0, then the used matrix for the tests is triangular unit
+// if singular = 1, then the used matrix for the tests is triangular non-unit and singular
+// otherwise, the used matrix is triangular non-unit and not singular
+
+// each uplo_range is {uplo}
+
+// case when n = 0 and uplo = L will also execute the bad arguments test
+// (null handle, null pointers and invalid values)
+
+const vector<char> uplo_range = {'L', 'U'};
+
+// for checkin_lapack tests
+const vector<vector<int>> matrix_size_range = {
+    // quick return
+    {0, 1, 0},
+    // invalid
+    {-1, 1, 0},
+    {20, 5, 0},
+    // normal (valid) samples
+    {20, 32, 0},
+    {30, 30, 1},
+    {40, 60, 2},
+    {80, 80, 2},
+    {90, 100, 1},
+    {100, 150, 0}};
+
+// for daily_lapack tests
+const vector<vector<int>> large_matrix_size_range
+    = {{192, 192, 1}, {500, 600, 2}, {640, 640, 0}, {1000, 1024, 1}, {1200, 1230, 2}};
+
+Arguments trtri_setup_arguments(trtri_tuple tup)
+{
+    vector<int> matrix_size = std::get<0>(tup);
+    char        uplo        = std::get<1>(tup);
+
+    Arguments arg;
+
+    arg.set<rocblas_int>("n", matrix_size[0]);
+    arg.set<rocblas_int>("lda", matrix_size[1]);
+
+    arg.set<char>("uplo", uplo);
+
+    if(matrix_size[2] == 0)
+        arg.set<char>("diag", 'U');
+    else
+        arg.set<char>("diag", 'N');
+
+    if(matrix_size[2] == 1)
+        arg.singular = 1;
+    else
+        arg.singular = 0;
+
+    // only testing standard use case/defaults for strides
+
+    arg.timing = 0;
+
+    return arg;
+}
+
+template <testAPI_t API, typename I, typename SIZE>
+class TRTRI_BASE : public ::TestWithParam<trtri_tuple>
+{
+protected:
+    void TearDown() override
+    {
+        ASSERT_EQ(hipGetLastError(), hipSuccess);
+    }
+
+    template <bool BATCHED, bool STRIDED, typename T>
+    void run_tests()
+    {
+        Arguments arg = trtri_setup_arguments(GetParam());
+
+        if(arg.peek<rocblas_int>("n") == 0 && arg.peek<char>("uplo") == 'L')
+            testing_trtri_bad_arg<API, BATCHED, STRIDED, T, I, SIZE>();
+
+        arg.batch_count = 1;
+        if(arg.singular == 1)
+            testing_trtri<API, BATCHED, STRIDED, T, I, SIZE>(arg);
+
+        arg.singular = 0;
+        testing_trtri<API, BATCHED, STRIDED, T, I, SIZE>(arg);
+    }
+};
+
+class TRTRI_COMPAT_64 : public TRTRI_BASE<API_COMPAT, int64_t, size_t>
+{
+};
+
+// non-batch tests
+
+TEST_P(TRTRI_COMPAT_64, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(TRTRI_COMPAT_64, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(TRTRI_COMPAT_64, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(TRTRI_COMPAT_64, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         TRTRI_COMPAT_64,
+                         Combine(ValuesIn(large_matrix_size_range), ValuesIn(uplo_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         TRTRI_COMPAT_64,
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(uplo_range)));

--- a/projects/hipsolver/clients/gtest/trtri_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/trtri_gtest.cpp
@@ -29,19 +29,19 @@ using ::testing::Values;
 using ::testing::ValuesIn;
 using namespace std;
 
-typedef std::tuple<vector<int>, char> trtri_tuple;
+typedef std::tuple<vector<int>, vector<char>> trtri_tuple;
 
 // each matrix_size_range vector is a {n, lda, singular/diag}
 // if singular = 0, then the used matrix for the tests is triangular unit
 // if singular = 1, then the used matrix for the tests is triangular non-unit and singular
 // otherwise, the used matrix is triangular non-unit and not singular
 
-// each uplo_range is {uplo}
+// each op_range vector is a {uplo}
 
 // case when n = 0 and uplo = L will also execute the bad arguments test
 // (null handle, null pointers and invalid values)
 
-const vector<char> uplo_range = {'L', 'U'};
+const vector<vector<char>> op_range = {{'L'}, {'U'}};
 
 // for checkin_lapack tests
 const vector<vector<int>> matrix_size_range = {
@@ -64,15 +64,15 @@ const vector<vector<int>> large_matrix_size_range
 
 Arguments trtri_setup_arguments(trtri_tuple tup)
 {
-    vector<int> matrix_size = std::get<0>(tup);
-    char        uplo        = std::get<1>(tup);
+    vector<int>  matrix_size = std::get<0>(tup);
+    vector<char> op          = std::get<1>(tup);
 
     Arguments arg;
 
     arg.set<rocblas_int>("n", matrix_size[0]);
     arg.set<rocblas_int>("lda", matrix_size[1]);
 
-    arg.set<char>("uplo", uplo);
+    arg.set<char>("uplo", op[0]);
 
     if(matrix_size[2] == 0)
         arg.set<char>("diag", 'U');
@@ -145,8 +145,8 @@ TEST_P(TRTRI_COMPAT_64, __double_complex)
 
 INSTANTIATE_TEST_SUITE_P(daily_lapack,
                          TRTRI_COMPAT_64,
-                         Combine(ValuesIn(large_matrix_size_range), ValuesIn(uplo_range)));
+                         Combine(ValuesIn(large_matrix_size_range), ValuesIn(op_range)));
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          TRTRI_COMPAT_64,
-                         Combine(ValuesIn(matrix_size_range), ValuesIn(uplo_range)));
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(op_range)));

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -7011,6 +7011,230 @@ inline hipsolverStatus_t hipsolver_potrs(testAPI_t               API,
                                         ldb,
                                         info,
                                         bc);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+/********************************************************/
+
+/******************** TRTRI ********************/
+// bufferSize
+inline hipsolverStatus_t hipsolver_trtri_bufferSize(testAPI_t           API,
+                                                    hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    hipsolverDiagType_t diag,
+                                                    int64_t             n,
+                                                    float*              A,
+                                                    int64_t             lda,
+                                                    size_t*             lworkOnDevice,
+                                                    size_t*             lworkOnHost)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXtrtri_bufferSize(
+            handle, uplo, diag, n, HIP_R_32F, A, lda, lworkOnDevice, lworkOnHost);
+    default:
+        *lworkOnDevice = 0;
+        *lworkOnHost   = 0;
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_trtri_bufferSize(testAPI_t           API,
+                                                    hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    hipsolverDiagType_t diag,
+                                                    int64_t             n,
+                                                    double*             A,
+                                                    int64_t             lda,
+                                                    size_t*             lworkOnDevice,
+                                                    size_t*             lworkOnHost)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXtrtri_bufferSize(
+            handle, uplo, diag, n, HIP_R_64F, A, lda, lworkOnDevice, lworkOnHost);
+    default:
+        *lworkOnDevice = 0;
+        *lworkOnHost   = 0;
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_trtri_bufferSize(testAPI_t           API,
+                                                    hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    hipsolverDiagType_t diag,
+                                                    int64_t             n,
+                                                    hipsolverComplex*   A,
+                                                    int64_t             lda,
+                                                    size_t*             lworkOnDevice,
+                                                    size_t*             lworkOnHost)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXtrtri_bufferSize(
+            handle, uplo, diag, n, HIP_C_32F, A, lda, lworkOnDevice, lworkOnHost);
+    default:
+        *lworkOnDevice = 0;
+        *lworkOnHost   = 0;
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_trtri_bufferSize(testAPI_t               API,
+                                                    hipsolverHandle_t       handle,
+                                                    hipsolverFillMode_t     uplo,
+                                                    hipsolverDiagType_t     diag,
+                                                    int64_t                 n,
+                                                    hipsolverDoubleComplex* A,
+                                                    int64_t                 lda,
+                                                    size_t*                 lworkOnDevice,
+                                                    size_t*                 lworkOnHost)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXtrtri_bufferSize(
+            handle, uplo, diag, n, HIP_C_64F, A, lda, lworkOnDevice, lworkOnHost);
+    default:
+        *lworkOnDevice = 0;
+        *lworkOnHost   = 0;
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+// trtri
+inline hipsolverStatus_t hipsolver_trtri(testAPI_t           API,
+                                         hipsolverHandle_t   handle,
+                                         hipsolverFillMode_t uplo,
+                                         hipsolverDiagType_t diag,
+                                         int64_t             n,
+                                         float*              A,
+                                         int64_t             lda,
+                                         float*              work,
+                                         size_t              lworkOnDevice,
+                                         float*              hwork,
+                                         size_t              lworkOnHost,
+                                         int*                devInfo)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXtrtri(handle,
+                                 uplo,
+                                 diag,
+                                 n,
+                                 HIP_R_32F,
+                                 A,
+                                 lda,
+                                 work,
+                                 lworkOnDevice,
+                                 hwork,
+                                 lworkOnHost,
+                                 devInfo);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_trtri(testAPI_t           API,
+                                         hipsolverHandle_t   handle,
+                                         hipsolverFillMode_t uplo,
+                                         hipsolverDiagType_t diag,
+                                         int64_t             n,
+                                         double*             A,
+                                         int64_t             lda,
+                                         double*             work,
+                                         size_t              lworkOnDevice,
+                                         double*             hwork,
+                                         size_t              lworkOnHost,
+                                         int*                devInfo)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXtrtri(handle,
+                                 uplo,
+                                 diag,
+                                 n,
+                                 HIP_R_64F,
+                                 A,
+                                 lda,
+                                 work,
+                                 lworkOnDevice,
+                                 hwork,
+                                 lworkOnHost,
+                                 devInfo);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_trtri(testAPI_t           API,
+                                         hipsolverHandle_t   handle,
+                                         hipsolverFillMode_t uplo,
+                                         hipsolverDiagType_t diag,
+                                         int64_t             n,
+                                         hipsolverComplex*   A,
+                                         int64_t             lda,
+                                         hipsolverComplex*   work,
+                                         size_t              lworkOnDevice,
+                                         hipsolverComplex*   hwork,
+                                         size_t              lworkOnHost,
+                                         int*                devInfo)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXtrtri(handle,
+                                 uplo,
+                                 diag,
+                                 n,
+                                 HIP_C_32F,
+                                 A,
+                                 lda,
+                                 work,
+                                 lworkOnDevice,
+                                 hwork,
+                                 lworkOnHost,
+                                 devInfo);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+}
+
+inline hipsolverStatus_t hipsolver_trtri(testAPI_t               API,
+                                         hipsolverHandle_t       handle,
+                                         hipsolverFillMode_t     uplo,
+                                         hipsolverDiagType_t     diag,
+                                         int64_t                 n,
+                                         hipsolverDoubleComplex* A,
+                                         int64_t                 lda,
+                                         hipsolverDoubleComplex* work,
+                                         size_t                  lworkOnDevice,
+                                         hipsolverDoubleComplex* hwork,
+                                         size_t                  lworkOnHost,
+                                         int*                    devInfo)
+{
+    switch(API)
+    {
+    case API_COMPAT:
+        return hipsolverDnXtrtri(handle,
+                                 uplo,
+                                 diag,
+                                 n,
+                                 HIP_C_64F,
+                                 A,
+                                 lda,
+                                 work,
+                                 lworkOnDevice,
+                                 hwork,
+                                 lworkOnHost,
+                                 devInfo);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }

--- a/projects/hipsolver/clients/include/hipsolver_datatype2string.hpp
+++ b/projects/hipsolver/clients/include/hipsolver_datatype2string.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -82,6 +82,8 @@ char hipsolver2char_operation(hipsolverOperation_t value);
 
 char hipsolver2char_fill(hipsolverFillMode_t value);
 
+char hipsolver2char_diag(hipsolverDiagType_t value);
+
 char hipsolver2char_side(hipsolverSideMode_t value);
 
 char hipsolver2char_evect(hipsolverEigMode_t value);
@@ -98,6 +100,8 @@ hipsolverStatus_t string2hipsolver_status(const std::string& value);
 hipsolverOperation_t char2hipsolver_operation(char value);
 
 hipsolverFillMode_t char2hipsolver_fill(char value);
+
+hipsolverDiagType_t char2hipsolver_diag(char value);
 
 hipsolverSideMode_t char2hipsolver_side(char value);
 

--- a/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
+++ b/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -52,6 +52,7 @@
 #include "testing_sygvj_hegvj.hpp"
 #include "testing_sytrd_hetrd.hpp"
 #include "testing_sytrf.hpp"
+#include "testing_trtri.hpp"
 
 #ifdef HAVE_HIPSPARSE
 #include "testing_csrlsvchol.hpp"
@@ -96,6 +97,7 @@ class hipsolver_dispatcher
             {"potrs", testing_potrs<API_NORMAL, false, false, T>},
             {"potrs_batched", testing_potrs<API_NORMAL, true, false, T>},
             {"sytrf", testing_sytrf<API_NORMAL, false, false, T>},
+            {"trtri_64", testing_trtri<API_COMPAT, false, false, T, int64_t, size_t>},
         };
 
         // Grab function from the map and execute

--- a/projects/hipsolver/clients/include/lapack_host_reference.hpp
+++ b/projects/hipsolver/clients/include/lapack_host_reference.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -239,6 +239,9 @@ void cpu_potri(hipsolverFillMode_t uplo, int n, T* A, int lda, int* info);
 
 template <typename T>
 void cpu_potrs(hipsolverFillMode_t uplo, int n, int nrhs, T* A, int lda, T* B, int ldb, int* info);
+
+template <typename T>
+void cpu_trtri(hipsolverFillMode_t uplo, hipsolverDiagType_t diag, int n, T* A, int lda, int* info);
 
 template <typename T, typename S>
 void cpu_syevd_heevd(hipsolverEigMode_t  evect,

--- a/projects/hipsolver/clients/include/testing_trtri.hpp
+++ b/projects/hipsolver/clients/include/testing_trtri.hpp
@@ -27,13 +27,7 @@
 
 #include "clientcommon.hpp"
 
-template <testAPI_t API,
-          typename I,
-          typename SIZE,
-          typename Td,
-          typename Th,
-          typename Ud,
-          typename Uh>
+template <testAPI_t API, typename I, typename SIZE, typename Td, typename Th, typename Ud>
 void trtri_checkBadArgs(const hipsolverHandle_t   handle,
                         const hipsolverFillMode_t uplo,
                         const hipsolverDiagType_t diag,
@@ -201,9 +195,9 @@ void trtri_initData(const int n, Td& dA, const int lda, Th& hA, const bool singu
 }
 
 template <testAPI_t API,
+          typename T,
           typename I,
           typename SIZE,
-          typename T,
           typename Td,
           typename Th,
           typename Ud,
@@ -260,9 +254,9 @@ void trtri_getError(const hipsolverHandle_t   handle,
 }
 
 template <testAPI_t API,
+          typename T,
           typename I,
           typename SIZE,
-          typename T,
           typename Td,
           typename Th,
           typename Ud,
@@ -442,27 +436,7 @@ void testing_trtri(Arguments& argus)
 
     // check computations
     if(argus.unit_check || argus.norm_check)
-        trtri_getError<API>(handle,
-                            uplo,
-                            diag,
-                            n,
-                            dA,
-                            lda,
-                            dWork,
-                            size_dW,
-                            hWork,
-                            size_hW,
-                            dInfo,
-                            hA,
-                            hARes,
-                            hInfo,
-                            hInfoRes,
-                            &max_error,
-                            singular);
-
-    // collect performance data
-    if(argus.timing)
-        trtri_getPerfData<API>(handle,
+        trtri_getError<API, T>(handle,
                                uplo,
                                diag,
                                n,
@@ -474,12 +448,32 @@ void testing_trtri(Arguments& argus)
                                size_hW,
                                dInfo,
                                hA,
+                               hARes,
                                hInfo,
-                               &gpu_time_used,
-                               &cpu_time_used,
-                               argus.perf ? 1 : argus.iters,
-                               argus.perf,
+                               hInfoRes,
+                               &max_error,
                                singular);
+
+    // collect performance data
+    if(argus.timing)
+        trtri_getPerfData<API, T>(handle,
+                                  uplo,
+                                  diag,
+                                  n,
+                                  dA,
+                                  lda,
+                                  dWork,
+                                  size_dW,
+                                  hWork,
+                                  size_hW,
+                                  dInfo,
+                                  hA,
+                                  hInfo,
+                                  &gpu_time_used,
+                                  &cpu_time_used,
+                                  argus.perf ? 1 : argus.iters,
+                                  argus.perf,
+                                  singular);
 
     // validate results for rocsolver-test
     // using n * machine_epsilon as tolerance
@@ -491,11 +485,15 @@ void testing_trtri(Arguments& argus)
     {
         if(!argus.perf)
         {
-            rocsolver_bench_header("Arguments:");
+            std::cerr << "\n============================================\n";
+            std::cerr << "Arguments:\n";
+            std::cerr << "============================================\n";
             rocsolver_bench_output("uplo", "diag", "n", "lda");
             rocsolver_bench_output(uploC, diagC, n, lda);
 
-            rocsolver_bench_header("Results:");
+            std::cerr << "\n============================================\n";
+            std::cerr << "Results:\n";
+            std::cerr << "============================================\n";
             if(argus.norm_check)
             {
                 rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
@@ -506,7 +504,7 @@ void testing_trtri(Arguments& argus)
                 rocsolver_bench_output("cpu_time_us", "gpu_time_us");
                 rocsolver_bench_output(cpu_time_used, gpu_time_used);
             }
-            rocsolver_bench_endl();
+            std::cerr << std::endl;
         }
         else
         {

--- a/projects/hipsolver/clients/include/testing_trtri.hpp
+++ b/projects/hipsolver/clients/include/testing_trtri.hpp
@@ -249,6 +249,18 @@ void trtri_getError(const hipsolverHandle_t   handle,
     // using frobenius norm
     if(hInfoRes[0][0] == 0)
     {
+        // for unit diagonal, trtri does not define the output diagonal values,
+        // so zero them out in both results before comparing
+        // specifically cuSOLVER does not mention if they reference or do not reference the diagonal values
+        if(diag == HIPSOLVER_DIAG_UNIT)
+        {
+            for(I i = 0; i < n; i++)
+            {
+                hA[0][i + i * lda]    = T(0);
+                hARes[0][i + i * lda] = T(0);
+            }
+        }
+
         *max_err = norm_error('F', n, n, lda, hA[0], hARes[0]);
     }
 }

--- a/projects/hipsolver/clients/include/testing_trtri.hpp
+++ b/projects/hipsolver/clients/include/testing_trtri.hpp
@@ -1,0 +1,522 @@
+/* ************************************************************************
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#pragma once
+
+#include <vector>
+
+#include "clientcommon.hpp"
+
+template <testAPI_t API,
+          typename I,
+          typename SIZE,
+          typename Td,
+          typename Th,
+          typename Ud,
+          typename Uh>
+void trtri_checkBadArgs(const hipsolverHandle_t   handle,
+                        const hipsolverFillMode_t uplo,
+                        const hipsolverDiagType_t diag,
+                        const I                   n,
+                        Td                        dA,
+                        const I                   lda,
+                        Td                        dWork,
+                        const SIZE                dlwork,
+                        Th                        hWork,
+                        const SIZE                hlwork,
+                        Ud                        dInfo)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_trtri(API, nullptr, uplo, diag, n, dA, lda, dWork, dlwork, hWork, hlwork, dInfo),
+        HIPSOLVER_STATUS_NOT_INITIALIZED);
+
+    // values
+    EXPECT_ROCBLAS_STATUS(hipsolver_trtri(API,
+                                          handle,
+                                          hipsolverFillMode_t(-1),
+                                          diag,
+                                          n,
+                                          dA,
+                                          lda,
+                                          dWork,
+                                          dlwork,
+                                          hWork,
+                                          hlwork,
+                                          dInfo),
+                          HIPSOLVER_STATUS_INVALID_ENUM);
+    EXPECT_ROCBLAS_STATUS(hipsolver_trtri(API,
+                                          handle,
+                                          uplo,
+                                          hipsolverDiagType_t(-1),
+                                          n,
+                                          dA,
+                                          lda,
+                                          dWork,
+                                          dlwork,
+                                          hWork,
+                                          hlwork,
+                                          dInfo),
+                          HIPSOLVER_STATUS_INVALID_ENUM);
+
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
+    // pointers
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_trtri(
+            API, handle, uplo, diag, n, (Td) nullptr, lda, dWork, dlwork, hWork, hlwork, dInfo),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_trtri(
+            API, handle, uplo, diag, n, dA, lda, dWork, dlwork, hWork, hlwork, (Ud) nullptr),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+
+    // quick return with invalid pointers
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_trtri(
+            API, handle, uplo, diag, 0, (Td) nullptr, lda, dWork, dlwork, hWork, hlwork, dInfo),
+        HIPSOLVER_STATUS_SUCCESS);
+#endif
+}
+
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T, typename I, typename SIZE>
+void testing_trtri_bad_arg()
+{
+    // safe arguments
+    hipsolver_local_handle handle;
+    I                      n    = 10;
+    I                      lda  = 10;
+    hipsolverFillMode_t    uplo = HIPSOLVER_FILL_MODE_LOWER;
+    hipsolverDiagType_t    diag = HIPSOLVER_DIAG_NON_UNIT;
+
+    if(BATCHED)
+    {
+        // memory allocations
+        // device_batch_vector<T>         dA(1, 1, 1);
+        // device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
+        // CHECK_HIP_ERROR(dA.memcheck());
+        // CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // SIZE size_dW, size_hW;
+        // hipsolver_trtri_bufferSize(API, handle, uplo, diag, n, dA.data(), lda, &size_dW, &size_hW);
+        // host_strided_batch_vector<T>   hWork(size_hW, 1, size_hW, 1);
+        // device_strided_batch_vector<T> dWork(size_dW, 1, size_dW, 1);
+        // if(size_dW)
+        //     CHECK_HIP_ERROR(dWork.memcheck());
+
+        // // check bad arguments
+        // trtri_checkBadArgs<API>(handle, uplo, diag, n, dA.data(), lda,
+        //                         dWork.data(), size_dW, hWork.data(), size_hW, dInfo.data());
+    }
+    else
+    {
+        // memory allocations
+        device_strided_batch_vector<T>   dA(1, 1, 1, 1);
+        device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        SIZE size_dW, size_hW;
+        hipsolver_trtri_bufferSize(API, handle, uplo, diag, n, dA.data(), lda, &size_dW, &size_hW);
+        host_strided_batch_vector<T>   hWork(size_hW, 1, size_hW, 1);
+        device_strided_batch_vector<T> dWork(size_dW, 1, size_dW, 1);
+        if(size_dW)
+            CHECK_HIP_ERROR(dWork.memcheck());
+
+        // check bad arguments
+        trtri_checkBadArgs<API>(handle,
+                                uplo,
+                                diag,
+                                n,
+                                dA.data(),
+                                lda,
+                                dWork.data(),
+                                size_dW,
+                                hWork.data(),
+                                size_hW,
+                                dInfo.data());
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void trtri_initData(const int n, Td& dA, const int lda, Th& hA, const bool singular)
+{
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        // scale A to avoid singularities
+        for(int i = 0; i < n; i++)
+        {
+            for(int j = 0; j < n; j++)
+            {
+                if(i == j)
+                    hA[0][i + j * lda] = hA[0][i + j * lda] / 10.0 + 1;
+                else
+                    hA[0][i + j * lda] = (hA[0][i + j * lda] - 4) / 10.0;
+            }
+        }
+
+        if(singular)
+        {
+            // add some singularities
+            // always the same elements for debugging purposes
+            // the algorithm must detect the first zero pivot in those positions
+            int i = n / 4;
+            i -= (i / n) * n;
+            hA[0][i + i * lda] = 0;
+            i                  = n / 2;
+            i -= (i / n) * n;
+            hA[0][i + i * lda] = 0;
+            i                  = n - 1;
+            i -= (i / n) * n;
+            hA[0][i + i * lda] = 0;
+        }
+    }
+
+    if(GPU)
+    {
+        // copy data from CPU to device
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+template <testAPI_t API,
+          typename I,
+          typename SIZE,
+          typename T,
+          typename Td,
+          typename Th,
+          typename Ud,
+          typename Uh>
+void trtri_getError(const hipsolverHandle_t   handle,
+                    const hipsolverFillMode_t uplo,
+                    const hipsolverDiagType_t diag,
+                    const I                   n,
+                    Td&                       dA,
+                    const I                   lda,
+                    Td&                       dWork,
+                    const SIZE                lworkOnDevice,
+                    Th&                       hWork,
+                    const SIZE                lworkOnHost,
+                    Ud&                       dInfo,
+                    Th&                       hA,
+                    Th&                       hARes,
+                    Uh&                       hInfo,
+                    Uh&                       hInfoRes,
+                    double*                   max_err,
+                    const bool                singular)
+{
+    // input data initialization
+    trtri_initData<true, true, T>(n, dA, lda, hA, singular);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(hipsolver_trtri(API,
+                                        handle,
+                                        uplo,
+                                        diag,
+                                        n,
+                                        dA.data(),
+                                        lda,
+                                        dWork.data(),
+                                        lworkOnDevice,
+                                        hWork.data(),
+                                        lworkOnHost,
+                                        dInfo.data()));
+    CHECK_HIP_ERROR(hARes.transfer_from(dA));
+    CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
+
+    // CPU lapack
+    cpu_trtri(uplo, diag, n, hA[0], lda, hInfo[0]);
+
+    // error is ||hA - hARes|| / ||hA||
+    // (THIS DOES NOT ACCOUNT FOR NUMERICAL REPRODUCIBILITY ISSUES.
+    // IT MIGHT BE REVISITED IN THE FUTURE)
+    // using frobenius norm
+    if(hInfoRes[0][0] == 0)
+    {
+        *max_err = norm_error('F', n, n, lda, hA[0], hARes[0]);
+    }
+}
+
+template <testAPI_t API,
+          typename I,
+          typename SIZE,
+          typename T,
+          typename Td,
+          typename Th,
+          typename Ud,
+          typename Uh>
+void trtri_getPerfData(const hipsolverHandle_t   handle,
+                       const hipsolverFillMode_t uplo,
+                       const hipsolverDiagType_t diag,
+                       const I                   n,
+                       Td&                       dA,
+                       const I                   lda,
+                       Td&                       dWork,
+                       const SIZE                lworkOnDevice,
+                       Th&                       hWork,
+                       const SIZE                lworkOnHost,
+                       Ud&                       dInfo,
+                       Th&                       hA,
+                       Uh&                       hInfo,
+                       double*                   gpu_time_used,
+                       double*                   cpu_time_used,
+                       const int                 hot_calls,
+                       const bool                perf,
+                       const bool                singular)
+{
+    if(!perf)
+    {
+        trtri_initData<true, false, T>(n, dA, lda, hA, singular);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us_no_sync();
+        cpu_trtri(uplo, diag, n, hA[0], lda, hInfo[0]);
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
+    }
+
+    trtri_initData<true, false, T>(n, dA, lda, hA, singular);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        trtri_initData<false, true, T>(n, dA, lda, hA, singular);
+
+        CHECK_ROCBLAS_ERROR(hipsolver_trtri(API,
+                                            handle,
+                                            uplo,
+                                            diag,
+                                            n,
+                                            dA.data(),
+                                            lda,
+                                            dWork.data(),
+                                            lworkOnDevice,
+                                            hWork.data(),
+                                            lworkOnHost,
+                                            dInfo.data()));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(hipsolverGetStream(handle, &stream));
+    double start;
+
+    for(int iter = 0; iter < hot_calls; iter++)
+    {
+        trtri_initData<false, true, T>(n, dA, lda, hA, singular);
+
+        start = get_time_us_sync(stream);
+        hipsolver_trtri(API,
+                        handle,
+                        uplo,
+                        diag,
+                        n,
+                        dA.data(),
+                        lda,
+                        dWork.data(),
+                        lworkOnDevice,
+                        hWork.data(),
+                        lworkOnHost,
+                        dInfo.data());
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T, typename I, typename SIZE>
+void testing_trtri(Arguments& argus)
+{
+    // get arguments
+    hipsolver_local_handle handle;
+    char                   uploC    = argus.get<char>("uplo");
+    char                   diagC    = argus.get<char>("diag");
+    I                      n        = argus.get<rocblas_int>("n");
+    I                      lda      = argus.get<rocblas_int>("lda");
+    bool                   singular = argus.singular;
+
+    hipsolverFillMode_t uplo = char2hipsolver_fill(uploC);
+    hipsolverDiagType_t diag = char2hipsolver_diag(diagC);
+
+    // check non-supported values
+    // N/A
+
+    // determine sizes
+    bool   checkBadArgs = (n == 0 && uploC == 'L');
+    size_t size_A       = size_t(lda) * n;
+    size_t size_ARes    = (argus.unit_check || argus.norm_check) ? size_A : 0;
+
+    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+
+    // check invalid sizes
+    bool invalid_size = (n < 0 || lda < n);
+    if(invalid_size || checkBadArgs)
+    {
+        if(BATCHED)
+        {
+            // RETURN_IF_ROCBLAS_ERROR(HIPSOLVER_STATUS_INVALID_VALUE);
+        }
+        else
+        {
+            EXPECT_ROCBLAS_STATUS(hipsolver_trtri(API,
+                                                  handle,
+                                                  uplo,
+                                                  diag,
+                                                  n,
+                                                  (T*)nullptr,
+                                                  lda,
+                                                  (T*)nullptr,
+                                                  0,
+                                                  (T*)nullptr,
+                                                  0,
+                                                  (int*)nullptr),
+                                  invalid_size ? HIPSOLVER_STATUS_INVALID_VALUE
+                                               : HIPSOLVER_STATUS_SUCCESS);
+        }
+
+        if(checkBadArgs)
+            testing_trtri_bad_arg<API, BATCHED, STRIDED, T, I, SIZE>();
+
+        return;
+    }
+
+    // memory allocations
+    host_strided_batch_vector<T>     hA(size_A, 1, size_A, 1);
+    host_strided_batch_vector<T>     hARes(size_ARes, 1, size_ARes, 1);
+    host_strided_batch_vector<int>   hInfo(1, 1, 1, 1);
+    host_strided_batch_vector<int>   hInfoRes(1, 1, 1, 1);
+    device_strided_batch_vector<T>   dA(size_A, 1, size_A, 1);
+    device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
+    if(size_A)
+        CHECK_HIP_ERROR(dA.memcheck());
+    CHECK_HIP_ERROR(dInfo.memcheck());
+
+    SIZE size_dW, size_hW;
+    hipsolver_trtri_bufferSize(API, handle, uplo, diag, n, dA.data(), lda, &size_dW, &size_hW);
+    host_strided_batch_vector<T>   hWork(size_hW, 1, size_hW, 1);
+    device_strided_batch_vector<T> dWork(size_dW, 1, size_dW, 1);
+    if(size_dW)
+        CHECK_HIP_ERROR(dWork.memcheck());
+
+    // check quick return
+    if(n == 0)
+    {
+        EXPECT_ROCBLAS_STATUS(hipsolver_trtri(API,
+                                              handle,
+                                              uplo,
+                                              diag,
+                                              n,
+                                              dA.data(),
+                                              lda,
+                                              dWork.data(),
+                                              size_dW,
+                                              hWork.data(),
+                                              size_hW,
+                                              dInfo.data()),
+                              HIPSOLVER_STATUS_SUCCESS);
+        if(argus.timing)
+            rocsolver_bench_inform(inform_quick_return);
+
+        return;
+    }
+
+    // check computations
+    if(argus.unit_check || argus.norm_check)
+        trtri_getError<API>(handle,
+                            uplo,
+                            diag,
+                            n,
+                            dA,
+                            lda,
+                            dWork,
+                            size_dW,
+                            hWork,
+                            size_hW,
+                            dInfo,
+                            hA,
+                            hARes,
+                            hInfo,
+                            hInfoRes,
+                            &max_error,
+                            singular);
+
+    // collect performance data
+    if(argus.timing)
+        trtri_getPerfData<API>(handle,
+                               uplo,
+                               diag,
+                               n,
+                               dA,
+                               lda,
+                               dWork,
+                               size_dW,
+                               hWork,
+                               size_hW,
+                               dInfo,
+                               hA,
+                               hInfo,
+                               &gpu_time_used,
+                               &cpu_time_used,
+                               argus.perf ? 1 : argus.iters,
+                               argus.perf,
+                               singular);
+
+    // validate results for rocsolver-test
+    // using n * machine_epsilon as tolerance
+    if(argus.unit_check)
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
+
+    // output results for rocsolver-bench
+    if(argus.timing)
+    {
+        if(!argus.perf)
+        {
+            rocsolver_bench_header("Arguments:");
+            rocsolver_bench_output("uplo", "diag", "n", "lda");
+            rocsolver_bench_output(uploC, diagC, n, lda);
+
+            rocsolver_bench_header("Results:");
+            if(argus.norm_check)
+            {
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
+            }
+            else
+            {
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used);
+            }
+            rocsolver_bench_endl();
+        }
+        else
+        {
+            if(argus.norm_check)
+                rocsolver_bench_output(gpu_time_used, max_error);
+            else
+                rocsolver_bench_output(gpu_time_used);
+        }
+    }
+
+    // ensure all arguments were consumed
+    argus.validate_consumed();
+}

--- a/projects/hipsolver/library/include/internal/hipsolver-dense64.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-dense64.h
@@ -151,7 +151,7 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXtrtri_bufferSize(hipsolverDnHandl
                                                                 hipsolverDiagType_t diag,
                                                                 int64_t             n,
                                                                 hipDataType         dataTypeA,
-                                                                const void*         A,
+                                                                void*               A,
                                                                 int64_t             lda,
                                                                 size_t*             lworkOnDevice,
                                                                 size_t*             lworkOnHost);

--- a/projects/hipsolver/library/include/internal/hipsolver-dense64.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-dense64.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #ifndef HIPSOLVER_DENSE64_H
@@ -144,6 +144,30 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXpotrs(hipsolverDnHandle_t handle,
                                                      void*               B,
                                                      int64_t             ldb,
                                                      int*                info);
+
+// trtri
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXtrtri_bufferSize(hipsolverDnHandle_t handle,
+                                                                hipsolverFillMode_t uplo,
+                                                                hipsolverDiagType_t diag,
+                                                                int64_t             n,
+                                                                hipDataType         dataTypeA,
+                                                                const void*         A,
+                                                                int64_t             lda,
+                                                                size_t*             lworkOnDevice,
+                                                                size_t*             lworkOnHost);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnXtrtri(hipsolverDnHandle_t handle,
+                                                     hipsolverFillMode_t uplo,
+                                                     hipsolverDiagType_t diag,
+                                                     int64_t             n,
+                                                     hipDataType         dataTypeA,
+                                                     void*               A,
+                                                     int64_t             lda,
+                                                     void*               workOnDevice,
+                                                     size_t              lworkOnDevice,
+                                                     void*               workOnHost,
+                                                     size_t              lworkOnHost,
+                                                     int*                devInfo);
 
 #ifdef __cplusplus
 }

--- a/projects/hipsolver/library/include/internal/hipsolver-types.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-types.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
@@ -155,5 +155,12 @@ typedef hipblasFillMode_t hipsolverFillMode_t;
 typedef hipblasSideMode_t hipsolverSideMode_t;
 #define HIPSOLVER_SIDE_LEFT HIPBLAS_SIDE_LEFT
 #define HIPSOLVER_SIDE_RIGHT HIPBLAS_SIDE_RIGHT
+
+/*! \brief Alias of hipblasDiagType_t. HIPSOLVER_DIAG_NON_UNIT and HIPSOLVER_DIAG_UNIT
+ *  are provided as equivalents to HIPBLAS_DIAG_NON_UNIT and HIPBLAS_DIAG_UNIT.
+ ********************************************************************************/
+typedef hipblasDiagType_t hipsolverDiagType_t;
+#define HIPSOLVER_DIAG_NON_UNIT HIPBLAS_DIAG_NON_UNIT
+#define HIPSOLVER_DIAG_UNIT HIPBLAS_DIAG_UNIT
 
 #endif // HIPSOLVER_TYPES_H

--- a/projects/hipsolver/library/src/amd_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver_conversions.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -80,6 +80,32 @@ hipsolverFillMode_t rocblas2hip_fill(rocblas_fill_ fill)
         return HIPSOLVER_FILL_MODE_UPPER;
     case rocblas_fill_lower:
         return HIPSOLVER_FILL_MODE_LOWER;
+    default:
+        throw HIPSOLVER_STATUS_INVALID_ENUM;
+    }
+}
+
+rocblas_diagonal_ hip2rocblas_diag(hipsolverDiagType_t diag)
+{
+    switch(diag)
+    {
+    case HIPSOLVER_DIAG_NON_UNIT:
+        return rocblas_diagonal_non_unit;
+    case HIPSOLVER_DIAG_UNIT:
+        return rocblas_diagonal_unit;
+    default:
+        throw HIPSOLVER_STATUS_INVALID_ENUM;
+    }
+}
+
+hipsolverDiagType_t rocblas2hip_diag(rocblas_diagonal_ diag)
+{
+    switch(diag)
+    {
+    case rocblas_diagonal_non_unit:
+        return HIPSOLVER_DIAG_NON_UNIT;
+    case rocblas_diagonal_unit:
+        return HIPSOLVER_DIAG_UNIT;
     default:
         throw HIPSOLVER_STATUS_INVALID_ENUM;
     }

--- a/projects/hipsolver/library/src/amd_detail/hipsolver_conversions.hpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver_conversions.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,10 @@ hipsolverOperation_t rocblas2hip_operation(rocblas_operation_ op);
 rocblas_fill_ hip2rocblas_fill(hipsolverFillMode_t fill);
 
 hipsolverFillMode_t rocblas2hip_fill(rocblas_fill_ fill);
+
+rocblas_diagonal_ hip2rocblas_diag(hipsolverDiagType_t diag);
+
+hipsolverDiagType_t rocblas2hip_diag(rocblas_diagonal_ diag);
 
 rocblas_side_ hip2rocblas_side(hipsolverSideMode_t side);
 

--- a/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
@@ -909,7 +909,7 @@ hipsolverStatus_t hipsolverDnXtrtri_bufferSize(hipsolverDnHandle_t handle,
                                                hipsolverDiagType_t diag,
                                                int64_t             n,
                                                hipDataType         dataTypeA,
-                                               const void*         A,
+                                               void*               A,
                                                int64_t             lda,
                                                size_t*             lworkOnDevice,
                                                size_t*             lworkOnHost)

--- a/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -132,6 +132,39 @@ rocblas_status rocsolver_zpotrf_info32(rocblas_handle          handle,
                                        rocblas_double_complex* A,
                                        const int64_t           lda,
                                        rocblas_int*            info);
+
+// Triangular matrix inversion - NOTE: Currently only 32-bit versions exist in rocSOLVER
+rocblas_status rocsolver_strtri(rocblas_handle         handle,
+                                const rocblas_fill     uplo,
+                                const rocblas_diagonal diag,
+                                const rocblas_int      n,
+                                float*                 A,
+                                const rocblas_int      lda,
+                                rocblas_int*           info);
+
+rocblas_status rocsolver_dtrtri(rocblas_handle         handle,
+                                const rocblas_fill     uplo,
+                                const rocblas_diagonal diag,
+                                const rocblas_int      n,
+                                double*                A,
+                                const rocblas_int      lda,
+                                rocblas_int*           info);
+
+rocblas_status rocsolver_ctrtri(rocblas_handle         handle,
+                                const rocblas_fill     uplo,
+                                const rocblas_diagonal diag,
+                                const rocblas_int      n,
+                                rocblas_float_complex* A,
+                                const rocblas_int      lda,
+                                rocblas_int*           info);
+
+rocblas_status rocsolver_ztrtri(rocblas_handle          handle,
+                                const rocblas_fill      uplo,
+                                const rocblas_diagonal  diag,
+                                const rocblas_int       n,
+                                rocblas_double_complex* A,
+                                const rocblas_int       lda,
+                                rocblas_int*            info);
 
 /******************** PARAMS ********************/
 struct hipsolverParams
@@ -864,6 +897,166 @@ try
     }
     else
         return HIPSOLVER_STATUS_INVALID_ENUM;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** TRTRI ********************/
+hipsolverStatus_t hipsolverDnXtrtri_bufferSize(hipsolverDnHandle_t handle,
+                                               hipsolverFillMode_t uplo,
+                                               hipsolverDiagType_t diag,
+                                               int64_t             n,
+                                               hipDataType         dataTypeA,
+                                               const void*         A,
+                                               int64_t             lda,
+                                               size_t*             lworkOnDevice,
+                                               size_t*             lworkOnHost)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lworkOnDevice || !lworkOnHost)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lworkOnDevice = 0;
+    *lworkOnHost   = 0;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status;
+
+    // TODO: Update to call 64-bit versions once rocSOLVER adds rocsolver_*trtri_64
+    // Currently rocSOLVER only has 32-bit versions, so we cast int64_t to rocblas_int
+    if(dataTypeA == HIP_R_32F)
+    {
+        status = hipsolver::rocblas2hip_status(rocsolver_strtri((rocblas_handle)handle,
+                                                                hipsolver::hip2rocblas_fill(uplo),
+                                                                hipsolver::hip2rocblas_diag(diag),
+                                                                static_cast<rocblas_int>(n),
+                                                                nullptr,
+                                                                static_cast<rocblas_int>(lda),
+                                                                nullptr));
+    }
+    else if(dataTypeA == HIP_R_64F)
+    {
+        status = hipsolver::rocblas2hip_status(rocsolver_dtrtri((rocblas_handle)handle,
+                                                                hipsolver::hip2rocblas_fill(uplo),
+                                                                hipsolver::hip2rocblas_diag(diag),
+                                                                static_cast<rocblas_int>(n),
+                                                                nullptr,
+                                                                static_cast<rocblas_int>(lda),
+                                                                nullptr));
+    }
+    else if(dataTypeA == HIP_C_32F)
+    {
+        status = hipsolver::rocblas2hip_status(rocsolver_ctrtri((rocblas_handle)handle,
+                                                                hipsolver::hip2rocblas_fill(uplo),
+                                                                hipsolver::hip2rocblas_diag(diag),
+                                                                static_cast<rocblas_int>(n),
+                                                                nullptr,
+                                                                static_cast<rocblas_int>(lda),
+                                                                nullptr));
+    }
+    else if(dataTypeA == HIP_C_64F)
+    {
+        status = hipsolver::rocblas2hip_status(rocsolver_ztrtri((rocblas_handle)handle,
+                                                                hipsolver::hip2rocblas_fill(uplo),
+                                                                hipsolver::hip2rocblas_diag(diag),
+                                                                static_cast<rocblas_int>(n),
+                                                                nullptr,
+                                                                static_cast<rocblas_int>(lda),
+                                                                nullptr));
+    }
+    else
+    {
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
+
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, lworkOnDevice);
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDnXtrtri(hipsolverDnHandle_t handle,
+                                    hipsolverFillMode_t uplo,
+                                    hipsolverDiagType_t diag,
+                                    int64_t             n,
+                                    hipDataType         dataTypeA,
+                                    void*               A,
+                                    int64_t             lda,
+                                    void*               workOnDevice,
+                                    size_t              lworkOnDevice,
+                                    void*               workOnHost,
+                                    size_t              lworkOnHost,
+                                    int*                devInfo)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    if(workOnDevice && lworkOnDevice)
+        CHECK_ROCBLAS_ERROR(
+            rocblas_set_workspace((rocblas_handle)handle, workOnDevice, lworkOnDevice));
+    else
+    {
+        size_t lwork_device, lwork_host;
+        CHECK_HIPSOLVER_ERROR(hipsolverDnXtrtri_bufferSize(
+            handle, uplo, diag, n, dataTypeA, A, lda, &lwork_device, &lwork_host));
+        if(lwork_device > 0)
+            CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork_device));
+    }
+
+    // TODO: Update to call 64-bit versions once rocSOLVER adds rocsolver_*trtri_64
+    // Currently rocSOLVER only has 32-bit versions, so we cast int64_t to rocblas_int
+
+    if(dataTypeA == HIP_R_32F)
+    {
+        return hipsolver::rocblas2hip_status(rocsolver_strtri((rocblas_handle)handle,
+                                                              hipsolver::hip2rocblas_fill(uplo),
+                                                              hipsolver::hip2rocblas_diag(diag),
+                                                              static_cast<rocblas_int>(n),
+                                                              (float*)A,
+                                                              static_cast<rocblas_int>(lda),
+                                                              devInfo));
+    }
+    else if(dataTypeA == HIP_R_64F)
+    {
+        return hipsolver::rocblas2hip_status(rocsolver_dtrtri((rocblas_handle)handle,
+                                                              hipsolver::hip2rocblas_fill(uplo),
+                                                              hipsolver::hip2rocblas_diag(diag),
+                                                              static_cast<rocblas_int>(n),
+                                                              (double*)A,
+                                                              static_cast<rocblas_int>(lda),
+                                                              devInfo));
+    }
+    else if(dataTypeA == HIP_C_32F)
+    {
+        return hipsolver::rocblas2hip_status(rocsolver_ctrtri((rocblas_handle)handle,
+                                                              hipsolver::hip2rocblas_fill(uplo),
+                                                              hipsolver::hip2rocblas_diag(diag),
+                                                              static_cast<rocblas_int>(n),
+                                                              (rocblas_float_complex*)A,
+                                                              static_cast<rocblas_int>(lda),
+                                                              devInfo));
+    }
+    else if(dataTypeA == HIP_C_64F)
+    {
+        return hipsolver::rocblas2hip_status(rocsolver_ztrtri((rocblas_handle)handle,
+                                                              hipsolver::hip2rocblas_fill(uplo),
+                                                              hipsolver::hip2rocblas_diag(diag),
+                                                              static_cast<rocblas_int>(n),
+                                                              (rocblas_double_complex*)A,
+                                                              static_cast<rocblas_int>(lda),
+                                                              devInfo));
+    }
+    else
+    {
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver_dense64.cpp
@@ -997,6 +997,10 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(n < 0 || lda < n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(n == 0)
+        return HIPSOLVER_STATUS_SUCCESS;
 
     if(workOnDevice && lworkOnDevice)
         CHECK_ROCBLAS_ERROR(

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -80,6 +80,32 @@ hipsolverFillMode_t cuda2hip_fill(cublasFillMode_t fill)
         return HIPSOLVER_FILL_MODE_UPPER;
     case CUBLAS_FILL_MODE_LOWER:
         return HIPSOLVER_FILL_MODE_LOWER;
+    default:
+        throw HIPSOLVER_STATUS_INVALID_ENUM;
+    }
+}
+
+cublasDiagType_t hip2cuda_diag(hipsolverDiagType_t diag)
+{
+    switch(diag)
+    {
+    case HIPSOLVER_DIAG_NON_UNIT:
+        return CUBLAS_DIAG_NON_UNIT;
+    case HIPSOLVER_DIAG_UNIT:
+        return CUBLAS_DIAG_UNIT;
+    default:
+        throw HIPSOLVER_STATUS_INVALID_ENUM;
+    }
+}
+
+hipsolverDiagType_t cuda2hip_diag(cublasDiagType_t diag)
+{
+    switch(diag)
+    {
+    case CUBLAS_DIAG_NON_UNIT:
+        return HIPSOLVER_DIAG_NON_UNIT;
+    case CUBLAS_DIAG_UNIT:
+        return HIPSOLVER_DIAG_UNIT;
     default:
         throw HIPSOLVER_STATUS_INVALID_ENUM;
     }

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,10 @@ hipsolverOperation_t cuda2hip_operation(cublasOperation_t op);
 cublasFillMode_t hip2cuda_fill(hipsolverFillMode_t fill);
 
 hipsolverFillMode_t cuda2hip_fill(cublasFillMode_t fill);
+
+cublasDiagType_t hip2cuda_diag(hipsolverDiagType_t diag);
+
+hipsolverDiagType_t cuda2hip_diag(cublasDiagType_t diag);
 
 cublasSideMode_t hip2cuda_side(hipsolverSideMode_t side);
 

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_dense64.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_dense64.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -378,6 +378,71 @@ try
                                                        B,
                                                        ldb,
                                                        info));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** TRTRI ********************/
+hipsolverStatus_t hipsolverDnXtrtri_bufferSize(hipsolverDnHandle_t handle,
+                                               hipsolverFillMode_t uplo,
+                                               hipsolverDiagType_t diag,
+                                               int64_t             n,
+                                               hipDataType         dataTypeA,
+                                               const void*         A,
+                                               int64_t             lda,
+                                               size_t*             lworkOnDevice,
+                                               size_t*             lworkOnHost)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    return hipsolver::cuda2hip_status(cusolverDnXtrtri_bufferSize((cusolverDnHandle_t)handle,
+                                                                  hipsolver::hip2cuda_fill(uplo),
+                                                                  hipsolver::hip2cuda_diag(diag),
+                                                                  n,
+                                                                  dataTypeA,
+                                                                  A,
+                                                                  lda,
+                                                                  lworkOnDevice,
+                                                                  lworkOnHost));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDnXtrtri(hipsolverDnHandle_t handle,
+                                    hipsolverFillMode_t uplo,
+                                    hipsolverDiagType_t diag,
+                                    int64_t             n,
+                                    hipDataType         dataTypeA,
+                                    void*               A,
+                                    int64_t             lda,
+                                    void*               workOnDevice,
+                                    size_t              lworkOnDevice,
+                                    void*               workOnHost,
+                                    size_t              lworkOnHost,
+                                    int*                devInfo)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    return hipsolver::cuda2hip_status(cusolverDnXtrtri((cusolverDnHandle_t)handle,
+                                                       hipsolver::hip2cuda_fill(uplo),
+                                                       hipsolver::hip2cuda_diag(diag),
+                                                       n,
+                                                       dataTypeA,
+                                                       A,
+                                                       lda,
+                                                       workOnDevice,
+                                                       lworkOnDevice,
+                                                       workOnHost,
+                                                       lworkOnHost,
+                                                       devInfo));
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_dense64.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_dense64.cpp
@@ -390,7 +390,7 @@ hipsolverStatus_t hipsolverDnXtrtri_bufferSize(hipsolverDnHandle_t handle,
                                                hipsolverDiagType_t diag,
                                                int64_t             n,
                                                hipDataType         dataTypeA,
-                                               const void*         A,
+                                               void*               A,
                                                int64_t             lda,
                                                size_t*             lworkOnDevice,
                                                size_t*             lworkOnHost)


### PR DESCRIPTION
## Motivation

We want to be able to test AMD vs. NVIDIA's (rocSOLVER vs cuSOLVER) implementation of `trtri` using a benchmark framework unified with the rest of hipSOLVER.

## Technical Details

We add `hipsolverDnXtrtri` to hipSOLVER's compatibility API, implement a backend for AMD and NVIDIA that calls the respective library, and add it to our testing/benchmarking client.

We make new function headers for `trtri` in the client's internal API and the testing files.

rocSOLVER has not yet implemented a 64 bit `trtri`, a TODO comment has been left, but currently we just call the 32 bit implementation.

### NOTE:
This change is made alongside changes to add `larft` and `syevBatched`. You can find PRs for each of these routines, each of them reading extremely similarly.

## Test Plan

Run new tests on AMD and NVIDIA hardware. Try invoking `trtri` from the benchmark client.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.