### PR TITLE
Fix abs function on Bf16 to not have an extra conversion to half

### DIFF
--- a/projects/miopen/src/kernels/miopen_math.hpp
+++ b/projects/miopen/src/kernels/miopen_math.hpp
@@ -147,7 +147,7 @@ __forceinline__ __device__ ushort cos(ushort x)
 }
 __forceinline__ __device__ ushort fabs(ushort x)
 {
-    return float_to_bfloat16(__habs(bfloat16_to_float(x)));
+    return float_to_bfloat16(fabsf((bfloat16_to_float(x)));
 }
 __forceinline__ __device__ ushort fmax(ushort x, ushort y)
 {

--- a/projects/miopen/src/kernels/miopen_math.hpp
+++ b/projects/miopen/src/kernels/miopen_math.hpp
@@ -147,7 +147,7 @@ __forceinline__ __device__ ushort cos(ushort x)
 }
 __forceinline__ __device__ ushort fabs(ushort x)
 {
-    return float_to_bfloat16(fabsf((bfloat16_to_float(x)));
+    return float_to_bfloat16(fabsf(bfloat16_to_float(x)));
 }
 __forceinline__ __device__ ushort fmax(ushort x, ushort y)
 {


### PR DESCRIPTION
## Motivation

Fix a likely precision error caused by extra casting and also prepare for newer HIP runtime versions where this code is causing a compile time failure.

## Technical Details

The code was using __habs after converting the BF6 to FP32  but __habs is for half values.  An implicit cast from FP32 to FP16 was being used so there was an extra conversion to FP16 that could impact precision.  And in newer version of HIP, the BF16 include file is added which adds a second version of __habs for BF16 and now at compile time it doesn't know which FP32 cast to do so we get an ambiguous error.

## Test Plan

Review kernels that use abs on BF16 values and test accuracy after this change to verify it is as good or better than it was before.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
