### PR TITLE
[hipDNN] Add transpose-aware stride inference to BlockScaleQuantizeNode

### DIFF
--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/ShapeUtilities.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/ShapeUtilities.hpp
@@ -6,6 +6,7 @@
 #include <hipdnn_data_sdk/logging/Logger.hpp>
 #include <hipdnn_data_sdk/utilities/StringUtil.hpp>
 #include <numeric>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -221,6 +222,70 @@ inline std::vector<int64_t> extractStrideOrder(const std::vector<int64_t>& strid
     }
 
     return strideOrder;
+}
+
+/**
+ * @brief Generates strides that make a specified axis the most tightly packed dimension
+ *
+ * Derives a stride ordering from a reference tensor's strides, optionally rotating
+ * the specified axis to be the most tightly packed (stride=1). Other dimensions
+ * preserve their relative ordering from the reference layout.
+ *
+ * @param referenceStrides Strides of the reference tensor (used to determine dimension ordering)
+ * @param referenceDims Dimensions of the reference tensor (used for singleton tiebreaking)
+ * @param targetDims Dimensions of the tensor to generate strides for
+ * @param axis If set, this dimension index becomes the most tightly packed (stride=1).
+ *             If not set, the reference stride ordering is preserved as-is.
+ * @return Strides for targetDims with the specified axis most tightly packed
+ *
+ * @code{.cpp}
+ * // NCHW input, make axis 1 (C) most packed:
+ * auto strides = generateStridesWithPackedAxis(
+ *     {65536, 1024, 32, 1}, {2, 64, 32, 32}, {2, 64, 32, 32}, 1);
+ * // Returns {64, 1, 4096, 128}
+ * @endcode
+ */
+inline std::vector<int64_t>
+    generateStridesWithPackedAxis(const std::vector<int64_t>& referenceStrides,
+                                  const std::vector<int64_t>& referenceDims,
+                                  const std::vector<int64_t>& targetDims,
+                                  std::optional<int64_t> axis = std::nullopt)
+{
+    size_t numDims = referenceStrides.size();
+
+    // Sort dimension indices by reference strides ascending,
+    // with singleton-dimension tiebreaker (singletons sort first)
+    std::vector<size_t> sortedIndices(numDims);
+    std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
+    std::sort(sortedIndices.begin(),
+              sortedIndices.end(),
+              [&referenceStrides, &referenceDims](size_t a, size_t b) {
+                  if(referenceStrides[a] != referenceStrides[b])
+                  {
+                      return referenceStrides[a] < referenceStrides[b];
+                  }
+                  return (referenceDims[a] == 1) > (referenceDims[b] == 1);
+              });
+
+    // If axis is set, rotate so the axis dimension becomes most packed
+    if(axis.has_value())
+    {
+        auto axisVal = static_cast<size_t>(axis.value());
+        auto it = std::find(sortedIndices.begin(), sortedIndices.end(), axisVal);
+        if(it != sortedIndices.end())
+        {
+            std::rotate(sortedIndices.begin(), it, sortedIndices.end());
+        }
+    }
+
+    // Build stride order from inverse permutation
+    std::vector<int64_t> strideOrder(numDims);
+    for(size_t i = 0; i < numDims; ++i)
+    {
+        strideOrder[sortedIndices[i]] = static_cast<int64_t>(i);
+    }
+
+    return generateStrides(targetDims, strideOrder);
 }
 
 // Checks if the tensor defined by dims and strides is packed (contiguous in memory).

--- a/projects/hipdnn/data_sdk/tests/utilities/TestShapeUtilities.cpp
+++ b/projects/hipdnn/data_sdk/tests/utilities/TestShapeUtilities.cpp
@@ -566,6 +566,77 @@ INSTANTIATE_TEST_SUITE_P(
         ExtractStrideOrderTestCase{
             {1, 4, 8, 8, 8, 1}, {1, 2, 5, 4, 3, 0}, true, {4, 2, 1, 1, 1, 1}}));
 
