### PR TITLE
Reducing problem size to improve overall execution time for common fo…

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
@@ -74,7 +74,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[255], [255], [1], [1, 148, 192]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -108,7 +108,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[255], [255], [1], [1, 148, 192]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -179,8 +179,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[160], [256], [1], [1,17,64]]
-          - Range: [[160], [256], [1], [32, 64, 256]]
+          - Range: [[160], [256], [1], [1,34,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -218,8 +217,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [160], [1], [1,17,64]]
-          - Range: [[256], [160], [1], [32, 64, 256]]
+          - Range: [[256], [160], [1], [1,34,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -253,8 +251,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [240], [1], [1, 17, 64]]
-          - Range: [[256], [240], [1], [32, 64, 256]]
+          - Range: [[256], [240], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -292,8 +289,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [208], [1], [1, 17, 64]]
-          - Range: [[256], [208], [1], [32, 64, 256]]
+          - Range: [[256], [208], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -331,8 +327,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[320], [192], [1], [1, 17, 64]]
-          - Range: [[320], [192], [1], [32, 64, 256]]
+          - Range: [[320], [192], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -366,8 +361,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [320], [1], [1, 17, 64]]
-          - Range: [[192], [320], [1], [32, 64, 256]]
+          - Range: [[192], [320], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -405,8 +399,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [32, 64, 256]]
-          - Range: [[256], [192], [1], [1,17,64]]
+          - Range: [[256], [192], [1], [1,34,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -440,8 +433,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[208], [256], [1], [1, 17, 64]]
-          - Range: [[208], [256], [1], [32, 64, 256]]
+          - Range: [[208], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -514,8 +506,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[240], [256], [1], [64, 64, 256]]
-          - Range: [[240], [256], [1], [1, 17, 256]]  
+          - Range: [[240], [256], [1], [64, 128, 256]]
           - Exact: [3840, 4096, 1, 8192]
         - BiasTypeArgs: ['b']          
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -548,8 +539,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [224], [1], [1,17,64]]
-          - Range: [[128], [224], [1], [32, 64, 256]]
+          - Range: [[128], [224], [1], [1,34,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -579,9 +569,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [256], [1], [64, 64, 256]]
-          - Range: [[128], [256], [1], [1,1,64]]
-          - Range: [[128], [256], [1], [32, 64, 256]]          
+          - Range: [[128], [256], [1], [1,26,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -616,9 +604,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [96], [1], [64, 64, 256]]
-          - Range: [[256], [96], [1], [1, 1, 64]]
-          - Range: [[256], [96], [1], [32, 64, 256]]
+          - Range: [[256], [96], [1], [1, 29, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -650,9 +636,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [128], [1], [64, 64, 256]]
-          - Range: [[224], [128], [1], [1,1,64]]
-          - Range: [[224], [128], [1], [32, 64, 256]]
+          - Range: [[224], [128], [1], [1,33,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 256x224x64 NN
       InitialSolutionParameters:
@@ -682,8 +666,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [224], [1], [ 1, 17,  64]]
-          - Range: [[256], [224], [1], [32, 64, 256]]
+          - Range: [[256], [224], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 256x224x64 NN
       InitialSolutionParameters:
@@ -713,8 +696,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [256], [1], [ 1, 17,  64]]
-          - Range: [[224], [256], [1], [32, 64, 256]]
+          - Range: [[224], [256], [1], [ 1, 33,  64]]
         - BiasTypeArgs: ['b']        
   ########################################
   # HHS NN - standard
@@ -761,7 +743,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[257], [257], [1], [1, 148, 192]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -794,7 +776,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[257], [257], [1], [1, 148, 192]]
     - # BenchmarkProblemSizeGroup - 96x256x64 NN (CMS)
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -826,8 +808,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[96], [256], [1], [1, 17, 64]]
-          - Range: [[96], [256], [1], [32, 64, 256]]
+          - Range: [[96], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -882,8 +863,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
-          - Range: [[613], [612], [1], [1, 1, 64]]
+          - Range: [[613], [612], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -931,7 +911,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[255], [257], [1], [1, 148, 192]]
 
   ########################################
   # BBS TN - standard
@@ -986,8 +966,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
-          - Range: [[613], [612], [1], [1, 1, 64]]
+          - Range: [[613], [612], [1], [1, 27, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 192x128x64 TN (CMS)
       InitialSolutionParameters:
@@ -1022,8 +1001,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [128], [1], [1, 17, 64]]
-          - Range: [[192], [128], [1], [32, 64, 256]]
+          - Range: [[192], [128], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 256x160x64 TN (match cms-tn.yaml)
       InitialSolutionParameters:
@@ -1057,8 +1035,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [160], [1], [1, 17, 64]]
-          - Range: [[256], [160], [1], [32, 64, 256]]
+          - Range: [[256], [160], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1091,8 +1068,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [256], [1], [1, 17, 64]]
-          - Range: [[192], [256], [1], [32, 64, 256]]
+          - Range: [[192], [256], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 96x256x64 TN
       InitialSolutionParameters:
@@ -1126,9 +1102,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1536, 4096, 1, 8192]
-          - Range: [[96], [256], [1], [64, 64, 256]]
-          - Range: [[96], [256], [1], [32, 64, 256]]
-          - Range: [[96], [256], [1], [1, 1, 64]]
+          - Range: [[96], [256], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1161,8 +1135,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [240], [1], [1, 17, 64]]
-          - Range: [[256], [240], [1], [32, 64, 256]]
+          - Range: [[256], [240], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1195,8 +1168,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [208], [1], [1, 17, 64]]
-          - Range: [[256], [208], [1], [32, 64, 256]]
+          - Range: [[256], [208], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1230,8 +1202,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [128], [1], [1, 17, 64]]
-          - Range: [[224], [128], [1], [32, 64, 256]]
+          - Range: [[224], [128], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1264,8 +1235,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [256], [1], [1, 17, 64]]
-          - Range: [[224], [256], [1], [32, 64, 256]]
+          - Range: [[224], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1298,8 +1268,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [224], [1], [1, 17, 64]]
-          - Range: [[256], [224], [1], [32, 64, 256]]
+          - Range: [[256], [224], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1332,8 +1301,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [1, 17, 64]]
-          - Range: [[256], [192], [1], [32, 64, 256]]
+          - Range: [[256], [192], [1], [1, 34, 64]]
           - Exact: [4096, 3072, 1, 8192]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1369,8 +1337,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [96], [1], [1, 17, 64]]
-          - Range: [[256], [96], [1], [32, 64, 256]]
+          - Range: [[256], [96], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1403,8 +1370,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[160], [256], [1], [1, 17, 64]]
-          - Range: [[160], [256], [1], [32, 64, 256]]
+          - Range: [[160], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1437,8 +1403,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [1, 17, 64]]
-          - Range: [[256], [192], [1], [32, 64, 256]]
+          - Range: [[256], [192], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1519,8 +1484,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[240], [256], [1], [1, 17, 64]]
-          - Range: [[240], [256], [1], [32, 64, 256]]
+          - Range: [[240], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1567,8 +1531,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[208], [256], [1], [1, 17, 64]]
-          - Range: [[208], [256], [1], [32, 64, 256]]
+          - Range: [[208], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1602,8 +1565,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [256], [1], [1, 17, 64]]
-          - Range: [[192], [256], [1], [32, 64, 256]]
+          - Range: [[192], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1629,8 +1591,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
       - ProblemSizes:
-        - Range: [[192], [320], [1], [1, 17, 64]]
-        - Range: [[192], [320], [1], [32, 64, 256]]
+        - Range: [[192], [320], [1], [1, 34, 64]]
       - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1663,8 +1624,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [224], [1], [1, 17, 64]]
-          - Range: [[128], [224], [1], [32, 64, 256]]
+          - Range: [[128], [224], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1698,8 +1658,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[320], [192], [1], [1, 17, 64]]
-          - Range: [[320], [192], [1], [32, 64, 256]]
+          - Range: [[320], [192], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 128x192x64 TN (CMS)
       InitialSolutionParameters:
@@ -1734,8 +1693,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [192], [1], [ 1, 17,  64]]
-          - Range: [[128], [192], [1], [32, 64, 256]]
+          - Range: [[128], [192], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 352x192x64 TN (CMS)
       InitialSolutionParameters:
@@ -1770,8 +1728,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[352], [192], [1], [1, 17,  64]]
-          - Range: [[352], [192], [1], [32, 64, 256]]
+          - Range: [[352], [192], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1805,8 +1762,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [320], [1], [1, 17, 64]]
-          - Range: [[224], [320], [1], [32, 64, 256]]
+          - Range: [[224], [320], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -1854,7 +1810,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[255], [257], [1], [1, 148, 192]]
 
   ########################################
   # F8BS TN - standard
@@ -1909,8 +1865,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [4, 4, 400]]
-          - Range: [[613], [612], [1], [1, 1, 128]]
+          - Range: [[17, 470, 750], [2, 254, 400], [1], [4, 128, 400]]
         #- BiasTypeArgs: ['b']
 
   ########################################
@@ -1965,8 +1920,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
-          - Range: [[613], [612], [1], [1, 1, 128]]
+          - Range: [[613], [612], [1], [1, 32, 128]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 224x128x64 NT
       InitialSolutionParameters:
@@ -2002,8 +1956,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [3584, 2048, 1, 8192]
-          - Range: [[224], [128], [1], [1, 16, 64]]
-          - Range: [[224], [128], [1], [32, 64, 256]]
+          - Range: [[224], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 128x224x64 NT
       InitialSolutionParameters:
@@ -2038,8 +1991,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [224], [1], [1, 17, 64]]
-          - Range: [[128], [224], [1], [32, 64, 256]]
+          - Range: [[128], [224], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2106,8 +2058,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[96], [256], [1], [1, 17, 64]]
-          - Range: [[96], [256], [1], [32, 64, 256]]
+          - Range: [[96], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2145,8 +2096,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[160], [256], [1], [1,17,64]]
-          - Range: [[160], [256], [1], [32, 64, 256]]
+          - Range: [[160], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2179,8 +2129,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [256], [1], [1, 17, 64]]
-          - Range: [[192], [256], [1], [32, 64, 256]]
+          - Range: [[192], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2218,8 +2167,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [160], [1], [1,17,64]]
-          - Range: [[256], [160], [1], [32, 64, 256]]
+          - Range: [[256], [160], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2253,8 +2201,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [240], [1], [1, 17, 64]]
-          - Range: [[256], [240], [1], [32, 64, 256]]
+          - Range: [[256], [240], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2327,8 +2274,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[240], [256], [1], [1, 17, 256]]
-          - Range: [[240], [256], [1], [32, 64, 256]]
+          - Range: [[240], [256], [1], [1, 34, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2362,8 +2308,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[320], [192], [1], [1, 17, 64]]
-          - Range: [[320], [192], [1], [32, 64, 256]]
+          - Range: [[320], [192], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2396,8 +2341,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[208], [256], [1], [1, 17, 64]]
-          - Range: [[208], [256], [1], [32, 64, 256]]
+          - Range: [[208], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2431,8 +2375,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [1, 17, 64]]
-          - Range: [[256], [192], [1], [32, 64, 256]]
+          - Range: [[256], [192], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2465,8 +2408,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [320], [1], [1, 17, 64]]
-          - Range: [[192], [320], [1], [32, 64, 256]]
+          - Range: [[192], [320], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2500,8 +2442,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [256], [1], [1, 17, 256]]
-          - Range: [[224], [256], [1], [32, 64, 256]]
+          - Range: [[224], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2531,8 +2472,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [224], [1], [1, 17, 64]]
-          - Range: [[256], [224], [1], [32, 64, 256]]
+          - Range: [[256], [224], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2567,8 +2507,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [96], [1], [1, 17, 256]]
-          - Range: [[256], [96], [1], [32, 64, 256]]
+          - Range: [[256], [96], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -2615,4 +2554,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[257], [255], [1], [1, 148, 192]]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
@@ -69,8 +69,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [[192], [256], [1], [64, 64, 256]]
-          - Range: [[192], [256], [1], [1,1,64]]
-          - Range: [[192], [256], [1], [32, 64, 256]]
+          - Range: [[192], [256], [1], [1,32,64]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -94,11 +93,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [192], [1], [64, 64, 256]]
-          - Range: [[128], [192], [1], [1,1,64]]
-          - Range: [[128], [192], [1], [32, 64, 256]]
-          - Range: [[4096], [6144], [1], [64, 64, 256]]
-          - Exact: [2048, 3072, 1, 8192]
+          - Range: [[128], [192], [1], [64, 128, 256]]
+          - Range: [[128], [192], [1], [1,33,64]]
+          - Range: [[4096], [6144], [1], [64, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -134,9 +131,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [256], [1], [64, 64, 256]]
-          - Range: [[256], [256], [1], [1,1,64]]
-          - Range: [[256], [256], [1], [32, 64, 256]]
+          - Range: [[256], [256], [1], [1,36,64]]
+          - Range: [[256], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -172,9 +168,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [128], [1], [64, 64, 256]]
-          - Range: [[128], [128], [1], [1,1,64]]
-          - Range: [[128], [128], [1], [32, 64, 256]]
+          - Range: [[128], [128], [1], [1,33,64]]
+          - Range: [[128], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem   
       # This test verifies correctness for a specific parameter combination: CMS=1, MIArchVgpr=True, MfmaInitCVgprs=True (set manually in _get_schedule_128x128x32_TF32)
@@ -248,9 +243,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [128], [1], [64, 64, 256]]
-          - Range: [[128], [128], [1], [1,1,64]]
-          - Range: [[128], [128], [1], [32, 64, 256]]
+          - Range: [[128], [128], [1], [1,35,64]]
+          - Range: [[128], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem   
       # This test verifies correctness for a specific parameter combination: CMS=1, MIArchVgpr=True, MfmaInitCVgprs=True (set manually in _get_schedule_128x128x32_TF32)
@@ -318,9 +312,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [128], [1], [64, 64, 256]]
-          - Range: [[128], [128], [1], [1,1,64]]
-          - Range: [[128], [128], [1], [32, 64, 256]]
+          - Range: [[128], [128], [1], [1,31,64]]
+          - Range: [[128], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -356,9 +349,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [128], [1], [64, 64, 256]]
-          - Range: [[192], [128], [1], [1,1,64]]
-          - Range: [[192], [128], [1], [32, 64, 256]]
+          - Range: [[192], [128], [1], [1,34,64]]
+          - Range: [[192], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -394,10 +386,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [32, 32, 128]]
-          - Range: [[256], [192], [1], [1, 1, 32]]
-          - Range: [[256], [192], [1], [16, 32, 128]]
-          - Range: [[8192], [6144], [1], [32, 32, 128]]
+          - Range: [[256], [192], [1], [32, 64, 128]]
+          - Range: [[256], [192], [1], [1, 17, 32]]
+          - Range: [[8192], [6144], [1], [128]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -432,9 +423,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [160], [1], [64, 64, 256]]
-          - Range: [[128], [160], [1], [1,1,64]]
-          - Range: [[128], [160], [1], [32, 64, 256]]
+          - Range: [[128], [160], [1], [1,32,64]]
+          - Range: [[128], [160], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -469,9 +459,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[160], [128], [1], [64, 64, 256]]
-          - Range: [[160], [128], [1], [1,1,64]]
-          - Range: [[160], [128], [1], [32, 64, 256]]
+          - Range: [[160], [128], [1], [64, 128, 256]]
+          - Range: [[160], [128], [1], [1,33,64]]
         - BiasTypeArgs: ['s']
 
     - # BenchmarkProblemSizeGroup - Standard
@@ -502,8 +491,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [[256], [128], [1], [32, 64, 256]]
-          - Range: [[256], [128], [1], [1, 1, 64]]
-          - Range: [[256], [128], [1], [64, 64, 256]]
+          - Range: [[256], [128], [1], [1, 33, 64]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -538,9 +526,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[64], [128], [1], [64, 64, 256]]
-          - Range: [[64], [128], [1], [1,1,64]]
-          - Range: [[64], [128], [1], [32, 64, 256]]
+          - Range: [[64], [128], [1], [64, 128, 256]]
+          - Range: [[64], [128], [1], [1,37,64]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -575,9 +562,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [64], [1], [64, 64, 256]]
-          - Range: [[128], [64], [1], [1,1,64]]
-          - Range: [[128], [64], [1], [32, 64, 256]]
+          - Range: [[128], [64], [1], [64, 128, 256]]
+          - Range: [[128], [64], [1], [1,41,64]]
         - BiasTypeArgs: ['s']
 
 ########################################
@@ -626,9 +612,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [256], [1], [64, 64, 256]]
-          - Range: [[192], [256], [1], [1,1,64]]
-          - Range: [[192], [256], [1], [32, 64, 256]]
+          - Range: [[192], [256], [1], [1,51,64]]
+          - Range: [[192], [256], [1], [32, 96, 256]]
         - BiasTypeArgs: ['s']
     
     # - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -701,9 +686,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [128], [1], [64, 64, 256]]
-          - Range: [[128], [128], [1], [1,1,64]]
-          - Range: [[128], [128], [1], [32, 64, 256]]
+          - Range: [[128], [128], [1], [1,61,64]]
+          - Range: [[128], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       # MT 128x128x64, DU=64, PGR=2, PLR=1, MI=16x16x32
@@ -734,9 +718,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [128], [1], [64, 64, 256]]
-          - Range: [[128], [128], [1], [1,1,64]]
-          - Range: [[128], [128], [1], [32, 64, 256]]
+          - Range: [[128], [128], [1], [1,21,64]]
+          - Range: [[128], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -766,9 +749,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [64, 64, 256]]
-          - Range: [[256], [192], [1], [1,1,64]]
-          - Range: [[256], [192], [1], [32, 64, 256]]
+          - Range: [[256], [192], [1], [1,31,64]]
+          - Range: [[256], [192], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -791,9 +773,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[160], [128], [1], [64, 64, 256]]
-          - Range: [[160], [128], [1], [1, 1, 256]]
-          - Range: [[160], [128], [1], [32, 64, 256]]
+          - Range: [[160], [128], [1], [1, 51, 256]]
+          - Range: [[160], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
 ########################################
 # TF32 NT - standard
@@ -851,9 +832,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [256], [1], [64, 64, 256]]
-          - Range: [[256], [256], [1], [1,1,64]]
-          - Range: [[256], [256], [1], [32, 64, 256]]
+          - Range: [[256], [256], [1], [1,21,64]]
+          - Range: [[256], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -886,7 +866,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [128], [1], [64, 64, 256]]
-          - Range: [[128], [128], [1], [1,1,64]]
-          - Range: [[128], [128], [1], [32, 64, 256]]
+          - Range: [[128], [128], [1], [1,41,64]]
+          - Range: [[128], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['s']        

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -59,7 +59,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[1,67,300], [1,93,300], [1], [1,76,192]]
+          - Range: [[300], [1], [1], [152]]
     - # Check DTL+nonDTL tuning
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -132,7 +132,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[1,67,300], [1,93,300], [1], [1,76,192]]
+          - Range: [[170], [186], [1], [152]]
 
   ########################################
   # F8HS TN DTL
@@ -195,10 +195,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[19], [19], [1], [1,3,12]]
-          - Range: [[31], [31], [1], [1,7,72]]
-          - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13], [17], [1], [258, 9, 384]]
+          - Range: [[19], [19], [1], [1,6,12]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -268,10 +265,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[19], [19], [1], [1,3,12]]
-          - Range: [[31], [31], [1], [1,7,72]]
-          - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13], [17], [1], [258, 9, 384]]
+          - Range: [[19], [19], [1], [1,6,12]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -316,12 +310,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,1,32],[28,1,29],[1],[1,1,64]]
-          - Range: [[16,1,32],[28,1,29],[1],[66,4,129]]
-          - Range: [[16,1,32],[28,1,29],[1],[65,4,129]]
-          - Range: [[28,1,29],[16,1,32],[1],[1,1,64]]
-          - Range: [[28,1,29],[16,1,32],[1],[66,4,129]]
-          - Range: [[28,1,29],[16,1,32],[1],[65,4,129]]
+          - Range: [[16,8,32],[28,1,29],[1],[1,31,64]]
+          - Range: [[28,1,29],[16,8,32],[1],[1,31,64]]
 
   ########################################
   # F8HHS TT DTL
