### PR TITLE
[hipblaslt] Optimize StoreSwapAddr

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -336,6 +336,7 @@ class StateValues:
   doPackPreSchedulingThisLoop: bool      = False
   doPackPreSchedulingNextLoop: bool      = False
   doFullPackCodePrefetch: bool           = False
+  useCommonSgprSwap: bool                = False
 
   # Epilogue states
   preloadScaleA = False
@@ -4921,6 +4922,14 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.states.oneBufferScheduling = (kernel["1LDSBuffer"]) or \
                                       ((kernel["DirectToLdsA"] or kernel["DirectToLdsB"]) and \
                                        self.states.numLDSBlk == kernel["PrefetchGlobalRead"])
+    # common sgprSwap
+    # enable it for the following case.
+    #  DTLA+B + StoreSwapAddr + numLDSBlk==2 + (not EPS) + (not sparse) + (MX or non CMS)
+    self.states.useCommonSgprSwap = False
+    if kernel["DirectToLds"] == 1 and kernel["StoreSwapAddr"] and self.states.numLDSBlk == 2 and \
+       (not kernel["ExpandPointerSwap"]) and (not kernel["ProblemType"]["Sparse"]) and \
+       (kernel["ProblemType"]["MXBlockA"] or kernel["ProblemType"]["MXBlockB"] or not kernel["UseCustomMainLoopSchedule"]):
+      self.states.useCommonSgprSwap = True
 
     # NamedTuple is immutable
     class intermediateTPValues(NamedTuple):
@@ -6656,16 +6665,19 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     # Allocate registers to swap between lds buffers
     if kernel["StoreSwapAddr"]:
-      if kernel["LocalWriteUseSgprA"]:
-        self.defineSgpr("SwapA", 1)
-      if kernel["LocalWriteUseSgprB"]:
-        self.defineSgpr("SwapB", 1)
-      if kernel["ProblemType"]["MXBlockA"] and kernel["LocalWriteUseSgprMXSA"]:
-          self.defineSgpr("SwapMXSA", 1)
-      if kernel["ProblemType"]["MXBlockB"] and kernel["LocalWriteUseSgprMXSB"]:
-          self.defineSgpr("SwapMXSB", 1)
-      if kernel["ProblemType"]["Sparse"] and kernel["LocalWriteUseSgprMetadata"]:
-        self.defineSgpr("SwapMetadata", 1)
+      if self.states.useCommonSgprSwap:
+        self.defineSgpr("SwapCommon", 1)
+      else:
+        if kernel["LocalWriteUseSgprA"]:
+          self.defineSgpr("SwapA", 1)
+        if kernel["LocalWriteUseSgprB"]:
+          self.defineSgpr("SwapB", 1)
+        if kernel["ProblemType"]["MXBlockA"] and kernel["LocalWriteUseSgprMXSA"]:
+            self.defineSgpr("SwapMXSA", 1)
+        if kernel["ProblemType"]["MXBlockB"] and kernel["LocalWriteUseSgprMXSB"]:
+            self.defineSgpr("SwapMXSB", 1)
+        if kernel["ProblemType"]["Sparse"] and kernel["LocalWriteUseSgprMetadata"]:
+          self.defineSgpr("SwapMetadata", 1)
 
     if kernel["GlobalSplitUAlgorithm"] == 'MultipleBufferSingleKernel':
       self.defineSgpr("AddressTD", numSgprAddressD, align=2)

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriter.py
@@ -4924,11 +4924,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
                                        self.states.numLDSBlk == kernel["PrefetchGlobalRead"])
     # common sgprSwap
     # enable it for the following case.
-    #  DTLA+B + StoreSwapAddr + numLDSBlk==2 + (not EPS) + (not sparse) + (MX or non CMS)
+    #  DTLA+B + numLDSBlk==2 + (not EPS) + (not sparse) + (MX or (StoreSwapAddr and (not CMS))
     self.states.useCommonSgprSwap = False
-    if kernel["DirectToLds"] == 1 and kernel["StoreSwapAddr"] and self.states.numLDSBlk == 2 and \
+    if kernel["DirectToLds"] == 1 and self.states.numLDSBlk == 2 and \
        (not kernel["ExpandPointerSwap"]) and (not kernel["ProblemType"]["Sparse"]) and \
-       (kernel["ProblemType"]["MXBlockA"] or kernel["ProblemType"]["MXBlockB"] or not kernel["UseCustomMainLoopSchedule"]):
+       ((kernel["ProblemType"]["MXBlockA"] or kernel["ProblemType"]["MXBlockB"]) or \
+         kernel["StoreSwapAddr"] and not kernel["UseCustomMainLoopSchedule"]):
       self.states.useCommonSgprSwap = True
 
     # NamedTuple is immutable
@@ -6664,20 +6665,19 @@ class KernelWriter(metaclass=abc.ABCMeta):
         self.defineSgpr("LocalWriteAddrMXSB", 1)
 
     # Allocate registers to swap between lds buffers