+TEST(TestShapeUtils, GenerateStridesWithPackedAxisNchwAxis1)
+{
+    // NCHW input, make axis 1 (C) most packed
+    auto strides
+        = generateStridesWithPackedAxis({65536, 1024, 32, 1}, {2, 64, 32, 32}, {2, 64, 32, 32}, 1);
+
+    // Sorted by stride ascending: [3,2,1,0], rotate axis=1 to front → [1,0,3,2]
+    // strideOrder=[1,0,3,2]: dim1 gets stride 1
+    EXPECT_EQ(strides, (std::vector<int64_t>{64, 1, 4096, 128}));
+}
+
+TEST(TestShapeUtils, GenerateStridesWithPackedAxisNhwcAxis3)
+{
+    // NHWC input, make axis 3 (W) most packed
+    auto strides
+        = generateStridesWithPackedAxis({65536, 1, 2048, 64}, {2, 64, 32, 32}, {2, 64, 32, 32}, 3);
+
+    EXPECT_EQ(strides, (std::vector<int64_t>{1024, 2048, 32, 1}));
+}
+
+TEST(TestShapeUtils, GenerateStridesWithPackedAxisNoAxisPreservesOrder)
+{
+    // Without axis, stride ordering matches the reference layout
+    auto strides
+        = generateStridesWithPackedAxis({65536, 1024, 32, 1}, {2, 64, 32, 32}, {2, 64, 32, 32});
+
+    EXPECT_EQ(strides, (std::vector<int64_t>{65536, 1024, 32, 1}));
+}
+
+TEST(TestShapeUtils, GenerateStridesWithPackedAxisDifferentTargetDims)
+{
+    // Target dims differ from reference (e.g., scale tensor with reduced axis dim)
+    auto strides
+        = generateStridesWithPackedAxis({65536, 1024, 32, 1}, {2, 64, 32, 32}, {2, 2, 32, 32}, 1);
+
+    EXPECT_EQ(strides, (std::vector<int64_t>{2, 1, 128, 4}));
+}
+
+TEST(TestShapeUtils, GenerateStridesWithPackedAxisSingletonTiebreaker)
+{
+    // Singletons with equal strides should sort before non-singletons
+    // dims {1, 4, 1, 4} with strides {4, 1, 4, 1}: dims 0 and 2 are singletons with stride 4
+    auto strides = generateStridesWithPackedAxis({4, 1, 4, 1}, {1, 4, 1, 4}, {1, 4, 1, 4}, 1);
+
+    // Sorted ascending: dim1(1), dim3(1), dim0(4,singleton), dim2(4,singleton)
+    // Rotate axis=1 to front: [1, 3, 0, 2]
+    // strideOrder: [2, 0, 3, 1] → dim1 gets stride 1
+    EXPECT_EQ(strides[1], 1); // axis dim is most packed
+}
+
+TEST(TestShapeUtils, GenerateStridesWithPackedAxis3D)
+{
+    // 3D tensor, axis=0
+    auto strides = generateStridesWithPackedAxis({12, 4, 1}, {3, 3, 4}, {3, 3, 4}, 0);
+
+    // Sorted ascending: [2,1,0], rotate axis=0 to front: [0,2,1]
+    // strideOrder: [0,2,1] → dim0 gets stride 1
+    EXPECT_EQ(strides[0], 1);
+    EXPECT_EQ(strides, (std::vector<int64_t>{1, 12, 3}));
+}
+
+TEST(TestShapeUtils, GenerateStridesWithPackedAxisLastAxis)
+{
+    // Packing the last axis (already most packed in NCHW) preserves original layout
+    auto strides
+        = generateStridesWithPackedAxis({65536, 1024, 32, 1}, {2, 64, 32, 32}, {2, 64, 32, 32}, 3);
+
+    // Sorted ascending: [3,2,1,0], rotate axis=3 (at position 0) to front → no change
+    EXPECT_EQ(strides, (std::vector<int64_t>{65536, 1024, 32, 1}));
+}
+
 TEST(TestShapeUtils, IsTensorPackedTrueForPackedTensor)
 {
     std::vector<int64_t> shape3D = {2, 3, 4};

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/BlockScaleDequantizeNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/BlockScaleDequantizeNode.hpp
@@ -39,6 +39,12 @@ public:
                                ErrorCode::ATTRIBUTE_NOT_SET,
                                "BlockScaleDequantizeNode missing y for pre-validation");
 
+        // Dequantize output must be a virtual tensor — it is consumed by downstream
+        // operations in a fused graph rather than written to user memory.
+        HIPDNN_RETURN_IF_FALSE(attributes.get_y()->get_is_virtual(),
+                               ErrorCode::INVALID_VALUE,
+                               "BlockScaleDequantizeNode output tensor y must be virtual");
+
         HIPDNN_RETURN_IF_FALSE(!attributes.get_block_size().empty(),
                                ErrorCode::ATTRIBUTE_NOT_SET,
                                "BlockScaleDequantizeNode block_size must not be empty");

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/BlockScaleQuantizeNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/BlockScaleQuantizeNode.hpp
@@ -126,6 +126,53 @@ public:
 
         HIPDNN_CHECK_ERROR(attributes.fill_from_context(graph_attributes));
 
