### PR TITLE
[hipSOLVER] Add geqrfBatched for testing

### DIFF
--- a/projects/hipsolver/CHANGELOG.md
+++ b/projects/hipsolver/CHANGELOG.md
@@ -6,6 +6,12 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ## (Unreleased) hipSOLVER
 
 ### Added
+
+* Added functions:
+  * geqrfBatched
+    * hipsolverXgeqrfBatched_bufferSize
+    * hipsolverXgeqrfBatched
+
 ### Changed
 ### Removed
 ### Optimized

--- a/projects/hipsolver/clients/gtest/geqrf_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/geqrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -100,7 +100,7 @@ protected:
         if(arg.peek<rocblas_int>("m") == -1 && arg.peek<rocblas_int>("n") == -1)
             testing_geqrf_bad_arg<API, BATCHED, STRIDED, T, I, SIZE>();
 
-        arg.batch_count = 1;
+        arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
         testing_geqrf<API, BATCHED, STRIDED, T, I, SIZE>(arg);
     }
 };
@@ -201,6 +201,28 @@ TEST_P(GEQRF_COMPAT_64, __float_complex)
 TEST_P(GEQRF_COMPAT_64, __double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
+}
+
+// batched tests
+
+TEST_P(GEQRF, batched__float)
+{
+    run_tests<true, false, float>();
+}
+
+TEST_P(GEQRF, batched__double)
+{
+    run_tests<true, false, double>();
+}
+
+TEST_P(GEQRF, batched__float_complex)
+{
+    run_tests<true, false, rocblas_float_complex>();
+}
+
+TEST_P(GEQRF, batched__double_complex)
+{
+    run_tests<true, false, rocblas_double_complex>();
 }
 
 // INSTANTIATE_TEST_SUITE_P(daily_lapack,

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -2877,6 +2877,111 @@ inline hipsolverStatus_t hipsolver_geqrf(testAPI_t               API,
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
+}
+
+// batched
+inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
+    hipsolverHandle_t handle, int m, int n, float** A, int lda, int* lwork, int bc)
+{
+    return hipsolverSgeqrfBatched_bufferSize(handle, m, n, A, lda, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
+    hipsolverHandle_t handle, int m, int n, double** A, int lda, int* lwork, int bc)
+{
+    return hipsolverDgeqrfBatched_bufferSize(handle, m, n, A, lda, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
+    hipsolverHandle_t handle, int m, int n, hipsolverComplex** A, int lda, int* lwork, int bc)
+{
+    return hipsolverCgeqrfBatched_bufferSize(handle, m, n, (hipFloatComplex**)A, lda, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
+    hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex** A, int lda, int* lwork, int bc)
+{
+    return hipsolverZgeqrfBatched_bufferSize(handle, m, n, (hipDoubleComplex**)A, lda, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_geqrf(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         float**           A,
+                                         int               lda,
+                                         float*            tau,
+                                         int               strideTau,
+                                         float*            work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               bc)
+{
+    return hipsolverSgeqrfBatched(handle, m, n, A, lda, tau, strideTau, work, lwork, devInfo, bc);
+}
+
+inline hipsolverStatus_t hipsolver_geqrf(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         double**          A,
+                                         int               lda,
+                                         double*           tau,
+                                         int               strideTau,
+                                         double*           work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               bc)
+{
+    return hipsolverDgeqrfBatched(handle, m, n, A, lda, tau, strideTau, work, lwork, devInfo, bc);
+}
+
+inline hipsolverStatus_t hipsolver_geqrf(hipsolverHandle_t  handle,
+                                         int                m,
+                                         int                n,
+                                         hipsolverComplex** A,
+                                         int                lda,
+                                         hipsolverComplex*  tau,
+                                         int                strideTau,
+                                         hipsolverComplex*  work,
+                                         int                lwork,
+                                         int*               devInfo,
+                                         int                bc)
+{
+    return hipsolverCgeqrfBatched(handle,
+                                  m,
+                                  n,
+                                  (hipFloatComplex**)A,
+                                  lda,
+                                  (hipFloatComplex*)tau,
+                                  strideTau,
+                                  (hipFloatComplex*)work,
+                                  lwork,
+                                  devInfo,
+                                  bc);
+}
+
+inline hipsolverStatus_t hipsolver_geqrf(hipsolverHandle_t        handle,
+                                         int                      m,
+                                         int                      n,
+                                         hipsolverDoubleComplex** A,
+                                         int                      lda,
+                                         hipsolverDoubleComplex*  tau,
+                                         int                      strideTau,
+                                         hipsolverDoubleComplex*  work,
+                                         int                      lwork,
+                                         int*                     devInfo,
+                                         int                      bc)
+{
+    return hipsolverZgeqrfBatched(handle,
+                                  m,
+                                  n,
+                                  (hipDoubleComplex**)A,
+                                  lda,
+                                  (hipDoubleComplex*)tau,
+                                  strideTau,
+                                  (hipDoubleComplex*)work,
+                                  lwork,
+                                  devInfo,
+                                  bc);
 }
 /********************************************************/
 

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -2880,71 +2880,71 @@ inline hipsolverStatus_t hipsolver_geqrf(testAPI_t               API,
 }
 
 // batched
-inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
+inline hipsolverStatus_t hipsolver_geqrfBatched_bufferSize(
     hipsolverHandle_t handle, int m, int n, float** A, int lda, int* lwork, int bc)
 {
     return hipsolverSgeqrfBatched_bufferSize(handle, m, n, A, lda, lwork, bc);
 }
 
-inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
+inline hipsolverStatus_t hipsolver_geqrfBatched_bufferSize(
     hipsolverHandle_t handle, int m, int n, double** A, int lda, int* lwork, int bc)
 {
     return hipsolverDgeqrfBatched_bufferSize(handle, m, n, A, lda, lwork, bc);
 }
 
-inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
+inline hipsolverStatus_t hipsolver_geqrfBatched_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipsolverComplex** A, int lda, int* lwork, int bc)
 {
     return hipsolverCgeqrfBatched_bufferSize(handle, m, n, (hipFloatComplex**)A, lda, lwork, bc);
 }
 
-inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
+inline hipsolverStatus_t hipsolver_geqrfBatched_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex** A, int lda, int* lwork, int bc)
 {
     return hipsolverZgeqrfBatched_bufferSize(handle, m, n, (hipDoubleComplex**)A, lda, lwork, bc);
 }
 
-inline hipsolverStatus_t hipsolver_geqrf(hipsolverHandle_t handle,
-                                         int               m,
-                                         int               n,
-                                         float**           A,
-                                         int               lda,
-                                         float*            tau,
-                                         int               strideTau,
-                                         float*            work,
-                                         int               lwork,
-                                         int*              devInfo,
-                                         int               bc)
+inline hipsolverStatus_t hipsolver_geqrfBatched(hipsolverHandle_t handle,
+                                                int               m,
+                                                int               n,
+                                                float**           A,
+                                                int               lda,
+                                                float*            tau,
+                                                int               strideTau,
+                                                float*            work,
+                                                int               lwork,
+                                                int*              devInfo,
+                                                int               bc)
 {
     return hipsolverSgeqrfBatched(handle, m, n, A, lda, tau, strideTau, work, lwork, devInfo, bc);
 }
 
-inline hipsolverStatus_t hipsolver_geqrf(hipsolverHandle_t handle,
-                                         int               m,
-                                         int               n,
-                                         double**          A,
-                                         int               lda,
-                                         double*           tau,
-                                         int               strideTau,
-                                         double*           work,
-                                         int               lwork,
-                                         int*              devInfo,
-                                         int               bc)
+inline hipsolverStatus_t hipsolver_geqrfBatched(hipsolverHandle_t handle,
+                                                int               m,
+                                                int               n,
+                                                double**          A,
+                                                int               lda,
+                                                double*           tau,
+                                                int               strideTau,
+                                                double*           work,
+                                                int               lwork,
+                                                int*              devInfo,
+                                                int               bc)
 {
     return hipsolverDgeqrfBatched(handle, m, n, A, lda, tau, strideTau, work, lwork, devInfo, bc);
 }
 
-inline hipsolverStatus_t hipsolver_geqrf(hipsolverHandle_t  handle,
-                                         int                m,
-                                         int                n,
-                                         hipsolverComplex** A,
-                                         int                lda,
-                                         hipsolverComplex*  tau,
-                                         int                strideTau,
-                                         hipsolverComplex*  work,
-                                         int                lwork,
-                                         int*               devInfo,
-                                         int                bc)
+inline hipsolverStatus_t hipsolver_geqrfBatched(hipsolverHandle_t  handle,
+                                                int                m,
+                                                int                n,
+                                                hipsolverComplex** A,
+                                                int                lda,
+                                                hipsolverComplex*  tau,
+                                                int                strideTau,
+                                                hipsolverComplex*  work,
+                                                int                lwork,
+                                                int*               devInfo,
+                                                int                bc)
 {
     return hipsolverCgeqrfBatched(handle,
                                   m,
@@ -2959,17 +2959,17 @@ inline hipsolverStatus_t hipsolver_geqrf(hipsolverHandle_t  handle,
                                   bc);
 }
 
-inline hipsolverStatus_t hipsolver_geqrf(hipsolverHandle_t        handle,
-                                         int                      m,
-                                         int                      n,
-                                         hipsolverDoubleComplex** A,
-                                         int                      lda,
-                                         hipsolverDoubleComplex*  tau,
-                                         int                      strideTau,
-                                         hipsolverDoubleComplex*  work,
-                                         int                      lwork,
-                                         int*                     devInfo,
-                                         int                      bc)
+inline hipsolverStatus_t hipsolver_geqrfBatched(hipsolverHandle_t        handle,
+                                                int                      m,
+                                                int                      n,
+                                                hipsolverDoubleComplex** A,
+                                                int                      lda,
+                                                hipsolverDoubleComplex*  tau,
+                                                int                      strideTau,
+                                                hipsolverDoubleComplex*  work,
+                                                int                      lwork,
+                                                int*                     devInfo,
+                                                int                      bc)
 {
     return hipsolverZgeqrfBatched(handle,
                                   m,

--- a/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
+++ b/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -80,6 +80,7 @@ class hipsolver_dispatcher
             {"gebrd", testing_gebrd<API_NORMAL, false, false, T>},
             {"gels", testing_gels<API_NORMAL, false, false, false, T>},
             {"geqrf", testing_geqrf<API_NORMAL, false, false, T, int, int>},
+            {"geqrf_batched", testing_geqrf<API_NORMAL, true, false, T, int, int>},
             {"geqrf_64", testing_geqrf<API_COMPAT, false, false, T, int64_t, size_t>},
             {"gesv", testing_gesv<API_NORMAL, false, false, false, T>},
             {"gesvd", testing_gesvd<API_NORMAL, false, false, false, T>},

--- a/projects/hipsolver/clients/include/testing_geqrf.hpp
+++ b/projects/hipsolver/clients/include/testing_geqrf.hpp
@@ -154,19 +154,22 @@ void geqrf_checkBadArgs(const hipsolverHandle_t handle,
 {
     // handle
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_geqrf(nullptr, m, n, dA, lda, dTau, strideTau, dWork, lwork, dInfo, bc),
+        hipsolver_geqrfBatched(nullptr, m, n, dA, lda, dTau, strideTau, dWork, lwork, dInfo, bc),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_geqrf(handle, m, n, (T**)nullptr, lda, dTau, strideTau, dWork, lwork, dInfo, bc),
+        hipsolver_geqrfBatched(
+            handle, m, n, (T**)nullptr, lda, dTau, strideTau, dWork, lwork, dInfo, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_geqrf(handle, m, n, dA, lda, (T*)nullptr, strideTau, dWork, lwork, dInfo, bc),
+        hipsolver_geqrfBatched(
+            handle, m, n, dA, lda, (T*)nullptr, strideTau, dWork, lwork, dInfo, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_geqrf(handle, m, n, dA, lda, dTau, strideTau, dWork, lwork, (int*)nullptr, bc),
+        hipsolver_geqrfBatched(
+            handle, m, n, dA, lda, dTau, strideTau, dWork, lwork, (int*)nullptr, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
@@ -195,7 +198,7 @@ void testing_geqrf_bad_arg()
         CHECK_HIP_ERROR(dInfo.memcheck());
 
         int size_W;
-        hipsolver_geqrf_bufferSize(handle, m, n, dA.data(), lda, &size_W, bc);
+        hipsolver_geqrfBatched_bufferSize(handle, m, n, dA.data(), lda, &size_W, bc);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
@@ -560,17 +563,17 @@ void geqrfBatched_getError(const hipsolverHandle_t handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(hipsolver_geqrf(handle,
-                                        m,
-                                        n,
-                                        dA.data(),
-                                        lda,
-                                        dTau.data(),
-                                        strideTau,
-                                        dWork.data(),
-                                        lwork,
-                                        dInfo.data(),
-                                        bc));
+    CHECK_ROCBLAS_ERROR(hipsolver_geqrfBatched(handle,
+                                               m,
+                                               n,
+                                               dA.data(),
+                                               lda,
+                                               dTau.data(),
+                                               strideTau,
+                                               dWork.data(),
+                                               lwork,
+                                               dInfo.data(),
+                                               bc));
     CHECK_HIP_ERROR(hARes.transfer_from(dA));
     CHECK_HIP_ERROR(hTauRes.transfer_from(dTau));
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
@@ -650,17 +653,17 @@ void geqrfBatched_getPerfData(const hipsolverHandle_t handle,
         geqrfBatched_initData<false, true, T>(
             handle, m, n, dA, lda, dTau, strideTau, dInfo, bc, hA, hTau, hInfo);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_geqrf(handle,
-                                            m,
-                                            n,
-                                            dA.data(),
-                                            lda,
-                                            dTau.data(),
-                                            strideTau,
-                                            dWork.data(),
-                                            lwork,
-                                            dInfo.data(),
-                                            bc));
+        CHECK_ROCBLAS_ERROR(hipsolver_geqrfBatched(handle,
+                                                   m,
+                                                   n,
+                                                   dA.data(),
+                                                   lda,
+                                                   dTau.data(),
+                                                   strideTau,
+                                                   dWork.data(),
+                                                   lwork,
+                                                   dInfo.data(),
+                                                   bc));
     }
 
     // gpu-lapack performance
@@ -674,17 +677,17 @@ void geqrfBatched_getPerfData(const hipsolverHandle_t handle,
             handle, m, n, dA, lda, dTau, strideTau, dInfo, bc, hA, hTau, hInfo);
 
         start = get_time_us_sync(stream);
-        hipsolver_geqrf(handle,
-                        m,
-                        n,
-                        dA.data(),
-                        lda,
-                        dTau.data(),
-                        strideTau,
-                        dWork.data(),
-                        lwork,
-                        dInfo.data(),
-                        bc);
+        hipsolver_geqrfBatched(handle,
+                               m,
+                               n,
+                               dA.data(),
+                               lda,
+                               dTau.data(),
+                               strideTau,
+                               dWork.data(),
+                               lwork,
+                               dInfo.data(),
+                               bc);
         *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
@@ -723,17 +726,17 @@ void testing_geqrf(Arguments& argus)
     {
         if constexpr(BATCHED)
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_geqrf(handle,
-                                                  m,
-                                                  n,
-                                                  (T**)nullptr,
-                                                  lda,
-                                                  (T*)nullptr,
-                                                  stP,
-                                                  (T*)nullptr,
-                                                  0,
-                                                  (int*)nullptr,
-                                                  bc),
+            EXPECT_ROCBLAS_STATUS(hipsolver_geqrfBatched(handle,
+                                                         m,
+                                                         n,
+                                                         (T**)nullptr,
+                                                         lda,
+                                                         (T*)nullptr,
+                                                         stP,
+                                                         (T*)nullptr,
+                                                         0,
+                                                         (int*)nullptr,
+                                                         bc),
                                   HIPSOLVER_STATUS_INVALID_VALUE);
         }
         else
@@ -767,7 +770,7 @@ void testing_geqrf(Arguments& argus)
     int  size_dW_batched;
     SIZE size_dW, size_hW;
     if constexpr(BATCHED)
-        hipsolver_geqrf_bufferSize(handle, m, n, (T**)nullptr, lda, &size_dW_batched, bc);
+        hipsolver_geqrfBatched_bufferSize(handle, m, n, (T**)nullptr, lda, &size_dW_batched, bc);
     else
         hipsolver_geqrf_bufferSize(
             API, handle, params, m, n, (T*)nullptr, lda, (T*)nullptr, &size_dW, &size_hW);

--- a/projects/hipsolver/clients/include/testing_geqrf.hpp
+++ b/projects/hipsolver/clients/include/testing_geqrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -138,6 +138,39 @@ void geqrf_checkBadArgs(const hipsolverHandle_t   handle,
 #endif
 }
 
+// batched
+template <typename T>
+void geqrf_checkBadArgs(const hipsolverHandle_t handle,
+                        const int               m,
+                        const int               n,
+                        T**                     dA,
+                        const int               lda,
+                        T*                      dTau,
+                        const int               strideTau,
+                        T*                      dWork,
+                        const int               lwork,
+                        int*                    dInfo,
+                        const int               bc)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_geqrf(nullptr, m, n, dA, lda, dTau, strideTau, dWork, lwork, dInfo, bc),
+        HIPSOLVER_STATUS_NOT_INITIALIZED);
+
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
+    // pointers
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_geqrf(handle, m, n, (T**)nullptr, lda, dTau, strideTau, dWork, lwork, dInfo, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_geqrf(handle, m, n, dA, lda, (T*)nullptr, strideTau, dWork, lwork, dInfo, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_geqrf(handle, m, n, dA, lda, dTau, strideTau, dWork, lwork, (int*)nullptr, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+#endif
+}
+
 template <testAPI_t API, bool BATCHED, bool STRIDED, typename T, typename I, typename SIZE>
 void testing_geqrf_bad_arg()
 {
@@ -151,40 +184,25 @@ void testing_geqrf_bad_arg()
     I                      stP = 1;
     int                    bc  = 1;
 
-    if(BATCHED)
+    if constexpr(BATCHED)
     {
-        // // memory allocations
-        // device_batch_vector<T>           dA(1, 1, 1);
-        // device_strided_batch_vector<T>   dIpiv(1, 1, 1, 1);
-        // device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
-        // CHECK_HIP_ERROR(dA.memcheck());
-        // CHECK_HIP_ERROR(dIpiv.memcheck());
-        // CHECK_HIP_ERROR(dInfo.memcheck());
+        // memory allocations (for bad args test)
+        device_batch_vector<T>           dA(1, 1, 1);
+        device_strided_batch_vector<T>   dTau(1, 1, 1, 1);
+        device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dTau.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
 
-        // SIZE size_dW, size_hW;
-        // hipsolver_geqrf_bufferSize(
-        //     API, handle, params, m, n, dA.data(), lda, dIpiv.data(), &size_dW, &size_hW);
-        // host_strided_batch_vector<T>   hWork(size_hW, 1, size_hW, 1);
-        // device_strided_batch_vector<T> dWork(size_dW, 1, size_dW, 1);
-        // if(size_dW)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
+        int size_W;
+        hipsolver_geqrf_bufferSize(handle, m, n, dA.data(), lda, &size_W, bc);
+        device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
+        if(size_W)
+            CHECK_HIP_ERROR(dWork.memcheck());
 
-        // // check bad arguments
-        // geqrf_checkBadArgs<API>(handle,
-        //                         params,
-        //                         m,
-        //                         n,
-        //                         dA.data(),
-        //                         lda,
-        //                         stA,
-        //                         dIpiv.data(),
-        //                         stP,
-        //                         dWork.data(),
-        //                         size_dW,
-        //                         hWork.data(),
-        //                         size_hW,
-        //                         dInfo.data(),
-        //                         bc);
+        // check bad arguments
+        geqrf_checkBadArgs(
+            handle, m, n, dA.data(), lda, dTau.data(), stP, dWork.data(), size_W, dInfo.data(), bc);
     }
     else
     {
@@ -457,6 +475,221 @@ void geqrf_getPerfData(const hipsolverHandle_t   handle,
     *gpu_time_used /= hot_calls;
 }
 
+/******************** BATCHED ********************/
+template <bool CPU,
+          bool GPU,
+          typename T,
+          typename TdA,
+          typename Td,
+          typename INTd,
+          typename Th,
+          typename Uh,
+          typename INTh>
+void geqrfBatched_initData(const hipsolverHandle_t handle,
+                           const int               m,
+                           const int               n,
+                           TdA&                    dA,
+                           const int               lda,
+                           Td&                     dTau,
+                           const int               strideTau,
+                           INTd&                   dInfo,
+                           const int               bc,
+                           Th&                     hA,
+                           Uh&                     hTau,
+                           INTh&                   hInfo)
+{
+    if(CPU)
+    {
+        rocblas_init<T>(hA, true);
+
+        for(int b = 0; b < bc; ++b)
+        {
+            // scale A to avoid singularities
+            for(int i = 0; i < m; i++)
+            {
+                for(int j = 0; j < n; j++)
+                {
+                    if(i == j)
+                        hA[b][i + j * lda] += 400;
+                    else
+                        hA[b][i + j * lda] -= 4;
+                }
+            }
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy data to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+    }
+}
+
+template <typename T,
+          typename TdA,
+          typename TdWork,
+          typename Td,
+          typename INTd,
+          typename Th,
+          typename Uh,
+          typename INTh>
+void geqrfBatched_getError(const hipsolverHandle_t handle,
+                           const int               m,
+                           const int               n,
+                           TdA&                    dA,
+                           const int               lda,
+                           TdWork&                 dWork,
+                           const int               lwork,
+                           Td&                     dTau,
+                           const int               strideTau,
+                           INTd&                   dInfo,
+                           const int               bc,
+                           Th&                     hA,
+                           Th&                     hARes,
+                           Uh&                     hTau,
+                           Uh&                     hTauRes,
+                           INTh&                   hInfo,
+                           INTh&                   hInfoRes,
+                           double*                 max_err)
+{
+    std::vector<T> hW(n);
+
+    // input data initialization
+    geqrfBatched_initData<true, true, T>(
+        handle, m, n, dA, lda, dTau, strideTau, dInfo, bc, hA, hTau, hInfo);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(hipsolver_geqrf(handle,
+                                        m,
+                                        n,
+                                        dA.data(),
+                                        lda,
+                                        dTau.data(),
+                                        strideTau,
+                                        dWork.data(),
+                                        lwork,
+                                        dInfo.data(),
+                                        bc));
+    CHECK_HIP_ERROR(hARes.transfer_from(dA));
+    CHECK_HIP_ERROR(hTauRes.transfer_from(dTau));
+    CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
+
+    // CPU lapack
+    for(int b = 0; b < bc; ++b)
+        cpu_geqrf(m, n, hA[b], lda, hTau[b], hW.data(), n, hInfo[b]);
+
+    // error is ||hA - hARes|| / ||hA||
+    // using frobenius norm
+    double err;
+    *max_err = 0;
+    for(int b = 0; b < bc; ++b)
+    {
+        err      = norm_error('F', m, n, lda, hA[b], hARes[b]);
+        *max_err = err > *max_err ? err : *max_err;
+    }
+
+    // also check info
+    err = 0;
+    for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
+        if(hInfo[b][0] != hInfoRes[b][0])
+            err++;
+    }
+    *max_err += err;
+}
+
+template <typename T,
+          typename TdA,
+          typename TdWork,
+          typename Td,
+          typename INTd,
+          typename Th,
+          typename Uh,
+          typename INTh>
+void geqrfBatched_getPerfData(const hipsolverHandle_t handle,
+                              const int               m,
+                              const int               n,
+                              TdA&                    dA,
+                              const int               lda,
+                              TdWork&                 dWork,
+                              const int               lwork,
+                              Td&                     dTau,
+                              const int               strideTau,
+                              INTd&                   dInfo,
+                              const int               bc,
+                              Th&                     hA,
+                              Uh&                     hTau,
+                              INTh&                   hInfo,
+                              double*                 gpu_time_used,
+                              double*                 cpu_time_used,
+                              const int               hot_calls,
+                              const bool              perf)
+{
+    std::vector<T> hW(n);
+
+    if(!perf)
+    {
+        geqrfBatched_initData<true, false, T>(
+            handle, m, n, dA, lda, dTau, strideTau, dInfo, bc, hA, hTau, hInfo);
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us_no_sync();
+        for(int b = 0; b < bc; ++b)
+            cpu_geqrf(m, n, hA[b], lda, hTau[b], hW.data(), n, hInfo[b]);
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
+    }
+
+    geqrfBatched_initData<true, false, T>(
+        handle, m, n, dA, lda, dTau, strideTau, dInfo, bc, hA, hTau, hInfo);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        geqrfBatched_initData<false, true, T>(
+            handle, m, n, dA, lda, dTau, strideTau, dInfo, bc, hA, hTau, hInfo);
+
+        CHECK_ROCBLAS_ERROR(hipsolver_geqrf(handle,
+                                            m,
+                                            n,
+                                            dA.data(),
+                                            lda,
+                                            dTau.data(),
+                                            strideTau,
+                                            dWork.data(),
+                                            lwork,
+                                            dInfo.data(),
+                                            bc));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(hipsolverGetStream(handle, &stream));
+    double start;
+
+    for(int iter = 0; iter < hot_calls; iter++)
+    {
+        geqrfBatched_initData<false, true, T>(
+            handle, m, n, dA, lda, dTau, strideTau, dInfo, bc, hA, hTau, hInfo);
+
+        start = get_time_us_sync(stream);
+        hipsolver_geqrf(handle,
+                        m,
+                        n,
+                        dA.data(),
+                        lda,
+                        dTau.data(),
+                        strideTau,
+                        dWork.data(),
+                        lwork,
+                        dInfo.data(),
+                        bc);
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
 template <testAPI_t API, bool BATCHED, bool STRIDED, typename T, typename I, typename SIZE>
 void testing_geqrf(Arguments& argus)
 {
@@ -488,25 +721,20 @@ void testing_geqrf(Arguments& argus)
     bool invalid_size = (m < 0 || n < 0 || lda < m || bc < 0);
     if(invalid_size)
     {
-        if(BATCHED)
+        if constexpr(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_geqrf(API,
-            //                                       handle,
-            //                                       params,
-            //                                       m,
-            //                                       n,
-            //                                       (T* const*)nullptr,
-            //                                       lda,
-            //                                       stA,
-            //                                       (T*)nullptr,
-            //                                       stP,
-            //                                       (T*)nullptr,
-            //                                       (SIZE)0,
-            //                                       (T*)nullptr,
-            //                                       (SIZE)0,
-            //                                       (int*)nullptr,
-            //                                       bc),
-            //                       HIPSOLVER_STATUS_INVALID_VALUE);
+            EXPECT_ROCBLAS_STATUS(hipsolver_geqrf(handle,
+                                                  m,
+                                                  n,
+                                                  (T**)nullptr,
+                                                  lda,
+                                                  (T*)nullptr,
+                                                  stP,
+                                                  (T*)nullptr,
+                                                  0,
+                                                  (int*)nullptr,
+                                                  bc),
+                                  HIPSOLVER_STATUS_INVALID_VALUE);
         }
         else
         {
@@ -536,85 +764,84 @@ void testing_geqrf(Arguments& argus)
     }
 
     // memory size query is necessary
+    int  size_dW_batched;
     SIZE size_dW, size_hW;
-    hipsolver_geqrf_bufferSize(
-        API, handle, params, m, n, (T*)nullptr, lda, (T*)nullptr, &size_dW, &size_hW);
+    if constexpr(BATCHED)
+        hipsolver_geqrf_bufferSize(handle, m, n, (T**)nullptr, lda, &size_dW_batched, bc);
+    else
+        hipsolver_geqrf_bufferSize(
+            API, handle, params, m, n, (T*)nullptr, lda, (T*)nullptr, &size_dW, &size_hW);
 
     if(argus.mem_query)
     {
-        rocsolver_bench_inform(inform_mem_query, size_dW);
+        rocsolver_bench_inform(inform_mem_query, BATCHED ? size_dW_batched : size_dW);
         return;
     }
 
-    if(BATCHED)
+    if constexpr(BATCHED)
     {
-        // // memory allocations
-        // host_batch_vector<T>             hA(size_A, 1, bc);
-        // host_batch_vector<T>             hARes(size_ARes, 1, bc);
-        // host_strided_batch_vector<T>     hIpiv(size_P, 1, stP, bc);
-        // host_strided_batch_vector<int>   hInfo(1, 1, 1, bc);
-        // host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
-        // host_strided_batch_vector<T>     hWork(size_hW, 1, size_hW, 1); // size_hW accounts for bc
-        // device_batch_vector<T>           dA(size_A, 1, bc);
-        // device_strided_batch_vector<T>   dIpiv(size_P, 1, stP, bc);
-        // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
-        // device_strided_batch_vector<T>   dWork(size_dW, 1, size_dW, 1); // size_dW accounts for bc
-        // if(size_A)
-        //     CHECK_HIP_ERROR(dA.memcheck());
-        // if(size_P)
-        //     CHECK_HIP_ERROR(dIpiv.memcheck());
-        // CHECK_HIP_ERROR(dInfo.memcheck());
-        // if(size_dW)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
+        // memory allocations
+        host_batch_vector<T>             hA(size_A, 1, bc);
+        host_batch_vector<T>             hARes(size_ARes, 1, bc);
+        host_strided_batch_vector<T>     hTau(size_P, 1, stP, bc);
+        host_strided_batch_vector<int>   hInfo(1, 1, 1, bc);
+        host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
+        device_batch_vector<T>           dA(size_A, 1, bc);
+        device_strided_batch_vector<T>   dTau(size_P, 1, stP, bc);
+        device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_dW_batched, 1, size_dW_batched, 1);
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+        if(size_P)
+            CHECK_HIP_ERROR(dTau.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+        if(size_dW_batched)
+            CHECK_HIP_ERROR(dWork.memcheck());
 
-        // // check computations
-        // if(argus.unit_check || argus.norm_check)
-        //     geqrf_getError<API, T>(handle,
-        //                            params,
-        //                            m,
-        //                            n,
-        //                            dA,
-        //                            lda,
-        //                            stA,
-        //                            dIpiv,
-        //                            stP,
-        //                            dWork,
-        //                            size_dW,
-        //                            hWork,
-        //                            size_hW,
-        //                            dInfo,
-        //                            bc,
-        //                            hA,
-        //                            hARes,
-        //                            hIpiv,
-        //                            hInfo,
-        //                            hInfoRes,
-        //                            &max_error);
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+        {
+            host_strided_batch_vector<T> hTauRes(size_P, 1, stP, bc);
+            geqrfBatched_getError<T>(handle,
+                                     m,
+                                     n,
+                                     dA,
+                                     lda,
+                                     dWork,
+                                     size_dW_batched,
+                                     dTau,
+                                     stP,
+                                     dInfo,
+                                     bc,
+                                     hA,
+                                     hARes,
+                                     hTau,
+                                     hTauRes,
+                                     hInfo,
+                                     hInfoRes,
+                                     &max_error);
+        }
 
-        // // collect performance data
-        // if(argus.timing)
-        //     geqrf_getPerfData<API, T>(handle,
-        //                               params,
-        //                               m,
-        //                               n,
-        //                               dA,
-        //                               lda,
-        //                               stA,
-        //                               dIpiv,
-        //                               stP,
-        //                               dWork,
-        //                               size_dW,
-        //                               hWork,
-        //                               size_hW,
-        //                               dInfo,
-        //                               bc,
-        //                               hA,
-        //                               hIpiv,
-        //                               hInfo,
-        //                               &gpu_time_used,
-        //                               &cpu_time_used,
-        //                               hot_calls,
-        //                               argus.perf);
+        // collect performance data
+        if(argus.timing)
+            geqrfBatched_getPerfData<T>(handle,
+                                        m,
+                                        n,
+                                        dA,
+                                        lda,
+                                        dWork,
+                                        size_dW_batched,
+                                        dTau,
+                                        stP,
+                                        dInfo,
+                                        bc,
+                                        hA,
+                                        hTau,
+                                        hInfo,
+                                        &gpu_time_used,
+                                        &cpu_time_used,
+                                        hot_calls,
+                                        argus.perf);
     }
 
     else
@@ -702,7 +929,7 @@ void testing_geqrf(Arguments& argus)
             std::cerr << "\n============================================\n";
             std::cerr << "Arguments:\n";
             std::cerr << "============================================\n";
-            if(BATCHED)
+            if constexpr(BATCHED)
             {
                 rocsolver_bench_output("m", "n", "lda", "strideP", "batch_c");
                 rocsolver_bench_output(m, n, lda, stP, bc);

--- a/projects/hipsolver/library/include/internal/hipsolver-functions.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-functions.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
@@ -768,6 +768,77 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgeqrf(hipsolverHandle_t handle,
                                                    hipDoubleComplex* work,
                                                    int               lwork,
                                                    int*              devInfo);
+
+// geqrfBatched
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgeqrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, float* A[], int lda, int* lwork, int batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgeqrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, double* A[], int lda, int* lwork, int batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgeqrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     hipFloatComplex*  A[],
+                                                                     int               lda,
+                                                                     int*              lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgeqrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     hipDoubleComplex* A[],
+                                                                     int               lda,
+                                                                     int*              lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgeqrfBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          float*            A[],
+                                                          int               lda,
+                                                          float*            tau,
+                                                          int               strideTau,
+                                                          float*            work,
+                                                          int               lwork,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgeqrfBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          double*           A[],
+                                                          int               lda,
+                                                          double*           tau,
+                                                          int               strideTau,
+                                                          double*           work,
+                                                          int               lwork,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgeqrfBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          hipFloatComplex*  A[],
+                                                          int               lda,
+                                                          hipFloatComplex*  tau,
+                                                          int               strideTau,
+                                                          hipFloatComplex*  work,
+                                                          int               lwork,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgeqrfBatched(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          hipDoubleComplex* A[],
+                                                          int               lda,
+                                                          hipDoubleComplex* tau,
+                                                          int               strideTau,
+                                                          hipDoubleComplex* work,
+                                                          int               lwork,
+                                                          int*              devInfo,
+                                                          int               batch_count);
 
 // gesv
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSSgesv_bufferSize(hipsolverHandle_t handle,

--- a/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -3866,6 +3866,277 @@ try
                                                           (rocblas_double_complex*)A,
                                                           lda,
                                                           (rocblas_double_complex*)tau));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** GEQRF_BATCHED ********************/
+hipsolverStatus_t hipsolverSgeqrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, float* A[], int lda, int* lwork, int batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_sgeqrf_batched(
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, 0, batch_count));
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgeqrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, double* A[], int lda, int* lwork, int batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_dgeqrf_batched(
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, 0, batch_count));
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgeqrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    hipFloatComplex*  A[],
+                                                    int               lda,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_cgeqrf_batched(
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, 0, batch_count));
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgeqrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    hipDoubleComplex* A[],
+                                                    int               lda,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status = hipsolver::rocblas2hip_status(rocsolver_zgeqrf_batched(
+        (rocblas_handle)handle, m, n, nullptr, lda, nullptr, 0, batch_count));
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSgeqrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         float*            A[],
+                                         int               lda,
+                                         float*            tau,
+                                         int               strideTau,
+                                         float*            work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverSgeqrfBatched_bufferSize(
+            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
+    return hipsolver::rocblas2hip_status(rocsolver_sgeqrf_batched(
+        (rocblas_handle)handle, m, n, A, lda, tau, strideTau, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgeqrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         double*           A[],
+                                         int               lda,
+                                         double*           tau,
+                                         int               strideTau,
+                                         double*           work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverDgeqrfBatched_bufferSize(
+            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
+    return hipsolver::rocblas2hip_status(rocsolver_dgeqrf_batched(
+        (rocblas_handle)handle, m, n, A, lda, tau, strideTau, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgeqrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         hipFloatComplex*  A[],
+                                         int               lda,
+                                         hipFloatComplex*  tau,
+                                         int               strideTau,
+                                         hipFloatComplex*  work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverCgeqrfBatched_bufferSize(
+            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
+    return hipsolver::rocblas2hip_status(rocsolver_cgeqrf_batched((rocblas_handle)handle,
+                                                                  m,
+                                                                  n,
+                                                                  (rocblas_float_complex**)A,
+                                                                  lda,
+                                                                  (rocblas_float_complex*)tau,
+                                                                  strideTau,
+                                                                  batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgeqrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         hipDoubleComplex* A[],
+                                         int               lda,
+                                         hipDoubleComplex* tau,
+                                         int               strideTau,
+                                         hipDoubleComplex* work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverZgeqrfBatched_bufferSize(
+            (rocblas_handle)handle, m, n, A, lda, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
+    return hipsolver::rocblas2hip_status(rocsolver_zgeqrf_batched((rocblas_handle)handle,
+                                                                  m,
+                                                                  n,
+                                                                  (rocblas_double_complex**)A,
+                                                                  lda,
+                                                                  (rocblas_double_complex*)tau,
+                                                                  strideTau,
+                                                                  batch_count));
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -2287,12 +2287,22 @@ try
     cublasCreate(&cublas_handle);
     cublasSetStream(cublas_handle, stream);
 
+    int hInfo = 0;
+
     auto status = hipsolver::cuda2hip_status(
-        cublasSgeqrfBatched(cublas_handle, m, n, A, lda, tauArray, devInfo, batch_count));
+        cublasSgeqrfBatched(cublas_handle, m, n, A, lda, tauArray, &hInfo, batch_count));
 
     cublasDestroy(cublas_handle);
 
     CHECK_HIP_ERROR(hipFree(tauArray));
+
+    if(status == HIPSOLVER_STATUS_SUCCESS)
+    {
+        CHECK_HIP_ERROR(hipMemset(devInfo, 0, batch_count * sizeof(int)));
+        if(hInfo < 0)
+            CHECK_HIP_ERROR(
+                hipMemcpy(devInfo + (-hInfo - 1), &hInfo, sizeof(int), hipMemcpyHostToDevice));
+    }
 
     return status;
 }
@@ -2336,12 +2346,22 @@ try
     cublasCreate(&cublas_handle);
     cublasSetStream(cublas_handle, stream);
 
+    int hInfo = 0;
+
     auto status = hipsolver::cuda2hip_status(
-        cublasDgeqrfBatched(cublas_handle, m, n, A, lda, tauArray, devInfo, batch_count));
+        cublasDgeqrfBatched(cublas_handle, m, n, A, lda, tauArray, &hInfo, batch_count));
 
     cublasDestroy(cublas_handle);
 
     CHECK_HIP_ERROR(hipFree(tauArray));
+
+    if(status == HIPSOLVER_STATUS_SUCCESS)
+    {
+        CHECK_HIP_ERROR(hipMemset(devInfo, 0, batch_count * sizeof(int)));
+        if(hInfo < 0)
+            CHECK_HIP_ERROR(
+                hipMemcpy(devInfo + (-hInfo - 1), &hInfo, sizeof(int), hipMemcpyHostToDevice));
+    }
 
     return status;
 }
@@ -2385,12 +2405,22 @@ try
     cublasCreate(&cublas_handle);
     cublasSetStream(cublas_handle, stream);
 
+    int hInfo = 0;
+
     auto status = hipsolver::cuda2hip_status(cublasCgeqrfBatched(
-        cublas_handle, m, n, (cuComplex**)A, lda, tauArray, devInfo, batch_count));
+        cublas_handle, m, n, (cuComplex**)A, lda, tauArray, &hInfo, batch_count));
 
     cublasDestroy(cublas_handle);
 
     CHECK_HIP_ERROR(hipFree(tauArray));
+
+    if(status == HIPSOLVER_STATUS_SUCCESS)
+    {
+        CHECK_HIP_ERROR(hipMemset(devInfo, 0, batch_count * sizeof(int)));
+        if(hInfo < 0)
+            CHECK_HIP_ERROR(
+                hipMemcpy(devInfo + (-hInfo - 1), &hInfo, sizeof(int), hipMemcpyHostToDevice));
+    }
 
     return status;
 }
@@ -2436,12 +2466,22 @@ try
     cublasCreate(&cublas_handle);
     cublasSetStream(cublas_handle, stream);
 
+    int hInfo = 0;
+
     auto status = hipsolver::cuda2hip_status(cublasZgeqrfBatched(
-        cublas_handle, m, n, (cuDoubleComplex**)A, lda, tauArray, devInfo, batch_count));
+        cublas_handle, m, n, (cuDoubleComplex**)A, lda, tauArray, &hInfo, batch_count));
 
     cublasDestroy(cublas_handle);
 
     CHECK_HIP_ERROR(hipFree(tauArray));
+
+    if(status == HIPSOLVER_STATUS_SUCCESS)
+    {
+        CHECK_HIP_ERROR(hipMemset(devInfo, 0, batch_count * sizeof(int)));
+        if(hInfo < 0)
+            CHECK_HIP_ERROR(
+                hipMemcpy(devInfo + (-hInfo - 1), &hInfo, sizeof(int), hipMemcpyHostToDevice));
+    }
 
     return status;
 }

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -2167,6 +2167,187 @@ try
                                                        (cuDoubleComplex*)work,
                                                        lwork,
                                                        devInfo));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** GEQRF_BATCHED ********************/
+hipsolverStatus_t hipsolverSgeqrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, float* A[], int lda, int* lwork, int batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgeqrfBatched_bufferSize(
+    hipsolverHandle_t handle, int m, int n, double* A[], int lda, int* lwork, int batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgeqrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    hipFloatComplex*  A[],
+                                                    int               lda,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgeqrfBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               m,
+                                                    int               n,
+                                                    hipDoubleComplex* A[],
+                                                    int               lda,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSgeqrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         float*            A[],
+                                         int               lda,
+                                         float*            tau,
+                                         int               strideTau,
+                                         float*            work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    return hipsolver::cuda2hip_status(
+        cublasSgeqrfBatched((cublasHandle_t)handle, m, n, A, lda, tau, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgeqrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         double*           A[],
+                                         int               lda,
+                                         double*           tau,
+                                         int               strideTau,
+                                         double*           work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    return hipsolver::cuda2hip_status(
+        cublasDgeqrfBatched((cublasHandle_t)handle, m, n, A, lda, tau, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgeqrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         hipFloatComplex*  A[],
+                                         int               lda,
+                                         hipFloatComplex*  tau,
+                                         int               strideTau,
+                                         hipFloatComplex*  work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    return hipsolver::cuda2hip_status(cublasCgeqrfBatched(
+        (cublasHandle_t)handle, m, n, (cuComplex**)A, lda, (cuComplex*)tau, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgeqrfBatched(hipsolverHandle_t handle,
+                                         int               m,
+                                         int               n,
+                                         hipDoubleComplex* A[],
+                                         int               lda,
+                                         hipDoubleComplex* tau,
+                                         int               strideTau,
+                                         hipDoubleComplex* work,
+                                         int               lwork,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
+    return hipsolver::cuda2hip_status(cublasZgeqrfBatched((cublasHandle_t)handle,
+                                                          m,
+                                                          n,
+                                                          (cuDoubleComplex**)A,
+                                                          lda,
+                                                          (cuDoubleComplex*)tau,
+                                                          devInfo,
+                                                          batch_count));
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -2280,8 +2280,17 @@ try
     CHECK_HIP_ERROR(hipMemcpy(
         tauArray, h_tauArray.data(), batch_count * sizeof(float*), hipMemcpyHostToDevice));
 
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
     auto status = hipsolver::cuda2hip_status(
-        cublasSgeqrfBatched((cublasHandle_t)handle, m, n, A, lda, tauArray, devInfo, batch_count));
+        cublasSgeqrfBatched(cublas_handle, m, n, A, lda, tauArray, devInfo, batch_count));
+
+    cublasDestroy(cublas_handle);
 
     CHECK_HIP_ERROR(hipFree(tauArray));
 
@@ -2320,8 +2329,17 @@ try
     CHECK_HIP_ERROR(hipMemcpy(
         tauArray, h_tauArray.data(), batch_count * sizeof(double*), hipMemcpyHostToDevice));
 
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
     auto status = hipsolver::cuda2hip_status(
-        cublasDgeqrfBatched((cublasHandle_t)handle, m, n, A, lda, tauArray, devInfo, batch_count));
+        cublasDgeqrfBatched(cublas_handle, m, n, A, lda, tauArray, devInfo, batch_count));
+
+    cublasDestroy(cublas_handle);
 
     CHECK_HIP_ERROR(hipFree(tauArray));
 
@@ -2360,8 +2378,17 @@ try
     CHECK_HIP_ERROR(hipMemcpy(
         tauArray, h_tauArray.data(), batch_count * sizeof(cuComplex*), hipMemcpyHostToDevice));
 
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
     auto status = hipsolver::cuda2hip_status(cublasCgeqrfBatched(
-        (cublasHandle_t)handle, m, n, (cuComplex**)A, lda, tauArray, devInfo, batch_count));
+        cublas_handle, m, n, (cuComplex**)A, lda, tauArray, devInfo, batch_count));
+
+    cublasDestroy(cublas_handle);
 
     CHECK_HIP_ERROR(hipFree(tauArray));
 
@@ -2402,8 +2429,17 @@ try
                               batch_count * sizeof(cuDoubleComplex*),
                               hipMemcpyHostToDevice));
 
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
     auto status = hipsolver::cuda2hip_status(cublasZgeqrfBatched(
-        (cublasHandle_t)handle, m, n, (cuDoubleComplex**)A, lda, tauArray, devInfo, batch_count));
+        cublas_handle, m, n, (cuDoubleComplex**)A, lda, tauArray, devInfo, batch_count));
+
+    cublasDestroy(cublas_handle);
 
     CHECK_HIP_ERROR(hipFree(tauArray));
 

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -2268,8 +2268,24 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    return hipsolver::cuda2hip_status(
-        cublasSgeqrfBatched((cublasHandle_t)handle, m, n, A, lda, tau, devInfo, batch_count));
+    // cuBLAS expects an array of pointers for tau, but hipSOLVER uses strided batched array
+    // Allocate and populate array of pointers on device
+    float** tauArray;
+    CHECK_HIP_ERROR(hipMalloc(&tauArray, batch_count * sizeof(float*)));
+
+    std::vector<float*> h_tauArray(batch_count);
+    for(int i = 0; i < batch_count; i++)
+        h_tauArray[i] = tau + i * strideTau;
+
+    CHECK_HIP_ERROR(hipMemcpy(
+        tauArray, h_tauArray.data(), batch_count * sizeof(float*), hipMemcpyHostToDevice));
+
+    auto status = hipsolver::cuda2hip_status(
+        cublasSgeqrfBatched((cublasHandle_t)handle, m, n, A, lda, tauArray, devInfo, batch_count));
+
+    CHECK_HIP_ERROR(hipFree(tauArray));
+
+    return status;
 }
 catch(...)
 {
@@ -2292,8 +2308,24 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    return hipsolver::cuda2hip_status(
-        cublasDgeqrfBatched((cublasHandle_t)handle, m, n, A, lda, tau, devInfo, batch_count));
+    // cuBLAS expects an array of pointers for tau, but hipSOLVER uses strided batched array
+    // Allocate and populate array of pointers on device
+    double** tauArray;
+    CHECK_HIP_ERROR(hipMalloc(&tauArray, batch_count * sizeof(double*)));
+
+    std::vector<double*> h_tauArray(batch_count);
+    for(int i = 0; i < batch_count; i++)
+        h_tauArray[i] = tau + i * strideTau;
+
+    CHECK_HIP_ERROR(hipMemcpy(
+        tauArray, h_tauArray.data(), batch_count * sizeof(double*), hipMemcpyHostToDevice));
+
+    auto status = hipsolver::cuda2hip_status(
+        cublasDgeqrfBatched((cublasHandle_t)handle, m, n, A, lda, tauArray, devInfo, batch_count));
+
+    CHECK_HIP_ERROR(hipFree(tauArray));
+
+    return status;
 }
 catch(...)
 {
@@ -2316,8 +2348,24 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    return hipsolver::cuda2hip_status(cublasCgeqrfBatched(
-        (cublasHandle_t)handle, m, n, (cuComplex**)A, lda, (cuComplex*)tau, devInfo, batch_count));
+    // cuBLAS expects an array of pointers for tau, but hipSOLVER uses strided batched array
+    // Allocate and populate array of pointers on device
+    cuComplex** tauArray;
+    CHECK_HIP_ERROR(hipMalloc(&tauArray, batch_count * sizeof(cuComplex*)));
+
+    std::vector<cuComplex*> h_tauArray(batch_count);
+    for(int i = 0; i < batch_count; i++)
+        h_tauArray[i] = (cuComplex*)(tau + i * strideTau);
+
+    CHECK_HIP_ERROR(hipMemcpy(
+        tauArray, h_tauArray.data(), batch_count * sizeof(cuComplex*), hipMemcpyHostToDevice));
+
+    auto status = hipsolver::cuda2hip_status(cublasCgeqrfBatched(
+        (cublasHandle_t)handle, m, n, (cuComplex**)A, lda, tauArray, devInfo, batch_count));
+
+    CHECK_HIP_ERROR(hipFree(tauArray));
+
+    return status;
 }
 catch(...)
 {
@@ -2340,14 +2388,26 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    return hipsolver::cuda2hip_status(cublasZgeqrfBatched((cublasHandle_t)handle,
-                                                          m,
-                                                          n,
-                                                          (cuDoubleComplex**)A,
-                                                          lda,
-                                                          (cuDoubleComplex*)tau,
-                                                          devInfo,
-                                                          batch_count));
+    // cuBLAS expects an array of pointers for tau, but hipSOLVER uses strided batched array
+    // Allocate and populate array of pointers on device
+    cuDoubleComplex** tauArray;
+    CHECK_HIP_ERROR(hipMalloc(&tauArray, batch_count * sizeof(cuDoubleComplex*)));
+
+    std::vector<cuDoubleComplex*> h_tauArray(batch_count);
+    for(int i = 0; i < batch_count; i++)
+        h_tauArray[i] = (cuDoubleComplex*)(tau + i * strideTau);
+
+    CHECK_HIP_ERROR(hipMemcpy(tauArray,
+                              h_tauArray.data(),
+                              batch_count * sizeof(cuDoubleComplex*),
+                              hipMemcpyHostToDevice));
+
+    auto status = hipsolver::cuda2hip_status(cublasZgeqrfBatched(
+        (cublasHandle_t)handle, m, n, (cuDoubleComplex**)A, lda, tauArray, devInfo, batch_count));
+
+    CHECK_HIP_ERROR(hipFree(tauArray));
+
+    return status;
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -280,6 +280,33 @@ hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus)
         return HIPSOLVER_STATUS_ZERO_PIVOT;
     case CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
         return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+    default:
+        return HIPSOLVER_STATUS_UNKNOWN;
+    }
+}
+
+hipsolverStatus_t cuda2hip_status(cublasStatus_t cuStatus)
+{
+    switch(cuStatus)
+    {
+    case CUBLAS_STATUS_SUCCESS:
+        return HIPSOLVER_STATUS_SUCCESS;
+    case CUBLAS_STATUS_NOT_INITIALIZED:
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    case CUBLAS_STATUS_ALLOC_FAILED:
+        return HIPSOLVER_STATUS_ALLOC_FAILED;
+    case CUBLAS_STATUS_INVALID_VALUE:
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    case CUBLAS_STATUS_MAPPING_ERROR:
+        return HIPSOLVER_STATUS_MAPPING_ERROR;
+    case CUBLAS_STATUS_EXECUTION_FAILED:
+        return HIPSOLVER_STATUS_EXECUTION_FAILED;
+    case CUBLAS_STATUS_INTERNAL_ERROR:
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+    case CUBLAS_STATUS_NOT_SUPPORTED:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    case CUBLAS_STATUS_ARCH_MISMATCH:
+        return HIPSOLVER_STATUS_ARCH_MISMATCH;
     default:
         return HIPSOLVER_STATUS_UNKNOWN;
     }

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,6 +65,8 @@ hipsolverDeterministicMode_t cuda2hip_deterministic(cusolverDeterministicMode_t 
 #endif
 
 hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus);
+
+hipsolverStatus_t cuda2hip_status(cublasStatus_t cuStatus);
 
 // Dense API
 cusolverDnFunction_t hip2cuda_function(hipsolverDnFunction_t func);


### PR DESCRIPTION
## Motivation

We want to be able to test AMD vs. NVIDIA's (rocSOLVER vs cuBLAS) implementation of `geqrf_batched` using a benchmark framework unified with the rest of hipSOLVER.

JIRA ID: AISOLVE-61

## Technical Details

We add `hipsolver_geqrfsXBatched` to hipSOLVER's API, implement a backend for AMD and NVIDIA that reconciles the differences in input parameters, and add it to our testing/benchmarking client.

We make new function headers for `geqrf_batched` in the client's internal API and the testing files as opposed to integrating the batched case into a function with the same function header. This is to account for the differences of `geqrf_batched` between cuSOLVER and cuBLAS, but breaks the pattern we typically follow in hipSOLVER.

### NOTE:
This change is made alongside changes to add `gels_batched`, `getrf_batched`, `getrs_batched`, and `getri_batched`. You can find PRs for each of these routines, each of them reading extremely similarly.

## Test Plan

Run new tests on AMD and NVIDIA hardware. Try invoking `geqrf_batched` from the benchmark client.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.