-    if kernel["StoreSwapAddr"]:
-      if self.states.useCommonSgprSwap:
-        self.defineSgpr("SwapCommon", 1)
-      else:
-        if kernel["LocalWriteUseSgprA"]:
-          self.defineSgpr("SwapA", 1)
-        if kernel["LocalWriteUseSgprB"]:
-          self.defineSgpr("SwapB", 1)
-        if kernel["ProblemType"]["MXBlockA"] and kernel["LocalWriteUseSgprMXSA"]:
-            self.defineSgpr("SwapMXSA", 1)
-        if kernel["ProblemType"]["MXBlockB"] and kernel["LocalWriteUseSgprMXSB"]:
-            self.defineSgpr("SwapMXSB", 1)
-        if kernel["ProblemType"]["Sparse"] and kernel["LocalWriteUseSgprMetadata"]:
-          self.defineSgpr("SwapMetadata", 1)
+    if self.states.useCommonSgprSwap:
+      self.defineSgpr("SwapCommon", 1)
+    elif kernel["StoreSwapAddr"]:
+      if kernel["LocalWriteUseSgprA"]:
+        self.defineSgpr("SwapA", 1)
+      if kernel["LocalWriteUseSgprB"]:
+        self.defineSgpr("SwapB", 1)
+      if kernel["ProblemType"]["MXBlockA"] and kernel["LocalWriteUseSgprMXSA"]:
+          self.defineSgpr("SwapMXSA", 1)
+      if kernel["ProblemType"]["MXBlockB"] and kernel["LocalWriteUseSgprMXSB"]:
+          self.defineSgpr("SwapMXSB", 1)
+      if kernel["ProblemType"]["Sparse"] and kernel["LocalWriteUseSgprMetadata"]:
+        self.defineSgpr("SwapMetadata", 1)
 
     if kernel["GlobalSplitUAlgorithm"] == 'MultipleBufferSingleKernel':
       self.defineSgpr("AddressTD", numSgprAddressD, align=2)

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4620,7 +4620,7 @@ class KernelWriterAssembly(KernelWriter):
         self.vgprPool.checkIn(tmpv)
       self.vgprPool.checkIn(destVgpr)
 
-    if kernel["StoreSwapAddr"]:
+    if kernel["StoreSwapAddr"] or self.states.useCommonSgprSwap:
       if kernel["LocalWriteUseSgpr%s"%tc]:
         if self.states.useCommonSgprSwap:
           # Need only once. Generate the code for "A" only

--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -1335,7 +1335,7 @@ class KernelWriterAssembly(KernelWriter):
       module.add(ValueSet("MTOffset", reductionOffsetLow32, format=1))
       module.add(ValueSet("MTOffsetH32", reductionOffsetHigh32, format=1))
 
-    if self.states.IncLdsBufSwitch:
+    if self.states.IncLdsBufSwitch or self.states.useCommonSgprSwap:
       module.addComment0("%d LDS Blocks for PGR %d"%(self.states.numLDSBlk, kernel["PrefetchGlobalRead"]))
       module.add(ValueSet("LdsOneBlockSize", kernel["LdsOffsetA_Blk"]))
       module.add(ValueSet("LdsBlockEndSize", kernel["LdsOffsetA_Blk"] * self.states.numLDSBlk))
@@ -4622,11 +4622,16 @@ class KernelWriterAssembly(KernelWriter):
 
     if kernel["StoreSwapAddr"]:
       if kernel["LocalWriteUseSgpr%s"%tc]:
-        # needed for the VReadfirstlaneB32 in the prior code block
-        if self.states.archCaps["CrosslaneWait"]:
-          module.add(SNop(waitState=0, comment="1 wait states"))
-        module.add(SAddU32(dst=sgpr("Swap%s"%tc), src0=sgpr("LocalWriteAddr%s"%tc), src1=kernel["LdsOffsetA_Blk"], comment="Calculate starting lds addr of second buffer"))
-        module.add(SXorB32(dst=sgpr("Swap%s"%tc), src0=sgpr("Swap%s"%tc), src1=sgpr("LocalWriteAddr%s"%tc), comment="xor both lds buffer offsets to enable swapping"))
+        if self.states.useCommonSgprSwap:
+          # Need only once. Generate the code for "A" only
+          if tc == "A":
+            module.add(SMovB32(dst=sgpr("SwapCommon"), src=0, comment="Initialize SwapCommon"))
+        else:
+          # needed for the VReadfirstlaneB32 in the prior code block
+          if self.states.archCaps["CrosslaneWait"]:
+            module.add(SNop(waitState=0, comment="1 wait states"))
+          module.add(SAddU32(dst=sgpr("Swap%s"%tc), src0=sgpr("LocalWriteAddr%s"%tc), src1=kernel["LdsOffsetA_Blk"], comment="Calculate starting lds addr of second buffer"))
+          module.add(SXorB32(dst=sgpr("Swap%s"%tc), src0=sgpr("Swap%s"%tc), src1=sgpr("LocalWriteAddr%s"%tc), comment="xor both lds buffer offsets to enable swapping"))
       else:
         module.add(VAddU32(dst=vgpr("LocalWriteSwapAddr%s"%tc), src0=kernel["LdsOffsetA_Blk"], src1=vgpr("LocalWriteAddr%s"%tc), \
                            comment="starting lds addr of second buffer" ))