+        auto axis = attributes.get_axis();
+
+        // Lambda for transposed stride inference: reorders strides so the block-scale axis
+        // becomes the most tightly packed dimension (stride=1).
+        auto inferStridesTransposed
+            = [&x](const std::shared_ptr<TensorAttributes>& t,
+                   const std::optional<int64_t>& axisOpt) {
+                  auto const& xStrides = x->get_stride();
+                  auto const& xDims    = x->get_dim();
+                  size_t numDims       = xStrides.size();
+
+                  // Sort dimension indices by X's strides ascending,
+                  // with singleton-dimension tiebreaker (singletons sort first)
+                  std::vector<size_t> sortedIndices(numDims);
+                  std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
+                  std::sort(sortedIndices.begin(),
+                            sortedIndices.end(),
+                            [&xStrides, &xDims](size_t a, size_t b) {
+                                if(xStrides[a] != xStrides[b])
+                                {
+                                    return xStrides[a] < xStrides[b];
+                                }
+                                return (xDims[a] == 1) > (xDims[b] == 1);
+                            });
+
+                  // If axis is set, rotate so the axis dimension becomes most packed
+                  if(axisOpt.has_value())
+                  {
+                      auto axisVal = static_cast<size_t>(axisOpt.value());
+                      auto it = std::find(sortedIndices.begin(), sortedIndices.end(), axisVal);
+                      if(it != sortedIndices.end())
+                      {
+                          std::rotate(sortedIndices.begin(), it, sortedIndices.end());
+                      }
+                  }
+
+                  // Build stride order from inverse permutation
+                  std::vector<int64_t> strideOrder(numDims);
+                  for(size_t i = 0; i < numDims; ++i)
+                  {
+                      strideOrder[sortedIndices[i]] = static_cast<int64_t>(i);
+                  }
+
+                  t->set_stride(
+                      hipdnn_data_sdk::utilities::generateStrides(t->get_dim(), strideOrder));
+              };
+
         // Infer Y dims and strides from X
         if(y->get_dim().empty())
         {
@@ -134,7 +181,11 @@ public:
 
         if(y->get_stride().empty())
         {
-            if(!x->get_stride().empty())
+            if(attributes.get_transpose() && !x->get_stride().empty())
+            {
+                inferStridesTransposed(y, axis);
+            }
+            else if(!x->get_stride().empty())
             {
                 y->set_stride(x->get_stride());
             }
@@ -151,8 +202,6 @@ public:
             if(blockSize.has_value() && blockSize.value() > 0)
             {
                 auto scaleDims = x->get_dim();
-                // Default axis is last dimension if not specified
-                auto axis = attributes.get_axis();
                 size_t scaleAxis
                     = axis.has_value() ? static_cast<size_t>(axis.value()) : scaleDims.size() - 1;
 
@@ -166,7 +215,11 @@ public:
 
         if(scale->get_stride().empty())
         {
-            if(!x->get_stride().empty() && !scale->get_dim().empty())
+            if(attributes.get_transpose() && !x->get_stride().empty() && !scale->get_dim().empty())
+            {
+                inferStridesTransposed(scale, axis);
+            }
+            else if(!x->get_stride().empty() && !scale->get_dim().empty())
             {
                 auto strideOrder = hipdnn_data_sdk::utilities::extractStrideOrder(x->get_stride());
                 scale->set_stride(

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/BlockScaleQuantizeNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/BlockScaleQuantizeNode.hpp
@@ -128,49 +128,6 @@ public:
 
         auto axis = attributes.get_axis();
 
-        // Lambda for transposed stride inference: reorders strides so the block-scale axis
-        // becomes the most tightly packed dimension (stride=1).
-        auto inferStridesTransposed = [&x](const std::shared_ptr<TensorAttributes>& t,
-                                           const std::optional<int64_t>& axisOpt) {
-            auto const& xStrides = x->get_stride();
-            auto const& xDims = x->get_dim();
-            size_t numDims = xStrides.size();
-
-            // Sort dimension indices by X's strides ascending,
-            // with singleton-dimension tiebreaker (singletons sort first)
-            std::vector<size_t> sortedIndices(numDims);
-            std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
-            std::sort(sortedIndices.begin(),
-                      sortedIndices.end(),
-                      [&xStrides, &xDims](size_t a, size_t b) {
-                          if(xStrides[a] != xStrides[b])
-                          {
-                              return xStrides[a] < xStrides[b];
-                          }
-                          return (xDims[a] == 1) > (xDims[b] == 1);
-                      });
-
-            // If axis is set, rotate so the axis dimension becomes most packed
-            if(axisOpt.has_value())
-            {
-                auto axisVal = static_cast<size_t>(axisOpt.value());
-                auto it = std::find(sortedIndices.begin(), sortedIndices.end(), axisVal);
-                if(it != sortedIndices.end())
-                {
-                    std::rotate(sortedIndices.begin(), it, sortedIndices.end());
-                }
-            }
-
-            // Build stride order from inverse permutation
-            std::vector<int64_t> strideOrder(numDims);
-            for(size_t i = 0; i < numDims; ++i)
-            {
-                strideOrder[sortedIndices[i]] = static_cast<int64_t>(i);
-            }
-
-            t->set_stride(hipdnn_data_sdk::utilities::generateStrides(t->get_dim(), strideOrder));
-        };
-
         // Infer Y dims and strides from X
         if(y->get_dim().empty())
         {
@@ -181,7 +138,8 @@ public:
         {
             if(attributes.get_transpose() && !x->get_stride().empty())
             {
-                inferStridesTransposed(y, axis);
+                y->set_stride(hipdnn_data_sdk::utilities::generateStridesWithPackedAxis(
+                    x->get_stride(), x->get_dim(), y->get_dim(), axis));
             }
             else if(!x->get_stride().empty())
             {
@@ -215,7 +173,8 @@ public:
         {
             if(attributes.get_transpose() && !x->get_stride().empty() && !scale->get_dim().empty())
             {
-                inferStridesTransposed(scale, axis);
+                scale->set_stride(hipdnn_data_sdk::utilities::generateStridesWithPackedAxis(
+                    x->get_stride(), x->get_dim(), scale->get_dim(), axis));
             }
             else if(!x->get_stride().empty() && !scale->get_dim().empty())
             {

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/BlockScaleQuantizeNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/BlockScaleQuantizeNode.hpp
@@ -130,48 +130,46 @@ public:
 
         // Lambda for transposed stride inference: reorders strides so the block-scale axis
         // becomes the most tightly packed dimension (stride=1).
-        auto inferStridesTransposed
-            = [&x](const std::shared_ptr<TensorAttributes>& t,
-                   const std::optional<int64_t>& axisOpt) {
-                  auto const& xStrides = x->get_stride();
-                  auto const& xDims    = x->get_dim();
-                  size_t numDims       = xStrides.size();
+        auto inferStridesTransposed = [&x](const std::shared_ptr<TensorAttributes>& t,
+                                           const std::optional<int64_t>& axisOpt) {
+            auto const& xStrides = x->get_stride();
+            auto const& xDims = x->get_dim();
+            size_t numDims = xStrides.size();
 
-                  // Sort dimension indices by X's strides ascending,
-                  // with singleton-dimension tiebreaker (singletons sort first)
-                  std::vector<size_t> sortedIndices(numDims);
-                  std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
-                  std::sort(sortedIndices.begin(),
-                            sortedIndices.end(),
-                            [&xStrides, &xDims](size_t a, size_t b) {
-                                if(xStrides[a] != xStrides[b])
-                                {
-                                    return xStrides[a] < xStrides[b];
-                                }
-                                return (xDims[a] == 1) > (xDims[b] == 1);
-                            });
+            // Sort dimension indices by X's strides ascending,
+            // with singleton-dimension tiebreaker (singletons sort first)
+            std::vector<size_t> sortedIndices(numDims);
+            std::iota(sortedIndices.begin(), sortedIndices.end(), 0);
+            std::sort(sortedIndices.begin(),
+                      sortedIndices.end(),
+                      [&xStrides, &xDims](size_t a, size_t b) {
+                          if(xStrides[a] != xStrides[b])
+                          {
+                              return xStrides[a] < xStrides[b];
+                          }
+                          return (xDims[a] == 1) > (xDims[b] == 1);
+                      });
 
-                  // If axis is set, rotate so the axis dimension becomes most packed
-                  if(axisOpt.has_value())
-                  {
-                      auto axisVal = static_cast<size_t>(axisOpt.value());
-                      auto it = std::find(sortedIndices.begin(), sortedIndices.end(), axisVal);
-                      if(it != sortedIndices.end())
-                      {
-                          std::rotate(sortedIndices.begin(), it, sortedIndices.end());
-                      }
-                  }
+            // If axis is set, rotate so the axis dimension becomes most packed
+            if(axisOpt.has_value())
+            {
+                auto axisVal = static_cast<size_t>(axisOpt.value());
+                auto it = std::find(sortedIndices.begin(), sortedIndices.end(), axisVal);
+                if(it != sortedIndices.end())
+                {
+                    std::rotate(sortedIndices.begin(), it, sortedIndices.end());
+                }
+            }
 
-                  // Build stride order from inverse permutation
-                  std::vector<int64_t> strideOrder(numDims);
-                  for(size_t i = 0; i < numDims; ++i)
-                  {
-                      strideOrder[sortedIndices[i]] = static_cast<int64_t>(i);
-                  }
+            // Build stride order from inverse permutation
+            std::vector<int64_t> strideOrder(numDims);
+            for(size_t i = 0; i < numDims; ++i)
+            {
+                strideOrder[sortedIndices[i]] = static_cast<int64_t>(i);
+            }
 
-                  t->set_stride(
-                      hipdnn_data_sdk::utilities::generateStrides(t->get_dim(), strideOrder));
-              };
+            t->set_stride(hipdnn_data_sdk::utilities::generateStrides(t->get_dim(), strideOrder));
+        };
 
         // Infer Y dims and strides from X
         if(y->get_dim().empty())

--- a/projects/hipdnn/frontend/tests/TestBlockScaleDequantizeNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestBlockScaleDequantizeNode.cpp
@@ -21,7 +21,9 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNode)
     scaleTensor->set_dim({2, 2, 32, 32});
     attrs.set_scale(scaleTensor);
 
-    attrs.set_y(std::make_shared<TensorAttributes>());
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_is_virtual(true);
+    attrs.set_y(yTensor);
     attrs.set_block_size(std::vector<int32_t>{32});
 
     GraphAttributes graphAttributes;
@@ -76,13 +78,34 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNodeMissingY)
     EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 }
 
+TEST(TestBlockScaleDequantizeNode, PreValidateNodeYNotVirtual)
+{
+    BlockScaleDequantizeAttributes attrs;
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_dim({2, 64, 32, 32}).set_stride({65536, 1024, 32, 1});
+    attrs.set_x(xTensor);
+
+    attrs.set_scale(std::make_shared<TensorAttributes>());
+    attrs.set_y(std::make_shared<TensorAttributes>()); // Not virtual
+    attrs.set_block_size(std::vector<int32_t>{32});
+
+    GraphAttributes graphAttributes;
+    BlockScaleDequantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.pre_validate_node();
+    EXPECT_EQ(error.code, ErrorCode::INVALID_VALUE);
+}
+
 TEST(TestBlockScaleDequantizeNode, PreValidateNodeMissingBlockSize)
 {
     BlockScaleDequantizeAttributes attrs;
 
     attrs.set_x(std::make_shared<TensorAttributes>());
     attrs.set_scale(std::make_shared<TensorAttributes>());
-    attrs.set_y(std::make_shared<TensorAttributes>());
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_is_virtual(true);
+    attrs.set_y(yTensor);
     // block_size is not set (empty)
 
     GraphAttributes graphAttributes;
@@ -105,7 +128,7 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNodeYShapeMismatch)
     attrs.set_scale(scaleTensor);
 
     auto yTensor = std::make_shared<TensorAttributes>();
-    yTensor->set_dim({2, 64, 16, 16}); // Mismatched dims
+    yTensor->set_dim({2, 64, 16, 16}).set_is_virtual(true); // Mismatched dims
     attrs.set_y(yTensor);
 
     attrs.set_block_size(std::vector<int32_t>{32});
@@ -129,7 +152,7 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNodeYRankMismatch)
     attrs.set_scale(scaleTensor);
 
     auto yTensor = std::make_shared<TensorAttributes>();
-    yTensor->set_dim({2, 64, 32}); // Different rank
+    yTensor->set_dim({2, 64, 32}).set_is_virtual(true); // Different rank
     attrs.set_y(yTensor);
 
     attrs.set_block_size(std::vector<int32_t>{32});
@@ -153,7 +176,9 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNodeYDimsNotSetPassesValidation)
     auto scaleTensor = std::make_shared<TensorAttributes>();
     attrs.set_scale(scaleTensor);
 
-    attrs.set_y(std::make_shared<TensorAttributes>()); // No dims set
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_is_virtual(true); // No dims set
+    attrs.set_y(yTensor);
     attrs.set_block_size(std::vector<int32_t>{32});
 
     GraphAttributes graphAttributes;
@@ -172,7 +197,9 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNodeBlockSizeZero)
     attrs.set_x(xTensor);
 
     attrs.set_scale(std::make_shared<TensorAttributes>());
-    attrs.set_y(std::make_shared<TensorAttributes>());
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_is_virtual(true);
+    attrs.set_y(yTensor);
     attrs.set_block_size(std::vector<int32_t>{0});
 
     GraphAttributes graphAttributes;
@@ -191,7 +218,9 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNodeBlockSizeNegative)
     attrs.set_x(xTensor);
 
     attrs.set_scale(std::make_shared<TensorAttributes>());
-    attrs.set_y(std::make_shared<TensorAttributes>());
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_is_virtual(true);
+    attrs.set_y(yTensor);
     attrs.set_block_size(std::vector<int32_t>{32, -1});
 
     GraphAttributes graphAttributes;
@@ -210,7 +239,9 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNodeBlockSizeExceedsRank)
     attrs.set_x(xTensor);
 
     attrs.set_scale(std::make_shared<TensorAttributes>());
-    attrs.set_y(std::make_shared<TensorAttributes>());
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_is_virtual(true);
+    attrs.set_y(yTensor);
     attrs.set_block_size(std::vector<int32_t>{32, 16, 8}); // 3 entries > rank 2
 
     GraphAttributes graphAttributes;
@@ -229,7 +260,9 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNodeBlockSizeMatchesRank)
     attrs.set_x(xTensor);
 
     attrs.set_scale(std::make_shared<TensorAttributes>());
-    attrs.set_y(std::make_shared<TensorAttributes>());
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_is_virtual(true);
+    attrs.set_y(yTensor);
     attrs.set_block_size(std::vector<int32_t>{2, 64, 32, 32}); // exactly matches rank
 
     GraphAttributes graphAttributes;
@@ -246,7 +279,9 @@ TEST(TestBlockScaleDequantizeNode, PreValidateNodeXDimsNotSetSkipsDimChecks)
 
     attrs.set_x(std::make_shared<TensorAttributes>()); // No dims
     attrs.set_scale(std::make_shared<TensorAttributes>());
-    attrs.set_y(std::make_shared<TensorAttributes>());
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_is_virtual(true);
+    attrs.set_y(yTensor);
     attrs.set_block_size(std::vector<int32_t>{32, 16, 8}); // Would fail if X had rank < 3
 
     GraphAttributes graphAttributes;

--- a/projects/hipdnn/frontend/tests/TestBlockScaleQuantizeNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestBlockScaleQuantizeNode.cpp
@@ -399,6 +399,19 @@ TEST(TestBlockScaleQuantizeNode, InferPropertiesNodeMissingY)
     EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
 }
 
+TEST(TestBlockScaleQuantizeNode, InferPropertiesNodeMissingScale)
+{
+    BlockScaleQuantizeAttributes attrs;
+    attrs.set_x(std::make_shared<TensorAttributes>());
+    attrs.set_y(std::make_shared<TensorAttributes>());
+
+    GraphAttributes graphAttributes;
+    BlockScaleQuantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::ATTRIBUTE_NOT_SET);
+}
+
 TEST(TestBlockScaleQuantizeNode, PackNode)
 {
     BlockScaleQuantizeAttributes attrs;
@@ -581,6 +594,8 @@ TEST(TestBlockScaleQuantizeNode, InferPropertiesTransposedYStridesWithAxis)
     EXPECT_EQ(error.code, ErrorCode::OK);
 
     EXPECT_EQ(yTensor->get_dim(), (std::vector<int64_t>{2, 64, 32, 32}));
+    // Derivation: sort indices by X strides ascending → [3,2,1,0], rotate axis=1 to front
+    // → [1,0,3,2], inverse permutation gives strideOrder=[1,0,3,2], so dim 1 gets stride 1.
     EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{64, 1, 4096, 128}));
 }
 
