### PR TITLE
[rocBLAS] stress tests changes for datatypes using hipblaslt batched API

### DIFF
--- a/projects/rocblas/clients/gtest/gemm_batched_gtest.yaml
+++ b/projects/rocblas/clients/gtest/gemm_batched_gtest.yaml
@@ -523,8 +523,9 @@ Tests:
   category: stress
   function:
     - gemm_batched: *single_precision
-    - gemm_batched_ex: *nonint8_real_precisions
-    - gemm_batched_ex: *int8_precision
+    # TODO put back after revising batched API
+    # - gemm_batched_ex: *nonint8_real_precisions
+    # - gemm_batched_ex: *int8_precision
   matrix_size:
     - { M: 3, N: 3, K: 3, lda: 3, ldb: 3, ldc: 3, batch_count: *c_grid_yz_require_passes }
   pointer_mode_device: false


### PR DESCRIPTION
This pull request makes a minor update to the grid launch limit constant and temporarily disables certain stress test cases for batched GEMM operations pending API revisions.