@@ -371,7 +361,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[63], [127], [1], [1,63,384]]
+          - Range: [[63], [127], [1], [1,175,384]]
 
   ########################################
   # F8B8HS TN DTL
@@ -434,7 +424,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,9,34], [16,9,34], [1], [1,3,12]]
+          - Range: [[34], [34], [1], [1,6,12]]
           - Exact: [256, 256, 1, 320]
 
   ########################################
@@ -496,10 +486,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[19], [19], [1], [1,3,12]]
-          - Range: [[31], [31], [1], [1,7,72]]
-          - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13],   [17], [1], [258, 9, 384]]
+          - Range: [[31], [31], [1], [1,27,72]]
+          - Range: [[13],   [17], [1], [258, 49, 384]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -554,7 +542,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[63], [127], [1], [1,31,384]]
+          - Range: [[63], [127], [1], [1,131,384]]
 
   ########################################
   # F8F8S TT DTL
@@ -615,10 +603,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[19], [19], [1], [1,3,12]]
-          - Range: [[31], [31], [1], [1,7,72]]
-          - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13],   [17], [1], [258, 9, 384]]
+          - Range: [[31], [31], [1], [1,37,72]]
+          - Range: [[127], [127], [1], [128]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -679,7 +665,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[65], [123], [1], [1,71,192]]
+          - Range: [[65], [123], [1], [1,171,192]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -790,7 +776,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[47], [97], [1], [1,31,192]]
+          - Range: [[47], [97], [1], [1,131,192]]
     - # ASEM/AFEM check
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -820,7 +806,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,2,32],[16,2,32],[1],[1,1,32]]
+          - Range: [[16,12,32],[16,12,32],[1],[1,21,32]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -903,7 +889,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 512]
-          - Range: [[18], [99], [1], [1,31,192]]
+          - Range: [[18], [99], [1], [1,74,192]]
 
   ########################################
   # HHS TT DTL
