### PR TITLE
de-boost tensile: drop Boost.Program_options and Boost.Filesystem

### DIFF
--- a/shared/tensile/HostLibraryTests/CMakeLists.txt
+++ b/shared/tensile/HostLibraryTests/CMakeLists.txt
@@ -80,8 +80,6 @@ if(NOT gtest_SOURCE_DIR)
     message(FATAL_ERROR "googletest not found.  Run git submodule update --init")
 endif()
 
-find_package(Boost COMPONENTS filesystem)
-
 #if(TENSILE_USE_HIP AND NOT HIP_DIR)
 if(TENSILE_USE_HIP)
     find_package(HIP REQUIRED CONFIG PATHS $ENV{ROCM_PATH} /opt/rocm)
@@ -181,7 +179,7 @@ if(NOT TENSILE_DISABLE_CTEST)
     endif()
 endif()
 
-target_link_libraries(TensileTests PUBLIC gtest TensileHost TensileTestLib ${Boost_LIBRARIES})
+target_link_libraries(TensileTests PUBLIC gtest TensileHost TensileTestLib)
 
 if(TENSILE_USE_LLVM)
     find_library(LLVMObjectYAML_LIBRARY

--- a/shared/tensile/HostLibraryTests/TestData_test.cpp
+++ b/shared/tensile/HostLibraryTests/TestData_test.cpp
@@ -26,6 +26,7 @@
 
 #include <TestData.hpp>
 
+#include <filesystem>
 #include <gtest/gtest.h>
 
 TEST(TestData, Simple)
@@ -36,7 +37,7 @@ TEST(TestData, Simple)
 
 #if defined(TENSILE_MSGPACK) || defined(TENSILE_LLVM)
     auto is_regular_file
-        = static_cast<bool (*)(boost::filesystem::path const&)>(boost::filesystem::is_regular_file);
+        = static_cast<bool (*)(std::filesystem::path const&)>(std::filesystem::is_regular_file);
 
     EXPECT_PRED1(is_regular_file, data.file("KernelsLite"));
     EXPECT_FALSE(is_regular_file(data.file("fjdlksljfjldskj")));

--- a/shared/tensile/HostLibraryTests/client/DataInitialization_test.cpp
+++ b/shared/tensile/HostLibraryTests/client/DataInitialization_test.cpp
@@ -26,14 +26,16 @@
 
 #include <gtest/gtest.h>
 
+#include <any>
 #include <tuple>
 
 #include <DataInitializationTyped.hpp>
+#include <ProgramOptions.hpp>
 
 using namespace Tensile;
 using namespace Tensile::Client;
 
-namespace po = boost::program_options;
+namespace po = Tensile::Client::po;
 
 template <typename TypedInputs>
 class DataInitializationTest : public ::testing::Test
@@ -69,12 +71,12 @@ public:
     {
         po::variables_map rv;
 
-        rv.insert({"a-type", val(TypeInfo<AType>::Enum, false)});
-        rv.insert({"b-type", val(TypeInfo<BType>::Enum, false)});
-        rv.insert({"c-type", val(TypeInfo<CType>::Enum, false)});
-        rv.insert({"d-type", val(TypeInfo<DType>::Enum, false)});
-        rv.insert({"alpha-type", val(TypeInfo<AlphaType>::Enum, false)});
-        rv.insert({"beta-type", val(TypeInfo<BetaType>::Enum, false)});
+        rv.insert({"a-type", val(std::any(TypeInfo<AType>::Enum))});
+        rv.insert({"b-type", val(std::any(TypeInfo<BType>::Enum))});
+        rv.insert({"c-type", val(std::any(TypeInfo<CType>::Enum))});
+        rv.insert({"d-type", val(std::any(TypeInfo<DType>::Enum))});
+        rv.insert({"alpha-type", val(std::any(TypeInfo<AlphaType>::Enum))});
+        rv.insert({"beta-type", val(std::any(TypeInfo<BetaType>::Enum))});
 
         return rv;
     }
@@ -85,21 +87,21 @@ public:
 
         po::variables_map args = this->DataTypeArgs();
 
-        args.insert({"init-a", val(InitMode::Zero, false)});
-        args.insert({"init-b", val(InitMode::Zero, false)});
-        args.insert({"init-c", val(InitMode::Zero, false)});
-        args.insert({"init-d", val(InitMode::Zero, false)});
-        args.insert({"init-alpha", val(InitMode::Zero, false)});
-        args.insert({"init-beta", val(InitMode::Zero, false)});
-        args.insert({"c-equal-d", val(cEqualD, false)});
-        args.insert({"pristine-on-gpu", val(pristineGPU, false)});
-        args.insert({"bounds-check", val(boundsCheck, false)});
-        args.insert({"num-elements-to-validate", val(1, false)});
-        args.insert({"offset-a", val((size_t)0, false)});
-        args.insert({"offset-b", val((size_t)0, false)});
-        args.insert({"offset-c", val((size_t)0, false)});
-        args.insert({"offset-d", val((size_t)0, false)});
-        args.insert({"strided-batched", val(false, false)});
+        args.insert({"init-a", val(std::any(InitMode::Zero))});
+        args.insert({"init-b", val(std::any(InitMode::Zero))});
+        args.insert({"init-c", val(std::any(InitMode::Zero))});
+        args.insert({"init-d", val(std::any(InitMode::Zero))});
+        args.insert({"init-alpha", val(std::any(InitMode::Zero))});
+        args.insert({"init-beta", val(std::any(InitMode::Zero))});
+        args.insert({"c-equal-d", val(std::any(cEqualD))});
+        args.insert({"pristine-on-gpu", val(std::any(pristineGPU))});
+        args.insert({"bounds-check", val(std::any(boundsCheck))});
+        args.insert({"num-elements-to-validate", val(std::any(1))});
+        args.insert({"offset-a", val(std::any((size_t)0))});
+        args.insert({"offset-b", val(std::any((size_t)0))});
+        args.insert({"offset-c", val(std::any((size_t)0))});
+        args.insert({"offset-d", val(std::any((size_t)0))});
+        args.insert({"strided-batched", val(std::any(false))});
 
         TensorDescriptor a(TypeInfo<typename TypedInputs::AType>::Enum, {10, 10, 1});
         TensorDescriptor b(TypeInfo<typename TypedInputs::BType>::Enum, {10, 10, 1});

--- a/shared/tensile/HostLibraryTests/llvm/LibraryPerformance_test.cpp
+++ b/shared/tensile/HostLibraryTests/llvm/LibraryPerformance_test.cpp
@@ -24,6 +24,7 @@
  *
  *******************************************************************************/
 
+#include <filesystem>
 #include <gtest/gtest.h>
 
 #include <Tensile/ContractionLibrary.hpp>
@@ -69,15 +70,15 @@ struct LibraryPerformanceTest
 
         if(library == nullptr)
         {
-            std::cout << libraryPath().native() << std::endl;
-            if(!boost::filesystem::is_regular_file(libraryPath()))
+            std::cout << libraryPath().string() << std::endl;
+            if(!std::filesystem::is_regular_file(libraryPath()))
                 GTEST_SKIP();
             else
                 ASSERT_NE(library, nullptr);
         }
     }
 
