### PR TITLE
[Origami] Expand README testing documentation

### DIFF
--- a/shared/origami/README.md
+++ b/shared/origami/README.md
@@ -253,23 +253,60 @@ cmake --install build/
 
 ## Origami Tests
 
+### Build and Run All Tests
+
+Build with both C++ and Python tests enabled:
+
 ```bash
 cd shared/origami
 
 cmake -S . -B build/ \
   -DCMAKE_PREFIX_PATH=/opt/rocm \
   -DCMAKE_CXX_COMPILER=/opt/rocm/bin/amdclang++ \
-  -DCMAKE_INSTALL_PREFIX=/opt/rocm \
-  -DORIGAMI_BUILD_TESTING=ON
+  -DORIGAMI_BUILD_TESTING=ON \
+  -DORIGAMI_ENABLE_PYTHON=ON
 
 cmake --build build/ --parallel
 
-# Run tests
+cd build/
 ctest --output-on-failure
 ```
 
 > [!NOTE]
 > Python tests are automatically added when `ORIGAMI_BUILD_TESTING=ON` and `ORIGAMI_ENABLE_PYTHON=ON`.
+
+### Running Specific Tests
+
+Run only C++ tests:
+
+```bash
+./build/tests/origami-tests
+```
+
+Run a specific C++ test by name:
+
+```bash
+./build/tests/origami-tests "Origami: select_config_mnk unit test"
+```
+
+Run only Python tests:
+
+```bash
+cd python
+python -m pytest tests/ -v
+```
+
+Run Python tests excluding slow tests:
+
+```bash
+python -m pytest tests/ -m "not slow"
+```
+
+Run selector tests (requires torch):
+
+```bash
+python -m pytest tests/test_selector.py -v
+```
 
 ## Contribute
 

--- a/shared/origami/README.md
+++ b/shared/origami/README.md
@@ -289,23 +289,22 @@ Run a specific C++ test by name:
 ./build/tests/origami-tests "Origami: select_config_mnk unit test"
 ```
 
-Run only Python tests:
+Run only Python tests (from `shared/origami/python`):
 
 ```bash
-cd python
-python -m pytest tests/ -v
+PYTHONPATH=src:$PYTHONPATH python -m pytest tests/ -v
 ```
 
 Run Python tests excluding slow tests:
 
 ```bash
-python -m pytest tests/ -m "not slow"
+PYTHONPATH=src:$PYTHONPATH python -m pytest tests/ -m "not slow"
 ```
 
 Run selector tests (requires torch):
 
 ```bash
-python -m pytest tests/test_selector.py -v
+PYTHONPATH=src:$PYTHONPATH python -m pytest tests/test_selector.py -v
 ```
 
 ## Contribute

--- a/shared/origami/README.md
+++ b/shared/origami/README.md
@@ -292,19 +292,20 @@ Run a specific C++ test by name:
 Run only Python tests (from `shared/origami/python`):
 
 ```bash
-PYTHONPATH=src:$PYTHONPATH python -m pytest tests/ -v
+pip install -e .
+python -m pytest tests/ -v
 ```
 
 Run Python tests excluding slow tests:
 
 ```bash
-PYTHONPATH=src:$PYTHONPATH python -m pytest tests/ -m "not slow"
+python -m pytest tests/ -m "not slow"
 ```
 
 Run selector tests (requires torch):
 
 ```bash
-PYTHONPATH=src:$PYTHONPATH python -m pytest tests/test_selector.py -v
+python -m pytest tests/test_selector.py -v
 ```
 
 ## Contribute


### PR DESCRIPTION
## Summary

- Expand the Origami Tests section in README with comprehensive testing documentation
- Add example for building and running all tests (C++ and Python)
- Add examples for running specific test subsets:
  - C++ tests only
  - Specific C++ test by name
  - Python tests only (with PYTHONPATH set correctly)
  - Python tests excluding slow tests
  - Selector tests (requires torch)

## Test plan

- [x] Verify test commands work as documented
- [x] Verify README renders correctly on GitHub