@@ -951,7 +937,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [512], [1], [64,64,192]]
+          - Range: [[256], [512], [1], [64,128,192]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -981,7 +967,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[4096], [8192], [1], [64,64,192]]
+          - Range: [[4096], [8192], [1], [64,128,192]]
 
   ########################################
   # HHS NT DTL
@@ -1066,7 +1052,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[65], [123], [1], [1,123,192]]
+          - Range: [[65], [123], [1], [192]]
     - # Check DTL for load width less than 32bits
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -1090,7 +1076,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[65], [123], [1], [1,63,192]]
+          - Range: [[65], [123], [1], [63]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -1119,7 +1105,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[4096], [8192], [1], [64,64,192]]
+          - Range: [[4096], [8192], [1], [64]]
 
 
   ########################################

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/mx32f4_tn.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/mx32f4_tn.yaml
@@ -110,38 +110,12 @@ BenchmarkProblems:
           # - Exact: [16, 16, 1, 128]
           - Exact: [32, 16, 1, 1024]
           - Exact: [256, 256, 1, 128]
-          - Exact: [1025, 513, 1, 2048]
-#          - Exact: [1026, 514, 1, 2048]
-#          - Exact: [1027, 515, 1, 2048]
-#          - Exact: [1028, 516, 1, 2048]
-#          - Exact: [1029, 517, 1, 2048]
-#          - Exact: [1030, 518, 1, 2048]
-#          - Exact: [1031, 519, 1, 2048]
-#          - Exact: [1032, 520, 1, 2048]
-#          - Exact: [1033, 521, 1, 2048]
-#          - Exact: [1034, 522, 1, 2048]
-#          - Exact: [1035, 523, 1, 2048]
-#          - Exact: [1036, 524, 1, 2048]
-#          - Exact: [1037, 525, 1, 2048]
-#          - Exact: [1038, 526, 1, 2048]
-#          - Exact: [1039, 527, 1, 2048]
-#          - Exact: [1040, 528, 1, 2048]
-#          - Exact: [1041, 529, 1, 2048]
-#          - Exact: [1042, 530, 1, 2048]
-#          - Exact: [1043, 531, 1, 2048]
           - Exact: [1044, 532, 1, 2048]
           - Exact: [127, 127, 1, 640] #special cleanup case
