### PR TITLE
Fix Integer Type Errors

### DIFF
--- a/projects/rocblas/clients/benchmarks/program_options.hpp
+++ b/projects/rocblas/clients/benchmarks/program_options.hpp
@@ -23,7 +23,15 @@
 
 #pragma once
 
+#if __GLIBC__ < 3 && __GLIBC__MINOR__ < 39
+#define SCNd32 "d"
+#define SCNu32 "u"
+#define SCNd64 "l"
+#define SCNu64 "lu"
+#undef _GLIBCXX_USE_C99_INTTYPES_TR1
+#endif
 #include <cinttypes>
+
 #include <cstdio>
 #include <iomanip>
 #include <map>

--- a/projects/rocblas/clients/include/d_vector.hpp
+++ b/projects/rocblas/clients/include/d_vector.hpp
@@ -27,6 +27,9 @@
 #include "rocblas_test.hpp"
 #include "singletons.hpp"
 
+#if __GLIBC__ < 3 && __GLIBC__MINOR__ < 39
+#undef _GLIBCXX_USE_C99_INTTYPES_TR1
+#endif
 #include <cinttypes>
 
 #define MEM_MAX_GUARD_PAD 8192

--- a/projects/rocblas/clients/include/rocblas_random.hpp
+++ b/projects/rocblas/clients/include/rocblas_random.hpp
@@ -24,6 +24,9 @@
 
 #include "rocblas.h"
 #include "rocblas_math.hpp"
+#if __GLIBC__ < 3 && __GLIBC__MINOR__ < 39
+#undef _GLIBCXX_USE_C99_INTTYPES_TR1
+#endif
 #include <cinttypes>
 #include <random>
 #include <thread>


### PR DESCRIPTION
A recent change to LLVM is causing missing integer type errors on Linux with GCC 12, GCC 15, and probably other versions.  This is part of a series of PRs to address that issue.

The root cause is probably the fact that we partially-but-not-completely have our own C standard library separate from the host library, but that's not something that can be avoided.