### PR TITLE
miopen: remove Boost dependency

### DIFF
--- a/projects/miopen/.clang-tidy
+++ b/projects/miopen/.clang-tidy
@@ -89,7 +89,6 @@ Checks: >-
   -abseil-*,
   -altera-*,
   -android-cloexec-fopen,
-  -boost-use-ranges,
   -bugprone-crtp-constructor-accessibility,
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,

--- a/projects/miopen/CMakeLists.txt
+++ b/projects/miopen/CMakeLists.txt
@@ -471,10 +471,6 @@ if(MIOPEN_USE_HIPRTC)
     message(STATUS "Build with hiprtc ${hiprtc_VERSION} ${hiprtc_DIR}")
 endif()
 
-option(Boost_USE_STATIC_LIBS "Use boost static libraries" ON)
-add_definitions(-DBOOST_ALL_NO_LIB=1)
-find_package(Boost REQUIRED COMPONENTS filesystem CONFIG)
-
 find_path(HALF_INCLUDE_DIR half/half.hpp)
 message(STATUS "HALF_INCLUDE_DIR: ${HALF_INCLUDE_DIR}")
 

--- a/projects/miopen/README.md
+++ b/projects/miopen/README.md
@@ -38,10 +38,6 @@ To install MIOpen, you must first install these prerequisites:
 * [ROCm CMake](https://github.com/ROCm/rocm-cmake): provides CMake modules for common build
   tasks needed for the ROCm software stack
 * [Half](http://half.sourceforge.net/): IEEE 754-based, half-precision floating-point library
-* [Boost](http://www.boost.org/): Version 1.79 is recommended, as older versions may need patches to
-  work on newer systems
-  * MIOpen uses `boost-system` and `boost-filesystem` packages to enable persistent
-    [kernel cache](https://rocm.docs.amd.com/projects/MIOpen/en/latest/cache.html)
 * [SQLite3](https://sqlite.org/index.html): A reading and writing performance database
 * lbzip2: A multi-threaded compress or decompress utility
 * [rocBLAS](https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas): AMD's library for Basic Linear Algebra Subprograms
@@ -329,19 +325,6 @@ If you are familiar with using Git LFS, a key difference with DVC is that you mu
 switch branches or merge changes in Git to ensure any large binaries are kept in sync with your checkout.
 
 ## Installing the dependencies manually
-
-If you're using Ubuntu v16, you can install the `Boost` packages using:
-
-```shell
-sudo apt-get install libboost-dev
-sudo apt-get install libboost-system-dev
-sudo apt-get install libboost-filesystem-dev
-```
-
->[!NOTE]
->By default, MIOpen attempts to build with Boost statically linked libraries. If required, you can build
-with dynamically linked Boost libraries using the `-DBoost_USE_STATIC_LIBS=Off` flag during the
-configuration stage. However, this is not recommended.
 
 You must install the `half` header from the [half website](http://half.sourceforge.net/).
 

--- a/projects/miopen/docs/install/build-source.rst
+++ b/projects/miopen/docs/install/build-source.rst
@@ -255,18 +255,4 @@ switch branches or merge changes in Git to ensure any large binaries are kept in
 Installing the dependencies manually
 ===============================================================
 
-If you're using Ubuntu v16, you can install the ``Boost`` packages using:
-
-.. code:: shell
-
-   sudo apt-get install libboost-dev
-   sudo apt-get install libboost-system-dev
-   sudo apt-get install libboost-filesystem-dev
-
-.. note::
-
-   By default, MIOpen attempts to build with Boost statically linked libraries. To build
-   with dynamically linked Boost libraries, use the ``-DBoost_USE_STATIC_LIBS=Off`` flag during the
-   configuration stage. However, this is not recommended.
-
 You must install the ``half`` header from the `half website <http://half.sourceforge.net/>`_.

--- a/projects/miopen/docs/install/prerequisites.rst
+++ b/projects/miopen/docs/install/prerequisites.rst
@@ -18,12 +18,6 @@ all types of MIOpen installations.
 * `ROCm CMake <https://github.com/ROCm/rocm-cmake>`_: CMake modules for common
   build tasks needed for the ROCm software stack
 * `Half <http://half.sourceforge.net/>`_: An IEEE 754-based, half-precision floating-point library
-* `Boost <http://www.boost.org/>`_: Version 1.79 is recommended, because older versions might need patches
-  to work on newer systems
-
-  * MIOpen uses the ``boost-system`` and ``boost-filesystem`` packages to enable persistent
-    :doc:`kernel cache <../conceptual/cache>`
-
 * `SQLite3 <https://sqlite.org/index.html>`_: A read-write performance database
 * lbzip2: A multi-threaded compression and decompression utility
 * :doc:`rocBLAS <rocblas:index>`: AMD's library for Basic Linear Algebra Subprograms (BLAS) on the

--- a/projects/miopen/requirements.txt
+++ b/projects/miopen/requirements.txt
@@ -1,5 +1,4 @@
 sqlite3@3.50.4 -DCMAKE_POSITION_INDEPENDENT_CODE=On
-boost@1.83 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build -DCMAKE_CXX_FLAGS=" -std=c++20 -Wno-enum-constexpr-conversion -Wno-deprecated-builtins -Wno-deprecated-declarations "
 facebook/zstd@v1.4.5 -X subdir -DCMAKE_DIR=build/cmake
 # ROCm/half@10abd99e7815f0ca5d892f58dd7d15a23b7cf92c --build
 ROCm/rocMLIR@rocm-5.5.0 -H sha256:a5f62769d28a73e60bc8d61022820f050e97c977c8f6f6275488db31512e1f42 -DBUILD_FAT_LIBROCKCOMPILER=1 -DCMAKE_IGNORE_PATH="/opt/conda/envs/py_3.8;/opt/conda/envs/py_3.9;/opt/conda/envs/py_3.10" -DCMAKE_IGNORE_PREFIX_PATH=/opt/conda -DCMAKE_CXX_FLAGS=" -Wno-deprecated-declarations "

--- a/projects/miopen/src/CMakeLists.txt
+++ b/projects/miopen/src/CMakeLists.txt
@@ -1053,10 +1053,6 @@ endif()
 target_link_libraries(MIOpen PRIVATE nlohmann_json::nlohmann_json)
 target_link_libraries(MIOpen INTERFACE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 
-target_internal_library(MIOpen Boost::filesystem)
-target_compile_definitions(MIOpen PRIVATE BOOST_DISABLE_EXPLICIT_SYMBOL_VISIBILITY)
-list(APPEND PACKAGE_STATIC_DEPENDS PACKAGE Boost COMPONENTS filesystem)
-
 if(NOT WIN32 AND NOT APPLE)
     target_link_libraries(MIOpen PRIVATE "-Wl,--exclude-libs,ALL")
     set_target_properties(MIOpen PROPERTIES CXX_VISIBILITY_PRESET hidden)
@@ -1069,7 +1065,7 @@ if(MIOPEN_ENABLE_SQLITE)
     target_link_libraries(MIOpen INTERFACE  $<BUILD_INTERFACE:SQLite::SQLite3>)
 endif()
 ############################################################
-# MIOpen depends on librt for Boost.Interprocess
+# MIOpen depends on librt
 if(NOT WIN32 AND NOT APPLE)
     find_library(LIBRT rt)
     if(LIBRT)

--- a/projects/miopen/test/gtest/CMakeLists.txt
+++ b/projects/miopen/test/gtest/CMakeLists.txt
@@ -83,7 +83,7 @@ function(add_gtest TEST_NAME TEST_CPP)
 
   # Workaround : change in rocm-cmake was causing linking error so had to add ${CMAKE_DL_LIBS}
   #               We can remove ${CMAKE_DL_LIBS} once root cause is identified.
-  target_link_libraries(${TEST_NAME} ${CMAKE_DL_LIBS} GTest::gtest GTest::gtest_main GTest::gmock MIOpen ${Boost_LIBRARIES} hip::host )
+  target_link_libraries(${TEST_NAME} ${CMAKE_DL_LIBS} GTest::gtest GTest::gtest_main GTest::gmock MIOpen hip::host )
   if(NOT MIOPEN_EMBED_DB STREQUAL "")
       target_link_libraries(${TEST_NAME} $<BUILD_INTERFACE:miopen_data>)
   endif()


### PR DESCRIPTION
- Drop find_package(Boost) and Boost::filesystem from top-level and src CMake
- Remove Boost_LIBRARIES from test/gtest and fin is de-boosted via submodule
- Update docs: remove Boost from prerequisites and install instructions (build-source, prerequisites, README)
- Remove boost from requirements.txt and -boost-use-ranges from .clang-tidy
- Simplify librt comment in src/CMakeLists.txt (no Boost.Interprocess)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