-          - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 640]
-          # - Exact: [128, 128, 1, 127]
-          # - Exact: [128, 128, 1, 129]
-          # - Exact: [111, 111, 1, 111]
-          # - Exact: [777, 777, 1, 777]
           - Exact: [128, 128, 1, 512]
-          #- Range: [[128], [128], [1], [1024,32,1280]]
           - Range: [[128], [128], [1], [1024,128,1280]] #make K value is multiple of DepthU
-          - Range: [[128,1,256], [128], [1], [1024]]
-          - Range: [[128], [128,1,256], [1], [1024]]
+          - Range: [[128,64,256], [128], [1], [1024]]
+          - Range: [[128], [128,64,256], [1], [1024]]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -170,16 +144,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [1025, 513, 1, 2048]
           - Exact: [127, 127, 1, 640] #special cleanup case
-          - Exact: [129, 129, 1, 640]
-          - Exact: [128, 128, 1, 512]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
 
-# LibraryLogic:
-#     ScheduleName: "aquavanjaram"
-#     DeviceNames: ["Device 0049"]
-#     ArchitectureName: "gfx950"
-#     LibraryType: "GridBased"
-#
-# LibraryClient:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/mx32f8_tn.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/mx32f8_tn.yaml
@@ -111,45 +111,14 @@ BenchmarkProblems:
           - Exact: [32, 16, 1, 1024]
           #- Exact: [256, 256, 1, 64]   # TODO: this fails as currently tailloop is not supported for MX types.
           - Exact: [1025, 513, 1, 2048]
