### PR TITLE
[hipDNN] Correct atomic memory ordering during logger shutdown.

### DIFF
--- a/projects/hipdnn/backend/src/logging/Logging.cpp
+++ b/projects/hipdnn/backend/src/logging/Logging.cpp
@@ -164,7 +164,7 @@ void logHipDeviceInfo(hipStream_t stream)
 
 void initialize()
 {
-    if(sLoggingShutdown.load(std::memory_order_relaxed))
+    if(sLoggingShutdown.load(std::memory_order_acquire))
     {
         // Program is shutting down; do not initialize the logger.
         return;
@@ -512,7 +512,7 @@ void backendLoggingCallback(hipdnnSeverity_t severity, const char* msg)
 {
     // Check the shutdown flag before accessing BackendLogState. The atexit handler sets this
     // flag to prevent any thread from accessing logging infrastructure during static destruction.
-    if(sLoggingShutdown.load(std::memory_order_relaxed))
+    if(sLoggingShutdown.load(std::memory_order_acquire))
     {
         return;
     }


### PR DESCRIPTION
## Motivation

Chance of inconsistent variable values being read between threads during logger shutdown.

## Technical Details

User correct memory ordering operations to ensure consistent view of memory by threads.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
