### PR TITLE
[hipBLASLt] Fix CI failures for gfx942

### DIFF
--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1422,11 +1422,42 @@ namespace TensileLite
 
                 virtual bool operator()(ContractionProblemGemm const& problem) const override
                 {
-                    return problem.a().dataType() == value[0] && problem.b().dataType() == value[1]
+                    auto ret = problem.a().dataType() == value[0] && problem.b().dataType() == value[1]
                            && problem.c().dataType() == value[2]
-                           && problem.d().dataType() == value[3]
-                           && problem.computeInputTypeA() == value[4]
-                           && problem.computeInputTypeB() == value[5];
+                           && problem.d().dataType() == value[3];
+
+                    using MyType = std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2>;
+                    std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> ciA =
+                    {{
+                        {rocisa::DataType::BFloat8_fnuz, rocisa::DataType::BFloat8Float8_fnuz},
+                        {rocisa::DataType::Float8_fnuz,  rocisa::DataType::Float8BFloat8_fnuz},
+                    }};
+
+                    std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> ciB =
+                    {{
+                        {rocisa::DataType::Float8_fnuz,  rocisa::DataType::BFloat8Float8_fnuz},
+                        {rocisa::DataType::BFloat8_fnuz, rocisa::DataType::Float8BFloat8_fnuz},
+                    }};
+
+                    auto check = [](MyType const& arr, rocisa::DataType const& t1, rocisa::DataType const& t2){
+                        if(t1 == t2)
+                            return true;
+                        return std::any_of(arr.begin(), arr.end(), [&](const auto& p){
+                                return (p == std::make_pair(t1, t2)) or (p == std::make_pair(t2, t1));
+                        });
+                    };
+
+                    ret = ret &&
+                          check(ciA, problem.computeInputTypeA(), value[4]) &&
+                          check(ciB, problem.computeInputTypeB(), value[5]);
+
+                    return ret;
+
+                    //return problem.a().dataType() == value[0] && problem.b().dataType() == value[1]
+                    //       && problem.c().dataType() == value[2]
+                    //       && problem.d().dataType() == value[3]
+                    //       && problem.computeInputTypeA() == value[4]
+                    //       && problem.computeInputTypeB() == value[5];
                 }
 
                 virtual std::string toString() const override

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1446,7 +1446,7 @@ namespace TensileLite
                         if(t1 == t2)
                             return true;
                         return std::any_of(arr.begin(), arr.end(), [&](const auto& p){
-                                return (p == std::make_pair(t1, t2)) or (p == std::make_pair(t2, t1));
+                                return (p == std::make_pair(t1, t2));
                         });
                     };
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1420,60 +1420,66 @@ namespace TensileLite
                     return "TypesEqual";
                 }
 
-		// This function checks if the computeInputType of a problem matches the computeInputType of a
-		// solution. Because for Float8_fnuz/BFloat8_fnuz, the computeInputTypeA and computeInputTypeB
-		// might be concatenated like this: computeInputTypeAcomputeInputTypeB_fnuz, this function
-		// includes special logic to inspect types at the concatenation position.
-		//
+                // This function checks if the computeInputType of a problem matches the computeInputType of a
+                // solution. Because for Float8{_fnuz}/BFloat8{_fnuz}, the computeInputTypeA and computeInputTypeB
+                // might be concatenated like this: computeInputTypeAcomputeInputTypeB{_fnuz}, this function
+                // includes special logic to inspect types at the concatenation position.
+                //
                 bool validateComputeType(rocisa::DataType const& problemComputeInputType, bool const isComputeInputTypeA) const
