### PR TITLE
[hipSOLVER] Add gelsBatched for testing

### DIFF
--- a/projects/hipsolver/CHANGELOG.md
+++ b/projects/hipsolver/CHANGELOG.md
@@ -6,6 +6,12 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ## (Unreleased) hipSOLVER
 
 ### Added
+
+* Added functions:
+  * gelsBatched
+    * hipsolverXXgelsBatched_bufferSize
+    * hipsolverXXgelsBatched
+
 ### Changed
 ### Removed
 ### Optimized

--- a/projects/hipsolver/clients/gtest/gels_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gels_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -132,6 +132,10 @@ class GELS_INPLACE : public GELS_BASE<API_NORMAL, true>
 {
 };
 
+class GELS_BATCHED : public GELS_BASE<API_NORMAL, false>
+{
+};
+
 // non-batch tests
 
 TEST_P(GELS, __float)
@@ -214,6 +218,36 @@ TEST_P(GELS_INPLACE, __double_complex)
     run_tests<false, false, rocblas_double_complex>();
 }
 
+// batched tests
+//
+TEST_P(GELS_BATCHED, batched__float)
+{
+    Arguments arg   = gels_setup_arguments(GetParam());
+    arg.batch_count = 3;
+    testing_gels<API_NORMAL, true, false, true, float>(arg); // INPLACE=true
+}
+
+TEST_P(GELS_BATCHED, batched__double)
+{
+    Arguments arg   = gels_setup_arguments(GetParam());
+    arg.batch_count = 3;
+    testing_gels<API_NORMAL, true, false, true, double>(arg);
+}
+
+TEST_P(GELS_BATCHED, batched__float_complex)
+{
+    Arguments arg   = gels_setup_arguments(GetParam());
+    arg.batch_count = 3;
+    testing_gels<API_NORMAL, true, false, true, rocblas_float_complex>(arg);
+}
+
+TEST_P(GELS_BATCHED, batched__double_complex)
+{
+    Arguments arg   = gels_setup_arguments(GetParam());
+    arg.batch_count = 3;
+    testing_gels<API_NORMAL, true, false, true, rocblas_double_complex>(arg);
+}
+
 // INSTANTIATE_TEST_SUITE_P(daily_lapack,
 //                          GELS,
 //                          Combine(ValuesIn(large_matrix_sizeA_range),
@@ -248,4 +282,8 @@ INSTANTIATE_TEST_SUITE_P(checkin_lapack,
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          GELS_INPLACE,
+                         Combine(ValuesIn(matrix_sizeA_range), ValuesIn(matrix_sizeB_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         GELS_BATCHED,
                          Combine(ValuesIn(matrix_sizeA_range), ValuesIn(matrix_sizeB_range)));

--- a/projects/hipsolver/clients/gtest/gels_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/gels_gtest.cpp
@@ -111,7 +111,7 @@ protected:
         if(arg.peek<rocblas_int>("n") == -1 && arg.peek<rocblas_int>("nrhs") == -1)
             testing_gels_bad_arg<API, BATCHED, STRIDED, T>();
 
-        arg.batch_count = 1;
+        arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
         testing_gels<API, BATCHED, STRIDED, INPLACE, T>(arg);
     }
 };
@@ -132,7 +132,7 @@ class GELS_INPLACE : public GELS_BASE<API_NORMAL, true>
 {
 };
 
-class GELS_BATCHED : public GELS_BASE<API_NORMAL, false>
+class GELS_BATCHED : public GELS_BASE<API_NORMAL, true>
 {
 };
 
@@ -219,33 +219,25 @@ TEST_P(GELS_INPLACE, __double_complex)
 }
 
 // batched tests
-//
+
 TEST_P(GELS_BATCHED, batched__float)
 {
-    Arguments arg   = gels_setup_arguments(GetParam());
-    arg.batch_count = 3;
-    testing_gels<API_NORMAL, true, false, true, float>(arg); // INPLACE=true
+    run_tests<true, false, float>();
 }
 
 TEST_P(GELS_BATCHED, batched__double)
 {
-    Arguments arg   = gels_setup_arguments(GetParam());
-    arg.batch_count = 3;
-    testing_gels<API_NORMAL, true, false, true, double>(arg);
+    run_tests<true, false, double>();
 }
 
 TEST_P(GELS_BATCHED, batched__float_complex)
 {
-    Arguments arg   = gels_setup_arguments(GetParam());
-    arg.batch_count = 3;
-    testing_gels<API_NORMAL, true, false, true, rocblas_float_complex>(arg);
+    run_tests<true, false, rocblas_float_complex>();
 }
 
 TEST_P(GELS_BATCHED, batched__double_complex)
 {
-    Arguments arg   = gels_setup_arguments(GetParam());
-    arg.batch_count = 3;
-    testing_gels<API_NORMAL, true, false, true, rocblas_double_complex>(arg);
+    run_tests<true, false, rocblas_double_complex>();
 }
 
 // INSTANTIATE_TEST_SUITE_P(daily_lapack,

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -2311,47 +2311,47 @@ inline hipsolverStatus_t hipsolver_gels(testAPI_t               API,
 }
 
 // gelsBatched - array of pointers
-inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t         API,
-                                                   hipsolverHandle_t handle,
-                                                   int               m,
-                                                   int               n,
-                                                   int               nrhs,
-                                                   float*            A[],
-                                                   int               lda,
-                                                   float*            B[],
-                                                   int               ldb,
-                                                   size_t*           lwork,
-                                                   int               bc)
+inline hipsolverStatus_t hipsolver_gelsBatched_bufferSize(testAPI_t         API,
+                                                          hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          int               nrhs,
+                                                          float*            A[],
+                                                          int               lda,
+                                                          float*            B[],
+                                                          int               ldb,
+                                                          size_t*           lwork,
+                                                          int               bc)
 {
     return hipsolverSSgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, B, ldb, lwork, bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t         API,
-                                                   hipsolverHandle_t handle,
-                                                   int               m,
-                                                   int               n,
-                                                   int               nrhs,
-                                                   double*           A[],
-                                                   int               lda,
-                                                   double*           B[],
-                                                   int               ldb,
-                                                   size_t*           lwork,
-                                                   int               bc)
+inline hipsolverStatus_t hipsolver_gelsBatched_bufferSize(testAPI_t         API,
+                                                          hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          int               nrhs,
+                                                          double*           A[],
+                                                          int               lda,
+                                                          double*           B[],
+                                                          int               ldb,
+                                                          size_t*           lwork,
+                                                          int               bc)
 {
     return hipsolverDDgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, B, ldb, lwork, bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t         API,
-                                                   hipsolverHandle_t handle,
-                                                   int               m,
-                                                   int               n,
-                                                   int               nrhs,
-                                                   hipsolverComplex* A[],
-                                                   int               lda,
-                                                   hipsolverComplex* B[],
-                                                   int               ldb,
-                                                   size_t*           lwork,
-                                                   int               bc)
+inline hipsolverStatus_t hipsolver_gelsBatched_bufferSize(testAPI_t         API,
+                                                          hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          int               nrhs,
+                                                          hipsolverComplex* A[],
+                                                          int               lda,
+                                                          hipsolverComplex* B[],
+                                                          int               ldb,
+                                                          size_t*           lwork,
+                                                          int               bc)
 {
     return hipsolverCCgelsBatched_bufferSize(handle,
                                              m,
@@ -2367,17 +2367,17 @@ inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t         API,
                                              bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t               API,
-                                                   hipsolverHandle_t       handle,
-                                                   int                     m,
-                                                   int                     n,
-                                                   int                     nrhs,
-                                                   hipsolverDoubleComplex* A[],
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* B[],
-                                                   int                     ldb,
-                                                   size_t*                 lwork,
-                                                   int                     bc)
+inline hipsolverStatus_t hipsolver_gelsBatched_bufferSize(testAPI_t               API,
+                                                          hipsolverHandle_t       handle,
+                                                          int                     m,
+                                                          int                     n,
+                                                          int                     nrhs,
+                                                          hipsolverDoubleComplex* A[],
+                                                          int                     lda,
+                                                          hipsolverDoubleComplex* B[],
+                                                          int                     ldb,
+                                                          size_t*                 lwork,
+                                                          int                     bc)
 {
     return hipsolverZZgelsBatched_bufferSize(handle,
                                              m,
@@ -2393,55 +2393,55 @@ inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t               API,
                                              bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels(testAPI_t         API,
-                                        hipsolverHandle_t handle,
-                                        int               m,
-                                        int               n,
-                                        int               nrhs,
-                                        float*            A[],
-                                        int               lda,
-                                        float*            B[],
-                                        int               ldb,
-                                        void*             work,
-                                        size_t            lwork,
-                                        int*              info,
-                                        int               bc)
+inline hipsolverStatus_t hipsolver_gelsBatched(testAPI_t         API,
+                                               hipsolverHandle_t handle,
+                                               int               m,
+                                               int               n,
+                                               int               nrhs,
+                                               float*            A[],
+                                               int               lda,
+                                               float*            B[],
+                                               int               ldb,
+                                               void*             work,
+                                               size_t            lwork,
+                                               int*              info,
+                                               int               bc)
 {
     return hipsolverSSgelsBatched(
         handle, m, n, nrhs, A, lda, B, ldb, B, ldb, work, lwork, info, bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels(testAPI_t         API,
-                                        hipsolverHandle_t handle,
-                                        int               m,
-                                        int               n,
-                                        int               nrhs,
-                                        double*           A[],
-                                        int               lda,
-                                        double*           B[],
-                                        int               ldb,
-                                        void*             work,
-                                        size_t            lwork,
-                                        int*              info,
-                                        int               bc)
+inline hipsolverStatus_t hipsolver_gelsBatched(testAPI_t         API,
+                                               hipsolverHandle_t handle,
+                                               int               m,
+                                               int               n,
+                                               int               nrhs,
+                                               double*           A[],
+                                               int               lda,
+                                               double*           B[],
+                                               int               ldb,
+                                               void*             work,
+                                               size_t            lwork,
+                                               int*              info,
+                                               int               bc)
 {
     return hipsolverDDgelsBatched(
         handle, m, n, nrhs, A, lda, B, ldb, B, ldb, work, lwork, info, bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels(testAPI_t         API,
-                                        hipsolverHandle_t handle,
-                                        int               m,
-                                        int               n,
-                                        int               nrhs,
-                                        hipsolverComplex* A[],
-                                        int               lda,
-                                        hipsolverComplex* B[],
-                                        int               ldb,
-                                        void*             work,
-                                        size_t            lwork,
-                                        int*              info,
-                                        int               bc)
+inline hipsolverStatus_t hipsolver_gelsBatched(testAPI_t         API,
+                                               hipsolverHandle_t handle,
+                                               int               m,
+                                               int               n,
+                                               int               nrhs,
+                                               hipsolverComplex* A[],
+                                               int               lda,
+                                               hipsolverComplex* B[],
+                                               int               ldb,
+                                               void*             work,
+                                               size_t            lwork,
+                                               int*              info,
+                                               int               bc)
 {
     return hipsolverCCgelsBatched(handle,
                                   m,
@@ -2459,19 +2459,19 @@ inline hipsolverStatus_t hipsolver_gels(testAPI_t         API,
                                   bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels(testAPI_t               API,
-                                        hipsolverHandle_t       handle,
-                                        int                     m,
-                                        int                     n,
-                                        int                     nrhs,
-                                        hipsolverDoubleComplex* A[],
-                                        int                     lda,
-                                        hipsolverDoubleComplex* B[],
-                                        int                     ldb,
-                                        void*                   work,
-                                        size_t                  lwork,
-                                        int*                    info,
-                                        int                     bc)
+inline hipsolverStatus_t hipsolver_gelsBatched(testAPI_t               API,
+                                               hipsolverHandle_t       handle,
+                                               int                     m,
+                                               int                     n,
+                                               int                     nrhs,
+                                               hipsolverDoubleComplex* A[],
+                                               int                     lda,
+                                               hipsolverDoubleComplex* B[],
+                                               int                     ldb,
+                                               void*                   work,
+                                               size_t                  lwork,
+                                               int*                    info,
+                                               int                     bc)
 {
     return hipsolverZZgelsBatched(handle,
                                   m,

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -2308,6 +2308,187 @@ inline hipsolverStatus_t hipsolver_gels(testAPI_t               API,
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
+}
+
+// gelsBatched - array of pointers
+inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
+                                                   testAPI_t         API,
+                                                   hipsolverHandle_t handle,
+                                                   int               m,
+                                                   int               n,
+                                                   int               nrhs,
+                                                   float*            A[],
+                                                   int               lda,
+                                                   float*            B[],
+                                                   int               ldb,
+                                                   float*            X[],
+                                                   int               ldx,
+                                                   size_t*           lwork,
+                                                   int               bc)
+{
+    if(!BATCHED)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    return hipsolverSSgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
+                                                   testAPI_t         API,
+                                                   hipsolverHandle_t handle,
+                                                   int               m,
+                                                   int               n,
+                                                   int               nrhs,
+                                                   double*           A[],
+                                                   int               lda,
+                                                   double*           B[],
+                                                   int               ldb,
+                                                   double*           X[],
+                                                   int               ldx,
+                                                   size_t*           lwork,
+                                                   int               bc)
+{
+    if(!BATCHED)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    return hipsolverDDgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
+                                                   testAPI_t         API,
+                                                   hipsolverHandle_t handle,
+                                                   int               m,
+                                                   int               n,
+                                                   int               nrhs,
+                                                   hipFloatComplex*  A[],
+                                                   int               lda,
+                                                   hipFloatComplex*  B[],
+                                                   int               ldb,
+                                                   hipFloatComplex*  X[],
+                                                   int               ldx,
+                                                   size_t*           lwork,
+                                                   int               bc)
+{
+    if(!BATCHED)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    return hipsolverCCgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
+                                                   testAPI_t         API,
+                                                   hipsolverHandle_t handle,
+                                                   int               m,
+                                                   int               n,
+                                                   int               nrhs,
+                                                   hipDoubleComplex* A[],
+                                                   int               lda,
+                                                   hipDoubleComplex* B[],
+                                                   int               ldb,
+                                                   hipDoubleComplex* X[],
+                                                   int               ldx,
+                                                   size_t*           lwork,
+                                                   int               bc)
+{
+    if(!BATCHED)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    return hipsolverZZgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
+                                        bool              INPLACE,
+                                        testAPI_t         API,
+                                        hipsolverHandle_t handle,
+                                        int               m,
+                                        int               n,
+                                        int               nrhs,
+                                        float*            A[],
+                                        int               lda,
+                                        float*            B[],
+                                        int               ldb,
+                                        float*            X[],
+                                        int               ldx,
+                                        void*             work,
+                                        size_t            lwork,
+                                        int*              niters,
+                                        int*              info,
+                                        int               bc)
+{
+    if(!BATCHED)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    return hipsolverSSgelsBatched(
+        handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info, bc);
+}
+
+inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
+                                        bool              INPLACE,
+                                        testAPI_t         API,
+                                        hipsolverHandle_t handle,
+                                        int               m,
+                                        int               n,
+                                        int               nrhs,
+                                        double*           A[],
+                                        int               lda,
+                                        double*           B[],
+                                        int               ldb,
+                                        double*           X[],
+                                        int               ldx,
+                                        void*             work,
+                                        size_t            lwork,
+                                        int*              niters,
+                                        int*              info,
+                                        int               bc)
+{
+    if(!BATCHED)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    return hipsolverDDgelsBatched(
+        handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info, bc);
+}
+
+inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
+                                        bool              INPLACE,
+                                        testAPI_t         API,
+                                        hipsolverHandle_t handle,
+                                        int               m,
+                                        int               n,
+                                        int               nrhs,
+                                        hipFloatComplex*  A[],
+                                        int               lda,
+                                        hipFloatComplex*  B[],
+                                        int               ldb,
+                                        hipFloatComplex*  X[],
+                                        int               ldx,
+                                        void*             work,
+                                        size_t            lwork,
+                                        int*              niters,
+                                        int*              info,
+                                        int               bc)
+{
+    if(!BATCHED)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    return hipsolverCCgelsBatched(
+        handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info, bc);
+}
+
+inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
+                                        bool              INPLACE,
+                                        testAPI_t         API,
+                                        hipsolverHandle_t handle,
+                                        int               m,
+                                        int               n,
+                                        int               nrhs,
+                                        hipDoubleComplex* A[],
+                                        int               lda,
+                                        hipDoubleComplex* B[],
+                                        int               ldb,
+                                        hipDoubleComplex* X[],
+                                        int               ldx,
+                                        void*             work,
+                                        size_t            lwork,
+                                        int*              niters,
+                                        int*              info,
+                                        int               bc)
+{
+    if(!BATCHED)
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    return hipsolverZZgelsBatched(
+        handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info, bc);
 }
 /********************************************************/
 

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -2311,8 +2311,7 @@ inline hipsolverStatus_t hipsolver_gels(testAPI_t               API,
 }
 
 // gelsBatched - array of pointers
-inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
-                                                   testAPI_t         API,
+inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t         API,
                                                    hipsolverHandle_t handle,
                                                    int               m,
                                                    int               n,
@@ -2321,18 +2320,13 @@ inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
                                                    int               lda,
                                                    float*            B[],
                                                    int               ldb,
-                                                   float*            X[],
-                                                   int               ldx,
                                                    size_t*           lwork,
                                                    int               bc)
 {
-    if(!BATCHED)
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    return hipsolverSSgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork, bc);
+    return hipsolverSSgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, B, ldb, lwork, bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
-                                                   testAPI_t         API,
+inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t         API,
                                                    hipsolverHandle_t handle,
                                                    int               m,
                                                    int               n,
@@ -2341,18 +2335,13 @@ inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
                                                    int               lda,
                                                    double*           B[],
                                                    int               ldb,
-                                                   double*           X[],
-                                                   int               ldx,
                                                    size_t*           lwork,
                                                    int               bc)
 {
-    if(!BATCHED)
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    return hipsolverDDgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork, bc);
+    return hipsolverDDgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, B, ldb, lwork, bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
-                                                   testAPI_t         API,
+inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t         API,
                                                    hipsolverHandle_t handle,
                                                    int               m,
                                                    int               n,
@@ -2361,13 +2350,9 @@ inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
                                                    int               lda,
                                                    hipsolverComplex* B[],
                                                    int               ldb,
-                                                   hipsolverComplex* X[],
-                                                   int               ldx,
                                                    size_t*           lwork,
                                                    int               bc)
 {
-    if(!BATCHED)
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
     return hipsolverCCgelsBatched_bufferSize(handle,
                                              m,
                                              n,
@@ -2376,14 +2361,13 @@ inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
                                              lda,
                                              (hipFloatComplex**)B,
                                              ldb,
-                                             (hipFloatComplex**)X,
-                                             ldx,
+                                             (hipFloatComplex**)B,
+                                             ldb,
                                              lwork,
                                              bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels_bufferSize(bool                    BATCHED,
-                                                   testAPI_t               API,
+inline hipsolverStatus_t hipsolver_gels_bufferSize(testAPI_t               API,
                                                    hipsolverHandle_t       handle,
                                                    int                     m,
                                                    int                     n,
@@ -2392,13 +2376,9 @@ inline hipsolverStatus_t hipsolver_gels_bufferSize(bool                    BATCH
                                                    int                     lda,
                                                    hipsolverDoubleComplex* B[],
                                                    int                     ldb,
-                                                   hipsolverDoubleComplex* X[],
-                                                   int                     ldx,
                                                    size_t*                 lwork,
                                                    int                     bc)
 {
-    if(!BATCHED)
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
     return hipsolverZZgelsBatched_bufferSize(handle,
                                              m,
                                              n,
@@ -2407,15 +2387,13 @@ inline hipsolverStatus_t hipsolver_gels_bufferSize(bool                    BATCH
                                              lda,
                                              (hipDoubleComplex**)B,
                                              ldb,
-                                             (hipDoubleComplex**)X,
-                                             ldx,
+                                             (hipDoubleComplex**)B,
+                                             ldb,
                                              lwork,
                                              bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
-                                        bool              INPLACE,
-                                        testAPI_t         API,
+inline hipsolverStatus_t hipsolver_gels(testAPI_t         API,
                                         hipsolverHandle_t handle,
                                         int               m,
                                         int               n,
@@ -2424,29 +2402,16 @@ inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
                                         int               lda,
                                         float*            B[],
                                         int               ldb,
-                                        float*            X[],
-                                        int               ldx,
                                         void*             work,
                                         size_t            lwork,
-                                        int*              niters,
                                         int*              info,
                                         int               bc)
 {
-    if(!BATCHED)
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    // For INPLACE, pass B as both B and X (output overwrites B)
-    // Note: niters parameter is ignored (not used by batched API)
-    if(INPLACE)
-        return hipsolverSSgelsBatched(
-            handle, m, n, nrhs, A, lda, B, ldb, B, ldb, work, lwork, info, bc);
-    else
-        return hipsolverSSgelsBatched(
-            handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, info, bc);
+    return hipsolverSSgelsBatched(
+        handle, m, n, nrhs, A, lda, B, ldb, B, ldb, work, lwork, info, bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
-                                        bool              INPLACE,
-                                        testAPI_t         API,
+inline hipsolverStatus_t hipsolver_gels(testAPI_t         API,
                                         hipsolverHandle_t handle,
                                         int               m,
                                         int               n,
@@ -2455,29 +2420,16 @@ inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
                                         int               lda,
                                         double*           B[],
                                         int               ldb,
-                                        double*           X[],
-                                        int               ldx,
                                         void*             work,
                                         size_t            lwork,
-                                        int*              niters,
                                         int*              info,
                                         int               bc)
 {
-    if(!BATCHED)
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    // For INPLACE, pass B as both B and X (output overwrites B)
-    // Note: niters parameter is ignored (not used by batched API)
-    if(INPLACE)
-        return hipsolverDDgelsBatched(
-            handle, m, n, nrhs, A, lda, B, ldb, B, ldb, work, lwork, info, bc);
-    else
-        return hipsolverDDgelsBatched(
-            handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, info, bc);
+    return hipsolverDDgelsBatched(
+        handle, m, n, nrhs, A, lda, B, ldb, B, ldb, work, lwork, info, bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
-                                        bool              INPLACE,
-                                        testAPI_t         API,
+inline hipsolverStatus_t hipsolver_gels(testAPI_t         API,
                                         hipsolverHandle_t handle,
                                         int               m,
                                         int               n,
@@ -2486,53 +2438,28 @@ inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
                                         int               lda,
                                         hipsolverComplex* B[],
                                         int               ldb,
-                                        hipsolverComplex* X[],
-                                        int               ldx,
                                         void*             work,
                                         size_t            lwork,
-                                        int*              niters,
                                         int*              info,
                                         int               bc)
 {
-    if(!BATCHED)
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    // For INPLACE, pass B as both B and X (output overwrites B)
-    // Note: niters parameter is ignored (not used by batched API)
-    if(INPLACE)
-        return hipsolverCCgelsBatched(handle,
-                                      m,
-                                      n,
-                                      nrhs,
-                                      (hipFloatComplex**)A,
-                                      lda,
-                                      (hipFloatComplex**)B,
-                                      ldb,
-                                      (hipFloatComplex**)B,
-                                      ldb,
-                                      work,
-                                      lwork,
-                                      info,
-                                      bc);
-    else
-        return hipsolverCCgelsBatched(handle,
-                                      m,
-                                      n,
-                                      nrhs,
-                                      (hipFloatComplex**)A,
-                                      lda,
-                                      (hipFloatComplex**)B,
-                                      ldb,
-                                      (hipFloatComplex**)X,
-                                      ldx,
-                                      work,
-                                      lwork,
-                                      info,
-                                      bc);
+    return hipsolverCCgelsBatched(handle,
+                                  m,
+                                  n,
+                                  nrhs,
+                                  (hipFloatComplex**)A,
+                                  lda,
+                                  (hipFloatComplex**)B,
+                                  ldb,
+                                  (hipFloatComplex**)B,
+                                  ldb,
+                                  work,
+                                  lwork,
+                                  info,
+                                  bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels(bool                    BATCHED,
-                                        bool                    INPLACE,
-                                        testAPI_t               API,
+inline hipsolverStatus_t hipsolver_gels(testAPI_t               API,
                                         hipsolverHandle_t       handle,
                                         int                     m,
                                         int                     n,
@@ -2541,48 +2468,25 @@ inline hipsolverStatus_t hipsolver_gels(bool                    BATCHED,
                                         int                     lda,
                                         hipsolverDoubleComplex* B[],
                                         int                     ldb,
-                                        hipsolverDoubleComplex* X[],
-                                        int                     ldx,
                                         void*                   work,
                                         size_t                  lwork,
-                                        int*                    niters,
                                         int*                    info,
                                         int                     bc)
 {
-    if(!BATCHED)
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    // For INPLACE, pass B as both B and X (output overwrites B)
-    // Note: niters parameter is ignored (not used by batched API)
-    if(INPLACE)
-        return hipsolverZZgelsBatched(handle,
-                                      m,
-                                      n,
-                                      nrhs,
-                                      (hipDoubleComplex**)A,
-                                      lda,
-                                      (hipDoubleComplex**)B,
-                                      ldb,
-                                      (hipDoubleComplex**)B,
-                                      ldb,
-                                      work,
-                                      lwork,
-                                      info,
-                                      bc);
-    else
-        return hipsolverZZgelsBatched(handle,
-                                      m,
-                                      n,
-                                      nrhs,
-                                      (hipDoubleComplex**)A,
-                                      lda,
-                                      (hipDoubleComplex**)B,
-                                      ldb,
-                                      (hipDoubleComplex**)X,
-                                      ldx,
-                                      work,
-                                      lwork,
-                                      info,
-                                      bc);
+    return hipsolverZZgelsBatched(handle,
+                                  m,
+                                  n,
+                                  nrhs,
+                                  (hipDoubleComplex**)A,
+                                  lda,
+                                  (hipDoubleComplex**)B,
+                                  ldb,
+                                  (hipDoubleComplex**)B,
+                                  ldb,
+                                  work,
+                                  lwork,
+                                  info,
+                                  bc);
 }
 /********************************************************/
 

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -2357,38 +2357,60 @@ inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
                                                    int               m,
                                                    int               n,
                                                    int               nrhs,
-                                                   hipFloatComplex*  A[],
+                                                   hipsolverComplex* A[],
                                                    int               lda,
-                                                   hipFloatComplex*  B[],
+                                                   hipsolverComplex* B[],
                                                    int               ldb,
-                                                   hipFloatComplex*  X[],
+                                                   hipsolverComplex* X[],
                                                    int               ldx,
                                                    size_t*           lwork,
                                                    int               bc)
 {
     if(!BATCHED)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    return hipsolverCCgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork, bc);
+    return hipsolverCCgelsBatched_bufferSize(handle,
+                                             m,
+                                             n,
+                                             nrhs,
+                                             (hipFloatComplex**)A,
+                                             lda,
+                                             (hipFloatComplex**)B,
+                                             ldb,
+                                             (hipFloatComplex**)X,
+                                             ldx,
+                                             lwork,
+                                             bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels_bufferSize(bool              BATCHED,
-                                                   testAPI_t         API,
-                                                   hipsolverHandle_t handle,
-                                                   int               m,
-                                                   int               n,
-                                                   int               nrhs,
-                                                   hipDoubleComplex* A[],
-                                                   int               lda,
-                                                   hipDoubleComplex* B[],
-                                                   int               ldb,
-                                                   hipDoubleComplex* X[],
-                                                   int               ldx,
-                                                   size_t*           lwork,
-                                                   int               bc)
+inline hipsolverStatus_t hipsolver_gels_bufferSize(bool                    BATCHED,
+                                                   testAPI_t               API,
+                                                   hipsolverHandle_t       handle,
+                                                   int                     m,
+                                                   int                     n,
+                                                   int                     nrhs,
+                                                   hipsolverDoubleComplex* A[],
+                                                   int                     lda,
+                                                   hipsolverDoubleComplex* B[],
+                                                   int                     ldb,
+                                                   hipsolverDoubleComplex* X[],
+                                                   int                     ldx,
+                                                   size_t*                 lwork,
+                                                   int                     bc)
 {
     if(!BATCHED)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    return hipsolverZZgelsBatched_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork, bc);
+    return hipsolverZZgelsBatched_bufferSize(handle,
+                                             m,
+                                             n,
+                                             nrhs,
+                                             (hipDoubleComplex**)A,
+                                             lda,
+                                             (hipDoubleComplex**)B,
+                                             ldb,
+                                             (hipDoubleComplex**)X,
+                                             ldx,
+                                             lwork,
+                                             bc);
 }
 
 inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
@@ -2412,8 +2434,14 @@ inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
 {
     if(!BATCHED)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    return hipsolverSSgelsBatched(
-        handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info, bc);
+    // For INPLACE, pass B as both B and X (output overwrites B)
+    // Note: niters parameter is ignored (not used by batched API)
+    if(INPLACE)
+        return hipsolverSSgelsBatched(
+            handle, m, n, nrhs, A, lda, B, ldb, B, ldb, work, lwork, info, bc);
+    else
+        return hipsolverSSgelsBatched(
+            handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, info, bc);
 }
 
 inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
@@ -2437,8 +2465,14 @@ inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
 {
     if(!BATCHED)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    return hipsolverDDgelsBatched(
-        handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info, bc);
+    // For INPLACE, pass B as both B and X (output overwrites B)
+    // Note: niters parameter is ignored (not used by batched API)
+    if(INPLACE)
+        return hipsolverDDgelsBatched(
+            handle, m, n, nrhs, A, lda, B, ldb, B, ldb, work, lwork, info, bc);
+    else
+        return hipsolverDDgelsBatched(
+            handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, info, bc);
 }
 
 inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
@@ -2448,11 +2482,11 @@ inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
                                         int               m,
                                         int               n,
                                         int               nrhs,
-                                        hipFloatComplex*  A[],
+                                        hipsolverComplex* A[],
                                         int               lda,
-                                        hipFloatComplex*  B[],
+                                        hipsolverComplex* B[],
                                         int               ldb,
-                                        hipFloatComplex*  X[],
+                                        hipsolverComplex* X[],
                                         int               ldx,
                                         void*             work,
                                         size_t            lwork,
@@ -2462,33 +2496,93 @@ inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
 {
     if(!BATCHED)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    return hipsolverCCgelsBatched(
-        handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info, bc);
+    // For INPLACE, pass B as both B and X (output overwrites B)
+    // Note: niters parameter is ignored (not used by batched API)
+    if(INPLACE)
+        return hipsolverCCgelsBatched(handle,
+                                      m,
+                                      n,
+                                      nrhs,
+                                      (hipFloatComplex**)A,
+                                      lda,
+                                      (hipFloatComplex**)B,
+                                      ldb,
+                                      (hipFloatComplex**)B,
+                                      ldb,
+                                      work,
+                                      lwork,
+                                      info,
+                                      bc);
+    else
+        return hipsolverCCgelsBatched(handle,
+                                      m,
+                                      n,
+                                      nrhs,
+                                      (hipFloatComplex**)A,
+                                      lda,
+                                      (hipFloatComplex**)B,
+                                      ldb,
+                                      (hipFloatComplex**)X,
+                                      ldx,
+                                      work,
+                                      lwork,
+                                      info,
+                                      bc);
 }
 
-inline hipsolverStatus_t hipsolver_gels(bool              BATCHED,
-                                        bool              INPLACE,
-                                        testAPI_t         API,
-                                        hipsolverHandle_t handle,
-                                        int               m,
-                                        int               n,
-                                        int               nrhs,
-                                        hipDoubleComplex* A[],
-                                        int               lda,
-                                        hipDoubleComplex* B[],
-                                        int               ldb,
-                                        hipDoubleComplex* X[],
-                                        int               ldx,
-                                        void*             work,
-                                        size_t            lwork,
-                                        int*              niters,
-                                        int*              info,
-                                        int               bc)
+inline hipsolverStatus_t hipsolver_gels(bool                    BATCHED,
+                                        bool                    INPLACE,
+                                        testAPI_t               API,
+                                        hipsolverHandle_t       handle,
+                                        int                     m,
+                                        int                     n,
+                                        int                     nrhs,
+                                        hipsolverDoubleComplex* A[],
+                                        int                     lda,
+                                        hipsolverDoubleComplex* B[],
+                                        int                     ldb,
+                                        hipsolverDoubleComplex* X[],
+                                        int                     ldx,
+                                        void*                   work,
+                                        size_t                  lwork,
+                                        int*                    niters,
+                                        int*                    info,
+                                        int                     bc)
 {
     if(!BATCHED)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    return hipsolverZZgelsBatched(
-        handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info, bc);
+    // For INPLACE, pass B as both B and X (output overwrites B)
+    // Note: niters parameter is ignored (not used by batched API)
+    if(INPLACE)
+        return hipsolverZZgelsBatched(handle,
+                                      m,
+                                      n,
+                                      nrhs,
+                                      (hipDoubleComplex**)A,
+                                      lda,
+                                      (hipDoubleComplex**)B,
+                                      ldb,
+                                      (hipDoubleComplex**)B,
+                                      ldb,
+                                      work,
+                                      lwork,
+                                      info,
+                                      bc);
+    else
+        return hipsolverZZgelsBatched(handle,
+                                      m,
+                                      n,
+                                      nrhs,
+                                      (hipDoubleComplex**)A,
+                                      lda,
+                                      (hipDoubleComplex**)B,
+                                      ldb,
+                                      (hipDoubleComplex**)X,
+                                      ldx,
+                                      work,
+                                      lwork,
+                                      info,
+                                      bc);
 }
 /********************************************************/
 

--- a/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
+++ b/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -79,6 +79,7 @@ class hipsolver_dispatcher
         static const func_map map = {
             {"gebrd", testing_gebrd<API_NORMAL, false, false, T>},
             {"gels", testing_gels<API_NORMAL, false, false, false, T>},
+            {"gels_batched", testing_gels<API_NORMAL, true, false, true, T>},
             {"geqrf", testing_geqrf<API_NORMAL, false, false, T, int, int>},
             {"geqrf_64", testing_geqrf<API_COMPAT, false, false, T, int64_t, size_t>},
             {"gesv", testing_gesv<API_NORMAL, false, false, false, T>},

--- a/projects/hipsolver/clients/include/testing_gels.hpp
+++ b/projects/hipsolver/clients/include/testing_gels.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -160,6 +160,42 @@ void gels_checkBadArgs(const hipsolverHandle_t handle,
 #endif
 }
 
+template <testAPI_t API, typename U>
+void gelsBatched_checkBadArgs(const hipsolverHandle_t handle,
+                              const int               m,
+                              const int               n,
+                              const int               nrhs,
+                              U                       dA,
+                              const int               lda,
+                              U                       dB,
+                              const int               ldb,
+                              void*                   dWork,
+                              const size_t            lwork,
+                              int*                    info,
+                              const int               bc)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_gels(API, nullptr, m, n, nrhs, dA, lda, dB, ldb, dWork, lwork, info, bc),
+        HIPSOLVER_STATUS_NOT_INITIALIZED);
+
+    // values
+    // N/A
+
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
+    // pointers
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_gels(API, handle, m, n, nrhs, (U) nullptr, lda, dB, ldb, dWork, lwork, info, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_gels(API, handle, m, n, nrhs, dA, lda, (U) nullptr, ldb, dWork, lwork, info, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_gels(API, handle, m, n, nrhs, dA, lda, dB, ldb, dWork, lwork, nullptr, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+#endif
+}
+
 template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_gels_bad_arg()
 {
@@ -178,43 +214,34 @@ void testing_gels_bad_arg()
 
     if(BATCHED)
     {
-        // // memory allocations
-        // host_strided_batch_vector<int>   hNIters(1, 1, 1, bc);
-        // device_batch_vector<T>           dA(1, 1, 1);
-        // device_batch_vector<T>           dB(1, 1, 1);
-        // device_batch_vector<T>           dX(1, 1, 1);
-        // device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
-        // CHECK_HIP_ERROR(dA.memcheck());
-        // CHECK_HIP_ERROR(dB.memcheck());
-        // CHECK_HIP_ERROR(dX.memcheck());
-        // CHECK_HIP_ERROR(dInfo.memcheck());
+        // memory allocations (batched uses array of pointers)
+        device_batch_vector<T>           dA(1, 1, bc);
+        device_batch_vector<T>           dB(1, 1, bc);
+        device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dB.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
 
-        // size_t size_W;
-        // hipsolver_gels_bufferSize(
-        //     API, handle, m, n, nrhs, dA.data(), lda, dB.data(), ldb, dX.data(), ldx, &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
-        // if(size_W)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
+        size_t size_W;
+        hipsolver_gels_bufferSize(
+            API, handle, m, n, nrhs, dA.data(), lda, dB.data(), ldb, &size_W, bc);
+        device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
+        if(size_W)
+            CHECK_HIP_ERROR(dWork.memcheck());
 
-        // // check bad arguments
-        // gels_checkBadArgs<API>(handle,
-        //                        m,
-        //                        n,
-        //                        nrhs,
-        //                        dA.data(),
-        //                        lda,
-        //                        stA,
-        //                        dB.data(),
-        //                        ldb,
-        //                        stB,
-        //                        dX.data(),
-        //                        ldx,
-        //                        stX,
-        //                        dWork.data(),
-        //                        size_W,
-        //                        hNIters.data(),
-        //                        dInfo.data(),
-        //                        bc);
+        // check bad arguments
+        gelsBatched_checkBadArgs<API>(handle,
+                                      m,
+                                      n,
+                                      nrhs,
+                                      dA.data(),
+                                      lda,
+                                      dB.data(),
+                                      ldb,
+                                      dWork.data(),
+                                      size_W,
+                                      dInfo.data(),
+                                      bc);
     }
     else
     {
@@ -314,6 +341,242 @@ void gels_initData(const hipsolverHandle_t handle,
         CHECK_HIP_ERROR(dA.transfer_from(hA));
         CHECK_HIP_ERROR(dB.transfer_from(hB));
     }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Th>
+void gelsBatched_initData(const hipsolverHandle_t handle,
+                          const int               m,
+                          const int               n,
+                          const int               nrhs,
+                          Td&                     dA,
+                          const int               lda,
+                          Td&                     dB,
+                          const int               ldb,
+                          const int               bc,
+                          Th&                     hA,
+                          Th&                     hB,
+                          Th&                     hX)
+{
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+        rocblas_init<T>(hB, true);
+
+        const int ldxCPU = max(m, n);
+
+        for(int b = 0; b < bc; ++b)
+        {
+            // scale A to avoid singularities
+            for(int i = 0; i < m; i++)
+            {
+                for(int j = 0; j < n; j++)
+                {
+                    if(i == j)
+                        hA[b][i + j * lda] += 400;
+                    else
+                        hA[b][i + j * lda] -= 4;
+                }
+            }
+
+            // populate hX with values from hB
+            for(int i = 0; i < m; i++)
+                for(int j = 0; j < nrhs; j++)
+                    hX[b][i + j * ldxCPU] = hB[b][i + j * ldb];
+        }
+    }
+
+    if(GPU)
+    {
+        // copy matrices to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+        CHECK_HIP_ERROR(dB.transfer_from(hB));
+    }
+}
+
+template <testAPI_t API,
+          typename T,
+          typename Td,
+          typename Twork,
+          typename Ud,
+          typename Th,
+          typename Uh>
+void gelsBatched_getError(const hipsolverHandle_t handle,
+                          const int               m,
+                          const int               n,
+                          const int               nrhs,
+                          Td&                     dA,
+                          const int               lda,
+                          Td&                     dB,
+                          const int               ldb,
+                          Twork&                  dWork,
+                          const size_t            lwork,
+                          Ud&                     dInfo,
+                          const int               bc,
+                          Th&                     hA,
+                          Th&                     hB,
+                          Th&                     hBRes,
+                          Th&                     hX,
+                          Uh&                     hInfo,
+                          Uh&                     hInfoRes,
+                          double*                 max_err)
+{
+    int            sizeW = max(1, min(m, n) + max(min(m, n), nrhs));
+    std::vector<T> hW(sizeW);
+
+    // input data initialization
+    gelsBatched_initData<true, true, T>(handle, m, n, nrhs, dA, lda, dB, ldb, bc, hA, hB, hX);
+
+    // execute computations
+    // GPU lapack - call gelsBatched (always in-place: result overwrites B)
+    CHECK_ROCBLAS_ERROR(hipsolver_gels(API,
+                                       handle,
+                                       m,
+                                       n,
+                                       nrhs,
+                                       dA.data(),
+                                       lda,
+                                       dB.data(),
+                                       ldb,
+                                       dWork.data(),
+                                       lwork,
+                                       dInfo.data(),
+                                       bc));
+    CHECK_HIP_ERROR(hBRes.transfer_from(dB));
+    CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
+
+    // CPU lapack
+    for(int b = 0; b < bc; ++b)
+    {
+        cpu_gels(
+            HIPSOLVER_OP_N, m, n, nrhs, hA[b], lda, hX[b], max(m, n), hW.data(), sizeW, hInfo[b]);
+    }
+
+    // error is ||hX - hBRes|| / ||hX||
+    // using vector-induced infinity norm
+    double err;
+    *max_err = 0;
+    for(int b = 0; b < bc; ++b)
+    {
+        if(hInfo[b][0] == 0)
+        {
+            err      = norm_error('I', n, nrhs, max(m, n), hX[b], hBRes[b], ldb);
+            *max_err = err > *max_err ? err : *max_err;
+        }
+    }
+
+    // also check info for singularities
+    err = 0;
+    for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
+        if(hInfo[b][0] != hInfoRes[b][0])
+            err++;
+    }
+    *max_err += err;
+}
+
+template <testAPI_t API,
+          typename T,
+          typename Td,
+          typename Twork,
+          typename Ud,
+          typename Th,
+          typename Uh>
+void gelsBatched_getPerfData(const hipsolverHandle_t handle,
+                             const int               m,
+                             const int               n,
+                             const int               nrhs,
+                             Td&                     dA,
+                             const int               lda,
+                             Td&                     dB,
+                             const int               ldb,
+                             Twork&                  dWork,
+                             const size_t            lwork,
+                             Ud&                     dInfo,
+                             const int               bc,
+                             Th&                     hA,
+                             Th&                     hB,
+                             Th&                     hX,
+                             Uh&                     hInfo,
+                             double*                 gpu_time_used,
+                             double*                 cpu_time_used,
+                             const int               hot_calls,
+                             const bool              perf)
+{
+    int            sizeW = max(1, min(m, n) + max(min(m, n), nrhs));
+    std::vector<T> hW(sizeW);
+
+    if(!perf)
+    {
+        gelsBatched_initData<true, false, T>(handle, m, n, nrhs, dA, lda, dB, ldb, bc, hA, hB, hX);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us_no_sync();
+        for(int b = 0; b < bc; ++b)
+        {
+            cpu_gels(HIPSOLVER_OP_N,
+                     m,
+                     n,
+                     nrhs,
+                     hA[b],
+                     lda,
+                     hX[b],
+                     max(m, n),
+                     hW.data(),
+                     sizeW,
+                     hInfo[b]);
+        }
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
+    }
+
+    gelsBatched_initData<true, false, T>(handle, m, n, nrhs, dA, lda, dB, ldb, bc, hA, hB, hX);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        gelsBatched_initData<false, true, T>(handle, m, n, nrhs, dA, lda, dB, ldb, bc, hA, hB, hX);
+
+        CHECK_ROCBLAS_ERROR(hipsolver_gels(API,
+                                           handle,
+                                           m,
+                                           n,
+                                           nrhs,
+                                           dA.data(),
+                                           lda,
+                                           dB.data(),
+                                           ldb,
+                                           dWork.data(),
+                                           lwork,
+                                           dInfo.data(),
+                                           bc));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(hipsolverGetStream(handle, &stream));
+    double start;
+
+    for(int iter = 0; iter < hot_calls; iter++)
+    {
+        gelsBatched_initData<false, true, T>(handle, m, n, nrhs, dA, lda, dB, ldb, bc, hA, hB, hX);
+
+        start = get_time_us_sync(stream);
+        hipsolver_gels(API,
+                       handle,
+                       m,
+                       n,
+                       nrhs,
+                       dA.data(),
+                       lda,
+                       dB.data(),
+                       ldb,
+                       dWork.data(),
+                       lwork,
+                       dInfo.data(),
+                       bc);
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
 }
 
 template <testAPI_t API,
@@ -602,27 +865,20 @@ void testing_gels(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_gels(API,
-            //                                      INPLACE,
-            //                                      handle,
-            //                                      m,
-            //                                      n,
-            //                                      nrhs,
-            //                                      (T* const*)nullptr,
-            //                                      lda,
-            //                                      stA,
-            //                                      (T* const*)nullptr,
-            //                                      ldb,
-            //                                      stB,
-            //                                      (T* const*)nullptr,
-            //                                      ldx,
-            //                                      stX,
-            //                                      (T*)nullptr,
-            //                                      0,
-            //                                      (int*)nullptr,
-            //                                      (int*)nullptr,
-            //                                      bc),
-            //                       HIPSOLVER_STATUS_INVALID_VALUE);
+            EXPECT_ROCBLAS_STATUS(hipsolver_gels(API,
+                                                 handle,
+                                                 m,
+                                                 n,
+                                                 nrhs,
+                                                 (T**)nullptr,
+                                                 lda,
+                                                 (T**)nullptr,
+                                                 ldb,
+                                                 (void*)nullptr,
+                                                 0,
+                                                 (int*)nullptr,
+                                                 bc),
+                                  HIPSOLVER_STATUS_INVALID_VALUE);
         }
         else
         {
@@ -657,8 +913,16 @@ void testing_gels(Arguments& argus)
 
     // memory size query is necessary
     size_t size_W;
-    hipsolver_gels_bufferSize(
-        API, handle, m, n, nrhs, (T*)nullptr, lda, (T*)nullptr, ldb, (T*)nullptr, ldx, &size_W);
+    if(BATCHED)
+    {
+        hipsolver_gels_bufferSize(
+            API, handle, m, n, nrhs, (T**)nullptr, lda, (T**)nullptr, ldb, &size_W, bc);
+    }
+    else
+    {
+        hipsolver_gels_bufferSize(
+            API, handle, m, n, nrhs, (T*)nullptr, lda, (T*)nullptr, ldb, (T*)nullptr, ldx, &size_W);
+    }
 
     if(argus.mem_query)
     {
@@ -668,88 +932,71 @@ void testing_gels(Arguments& argus)
 
     if(BATCHED)
     {
-        // // memory allocations
-        // host_batch_vector<T>             hA(size_A, 1, bc);
-        // host_batch_vector<T>             hB(size_B, 1, bc);
-        // host_batch_vector<T>             hBRes(size_BRes, 1, bc);
-        // host_batch_vector<T>             hX(max(m, n) * nrhs, 1, bc);
-        // host_batch_vector<T>             hXRes(size_XRes, 1, bc);
-        // host_strided_batch_vector<int>   hNIters(1, 1, 1, bc);
-        // host_strided_batch_vector<int>   hInfo(1, 1, 1, bc);
-        // host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
-        // device_batch_vector<T>           dA(size_A, 1, bc);
-        // device_batch_vector<T>           dB(size_B, 1, bc);
-        // device_batch_vector<T>           dX(size_X, 1, bc);
-        // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
-        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, 1); // size_W accounts for bc
-        // if(size_A)
-        //     CHECK_HIP_ERROR(dA.memcheck());
-        // if(size_B)
-        //     CHECK_HIP_ERROR(dB.memcheck());
-        // if(size_X)
-        //     CHECK_HIP_ERROR(dX.memcheck());
-        // if(bc)
-        //     CHECK_HIP_ERROR(dInfo.memcheck());
-        // if(size_W)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
+        // memory allocations (batched uses array of pointers)
+        // Note: gelsBatched is always in-place (result overwrites B), no separate X needed
+        host_batch_vector<T>             hA(size_A, 1, bc);
+        host_batch_vector<T>             hB(size_B, 1, bc);
+        host_batch_vector<T>             hBRes(size_BRes, 1, bc);
+        host_batch_vector<T>             hX(max(m, n) * nrhs, 1, bc);
+        host_strided_batch_vector<int>   hInfo(1, 1, 1, bc);
+        host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
+        device_batch_vector<T>           dA(size_A, 1, bc);
+        device_batch_vector<T>           dB(size_B, 1, bc);
+        device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, 1); // size_W accounts for bc
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+        if(size_B)
+            CHECK_HIP_ERROR(dB.memcheck());
+        if(bc)
+            CHECK_HIP_ERROR(dInfo.memcheck());
+        if(size_W)
+            CHECK_HIP_ERROR(dWork.memcheck());
 
-        // // check computations
-        // if(argus.unit_check || argus.norm_check)
-        //     gels_getError<API, INPLACE, T>(handle,
-        //                                    m,
-        //                                    n,
-        //                                    nrhs,
-        //                                    dA,
-        //                                    lda,
-        //                                    stA,
-        //                                    dB,
-        //                                    ldb,
-        //                                    stB,
-        //                                    dX,
-        //                                    ldx,
-        //                                    stX,
-        //                                    dWork,
-        //                                    size_W,
-        //                                    dInfo,
-        //                                    bc,
-        //                                    hA,
-        //                                    hB,
-        //                                    hBRes,
-        //                                    hX,
-        //                                    hXRes,
-        //                                    hNIters,
-        //                                    hInfo,
-        //                                    hInfoRes,
-        //                                    &max_error);
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+            gelsBatched_getError<API, T>(handle,
+                                         m,
+                                         n,
+                                         nrhs,
+                                         dA,
+                                         lda,
+                                         dB,
+                                         ldb,
+                                         dWork,
+                                         size_W,
+                                         dInfo,
+                                         bc,
+                                         hA,
+                                         hB,
+                                         hBRes,
+                                         hX,
+                                         hInfo,
+                                         hInfoRes,
+                                         &max_error);
 
-        // // collect performance data
-        // if(argus.timing)
-        //     gels_getPerfData<API, INPLACE, T>(handle,
-        //                                       m,
-        //                                       n,
-        //                                       nrhs,
-        //                                       dA,
-        //                                       lda,
-        //                                       stA,
-        //                                       dB,
-        //                                       ldb,
-        //                                       stB,
-        //                                       dX,
-        //                                       ldx,
-        //                                       stX,
-        //                                       dWork,
-        //                                       size_W,
-        //                                       dInfo,
-        //                                       bc,
-        //                                       hA,
-        //                                       hB,
-        //                                       hX,
-        //                                       hNIters,
-        //                                       hInfo,
-        //                                       &gpu_time_used,
-        //                                       &cpu_time_used,
-        //                                       hot_calls,
-        //                                       argus.perf);
+        // collect performance data
+        if(argus.timing)
+            gelsBatched_getPerfData<API, T>(handle,
+                                            m,
+                                            n,
+                                            nrhs,
+                                            dA,
+                                            lda,
+                                            dB,
+                                            ldb,
+                                            dWork,
+                                            size_W,
+                                            dInfo,
+                                            bc,
+                                            hA,
+                                            hB,
+                                            hX,
+                                            hInfo,
+                                            &gpu_time_used,
+                                            &cpu_time_used,
+                                            hot_calls,
+                                            argus.perf);
     }
     else
     {
@@ -851,8 +1098,8 @@ void testing_gels(Arguments& argus)
             std::cerr << "============================================\n";
             if(BATCHED)
             {
-                rocsolver_bench_output("m", "n", "nrhs", "lda", "ldb", "ldx", "batch_c");
-                rocsolver_bench_output(m, n, nrhs, lda, ldb, ldx, bc);
+                rocsolver_bench_output("m", "n", "nrhs", "lda", "ldb", "batch_c");
+                rocsolver_bench_output(m, n, nrhs, lda, ldb, bc);
             }
             else if(STRIDED)
             {

--- a/projects/hipsolver/clients/include/testing_gels.hpp
+++ b/projects/hipsolver/clients/include/testing_gels.hpp
@@ -176,7 +176,7 @@ void gelsBatched_checkBadArgs(const hipsolverHandle_t handle,
 {
     // handle
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_gels(API, nullptr, m, n, nrhs, dA, lda, dB, ldb, dWork, lwork, info, bc),
+        hipsolver_gelsBatched(API, nullptr, m, n, nrhs, dA, lda, dB, ldb, dWork, lwork, info, bc),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
@@ -185,13 +185,15 @@ void gelsBatched_checkBadArgs(const hipsolverHandle_t handle,
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_gels(API, handle, m, n, nrhs, (U) nullptr, lda, dB, ldb, dWork, lwork, info, bc),
+        hipsolver_gelsBatched(
+            API, handle, m, n, nrhs, (U) nullptr, lda, dB, ldb, dWork, lwork, info, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_gels(API, handle, m, n, nrhs, dA, lda, (U) nullptr, ldb, dWork, lwork, info, bc),
+        hipsolver_gelsBatched(
+            API, handle, m, n, nrhs, dA, lda, (U) nullptr, ldb, dWork, lwork, info, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_gels(API, handle, m, n, nrhs, dA, lda, dB, ldb, dWork, lwork, nullptr, bc),
+        hipsolver_gelsBatched(API, handle, m, n, nrhs, dA, lda, dB, ldb, dWork, lwork, nullptr, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
@@ -223,7 +225,7 @@ void testing_gels_bad_arg()
         CHECK_HIP_ERROR(dInfo.memcheck());
 
         size_t size_W;
-        hipsolver_gels_bufferSize(
+        hipsolver_gelsBatched_bufferSize(
             API, handle, m, n, nrhs, dA.data(), lda, dB.data(), ldb, &size_W, bc);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
         if(size_W)
@@ -428,19 +430,19 @@ void gelsBatched_getError(const hipsolverHandle_t handle,
 
     // execute computations
     // GPU lapack - call gelsBatched (always in-place: result overwrites B)
-    CHECK_ROCBLAS_ERROR(hipsolver_gels(API,
-                                       handle,
-                                       m,
-                                       n,
-                                       nrhs,
-                                       dA.data(),
-                                       lda,
-                                       dB.data(),
-                                       ldb,
-                                       dWork.data(),
-                                       lwork,
-                                       dInfo.data(),
-                                       bc));
+    CHECK_ROCBLAS_ERROR(hipsolver_gelsBatched(API,
+                                              handle,
+                                              m,
+                                              n,
+                                              nrhs,
+                                              dA.data(),
+                                              lda,
+                                              dB.data(),
+                                              ldb,
+                                              dWork.data(),
+                                              lwork,
+                                              dInfo.data(),
+                                              bc));
     CHECK_HIP_ERROR(hBRes.transfer_from(dB));
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
@@ -536,19 +538,19 @@ void gelsBatched_getPerfData(const hipsolverHandle_t handle,
     {
         gelsBatched_initData<false, true, T>(handle, m, n, nrhs, dA, lda, dB, ldb, bc, hA, hB, hX);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_gels(API,
-                                           handle,
-                                           m,
-                                           n,
-                                           nrhs,
-                                           dA.data(),
-                                           lda,
-                                           dB.data(),
-                                           ldb,
-                                           dWork.data(),
-                                           lwork,
-                                           dInfo.data(),
-                                           bc));
+        CHECK_ROCBLAS_ERROR(hipsolver_gelsBatched(API,
+                                                  handle,
+                                                  m,
+                                                  n,
+                                                  nrhs,
+                                                  dA.data(),
+                                                  lda,
+                                                  dB.data(),
+                                                  ldb,
+                                                  dWork.data(),
+                                                  lwork,
+                                                  dInfo.data(),
+                                                  bc));
     }
 
     // gpu-lapack performance
@@ -561,19 +563,19 @@ void gelsBatched_getPerfData(const hipsolverHandle_t handle,
         gelsBatched_initData<false, true, T>(handle, m, n, nrhs, dA, lda, dB, ldb, bc, hA, hB, hX);
 
         start = get_time_us_sync(stream);
-        hipsolver_gels(API,
-                       handle,
-                       m,
-                       n,
-                       nrhs,
-                       dA.data(),
-                       lda,
-                       dB.data(),
-                       ldb,
-                       dWork.data(),
-                       lwork,
-                       dInfo.data(),
-                       bc);
+        hipsolver_gelsBatched(API,
+                              handle,
+                              m,
+                              n,
+                              nrhs,
+                              dA.data(),
+                              lda,
+                              dB.data(),
+                              ldb,
+                              dWork.data(),
+                              lwork,
+                              dInfo.data(),
+                              bc);
         *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
@@ -865,19 +867,19 @@ void testing_gels(Arguments& argus)
     {
         if(BATCHED)
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_gels(API,
-                                                 handle,
-                                                 m,
-                                                 n,
-                                                 nrhs,
-                                                 (T**)nullptr,
-                                                 lda,
-                                                 (T**)nullptr,
-                                                 ldb,
-                                                 (void*)nullptr,
-                                                 0,
-                                                 (int*)nullptr,
-                                                 bc),
+            EXPECT_ROCBLAS_STATUS(hipsolver_gelsBatched(API,
+                                                        handle,
+                                                        m,
+                                                        n,
+                                                        nrhs,
+                                                        (T**)nullptr,
+                                                        lda,
+                                                        (T**)nullptr,
+                                                        ldb,
+                                                        (void*)nullptr,
+                                                        0,
+                                                        (int*)nullptr,
+                                                        bc),
                                   HIPSOLVER_STATUS_INVALID_VALUE);
         }
         else
@@ -915,7 +917,7 @@ void testing_gels(Arguments& argus)
     size_t size_W;
     if(BATCHED)
     {
-        hipsolver_gels_bufferSize(
+        hipsolver_gelsBatched_bufferSize(
             API, handle, m, n, nrhs, (T**)nullptr, lda, (T**)nullptr, ldb, &size_W, bc);
     }
     else

--- a/projects/hipsolver/library/include/internal/hipsolver-functions.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-functions.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
@@ -715,6 +715,123 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZZgels(hipsolverHandle_t handle,
                                                    size_t            lwork,
                                                    int*              niters,
                                                    int*              devInfo);
+
+// gels_batched
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSSgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     int               nrhs,
+                                                                     float*            A[],
+                                                                     int               lda,
+                                                                     float*            B[],
+                                                                     int               ldb,
+                                                                     float*            X[],
+                                                                     int               ldx,
+                                                                     size_t*           lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDDgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     int               nrhs,
+                                                                     double*           A[],
+                                                                     int               lda,
+                                                                     double*           B[],
+                                                                     int               ldb,
+                                                                     double*           X[],
+                                                                     int               ldx,
+                                                                     size_t*           lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCCgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     int               nrhs,
+                                                                     hipFloatComplex*  A[],
+                                                                     int               lda,
+                                                                     hipFloatComplex*  B[],
+                                                                     int               ldb,
+                                                                     hipFloatComplex*  X[],
+                                                                     int               ldx,
+                                                                     size_t*           lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZZgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     int               nrhs,
+                                                                     hipDoubleComplex* A[],
+                                                                     int               lda,
+                                                                     hipDoubleComplex* B[],
+                                                                     int               ldb,
+                                                                     hipDoubleComplex* X[],
+                                                                     int               ldx,
+                                                                     size_t*           lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSSgelsBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          int               nrhs,
+                                                          float*            A[],
+                                                          int               lda,
+                                                          float*            B[],
+                                                          int               ldb,
+                                                          float*            X[],
+                                                          int               ldx,
+                                                          void*             work,
+                                                          size_t            lwork,
+                                                          int*              niters,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDDgelsBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          int               nrhs,
+                                                          double*           A[],
+                                                          int               lda,
+                                                          double*           B[],
+                                                          int               ldb,
+                                                          double*           X[],
+                                                          int               ldx,
+                                                          void*             work,
+                                                          size_t            lwork,
+                                                          int*              niters,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCCgelsBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          int               nrhs,
+                                                          hipFloatComplex*  A[],
+                                                          int               lda,
+                                                          hipFloatComplex*  B[],
+                                                          int               ldb,
+                                                          hipFloatComplex*  X[],
+                                                          int               ldx,
+                                                          void*             work,
+                                                          size_t            lwork,
+                                                          int*              niters,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZZgelsBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          int               nrhs,
+                                                          hipDoubleComplex* A[],
+                                                          int               lda,
+                                                          hipDoubleComplex* B[],
+                                                          int               ldb,
+                                                          hipDoubleComplex* X[],
+                                                          int               ldx,
+                                                          void*             work,
+                                                          size_t            lwork,
+                                                          int*              niters,
+                                                          int*              devInfo,
+                                                          int               batch_count);
 
 // geqrf
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgeqrf_bufferSize(

--- a/projects/hipsolver/library/include/internal/hipsolver-functions.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-functions.h
@@ -781,7 +781,6 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSSgelsBatched(hipsolverHandle_t hand
                                                           int               ldx,
                                                           void*             work,
                                                           size_t            lwork,
-                                                          int*              niters,
                                                           int*              devInfo,
                                                           int               batch_count);
 
@@ -797,7 +796,6 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDDgelsBatched(hipsolverHandle_t hand
                                                           int               ldx,
                                                           void*             work,
                                                           size_t            lwork,
-                                                          int*              niters,
                                                           int*              devInfo,
                                                           int               batch_count);
 
@@ -813,7 +811,6 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCCgelsBatched(hipsolverHandle_t hand
                                                           int               ldx,
                                                           void*             work,
                                                           size_t            lwork,
-                                                          int*              niters,
                                                           int*              devInfo,
                                                           int               batch_count);
 
@@ -829,7 +826,6 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZZgelsBatched(hipsolverHandle_t hand
                                                           int               ldx,
                                                           void*             work,
                                                           size_t            lwork,
-                                                          int*              niters,
                                                           int*              devInfo,
                                                           int               batch_count);
 

--- a/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
@@ -3856,6 +3856,8 @@ try
     if(B != X)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
     return hipsolver::rocblas2hip_status(rocsolver_sgels_batched((rocblas_handle)handle,
                                                                  rocblas_operation_none,
                                                                  m,
@@ -3906,6 +3908,8 @@ try
     // TODO: Implement proper out-of-place support with B->X copying
     if(B != X)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
 
     return hipsolver::rocblas2hip_status(rocsolver_dgels_batched((rocblas_handle)handle,
                                                                  rocblas_operation_none,
@@ -3958,6 +3962,8 @@ try
     if(B != X)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
     return hipsolver::rocblas2hip_status(rocsolver_cgels_batched((rocblas_handle)handle,
                                                                  rocblas_operation_none,
                                                                  m,
@@ -4008,6 +4014,8 @@ try
     // TODO: Implement proper out-of-place support with B->X copying
     if(B != X)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
 
     return hipsolver::rocblas2hip_status(rocsolver_zgels_batched((rocblas_handle)handle,
                                                                  rocblas_operation_none,

--- a/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
@@ -3832,13 +3832,14 @@ hipsolverStatus_t hipsolverSSgelsBatched(hipsolverHandle_t handle,
                                          int               ldx,
                                          void*             work,
                                          size_t            lwork,
-                                         int*              niters,
                                          int*              devInfo,
                                          int               batch_count)
 try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!A || !B || !X || !devInfo)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     if(work && lwork)
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
@@ -3850,28 +3851,22 @@ try
     }
 
     // ROCsolver gels_batched only supports in-place operation on B
-    // Copy B to X if out-of-place is requested
+    // For now, only support in-place (B == X)
+    // TODO: Implement proper out-of-place support with B->X copying
     if(B != X)
-    {
-        for(int i = 0; i < batch_count; i++)
-        {
-            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(float);
-            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
-        }
-    }
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
-    return hipsolver::rocblas2hip_status(
-        rocsolver_sgels_batched((rocblas_handle)handle,
-                                rocblas_operation_none,
-                                m,
-                                n,
-                                nrhs,
-                                A,
-                                lda,
-                                (B == X) ? B : X, // Use X if we copied B to X
-                                (B == X) ? ldb : ldx,
-                                devInfo,
-                                batch_count));
+    return hipsolver::rocblas2hip_status(rocsolver_sgels_batched((rocblas_handle)handle,
+                                                                 rocblas_operation_none,
+                                                                 m,
+                                                                 n,
+                                                                 nrhs,
+                                                                 A,
+                                                                 lda,
+                                                                 B,
+                                                                 ldb,
+                                                                 devInfo,
+                                                                 batch_count));
 }
 catch(...)
 {
@@ -3890,7 +3885,6 @@ hipsolverStatus_t hipsolverDDgelsBatched(hipsolverHandle_t handle,
                                          int               ldx,
                                          void*             work,
                                          size_t            lwork,
-                                         int*              niters,
                                          int*              devInfo,
                                          int               batch_count)
 try
@@ -3908,15 +3902,10 @@ try
     }
 
     // ROCsolver gels_batched only supports in-place operation on B
-    // Copy B to X if out-of-place is requested
+    // For now, only support in-place (B == X)
+    // TODO: Implement proper out-of-place support with B->X copying
     if(B != X)
-    {
-        for(int i = 0; i < batch_count; i++)
-        {
-            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(double);
-            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
-        }
-    }
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
     return hipsolver::rocblas2hip_status(rocsolver_dgels_batched((rocblas_handle)handle,
                                                                  rocblas_operation_none,
@@ -3925,8 +3914,8 @@ try
                                                                  nrhs,
                                                                  A,
                                                                  lda,
-                                                                 (B == X) ? B : X,
-                                                                 (B == X) ? ldb : ldx,
+                                                                 B,
+                                                                 ldb,
                                                                  devInfo,
                                                                  batch_count));
 }
@@ -3947,7 +3936,6 @@ hipsolverStatus_t hipsolverCCgelsBatched(hipsolverHandle_t handle,
                                          int               ldx,
                                          void*             work,
                                          size_t            lwork,
-                                         int*              niters,
                                          int*              devInfo,
                                          int               batch_count)
 try
@@ -3965,28 +3953,22 @@ try
     }
 
     // ROCsolver gels_batched only supports in-place operation on B
-    // Copy B to X if out-of-place is requested
+    // For now, only support in-place (B == X)
+    // TODO: Implement proper out-of-place support with B->X copying
     if(B != X)
-    {
-        for(int i = 0; i < batch_count; i++)
-        {
-            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(hipFloatComplex);
-            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
-        }
-    }
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
-    return hipsolver::rocblas2hip_status(
-        rocsolver_cgels_batched((rocblas_handle)handle,
-                                rocblas_operation_none,
-                                m,
-                                n,
-                                nrhs,
-                                (rocblas_float_complex**)A,
-                                lda,
-                                (B == X) ? (rocblas_float_complex**)B : (rocblas_float_complex**)X,
-                                (B == X) ? ldb : ldx,
-                                devInfo,
-                                batch_count));
+    return hipsolver::rocblas2hip_status(rocsolver_cgels_batched((rocblas_handle)handle,
+                                                                 rocblas_operation_none,
+                                                                 m,
+                                                                 n,
+                                                                 nrhs,
+                                                                 (rocblas_float_complex**)A,
+                                                                 lda,
+                                                                 (rocblas_float_complex**)B,
+                                                                 ldb,
+                                                                 devInfo,
+                                                                 batch_count));
 }
 catch(...)
 {
@@ -4005,7 +3987,6 @@ hipsolverStatus_t hipsolverZZgelsBatched(hipsolverHandle_t handle,
                                          int               ldx,
                                          void*             work,
                                          size_t            lwork,
-                                         int*              niters,
                                          int*              devInfo,
                                          int               batch_count)
 try
@@ -4023,28 +4004,22 @@ try
     }
 
     // ROCsolver gels_batched only supports in-place operation on B
-    // Copy B to X if out-of-place is requested
+    // For now, only support in-place (B == X)
+    // TODO: Implement proper out-of-place support with B->X copying
     if(B != X)
-    {
-        for(int i = 0; i < batch_count; i++)
-        {
-            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(hipDoubleComplex);
-            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
-        }
-    }
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
-    return hipsolver::rocblas2hip_status(rocsolver_zgels_batched(
-        (rocblas_handle)handle,
-        rocblas_operation_none,
-        m,
-        n,
-        nrhs,
-        (rocblas_double_complex**)A,
-        lda,
-        (B == X) ? (rocblas_double_complex**)B : (rocblas_double_complex**)X,
-        (B == X) ? ldb : ldx,
-        devInfo,
-        batch_count));
+    return hipsolver::rocblas2hip_status(rocsolver_zgels_batched((rocblas_handle)handle,
+                                                                 rocblas_operation_none,
+                                                                 m,
+                                                                 n,
+                                                                 nrhs,
+                                                                 (rocblas_double_complex**)A,
+                                                                 lda,
+                                                                 (rocblas_double_complex**)B,
+                                                                 ldb,
+                                                                 devInfo,
+                                                                 batch_count));
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -3621,6 +3621,430 @@ try
                                                                         (rocblas_double_complex*)X,
                                                                         ldx,
                                                                         devInfo));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** GELS_BATCHED ********************/
+hipsolverStatus_t hipsolverSSgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    int               nrhs,
+                                                    float*            A[],
+                                                    int               lda,
+                                                    float*            B[],
+                                                    int               ldb,
+                                                    float*            X[],
+                                                    int               ldx,
+                                                    size_t*           lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status
+        = hipsolver::rocblas2hip_status(rocsolver_sgels_batched((rocblas_handle)handle,
+                                                                rocblas_operation_none,
+                                                                m,
+                                                                n,
+                                                                nrhs,
+                                                                nullptr,
+                                                                lda,
+                                                                nullptr,
+                                                                ldb,
+                                                                nullptr,
+                                                                batch_count));
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+
+    *lwork = sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDDgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    int               nrhs,
+                                                    double*           A[],
+                                                    int               lda,
+                                                    double*           B[],
+                                                    int               ldb,
+                                                    double*           X[],
+                                                    int               ldx,
+                                                    size_t*           lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status
+        = hipsolver::rocblas2hip_status(rocsolver_dgels_batched((rocblas_handle)handle,
+                                                                rocblas_operation_none,
+                                                                m,
+                                                                n,
+                                                                nrhs,
+                                                                nullptr,
+                                                                lda,
+                                                                nullptr,
+                                                                ldb,
+                                                                nullptr,
+                                                                batch_count));
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+
+    *lwork = sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCCgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    int               nrhs,
+                                                    hipFloatComplex*  A[],
+                                                    int               lda,
+                                                    hipFloatComplex*  B[],
+                                                    int               ldb,
+                                                    hipFloatComplex*  X[],
+                                                    int               ldx,
+                                                    size_t*           lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status
+        = hipsolver::rocblas2hip_status(rocsolver_cgels_batched((rocblas_handle)handle,
+                                                                rocblas_operation_none,
+                                                                m,
+                                                                n,
+                                                                nrhs,
+                                                                nullptr,
+                                                                lda,
+                                                                nullptr,
+                                                                ldb,
+                                                                nullptr,
+                                                                batch_count));
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+
+    *lwork = sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZZgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    int               nrhs,
+                                                    hipDoubleComplex* A[],
+                                                    int               lda,
+                                                    hipDoubleComplex* B[],
+                                                    int               ldb,
+                                                    hipDoubleComplex* X[],
+                                                    int               ldx,
+                                                    size_t*           lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status
+        = hipsolver::rocblas2hip_status(rocsolver_zgels_batched((rocblas_handle)handle,
+                                                                rocblas_operation_none,
+                                                                m,
+                                                                n,
+                                                                nrhs,
+                                                                nullptr,
+                                                                lda,
+                                                                nullptr,
+                                                                ldb,
+                                                                nullptr,
+                                                                batch_count));
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+
+    *lwork = sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSSgelsBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         int               nrhs,
+                                         float*            A[],
+                                         int               lda,
+                                         float*            B[],
+                                         int               ldb,
+                                         float*            X[],
+                                         int               ldx,
+                                         void*             work,
+                                         size_t            lwork,
+                                         int*              niters,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverSSgelsBatched_bufferSize(
+            handle, m, n, nrhs, A, lda, B, ldb, X, ldx, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    // ROCsolver gels_batched only supports in-place operation on B
+    // Copy B to X if out-of-place is requested
+    if(B != X)
+    {
+        for(int i = 0; i < batch_count; i++)
+        {
+            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(float);
+            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
+        }
+    }
+
+    return hipsolver::rocblas2hip_status(
+        rocsolver_sgels_batched((rocblas_handle)handle,
+                                rocblas_operation_none,
+                                m,
+                                n,
+                                nrhs,
+                                A,
+                                lda,
+                                (B == X) ? B : X, // Use X if we copied B to X
+                                (B == X) ? ldb : ldx,
+                                devInfo,
+                                batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDDgelsBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         int               nrhs,
+                                         double*           A[],
+                                         int               lda,
+                                         double*           B[],
+                                         int               ldb,
+                                         double*           X[],
+                                         int               ldx,
+                                         void*             work,
+                                         size_t            lwork,
+                                         int*              niters,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverDDgelsBatched_bufferSize(
+            handle, m, n, nrhs, A, lda, B, ldb, X, ldx, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    // ROCsolver gels_batched only supports in-place operation on B
+    // Copy B to X if out-of-place is requested
+    if(B != X)
+    {
+        for(int i = 0; i < batch_count; i++)
+        {
+            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(double);
+            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
+        }
+    }
+
+    return hipsolver::rocblas2hip_status(rocsolver_dgels_batched((rocblas_handle)handle,
+                                                                 rocblas_operation_none,
+                                                                 m,
+                                                                 n,
+                                                                 nrhs,
+                                                                 A,
+                                                                 lda,
+                                                                 (B == X) ? B : X,
+                                                                 (B == X) ? ldb : ldx,
+                                                                 devInfo,
+                                                                 batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCCgelsBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         int               nrhs,
+                                         hipFloatComplex*  A[],
+                                         int               lda,
+                                         hipFloatComplex*  B[],
+                                         int               ldb,
+                                         hipFloatComplex*  X[],
+                                         int               ldx,
+                                         void*             work,
+                                         size_t            lwork,
+                                         int*              niters,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverCCgelsBatched_bufferSize(
+            handle, m, n, nrhs, A, lda, B, ldb, X, ldx, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    // ROCsolver gels_batched only supports in-place operation on B
+    // Copy B to X if out-of-place is requested
+    if(B != X)
+    {
+        for(int i = 0; i < batch_count; i++)
+        {
+            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(hipFloatComplex);
+            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
+        }
+    }
+
+    return hipsolver::rocblas2hip_status(
+        rocsolver_cgels_batched((rocblas_handle)handle,
+                                rocblas_operation_none,
+                                m,
+                                n,
+                                nrhs,
+                                (rocblas_float_complex**)A,
+                                lda,
+                                (B == X) ? (rocblas_float_complex**)B : (rocblas_float_complex**)X,
+                                (B == X) ? ldb : ldx,
+                                devInfo,
+                                batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZZgelsBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         int               nrhs,
+                                         hipDoubleComplex* A[],
+                                         int               lda,
+                                         hipDoubleComplex* B[],
+                                         int               ldb,
+                                         hipDoubleComplex* X[],
+                                         int               ldx,
+                                         void*             work,
+                                         size_t            lwork,
+                                         int*              niters,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverZZgelsBatched_bufferSize(
+            handle, m, n, nrhs, A, lda, B, ldb, X, ldx, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    // ROCsolver gels_batched only supports in-place operation on B
+    // Copy B to X if out-of-place is requested
+    if(B != X)
+    {
+        for(int i = 0; i < batch_count; i++)
+        {
+            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(hipDoubleComplex);
+            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
+        }
+    }
+
+    return hipsolver::rocblas2hip_status(rocsolver_zgels_batched(
+        (rocblas_handle)handle,
+        rocblas_operation_none,
+        m,
+        n,
+        nrhs,
+        (rocblas_double_complex**)A,
+        lda,
+        (B == X) ? (rocblas_double_complex**)B : (rocblas_double_complex**)X,
+        (B == X) ? ldb : ldx,
+        devInfo,
+        batch_count));
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -2030,8 +2030,7 @@ try
     if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // cuBLAS gelsBatched requires workspace for info parameter
-    *lwork = sizeof(int);
+    *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
 catch(...)
@@ -2058,8 +2057,7 @@ try
     if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // cuBLAS gelsBatched requires workspace for info parameter
-    *lwork = sizeof(int);
+    *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
 catch(...)
@@ -2086,8 +2084,7 @@ try
     if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // cuBLAS gelsBatched requires workspace for info parameter
-    *lwork = sizeof(int);
+    *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
 catch(...)
@@ -2114,8 +2111,7 @@ try
     if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // cuBLAS gelsBatched requires workspace for info parameter
-    *lwork = sizeof(int);
+    *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
 catch(...)
@@ -2150,12 +2146,7 @@ try
     if(B != X)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
-    // cuBLAS needs workspace for info parameter
-    if(!work || lwork < sizeof(int))
-        return HIPSOLVER_STATUS_INVALID_VALUE;
-
-    // Use work buffer as info pointer (cuBLAS info parameter for input validation)
-    int* info = static_cast<int*>(work);
+    int hInfo = 0;
 
     cudaStream_t stream;
     cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
@@ -2164,21 +2155,21 @@ try
     cublasCreate(&cublas_handle);
     cublasSetStream(cublas_handle, stream);
 
-    cublasStatus_t status = cublasSgelsBatched(cublas_handle,
-                                               CUBLAS_OP_N,
-                                               m,
-                                               n,
-                                               nrhs,
-                                               (float* const*)A,
-                                               lda,
-                                               (float**)B,
-                                               ldb,
-                                               devInfo,
-                                               info,
-                                               batch_count);
+    auto status = hipsolver::cuda2hip_status(cublasSgelsBatched(cublas_handle,
+                                                                CUBLAS_OP_N,
+                                                                m,
+                                                                n,
+                                                                nrhs,
+                                                                (float* const*)A,
+                                                                lda,
+                                                                (float**)B,
+                                                                ldb,
+                                                                &hInfo,
+                                                                devInfo,
+                                                                batch_count));
 
     cublasDestroy(cublas_handle);
-    return hipsolver::cuda2hip_status(status);
+    return status;
 }
 catch(...)
 {
@@ -2212,12 +2203,7 @@ try
     if(B != X)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
-    // cuBLAS needs workspace for info parameter
-    if(!work || lwork < sizeof(int))
-        return HIPSOLVER_STATUS_INVALID_VALUE;
-
-    // Use work buffer as info pointer (cuBLAS info parameter for input validation)
-    int* info = static_cast<int*>(work);
+    int hInfo = 0;
 
     cudaStream_t stream;
     cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
@@ -2226,21 +2212,21 @@ try
     cublasCreate(&cublas_handle);
     cublasSetStream(cublas_handle, stream);
 
-    cublasStatus_t status = cublasDgelsBatched(cublas_handle,
-                                               CUBLAS_OP_N,
-                                               m,
-                                               n,
-                                               nrhs,
-                                               (double* const*)A,
-                                               lda,
-                                               (double**)B,
-                                               ldb,
-                                               devInfo,
-                                               info,
-                                               batch_count);
+    auto status = hipsolver::cuda2hip_status(cublasDgelsBatched(cublas_handle,
+                                                                CUBLAS_OP_N,
+                                                                m,
+                                                                n,
+                                                                nrhs,
+                                                                (double* const*)A,
+                                                                lda,
+                                                                (double**)B,
+                                                                ldb,
+                                                                &hInfo,
+                                                                devInfo,
+                                                                batch_count));
 
     cublasDestroy(cublas_handle);
-    return hipsolver::cuda2hip_status(status);
+    return status;
 }
 catch(...)
 {
@@ -2272,12 +2258,7 @@ try
     if(B != X)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
-    // cuBLAS needs workspace for info parameter
-    if(!work || lwork < sizeof(int))
-        return HIPSOLVER_STATUS_INVALID_VALUE;
-
-    // Use work buffer as info pointer (cuBLAS info parameter for input validation)
-    int* info = static_cast<int*>(work);
+    int hInfo = 0;
 
     cudaStream_t stream;
     cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
@@ -2286,21 +2267,21 @@ try
     cublasCreate(&cublas_handle);
     cublasSetStream(cublas_handle, stream);
 
-    cublasStatus_t status = cublasCgelsBatched(cublas_handle,
-                                               CUBLAS_OP_N,
-                                               m,
-                                               n,
-                                               nrhs,
-                                               (cuComplex* const*)A,
-                                               lda,
-                                               (cuComplex**)B,
-                                               ldb,
-                                               devInfo,
-                                               info,
-                                               batch_count);
+    auto status = hipsolver::cuda2hip_status(cublasCgelsBatched(cublas_handle,
+                                                                CUBLAS_OP_N,
+                                                                m,
+                                                                n,
+                                                                nrhs,
+                                                                (cuComplex* const*)A,
+                                                                lda,
+                                                                (cuComplex**)B,
+                                                                ldb,
+                                                                &hInfo,
+                                                                devInfo,
+                                                                batch_count));
 
     cublasDestroy(cublas_handle);
-    return hipsolver::cuda2hip_status(status);
+    return status;
 }
 catch(...)
 {
@@ -2332,12 +2313,7 @@ try
     if(B != X)
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
-    // cuBLAS needs workspace for info parameter
-    if(!work || lwork < sizeof(int))
-        return HIPSOLVER_STATUS_INVALID_VALUE;
-
-    // Use work buffer as info pointer (cuBLAS info parameter for input validation)
-    int* info = static_cast<int*>(work);
+    int hInfo = 0;
 
     cudaStream_t stream;
     cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
@@ -2346,21 +2322,21 @@ try
     cublasCreate(&cublas_handle);
     cublasSetStream(cublas_handle, stream);
 
-    cublasStatus_t status = cublasZgelsBatched(cublas_handle,
-                                               CUBLAS_OP_N,
-                                               m,
-                                               n,
-                                               nrhs,
-                                               (cuDoubleComplex* const*)A,
-                                               lda,
-                                               (cuDoubleComplex**)B,
-                                               ldb,
-                                               devInfo,
-                                               info,
-                                               batch_count);
+    auto status = hipsolver::cuda2hip_status(cublasZgelsBatched(cublas_handle,
+                                                                CUBLAS_OP_N,
+                                                                m,
+                                                                n,
+                                                                nrhs,
+                                                                (cuDoubleComplex* const*)A,
+                                                                lda,
+                                                                (cuDoubleComplex**)B,
+                                                                ldb,
+                                                                &hInfo,
+                                                                devInfo,
+                                                                batch_count));
 
     cublasDestroy(cublas_handle);
-    return hipsolver::cuda2hip_status(status);
+    return status;
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -2030,8 +2030,8 @@ try
     if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // cuBLAS gelsBatched typically requires no workspace
-    *lwork = 0;
+    // cuBLAS gelsBatched requires workspace for info parameter
+    *lwork = sizeof(int);
     return HIPSOLVER_STATUS_SUCCESS;
 }
 catch(...)
@@ -2058,8 +2058,8 @@ try
     if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // cuBLAS gelsBatched typically requires no workspace
-    *lwork = 0;
+    // cuBLAS gelsBatched requires workspace for info parameter
+    *lwork = sizeof(int);
     return HIPSOLVER_STATUS_SUCCESS;
 }
 catch(...)
@@ -2086,8 +2086,8 @@ try
     if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // cuBLAS gelsBatched typically requires no workspace
-    *lwork = 0;
+    // cuBLAS gelsBatched requires workspace for info parameter
+    *lwork = sizeof(int);
     return HIPSOLVER_STATUS_SUCCESS;
 }
 catch(...)
@@ -2114,8 +2114,8 @@ try
     if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // cuBLAS gelsBatched typically requires no workspace
-    *lwork = 0;
+    // cuBLAS gelsBatched requires workspace for info parameter
+    *lwork = sizeof(int);
     return HIPSOLVER_STATUS_SUCCESS;
 }
 catch(...)
@@ -2135,27 +2135,28 @@ hipsolverStatus_t hipsolverSSgelsBatched(hipsolverHandle_t handle,
                                          int               ldx,
                                          void*             work,
                                          size_t            lwork,
-                                         int*              niters,
                                          int*              devInfo,
                                          int               batch_count)
 try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!A || !B || !X || !devInfo)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // Copy B to X if they're different (cuBLAS likely operates in-place)
+    // cuBLAS gelsBatched operates in-place on B
+    // For now, only support in-place (B == X)
+    // TODO: Implement proper out-of-place support with B->X copying
     if(B != X)
-    {
-        for(int i = 0; i < batch_count; i++)
-        {
-            // Calculate the actual matrix size (max(m,n) x nrhs)
-            int    rows = (m >= n) ? m : n;
-            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(float);
-            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
-        }
-    }
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
 
-    // Call cuBLAS gelsBatched
+    // cuBLAS needs workspace for info parameter
+    if(!work || lwork < sizeof(int))
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // Use work buffer as info pointer (cuBLAS info parameter for input validation)
+    int* info = static_cast<int*>(work);
+
     return hipsolver::cuda2hip_status(cublasSgelsBatched((cublasHandle_t)handle,
                                                          CUBLAS_OP_N,
                                                          m,
@@ -2163,10 +2164,10 @@ try
                                                          nrhs,
                                                          (float* const*)A,
                                                          lda,
-                                                         (float**)((B == X) ? B : X),
-                                                         (B == X) ? ldb : ldx,
+                                                         (float**)B,
+                                                         ldb,
                                                          devInfo,
-                                                         nullptr,
+                                                         info,
                                                          batch_count));
 }
 catch(...)
@@ -2186,24 +2187,27 @@ hipsolverStatus_t hipsolverDDgelsBatched(hipsolverHandle_t handle,
                                          int               ldx,
                                          void*             work,
                                          size_t            lwork,
-                                         int*              niters,
                                          int*              devInfo,
                                          int               batch_count)
 try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!A || !B || !X || !devInfo)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // Copy B to X if they're different (cuBLAS likely operates in-place)
+    // cuBLAS gelsBatched operates in-place on B
+    // For now, only support in-place (B == X)
+    // TODO: Implement proper out-of-place support with B->X copying
     if(B != X)
-    {
-        for(int i = 0; i < batch_count; i++)
-        {
-            int    rows = (m >= n) ? m : n;
-            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(double);
-            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
-        }
-    }
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+
+    // cuBLAS needs workspace for info parameter
+    if(!work || lwork < sizeof(int))
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // Use work buffer as info pointer (cuBLAS info parameter for input validation)
+    int* info = static_cast<int*>(work);
 
     return hipsolver::cuda2hip_status(cublasDgelsBatched((cublasHandle_t)handle,
                                                          CUBLAS_OP_N,
@@ -2212,10 +2216,10 @@ try
                                                          nrhs,
                                                          (double* const*)A,
                                                          lda,
-                                                         (double**)((B == X) ? B : X),
-                                                         (B == X) ? ldb : ldx,
+                                                         (double**)B,
+                                                         ldb,
                                                          devInfo,
-                                                         nullptr,
+                                                         info,
                                                          batch_count));
 }
 catch(...)
@@ -2235,24 +2239,25 @@ hipsolverStatus_t hipsolverCCgelsBatched(hipsolverHandle_t handle,
                                          int               ldx,
                                          void*             work,
                                          size_t            lwork,
-                                         int*              niters,
                                          int*              devInfo,
                                          int               batch_count)
 try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!A || !B || !X || !devInfo)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // Copy B to X if they're different (cuBLAS likely operates in-place)
+    // cuBLAS gelsBatched operates in-place on B
     if(B != X)
-    {
-        for(int i = 0; i < batch_count; i++)
-        {
-            int    rows = (m >= n) ? m : n;
-            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(hipFloatComplex);
-            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
-        }
-    }
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+
+    // cuBLAS needs workspace for info parameter
+    if(!work || lwork < sizeof(int))
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // Use work buffer as info pointer (cuBLAS info parameter for input validation)
+    int* info = static_cast<int*>(work);
 
     return hipsolver::cuda2hip_status(cublasCgelsBatched((cublasHandle_t)handle,
                                                          CUBLAS_OP_N,
@@ -2261,10 +2266,10 @@ try
                                                          nrhs,
                                                          (cuComplex* const*)A,
                                                          lda,
-                                                         (cuComplex**)((B == X) ? B : X),
-                                                         (B == X) ? ldb : ldx,
+                                                         (cuComplex**)B,
+                                                         ldb,
                                                          devInfo,
-                                                         nullptr,
+                                                         info,
                                                          batch_count));
 }
 catch(...)
@@ -2284,24 +2289,25 @@ hipsolverStatus_t hipsolverZZgelsBatched(hipsolverHandle_t handle,
                                          int               ldx,
                                          void*             work,
                                          size_t            lwork,
-                                         int*              niters,
                                          int*              devInfo,
                                          int               batch_count)
 try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!A || !B || !X || !devInfo)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    // Copy B to X if they're different (cuBLAS likely operates in-place)
+    // cuBLAS gelsBatched operates in-place on B
     if(B != X)
-    {
-        for(int i = 0; i < batch_count; i++)
-        {
-            int    rows = (m >= n) ? m : n;
-            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(hipDoubleComplex);
-            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
-        }
-    }
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+
+    // cuBLAS needs workspace for info parameter
+    if(!work || lwork < sizeof(int))
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // Use work buffer as info pointer (cuBLAS info parameter for input validation)
+    int* info = static_cast<int*>(work);
 
     return hipsolver::cuda2hip_status(cublasZgelsBatched((cublasHandle_t)handle,
                                                          CUBLAS_OP_N,
@@ -2310,10 +2316,10 @@ try
                                                          nrhs,
                                                          (cuDoubleComplex* const*)A,
                                                          lda,
-                                                         (cuDoubleComplex**)((B == X) ? B : X),
-                                                         (B == X) ? ldb : ldx,
+                                                         (cuDoubleComplex**)B,
+                                                         ldb,
                                                          devInfo,
-                                                         nullptr,
+                                                         info,
                                                          batch_count));
 }
 catch(...)

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -2004,6 +2004,317 @@ try
                                                        lwork,
                                                        niters,
                                                        devInfo));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** GELS_BATCHED ********************/
+hipsolverStatus_t hipsolverSSgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    int               nrhs,
+                                                    float*            A[],
+                                                    int               lda,
+                                                    float*            B[],
+                                                    int               ldb,
+                                                    float*            X[],
+                                                    int               ldx,
+                                                    size_t*           lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // cuBLAS gelsBatched typically requires no workspace
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDDgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    int               nrhs,
+                                                    double*           A[],
+                                                    int               lda,
+                                                    double*           B[],
+                                                    int               ldb,
+                                                    double*           X[],
+                                                    int               ldx,
+                                                    size_t*           lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // cuBLAS gelsBatched typically requires no workspace
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCCgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    int               nrhs,
+                                                    hipFloatComplex*  A[],
+                                                    int               lda,
+                                                    hipFloatComplex*  B[],
+                                                    int               ldb,
+                                                    hipFloatComplex*  X[],
+                                                    int               ldx,
+                                                    size_t*           lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // cuBLAS gelsBatched typically requires no workspace
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZZgelsBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    int               nrhs,
+                                                    hipDoubleComplex* A[],
+                                                    int               lda,
+                                                    hipDoubleComplex* B[],
+                                                    int               ldb,
+                                                    hipDoubleComplex* X[],
+                                                    int               ldx,
+                                                    size_t*           lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // cuBLAS gelsBatched typically requires no workspace
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSSgelsBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         int               nrhs,
+                                         float*            A[],
+                                         int               lda,
+                                         float*            B[],
+                                         int               ldb,
+                                         float*            X[],
+                                         int               ldx,
+                                         void*             work,
+                                         size_t            lwork,
+                                         int*              niters,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    // Copy B to X if they're different (cuBLAS likely operates in-place)
+    if(B != X)
+    {
+        for(int i = 0; i < batch_count; i++)
+        {
+            // Calculate the actual matrix size (max(m,n) x nrhs)
+            int    rows = (m >= n) ? m : n;
+            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(float);
+            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
+        }
+    }
+
+    // Call cuBLAS gelsBatched
+    return hipsolver::cuda2hip_status(cublasSgelsBatched((cublasHandle_t)handle,
+                                                         CUBLAS_OP_N,
+                                                         m,
+                                                         n,
+                                                         nrhs,
+                                                         (float* const*)A,
+                                                         lda,
+                                                         (float**)((B == X) ? B : X),
+                                                         (B == X) ? ldb : ldx,
+                                                         devInfo,
+                                                         nullptr,
+                                                         batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDDgelsBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         int               nrhs,
+                                         double*           A[],
+                                         int               lda,
+                                         double*           B[],
+                                         int               ldb,
+                                         double*           X[],
+                                         int               ldx,
+                                         void*             work,
+                                         size_t            lwork,
+                                         int*              niters,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    // Copy B to X if they're different (cuBLAS likely operates in-place)
+    if(B != X)
+    {
+        for(int i = 0; i < batch_count; i++)
+        {
+            int    rows = (m >= n) ? m : n;
+            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(double);
+            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
+        }
+    }
+
+    return hipsolver::cuda2hip_status(cublasDgelsBatched((cublasHandle_t)handle,
+                                                         CUBLAS_OP_N,
+                                                         m,
+                                                         n,
+                                                         nrhs,
+                                                         (double* const*)A,
+                                                         lda,
+                                                         (double**)((B == X) ? B : X),
+                                                         (B == X) ? ldb : ldx,
+                                                         devInfo,
+                                                         nullptr,
+                                                         batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCCgelsBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         int               nrhs,
+                                         hipFloatComplex*  A[],
+                                         int               lda,
+                                         hipFloatComplex*  B[],
+                                         int               ldb,
+                                         hipFloatComplex*  X[],
+                                         int               ldx,
+                                         void*             work,
+                                         size_t            lwork,
+                                         int*              niters,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    // Copy B to X if they're different (cuBLAS likely operates in-place)
+    if(B != X)
+    {
+        for(int i = 0; i < batch_count; i++)
+        {
+            int    rows = (m >= n) ? m : n;
+            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(hipFloatComplex);
+            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
+        }
+    }
+
+    return hipsolver::cuda2hip_status(cublasCgelsBatched((cublasHandle_t)handle,
+                                                         CUBLAS_OP_N,
+                                                         m,
+                                                         n,
+                                                         nrhs,
+                                                         (cuComplex* const*)A,
+                                                         lda,
+                                                         (cuComplex**)((B == X) ? B : X),
+                                                         (B == X) ? ldb : ldx,
+                                                         devInfo,
+                                                         nullptr,
+                                                         batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZZgelsBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         int               nrhs,
+                                         hipDoubleComplex* A[],
+                                         int               lda,
+                                         hipDoubleComplex* B[],
+                                         int               ldb,
+                                         hipDoubleComplex* X[],
+                                         int               ldx,
+                                         void*             work,
+                                         size_t            lwork,
+                                         int*              niters,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    // Copy B to X if they're different (cuBLAS likely operates in-place)
+    if(B != X)
+    {
+        for(int i = 0; i < batch_count; i++)
+        {
+            int    rows = (m >= n) ? m : n;
+            size_t size = static_cast<size_t>(ldb) * nrhs * sizeof(hipDoubleComplex);
+            CHECK_HIP_ERROR(hipMemcpy(X[i], B[i], size, hipMemcpyDeviceToDevice));
+        }
+    }
+
+    return hipsolver::cuda2hip_status(cublasZgelsBatched((cublasHandle_t)handle,
+                                                         CUBLAS_OP_N,
+                                                         m,
+                                                         n,
+                                                         nrhs,
+                                                         (cuDoubleComplex* const*)A,
+                                                         lda,
+                                                         (cuDoubleComplex**)((B == X) ? B : X),
+                                                         (B == X) ? ldb : ldx,
+                                                         devInfo,
+                                                         nullptr,
+                                                         batch_count));
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -2157,18 +2157,28 @@ try
     // Use work buffer as info pointer (cuBLAS info parameter for input validation)
     int* info = static_cast<int*>(work);
 
-    return hipsolver::cuda2hip_status(cublasSgelsBatched((cublasHandle_t)handle,
-                                                         CUBLAS_OP_N,
-                                                         m,
-                                                         n,
-                                                         nrhs,
-                                                         (float* const*)A,
-                                                         lda,
-                                                         (float**)B,
-                                                         ldb,
-                                                         devInfo,
-                                                         info,
-                                                         batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status = cublasSgelsBatched(cublas_handle,
+                                               CUBLAS_OP_N,
+                                               m,
+                                               n,
+                                               nrhs,
+                                               (float* const*)A,
+                                               lda,
+                                               (float**)B,
+                                               ldb,
+                                               devInfo,
+                                               info,
+                                               batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {
@@ -2209,18 +2219,28 @@ try
     // Use work buffer as info pointer (cuBLAS info parameter for input validation)
     int* info = static_cast<int*>(work);
 
-    return hipsolver::cuda2hip_status(cublasDgelsBatched((cublasHandle_t)handle,
-                                                         CUBLAS_OP_N,
-                                                         m,
-                                                         n,
-                                                         nrhs,
-                                                         (double* const*)A,
-                                                         lda,
-                                                         (double**)B,
-                                                         ldb,
-                                                         devInfo,
-                                                         info,
-                                                         batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status = cublasDgelsBatched(cublas_handle,
+                                               CUBLAS_OP_N,
+                                               m,
+                                               n,
+                                               nrhs,
+                                               (double* const*)A,
+                                               lda,
+                                               (double**)B,
+                                               ldb,
+                                               devInfo,
+                                               info,
+                                               batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {
@@ -2259,18 +2279,28 @@ try
     // Use work buffer as info pointer (cuBLAS info parameter for input validation)
     int* info = static_cast<int*>(work);
 
-    return hipsolver::cuda2hip_status(cublasCgelsBatched((cublasHandle_t)handle,
-                                                         CUBLAS_OP_N,
-                                                         m,
-                                                         n,
-                                                         nrhs,
-                                                         (cuComplex* const*)A,
-                                                         lda,
-                                                         (cuComplex**)B,
-                                                         ldb,
-                                                         devInfo,
-                                                         info,
-                                                         batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status = cublasCgelsBatched(cublas_handle,
+                                               CUBLAS_OP_N,
+                                               m,
+                                               n,
+                                               nrhs,
+                                               (cuComplex* const*)A,
+                                               lda,
+                                               (cuComplex**)B,
+                                               ldb,
+                                               devInfo,
+                                               info,
+                                               batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {
@@ -2309,18 +2339,28 @@ try
     // Use work buffer as info pointer (cuBLAS info parameter for input validation)
     int* info = static_cast<int*>(work);
 
-    return hipsolver::cuda2hip_status(cublasZgelsBatched((cublasHandle_t)handle,
-                                                         CUBLAS_OP_N,
-                                                         m,
-                                                         n,
-                                                         nrhs,
-                                                         (cuDoubleComplex* const*)A,
-                                                         lda,
-                                                         (cuDoubleComplex**)B,
-                                                         ldb,
-                                                         devInfo,
-                                                         info,
-                                                         batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status = cublasZgelsBatched(cublas_handle,
+                                               CUBLAS_OP_N,
+                                               m,
+                                               n,
+                                               nrhs,
+                                               (cuDoubleComplex* const*)A,
+                                               lda,
+                                               (cuDoubleComplex**)B,
+                                               ldb,
+                                               devInfo,
+                                               info,
+                                               batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -280,6 +280,33 @@ hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus)
         return HIPSOLVER_STATUS_ZERO_PIVOT;
     case CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
         return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+    default:
+        return HIPSOLVER_STATUS_UNKNOWN;
+    }
+}
+
+hipsolverStatus_t cuda2hip_status(cublasStatus_t cuStatus)
+{
+    switch(cuStatus)
+    {
+    case CUBLAS_STATUS_SUCCESS:
+        return HIPSOLVER_STATUS_SUCCESS;
+    case CUBLAS_STATUS_NOT_INITIALIZED:
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    case CUBLAS_STATUS_ALLOC_FAILED:
+        return HIPSOLVER_STATUS_ALLOC_FAILED;
+    case CUBLAS_STATUS_INVALID_VALUE:
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    case CUBLAS_STATUS_MAPPING_ERROR:
+        return HIPSOLVER_STATUS_MAPPING_ERROR;
+    case CUBLAS_STATUS_EXECUTION_FAILED:
+        return HIPSOLVER_STATUS_EXECUTION_FAILED;
+    case CUBLAS_STATUS_INTERNAL_ERROR:
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+    case CUBLAS_STATUS_NOT_SUPPORTED:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    case CUBLAS_STATUS_ARCH_MISMATCH:
+        return HIPSOLVER_STATUS_ARCH_MISMATCH;
     default:
         return HIPSOLVER_STATUS_UNKNOWN;
     }

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,6 +65,8 @@ hipsolverDeterministicMode_t cuda2hip_deterministic(cusolverDeterministicMode_t 
 #endif
 
 hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus);
+
+hipsolverStatus_t cuda2hip_status(cublasStatus_t cuStatus);
 
 // Dense API
 cusolverDnFunction_t hip2cuda_function(hipsolverDnFunction_t func);


### PR DESCRIPTION
## Motivation

We want to be able to test AMD vs. NVIDIA's (rocSOLVER vs cuBLAS) implementation of `gels_batched` using a benchmark framework unified with the rest of hipSOLVER.

## Technical Details

We add `hipsolver_gelsXXBatched` to hipSOLVER's API, implement a backend for AMD and NVIDIA that reconciles the differences in input parameters, and add it to our testing/benchmarking client.

We make new function headers for `gels_batched` in the client's internal API and the testing files as opposed to integrating the batched case into a function with the same function header. This is to account for the differences of `gels_batched` between cuSOLVER and cuBLAS, but breaks the pattern we typically follow in hipSOLVER.

### NOTE:
This change is made alongside changes to add `geqrf_batched`, `getrf_batched`, `getrs_batched`, and `getri_batched`. You can find PRs for each of these routines, each of them reading extremely similarly.

## Test Plan

Run new tests on AMD and NVIDIA hardware. Try invoking `gels_batched` from the benchmark client.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
