### PR TITLE
[hipSOLVER] Add getriBatched for testing

### DIFF
--- a/projects/hipsolver/CHANGELOG.md
+++ b/projects/hipsolver/CHANGELOG.md
@@ -6,6 +6,12 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ## (Unreleased) hipSOLVER
 
 ### Added
+
+* Added functions:
+  * getriBatched
+    * hipsolverXgetriBatched_bufferSize
+    * hipsolverXgetriBatched
+
 ### Changed
 ### Removed
 ### Optimized

--- a/projects/hipsolver/clients/common/lapack_host_reference.cpp
+++ b/projects/hipsolver/clients/common/lapack_host_reference.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,7 @@
 
 #include "../include/lapack_host_reference.hpp"
 #include "hipsolver.h"
+#include <vector>
 
 /*!\file
  * \brief provide template functions interfaces to BLAS and LAPACK interfaces, it is
@@ -773,6 +774,23 @@ void sgetrf_(int* m, int* n, float* A, int* lda, int* ipiv, int* info);
 void dgetrf_(int* m, int* n, double* A, int* lda, int* ipiv, int* info);
 void cgetrf_(int* m, int* n, hipsolverComplex* A, int* lda, int* ipiv, int* info);
 void zgetrf_(int* m, int* n, hipsolverDoubleComplex* A, int* lda, int* ipiv, int* info);
+
+void sgetri_(int* n, float* A, int* lda, int* ipiv, float* work, int* lwork, int* info);
+void dgetri_(int* n, double* A, int* lda, int* ipiv, double* work, int* lwork, int* info);
+void cgetri_(int*              n,
+             hipsolverComplex* A,
+             int*              lda,
+             int*              ipiv,
+             hipsolverComplex* work,
+             int*              lwork,
+             int*              info);
+void zgetri_(int*                    n,
+             hipsolverDoubleComplex* A,
+             int*                    lda,
+             int*                    ipiv,
+             hipsolverDoubleComplex* work,
+             int*                    lwork,
+             int*                    info);
 
 void sgetrs_(
     char* trans, int* n, int* nrhs, float* A, int* lda, int* ipiv, float* B, int* ldb, int* info);
@@ -2510,6 +2528,64 @@ void cpu_getrf<hipsolverDoubleComplex>(
     int m, int n, hipsolverDoubleComplex* A, int lda, int* ipiv, int* info)
 {
     zgetrf_(&m, &n, A, &lda, ipiv, info);
+}
+
+// getri
+template <>
+void cpu_getri<float>(int n, float* A, int lda, int* ipiv, int* info)
+{
+    // Query optimal workspace size
+    int   lwork = -1;
+    float work_query;
+    sgetri_(&n, A, &lda, ipiv, &work_query, &lwork, info);
+
+    // Allocate workspace and perform computation
+    lwork = static_cast<int>(work_query);
+    std::vector<float> work(lwork);
+    sgetri_(&n, A, &lda, ipiv, work.data(), &lwork, info);
+}
+
+template <>
+void cpu_getri<double>(int n, double* A, int lda, int* ipiv, int* info)
+{
+    // Query optimal workspace size
+    int    lwork = -1;
+    double work_query;
+    dgetri_(&n, A, &lda, ipiv, &work_query, &lwork, info);
+
+    // Allocate workspace and perform computation
+    lwork = static_cast<int>(work_query);
+    std::vector<double> work(lwork);
+    dgetri_(&n, A, &lda, ipiv, work.data(), &lwork, info);
+}
+
+template <>
+void cpu_getri<hipsolverComplex>(int n, hipsolverComplex* A, int lda, int* ipiv, int* info)
+{
+    // Query optimal workspace size
+    int              lwork = -1;
+    hipsolverComplex work_query;
+    cgetri_(&n, A, &lda, ipiv, &work_query, &lwork, info);
+
+    // Allocate workspace and perform computation
+    lwork = static_cast<int>(work_query.real());
+    std::vector<hipsolverComplex> work(lwork);
+    cgetri_(&n, A, &lda, ipiv, work.data(), &lwork, info);
+}
+
+template <>
+void cpu_getri<hipsolverDoubleComplex>(
+    int n, hipsolverDoubleComplex* A, int lda, int* ipiv, int* info)
+{
+    // Query optimal workspace size
+    int                    lwork = -1;
+    hipsolverDoubleComplex work_query;
+    zgetri_(&n, A, &lda, ipiv, &work_query, &lwork, info);
+
+    // Allocate workspace and perform computation
+    lwork = static_cast<int>(work_query.real());
+    std::vector<hipsolverDoubleComplex> work(lwork);
+    zgetri_(&n, A, &lda, ipiv, work.data(), &lwork, info);
 }
 
 // getrs

--- a/projects/hipsolver/clients/gtest/CMakeLists.txt
+++ b/projects/hipsolver/clients/gtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,7 @@ set(hipsolverDn_test_source
   hipsolver_gtest_main.cpp
   getrs_gtest.cpp
   getrf_gtest.cpp
+  getri_gtest.cpp
   gebrd_gtest.cpp
   gels_gtest.cpp
   geqrf_gtest.cpp

--- a/projects/hipsolver/clients/gtest/getri_gtest.cpp
+++ b/projects/hipsolver/clients/gtest/getri_gtest.cpp
@@ -1,0 +1,152 @@
+/* ************************************************************************
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#include "testing_getri.hpp"
+
+using ::testing::Combine;
+using ::testing::TestWithParam;
+using ::testing::Values;
+using ::testing::ValuesIn;
+using namespace std;
+
+typedef std::tuple<int, int> getri_tuple;
+
+// each tuple is {n, lda}
+// case when n = -1 will also execute the bad arguments test
+// (null handle, null pointers and invalid values)
+
+// for checkin_lapack tests
+const vector<int> n_size_range = {
+    // invalid
+    -1,
+    // normal (valid) samples
+    1,
+    20,
+    64,
+    100,
+};
+
+const vector<int> lda_size_range = {
+    // invalid (lda < n)
+    1,
+    // normal (valid) samples
+    20,
+    64,
+    100,
+    150,
+};
+
+Arguments getri_setup_arguments(getri_tuple tup)
+{
+    int n_size   = std::get<0>(tup);
+    int lda_size = std::get<1>(tup);
+
+    Arguments arg;
+
+    arg.set<int>("n", n_size);
+    arg.set<int>("lda", lda_size);
+
+    // only testing standard use case/defaults for strides
+    arg.timing = 0;
+
+    return arg;
+}
+
+template <testAPI_t API, bool NPVT, typename I, typename SIZE>
+class GETRI_BASE : public ::TestWithParam<getri_tuple>
+{
+protected:
+    void TearDown() override
+    {
+        ASSERT_EQ(hipGetLastError(), hipSuccess);
+    }
+
+    template <bool BATCHED, bool STRIDED, typename T>
+    void run_tests()
+    {
+        Arguments arg = getri_setup_arguments(GetParam());
+
+        if(arg.peek<rocblas_int>("n") == -1)
+            testing_getri_bad_arg<API, BATCHED, STRIDED, NPVT, T, I, SIZE>();
+
+        arg.batch_count = (BATCHED || STRIDED ? 3 : 1);
+        testing_getri<API, BATCHED, STRIDED, NPVT, T, I, SIZE>(arg);
+    }
+};
+
+class GETRI : public GETRI_BASE<API_NORMAL, false, int, int>
+{
+};
+
+class GETRI_NPVT : public GETRI_BASE<API_NORMAL, true, int, int>
+{
+};
+
+// batched tests
+TEST_P(GETRI, batched__float)
+{
+    run_tests<true, false, float>();
+}
+
+TEST_P(GETRI, batched__double)
+{
+    run_tests<true, false, double>();
+}
+
+TEST_P(GETRI, batched__float_complex)
+{
+    run_tests<true, false, hipsolverComplex>();
+}
+
+TEST_P(GETRI, batched__double_complex)
+{
+    run_tests<true, false, hipsolverDoubleComplex>();
+}
+
+TEST_P(GETRI_NPVT, batched__float)
+{
+    run_tests<true, false, float>();
+}
+
+TEST_P(GETRI_NPVT, batched__double)
+{
+    run_tests<true, false, double>();
+}
+
+TEST_P(GETRI_NPVT, batched__float_complex)
+{
+    run_tests<true, false, hipsolverComplex>();
+}
+
+TEST_P(GETRI_NPVT, batched__double_complex)
+{
+    run_tests<true, false, hipsolverDoubleComplex>();
+}
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         GETRI,
+                         Combine(ValuesIn(n_size_range), ValuesIn(lda_size_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         GETRI_NPVT,
+                         Combine(ValuesIn(n_size_range), ValuesIn(lda_size_range)));

--- a/projects/hipsolver/clients/include/hipsolver.hpp
+++ b/projects/hipsolver/clients/include/hipsolver.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -5350,6 +5350,167 @@ inline hipsolverStatus_t hipsolver_getrf(testAPI_t               API,
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
+}
+/********************************************************/
+
+/******************** GETRI_BATCHED ********************/
+// batched
+inline hipsolverStatus_t hipsolver_getriBatched_bufferSize(hipsolverHandle_t handle,
+                                                           int               n,
+                                                           float**           A,
+                                                           int               lda,
+                                                           float**           C,
+                                                           int               ldc,
+                                                           int               strideP,
+                                                           int*              lwork,
+                                                           int               batch_count)
+{
+    return hipsolverSgetriBatched_bufferSize(
+        handle, n, A, lda, C, ldc, strideP, lwork, batch_count);
+}
+
+inline hipsolverStatus_t hipsolver_getriBatched_bufferSize(hipsolverHandle_t handle,
+                                                           int               n,
+                                                           double**          A,
+                                                           int               lda,
+                                                           double**          C,
+                                                           int               ldc,
+                                                           int               strideP,
+                                                           int*              lwork,
+                                                           int               batch_count)
+{
+    return hipsolverDgetriBatched_bufferSize(
+        handle, n, A, lda, C, ldc, strideP, lwork, batch_count);
+}
+
+inline hipsolverStatus_t hipsolver_getriBatched_bufferSize(hipsolverHandle_t  handle,
+                                                           int                n,
+                                                           hipsolverComplex** A,
+                                                           int                lda,
+                                                           hipsolverComplex** C,
+                                                           int                ldc,
+                                                           int                strideP,
+                                                           int*               lwork,
+                                                           int                batch_count)
+{
+    return hipsolverCgetriBatched_bufferSize(handle,
+                                             n,
+                                             (hipFloatComplex**)A,
+                                             lda,
+                                             (hipFloatComplex**)C,
+                                             ldc,
+                                             strideP,
+                                             lwork,
+                                             batch_count);
+}
+
+inline hipsolverStatus_t hipsolver_getriBatched_bufferSize(hipsolverHandle_t        handle,
+                                                           int                      n,
+                                                           hipsolverDoubleComplex** A,
+                                                           int                      lda,
+                                                           hipsolverDoubleComplex** C,
+                                                           int                      ldc,
+                                                           int                      strideP,
+                                                           int*                     lwork,
+                                                           int                      batch_count)
+{
+    return hipsolverZgetriBatched_bufferSize(handle,
+                                             n,
+                                             (hipDoubleComplex**)A,
+                                             lda,
+                                             (hipDoubleComplex**)C,
+                                             ldc,
+                                             strideP,
+                                             lwork,
+                                             batch_count);
+}
+
+inline hipsolverStatus_t hipsolver_getriBatched(hipsolverHandle_t handle,
+                                                int               n,
+                                                float**           A,
+                                                int               lda,
+                                                float**           C,
+                                                int               ldc,
+                                                float*            work,
+                                                int               lwork,
+                                                int*              devIpiv,
+                                                int               strideP,
+                                                int*              devInfo,
+                                                int               batch_count)
+{
+    return hipsolverSgetriBatched(
+        handle, n, A, lda, C, ldc, work, lwork, devIpiv, strideP, devInfo, batch_count);
+}
+
+inline hipsolverStatus_t hipsolver_getriBatched(hipsolverHandle_t handle,
+                                                int               n,
+                                                double**          A,
+                                                int               lda,
+                                                double**          C,
+                                                int               ldc,
+                                                double*           work,
+                                                int               lwork,
+                                                int*              devIpiv,
+                                                int               strideP,
+                                                int*              devInfo,
+                                                int               batch_count)
+{
+    return hipsolverDgetriBatched(
+        handle, n, A, lda, C, ldc, work, lwork, devIpiv, strideP, devInfo, batch_count);
+}
+
+inline hipsolverStatus_t hipsolver_getriBatched(hipsolverHandle_t  handle,
+                                                int                n,
+                                                hipsolverComplex** A,
+                                                int                lda,
+                                                hipsolverComplex** C,
+                                                int                ldc,
+                                                hipsolverComplex*  work,
+                                                int                lwork,
+                                                int*               devIpiv,
+                                                int                strideP,
+                                                int*               devInfo,
+                                                int                batch_count)
+{
+    return hipsolverCgetriBatched(handle,
+                                  n,
+                                  (hipFloatComplex**)A,
+                                  lda,
+                                  (hipFloatComplex**)C,
+                                  ldc,
+                                  (hipFloatComplex*)work,
+                                  lwork,
+                                  devIpiv,
+                                  strideP,
+                                  devInfo,
+                                  batch_count);
+}
+
+inline hipsolverStatus_t hipsolver_getriBatched(hipsolverHandle_t        handle,
+                                                int                      n,
+                                                hipsolverDoubleComplex** A,
+                                                int                      lda,
+                                                hipsolverDoubleComplex** C,
+                                                int                      ldc,
+                                                hipsolverDoubleComplex*  work,
+                                                int                      lwork,
+                                                int*                     devIpiv,
+                                                int                      strideP,
+                                                int*                     devInfo,
+                                                int                      batch_count)
+{
+    return hipsolverZgetriBatched(handle,
+                                  n,
+                                  (hipDoubleComplex**)A,
+                                  lda,
+                                  (hipDoubleComplex**)C,
+                                  ldc,
+                                  (hipDoubleComplex*)work,
+                                  lwork,
+                                  devIpiv,
+                                  strideP,
+                                  devInfo,
+                                  batch_count);
 }
 /********************************************************/
 