-		{
-		    // computeInputTypeA corresponds to the first type in the concatenated type
-                    std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> const computeInputTypeAMapping =
+                {
+                    using ArrType = std::array<std::pair<rocisa::DataType, rocisa::DataType>, 4>;
+
+                    // computeInputTypeA corresponds to the first type in the concatenated type
+                    ArrType const computeInputTypeAMapping =
                     {{
                         {rocisa::DataType::BFloat8_fnuz, rocisa::DataType::BFloat8Float8_fnuz},
                         {rocisa::DataType::Float8_fnuz,  rocisa::DataType::Float8BFloat8_fnuz},
+                        {rocisa::DataType::BFloat8, rocisa::DataType::BFloat8Float8},
+                        {rocisa::DataType::Float8,  rocisa::DataType::Float8BFloat8}
                     }};
 
-		    // computeInputTypeB corresponds to the second type in the concatenated type
-                    std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> const computeInputTypeBMapping =
+                    // computeInputTypeB corresponds to the second type in the concatenated type
+                    ArrType const computeInputTypeBMapping =
                     {{
                         {rocisa::DataType::Float8_fnuz,  rocisa::DataType::BFloat8Float8_fnuz},
                         {rocisa::DataType::BFloat8_fnuz, rocisa::DataType::Float8BFloat8_fnuz},
+                        {rocisa::DataType::Float8,  rocisa::DataType::BFloat8Float8},
+                        {rocisa::DataType::BFloat8, rocisa::DataType::Float8BFloat8}
                     }};
 
-                    auto validate = [](std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> const& arr,
-			    rocisa::DataType const& t1, rocisa::DataType const& t2){
-                        if(t1 == t2)
-                            return true;
-                        return std::any_of(arr.begin(), arr.end(), [&](const auto& p){
-                                return (p == std::make_pair(t1, t2));
+                    auto validate = [](ArrType const& arr,
+                            rocisa::DataType const& t1, rocisa::DataType const& t2){
+                          if(t1 == t2)
+                              return true;
+                          return std::any_of(arr.begin(), arr.end(), [&](const auto& p){
+                                  return (p == std::make_pair(t1, t2)) or (p == std::make_pair(t2, t1));
                         });
                     };
 
-		    if(isComputeInputTypeA)
-		    {
-			// value[4] is computeInputTypeA
-			return
-			    validate(computeInputTypeAMapping, problemComputeInputType, value[4]);
-		    }
-		    else
-		    {
-			// value[5] is computeInputTypeB
-			return
-			    validate(computeInputTypeBMapping, problemComputeInputType, value[5]);
-		    }
-		}
+                    if(isComputeInputTypeA)
+                    {
+                        // value[4] is computeInputTypeA
+                        return
+                            validate(computeInputTypeAMapping, problemComputeInputType, value[4]);
+                    }
+                    else
+                    {
+                        // value[5] is computeInputTypeB
+                        return
+                            validate(computeInputTypeBMapping, problemComputeInputType, value[5]);
+                    }
+                }
 
                 virtual bool operator()(ContractionProblemGemm const& problem) const override
                 {
                     auto ret = problem.a().dataType() == value[0]
-			    && problem.b().dataType() == value[1]
+                            && problem.b().dataType() == value[1]
                             && problem.c().dataType() == value[2]
                             && problem.d().dataType() == value[3];
 
-		    return ret &&
-			validateComputeType(problem.computeInputTypeA(), true) &&
-			validateComputeType(problem.computeInputTypeB(), false);
+                    return ret &&
+                        validateComputeType(problem.computeInputTypeA(), true /* isComputeInputTypeA */) &&
+                        validateComputeType(problem.computeInputTypeB(), false /* isComputeInputTypeA */);
                 }
 
                 virtual std::string toString() const override

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1478,8 +1478,8 @@ namespace TensileLite
                             && problem.d().dataType() == value[3];
 
                     return ret &&
-                        validateComputeType(problem.computeInputTypeA(), true /* isComputeInputTypeA */) &&
-                        validateComputeType(problem.computeInputTypeB(), false /* isComputeInputTypeA */);
+                        validateComputeType(problem.computeInputTypeA(), true) &&
+                        validateComputeType(problem.computeInputTypeB(), false);
                 }
 
                 virtual std::string toString() const override

--- a/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/ContractionProblemPredicates.hpp
@@ -1420,26 +1420,29 @@ namespace TensileLite
                     return "TypesEqual";
                 }
 
-                virtual bool operator()(ContractionProblemGemm const& problem) const override
-                {
-                    auto ret = problem.a().dataType() == value[0] && problem.b().dataType() == value[1]
-                           && problem.c().dataType() == value[2]
-                           && problem.d().dataType() == value[3];
-
-                    using MyType = std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2>;
-                    std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> ciA =
+		// This function checks if the computeInputType of a problem matches the computeInputType of a
+		// solution. Because for Float8_fnuz/BFloat8_fnuz, the computeInputTypeA and computeInputTypeB
+		// might be concatenated like this: computeInputTypeAcomputeInputTypeB_fnuz, this function
+		// includes special logic to inspect types at the concatenation position.
+		//
+                bool validateComputeType(rocisa::DataType const& problemComputeInputType, bool const isComputeInputTypeA) const
+		{
+		    // computeInputTypeA corresponds to the first type in the concatenated type
+                    std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> const computeInputTypeAMapping =
                     {{
                         {rocisa::DataType::BFloat8_fnuz, rocisa::DataType::BFloat8Float8_fnuz},
                         {rocisa::DataType::Float8_fnuz,  rocisa::DataType::Float8BFloat8_fnuz},
                     }};
 
-                    std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> ciB =
+		    // computeInputTypeB corresponds to the second type in the concatenated type
+                    std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> const computeInputTypeBMapping =
                     {{
                         {rocisa::DataType::Float8_fnuz,  rocisa::DataType::BFloat8Float8_fnuz},
                         {rocisa::DataType::BFloat8_fnuz, rocisa::DataType::Float8BFloat8_fnuz},
                     }};
 
-                    auto check = [](MyType const& arr, rocisa::DataType const& t1, rocisa::DataType const& t2){
+                    auto validate = [](std::array<std::pair<rocisa::DataType, rocisa::DataType>, 2> const& arr,
+			    rocisa::DataType const& t1, rocisa::DataType const& t2){
                         if(t1 == t2)
                             return true;
                         return std::any_of(arr.begin(), arr.end(), [&](const auto& p){
@@ -1447,17 +1450,30 @@ namespace TensileLite
                         });
                     };
 
-                    ret = ret &&
-                          check(ciA, problem.computeInputTypeA(), value[4]) &&
-                          check(ciB, problem.computeInputTypeB(), value[5]);
+		    if(isComputeInputTypeA)
+		    {
+			// value[4] is computeInputTypeA
+			return
+			    validate(computeInputTypeAMapping, problemComputeInputType, value[4]);
+		    }
+		    else
+		    {
+			// value[5] is computeInputTypeB
+			return
+			    validate(computeInputTypeBMapping, problemComputeInputType, value[5]);
+		    }
+		}
 
-                    return ret;
+                virtual bool operator()(ContractionProblemGemm const& problem) const override
+                {
+                    auto ret = problem.a().dataType() == value[0]
+			    && problem.b().dataType() == value[1]
+                            && problem.c().dataType() == value[2]
+                            && problem.d().dataType() == value[3];
 
-                    //return problem.a().dataType() == value[0] && problem.b().dataType() == value[1]
-                    //       && problem.c().dataType() == value[2]
-                    //       && problem.d().dataType() == value[3]
-                    //       && problem.computeInputTypeA() == value[4]
-                    //       && problem.computeInputTypeB() == value[5];
+		    return ret &&
+			validateComputeType(problem.computeInputTypeA(), true) &&
+			validateComputeType(problem.computeInputTypeB(), false);
                 }
 
                 virtual std::string toString() const override


### PR DESCRIPTION
## Motivation

This PR fixes failed gfx942 tests in CI.

## Technical Details

For fnuz/non-fnuz f8 types, the `ComputeInputType` might appear in a concatenated form:`ComputeInputTypeAComputeInputTypeB` (e.g., `BFloat8Float8_fnuz`). This leads to type mismatches when selecting solutions. This PR adds logic to correctly interpret concatenated types by checking the type at the corresponding position.

## Test Plan

Manually run these tests:

gfx942:
- `./clients/hipblaslt-test --gtest_filter=*pre_checkin_matmul_real_1b_fnuz_dst_1b_fnuz_smallsize_bf8_fnuz_rf8_fnuz_rbf8_fnuz_rbf8_fnuz_rf32_r_NT_3_128_128_1_3_128_2_3_3_1_SA_SB*`

gfx950:
- `./clients/hipblaslt-test --gtest_filter=*matmul_f8_dst_bf16*`
- `./clients/hipblaslt-test --gtest_filter=*matmul_f8_bf8_dst_bf16*`
- `./clients/hipblaslt-test --gtest_filter=*matmul_f8_bf8_dst_fp32*`


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