@@ -9392,6 +9397,9 @@ class KernelWriterAssembly(KernelWriter):
       if self.states.IncLdsBufSwitch:
         DtldsModule.add(SAddU32(dst=mgpr(0), src0=sgpr("LocalWriteAddr%s"%tc), \
                       src1=sgpr("LDSBufferWriteInc"), comment="m0 <- LDS write address (base + inc)"))
+      elif self.states.useCommonSgprSwap:
+        DtldsModule.add(SAddU32(dst=mgpr(0), src0=sgpr("LocalWriteAddr%s"%tc), \
+                      src1=sgpr("SwapCommon"), comment="m0 <- LDS write address (base + inc)"))
       elif kernel["ExpandPointerSwap"]:
         DtldsModule.add(SAddU32(dst=mgpr(0), src0=sgpr("LocalWriteAddr%s"%tc), \
                       src1=tP["localWriteSwapByteOffset"], comment="m0 <- LDS write address"))
@@ -9828,6 +9836,15 @@ class KernelWriterAssembly(KernelWriter):
         module.add(SCmpEQU32(src0=sgpr("LDSBufferWriteInc"), src1="LdsBlockEndSize", comment="LDSBufferWriteInc == End ?"))
         module.add(SCMovB32(dst=sgpr("LDSBufferWriteInc"), src=0, comment="LDSBufferWriteInc loop back to 0"))
 
+    def localWriteSwapCommon(tc):
+      is1st = tc == "A" # so far, A is always first
+      if is1st:
+        module.add(SXorB32(
+          dst=sgpr("SwapCommon"), \
+          src0="LdsOneBlockSize", \
+          src1=sgpr("SwapCommon"), \
+          comment="xor LDS block size"))
+
     def getSrc0Val(tc):
       src0Val = None
       if kernel["StoreSwapAddr"]:
@@ -9853,6 +9870,10 @@ class KernelWriterAssembly(KernelWriter):
         # 3 or more LDS block case, we do not use xor. Instead, use add and max check for round back
         # (numLDSBlk>=3 is for DTL (and LocalWriteUseSgpr) only)
         localWriteAddRound(tc)
+      elif self.states.useCommonSgprSwap:
+        # commonSwap case, need only 1 swap
+        # (generate at "A" only)
+        localWriteSwapCommon(tc)
       else:
         src0Val = getSrc0Val(tc)
         numLwa = self.states.a.numVgprLocalWriteAddr if tP["isA"] else self.states.b.numVgprLocalWriteAddr
@@ -9902,8 +9923,7 @@ class KernelWriterAssembly(KernelWriter):
     module = Module("localWriteResetOffsets")
     if needReset:
       resetMask = hex(kernel["LdsOffsetA_Blk"]-1 | self.consts.ldsOOB)
-      # MXSA/MXSB do not use swap addresses, use else branch instead
-      useSwapAddr = (internalPointerSwap or kernel["StoreSwapAddr"]) and tc not in ("MXSA", "MXSB")
+      useSwapAddr = (internalPointerSwap or (kernel["StoreSwapAddr"] and not self.states.useCommonSgprSwap))
       if useSwapAddr:
         if internalPointerSwap:
           tP["localWriteSwapByteOffset"] = 0
@@ -9938,6 +9958,14 @@ class KernelWriterAssembly(KernelWriter):
           dst=sgpr("LDSBufferWriteInc"), \
           src=0, \
           comment="reset incSgpr"))
+      elif self.states.useCommonSgprSwap:
+        # commonSwap case, back to 0
+        # (generate at "A" only)
+        if tc == "A":
+          module.add(SMovB32(
+            dst=sgpr("SwapCommon"), \
+            src=0, \
+            comment="reset swapCommon"))
       else:
         if kernel["LocalWriteUseSgpr%s"%tc]:
           module.add(SAndB32(
@@ -10919,8 +10947,7 @@ class KernelWriterAssembly(KernelWriter):
         dst=vgpr("LocalReadAddr%s"%(tc)), \
         src=vgpr("LocalReadAddrOrig%s"%(tc)), \
         comment="set LocalReadAddrOrig to LocalReadAddr"))
-    # MXSA/MXSB do not use swap addresses
-    elif kernel["StoreSwapAddr"] and tc not in ("MXSA", "MXSB"):
+    elif kernel["StoreSwapAddr"]:
       # Reset offset, by picking smaller of the two
       tmpvgpr = self.vgprPool.checkOut(1) # contains other offsets
       module.add(VXorB32(


### PR DESCRIPTION
## Motivation

optimize sgpr allocation for StoreSwapAddr

## Technical Details

- use 1 common sgpr (swapCommon) for all (A,B,MXSA,MXSB)
- use s_add m0, swapCommon, LocalWriteAddr for m0 initialization

## Test Plan

Run existing dtl test

## Test Result

dtl.yaml passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