-#          - Exact: [1026, 514, 1, 2048]
-#          - Exact: [1027, 515, 1, 2048]
-#          - Exact: [1028, 516, 1, 2048]
-#          - Exact: [1029, 517, 1, 2048]
-#          - Exact: [1030, 518, 1, 2048]
-#          - Exact: [1031, 519, 1, 2048]
-#          - Exact: [1032, 520, 1, 2048]
-#          - Exact: [1033, 521, 1, 2048]
-#          - Exact: [1034, 522, 1, 2048]
-#          - Exact: [1035, 523, 1, 2048]
-#          - Exact: [1036, 524, 1, 2048]
-#          - Exact: [1037, 525, 1, 2048]
-#          - Exact: [1038, 526, 1, 2048]
-#          - Exact: [1039, 527, 1, 2048]
-#          - Exact: [1040, 528, 1, 2048]
-#          - Exact: [1041, 529, 1, 2048]
-#          - Exact: [1042, 530, 1, 2048]
-#          - Exact: [1043, 531, 1, 2048]
           - Exact: [1044, 532, 1, 2048]
           - Exact: [127, 127, 1, 640] #special cleanup case
           - Exact: [128, 128, 1, 128]
           - Exact: [129, 129, 1, 640]
-          # - Exact: [128, 128, 1, 127]
-          # - Exact: [128, 128, 1, 129]
-          # - Exact: [111, 111, 1, 111]
-          # - Exact: [777, 777, 1, 777]
           - Exact: [128, 128, 1, 512]
