### PR TITLE
Changing TF32 CMS tests to use trig inits and no alphaVector

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling_tf32.yaml
@@ -9,8 +9,8 @@ GlobalParameters:
   EnqueuesPerSync: 1
   DataInitTypeBeta: 0
   DataInitTypeAlpha: 1
-  DataInitTypeA: 3
-  DataInitTypeB: 3
+  DataInitTypeA: 12
+  DataInitTypeB: 13
   NewClient: 2
   CSVExportWinner: 1
   CSVMergeSameProblemID: 1
@@ -595,7 +595,7 @@ BenchmarkProblems:
       Batched: True
       UseBias: 1
       BiasDataTypeList: [s,b]
-      UseScaleAlphaVec: 1
+      UseScaleAlphaVec: 0
       Activation: true
       ActivationType: hipblaslt_all
       ActivationFuncCall: false
@@ -810,7 +810,7 @@ BenchmarkProblems:
       Batched: True
       UseBias: 1
       BiasDataTypeList: [s,b]
-      UseScaleAlphaVec: 1
+      UseScaleAlphaVec: 0
       Activation: true
       ActivationType: hipblaslt_all
       ActivationFuncCall: false


### PR DESCRIPTION
## Motivation

Int init tests fail to test accuracy of lower bits in tf32 emulation. AlphaVector scales error range to beyond threshold bounds and should not be used with random int init (too large).

## Technical Details

DataTypeInit changed to 12/13.  ScaleAlphaVector set to 0.

## Test Plan

tensile.sh mainloop_tf32.yaml

## Test Result

PASS
