### PR TITLE
Enable verbose cppcheck output and diagnostics

### DIFF
--- a/projects/miopen/cmake/CppCheck.cmake
+++ b/projects/miopen/cmake/CppCheck.cmake
@@ -90,9 +90,8 @@ macro(enable_cppcheck)
         file(GLOB_RECURSE GSRCS ${GLOBS})
         set(CPPCHECK_COMMAND
             ${CPPCHECK_EXE}
-            -q
-            # -v
-            # --report-progress
+            -v
+            --checkers-report=${CMAKE_BINARY_DIR}/cppcheck-checkers-report.txt
             ${CPPCHECK_FORCE}
             --cppcheck-build-dir=${CPPCHECK_BUILD_DIR}
             --platform=native
@@ -115,6 +114,11 @@ macro(enable_cppcheck)
             RESULT_VARIABLE RESULT
         )
         if(NOT RESULT EQUAL 0)
+            message(WARNING \"Cppcheck failed with exit code \${RESULT}\")
+            if(EXISTS \"${CMAKE_BINARY_DIR}/cppcheck-checkers-report.txt\")
+                file(READ \"${CMAKE_BINARY_DIR}/cppcheck-checkers-report.txt\" CHECKERS_REPORT)
+                message(WARNING \"\${CHECKERS_REPORT}\")
+            endif()
             message(FATAL_ERROR \"Cppcheck failed\")
         endif()
 ")


### PR DESCRIPTION

## Motivation
Replace the quiet flag (-q) with verbose (-v) to provide progress visibility during long-running cppcheck analysis (30-60+ minutes).

Changes:
- Replace -q with -v for real-time progress monitoring
- Add --checkers-report to generate detailed checker diagnostics
- Enhanced error handling to display exit code and checker report when cppcheck fails

This improves CI/CD debugging and prevents confusion when cppcheck appears to hang during full codebase analysis.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