-          #- Range: [[128], [128], [1], [1024,32,1280]]
-          #- Range: [[128], [128], [1], [1024,64,1280]] # TODO: passed for DepthU = 64 but failed for DepthU = 128 since we currently don't support tailloop in MX feature.
-          - Range: [[128,1,256], [128], [1], [1024]]
-          - Range: [[128], [128,1,256], [1], [1024]]
+          - Range: [[128,33,256], [128], [1], [1024]]
+          - Range: [[128], [128,33,256], [1], [1024]]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
 
-# LibraryLogic:
-#     ScheduleName: "aquavanjaram"
-#     DeviceNames: ["Device 0049"]
-#     ArchitectureName: "gfx950"
-#     LibraryType: "GridBased"
-#
-# LibraryClient:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/plr_zero.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/plr_zero.yaml
@@ -117,7 +117,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [255], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -148,7 +148,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [257], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -173,7 +173,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [255], [1], [1, 64, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -251,7 +251,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [4096, 4096, 1, 16384]
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [257], [1], [1, 71, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -278,7 +278,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [255], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -304,7 +304,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [257], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -379,7 +379,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [4096, 4096, 1, 16384]
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [255], [1], [1, 81, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -406,7 +406,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [257], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -432,7 +432,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [255], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -508,7 +508,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [4096, 4096, 1, 16384]
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [257], [1], [1, 81, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -535,7 +535,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [255], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -561,7 +561,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [257], [1], [1, 73, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -638,4 +638,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [2, 37, 512]]
+          - Range: [[257], [257], [1], [2, 148, 512]]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_bf16.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_bf16.yaml
@@ -84,13 +84,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s', 'b']
         - FactorDimArgs: [0,1]
@@ -164,13 +158,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
           - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
@@ -244,14 +232,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
           - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
           - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
@@ -324,15 +306,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -403,20 +378,8 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
           - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
           - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
@@ -487,22 +450,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
           - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -571,28 +520,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
           - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [16, 16, 1, 16] # classic format
-          - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 48] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 192] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
           - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -661,22 +591,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
           - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16.yaml
@@ -85,15 +85,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
           - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s', 'h']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -167,15 +160,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
           - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -248,13 +234,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
@@ -330,14 +310,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
           - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -407,22 +380,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
           - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -492,22 +451,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
           - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -576,28 +521,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
           - Exact: [16, 16, 1, 16] # classic format
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 48] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 192] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
           - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -666,22 +591,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
           - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16_sb.yaml