--- a/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
+++ b/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,6 +35,7 @@
 #include "testing_gesvda.hpp"
 #include "testing_gesvdj.hpp"
 #include "testing_getrf.hpp"
+// #include "testing_getri.hpp"  // TODO: Fix template issues in testing file
 #include "testing_getrs.hpp"
 #include "testing_orgbr_ungbr.hpp"
 #include "testing_orgqr_ungqr.hpp"
@@ -88,6 +89,7 @@ class hipsolver_dispatcher
             {"gesvdj_batched", testing_gesvdj<API_NORMAL, false, true, T>},
             {"getrf", testing_getrf<API_NORMAL, false, false, false, T, int, int>},
             {"getrf_64", testing_getrf<API_COMPAT, false, false, false, T, int64_t, size_t>},
+            // {"getri_batched", testing_getri<API_NORMAL, true, false, false, T, int, int>},  // TODO: Fix template issues
             {"getrs", testing_getrs<API_NORMAL, false, false, T, int, int>},
             {"getrs_64", testing_getrs<API_COMPAT, false, false, T, int64_t, size_t>},
             {"potrf", testing_potrf<API_NORMAL, false, false, T>},

--- a/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
+++ b/projects/hipsolver/clients/include/hipsolver_dispatcher.hpp
@@ -35,7 +35,7 @@
 #include "testing_gesvda.hpp"
 #include "testing_gesvdj.hpp"
 #include "testing_getrf.hpp"