@@ -750,6 +765,70 @@ TEST(TestBlockScaleQuantizeNode, InferPropertiesNonTransposeScaleStrides)
     // Non-transpose: Y gets X strides, scale gets stride order from extractStrideOrder
     EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{65536, 1024, 32, 1}));
     EXPECT_EQ(scaleTensor->get_dim(), (std::vector<int64_t>{2, 2, 32, 32}));
+    EXPECT_EQ(scaleTensor->get_stride(), (std::vector<int64_t>{2048, 1024, 32, 1}));
+}
+
+TEST(TestBlockScaleQuantizeNode, InferPropertiesYStridesFallbackNoXStrides)
+{
+    // When X has dims but no strides, Y strides fall back to generateStrides(y->get_dim())
+    BlockScaleQuantizeAttributes attrs;
+    attrs.set_block_size(32);
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_uid(1)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 32, 32}); // No strides set
+    attrs.set_x(xTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_uid(2).set_name("Y");
+    attrs.set_y(yTensor);
+
+    attrs.set_scale(std::make_shared<TensorAttributes>());
+
+    GraphAttributes graphAttributes;
+    BlockScaleQuantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    EXPECT_EQ(yTensor->get_dim(), (std::vector<int64_t>{2, 64, 32, 32}));
+    // Default generateStrides produces row-major strides
+    EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{65536, 1024, 32, 1}));
+}
+
+TEST(TestBlockScaleQuantizeNode, InferPropertiesScaleStridesFallbackNoXStrides)
+{
+    // When X has dims but no strides, scale strides fall back to generateStrides(scale->get_dim())
+    BlockScaleQuantizeAttributes attrs;
+    attrs.set_block_size(32);
+    attrs.set_axis(1);
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_uid(1)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 32, 32}); // No strides set
+    attrs.set_x(xTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_uid(2).set_name("Y");
+    attrs.set_y(yTensor);
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_uid(3).set_name("Scale");
+    attrs.set_scale(scaleTensor);
+
+    GraphAttributes graphAttributes;
+    BlockScaleQuantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    // Scale dims inferred: axis=1 → dim[1]/32 = 64/32 = 2
+    EXPECT_EQ(scaleTensor->get_dim(), (std::vector<int64_t>{2, 2, 32, 32}));
+    // Default generateStrides produces row-major strides
     EXPECT_EQ(scaleTensor->get_stride(), (std::vector<int64_t>{2048, 1024, 32, 1}));
 }
 

