### PR TITLE
[ci] Removing `ready_for_review` during PR checks

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -10,7 +10,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - ready_for_review
   workflow_dispatch:
     inputs:
       projects:


### PR DESCRIPTION
During PR checks, we don't need to run the entire CI again for `ready_for_review`. Removing as not needed