-// #include "testing_getri.hpp"  // TODO: Fix template issues in testing file
+#include "testing_getri.hpp"
 #include "testing_getrs.hpp"
 #include "testing_orgbr_ungbr.hpp"
 #include "testing_orgqr_ungqr.hpp"
@@ -89,7 +89,7 @@ class hipsolver_dispatcher
             {"gesvdj_batched", testing_gesvdj<API_NORMAL, false, true, T>},
             {"getrf", testing_getrf<API_NORMAL, false, false, false, T, int, int>},
             {"getrf_64", testing_getrf<API_COMPAT, false, false, false, T, int64_t, size_t>},
-            // {"getri_batched", testing_getri<API_NORMAL, true, false, false, T, int, int>},  // TODO: Fix template issues
+            {"getri_batched", testing_getri<API_NORMAL, true, false, false, T, int, int>},
             {"getrs", testing_getrs<API_NORMAL, false, false, T, int, int>},
             {"getrs_64", testing_getrs<API_COMPAT, false, false, T, int64_t, size_t>},
             {"potrf", testing_potrf<API_NORMAL, false, false, T>},

--- a/projects/hipsolver/clients/include/lapack_host_reference.hpp
+++ b/projects/hipsolver/clients/include/lapack_host_reference.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -219,6 +219,9 @@ void cpu_gesvdx(hipsolverEigMode_t leftv,
 
 template <typename T>
 void cpu_getrf(int m, int n, T* A, int lda, int* ipiv, int* info);
+
+template <typename T>
+void cpu_getri(int n, T* A, int lda, int* ipiv, int* info);
 
 template <typename T>
 void cpu_getrs(hipsolverOperation_t trans,

--- a/projects/hipsolver/clients/include/testing_getri.hpp
+++ b/projects/hipsolver/clients/include/testing_getri.hpp
@@ -1,0 +1,585 @@
+/* ************************************************************************
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#include "clientcommon.hpp"
+
+template <bool BATCHED,
+          bool NPVT,
+          typename I,
+          typename Td,
+          typename Twork,
+          typename Id,
+          typename INTd>
+void getri_checkBadArgs(const hipsolverHandle_t handle,
+                        const I                 n,
+                        Td                      dA,
+                        const I                 lda,
+                        Td                      dC,
+                        const I                 ldc,
+                        Twork                   dWork,
+                        const I                 lwork,
+                        Id                      dIpiv,
+                        const I                 stP,
+                        INTd                    dinfo,
+                        const int               bc)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_getriBatched(nullptr, n, dA, lda, dC, ldc, dWork, lwork, dIpiv, stP, dinfo, bc),
+        HIPSOLVER_STATUS_NOT_INITIALIZED);
+
+    // values
+    // N/A
+
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
+    // pointers
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_getriBatched(
+            handle, n, (Td) nullptr, lda, dC, ldc, dWork, lwork, dIpiv, stP, dinfo, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_getriBatched(
+            handle, n, dA, lda, (Td) nullptr, ldc, dWork, lwork, dIpiv, stP, dinfo, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_getriBatched(
+            handle, n, dA, lda, dC, ldc, dWork, lwork, dIpiv, stP, (INTd) nullptr, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+#endif
+}
+
+template <testAPI_t API,
+          bool      BATCHED,
+          bool      STRIDED,
+          bool      NPVT,
+          typename T,
+          typename I,
+          typename SIZE>
+void testing_getri_bad_arg()
+{
+    // safe arguments
+    hipsolver_local_handle handle;
+    I                      n     = 1;
+    I                      lda   = 1;
+    I                      stP   = 1;
+    I                      lwork = 1;
+    int                    bc    = 1;
+
+    if(BATCHED)
+    {
+        // memory allocations
+        device_batch_vector<T>           dA(1, 1, 1);
+        device_batch_vector<T>           dC(1, 1, 1);
+        device_strided_batch_vector<T>   dWork(1, 1, 1, 1);
+        device_strided_batch_vector<int> dIpiv(1, 1, 1, 1);
+        device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
+        CHECK_HIP_ERROR(dA.memcheck());
+        CHECK_HIP_ERROR(dC.memcheck());
+        CHECK_HIP_ERROR(dWork.memcheck());
+        CHECK_HIP_ERROR(dIpiv.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+
+        // check bad arguments
+        getri_checkBadArgs<BATCHED, NPVT, I, T**, T*, int*, int*>(handle,
+                                                                  n,
+                                                                  dA.data(),
+                                                                  lda,
+                                                                  dC.data(),
+                                                                  lda,
+                                                                  dWork.data(),
+                                                                  lwork,
+                                                                  dIpiv.data(),
+                                                                  stP,
+                                                                  dInfo.data(),
+                                                                  bc);
+    }
+}
+
+template <bool NPVT,
+          bool CPU,
+          bool GPU,
+          typename T,
+          typename I,
+          typename Td,
+          typename Id,
+          typename INTd,
+          typename Th,
+          typename Ih,
+          typename INTh>
+void getriBatched_initData(const hipsolverHandle_t handle,
+                           const I                 n,
+                           Td&                     dA,
+                           const I                 lda,
+                           Td&                     dC,
+                           const I                 ldc,
+                           Id&                     dIpiv,
+                           const I                 stP,
+                           INTd&                   dInfo,
+                           const int               bc,
+                           Th&                     hA,
+                           Th&                     hC,
+                           Ih&                     hIpiv,
+                           INTh&                   hInfo)
+{
+    if(CPU)
+    {
+        T tmp;
+        rocblas_init<T>(hA, true);
+
+        for(int b = 0; b < bc; ++b)
+        {
+            // scale A to avoid singularities
+            // make it well-conditioned for inversion
+            for(I i = 0; i < n; i++)
+            {
+                for(I j = 0; j < n; j++)
+                {
+                    if(i == j)
+                        hA[b][i + j * lda] = (hA[b][i + j * lda] / 10.0) + 10;
+                    else
+                        hA[b][i + j * lda] = (hA[b][i + j * lda] - 4) / 10.0;
+                }
+            }
+
+            // shuffle rows to test pivoting
+            // always the same permuation for debugging purposes
+            for(rocblas_int i = 0; i < n / 2; i++)
+            {
+                for(rocblas_int j = 0; j < n; j++)
+                {
+                    tmp                        = hA[b][i + j * lda];
+                    hA[b][i + j * lda]         = hA[b][n - 1 - i + j * lda];
+                    hA[b][n - 1 - i + j * lda] = tmp;
+                }
+            }
+
+            // compute LU factorization as getri requires LU-factorized input
+            cpu_getrf(n, n, hA[b], lda, hIpiv[b], hInfo[b]);
+        }
+    }
+
+    if(GPU)
+    {
+        // now copy LU-factorized data and pivots to the GPU
+        CHECK_HIP_ERROR(dA.transfer_from(hA));
+        CHECK_HIP_ERROR(dIpiv.transfer_from(hIpiv));
+    }
+}
+
+template <bool NPVT,
+          typename T,
+          typename I,
+          typename Td,
+          typename Twork,
+          typename Id,
+          typename INTd,
+          typename Th,
+          typename Ih,
+          typename INTh>
+void getriBatched_getError(const hipsolverHandle_t handle,
+                           const I                 n,
+                           Td&                     dA,
+                           const I                 lda,
+                           Td&                     dC,
+                           const I                 ldc,
+                           Id&                     dIpiv,
+                           const I                 stP,
+                           Twork&                  dWork,
+                           const I                 lwork,
+                           INTd&                   dInfo,
+                           const int               bc,
+                           Th&                     hA,
+                           Th&                     hC,
+                           Th&                     hCRes,
+                           Ih&                     hIpiv,
+                           Ih&                     hIpivRes,
+                           INTh&                   hInfo,
+                           INTh&                   hInfoRes,
+                           double*                 max_err)
+{
+    // input data initialization (includes cpu_getrf to compute LU factorization)
+    getriBatched_initData<NPVT, true, true, T>(
+        handle, n, dA, lda, dC, ldc, dIpiv, stP, dInfo, bc, hA, hC, hIpiv, hInfo);
+
+    // save LU-factorized matrix for CPU reference
+    Th hA_LU(hA.n(), 1, hA.stride(), bc);
+    for(int b = 0; b < bc; ++b)
+    {
+        for(I i = 0; i < n * lda; ++i)
+            hA_LU[b][i] = hA[b][i];
+    }
+
+    // execute computations
+    // GPU lapack - A is input (LU), C is output (inverse)
+    CHECK_ROCBLAS_ERROR(hipsolver_getriBatched(handle,
+                                               n,
+                                               dA.data(),
+                                               lda,
+                                               dC.data(),
+                                               ldc,
+                                               dWork.data(),
+                                               lwork,
+                                               dIpiv.data(),
+                                               stP,
+                                               dInfo.data(),
+                                               bc));
+    CHECK_HIP_ERROR(hCRes.transfer_from(dC));
+    CHECK_HIP_ERROR(hIpivRes.transfer_from(dIpiv));
+    CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
+
+    // CPU lapack - compute inverse from LU factorization
+    for(int b = 0; b < bc; ++b)
+        cpu_getri(n, hA_LU[b], lda, hIpiv[b], hInfo[b]);
+
+    // expecting original matrix to be non-singular
+    // error is ||hA_LU_inv - hCRes|| / ||hA_LU_inv||
+    // using frobenius norm
+    // NOTE: hA_LU has lda, hCRes has ldc
+    double err;
+    *max_err = 0;
+    for(int b = 0; b < bc; ++b)
+    {
+        err      = norm_error('F', n, n, lda, hA_LU[b], hCRes[b], ldc);
+        *max_err = err > *max_err ? err : *max_err;
+    }
+
+    // also check info for singularities
+    err = 0;
+    for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
+        if(hInfo[b][0] != hInfoRes[b][0])
+            err++;
+    }
+    *max_err += err;
+}
+
+template <bool NPVT,
+          typename T,
+          typename I,
+          typename Td,
+          typename Twork,
+          typename Id,
+          typename INTd,
+          typename Th,
+          typename Ih,
+          typename INTh>
+void getriBatched_getPerfData(const hipsolverHandle_t handle,
+                              const I                 n,
+                              Td&                     dA,
+                              const I                 lda,
+                              Td&                     dC,
+                              const I                 ldc,
+                              Id&                     dIpiv,
+                              const I                 stP,
+                              Twork&                  dWork,
+                              const I                 lwork,
+                              INTd&                   dInfo,
+                              const int               bc,
+                              Th&                     hA,
+                              Th&                     hC,
+                              Ih&                     hIpiv,
+                              INTh&                   hInfo,
+                              double*                 gpu_time_used,
+                              double*                 cpu_time_used,
+                              const int               hot_calls,
+                              const bool              perf)
+{
+    if(!perf)
+    {
+        getriBatched_initData<NPVT, true, false, T>(
+            handle, n, dA, lda, dC, ldc, dIpiv, stP, dInfo, bc, hA, hC, hIpiv, hInfo);
+
+        // save LU-factorized matrix for CPU reference
+        Th hA_LU(hA.n(), 1, hA.stride(), bc);
+        for(int b = 0; b < bc; ++b)
+        {
+            for(I i = 0; i < n * lda; ++i)
+                hA_LU[b][i] = hA[b][i];
+        }
+
+        // cpu-lapack performance (only if not in perf mode)
+        *cpu_time_used = get_time_us_no_sync();
+        for(int b = 0; b < bc; ++b)
+            cpu_getri(n, hA_LU[b], lda, hIpiv[b], hInfo[b]);
+        *cpu_time_used = get_time_us_no_sync() - *cpu_time_used;
+    }
+
+    getriBatched_initData<NPVT, true, false, T>(
+        handle, n, dA, lda, dC, ldc, dIpiv, stP, dInfo, bc, hA, hC, hIpiv, hInfo);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        getriBatched_initData<NPVT, false, true, T>(
+            handle, n, dA, lda, dC, ldc, dIpiv, stP, dInfo, bc, hA, hC, hIpiv, hInfo);
+
+        CHECK_ROCBLAS_ERROR(hipsolver_getriBatched(handle,
+                                                   n,
+                                                   dA.data(),
+                                                   lda,
+                                                   dC.data(),
+                                                   ldc,
+                                                   dWork.data(),
+                                                   lwork,
+                                                   dIpiv.data(),
+                                                   stP,
+                                                   dInfo.data(),
+                                                   bc));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(hipsolverGetStream(handle, &stream));
+    double start;
+
+    for(int iter = 0; iter < hot_calls; iter++)
+    {
+        getriBatched_initData<NPVT, false, true, T>(
+            handle, n, dA, lda, dC, ldc, dIpiv, stP, dInfo, bc, hA, hC, hIpiv, hInfo);
+
+        start = get_time_us_sync(stream);
+        hipsolver_getriBatched(handle,
+                               n,
+                               dA.data(),
+                               lda,
+                               dC.data(),
+                               ldc,
+                               dWork.data(),
+                               lwork,
+                               dIpiv.data(),
+                               stP,
+                               dInfo.data(),
+                               bc);
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <testAPI_t API,
+          bool      BATCHED,
+          bool      STRIDED,
+          bool      NPVT,
+          typename T,
+          typename I,
+          typename SIZE>
+void testing_getri(Arguments& argus)
+{
+    // get arguments
+    hipsolver_local_handle handle;
+    I                      n   = argus.get<int>("n");
+    I                      lda = argus.get<int>("lda", n);
+    I                      ldc = argus.get<int>("ldc", n);
+    I                      stP = argus.get<int>("strideP", n);
+
+    int bc        = argus.batch_count;
+    int hot_calls = argus.iters;
+
+    I stPRes = (argus.unit_check || argus.norm_check) ? stP : 0;
+
+    // check non-supported values
+    // N/A
+
+    // determine sizes
+    size_t size_A    = size_t(lda) * n;
+    size_t size_C    = size_t(ldc) * n;
+    size_t size_P    = size_t(n);
+    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+
+    size_t size_ARes = (argus.unit_check || argus.norm_check) ? size_A : 0;
+    size_t size_CRes = (argus.unit_check || argus.norm_check) ? size_C : 0;
+    size_t size_PRes = (argus.unit_check || argus.norm_check) ? size_P : 0;
+
+    // check invalid sizes
+    bool invalid_size = (n < 0 || lda < n || ldc < n || bc < 0);
+    if(invalid_size)
+    {
+        if(BATCHED)
+        {
+            EXPECT_ROCBLAS_STATUS(hipsolver_getriBatched(handle,
+                                                         n,
+                                                         (T**)nullptr,
+                                                         lda,
+                                                         (T**)nullptr,
+                                                         ldc,
+                                                         (T*)nullptr,
+                                                         0,
+                                                         (int*)nullptr,
+                                                         stP,
+                                                         (int*)nullptr,
+                                                         bc),
+                                  HIPSOLVER_STATUS_INVALID_VALUE);
+        }
+
+        if(argus.timing)
+            rocsolver_bench_inform(inform_invalid_size);
+
+        return;
+    }
+
+    // memory size query is necessary
+    I lwork;
+    hipsolver_getriBatched_bufferSize(
+        handle, n, (T**)nullptr, lda, (T**)nullptr, ldc, stP, &lwork, bc);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, lwork);
+        return;
+    }
+
+    if(BATCHED)
+    {
+        // memory allocations
+        host_batch_vector<T>             hA(size_A, 1, bc);
+        host_batch_vector<T>             hC(size_C, 1, bc);
+        host_batch_vector<T>             hCRes(size_CRes, 1, bc);
+        host_strided_batch_vector<int>   hIpiv(size_P, 1, stP, bc);
+        host_strided_batch_vector<int>   hIpivRes(size_PRes, 1, stPRes, bc);
+        host_strided_batch_vector<int>   hInfo(1, 1, 1, bc);
+        host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
+        device_batch_vector<T>           dA(size_A, 1, bc);
+        device_batch_vector<T>           dC(size_C, 1, bc);
+        device_strided_batch_vector<T>   dWork(lwork, 1, lwork, bc);
+        device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
+        device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        if(size_A)
+            CHECK_HIP_ERROR(dA.memcheck());
+        if(size_C)
+            CHECK_HIP_ERROR(dC.memcheck());
+        CHECK_HIP_ERROR(dInfo.memcheck());
+        if(size_P)
+            CHECK_HIP_ERROR(dIpiv.memcheck());
+        if(lwork)
+            CHECK_HIP_ERROR(dWork.memcheck());
+
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+            getriBatched_getError<NPVT,
+                                  T,
+                                  I,
+                                  device_batch_vector<T>,
+                                  device_strided_batch_vector<T>,
+                                  device_strided_batch_vector<int>,
+                                  device_strided_batch_vector<int>,
+                                  host_batch_vector<T>,
+                                  host_strided_batch_vector<int>,
+                                  host_strided_batch_vector<int>>(handle,
+                                                                  n,
+                                                                  dA,
+                                                                  lda,
+                                                                  dC,
+                                                                  ldc,
+                                                                  dIpiv,
+                                                                  stP,
+                                                                  dWork,
+                                                                  lwork,
+                                                                  dInfo,
+                                                                  bc,
+                                                                  hA,
+                                                                  hC,
+                                                                  hCRes,
+                                                                  hIpiv,
+                                                                  hIpivRes,
+                                                                  hInfo,
+                                                                  hInfoRes,
+                                                                  &max_error);
+
+        // collect performance data
+        if(argus.timing)
+            getriBatched_getPerfData<NPVT,
+                                     T,
+                                     I,
+                                     device_batch_vector<T>,
+                                     device_strided_batch_vector<T>,
+                                     device_strided_batch_vector<int>,
+                                     device_strided_batch_vector<int>,
+                                     host_batch_vector<T>,
+                                     host_strided_batch_vector<int>,
+                                     host_strided_batch_vector<int>>(handle,
+                                                                     n,
+                                                                     dA,
+                                                                     lda,
+                                                                     dC,
+                                                                     ldc,
+                                                                     dIpiv,
+                                                                     stP,
+                                                                     dWork,
+                                                                     lwork,
+                                                                     dInfo,
+                                                                     bc,
+                                                                     hA,
+                                                                     hC,
+                                                                     hIpiv,
+                                                                     hInfo,
+                                                                     &gpu_time_used,
+                                                                     &cpu_time_used,
+                                                                     hot_calls,
+                                                                     argus.perf);
+    }
+
+    // validate results for rocsolver-test
+    // using n * machine_precision as tolerance
+    if(argus.unit_check)
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
+
+    // output results for rocsolver-bench
+    if(argus.timing)
+    {
+        if(!argus.perf)
+        {
+            std::cerr << "\n============================================\n";
+            std::cerr << "Arguments:\n";
+            std::cerr << "============================================\n";
+            if(BATCHED)
+            {
+                rocsolver_bench_output("n", "lda", "strideP", "batch_c");
+                rocsolver_bench_output(n, lda, stP, bc);
+            }
+            std::cerr << "\n============================================\n";
+            std::cerr << "Results:\n";
+            std::cerr << "============================================\n";
+            if(argus.norm_check)
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time", "error");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
+            }
+            else
+            {
+                rocsolver_bench_output("cpu_time", "gpu_time");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used);
+            }
+            std::cerr << std::endl;
+        }
+        else
+        {
+            if(argus.norm_check)
+                rocsolver_bench_output(gpu_time_used, max_error);
+            else
+                rocsolver_bench_output(gpu_time_used);
+        }
+    }
+
+    // ensure all arguments were consumed
+    argus.validate_consumed();
+}

--- a/projects/hipsolver/library/include/internal/hipsolver-functions.h
+++ b/projects/hipsolver/library/include/internal/hipsolver-functions.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
@@ -1269,6 +1269,99 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t handle,
                                                    int               lwork,
                                                    int*              devIpiv,
                                                    int*              devInfo);
+
+// getriBatched
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetriBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               n,
+                                                                     float**           A,
+                                                                     int               lda,
+                                                                     float**           C,
+                                                                     int               ldc,
+                                                                     int               strideP,
+                                                                     int*              lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetriBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               n,
+                                                                     double**          A,
+                                                                     int               lda,
+                                                                     double**          C,
+                                                                     int               ldc,
+                                                                     int               strideP,
+                                                                     int*              lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetriBatched_bufferSize(hipsolverHandle_t handle,
+                                                                     int               n,
+                                                                     hipFloatComplex** A,
+                                                                     int               lda,
+                                                                     hipFloatComplex** C,
+                                                                     int               ldc,
+                                                                     int               strideP,
+                                                                     int*              lwork,
+                                                                     int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetriBatched_bufferSize(hipsolverHandle_t  handle,
+                                                                     int                n,
+                                                                     hipDoubleComplex** A,
+                                                                     int                lda,
+                                                                     hipDoubleComplex** C,
+                                                                     int                ldc,
+                                                                     int                strideP,
+                                                                     int*               lwork,
+                                                                     int batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetriBatched(hipsolverHandle_t handle,
+                                                          int               n,
+                                                          float**           A,
+                                                          int               lda,
+                                                          float**           C,
+                                                          int               ldc,
+                                                          float*            work,
+                                                          int               lwork,
+                                                          int*              devIpiv,
+                                                          int               strideP,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetriBatched(hipsolverHandle_t handle,
+                                                          int               n,
+                                                          double**          A,
+                                                          int               lda,
+                                                          double**          C,
+                                                          int               ldc,
+                                                          double*           work,
+                                                          int               lwork,
+                                                          int*              devIpiv,
+                                                          int               strideP,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetriBatched(hipsolverHandle_t handle,
+                                                          int               n,
+                                                          hipFloatComplex** A,
+                                                          int               lda,
+                                                          hipFloatComplex** C,
+                                                          int               ldc,
+                                                          hipFloatComplex*  work,
+                                                          int               lwork,
+                                                          int*              devIpiv,
+                                                          int               strideP,
+                                                          int*              devInfo,
+                                                          int               batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetriBatched(hipsolverHandle_t  handle,
+                                                          int                n,
+                                                          hipDoubleComplex** A,
+                                                          int                lda,
+                                                          hipDoubleComplex** C,
+                                                          int                ldc,
+                                                          hipDoubleComplex*  work,
+                                                          int                lwork,
+                                                          int*               devIpiv,
+                                                          int                strideP,
+                                                          int*               devInfo,
+                                                          int                batch_count);
 
 // getrs
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,

--- a/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/amd_detail/hipsolver.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -7011,6 +7011,407 @@ try
     else
         return hipsolver::rocblas2hip_status(rocsolver_zgetrf_npvt(
             (rocblas_handle)handle, m, n, (rocblas_double_complex*)A, lda, devInfo));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** GETRI_BATCHED ********************/
+hipsolverStatus_t hipsolverSgetriBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               n,
+                                                    float**           A,
+                                                    int               lda,
+                                                    float**           C,
+                                                    int               ldc,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status
+        = hipsolver::rocblas2hip_status(rocsolver_sgetri_outofplace_batched((rocblas_handle)handle,
+                                                                            n,
+                                                                            nullptr,
+                                                                            lda,
+                                                                            nullptr,
+                                                                            strideP,
+                                                                            nullptr,
+                                                                            ldc,
+                                                                            nullptr,
+                                                                            batch_count));
+    rocsolver_sgetri_npvt_outofplace_batched(
+        (rocblas_handle)handle, n, nullptr, lda, nullptr, ldc, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetriBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               n,
+                                                    double**          A,
+                                                    int               lda,
+                                                    double**          C,
+                                                    int               ldc,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status
+        = hipsolver::rocblas2hip_status(rocsolver_dgetri_outofplace_batched((rocblas_handle)handle,
+                                                                            n,
+                                                                            nullptr,
+                                                                            lda,
+                                                                            nullptr,
+                                                                            strideP,
+                                                                            nullptr,
+                                                                            ldc,
+                                                                            nullptr,
+                                                                            batch_count));
+    rocsolver_dgetri_npvt_outofplace_batched(
+        (rocblas_handle)handle, n, nullptr, lda, nullptr, ldc, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetriBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               n,
+                                                    hipFloatComplex** A,
+                                                    int               lda,
+                                                    hipFloatComplex** C,
+                                                    int               ldc,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status
+        = hipsolver::rocblas2hip_status(rocsolver_cgetri_outofplace_batched((rocblas_handle)handle,
+                                                                            n,
+                                                                            nullptr,
+                                                                            lda,
+                                                                            nullptr,
+                                                                            strideP,
+                                                                            nullptr,
+                                                                            ldc,
+                                                                            nullptr,
+                                                                            batch_count));
+    rocsolver_cgetri_npvt_outofplace_batched(
+        (rocblas_handle)handle, n, nullptr, lda, nullptr, ldc, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetriBatched_bufferSize(hipsolverHandle_t  handle,
+                                                    int                n,
+                                                    hipDoubleComplex** A,
+                                                    int                lda,
+                                                    hipDoubleComplex** C,
+                                                    int                ldc,
+                                                    int                strideP,
+                                                    int*               lwork,
+                                                    int                batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *lwork = 0;
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    hipsolverStatus_t status
+        = hipsolver::rocblas2hip_status(rocsolver_zgetri_outofplace_batched((rocblas_handle)handle,
+                                                                            n,
+                                                                            nullptr,
+                                                                            lda,
+                                                                            nullptr,
+                                                                            strideP,
+                                                                            nullptr,
+                                                                            ldc,
+                                                                            nullptr,
+                                                                            batch_count));
+    rocsolver_zgetri_npvt_outofplace_batched(
+        (rocblas_handle)handle, n, nullptr, lda, nullptr, ldc, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(status != HIPSOLVER_STATUS_SUCCESS)
+        return status;
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return status;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSgetriBatched(hipsolverHandle_t handle,
+                                         int               n,
+                                         float**           A,
+                                         int               lda,
+                                         float**           C,
+                                         int               ldc,
+                                         float*            work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int               strideP,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!A || !C || !devInfo)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(n < 0 || lda < n || ldc < n || batch_count < 0)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverSgetriBatched_bufferSize(
+            handle, n, A, lda, C, ldc, strideP, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
+    if(devIpiv != nullptr)
+        return hipsolver::rocblas2hip_status(rocsolver_sgetri_outofplace_batched(
+            (rocblas_handle)handle, n, A, lda, devIpiv, strideP, C, ldc, devInfo, batch_count));
+    else
+        return hipsolver::rocblas2hip_status(rocsolver_sgetri_npvt_outofplace_batched(
+            (rocblas_handle)handle, n, A, lda, C, ldc, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetriBatched(hipsolverHandle_t handle,
+                                         int               n,
+                                         double**          A,
+                                         int               lda,
+                                         double**          C,
+                                         int               ldc,
+                                         double*           work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int               strideP,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!A || !C || !devInfo)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(n < 0 || lda < n || ldc < n || batch_count < 0)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverDgetriBatched_bufferSize(
+            handle, n, A, lda, C, ldc, strideP, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
+    if(devIpiv != nullptr)
+        return hipsolver::rocblas2hip_status(rocsolver_dgetri_outofplace_batched(
+            (rocblas_handle)handle, n, A, lda, devIpiv, strideP, C, ldc, devInfo, batch_count));
+    else
+        return hipsolver::rocblas2hip_status(rocsolver_dgetri_npvt_outofplace_batched(
+            (rocblas_handle)handle, n, A, lda, C, ldc, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetriBatched(hipsolverHandle_t handle,
+                                         int               n,
+                                         hipFloatComplex** A,
+                                         int               lda,
+                                         hipFloatComplex** C,
+                                         int               ldc,
+                                         hipFloatComplex*  work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int               strideP,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!A || !C || !devInfo)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(n < 0 || lda < n || ldc < n || batch_count < 0)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverCgetriBatched_bufferSize(
+            handle, n, A, lda, C, ldc, strideP, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
+    if(devIpiv != nullptr)
+        return hipsolver::rocblas2hip_status(
+            rocsolver_cgetri_outofplace_batched((rocblas_handle)handle,
+                                                n,
+                                                (rocblas_float_complex**)A,
+                                                lda,
+                                                devIpiv,
+                                                strideP,
+                                                (rocblas_float_complex**)C,
+                                                ldc,
+                                                devInfo,
+                                                batch_count));
+    else
+        return hipsolver::rocblas2hip_status(
+            rocsolver_cgetri_npvt_outofplace_batched((rocblas_handle)handle,
+                                                     n,
+                                                     (rocblas_float_complex**)A,
+                                                     lda,
+                                                     (rocblas_float_complex**)C,
+                                                     ldc,
+                                                     devInfo,
+                                                     batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetriBatched(hipsolverHandle_t  handle,
+                                         int                n,
+                                         hipDoubleComplex** A,
+                                         int                lda,
+                                         hipDoubleComplex** C,
+                                         int                ldc,
+                                         hipDoubleComplex*  work,
+                                         int                lwork,
+                                         int*               devIpiv,
+                                         int                strideP,
+                                         int*               devInfo,
+                                         int                batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!A || !C || !devInfo)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(n < 0 || lda < n || ldc < n || batch_count < 0)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    if(work && lwork)
+        CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
+    else
+    {
+        CHECK_HIPSOLVER_ERROR(hipsolverZgetriBatched_bufferSize(
+            handle, n, A, lda, C, ldc, strideP, &lwork, batch_count));
+        CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
+    }
+
+    CHECK_ROCBLAS_ERROR(hipsolverZeroInfo((rocblas_handle)handle, devInfo, batch_count));
+
+    if(devIpiv != nullptr)
+        return hipsolver::rocblas2hip_status(
+            rocsolver_zgetri_outofplace_batched((rocblas_handle)handle,
+                                                n,
+                                                (rocblas_double_complex**)A,
+                                                lda,
+                                                devIpiv,
+                                                strideP,
+                                                (rocblas_double_complex**)C,
+                                                ldc,
+                                                devInfo,
+                                                batch_count));
+    else
+        return hipsolver::rocblas2hip_status(
+            rocsolver_zgetri_npvt_outofplace_batched((rocblas_handle)handle,
+                                                     n,
+                                                     (rocblas_double_complex**)A,
+                                                     lda,
+                                                     (rocblas_double_complex**)C,
+                                                     ldc,
+                                                     devInfo,
+                                                     batch_count));
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -4057,8 +4057,18 @@ try
     if(strideP != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(cublasSgetriBatched(
-        (cublasHandle_t)handle, n, A, lda, devIpiv, C, ldc, devInfo, batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status
+        = cublasSgetriBatched(cublas_handle, n, A, lda, devIpiv, C, ldc, devInfo, batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {
@@ -4084,8 +4094,18 @@ try
     if(strideP != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(cublasDgetriBatched(
-        (cublasHandle_t)handle, n, A, lda, devIpiv, C, ldc, devInfo, batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status
+        = cublasDgetriBatched(cublas_handle, n, A, lda, devIpiv, C, ldc, devInfo, batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {
@@ -4111,15 +4131,25 @@ try
     if(strideP != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(cublasCgetriBatched((cublasHandle_t)handle,
-                                                          n,
-                                                          (cuFloatComplex**)A,
-                                                          lda,
-                                                          devIpiv,
-                                                          (cuFloatComplex**)C,
-                                                          ldc,
-                                                          devInfo,
-                                                          batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status = cublasCgetriBatched(cublas_handle,
+                                                n,
+                                                (cuFloatComplex**)A,
+                                                lda,
+                                                devIpiv,
+                                                (cuFloatComplex**)C,
+                                                ldc,
+                                                devInfo,
+                                                batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {
@@ -4145,15 +4175,25 @@ try
     if(strideP != n)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
-    return hipsolver::cuda2hip_status(cublasZgetriBatched((cublasHandle_t)handle,
-                                                          n,
-                                                          (cuDoubleComplex**)A,
-                                                          lda,
-                                                          devIpiv,
-                                                          (cuDoubleComplex**)C,
-                                                          ldc,
-                                                          devInfo,
-                                                          batch_count));
+    cudaStream_t stream;
+    cusolverDnGetStream((cusolverDnHandle_t)handle, &stream);
+
+    cublasHandle_t cublas_handle;
+    cublasCreate(&cublas_handle);
+    cublasSetStream(cublas_handle, stream);
+
+    cublasStatus_t status = cublasZgetriBatched(cublas_handle,
+                                                n,
+                                                (cuDoubleComplex**)A,
+                                                lda,
+                                                devIpiv,
+                                                (cuDoubleComplex**)C,
+                                                ldc,
+                                                devInfo,
+                                                batch_count);
+
+    cublasDestroy(cublas_handle);
+    return hipsolver::cuda2hip_status(status);
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -3931,6 +3931,229 @@ try
                                                        (cuDoubleComplex*)work,
                                                        devIpiv,
                                                        devInfo));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+/******************** GETRI_BATCHED ********************/
+hipsolverStatus_t hipsolverSgetriBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               n,
+                                                    float**           A,
+                                                    int               lda,
+                                                    float**           C,
+                                                    int               ldc,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // cuBLAS doesn't need workspace for getri
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetriBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               n,
+                                                    double**          A,
+                                                    int               lda,
+                                                    double**          C,
+                                                    int               ldc,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // cuBLAS doesn't need workspace for getri
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetriBatched_bufferSize(hipsolverHandle_t handle,
+                                                    int               n,
+                                                    hipFloatComplex** A,
+                                                    int               lda,
+                                                    hipFloatComplex** C,
+                                                    int               ldc,
+                                                    int               strideP,
+                                                    int*              lwork,
+                                                    int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // cuBLAS doesn't need workspace for getri
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetriBatched_bufferSize(hipsolverHandle_t  handle,
+                                                    int                n,
+                                                    hipDoubleComplex** A,
+                                                    int                lda,
+                                                    hipDoubleComplex** C,
+                                                    int                ldc,
+                                                    int                strideP,
+                                                    int*               lwork,
+                                                    int                batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    // cuBLAS doesn't need workspace for getri
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSgetriBatched(hipsolverHandle_t handle,
+                                         int               n,
+                                         float**           A,
+                                         int               lda,
+                                         float**           C,
+                                         int               ldc,
+                                         float*            work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int               strideP,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(strideP != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasSgetriBatched(
+        (cublasHandle_t)handle, n, A, lda, devIpiv, C, ldc, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetriBatched(hipsolverHandle_t handle,
+                                         int               n,
+                                         double**          A,
+                                         int               lda,
+                                         double**          C,
+                                         int               ldc,
+                                         double*           work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int               strideP,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(strideP != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasDgetriBatched(
+        (cublasHandle_t)handle, n, A, lda, devIpiv, C, ldc, devInfo, batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetriBatched(hipsolverHandle_t handle,
+                                         int               n,
+                                         hipFloatComplex** A,
+                                         int               lda,
+                                         hipFloatComplex** C,
+                                         int               ldc,
+                                         hipFloatComplex*  work,
+                                         int               lwork,
+                                         int*              devIpiv,
+                                         int               strideP,
+                                         int*              devInfo,
+                                         int               batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(strideP != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasCgetriBatched((cublasHandle_t)handle,
+                                                          n,
+                                                          (cuFloatComplex**)A,
+                                                          lda,
+                                                          devIpiv,
+                                                          (cuFloatComplex**)C,
+                                                          ldc,
+                                                          devInfo,
+                                                          batch_count));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetriBatched(hipsolverHandle_t  handle,
+                                         int                n,
+                                         hipDoubleComplex** A,
+                                         int                lda,
+                                         hipDoubleComplex** C,
+                                         int                ldc,
+                                         hipDoubleComplex*  work,
+                                         int                lwork,
+                                         int*               devIpiv,
+                                         int                strideP,
+                                         int*               devInfo,
+                                         int                batch_count)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(strideP != n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cublasZgetriBatched((cublasHandle_t)handle,
+                                                          n,
+                                                          (cuDoubleComplex**)A,
+                                                          lda,
+                                                          devIpiv,
+                                                          (cuDoubleComplex**)C,
+                                                          ldc,
+                                                          devInfo,
+                                                          batch_count));
 }
 catch(...)
 {

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -280,6 +280,33 @@ hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus)
         return HIPSOLVER_STATUS_ZERO_PIVOT;
     case CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
         return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+    default:
+        return HIPSOLVER_STATUS_UNKNOWN;
+    }
+}
+
+hipsolverStatus_t cuda2hip_status(cublasStatus_t cuStatus)
+{
+    switch(cuStatus)
+    {
+    case CUBLAS_STATUS_SUCCESS:
+        return HIPSOLVER_STATUS_SUCCESS;
+    case CUBLAS_STATUS_NOT_INITIALIZED:
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    case CUBLAS_STATUS_ALLOC_FAILED:
+        return HIPSOLVER_STATUS_ALLOC_FAILED;
+    case CUBLAS_STATUS_INVALID_VALUE:
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    case CUBLAS_STATUS_MAPPING_ERROR:
+        return HIPSOLVER_STATUS_MAPPING_ERROR;
+    case CUBLAS_STATUS_EXECUTION_FAILED:
+        return HIPSOLVER_STATUS_EXECUTION_FAILED;
+    case CUBLAS_STATUS_INTERNAL_ERROR:
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+    case CUBLAS_STATUS_NOT_SUPPORTED:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    case CUBLAS_STATUS_ARCH_MISMATCH:
+        return HIPSOLVER_STATUS_ARCH_MISMATCH;
     default:
         return HIPSOLVER_STATUS_UNKNOWN;
     }

--- a/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
+++ b/projects/hipsolver/library/src/nvidia_detail/hipsolver_conversions.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,6 +65,8 @@ hipsolverDeterministicMode_t cuda2hip_deterministic(cusolverDeterministicMode_t 
 #endif
 
 hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus);
+
+hipsolverStatus_t cuda2hip_status(cublasStatus_t cuStatus);
 
 // Dense API
 cusolverDnFunction_t hip2cuda_function(hipsolverDnFunction_t func);


### PR DESCRIPTION
## Motivation

We want to be able to test AMD vs. NVIDIA's (rocSOLVER vs cuBLAS) implementation of `getri_batched` using a benchmark framework unified with the rest of hipSOLVER.

## Technical Details

We add `hipsolver_getriXBatched` to hipSOLVER's API, implement a backend for AMD and NVIDIA that reconciles the differences in input parameters, and add it to our testing/benchmarking client.

We make new function headers for `getri_batched` in the client's internal API and the testing files as opposed to integrating the batched case into a function with the same function header. This is to account for the differences of `getri_batched` between cuSOLVER and cuBLAS, but breaks the pattern we typically follow in hipSOLVER.

### NOTE:
This change is made alongside changes to add `geqrf_batched`, `getrf_batched`, `getrs_batched`, and `gels_batched`. You can find PRs for each of these routines, each of them reading extremely similarly.

## Test Plan

Run new tests on AMD and NVIDIA hardware. Try invoking `getri_batched` from the benchmark client.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.