@@ -88,13 +88,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
           - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s', 'h']
         - FactorDimArgs: [0,1]
@@ -169,15 +163,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
           - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -250,15 +237,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
           - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -331,13 +311,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
@@ -409,21 +383,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
           - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
           - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
@@ -494,22 +455,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
           - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -578,28 +525,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [16, 16, 1, 16] # classic format
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 48] # classic format
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 192] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
           - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -668,21 +596,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
           - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
           - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
           - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8.yaml
@@ -83,15 +83,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
           - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
           - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
@@ -165,16 +157,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
           - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -247,16 +231,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
           - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -329,16 +305,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -410,17 +378,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -492,17 +450,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -573,18 +521,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
           - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -655,18 +593,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
           - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8_sb.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8_sb.yaml
@@ -83,16 +83,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
           - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -165,16 +157,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
           - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -247,15 +231,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
           - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
           - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
@@ -329,16 +305,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -410,17 +378,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -491,17 +449,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
           - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
           - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
@@ -574,17 +522,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -655,18 +593,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
           - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8.yaml
@@ -84,15 +84,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -165,16 +157,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -247,16 +231,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
           - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -329,16 +305,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
           - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -409,17 +377,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
           - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
           - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
@@ -492,17 +450,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -573,18 +521,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
           - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -655,18 +593,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
           - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8bs.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8bs.yaml
