### PR TITLE
[hipblaslt] Fix for TF32 + UsePLRPack + UnrollLoopSwapGlobalReadOrder

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -2515,7 +2515,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
       vregSetIdxMFMA = 1 - vregSetIdxGR
     tPM = tensorParametersA["tpsMetadata"] if tensorParametersA["is_sparse"] else tensorParametersB["tpsMetadata"]
 
-    self.states.SubTileIdx = 1 # For SubIter. Start from 1
+    # initialize SubTileIdx
+    self.states.SubTileIdx = 1 if self.states.numItersPLR and kernel["numSubTiles"] else 0
 
     for uIdx in range(0, kernel["LoopIters"]):
       u = uIdx % kernel["LoopIters"]    #   u: index in compute loop (in contrast to the notion of global read loop)
@@ -2924,6 +2925,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
   def _loopBody( self, kernel, tensorParametersA, tensorParametersB, pack, packPre, lc, loopCopies, finalLoop, firstIter=False, dsWriteBA=False, grBA=False, isDTVGRSecondBuf=False, skipClose=False ):
     module = Module("loopBody")
     expand = kernel["ExpandPointerSwap"]
+    # initialize SubTileIdx
+    self.states.SubTileIdx = 1 if self.states.numItersPLR and kernel["numSubTiles"] else 0
 
     # not generate openLoop for firstIter
     if not firstIter:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/xfp32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/xfp32.yaml
@@ -76,8 +76,9 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [16, 16, 32, 1, 1, 2, 3, 2, 2]
           - [16, 16, 32, 1, 1, 2, 2, 2, 2]
+          - [16, 16, 32, 1, 1, 4, 4, 2, 2]
           - [16, 16, 32, 1, 1, 3, 2, 2, 2]
-        - DepthU: [64]
+        - DepthU: [32,64]
           #- AssertSummationElementMultiple: [64]
         - LdsPadA: [-1]
         - LdsPadB: [-1]
@@ -104,6 +105,7 @@ BenchmarkProblems:
         - WorkGroupMappingXCC: [8]
         - StoreVectorWidth: [2]
         - UsePLRPack: [0,1]
+        - UnrollLoopSwapGlobalReadOrder: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
@@ -234,6 +236,7 @@ BenchmarkProblems:
         - VectorWidthA: [-1,2]
         - VectorWidthB: [-1,2]
         - UsePLRPack: [0,1]
+        - UnrollLoopSwapGlobalReadOrder: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:


### PR DESCRIPTION
## Motivation

Fix hipblaslt-bench verification fail with TF32 + UsePLRPack + UnrollLoopSwapGlobalReadOrder

## Technical Details

- Added code to update SubTileIdx at the beginning of loopBody
- Added test case for the fail

## Test Plan

- added test case in xfp32.yaml

## Test Result

- local test with xfp32.yaml passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