-    boost::filesystem::path libraryPath()
+    std::filesystem::path libraryPath()
     {
         return TestData::Instance().file(filename);
     }
@@ -87,7 +88,7 @@ struct LibraryPerformanceTest
         if(!cache)
             return loadLibraryNoCache();
 
-        auto pathStr = libraryPath().native();
+        auto pathStr = libraryPath().string();
 
         auto iter = libraryCache.find(pathStr);
         if(iter != libraryCache.end())
@@ -100,8 +101,8 @@ struct LibraryPerformanceTest
     {
         auto path = libraryPath();
 
-        if(boost::filesystem::is_regular_file(path))
-            return LoadLibraryFile<ContractionProblem>(path.native());
+        if(std::filesystem::is_regular_file(path))
+            return LoadLibraryFile<ContractionProblem>(path.string());
 
         return nullptr;
     }

--- a/shared/tensile/HostLibraryTests/testlib/CMakeLists.txt
+++ b/shared/tensile/HostLibraryTests/testlib/CMakeLists.txt
@@ -29,9 +29,7 @@ add_library(TensileTestLib STATIC ${testlib_sources})
 
 target_include_directories(TensileTestLib PUBLIC include)
 
-target_compile_definitions(TensileTestLib PRIVATE BOOST_ERROR_CODE_HEADER_ONLY)
-
-target_link_libraries(TensileTestLib PUBLIC TensileHost ${Boost_LIBRARIES})
+target_link_libraries(TensileTestLib PUBLIC TensileHost)
 if(TENSILE_USE_OPENMP)
     target_link_libraries(TensileTestLib PRIVATE custom_openmp_cxx)
 endif()

--- a/shared/tensile/HostLibraryTests/testlib/include/TestData.hpp
+++ b/shared/tensile/HostLibraryTests/testlib/include/TestData.hpp
@@ -26,7 +26,9 @@
 
 #pragma once
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
+#include <string>
+#include <vector>
 
 #include <Tensile/Singleton.hpp>
 
@@ -39,23 +41,23 @@ struct TestData : public Tensile::LazySingleton<TestData>
     static TestData Invalid();
     static TestData Env(std::string const& varName);
 
-    boost::filesystem::path dataDir() const;
+    std::filesystem::path dataDir() const;
 
-    boost::filesystem::path file(std::string const& filename) const;
-    boost::filesystem::path file(std::string const& filename, std::string const& extension) const;
+    std::filesystem::path file(std::string const& filename) const;
+    std::filesystem::path file(std::string const& filename, std::string const& extension) const;
 
-    std::vector<boost::filesystem::path> glob(std::string const& pattern) const;
+    std::vector<std::filesystem::path> glob(std::string const& pattern) const;
 
 private:
     friend Base;
 
-    boost::filesystem::path m_dataDir;
+    std::filesystem::path m_dataDir;
 
     struct invalid_data
     {
     };
 
-    static boost::filesystem::path ProgramLocation();
+    static std::filesystem::path ProgramLocation();
 
     TestData();
     TestData(std::string const& dataDir);

--- a/shared/tensile/HostLibraryTests/testlib/source/TestData.cpp
+++ b/shared/tensile/HostLibraryTests/testlib/source/TestData.cpp
@@ -29,19 +29,18 @@
 #include <glob.h>
 #include <unistd.h>
 
-#include <boost/version.hpp>
-
-#if BOOST_VERSION >= 106100
-#include <boost/dll/runtime_symbol_info.hpp>
-#else
-#define TEST_DATA_USE_PROC_EXE
-#endif
+#include <stdexcept>
+#include <vector>
 
 #include <Tensile/Utils.hpp>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 TestData::operator bool() const
 {
-    return boost::filesystem::is_directory(dataDir());
+    return std::filesystem::is_directory(dataDir());
 }
 
 TestData TestData::Invalid()
@@ -59,37 +58,37 @@ TestData TestData::Env(std::string const& varName)
     return TestData(var);
 }
 
-boost::filesystem::path TestData::dataDir() const
+std::filesystem::path TestData::dataDir() const
 {
     return m_dataDir;
 }
 
-boost::filesystem::path TestData::file(std::string const& filename) const
+std::filesystem::path TestData::file(std::string const& filename) const
 {
     auto simple = dataDir() / filename;
-    if(boost::filesystem::is_regular_file(simple))
+    if(std::filesystem::is_regular_file(simple))
         return simple;
 
     auto datFile = file(filename, "dat");
-    if(boost::filesystem::is_regular_file(datFile))
+    if(std::filesystem::is_regular_file(datFile))
         return datFile;
 
     auto yamlFile = file(filename, "yaml");
-    if(boost::filesystem::is_regular_file(yamlFile))
+    if(std::filesystem::is_regular_file(yamlFile))
         return yamlFile;
 
     return simple;
 }
 
-boost::filesystem::path TestData::file(std::string const& filename,
-                                       std::string const& extension) const
+std::filesystem::path TestData::file(std::string const& filename,
+                                     std::string const& extension) const
 {
     return dataDir() / (filename + "." + extension);
 }
 
-std::vector<boost::filesystem::path> TestData::glob(std::string const& pattern) const
+std::vector<std::filesystem::path> TestData::glob(std::string const& pattern) const
 {
-    std::string wholePattern = (dataDir() / pattern).native();
+    std::string wholePattern = (dataDir() / pattern).string();
 
     glob_t result;
     result.gl_pathc = 0;
@@ -104,7 +103,7 @@ std::vector<boost::filesystem::path> TestData::glob(std::string const& pattern) 
     if(err == GLOB_NOSPACE || err == GLOB_ABORTED)
         throw std::runtime_error(Tensile::concatenate("Glob ", wholePattern, " failed."));
 
-    std::vector<boost::filesystem::path> rv(result.gl_pathc);
+    std::vector<std::filesystem::path> rv(result.gl_pathc);
 
     for(size_t i = 0; i < result.gl_pathc; i++)
         rv[i] = result.gl_pathv[i];
@@ -112,22 +111,32 @@ std::vector<boost::filesystem::path> TestData::glob(std::string const& pattern) 
     return rv;
 }
 
-boost::filesystem::path TestData::ProgramLocation()
+std::filesystem::path TestData::ProgramLocation()
 {
-#ifdef TEST_DATA_USE_PROC_EXE
-    return boost::filesystem::read_symlink("/proc/self/exe");
+#if defined(__linux__)
+    return std::filesystem::read_symlink("/proc/self/exe");
+#elif defined(_WIN32)
+    // Use buffer large enough for Windows long path (up to 32767 chars).
+    constexpr DWORD      kMaxPathChars = 32768;
+    std::vector<wchar_t> buf(kMaxPathChars);
+    DWORD n = GetModuleFileNameW(nullptr, buf.data(), static_cast<DWORD>(buf.size()));
+    if(n == 0)
+        throw std::runtime_error("GetModuleFileNameW failed");
+    if(n >= buf.size())
+        throw std::runtime_error("GetModuleFileNameW: path longer than maximum supported");
+    return std::filesystem::path(buf.data());
 #else
-    return boost::dll::program_location();
+    throw std::runtime_error("ProgramLocation() not implemented for this platform");
 #endif
 }
 
 TestData::TestData()
     : m_dataDir(ProgramLocation().parent_path() / "data")
 {
-    if(!boost::filesystem::is_directory(m_dataDir))
+    if(!std::filesystem::is_directory(m_dataDir))
     {
         auto newValue = ProgramLocation().parent_path().parent_path() / "data";
-        if(boost::filesystem::is_directory(newValue))
+        if(std::filesystem::is_directory(newValue))
             m_dataDir = newValue;
     }
 }