@@ -84,15 +84,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -164,17 +156,8 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
           - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_ldstr.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_ldstr.yaml
@@ -75,15 +75,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0]
         - ActivationArgs:
@@ -146,15 +139,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
           - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [1]
         - ActivationArgs:
@@ -218,14 +204,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
           - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format          
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0]
         - ActivationArgs:
@@ -288,13 +267,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
           - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [256, 256, 1, 384] # classic format
           - Exact: [1024, 1024, 1, 1024] # classic format          
         - BiasTypeArgs: ['s']


### PR DESCRIPTION
## Motivation

Currently the execution time for common folder takes around ~2hr and this is mainly due to large range of problem size which is not needed. 

## Technical Details

This change is to reduce the problem size, which is not very useful so that the execution time can improve

https://github.com/ROCm/rocm-libraries/commit/08937390b673bf4a0f664a04a99a8828b2527603
## Test Plan


N/A
## Test Result
```
Old time      New time                      YAML path
5235.18s     1134.15s    Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml]
1607.35s     529.29s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_f16.yaml]
2747.06s     498.35s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_f16_sb.yaml]
2649.23s     448.99s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_f8_sb.yaml]
635.55s      361.87s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/dtl.yaml]
1130.46s     228.85s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml]
982.54s      218.86s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/plr_zero.yaml]
2858.80s     154.97s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_f8.yaml]
2708.34s     129.11s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/mx32f8_tn.yaml]
771.92s      112.84s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_i8.yaml]
4154.73s     97.39s      Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_bf16.yaml]
1644.81s     84.20s      Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_i8bs.yaml]
2371.44s     48.44s      Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/mx32f4_tn.yaml]
1306.23s     47.93s      Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_ldstr.yaml]
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
