### PR TITLE
enabling equal distribution of GPU based on worker

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/conftest.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/conftest.py
@@ -125,8 +125,9 @@ def worker_lock_instance(worker_lock_path):
 @pytest.fixture
 def tensile_args(pytestconfig, builddir, worker_lock_path):
     rv = []
-    if worker_lock_path:
-        rv += ["--client-lock", str(worker_lock_path)]
+    # Client lock disabled to allow parallel test execution
+    #if worker_lock_path:
+    #    rv += ["--client-lock", str(worker_lock_path)]
 
     extraOptions = pytestconfig.getoption("--tensile-options")
     if extraOptions is not None:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/conftest.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/conftest.py
@@ -96,41 +96,17 @@ def assign_gpu_to_worker(worker_id):
         # Single worker or master process - use all GPUs
         return
 
-    # Detect number of available GPUs
-    import subprocess
     import re
+    from Tensile.ParallelExecution import detectAvailableGpus
 
-    num_gpus = 1  # default to 1 GPU
-    try:
-        # Try using rocm-smi to detect GPUs
-        result = subprocess.run(['rocm-smi', '--showid'],
-                              capture_output=True, text=True, timeout=5)
-        if result.returncode == 0:
-            # Count GPU entries in rocm-smi output
-            gpu_count = len([line for line in result.stdout.split('\n')
-                           if 'GPU[' in line or 'GPU' in line and 'device' in line.lower()])
-            if gpu_count > 0:
-                num_gpus = gpu_count
-    except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
-        # rocm-smi not available, try checking HIP_VISIBLE_DEVICES
-        if 'HIP_VISIBLE_DEVICES' in os.environ:
-            devices = os.environ['HIP_VISIBLE_DEVICES'].split(',')
-            num_gpus = len(devices)
-        else:
-            # Fallback: try counting /dev/kfd nodes or default to 1
-            import glob
-            kfd_nodes = glob.glob('/sys/class/kfd/kfd/topology/nodes/*/gpu_id')
-            if kfd_nodes:
-                num_gpus = len([f for f in kfd_nodes
-                              if open(f).read().strip() != '0'])
-
+    num_gpus = detectAvailableGpus()
     # Extract numeric ID from worker_id (e.g., 'gw0' -> 0, 'gw1' -> 1)
     match = re.search(r'\d+', worker_id)
     if match:
         worker_num = int(match.group())
         gpu_id = worker_num % num_gpus  # Use modulo to wrap around available GPUs
         os.environ['HIP_VISIBLE_DEVICES'] = str(gpu_id)
-        print(f"Worker {worker_id} (worker #{worker_num}) assigned to GPU {gpu_id} (total GPUs: {num_gpus})")
+        print(f"Worker {worker_id} assigned to GPU {gpu_id} (total GPUs: {num_gpus})")
     else:
         print(f"Warning: Could not parse worker_id '{worker_id}' for GPU assignment")
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/conftest.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/conftest.py
@@ -81,6 +81,59 @@ def worker_lock_path(tmp_path_factory, worker_id):
 
     return tmp_path_factory.getbasetemp().parent / "client_execution.lock"
 
+@pytest.fixture(scope="session", autouse=True)
+def assign_gpu_to_worker(worker_id):
+    """
+    Assigns a GPU to each pytest-xdist worker using modulo arithmetic.
+    Worker IDs are in format 'gw0', 'gw1', 'gw2', etc.
+    Sets HIP_VISIBLE_DEVICES to isolate GPU access per worker.
+
+    If you have N GPUs and M workers:
+    - Worker 0 -> GPU 0, Worker 1 -> GPU 1, ..., Worker N-1 -> GPU N-1
+    - Worker N -> GPU 0, Worker N+1 -> GPU 1, etc. (wraps around)
+    """
+    if not worker_id or worker_id == "master":
+        # Single worker or master process - use all GPUs
+        return
+
+    # Detect number of available GPUs
+    import subprocess
+    import re
+
+    num_gpus = 1  # default to 1 GPU
+    try:
+        # Try using rocm-smi to detect GPUs
+        result = subprocess.run(['rocm-smi', '--showid'],
+                              capture_output=True, text=True, timeout=5)
+        if result.returncode == 0:
+            # Count GPU entries in rocm-smi output
+            gpu_count = len([line for line in result.stdout.split('\n')
+                           if 'GPU[' in line or 'GPU' in line and 'device' in line.lower()])
+            if gpu_count > 0:
+                num_gpus = gpu_count
+    except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
+        # rocm-smi not available, try checking HIP_VISIBLE_DEVICES
+        if 'HIP_VISIBLE_DEVICES' in os.environ:
+            devices = os.environ['HIP_VISIBLE_DEVICES'].split(',')
+            num_gpus = len(devices)
+        else:
+            # Fallback: try counting /dev/kfd nodes or default to 1
+            import glob
+            kfd_nodes = glob.glob('/sys/class/kfd/kfd/topology/nodes/*/gpu_id')
+            if kfd_nodes:
+                num_gpus = len([f for f in kfd_nodes
+                              if open(f).read().strip() != '0'])
+
+    # Extract numeric ID from worker_id (e.g., 'gw0' -> 0, 'gw1' -> 1)
+    match = re.search(r'\d+', worker_id)
+    if match:
+        worker_num = int(match.group())
+        gpu_id = worker_num % num_gpus  # Use modulo to wrap around available GPUs
+        os.environ['HIP_VISIBLE_DEVICES'] = str(gpu_id)
+        print(f"Worker {worker_id} (worker #{worker_num}) assigned to GPU {gpu_id} (total GPUs: {num_gpus})")
+    else:
+        print(f"Warning: Could not parse worker_id '{worker_id}' for GPU assignment")
+
 @pytest.fixture
 def tensile_script_path():
     return os.path.join(moddir, 'bin', 'Tensile')


### PR DESCRIPTION
## Motivation

When we run `tox` command on `common` folder, it takes around 45-50 minutes and not utilizing the gpu correctly when we have 8 GPU system.


## Technical Details

On 8 GPU system, we can increase the number of worker to `8` and the present change will distribute the GPU uniformly 

https://github.com/ROCm/rocm-libraries/commit/746b17b185b03f9cd086402f2492d5c91f41d5dd

## Test Plan

N/A 
## Test Result

With above change, the run time reduced from `45-50 minutes` to `19-20 minutes `

` 2 failed, 108 passed, 83 skipped, 11 xfailed, 10 warnings in 1190.83s (0:19:50)`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
