### PR TITLE
Completely remove boost in hipblaslt

### DIFF
--- a/projects/hipblaslt/tensilelite/client/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/client/CMakeLists.txt
@@ -1,9 +1,6 @@
 # Copyright Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
-
-find_package(Boost COMPONENTS program_options filesystem REQUIRED)
-
 add_executable(tensilelite-client "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp")
 
 add_executable(cpu-gemm-driver "${CMAKE_CURRENT_SOURCE_DIR}/cpu_gemm_driver.cpp")
@@ -13,8 +10,6 @@ set(COMMON_CLIENT_LIBS
     hip::host
     tensilelite::tensilelite-host
     rocisa::rocisa-cpp
-    Boost::program_options
-    Boost::filesystem
     OpenMP::OpenMP_CXX
 )
 

--- a/projects/hipblaslt/tensilelite/client/include/CSVStackFile.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/CSVStackFile.hpp
@@ -28,10 +28,9 @@
 
 #include <fstream>
 #include <memory>
+#include <sstream>
 #include <unordered_map>
 #include <vector>
-
-#include <boost/lexical_cast.hpp>
 
 namespace TensileLite
 {
@@ -55,7 +54,9 @@ namespace TensileLite
             typename std::enable_if<!std::is_same<T, std::string>::value, void>::type
                 setValueForKey(std::string const& key, T const& value)
             {
-                setValueForKey(key, boost::lexical_cast<std::string>(value));
+                std::ostringstream oss;
+                oss << value;
+                setValueForKey(key, oss.str());
             }
 
             std::string readValueFromKey(std::string const& key);

--- a/projects/hipblaslt/tensilelite/client/src/LibraryUpdateReporter.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/LibraryUpdateReporter.cpp
@@ -28,6 +28,7 @@
 #include "TimingInstrumentation.hpp"
 
 #include <cstddef>
+#include <sstream>
 
 namespace TensileLite
 {
@@ -71,7 +72,9 @@ namespace TensileLite
         template <typename T>
         void LibraryUpdateReporter::reportValue(std::string const& key, T const& value)
         {
-            std::string valueStr = boost::lexical_cast<std::string>(value);
+            std::ostringstream oss;
+            oss << value;
+            std::string valueStr = oss.str();
             //m_stream << key << " = " << valueStr << std::endl;
 
             if(key == ResultKey::Validation)

--- a/projects/hipblaslt/tensilelite/client/src/ProgramOptions.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/ProgramOptions.cpp
@@ -81,7 +81,7 @@ namespace TensileLite
                             if(i + 1 < argc && argv[i + 1][0] != '-')
                             {
                                 i++;
-                                std::any parsed = opt.value_semantic->parser()(argv[i]);
+                                std::any parsed         = opt.value_semantic->parser()(argv[i]);
                                 m_vm[canonical].value() = std::move(parsed);
                             }
                             else
@@ -120,8 +120,14 @@ namespace TensileLite
                     std::string canonical = get_canonical_option_name(options[i].opts);
                     if(canonical == "help")
                         continue;
-                    if(!m_vm.count(canonical) || m_vm[canonical].empty())
+                    // Only set default for options that explicitly have one; otherwise
+                    // unspecified options (e.g. convolution-identifier) would get empty
+                    // string and count() would be true with an incomplete value.
+                    if((!m_vm.count(canonical) || m_vm[canonical].empty())
+                       && options[i].value_semantic->has_explicit_default())
+                    {
                         m_vm[canonical].value() = options[i].value_semantic->get_default();
+                    }
                 }
                 return m_vm;
             }

--- a/projects/hipblaslt/tensilelite/client/src/ResultFileReporter.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/ResultFileReporter.cpp
@@ -28,6 +28,7 @@
 #include "TimingInstrumentation.hpp"
 
 #include <cstddef>
+#include <sstream>
 
 namespace TensileLite
 {
@@ -61,7 +62,9 @@ namespace TensileLite
         template <typename T>
         void ResultFileReporter::reportValue(std::string const& key, T const& value)
         {
-            std::string valueStr = boost::lexical_cast<std::string>(value);
+            std::ostringstream oss;
+            oss << value;
+            std::string valueStr = oss.str();
 
             if(key == ResultKey::Validation)
             {


### PR DESCRIPTION
The first commit is ported fix from Tensile

In tensilelite’s ProgramOptions.cpp, `parse_command_line()` had a loop that filled every option that was missing or empty with `get_default()`. For options like convolution-identifier that are declared as `po::value<std::string>()` with no default, `get_default()` still returns `std::any(std::string{})`, i.e. an empty string. So:
`args.count("convolution-identifier")` was 1 (the key existed), `args["convolution-identifier"].as<std::string>()` was "" (empty),

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
