### PR TITLE
Better rrperf default build dir

### DIFF
--- a/shared/rocroller/scripts/lib/rrperf/utils.py
+++ b/shared/rocroller/scripts/lib/rrperf/utils.py
@@ -72,11 +72,7 @@ def get_build_dir() -> Path:
     varname = "ROCROLLER_BUILD_DIR"
     if varname in os.environ:
         return Path(os.environ[varname])
-    default = rrperf.git.top() / "shared" / "rocroller" / "build"
-    if default.is_dir():
-        return default
-
-    raise RuntimeError(f"Build directory not found.  Set {varname} to override.")
+    return Path.cwd()
 
 
 def get_dataclass_id(obj):


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Uses current dir as default.

```bash
~/r/r/u/k/g/s/r/build_release[130]►pwd                                                                                                                                                                                                10.837s (users/kerrwang/git-top|💩) 23:52
/home/kerrwang/repos/rocm-libraries/users/kerrwang/git-top/shared/rocroller/build_release
~/r/r/u/k/g/s/r/build_release►../scripts/rrperf run                                                                                                                                                                                           (users/kerrwang/git-top|💩) 23:52
running:
  id: 249dafaa8d02fd5c0bbc1efe93406b89f93596e9
  command: client/rocroller-gemm --mac_m=256 --mac_n=256 --mac_k=128 --wave_m=32 --wave_n=32 --wave_k=64 --wave_b=1 --workgroup_size_x=128 --workgroup_size_y=2 --workgroupRemapXCC=False --workgroupRemapXCCValue=-1 --load_A=BufferToLDSViaVGPR --load_B=BufferToLDSViaVGPR --store=VGPRToGlobalMemoryViaLDSWithBuffer --betaInFma=True --padLDS_A=0,0 --padLDS_B=0,0 --scheduler=Priority --schedulerCost=LinearWeighted --prefetch=True --prefetchInFlight=2 --prefetchLDSFactor=2 --prefetchMixMemOps=False --loadScale_A=BufferToLDSViaVGPR --loadScale_B=BufferToLDSViaVGPR --swizzleScale=False --sts=64x8/64x8 --prefetchScale=False --pretileScale=False --streamK=None --numWGs=0 --tailLoops=True --M=4096 --N=4096 --K=32768 --alpha=2.0 --beta=0.5 --type_A=fp4 --type_B=fp4 --type_C=half --type_D=half --type_acc=float --trans_A=T --trans_B=N --scale_A=Separate --scaleType_A=E8M0 --scale_B=Separate --scaleType_B=E8M0 --scaleBlockSize=32 --scaleSkipPermlane=None --scaleValue_A=1.0 --scaleValue_B=1.0 --initMode_A=Bounded --initMode_B=Bounded --initMode_C=Bounded --workgroupMappingDim=-1 --workgroupMappingValue=-1 --num_warmup=1000 --num_outer=1 --num_inner=1000 --noCheck=False --visualize=False --yaml=/home/kerrwang/repos/rocm-libraries/users/kerrwang/git-top/shared/rocroller/build_release/2026-03-06-462515675f-001/gemm-000000.yaml
  wrkdir:  /home/kerrwang/repos/rocm-libraries/users/kerrwang/git-top/shared/rocroller/build_release/2026-03-06-462515675f-001
  log:     /home/kerrwang/repos/rocm-libraries/users/kerrwang/git-top/shared/rocroller/build_release/2026-03-06-462515675f-001/gemm-000000.log
Average GFLOPS:      2.36481e+06
  status:  ok
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