--- a/shared/tensile/Tensile/Source/client/CMakeLists.txt
+++ b/shared/tensile/Tensile/Source/client/CMakeLists.txt
@@ -32,6 +32,7 @@ set(client_sources
     source/LibraryUpdateReporter.cpp
     source/MetaRunListener.cpp
     source/PerformanceReporter.cpp
+    source/ProgramOptions.cpp
     source/ProgressListener.cpp
     source/Reference.cpp
     source/ReferenceValidator.cpp
@@ -55,8 +56,6 @@ set_target_properties(TensileClient
                       CXX_STANDARD_REQUIRED ON
                       CXX_EXTENSIONS OFF)
 
-find_package(Boost COMPONENTS program_options REQUIRED)
-
 if (NOT WIN32)
     find_package(ROCmSMI QUIET)
     if(NOT ROCmSMI_FOUND)
@@ -65,11 +64,9 @@ if (NOT WIN32)
     endif()
 endif()
 
-include_directories(${Boost_INCLUDE_DIR})
-
 target_include_directories(TensileClient PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")# "${rocm_smi_root}/include")
 
-target_link_libraries(TensileClient PRIVATE TensileHost ${Boost_LIBRARIES})
+target_link_libraries(TensileClient PRIVATE TensileHost)
 
 if(NOT WIN32)
     target_link_libraries(TensileClient PRIVATE TensileHost rocm_smi)
@@ -87,7 +84,7 @@ set_target_properties(tensile_client
                       CXX_STANDARD_REQUIRED ON
                       CXX_EXTENSIONS OFF)
 
-target_link_libraries(tensile_client PRIVATE TensileHost TensileClient ${Boost_LIBRARIES})
+target_link_libraries(tensile_client PRIVATE TensileHost TensileClient)
 if(TENSILE_USE_OPENMP)
     target_link_libraries(tensile_client PRIVATE custom_openmp_cxx)
 endif()

--- a/shared/tensile/Tensile/Source/client/include/BenchmarkTimer.hpp
+++ b/shared/tensile/Tensile/Source/client/include/BenchmarkTimer.hpp
@@ -31,7 +31,7 @@
 #include <chrono>
 #include <cstddef>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <Tensile/ContractionProblem.hpp>
 #include <Tensile/ContractionSolution.hpp>
@@ -40,8 +40,6 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
-
         class BenchmarkTimer : public RunListener
         {
         public:

--- a/shared/tensile/Tensile/Source/client/include/CSVStackFile.hpp
+++ b/shared/tensile/Tensile/Source/client/include/CSVStackFile.hpp
@@ -31,7 +31,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <boost/lexical_cast.hpp>
+#include <sstream>
 
 namespace Tensile
 {
@@ -55,7 +55,9 @@ namespace Tensile
             typename std::enable_if<!std::is_same<T, std::string>::value, void>::type
                 setValueForKey(std::string const& key, T const& value)
             {
-                setValueForKey(key, boost::lexical_cast<std::string>(value));
+                std::ostringstream ss;
+                ss << value;
+                setValueForKey(key, ss.str());
             }
 
             void push();

--- a/shared/tensile/Tensile/Source/client/include/ClientProblemFactory.hpp
+++ b/shared/tensile/Tensile/Source/client/include/ClientProblemFactory.hpp
@@ -31,7 +31,7 @@
 #include <Tensile/KernelLanguageTypes.hpp>
 #include <Tensile/Tensile.hpp>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <cstddef>
 
@@ -39,8 +39,6 @@ namespace Tensile
 {
     namespace Client
     {
-
-        namespace po = boost::program_options;
 
         class ClientProblemFactory
         {

--- a/shared/tensile/Tensile/Source/client/include/DataInitialization.hpp
+++ b/shared/tensile/Tensile/Source/client/include/DataInitialization.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <Tensile/ContractionProblem.hpp>
 
@@ -37,7 +37,7 @@
 
 #include "RunListener.hpp"
 
-namespace po = boost::program_options;
+namespace po = Tensile::Client::po;
 
 namespace Tensile
 {

--- a/shared/tensile/Tensile/Source/client/include/HardwareMonitorListener.hpp
+++ b/shared/tensile/Tensile/Source/client/include/HardwareMonitorListener.hpp
@@ -32,7 +32,7 @@
 #include <cstddef>
 #include <future>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include "HardwareMonitor_fwd.hpp"
 
@@ -40,8 +40,6 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
-
         class HardwareMonitorListener : public RunListener
         {
         public:

--- a/shared/tensile/Tensile/Source/client/include/LibraryUpdateReporter.hpp
+++ b/shared/tensile/Tensile/Source/client/include/LibraryUpdateReporter.hpp
@@ -29,7 +29,7 @@
 #include "CSVStackFile.hpp"
 #include "ResultReporter.hpp"
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <cstddef>
 
@@ -37,8 +37,6 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
-
         class LibraryUpdateReporter : public ResultReporter
         {
         public:

--- a/shared/tensile/Tensile/Source/client/include/LogReporter.hpp
+++ b/shared/tensile/Tensile/Source/client/include/LogReporter.hpp
@@ -33,10 +33,11 @@
 #include <string>
 #include <unordered_set>
 
-#include <boost/lexical_cast.hpp>
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
-namespace po = boost::program_options;
+#include <sstream>
+
+namespace po = Tensile::Client::po;
 
 namespace Tensile
 {

--- a/shared/tensile/Tensile/Source/client/include/PerformanceReporter.hpp
+++ b/shared/tensile/Tensile/Source/client/include/PerformanceReporter.hpp
@@ -35,15 +35,13 @@
 #include <limits>
 #include <string>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 #include <hip/hip_runtime.h>
 
 namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
-
         class PerformanceReporter : public ResultReporter
         {
         public:

--- a/shared/tensile/Tensile/Source/client/include/ProgramOptions.hpp
+++ b/shared/tensile/Tensile/Source/client/include/ProgramOptions.hpp
@@ -1,0 +1,650 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <any>
+#include <cctype>
+#include <functional>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace Tensile
+{
+    namespace Client
+    {
+        namespace po
+        {
+
+            inline std::vector<std::string> split_string(std::string const& s,
+                                                         char const*        sep = ",;")
+            {
+                std::vector<std::string> out;
+                std::string::size_type   pos = 0;
+                for(;;)
+                {
+                    auto next = s.find_first_of(sep, pos);
+                    if(next == std::string::npos)
+                    {
+                        if(pos < s.size())
+                        {
+                            std::string part = s.substr(pos);
+                            if(!part.empty())
+                                out.push_back(std::move(part));
+                        }
+                        break;
+                    }
+                    if(next > pos)
+                        out.push_back(s.substr(pos, next - pos));
+                    pos = next + 1;
+                }
+                return out;
+            }
+
+            inline bool parse_bool_string(std::string const& s)
+            {
+                std::string lower;
+                lower.reserve(s.size());
+                for(char c : s)
+                    lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+                if(lower == "1" || lower == "true" || lower == "yes")
+                    return true;
+                if(lower == "0" || lower == "false" || lower == "no")
+                    return false;
+                throw std::runtime_error("Failed to parse bool: " + s);
+            }
+
+            inline std::string trim_opt(std::string s)
+            {
+                auto start = s.find_first_not_of(" \t");
+                if(start == std::string::npos)
+                    return {};
+                auto end = s.find_last_not_of(" \t");
+                return s.substr(start, end == std::string::npos ? end : end - start + 1);
+            }
+
+            inline std::string get_canonical_option_name(std::string const& opts)
+            {
+                auto pos = opts.find(',');
+                if(pos == std::string::npos)
+                    return trim_opt(opts);
+                return trim_opt(opts.substr(0, pos));
+            }
+
+            class variable_value
+            {
+                std::any m_value;
+
+            public:
+                variable_value() = default;
+                variable_value(variable_value const& other);
+                variable_value(variable_value&& other) noexcept;
+                variable_value& operator=(variable_value const& other);
+                variable_value& operator=(variable_value&& other) noexcept;
+
+                explicit variable_value(std::any v)
+                    : m_value(std::move(v))
+                {
+                }
+
+                bool empty() const
+                {
+                    return !m_value.has_value();
+                }
+
+                std::any& value()
+                {
+                    return m_value;
+                }
+                std::any const& value() const
+                {
+                    return m_value;
+                }
+
+                template <typename T>
+                T const& as() const
+                {
+                    if(!m_value.has_value())
+                    {
+                        // Match Boost: unset option yields default-constructed T when .as<T>() is used
+                        static T const defaultVal{};
+                        return defaultVal;
+                    }
+                    try
+                    {
+                        return std::any_cast<T const&>(m_value);
+                    }
+                    catch(std::bad_any_cast const&)
+                    {
+                        // Allow bool option stored as string (e.g. "True"/"False" from config)
+                        if constexpr(std::is_same_v<T, bool>)
+                        {
+                            if(m_value.type() == typeid(std::string))
+                            {
+                                return parse_bool_string(
+                                    std::any_cast<std::string const&>(m_value));
+                            }
+                        }
+                        throw std::runtime_error(
+                            "program_options: bad_any_cast - stored option value has a different "
+                            "type than the requested .as<T>()");
+                    }
+                }
+            };
+
+            class variables_map
+            {
+                std::map<std::string, variable_value> m_map;
+                static variable_value const           s_empty;
+
+            public:
+                using key_type       = std::string;
+                using mapped_type    = variable_value;
+                using value_type     = std::pair<const std::string, variable_value>;
+                using iterator       = std::map<std::string, variable_value>::iterator;
+                using const_iterator = std::map<std::string, variable_value>::const_iterator;
+
+                variable_value& operator[](key_type const& k)
+                {
+                    return m_map[k];
+                }
+                variable_value const& operator[](key_type const& k) const
+                {
+                    auto it = m_map.find(k);
+                    if(it != m_map.end())
+                        return it->second;
+                    return s_empty;
+                }
+
+                variable_value& at(key_type const& k)
+                {
+                    return m_map.at(k);
+                }
+                variable_value const& at(key_type const& k) const
+                {
+                    return m_map.at(k);
+                }
+
+                size_t count(key_type const& k) const
+                {
+                    return m_map.count(k);
+                }
+
+                iterator begin()
+                {
+                    return m_map.begin();
+                }
+                iterator end()
+                {
+                    return m_map.end();
+                }
+                const_iterator begin() const
+                {
+                    return m_map.begin();
+                }
+                const_iterator end() const
+                {
+                    return m_map.end();
+                }
+                const_iterator find(key_type const& k) const
+                {
+                    return m_map.find(k);
+                }
+                iterator find(key_type const& k)
+                {
+                    return m_map.find(k);
+                }
+
+                std::pair<iterator, bool> insert(value_type const& v)
+                {
+                    return m_map.insert(v);
+                }
+                void clear()
+                {
+                    m_map.clear();
+                }
+            };
+
+            struct option_value_base
+            {
+                virtual ~option_value_base()                                            = default;
+                virtual std::any                                    get_default() const = 0;
+                virtual std::function<std::any(std::string const&)> parser() const      = 0;
+                /** Parse one line from config file. Default: parser()(value). Override for Boost-compatible
+                 *  behaviour where each config line is one value (no comma split). */
+                virtual std::any parse_config_line(std::string const& value) const
+                {
+                    return parser()(value);
+                }
+                virtual bool is_multivalued() const
+                {
+                    return false;
+                }
+                virtual bool is_flag() const
+                {
+                    return false;
+                }
+                virtual bool has_explicit_default() const
+                {
+                    return false;
+                }
+                virtual bool has_implicit_value() const
+                {
+                    return false;
+                }
+                virtual std::any get_implicit_value() const
+                {
+                    return std::any();
+                }
+                virtual void merge_into(std::any& current, std::any const& new_val) const
+                {
+                    current = new_val;
+                }
+            };
+
+            template <typename T>
+            struct typed_value_holder : option_value_base
+            {
+                T    m_default{};
+                bool m_has_explicit_default = false;
+
+                typed_value_holder* default_value(T v)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(T v, std::string const&)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) {
+                        T                  t;
+                        std::istringstream ss(s);
+                        ss >> t;
+                        if(!ss && !ss.eof())
+                            throw std::runtime_error("Failed to parse option value: " + s);
+                        return std::any(t);
+                    };
+                }
+
+                bool is_flag() const override
+                {
+                    return false;
+                }
+            };
+
+            template <>
+            struct typed_value_holder<bool> : option_value_base
+            {
+                bool m_default              = false;
+                bool m_has_explicit_default = false;
+                bool m_has_implicit         = false;
+                bool m_implicit_value       = false;
+
+                typed_value_holder* default_value(bool v)
+                {
+                    m_default              = v;
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(bool v, std::string const&)
+                {
+                    m_default              = v;
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* implicit_value(bool v)
+                {
+                    m_has_implicit   = true;
+                    m_implicit_value = v;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+                bool has_implicit_value() const override
+                {
+                    return m_has_implicit;
+                }
+                std::any get_implicit_value() const override
+                {
+                    return std::any(m_implicit_value);
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) { return std::any(parse_bool_string(s)); };
+                }
+
+                bool is_flag() const override
+                {
+                    return true;
+                }
+            };
+
+            template <typename U>
+            struct typed_value_holder<std::vector<U>> : option_value_base
+            {
+                std::vector<U> m_default;
+                bool           m_has_explicit_default = false;
+
+                typed_value_holder* default_value(std::vector<U> v)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(std::vector<U> v, std::string const&)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                bool is_multivalued() const override
+                {
+                    return true;
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) {
+                        auto           parts = split_string(s);
+                        std::vector<U> out;
+                        out.reserve(parts.size());
+                        for(auto const& p : parts)
+                        {
+                            if(p.empty())
+                                continue;
+                            U                  u;
+                            std::istringstream ss(p);
+                            ss >> u;
+                            if(!ss && !ss.eof())
+                                throw std::runtime_error("Failed to parse: " + p);
+                            out.push_back(std::move(u));
+                        }
+                        return std::any(out);
+                    };
+                }
+
+                void merge_into(std::any& current, std::any const& new_val) const override
+                {
+                    auto&       c = std::any_cast<std::vector<U>&>(current);
+                    auto const& n = std::any_cast<std::vector<U> const&>(new_val);
+                    c.insert(c.end(), n.begin(), n.end());
+                }
+            };
+
+            template <>
+            struct typed_value_holder<std::vector<std::string>> : option_value_base
+            {
+                std::vector<std::string> m_default;
+                bool                     m_has_explicit_default = false;
+
+                typed_value_holder* default_value(std::vector<std::string> v)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(std::vector<std::string> v, std::string const&)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                bool is_multivalued() const override
+                {
+                    return true;
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) { return std::any(split_string(s)); };
+                }
+
+                /** Boost config file behaviour: each line is one value (no comma split). */
+                std::any parse_config_line(std::string const& value) const override
+                {
+                    std::string t = trim_opt(value);
+                    if(t.empty())
+                        return std::any(std::vector<std::string>{});
+                    return std::any(std::vector<std::string>{std::move(t)});
+                }
+
+                void merge_into(std::any& current, std::any const& new_val) const override
+                {
+                    auto&       c = std::any_cast<std::vector<std::string>&>(current);
+                    auto const& n = std::any_cast<std::vector<std::string> const&>(new_val);
+                    c.insert(c.end(), n.begin(), n.end());
+                }
+            };
+
+            template <>
+            struct typed_value_holder<std::vector<bool>> : option_value_base
+            {
+                std::vector<bool> m_default;
+                bool              m_has_explicit_default = false;
+
+                typed_value_holder* default_value(std::vector<bool> v)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+                typed_value_holder* default_value(std::vector<bool> v, std::string const&)
+                {
+                    m_default              = std::move(v);
+                    m_has_explicit_default = true;
+                    return this;
+                }
+
+                bool has_explicit_default() const override
+                {
+                    return m_has_explicit_default;
+                }
+
+                std::any get_default() const override
+                {
+                    return std::any(m_default);
+                }
+
+                bool is_multivalued() const override
+                {
+                    return true;
+                }
+
+                std::function<std::any(std::string const&)> parser() const override
+                {
+                    return [](std::string const& s) {
+                        auto              parts = split_string(s);
+                        std::vector<bool> out;
+                        out.reserve(parts.size());
+                        for(auto const& p : parts)
+                        {
+                            if(p.empty())
+                                continue;
+                            out.push_back(parse_bool_string(p));
+                        }
+                        return std::any(out);
+                    };
+                }
+
+                void merge_into(std::any& current, std::any const& new_val) const override
+                {
+                    auto&       c = std::any_cast<std::vector<bool>&>(current);
+                    auto const& n = std::any_cast<std::vector<bool> const&>(new_val);
+                    c.insert(c.end(), n.begin(), n.end());
+                }
+            };
+
+            template <typename T>
+            using typed_value = typed_value_holder<T>;
+
+            template <typename T>
+            typed_value_holder<T>* value()
+            {
+                return new typed_value_holder<T>();
+            }
+
+            class options_description
+            {
+            public:
+                struct option_entry
+                {
+                    std::string                        opts; // e.g. "help,h"
+                    std::string                        description;
+                    std::unique_ptr<option_value_base> value_semantic;
+                };
+                using option_list = std::vector<option_entry>;
+
+                explicit options_description(std::string const&) {}
+
+                class add_options_helper
+                {
+                    option_list& m_list;
+
+                public:
+                    explicit add_options_helper(option_list& list)
+                        : m_list(list)
+                    {
+                    }
+
+                    add_options_helper& operator()(std::string const& opts, std::string const& desc)
+                    {
+                        auto* e = new typed_value_holder<bool>();
+                        e->default_value(false);
+                        m_list.push_back({opts, desc, std::unique_ptr<option_value_base>(e)});
+                        return *this;
+                    }
+
+                    template <typename T>
+                    add_options_helper& operator()(std::string const&     opts,
+                                                   typed_value_holder<T>* val,
+                                                   std::string const&     desc)
+                    {
+                        m_list.push_back({opts, desc, std::unique_ptr<option_value_base>(val)});
+                        return *this;
+                    }
+                };
+
+                add_options_helper add_options()
+                {
+                    return add_options_helper(m_options);
+                }
+
+                option_list const& options() const
+                {
+                    return m_options;
+                }
+
+            private:
+                option_list m_options;
+            };
+
+            variables_map parse_command_line(int                        argc,
+                                             char const* const          argv[],
+                                             options_description const& desc);
+
+            variables_map parse_config_file(std::istream& is, options_description const& desc);
+
+            inline void store(variables_map const& from, variables_map& to)
+            {
+                for(auto const& kv : from)
+                    to[kv.first].value() = kv.second.value();
+            }
+
+            inline void notify(variables_map const&) {}
+
+            std::ostream& operator<<(std::ostream& os, options_description const& desc);
+
+        } // namespace po
+    } // namespace Client
+} // namespace Tensile
+
+// Specialize std traits so HIP-compiled TUs don't instantiate
+// __is_constructible_impl<variable_value,...>, which can hit "incomplete type"
+// when the HIP runtime wrapper pulls in <type_traits> before the type is complete.
+namespace std
+{
+    template <>
+    struct is_copy_constructible<Tensile::Client::po::variable_value> : true_type
+    {
+    };
+    template <>
+    struct is_move_constructible<Tensile::Client::po::variable_value> : true_type
+    {
+    };
+} // namespace std

--- a/shared/tensile/Tensile/Source/client/include/ProgressListener.hpp
+++ b/shared/tensile/Tensile/Source/client/include/ProgressListener.hpp
@@ -32,14 +32,12 @@
 
 #include <cstddef>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
-
         class ProgressListener : public RunListener
         {
         public:

--- a/shared/tensile/Tensile/Source/client/include/ReferenceValidator.hpp
+++ b/shared/tensile/Tensile/Source/client/include/ReferenceValidator.hpp
@@ -28,7 +28,7 @@
 
 #include "RunListener.hpp"
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <ConvolutionProblem.hpp>
 #include <Tensile/ContractionProblem.hpp>
@@ -42,8 +42,6 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
-
         class ReferenceValidator : public RunListener
         {
         public:

--- a/shared/tensile/Tensile/Source/client/include/ResultFileReporter.hpp
+++ b/shared/tensile/Tensile/Source/client/include/ResultFileReporter.hpp
@@ -29,7 +29,7 @@
 #include "CSVStackFile.hpp"
 #include "ResultReporter.hpp"
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <cstddef>
 
@@ -37,8 +37,6 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
-
         class ResultFileReporter : public ResultReporter
         {
         public:

--- a/shared/tensile/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/shared/tensile/Tensile/Source/client/include/SolutionIterator.hpp
@@ -28,7 +28,7 @@
 
 #include <Tensile/MasterSolutionLibrary.hpp>
 
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <functional>
 #include <vector>
@@ -39,8 +39,6 @@ namespace Tensile
 {
     namespace Client
     {
-        namespace po = boost::program_options;
-
         /**
  * Not an iterator by the traditional definition but I can't think of a better
  * name

--- a/shared/tensile/Tensile/Source/client/main.cpp
+++ b/shared/tensile/Tensile/Source/client/main.cpp
@@ -50,13 +50,12 @@
 #include "ResultFileReporter.hpp"
 #include "ResultReporter.hpp"
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/program_options.hpp>
+#include "ProgramOptions.hpp"
 
 #include <cstddef>
+#include <sstream>
 
-namespace po = boost::program_options;
+namespace po = Tensile::Client::po;
 
 namespace Tensile
 {
@@ -350,15 +349,20 @@ namespace Tensile
 
         std::vector<size_t> split_ints(std::string const& value)
         {
-            std::vector<std::string> parts;
-            boost::split(parts, value, boost::algorithm::is_any_of(",;"));
+            std::vector<std::string> parts = po::split_string(value, ",;");
 
             std::vector<size_t> rv;
             rv.reserve(parts.size());
 
             for(auto const& part : parts)
                 if(part != "")
-                    rv.push_back(boost::lexical_cast<size_t>(part));
+                {
+                    size_t             v;
+                    std::istringstream ss(part);
+                    if(!(ss >> v))
+                        throw std::runtime_error("Failed to parse size_t: " + part);
+                    rv.push_back(v);
+                }
 
             return rv;
         }
@@ -372,7 +376,7 @@ namespace Tensile
             for(auto const& str : inValue)
                 outValue.push_back(split_ints(str));
 
-            boost::any v(outValue);
+            std::any v(outValue);
 
             args.at(name).value() = v;
         }
@@ -386,12 +390,12 @@ namespace Tensile
             if(type == DataType::Float || type == DataType::Double || type == DataType::ComplexFloat
                || type == DataType::ComplexDouble || type == DataType::Int32)
             {
-                args.at("a-type").value()     = boost::any(type);
-                args.at("b-type").value()     = boost::any(type);
-                args.at("c-type").value()     = boost::any(type);
-                args.at("d-type").value()     = boost::any(type);
-                args.at("alpha-type").value() = boost::any(type);
-                args.at("beta-type").value()  = boost::any(type);
+                args.at("a-type").value()     = std::any(type);
+                args.at("b-type").value()     = std::any(type);
+                args.at("c-type").value()     = std::any(type);
+                args.at("d-type").value()     = std::any(type);
+                args.at("alpha-type").value() = std::any(type);
+                args.at("beta-type").value()  = std::any(type);
             }
         }
 

--- a/shared/tensile/Tensile/Source/client/source/ConvolutionProblem.cpp
+++ b/shared/tensile/Tensile/Source/client/source/ConvolutionProblem.cpp
@@ -24,12 +24,12 @@
  *
  *******************************************************************************/
 
+#include "ProgramOptions.hpp"
 #include <ConvolutionProblem.hpp>
 #include <Tensile/ContractionProblem.hpp>
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/lexical_cast.hpp>
 #include <vector>
+
+namespace po = Tensile::Client::po;
 
 namespace Tensile
 {
@@ -305,8 +305,7 @@ namespace Tensile
     {
         // example identifier:
         // ConvolutionForward_NCHW_KCHW_NCHW_filter:3x3x1_stride:1x1x1_dilation:1x1x1_groups:1
-        std::vector<std::string> parts;
-        boost::split(parts, identifier, boost::algorithm::is_any_of("_"));
+        std::vector<std::string> parts = po::split_string(identifier, "_");
 
         if(parts.size() < 4)
             // id, formatA, formatB, outputTensor
@@ -323,18 +322,17 @@ namespace Tensile
 
         for(auto part = parts.begin() + 4; part != parts.end(); part++)
         {
-            std::vector<std::string> flags;
-            boost::split(flags, *part, boost::algorithm::is_any_of(":"));
+            std::vector<std::string> flags = po::split_string(*part, ":");
             assert(flags.size() == 2); // must be key:value pair
 
             if(flags[0] == "spatialDims")
-                m_numSpatialDims = boost::lexical_cast<size_t>(flags[1]);
+                m_numSpatialDims = std::stoull(flags[1]);
             else if(flags[0] == "indices")
             {
             }
             else if(flags[0] == "groups")
             {
-                m_groups = boost::lexical_cast<int>(flags[1]);
+                m_groups = std::stoi(flags[1]);
                 assert(m_groups == 1); // not supported yet
             }
             else

--- a/shared/tensile/Tensile/Source/client/source/LibraryUpdateReporter.cpp
+++ b/shared/tensile/Tensile/Source/client/source/LibraryUpdateReporter.cpp
@@ -27,6 +27,7 @@
 #include <LibraryUpdateReporter.hpp>
 
 #include <cstddef>
+#include <sstream>
 
 namespace Tensile
 {
@@ -70,7 +71,9 @@ namespace Tensile
         template <typename T>
         void LibraryUpdateReporter::reportValue(std::string const& key, T const& value)
         {
-            std::string valueStr = boost::lexical_cast<std::string>(value);
+            std::ostringstream ss;
+            ss << value;
+            std::string valueStr = ss.str();
             //m_stream << key << " = " << valueStr << std::endl;
 
             if(key == ResultKey::Validation)

--- a/shared/tensile/Tensile/Source/client/source/ProgramOptions.cpp
+++ b/shared/tensile/Tensile/Source/client/source/ProgramOptions.cpp
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ *******************************************************************************/
+
+#include "ProgramOptions.hpp"
+
+#include <iomanip>
+#include <iostream>
+
+namespace Tensile
+{
+    namespace Client
+    {
+        namespace po
+        {
+
+            variable_value const variables_map::s_empty;
+
+            variable_value::variable_value(variable_value const& other)
+                : m_value(other.m_value)
+            {
+            }
+
+            variable_value::variable_value(variable_value&& other) noexcept
+                : m_value(std::move(other.m_value))
+            {
+            }
+
+            variable_value& variable_value::operator=(variable_value const& other)
+            {
+                m_value = other.m_value;
+                return *this;
+            }
+
+            variable_value& variable_value::operator=(variable_value&& other) noexcept
+            {
+                m_value = std::move(other.m_value);
+                return *this;
+            }
+
+            static std::vector<std::string> get_option_names(std::string const& opts)
+            {
+                std::vector<std::string> names;
+                std::string::size_type   pos = 0;
+                for(;;)
+                {
+                    auto next = opts.find(',', pos);
+                    if(next == std::string::npos)
+                    {
+                        names.push_back(trim_opt(opts.substr(pos)));
+                        break;
+                    }
+                    names.push_back(trim_opt(opts.substr(pos, next - pos)));
+                    pos = next + 1;
+                }
+                return names;
+            }
+
+            variables_map parse_command_line(int                        argc,
+                                             char const* const          argv[],
+                                             options_description const& desc)
+            {
+                variables_map m_vm;
+                auto const&   options = desc.options();
+
+                std::map<std::string, std::pair<size_t, std::string>> arg_to_option;
+                for(size_t i = 0; i < options.size(); i++)
+                {
+                    std::string canonical = get_canonical_option_name(options[i].opts);
+                    auto        names     = get_option_names(options[i].opts);
+                    for(auto const& name : names)
+                    {
+                        if(name.empty())
+                            continue;
+                        std::string key    = (name.size() == 1 ? "-" : "--") + name;
+                        arg_to_option[key] = {i, canonical};
+                    }
+                }
+
+                for(int i = 1; i < argc; i++)
+                {
+                    std::string arg = argv[i];
+                    auto        it  = arg_to_option.find(arg);
+                    if(it == arg_to_option.end())
+                        throw std::invalid_argument("Unknown option: " + arg);
+
+                    size_t      idx       = it->second.first;
+                    std::string canonical = it->second.second;
+                    auto const& opt       = options[idx];
+
+                    if(!opt.value_semantic)
+                        continue;
+
+                    if(opt.value_semantic->is_flag())
+                    {
+                        if(opt.value_semantic->has_implicit_value())
+                        {
+                            // Optional value: --opt means implicit value; --opt false means parse value
+                            if(i + 1 < argc && argv[i + 1][0] != '-')
+                            {
+                                i++;
+                                std::any parsed         = opt.value_semantic->parser()(argv[i]);
+                                m_vm[canonical].value() = std::move(parsed);
+                            }
+                            else
+                            {
+                                m_vm[canonical].value() = opt.value_semantic->get_implicit_value();
+                            }
+                        }
+                        else
+                        {
+                            m_vm[canonical].value() = std::any(true);
+                        }
+                        continue;
+                    }
+
+                    i++;
+                    if(i >= argc)
+                        throw std::invalid_argument("Missing value for option " + arg);
+                    std::string value_str = argv[i];
+                    std::any    parsed    = opt.value_semantic->parser()(value_str);
+
+                    if(opt.value_semantic->is_multivalued() && m_vm.count(canonical)
+                       && !m_vm[canonical].empty())
+                    {
+                        opt.value_semantic->merge_into(m_vm[canonical].value(), parsed);
+                    }
+                    else
+                    {
+                        m_vm[canonical].value() = std::move(parsed);
+                    }
+                }
+
+                for(size_t i = 0; i < options.size(); i++)
+                {
+                    if(!options[i].value_semantic)
+                        continue;
+                    std::string canonical = get_canonical_option_name(options[i].opts);
+                    if(canonical == "help")
+                        continue;
+                    // Only set default for options that explicitly have one; otherwise
+                    // unspecified options (e.g. convolution-identifier) would get empty
+                    // string and count() would be true with an incomplete value.
+                    if((!m_vm.count(canonical) || m_vm[canonical].empty())
+                       && options[i].value_semantic->has_explicit_default())
+                    {
+                        m_vm[canonical].value() = options[i].value_semantic->get_default();
+                    }
+                }
+                return m_vm;
+            }
+
+            variables_map parse_config_file(std::istream& is, options_description const& desc)
+            {
+                variables_map                                         m_vm;
+                auto const&                                           options = desc.options();
+                std::map<std::string, std::pair<size_t, std::string>> name_to_option;
+                for(size_t i = 0; i < options.size(); i++)
+                {
+                    std::string canonical = get_canonical_option_name(options[i].opts);
+                    auto        names     = get_option_names(options[i].opts);
+                    for(auto const& name : names)
+                    {
+                        if(name.empty())
+                            continue;
+                        name_to_option[name] = {i, canonical};
+                    }
+                }
+
+                std::string line;
+                while(std::getline(is, line))
+                {
+                    auto hash = line.find('#');
+                    if(hash != std::string::npos)
+                        line.resize(hash);
+                    line = trim_opt(line);
+                    if(line.empty())
+                        continue;
+
+                    auto eq = line.find('=');
+                    if(eq == std::string::npos)
+                        continue;
+
+                    std::string key   = trim_opt(line.substr(0, eq));
+                    std::string value = trim_opt(line.substr(eq + 1));
+                    if(key.empty())
+                        continue;
+
+                    auto it = name_to_option.find(key);
+                    if(it == name_to_option.end())
+                        continue;
+
+                    size_t      idx       = it->second.first;
+                    std::string canonical = it->second.second;
+                    auto const& opt       = options[idx];
+
+                    if(!opt.value_semantic)
+                        continue;
+
+                    std::any parsed = opt.value_semantic->parse_config_line(value);
+                    if(opt.value_semantic->is_multivalued() && m_vm.count(canonical)
+                       && !m_vm[canonical].empty())
+                    {
+                        opt.value_semantic->merge_into(m_vm[canonical].value(), parsed);
+                    }
+                    else
+                    {
+                        m_vm[canonical].value() = std::move(parsed);
+                    }
+                }
+                return m_vm;
+            }
+
+            std::ostream& operator<<(std::ostream& os, options_description const& desc)
+            {
+                for(auto const& opt : desc.options())
+                {
+                    auto               names = get_option_names(opt.opts);
+                    std::ostringstream left;
+                    bool               first = true;
+                    for(auto const& name : names)
+                    {
+                        if(!first)
+                            left << "|";
+                        left << (name.size() == 1 ? "-" : "--") << name;
+                        first = false;
+                    }
+                    bool print_value = true;
+                    if(opt.value_semantic && opt.value_semantic->is_flag())
+                        print_value = false;
+                    if(print_value)
+                        left << " <value>";
+                    os << std::setw(34) << std::left << left.str() << " " << std::setw(82)
+                       << std::left << opt.description << "\n";
+                }
+                return os << std::flush;
+            }
+
+        } // namespace po
+    } // namespace Client
+} // namespace Tensile

--- a/shared/tensile/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/shared/tensile/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -27,6 +27,7 @@
 #include <ResultFileReporter.hpp>
 
 #include <cstddef>
+#include <sstream>
 
 namespace Tensile
 {
@@ -60,7 +61,9 @@ namespace Tensile
         template <typename T>
         void ResultFileReporter::reportValue(std::string const& key, T const& value)
         {
-            std::string valueStr = boost::lexical_cast<std::string>(value);
+            std::ostringstream ss;
+            ss << value;
+            std::string valueStr = ss.str();
 
             if(key == ResultKey::Validation)
             {

--- a/shared/tensile/docker/dockerfile-build-ubuntu-rock
+++ b/shared/tensile/docker/dockerfile-build-ubuntu-rock
@@ -49,7 +49,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python3-joblib \
     python3-yaml \
     libnuma1 \
-    libboost-all-dev \
     zlib1g-dev \
     libomp-dev \
     && \

--- a/shared/tensile/docker/dockerfile-tensile-tuning-slurm
+++ b/shared/tensile/docker/dockerfile-tensile-tuning-slurm
@@ -51,7 +51,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     python3-setuptools \
     python3-yaml \
     libnuma1 \
-    libboost-all-dev \
     zlib1g-dev \
     libomp-dev \
     && \

--- a/shared/tensile/docs/src/install/installation.rst
+++ b/shared/tensile/docs/src/install/installation.rst
@@ -32,8 +32,7 @@ Install OS dependencies
 
    .. code-block::
 
-    apt-get install libyaml python3-yaml \
-        libomp-dev libboost-program-options-dev libboost-filesystem-dev
+    apt-get install libyaml python3-yaml libomp-dev
 
 2. Install one of the following, depending on your preferred Tensile data format. If both are installed, ``msgpack`` is preferred:
 

--- a/shared/tensile/next-cmake/CMakeLists.txt
+++ b/shared/tensile/next-cmake/CMakeLists.txt
@@ -131,11 +131,10 @@ if(TENSILE_ENABLE_ROCM_SMI)
 endif()
 
 if(TENSILE_ENABLE_CLIENT)
-  find_package(Boost REQUIRED COMPONENTS program_options)
   add_library(tensile-client-lib OBJECT)
   add_library(tensile::tensile-client-lib ALIAS tensile-client-lib)
   target_link_libraries(
-    tensile-client-lib PRIVATE Boost::boost Boost::program_options tensile-host OpenMP::OpenMP_CXX)
+    tensile-client-lib PRIVATE tensile-host OpenMP::OpenMP_CXX)
     target_compile_features(tensile-client-lib PUBLIC cxx_std_${TENSILE_CXX_STANDARD})
 
   if(rocm_smi_FOUND)
@@ -149,21 +148,14 @@ if(TENSILE_ENABLE_CLIENT)
   target_link_libraries(
     tensile-client PRIVATE roc::tensile-host tensile::tensile-client-lib)
   target_compile_features(tensile-client PUBLIC cxx_std_${TENSILE_CXX_STANDARD})
-  target_compile_definitions(
-    tensile-client
-    PRIVATE BOOST_ALL_NO_LIB BOOST_PROGRAM_OPTIONS_DYN_LINK)
   add_subdirectory(client)
 endif()
 
 if(TENSILE_BUILD_TESTING)
-  find_package(Boost REQUIRED COMPONENTS filesystem)
   find_package(GTest REQUIRED)
 
   add_library(tensile-test-lib OBJECT)
   add_library(tensile::tensile-test-lib ALIAS tensile-test-lib)
-  target_compile_definitions(
-    tensile-test-lib
-    PRIVATE BOOST_ALL_NO_LIB BOOST_ERROR_CODE_HEADER_ONLY BOOST_FILESYSTEM_DYN_LINK)
   target_compile_features(tensile-test-lib PRIVATE cxx_std_${TENSILE_CXX_STANDARD})
   target_link_libraries(tensile-test-lib PRIVATE roc::tensile-host)
 
@@ -175,7 +167,7 @@ if(TENSILE_BUILD_TESTING)
   add_executable(tensile-tests)
   target_link_libraries(
     tensile-tests PRIVATE GTest::gtest roc::tensile-host tensile::tensile-test-lib
-                          Boost::filesystem hip::host test-device-kernels
+                          hip::host test-device-kernels
                           tensile-client-lib OpenMP::OpenMP_CXX)
   if(TENSILE_ENABLE_LLVM)
       target_link_libraries(tensile-tests PRIVATE LLVMObjectYAML)

--- a/shared/tensile/next-cmake/client/src/CMakeLists.txt
+++ b/shared/tensile/next-cmake/client/src/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(
           "${_CMAKE_CURRENT_SOURCE_DIR}/LibraryUpdateReporter.cpp"
           "${_CMAKE_CURRENT_SOURCE_DIR}/MetaRunListener.cpp"
           "${_CMAKE_CURRENT_SOURCE_DIR}/PerformanceReporter.cpp"
+          "${_CMAKE_CURRENT_SOURCE_DIR}/ProgramOptions.cpp"
           "${_CMAKE_CURRENT_SOURCE_DIR}/ProgressListener.cpp"
           "${_CMAKE_CURRENT_SOURCE_DIR}/Reference.cpp"
           "${_CMAKE_CURRENT_SOURCE_DIR}/ReferenceValidator.cpp"

--- a/shared/tensile/tuning_docs/tensile_tuning.tex
+++ b/shared/tensile/tuning_docs/tensile_tuning.tex
@@ -1312,7 +1312,7 @@ Use the following steps to install the Tensile and automation dependencies. \new
 sudo apt install -y --no-install-recommends cmake make ca-certificates git \
 pkg-config python3 python3-dev python3-matplotlib python3-pandas python3-pip \
 python3-setuptools python3-tk python3-venv python3-yaml libnuma1 llvm-6.0-dev \
-libboost-all-dev zlib1g-dev libomp-dev gfortran libpthread-stubs0-dev \
+zlib1g-dev libomp-dev gfortran libpthread-stubs0-dev \
 libmsgpack-dev libmsgpackc2 wget
 \end{lstlisting}
 

--- a/shared/tensile/tuning_docs/tuning_client_design.md
+++ b/shared/tensile/tuning_docs/tuning_client_design.md
@@ -2,12 +2,7 @@
 
 The tuning client is written to exercise Tensile kernels by allocating and initializing input and output memory and calling the kernels while recording their run time and reporting the speed (in GFlops) back to the Python code.
 
-It is written in a modular, structured way which involves the cooperation of many different classes and class hierarchies. It uses the Tensile host runtime library (sometimes referred to as the 'new client') and several Boost libraries:
-
- - Algorithm
- - Any
- - Program options
- - Lexical Cast
+It is written in a modular, structured way which involves the cooperation of many different classes and class hierarchies. It uses the Tensile host runtime library (sometimes referred to as the 'new client') and standard library or custom replacements for program options and value reporting.
 
 This document assumes general familiarity with the Tensile host runtime library.
 
@@ -108,7 +103,7 @@ Right now, to get around the limitation in C++ against overloaded virtual functi
      - `reportValue_sizes()`
   - The `MetaResultReporter` implements these virtual functions, forwarding the calls to the child reporters.
 
-The overloading to renamed functions is awkward and may be replaced with `boost::any` or a CRTP implementation at some point.
+The overloading to renamed functions is awkward and may be replaced with `std::any` or a CRTP implementation at some point.
 
 The keys are generally declared as string constants in the `ResultKey` namespace, in order to prevent misspellings from causing uncaught bugs.
 


### PR DESCRIPTION
- Client: add ProgramOptions.hpp/cpp (std::any, no Boost); match Boost semantics for CLI/config and bool/vector options; single LogReporter (console or file) so "Log level" prints once; keep option dump for CI.
- Tests: switch TestData and RangeLibrary_test to std::filesystem; ProgramLocation via /proc/self/exe on Linux; remove Boost from tests CMake.
- Cleanup: remove dead code and duplicate trim in ProgramOptions.
- #5127 for TensileLite

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