--- a/projects/hipdnn/frontend/tests/TestBlockScaleQuantizeNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestBlockScaleQuantizeNode.cpp
@@ -553,6 +553,206 @@ TEST(TestBlockScaleQuantizeNode, PackNodeWithoutAxis)
     EXPECT_EQ(packedAttributes->transpose(), false);
 }
 
+TEST(TestBlockScaleQuantizeNode, InferPropertiesTransposedYStridesWithAxis)
+{
+    BlockScaleQuantizeAttributes attrs;
+    attrs.set_block_size(32);
+    attrs.set_axis(1);
+    attrs.set_transpose(true);
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_uid(1)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 32, 32})
+        .set_stride({65536, 1024, 32, 1});
+    attrs.set_x(xTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_uid(2).set_name("Y");
+    attrs.set_y(yTensor);
+
+    attrs.set_scale(std::make_shared<TensorAttributes>());
+
+    GraphAttributes graphAttributes;
+    BlockScaleQuantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    EXPECT_EQ(yTensor->get_dim(), (std::vector<int64_t>{2, 64, 32, 32}));
+    EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{64, 1, 4096, 128}));
+}
+
+TEST(TestBlockScaleQuantizeNode, InferPropertiesTransposedScaleStridesWithAxis)
+{
+    BlockScaleQuantizeAttributes attrs;
+    attrs.set_block_size(32);
+    attrs.set_axis(1);
+    attrs.set_transpose(true);
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_uid(1)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 32, 32})
+        .set_stride({65536, 1024, 32, 1});
+    attrs.set_x(xTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_uid(2).set_name("Y");
+    attrs.set_y(yTensor);
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_uid(3).set_name("Scale");
+    attrs.set_scale(scaleTensor);
+
+    GraphAttributes graphAttributes;
+    BlockScaleQuantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    EXPECT_EQ(scaleTensor->get_dim(), (std::vector<int64_t>{2, 2, 32, 32}));
+    EXPECT_EQ(scaleTensor->get_stride(), (std::vector<int64_t>{2, 1, 128, 4}));
+}
+
+TEST(TestBlockScaleQuantizeNode, InferPropertiesTransposedDefaultAxis)
+{
+    BlockScaleQuantizeAttributes attrs;
+    attrs.set_block_size(32);
+    // No axis set
+    attrs.set_transpose(true);
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_uid(1)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 32, 32})
+        .set_stride({65536, 1024, 32, 1});
+    attrs.set_x(xTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_uid(2).set_name("Y");
+    attrs.set_y(yTensor);
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_uid(3).set_name("Scale");
+    attrs.set_scale(scaleTensor);
+
+    GraphAttributes graphAttributes;
+    BlockScaleQuantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    // Without axis, transpose produces same stride ordering as X
+    EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{65536, 1024, 32, 1}));
+    // Scale dims: last dim divided by block_size
+    EXPECT_EQ(scaleTensor->get_dim(), (std::vector<int64_t>{2, 64, 32, 1}));
+    EXPECT_EQ(scaleTensor->get_stride(), (std::vector<int64_t>{2048, 32, 1, 1}));
+}
+
+TEST(TestBlockScaleQuantizeNode, InferPropertiesTransposedNhwcInput)
+{
+    BlockScaleQuantizeAttributes attrs;
+    attrs.set_block_size(32);
+    attrs.set_axis(3);
+    attrs.set_transpose(true);
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_uid(1)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 32, 32})
+        .set_stride({65536, 1, 2048, 64}); // NHWC layout
+    attrs.set_x(xTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_uid(2).set_name("Y");
+    attrs.set_y(yTensor);
+
+    attrs.set_scale(std::make_shared<TensorAttributes>());
+
+    GraphAttributes graphAttributes;
+    BlockScaleQuantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    EXPECT_EQ(yTensor->get_dim(), (std::vector<int64_t>{2, 64, 32, 32}));
+    EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{1024, 2048, 32, 1}));
+}
+
+TEST(TestBlockScaleQuantizeNode, InferPropertiesTransposePreservesExistingStrides)
+{
+    BlockScaleQuantizeAttributes attrs;
+    attrs.set_block_size(32);
+    attrs.set_axis(1);
+    attrs.set_transpose(true);
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_uid(1)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 32, 32})
+        .set_stride({65536, 1024, 32, 1});
+    attrs.set_x(xTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_uid(2)
+        .set_name("Y")
+        .set_dim({2, 64, 32, 32})
+        .set_stride({65536, 1024, 32, 1}); // User-set strides
+    attrs.set_y(yTensor);
+
+    attrs.set_scale(std::make_shared<TensorAttributes>());
+
+    GraphAttributes graphAttributes;
+    BlockScaleQuantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    // Existing strides should not be overwritten
+    EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{65536, 1024, 32, 1}));
+}
+
+TEST(TestBlockScaleQuantizeNode, InferPropertiesNonTransposeScaleStrides)
+{
+    BlockScaleQuantizeAttributes attrs;
+    attrs.set_block_size(32);
+    attrs.set_axis(1);
+    // transpose is false by default
+
+    auto xTensor = std::make_shared<TensorAttributes>();
+    xTensor->set_uid(1)
+        .set_name("X")
+        .set_data_type(DataType::FLOAT)
+        .set_dim({2, 64, 32, 32})
+        .set_stride({65536, 1024, 32, 1});
+    attrs.set_x(xTensor);
+
+    auto yTensor = std::make_shared<TensorAttributes>();
+    yTensor->set_uid(2).set_name("Y");
+    attrs.set_y(yTensor);
+
+    auto scaleTensor = std::make_shared<TensorAttributes>();
+    scaleTensor->set_uid(3).set_name("Scale");
+    attrs.set_scale(scaleTensor);
+
+    GraphAttributes graphAttributes;
+    BlockScaleQuantizeNode node(std::move(attrs), graphAttributes);
+
+    auto error = node.infer_properties_node();
+    EXPECT_EQ(error.code, ErrorCode::OK);
+
+    // Non-transpose: Y gets X strides, scale gets stride order from extractStrideOrder
+    EXPECT_EQ(yTensor->get_stride(), (std::vector<int64_t>{65536, 1024, 32, 1}));
+    EXPECT_EQ(scaleTensor->get_dim(), (std::vector<int64_t>{2, 2, 32, 32}));
+    EXPECT_EQ(scaleTensor->get_stride(), (std::vector<int64_t>{2048, 1024, 32, 1}));
+}
+
 TEST(TestBlockScaleQuantizeNode, GatherHipdnnTensors)
 {
     BlockScaleQuantizeAttributes attrs;


### PR DESCRIPTION
## Summary
- Add `inferStridesTransposed` lambda to `BlockScaleQuantizeNode::infer_properties_node()` that reorders strides so the block-scale axis becomes the most tightly packed dimension (stride=1) when `transpose=true`
- Branch on `attributes.get_transpose()` for both Y and scale stride inference, falling back to existing behavior when `transpose=false`
- Add 6 new unit tests covering NCHW/NHWC inputs, default axis, user-set stride preservation, and non-transpose regression

## Details

The block-scale quantize frontend (merged in #5035) stores and serializes the `transpose` attribute but never uses it during stride inference. We needed to add an `infer_strides_transposed` helper that reorders strides so the block-scale axis becomes the most tightly packed dimension when `transpose=true`. This is needed for efficient block-wise memory access during quantization.

The lambda:
1. Sorts dimension indices by X's strides ascending (singleton-dimension tiebreaker)
2. If axis is set, rotates the sorted indices so the axis dimension becomes most packed
3. Builds a stride order from the inverse permutation
4. Calls `generateStrides(T->get_dim(), strideOrder)`

## Test plan
- [x] All 32 `TestBlockScaleQuantizeNode` tests pass (26 existing + 6 new)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)