### PR TITLE
perf(miopen): Softmax optimization

### DIFF
--- a/projects/miopen/src/include/miopen/softmax/invoke_params.hpp
+++ b/projects/miopen/src/include/miopen/softmax/invoke_params.hpp
@@ -39,15 +39,8 @@ struct InvokeParams : public miopen::InvokeParams
                  const TensorDescriptor& xDesc_,
                  ConstData_t x_,
                  const TensorDescriptor& yDesc_,
-                 Data_t y_,
-                 miopenSoftmaxAlgorithm_t algorithm_,
-                 miopenSoftmaxMode_t mode_,
-                 int x_offset_ = 0,
-                 int y_offset_ = 0)
-        : algorithm(algorithm_),
-          mode(mode_),
-
-          xdxDesc(xDesc_),
+                 Data_t y_)
+        : xdxDesc(xDesc_),
           x(x_),
           dx(nullptr),
 
@@ -55,11 +48,7 @@ struct InvokeParams : public miopen::InvokeParams
           forward_y(y_),
           backward_y(nullptr),
 
-          dy(nullptr),
-
-          xdx_offset(x_offset_),
-          y_offset(y_offset_),
-          dy_offset(0)
+          dy(nullptr)
     {
         InitializeAlphaBeta(alpha_, beta_);
     }
@@ -71,16 +60,8 @@ struct InvokeParams : public miopen::InvokeParams
                  const TensorDescriptor& dyDesc_,
                  ConstData_t dy_,
                  const TensorDescriptor& dxDesc_,
-                 Data_t dx_,
-                 miopenSoftmaxAlgorithm_t algorithm_,
-                 miopenSoftmaxMode_t mode_,
-                 int y_offset_  = 0,
-                 int dy_offset_ = 0,
-                 int dx_offset_ = 0)
-        : algorithm(algorithm_),
-          mode(mode_),
-
-          xdxDesc(dxDesc_),
+                 Data_t dx_)
+        : xdxDesc(dxDesc_),
           x(nullptr),
           dx(dx_),
 
@@ -89,11 +70,7 @@ struct InvokeParams : public miopen::InvokeParams
           backward_y(y_),
 
           dyDesc(dyDesc_),
-          dy(dy_),
-
-          xdx_offset(dx_offset_),
-          y_offset(y_offset_),
-          dy_offset(dy_offset_)
+          dy(dy_)
     {
         InitializeAlphaBeta(alpha_, beta_);
     }
@@ -104,8 +81,6 @@ struct InvokeParams : public miopen::InvokeParams
 public:
     float alpha;
     float beta;
-    miopenSoftmaxAlgorithm_t algorithm;
-    miopenSoftmaxMode_t mode;
 
     // xdxDesc is used for both forward and backward
     TensorDescriptor xdxDesc;
@@ -119,11 +94,6 @@ public:
     // backward specific part
     TensorDescriptor dyDesc;
     ConstData_t dy;
-
-    // xdx_offset is used for both forward and backward
-    int xdx_offset;
-    int y_offset;
-    int dy_offset;
 
 private:
     void InitializeAlphaBeta(const void* alpha_, const void* beta_)

--- a/projects/miopen/src/include/miopen/softmax/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/softmax/problem_description.hpp
@@ -34,13 +34,19 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
                        const TensorDescriptor& xDesc_,
                        const TensorDescriptor& yDesc_,
                        miopenSoftmaxAlgorithm_t algorithm_,
-                       miopenSoftmaxMode_t mode_)
+                       miopenSoftmaxMode_t mode_,
+                       int x_offset_ = 0,
+                       int y_offset_ = 0)
         : isForward(true),
           xdxDesc(xDesc_),
           yDesc(yDesc_),
 
           algorithm(algorithm_),
-          mode(mode_)
+          mode(mode_),
+          x_offset(x_offset_),
+          y_offset(y_offset_),
+          dx_offset(0),
+          dy_offset(0)
     {
         CheckAndAssignAlphaBeta(alpha_, beta_);
 
@@ -61,13 +67,20 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
                        const TensorDescriptor& dyDesc_,
                        const TensorDescriptor& dxDesc_,
                        miopenSoftmaxAlgorithm_t algorithm_,
-                       miopenSoftmaxMode_t mode_)
+                       miopenSoftmaxMode_t mode_,
+                       int y_offset_  = 0,
+                       int dy_offset_ = 0,
+                       int dx_offset_ = 0)
         : isForward(false),
           xdxDesc(dxDesc_),
           yDesc(yDesc_),
           dyDesc(dyDesc_),
           algorithm(algorithm_),
-          mode(mode_)
+          mode(mode_),
+          x_offset(0),
+          y_offset(y_offset_),
+          dx_offset(dx_offset_),
+          dy_offset(dy_offset_)
     {
         CheckAndAssignAlphaBeta(alpha_, beta_);
 
@@ -90,6 +103,10 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
     bool IsForward() const { return isForward; }
     miopenSoftmaxAlgorithm_t GetAlgorithm() const { return algorithm; }
     miopenSoftmaxMode_t GetMode() const { return mode; }
+    int GetXOffset() const { return x_offset; }
+    int GetYOffset() const { return y_offset; }
+    int GetdXOffset() const { return dx_offset; }
+    int GetdYOffset() const { return dy_offset; }
     float GetAlpha() const { return alpha; }
     float GetBeta() const { return beta; }
 
@@ -116,6 +133,10 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
         f(self.GetWidth(), "in_w");
         f(static_cast<uint64_t>(self.algorithm), "algorithm");
         f(static_cast<uint64_t>(self.mode), "mode");
+        f(static_cast<uint64_t>(self.x_offset), "x_offset");
+        f(static_cast<uint64_t>(self.y_offset), "y_offset");
+        f(static_cast<uint64_t>(self.dx_offset), "dx_offset");
+        f(static_cast<uint64_t>(self.dy_offset), "dy_offset");
     }
 
     template <class Self>
@@ -168,6 +189,11 @@ private:
 
     const miopenSoftmaxAlgorithm_t algorithm;
     const miopenSoftmaxMode_t mode;
+
+    int x_offset;
+    int y_offset;
+    int dx_offset;
+    int dy_offset;
 
     std::size_t GetBatchSize() const { return yDesc.GetLengths()[0]; }
     std::size_t GetChannels() const { return yDesc.GetLengths()[1]; }

--- a/projects/miopen/src/include/miopen/softmax/problem_description.hpp
+++ b/projects/miopen/src/include/miopen/softmax/problem_description.hpp
@@ -21,6 +21,12 @@ struct ProblemDescriptionTag
 {
 };
 
+size_t GetStride(const TensorDescriptor& desc, miopenSoftmaxMode_t mode);
+
+size_t GetOuterSize(const TensorDescriptor& desc, miopenSoftmaxMode_t mode);
+
+size_t GetInnerSize(const TensorDescriptor& desc, miopenSoftmaxMode_t mode);
+
 struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
                                                     ProblemDescriptionTag
 #if MIOPEN_ENABLE_SQLITE
@@ -37,7 +43,10 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
                        miopenSoftmaxMode_t mode_,
                        int x_offset_ = 0,
                        int y_offset_ = 0)
-        : isForward(true),
+        : stride(GetStride(xDesc_, mode_)),
+          outer_size(GetOuterSize(xDesc_, mode_)),
+          inner_size(GetInnerSize(xDesc_, mode_)),
+          isForward(true),
           xdxDesc(xDesc_),
           yDesc(yDesc_),
 
@@ -71,7 +80,10 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
                        int y_offset_  = 0,
                        int dy_offset_ = 0,
                        int dx_offset_ = 0)
-        : isForward(false),
+        : stride(GetStride(yDesc_, mode_)),
+          outer_size(GetOuterSize(yDesc_, mode_)),
+          inner_size(GetInnerSize(yDesc_, mode_)),
+          isForward(false),
           xdxDesc(dxDesc_),
           yDesc(yDesc_),
           dyDesc(dyDesc_),
@@ -125,25 +137,18 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
     template <class Self>
     static void Visit(Self&& self, std::function<void(int64_t, std::string)> f)
     {
-        // The column names match the driver command line argument names
         f(static_cast<uint64_t>(self.isForward), "forw");
-        f(self.GetBatchSize(), "batchsize");
-        f(self.GetChannels(), "in_channels");
-        f(self.GetHeight(), "in_h");
-        f(self.GetWidth(), "in_w");
+        f(self.outer_size, "outer_size");
+        f(self.inner_size, "inner_size");
+        f(self.stride, "stride");
         f(static_cast<uint64_t>(self.algorithm), "algorithm");
         f(static_cast<uint64_t>(self.mode), "mode");
-        f(static_cast<uint64_t>(self.x_offset), "x_offset");
-        f(static_cast<uint64_t>(self.y_offset), "y_offset");
-        f(static_cast<uint64_t>(self.dx_offset), "dx_offset");
-        f(static_cast<uint64_t>(self.dy_offset), "dy_offset");
     }
 
     template <class Self>
     static void Visit(Self&& self, std::function<void(std::string, std::string)> f)
     {
         f(GetDataTypeName(self.yDesc.GetType()), "data_type");
-        f(self.GetLayout(), "layout");
     }
 
     template <class Self, class Visitor>
@@ -159,6 +164,11 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase,
     // It has to be discoverable via ADL from problem description.
     friend auto GetDb(const ExecutionContext& context,
                       const ProblemDescriptionTag&) -> PerformanceDb;
+
+public:
+    const size_t stride;
+    const size_t outer_size;
+    const size_t inner_size;
 
 private:
     void CheckAndAssignAlphaBeta(const void* alpha_, const void* beta_)

--- a/projects/miopen/src/include/miopen/softmax/solvers.hpp
+++ b/projects/miopen/src/include/miopen/softmax/solvers.hpp
@@ -34,11 +34,15 @@ struct PerformanceConfigSoftmax : PerfConfigBase<PerformanceConfigSoftmax>
     {
     }
     PerformanceConfigSoftmax()
-        : local_size(static_cast<int>(start_local_size)), vectorized(start_vectorized), separate_stride(start_separate_stride)
+        : local_size(static_cast<int>(start_local_size)),
+          vectorized(start_vectorized),
+          separate_stride(start_separate_stride)
     {
     }
     PerformanceConfigSoftmax(bool)
-        : local_size(static_cast<int>(start_local_size)), vectorized(start_vectorized), separate_stride(start_separate_stride)
+        : local_size(static_cast<int>(start_local_size)),
+          vectorized(start_vectorized),
+          separate_stride(start_separate_stride)
     {
     }
     void HeuristicInit(const miopen::softmax::ProblemDescription& problem);
@@ -64,9 +68,9 @@ public:
     {
         return problem.stride == 1;
     }
-    static constexpr auto start_vectorized   = false;
+    static constexpr auto start_vectorized        = false;
     static constexpr auto default_separate_stride = true;
-    static constexpr auto start_separate_stride = false;
+    static constexpr auto start_separate_stride   = false;
 };
 
 struct Softmax final : SoftmaxTunableSolver<PerformanceConfigSoftmax>

--- a/projects/miopen/src/include/miopen/softmax/solvers.hpp
+++ b/projects/miopen/src/include/miopen/softmax/solvers.hpp
@@ -28,18 +28,17 @@ struct PerformanceConfigSoftmax : PerfConfigBase<PerformanceConfigSoftmax>
     int local_size;
     bool vectorized;
     bool separate_stride;
-    bool stride_in_local_size;
     bool initialized = false;
-    PerformanceConfigSoftmax(int _local_size, bool _vectorized, bool _separate_stride, bool _stride_in_local_size)
-        : local_size(_local_size), vectorized(_vectorized), separate_stride(_separate_stride), stride_in_local_size(_stride_in_local_size)
+    PerformanceConfigSoftmax(int _local_size, bool _vectorized, bool _separate_stride)
+        : local_size(_local_size), vectorized(_vectorized), separate_stride(_separate_stride)
     {
     }
     PerformanceConfigSoftmax()
-        : local_size(static_cast<int>(start_local_size)), vectorized(start_vectorized), separate_stride(start_separate_stride), stride_in_local_size(start_stride_in_local_size)
+        : local_size(static_cast<int>(start_local_size)), vectorized(start_vectorized), separate_stride(start_separate_stride)
     {
     }
     PerformanceConfigSoftmax(bool)
-        : local_size(static_cast<int>(start_local_size)), vectorized(start_vectorized), separate_stride(start_separate_stride), stride_in_local_size(start_stride_in_local_size)
+        : local_size(static_cast<int>(start_local_size)), vectorized(start_vectorized), separate_stride(start_separate_stride)
     {
     }
     void HeuristicInit(const miopen::softmax::ProblemDescription& problem);
@@ -54,7 +53,6 @@ struct PerformanceConfigSoftmax : PerfConfigBase<PerformanceConfigSoftmax>
         f(s.local_size, "local_size");
         f(s.vectorized, "vectorized");
         f(s.separate_stride, "separate_stride");
-        f(s.stride_in_local_size, "stride_in_local_size");
     }
     bool operator==(const PerformanceConfigSoftmax& other) const;
 
@@ -69,8 +67,6 @@ public:
     static constexpr auto start_vectorized   = false;
     static constexpr auto default_separate_stride = true;
     static constexpr auto start_separate_stride = false;
-    static constexpr auto default_stride_in_local_size = true;
-    static constexpr auto start_stride_in_local_size = false;
 };
 
 struct Softmax final : SoftmaxTunableSolver<PerformanceConfigSoftmax>

--- a/projects/miopen/src/include/miopen/softmax/solvers.hpp
+++ b/projects/miopen/src/include/miopen/softmax/solvers.hpp
@@ -27,13 +27,21 @@ struct PerformanceConfigSoftmax : PerfConfigBase<PerformanceConfigSoftmax>
 {
     int local_size;
     bool vectorized;
+    bool separate_stride;
+    bool stride_in_local_size;
     bool initialized = false;
-    PerformanceConfigSoftmax(int _local_size, bool _vectorized)
-        : local_size(_local_size), vectorized(_vectorized)
+    PerformanceConfigSoftmax(int _local_size, bool _vectorized, bool _separate_stride, bool _stride_in_local_size)
+        : local_size(_local_size), vectorized(_vectorized), separate_stride(_separate_stride), stride_in_local_size(_stride_in_local_size)
     {
     }
-    PerformanceConfigSoftmax() : local_size(start_local_size), vectorized(start_vectorized) {}
-    PerformanceConfigSoftmax(bool) : local_size(start_local_size), vectorized(start_vectorized) {}
+    PerformanceConfigSoftmax()
+        : local_size(static_cast<int>(start_local_size)), vectorized(start_vectorized), separate_stride(start_separate_stride), stride_in_local_size(start_stride_in_local_size)
+    {
+    }
+    PerformanceConfigSoftmax(bool)
+        : local_size(static_cast<int>(start_local_size)), vectorized(start_vectorized), separate_stride(start_separate_stride), stride_in_local_size(start_stride_in_local_size)
+    {
+    }
     void HeuristicInit(const miopen::softmax::ProblemDescription& problem);
     bool SetNextValue(const miopen::softmax::ProblemDescription& problem);
     bool IsValidValue() const;
@@ -45,6 +53,8 @@ struct PerformanceConfigSoftmax : PerfConfigBase<PerformanceConfigSoftmax>
     {
         f(s.local_size, "local_size");
         f(s.vectorized, "vectorized");
+        f(s.separate_stride, "separate_stride");
+        f(s.stride_in_local_size, "stride_in_local_size");
     }
     bool operator==(const PerformanceConfigSoftmax& other) const;
 
@@ -52,8 +62,15 @@ public:
     static constexpr auto default_local_size = 1024;
     static constexpr auto max_local_size     = 1024;
     static constexpr auto start_local_size   = 1;
-    static constexpr auto default_vectorized = false;
+    static constexpr auto default_vectorized(const miopen::softmax::ProblemDescription& problem)
+    {
+        return problem.stride == 1;
+    }
     static constexpr auto start_vectorized   = false;
+    static constexpr auto default_separate_stride = true;
+    static constexpr auto start_separate_stride = false;
+    static constexpr auto default_stride_in_local_size = true;
+    static constexpr auto start_stride_in_local_size = false;
 };
 
 struct Softmax final : SoftmaxTunableSolver<PerformanceConfigSoftmax>

--- a/projects/miopen/src/include/miopen/softmax/solvers.hpp
+++ b/projects/miopen/src/include/miopen/softmax/solvers.hpp
@@ -26,10 +26,14 @@ using SoftmaxTunableSolver =
 struct PerformanceConfigSoftmax : PerfConfigBase<PerformanceConfigSoftmax>
 {
     int local_size;
+    bool vectorized;
     bool initialized = false;
-    PerformanceConfigSoftmax(int _local_size) : local_size(_local_size) {}
-    PerformanceConfigSoftmax() : local_size(start_local_size) {}
-    PerformanceConfigSoftmax(bool) : local_size(start_local_size) {}
+    PerformanceConfigSoftmax(int _local_size, bool _vectorized)
+        : local_size(_local_size), vectorized(_vectorized)
+    {
+    }
+    PerformanceConfigSoftmax() : local_size(start_local_size), vectorized(start_vectorized) {}
+    PerformanceConfigSoftmax(bool) : local_size(start_local_size), vectorized(start_vectorized) {}
     void HeuristicInit(const miopen::softmax::ProblemDescription& problem);
     bool SetNextValue(const miopen::softmax::ProblemDescription& problem);
     bool IsValidValue() const;
@@ -40,6 +44,7 @@ struct PerformanceConfigSoftmax : PerfConfigBase<PerformanceConfigSoftmax>
     static void Visit(Self&& s, F f)
     {
         f(s.local_size, "local_size");
+        f(s.vectorized, "vectorized");
     }
     bool operator==(const PerformanceConfigSoftmax& other) const;
 
@@ -47,6 +52,8 @@ public:
     static constexpr auto default_local_size = 1024;
     static constexpr auto max_local_size     = 1024;
     static constexpr auto start_local_size   = 1;
+    static constexpr auto default_vectorized = false;
+    static constexpr auto start_vectorized   = false;
 };
 
 struct Softmax final : SoftmaxTunableSolver<PerformanceConfigSoftmax>

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -190,14 +190,7 @@ __forceinline__ __device__ void get_indices(unsigned int& gid, unsigned int& o, 
     if constexpr(SEPARATE_STRIDE)
     {
         o = blockIdx.x;
-        if constexpr(LOCAL_SIZE_Y > 1)
-        {
-            s = threadIdx.y;
-        }
-        else
-        {
-            s = blockIdx.y;
-        }
+        s = blockIdx.y;
         gid = o * STRIDE + s;
     }
     else
@@ -213,14 +206,7 @@ __forceinline__ __device__ void get_indices_stream(unsigned int& o, unsigned int
     if constexpr(SEPARATE_STRIDE)
     {
         o = NUM_BATCH * blockIdx.x + batch;
-        if constexpr(LOCAL_SIZE_Y > 1)
-        {
-            s = threadIdx.y;
-        }
-        else
-        {
-            s = blockIdx.y;
-        }
+        s = blockIdx.y;
     }
     else
     {
@@ -234,7 +220,7 @@ __forceinline__ __device__ void
 softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const float beta)
 {
     const unsigned int lid = threadIdx.x;
-    __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE_X];
+    __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE];
 
     if constexpr(NUM_BATCH == 1) // CSR-Vector like approach
     {
@@ -249,8 +235,8 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
             {
                 unsigned int i = lid * load_factor<T>;
                 auto xdata     = load<T, true>(i, offset + X_OFFSET, x);
-                i += LOCAL_SIZE_X * load_factor<T>;
-                for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
+                i += LOCAL_SIZE * load_factor<T>;
+                for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
                 {
                     auto xtmp = load<T, true>(i, offset + X_OFFSET, x);
 #pragma unroll
@@ -268,13 +254,13 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
             }
             else
             {
-                for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
+                for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
                 {
                     auto x_idx = i * STRIDE + offset + X_OFFSET;
                     tmp        = max(CVT_FLOAT2ACCUM(x[x_idx]), tmp);
                 }
             }
-            reduce<LOCAL_SIZE_X>(ltmp, lid, tmp, reduce_max);
+            reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_max);
             channel_max = ltmp[0];
             __syncthreads();
         }
@@ -291,8 +277,8 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         {
             unsigned int i = lid * load_factor<T>;
             auto xdata     = load<T, true>(i, offset + X_OFFSET, x);
-            i += LOCAL_SIZE_X * load_factor<T>;
-            for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
+            i += LOCAL_SIZE * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
             {
                 auto xtmp = load<T, true>(i, offset + X_OFFSET, x);
 #pragma unroll
@@ -326,7 +312,7 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         }
         else
         {
-            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
             {
                 auto x_idx        = i * STRIDE + offset + X_OFFSET;
                 FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]) - channel_max;
@@ -340,45 +326,17 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 }
             }
         }
-        FLOAT_ACCUM channel_sum;
-        if constexpr(LOCAL_SIZE_Y > 1)
-        {
-            for(unsigned int j = 0; j < STRIDE; ++j)
-            {
-                if(j == s)
-                {
-                    ltmp[lid] = tmp;
-                }
-                __syncthreads();
-                for(unsigned int k = LOCAL_SIZE_X >> 1; k > 0; k >>= 1)
-                {
-                    if(j == s && lid < k)
-                    {
-                        ltmp[lid] = reduce_sum_log(ltmp[lid], ltmp[lid + k]);
-                    }
-                    __syncthreads();
-                }
-                if(j == s)
-                {
-                    channel_sum = ltmp[0];
-                }
-                __syncthreads();
-            }
-        }
-        else
-        {
-            // TODO: if constexpr(LOCAL_SIZE_X > 1)
-            reduce<LOCAL_SIZE_X>(ltmp, lid, tmp, reduce_sum_log);
-            channel_sum = ltmp[0];
-        }
+        // TODO: if constexpr(LOCAL_SIZE > 1)
+        reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_sum_log);
+        FLOAT_ACCUM channel_sum = ltmp[0];
 
         if constexpr(VECTORIZED)
         {
             unsigned int i = lid * load_factor<T>;
             auto xdata     = load<T, !USE_SOFTMAX_LOG>(i, offset + X_OFFSET, x);
             auto ydata     = load(i, offset + Y_OFFSET, y);
-            i += LOCAL_SIZE_X * load_factor<T>;
-            for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
+            i += LOCAL_SIZE * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
             {
                 auto xtmp = load<T, !USE_SOFTMAX_LOG>(i, offset + X_OFFSET, x);
                 auto ytmp = load(i, offset + Y_OFFSET, y);
@@ -405,7 +363,7 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                             CVT_FLOAT2ACCUM(ydata.data[k]) * CVT_FP32_2ACCUM(beta);
                     ydata.data[k] = CVT_ACCUM2FLOAT(value);
                 }
-                store(i - LOCAL_SIZE_X * load_factor<T>, offset + Y_OFFSET, y, ydata);
+                store(i - LOCAL_SIZE * load_factor<T>, offset + Y_OFFSET, y, ydata);
                 xdata = xtmp;
                 ydata = ytmp;
             }
@@ -429,11 +387,11 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                         CVT_FLOAT2ACCUM(ydata.data[k]) * CVT_FP32_2ACCUM(beta);
                 ydata.data[k] = CVT_ACCUM2FLOAT(value);
             }
-            store(i - LOCAL_SIZE_X * load_factor<T>, offset + Y_OFFSET, y, ydata);
+            store(i - LOCAL_SIZE * load_factor<T>, offset + Y_OFFSET, y, ydata);
         }
         else
         {
-            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
             {
                 auto x_idx        = i * STRIDE + offset + X_OFFSET;
                 auto y_idx        = i * STRIDE + offset + Y_OFFSET;
@@ -523,7 +481,7 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         if constexpr(!USE_SOFTMAX_FAST)
         {
             // TODO: if constexpr(BATCH_SIZE > 1)
-            reduce_block<LOCAL_SIZE_X, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_max);
+            reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_max);
             channel_max = ltmp[batch * BATCH_SIZE];
             __syncthreads();
         }
@@ -584,37 +542,9 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 ++index;
             }
         }
-        FLOAT_ACCUM channel_sum;
-        if(LOCAL_SIZE_Y > 1)
-        {
-            for(unsigned int j = 0; j < STRIDE; ++j)
-            {
-                if(j == s)
-                {
-                    ltmp[lid] = tmp;
-                }
-                __syncthreads();
-                for(unsigned int k = BATCH_SIZE >> 1; k > 0; k >>= 1)
-                {
-                    if(j == s && batch_lid < k)
-                    {
-                        ltmp[lid] = reduce_sum_log(ltmp[lid], ltmp[lid + k]);
-                    }
-                    __syncthreads();
-                }
-                if(j == s)
-                {
-                    channel_sum = ltmp[batch * BATCH_SIZE];
-                }
-                __syncthreads();
-            }
-        }
-        else
-        {
-            // TODO: if constexpr(BATCH_SIZE > 1)
-            reduce_block<LOCAL_SIZE_X, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_sum_log);
-            channel_sum = ltmp[batch * BATCH_SIZE];
-        }
+        // TODO: if constexpr(BATCH_SIZE > 1)
+        reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_sum_log);
+        FLOAT_ACCUM channel_sum = ltmp[batch * BATCH_SIZE];
 
         index = 0;
         if constexpr(VECTORIZED)
@@ -702,7 +632,7 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                                            const float beta)
 {
     const unsigned int lid = threadIdx.x;
-    __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE_X];
+    __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE];
 
     if constexpr(NUM_BATCH == 1) // CSR-Vector like approach
     {
@@ -719,8 +649,8 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
             {
                 ydata = load(i, offset + Y_OFFSET, y);
             }
-            i += LOCAL_SIZE_X * load_factor<T>;
-            for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
+            i += LOCAL_SIZE * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
             {
                 auto dytmp = load(i, offset + DY_OFFSET, dy);
                 vec_t<T> ytmp;
@@ -757,7 +687,7 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
         }
         else
         {
-            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
             {
                 auto dy_idx       = i * STRIDE + offset + DY_OFFSET;
                 FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
@@ -769,36 +699,9 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 channel_dot += value;
             }
         }
-        if constexpr(LOCAL_SIZE_Y > 1)
-        {
-            for(unsigned int j = 0; j < STRIDE; ++j)
-            {
-                if(j == s)
-                {
-                    ltmp[lid] = channel_dot;
-                }
-                __syncthreads();
-                for(unsigned int k = LOCAL_SIZE_X >> 1; k > 0; k >>= 1)
-                {
-                    if(j == s && lid < k)
-                    {
-                        ltmp[lid] = reduce_sum(ltmp[lid], ltmp[lid + k]);
-                    }
-                    __syncthreads();
-                }
-                if(j == s)
-                {
-                    channel_dot = ltmp[0];
-                }
-                __syncthreads();
-            }
-        }
-        else
-        {
-            // TODO: if constexpr(LOCAL_SIZE_X > 1)
-            reduce<LOCAL_SIZE_X>(ltmp, lid, channel_dot, reduce_sum);
-            channel_dot = ltmp[0];
-        }
+        // TODO: if constexpr(LOCAL_SIZE > 1)
+        reduce<LOCAL_SIZE>(ltmp, lid, channel_dot, reduce_sum);
+        channel_dot = ltmp[0];
 
         if constexpr(VECTORIZED)
         {
@@ -806,8 +709,8 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
             auto dydata    = load(i, offset + DY_OFFSET, dy);
             auto ydata     = load(i, offset + Y_OFFSET, y);
             auto dxdata    = load(i, offset + DX_OFFSET, dx);
-            i += LOCAL_SIZE_X * load_factor<T>;
-            for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
+            i += LOCAL_SIZE * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
             {
                 auto dytmp = load(i, offset + DY_OFFSET, dy);
                 auto ytmp  = load(i, offset + Y_OFFSET, y);
@@ -828,7 +731,7 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                             CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
                     dxdata.data[k] = CVT_ACCUM2FLOAT(value);
                 }
-                store(i - LOCAL_SIZE_X * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
+                store(i - LOCAL_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
                 dydata = dytmp;
                 ydata  = ytmp;
                 dxdata = dxtmp;
@@ -849,11 +752,11 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                         CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
                 dxdata.data[k] = CVT_ACCUM2FLOAT(value);
             }
-            store(i - LOCAL_SIZE_X * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
+            store(i - LOCAL_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
         }
         else
         {
-            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
             {
                 auto dy_idx       = i * STRIDE + offset + DY_OFFSET;
                 auto y_idx        = i * STRIDE + offset + Y_OFFSET;
@@ -952,35 +855,8 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 ++index;
             }
         }
-        if(LOCAL_SIZE_Y > 1)
-        {
-            for(unsigned int j = 0; j < STRIDE; ++j)
-            {
-                if(j == s)
-                {
-                    ltmp[lid] = channel_dot;
-                }
-                __syncthreads();
-                for(unsigned int k = BATCH_SIZE >> 1; k > 0; k >>= 1)
-                {
-                    if(j == s && batch_lid < k)
-                    {
-                        ltmp[lid] = reduce_sum(ltmp[lid], ltmp[lid + k]);
-                    }
-                    __syncthreads();
-                }
-                if(j == s)
-                {
-                    channel_dot = ltmp[batch * BATCH_SIZE];
-                }
-                __syncthreads();
-            }
-        }
-        else
-        {
-            reduce_block<LOCAL_SIZE_X, BATCH_SIZE>(ltmp, lid, batch_lid, channel_dot, reduce_sum);
-            channel_dot = ltmp[batch * BATCH_SIZE];
-        }
+        reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, channel_dot, reduce_sum);
+        channel_dot = ltmp[batch * BATCH_SIZE];
 
         index = 0;
         if constexpr(VECTORIZED)
@@ -1049,7 +925,7 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
     }
 }
 
-extern "C" __global__ __launch_bounds__(LOCAL_SIZE_X * LOCAL_SIZE_Y) void SoftmaxFwd(const DATA_TYPE* __restrict__ x,
+extern "C" __global__ __launch_bounds__(LOCAL_SIZE) void SoftmaxFwd(const DATA_TYPE* __restrict__ x,
                                       DATA_TYPE* __restrict__ y,
                                       const float alpha,
                                       const float beta)
@@ -1057,7 +933,7 @@ extern "C" __global__ __launch_bounds__(LOCAL_SIZE_X * LOCAL_SIZE_Y) void Softma
     softmaxfwd<DATA_TYPE>(x, y, alpha, beta);
 }
 
-extern "C" __global__ __launch_bounds__(LOCAL_SIZE_X * LOCAL_SIZE_Y) void SoftmaxBwd(const DATA_TYPE* __restrict__ y,
+extern "C" __global__ __launch_bounds__(LOCAL_SIZE) void SoftmaxBwd(const DATA_TYPE* __restrict__ y,
                                       const DATA_TYPE* __restrict__ dy,
                                       DATA_TYPE* __restrict__ dx,
                                       const float alpha,

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -185,18 +185,61 @@ __device__ void loop(const unsigned int lid, LAMBDA&& lambda)
     }
 }
 
+__forceinline__ __device__ void get_indices(unsigned int& gid, unsigned int& o, unsigned int& s)
+{
+    if constexpr(SEPARATE_STRIDE)
+    {
+        o = blockIdx.x;
+        if constexpr(LOCAL_SIZE_Y > 1)
+        {
+            s = threadIdx.y;
+        }
+        else
+        {
+            s = blockIdx.y;
+        }
+        gid = o * STRIDE + s;
+    }
+    else
+    {
+        gid = blockIdx.x;
+        o = blockIdx.x / STRIDE;
+        s = blockIdx.x % STRIDE;
+    }
+}
+
+__forceinline__ __device__ void get_indices_stream(unsigned int& o, unsigned int& s, const unsigned int batch)
+{
+    if constexpr(SEPARATE_STRIDE)
+    {
+        o = NUM_BATCH * blockIdx.x + batch;
+        if constexpr(LOCAL_SIZE_Y > 1)
+        {
+            s = threadIdx.y;
+        }
+        else
+        {
+            s = blockIdx.y;
+        }
+    }
+    else
+    {
+        o = (NUM_BATCH * blockIdx.x + batch) / STRIDE;
+        s = (NUM_BATCH * blockIdx.x + batch) % STRIDE;
+    }
+}
+
 template <typename T>
 __forceinline__ __device__ void
 softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const float beta)
 {
-    const unsigned int gid = blockIdx.x;
     const unsigned int lid = threadIdx.x;
-    __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE];
+    __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE_X];
 
     if constexpr(NUM_BATCH == 1) // CSR-Vector like approach
     {
-        const unsigned int o      = gid / STRIDE;
-        const unsigned int s      = gid % STRIDE;
+        unsigned int gid, o, s;
+        get_indices(gid, o, s);
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM tmp           = -MAX_VAL_ACCUM;
         FLOAT_ACCUM channel_max   = 0;
@@ -206,8 +249,8 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
             {
                 unsigned int i = lid * load_factor<T>;
                 auto xdata     = load<T, true>(i, offset + X_OFFSET, x);
-                i += LOCAL_SIZE * load_factor<T>;
-                for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
+                i += LOCAL_SIZE_X * load_factor<T>;
+                for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
                 {
                     auto xtmp = load<T, true>(i, offset + X_OFFSET, x);
 #pragma unroll
@@ -225,13 +268,13 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
             }
             else
             {
-                for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+                for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
                 {
                     auto x_idx = i * STRIDE + offset + X_OFFSET;
                     tmp        = max(CVT_FLOAT2ACCUM(x[x_idx]), tmp);
                 }
             }
-            reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_max);
+            reduce<LOCAL_SIZE_X>(ltmp, lid, tmp, reduce_max);
             channel_max = ltmp[0];
             __syncthreads();
         }
@@ -248,8 +291,8 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         {
             unsigned int i = lid * load_factor<T>;
             auto xdata     = load<T, true>(i, offset + X_OFFSET, x);
-            i += LOCAL_SIZE * load_factor<T>;
-            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
+            i += LOCAL_SIZE_X * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
             {
                 auto xtmp = load<T, true>(i, offset + X_OFFSET, x);
 #pragma unroll
@@ -283,7 +326,7 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         }
         else
         {
-            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
             {
                 auto x_idx        = i * STRIDE + offset + X_OFFSET;
                 FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]) - channel_max;
@@ -297,16 +340,45 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 }
             }
         }
-        reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_sum_log);
-        FLOAT_ACCUM channel_sum = ltmp[0];
+        FLOAT_ACCUM channel_sum;
+        if constexpr(LOCAL_SIZE_Y > 1)
+        {
+            for(unsigned int j = 0; j < STRIDE; ++j)
+            {
+                if(j == s)
+                {
+                    ltmp[lid] = tmp;
+                }
+                __syncthreads();
+                for(unsigned int k = LOCAL_SIZE_X >> 1; k > 0; k >>= 1)
+                {
+                    if(j == s && lid < k)
+                    {
+                        ltmp[lid] = reduce_sum_log(ltmp[lid], ltmp[lid + k]);
+                    }
+                    __syncthreads();
+                }
+                if(j == s)
+                {
+                    channel_sum = ltmp[0];
+                }
+                __syncthreads();
+            }
+        }
+        else
+        {
+            // TODO: if constexpr(LOCAL_SIZE_X > 1)
+            reduce<LOCAL_SIZE_X>(ltmp, lid, tmp, reduce_sum_log);
+            channel_sum = ltmp[0];
+        }
 
         if constexpr(VECTORIZED)
         {
             unsigned int i = lid * load_factor<T>;
             auto xdata     = load<T, !USE_SOFTMAX_LOG>(i, offset + X_OFFSET, x);
             auto ydata     = load(i, offset + Y_OFFSET, y);
-            i += LOCAL_SIZE * load_factor<T>;
-            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
+            i += LOCAL_SIZE_X * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
             {
                 auto xtmp = load<T, !USE_SOFTMAX_LOG>(i, offset + X_OFFSET, x);
                 auto ytmp = load(i, offset + Y_OFFSET, y);
@@ -333,7 +405,7 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                             CVT_FLOAT2ACCUM(ydata.data[k]) * CVT_FP32_2ACCUM(beta);
                     ydata.data[k] = CVT_ACCUM2FLOAT(value);
                 }
-                store(i - LOCAL_SIZE * load_factor<T>, offset + Y_OFFSET, y, ydata);
+                store(i - LOCAL_SIZE_X * load_factor<T>, offset + Y_OFFSET, y, ydata);
                 xdata = xtmp;
                 ydata = ytmp;
             }
@@ -357,11 +429,11 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                         CVT_FLOAT2ACCUM(ydata.data[k]) * CVT_FP32_2ACCUM(beta);
                 ydata.data[k] = CVT_ACCUM2FLOAT(value);
             }
-            store(i - LOCAL_SIZE * load_factor<T>, offset + Y_OFFSET, y, ydata);
+            store(i - LOCAL_SIZE_X * load_factor<T>, offset + Y_OFFSET, y, ydata);
         }
         else
         {
-            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
             {
                 auto x_idx        = i * STRIDE + offset + X_OFFSET;
                 auto y_idx        = i * STRIDE + offset + Y_OFFSET;
@@ -388,15 +460,15 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
     {
         const unsigned int batch_lid = lid % BATCH_SIZE;
         const unsigned int batch     = lid / BATCH_SIZE;
-        const unsigned int o         = (NUM_BATCH * gid + batch) / STRIDE;
+        unsigned int o, s;
+        get_indices_stream(o, s, batch);
         if(o >= OUTER_SIZE)
         {
             return;
         }
-        const unsigned int s      = (NUM_BATCH * gid + batch) % STRIDE;
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM tmp           = -MAX_VAL_ACCUM;
-        FLOAT_ACCUM x_values[U_BATCH_SIZE * load_factor<T>];
+        FLOAT_ACCUM x_values[U_BATCH_SIZE * load_factor<T>]; // TODO: VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE
         for(FLOAT_ACCUM& x_value : x_values)
         {
             x_value = -MAX_VAL_ACCUM;
@@ -450,7 +522,8 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         FLOAT_ACCUM channel_max = 0;
         if constexpr(!USE_SOFTMAX_FAST)
         {
-            reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_max);
+            // TODO: if constexpr(BATCH_SIZE > 1)
+            reduce_block<LOCAL_SIZE_X, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_max);
             channel_max = ltmp[batch * BATCH_SIZE];
             __syncthreads();
         }
@@ -511,8 +584,37 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 ++index;
             }
         }
-        reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_sum_log);
-        FLOAT_ACCUM channel_sum = ltmp[batch * BATCH_SIZE];
+        FLOAT_ACCUM channel_sum;
+        if(LOCAL_SIZE_Y > 1)
+        {
+            for(unsigned int j = 0; j < STRIDE; ++j)
+            {
+                if(j == s)
+                {
+                    ltmp[lid] = tmp;
+                }
+                __syncthreads();
+                for(unsigned int k = BATCH_SIZE >> 1; k > 0; k >>= 1)
+                {
+                    if(j == s && batch_lid < k)
+                    {
+                        ltmp[lid] = reduce_sum_log(ltmp[lid], ltmp[lid + k]);
+                    }
+                    __syncthreads();
+                }
+                if(j == s)
+                {
+                    channel_sum = ltmp[batch * BATCH_SIZE];
+                }
+                __syncthreads();
+            }
+        }
+        else
+        {
+            // TODO: if constexpr(BATCH_SIZE > 1)
+            reduce_block<LOCAL_SIZE_X, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_sum_log);
+            channel_sum = ltmp[batch * BATCH_SIZE];
+        }
 
         index = 0;
         if constexpr(VECTORIZED)
@@ -599,14 +701,13 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                                            const float alpha,
                                            const float beta)
 {
-    const unsigned int gid = blockIdx.x;
     const unsigned int lid = threadIdx.x;
-    __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE];
+    __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE_X];
 
     if constexpr(NUM_BATCH == 1) // CSR-Vector like approach
     {
-        const unsigned int o      = gid / STRIDE;
-        const unsigned int s      = gid % STRIDE;
+        unsigned int gid, o, s;
+        get_indices(gid, o, s);
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM channel_dot   = 0;
         if constexpr(VECTORIZED)
@@ -618,8 +719,8 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
             {
                 ydata = load(i, offset + Y_OFFSET, y);
             }
-            i += LOCAL_SIZE * load_factor<T>;
-            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
+            i += LOCAL_SIZE_X * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
             {
                 auto dytmp = load(i, offset + DY_OFFSET, dy);
                 vec_t<T> ytmp;
@@ -656,7 +757,7 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
         }
         else
         {
-            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
             {
                 auto dy_idx       = i * STRIDE + offset + DY_OFFSET;
                 FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
@@ -668,8 +769,36 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 channel_dot += value;
             }
         }
-        reduce<LOCAL_SIZE>(ltmp, lid, channel_dot, reduce_sum);
-        channel_dot = ltmp[0];
+        if constexpr(LOCAL_SIZE_Y > 1)
+        {
+            for(unsigned int j = 0; j < STRIDE; ++j)
+            {
+                if(j == s)
+                {
+                    ltmp[lid] = channel_dot;
+                }
+                __syncthreads();
+                for(unsigned int k = LOCAL_SIZE_X >> 1; k > 0; k >>= 1)
+                {
+                    if(j == s && lid < k)
+                    {
+                        ltmp[lid] = reduce_sum(ltmp[lid], ltmp[lid + k]);
+                    }
+                    __syncthreads();
+                }
+                if(j == s)
+                {
+                    channel_dot = ltmp[0];
+                }
+                __syncthreads();
+            }
+        }
+        else
+        {
+            // TODO: if constexpr(LOCAL_SIZE_X > 1)
+            reduce<LOCAL_SIZE_X>(ltmp, lid, channel_dot, reduce_sum);
+            channel_dot = ltmp[0];
+        }
 
         if constexpr(VECTORIZED)
         {
@@ -677,8 +806,8 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
             auto dydata    = load(i, offset + DY_OFFSET, dy);
             auto ydata     = load(i, offset + Y_OFFSET, y);
             auto dxdata    = load(i, offset + DX_OFFSET, dx);
-            i += LOCAL_SIZE * load_factor<T>;
-            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
+            i += LOCAL_SIZE_X * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE_X * load_factor<T>)
             {
                 auto dytmp = load(i, offset + DY_OFFSET, dy);
                 auto ytmp  = load(i, offset + Y_OFFSET, y);
@@ -699,7 +828,7 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                             CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
                     dxdata.data[k] = CVT_ACCUM2FLOAT(value);
                 }
-                store(i - LOCAL_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
+                store(i - LOCAL_SIZE_X * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
                 dydata = dytmp;
                 ydata  = ytmp;
                 dxdata = dxtmp;
@@ -720,11 +849,11 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                         CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
                 dxdata.data[k] = CVT_ACCUM2FLOAT(value);
             }
-            store(i - LOCAL_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
+            store(i - LOCAL_SIZE_X * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
         }
         else
         {
-            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE_X)
             {
                 auto dy_idx       = i * STRIDE + offset + DY_OFFSET;
                 auto y_idx        = i * STRIDE + offset + Y_OFFSET;
@@ -746,14 +875,16 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
     }
     else // CSR-Stream like approach
     {
+        unsigned int gid, o, s;
+        get_indices(gid, o, s);
         const unsigned int batch_lid = lid % BATCH_SIZE;
         const unsigned int batch     = lid / BATCH_SIZE;
-        const unsigned int o         = (NUM_BATCH * gid + batch) / STRIDE;
+        o         = (NUM_BATCH * gid + batch) / STRIDE;
         if(o >= OUTER_SIZE)
         {
             return;
         }
-        const unsigned int s      = (NUM_BATCH * gid + batch) % STRIDE;
+        s      = (NUM_BATCH * gid + batch) % STRIDE;
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM channel_dot   = 0;
         FLOAT_ACCUM y_values[U_BATCH_SIZE * load_factor<T>];
@@ -821,8 +952,35 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 ++index;
             }
         }
-        reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, channel_dot, reduce_sum);
-        channel_dot = ltmp[batch * BATCH_SIZE];
+        if(LOCAL_SIZE_Y > 1)
+        {
+            for(unsigned int j = 0; j < STRIDE; ++j)
+            {
+                if(j == s)
+                {
+                    ltmp[lid] = channel_dot;
+                }
+                __syncthreads();
+                for(unsigned int k = BATCH_SIZE >> 1; k > 0; k >>= 1)
+                {
+                    if(j == s && batch_lid < k)
+                    {
+                        ltmp[lid] = reduce_sum(ltmp[lid], ltmp[lid + k]);
+                    }
+                    __syncthreads();
+                }
+                if(j == s)
+                {
+                    channel_dot = ltmp[batch * BATCH_SIZE];
+                }
+                __syncthreads();
+            }
+        }
+        else
+        {
+            reduce_block<LOCAL_SIZE_X, BATCH_SIZE>(ltmp, lid, batch_lid, channel_dot, reduce_sum);
+            channel_dot = ltmp[batch * BATCH_SIZE];
+        }
 
         index = 0;
         if constexpr(VECTORIZED)
@@ -891,7 +1049,7 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
     }
 }
 
-extern "C" __global__ void SoftmaxFwd(const DATA_TYPE* __restrict__ x,
+extern "C" __global__ __launch_bounds__(LOCAL_SIZE_X * LOCAL_SIZE_Y) void SoftmaxFwd(const DATA_TYPE* __restrict__ x,
                                       DATA_TYPE* __restrict__ y,
                                       const float alpha,
                                       const float beta)
@@ -899,7 +1057,7 @@ extern "C" __global__ void SoftmaxFwd(const DATA_TYPE* __restrict__ x,
     softmaxfwd<DATA_TYPE>(x, y, alpha, beta);
 }
 
-extern "C" __global__ void SoftmaxBwd(const DATA_TYPE* __restrict__ y,
+extern "C" __global__ __launch_bounds__(LOCAL_SIZE_X * LOCAL_SIZE_Y) void SoftmaxBwd(const DATA_TYPE* __restrict__ y,
                                       const DATA_TYPE* __restrict__ dy,
                                       DATA_TYPE* __restrict__ dx,
                                       const float alpha,

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -13,6 +13,88 @@ constexpr T NEGATIVE_CUTOFF_VAL = T{-1e20};
 template <typename T>
 constexpr T EPSILON = T{1e-12};
 
+template <bool IS_CONTIGUOUS>
+constexpr bool VECTORIZED_C =
+    VECTORIZED &&
+    ((IS_CONTIGUOUS && SPATIAL_DIM == 1) ||
+     (!IS_CONTIGUOUS && USE_SOFTMAX_MODE_INSTANCE && HEIGHT * WIDTH == 1 && C_STRIDE == 1) ||
+     (!IS_CONTIGUOUS && USE_SOFTMAX_MODE_CHANNEL && C_STRIDE == 1));
+constexpr bool VECTORIZED_C_X  = VECTORIZED_C<IS_INPUT_CONTIGUOUS>;
+constexpr bool VECTORIZED_C_Y  = VECTORIZED_C<IS_OUTPUT_CONTIGUOUS>;
+constexpr bool VECTORIZED_C_DX = VECTORIZED_C<IS_DINPUT_CONTIGUOUS>;
+constexpr bool VECTORIZED_C_DY = VECTORIZED_C<IS_DOUTPUT_CONTIGUOUS>;
+
+using load_t = int4;
+
+template <typename T, unsigned int N>
+struct array
+{
+    T data[N];
+};
+
+template <typename T>
+constexpr static unsigned int load_factor = sizeof(load_t) / sizeof(T);
+
+template <typename T, bool IS_VECTORIZED>
+constexpr static unsigned int ADJUSTED_U_BATCH_SIZE =
+    IS_VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE;
+
+template <typename T>
+using vec_t = array<T, load_factor<T>>;
+
+template <typename T,
+          unsigned int BOUND,
+          bool IS_CONTIGUOUS,
+          bool DEFAULT_NEGATIVE_CUTOFF_VAL = false>
+__forceinline__ __device__ static vec_t<T>
+load(unsigned long i, const unsigned long i_offset, const T* __restrict__ src)
+{
+    if(IS_CONTIGUOUS && i + load_factor<T> < BOUND)
+    {
+        const load_t value = *reinterpret_cast<const load_t*>(&src[i + i_offset]);
+        const auto values  = *reinterpret_cast<const vec_t<T>*>(&value);
+        return values;
+    }
+    else
+    {
+        vec_t<T> values = {{}};
+#pragma unroll
+        for(int k = 0; k < load_factor<T>; ++k)
+        {
+            if(i + k < BOUND)
+            {
+                values.data[k] = src[i + k + i_offset];
+            }
+            else if constexpr(DEFAULT_NEGATIVE_CUTOFF_VAL)
+            {
+                values.data[k] = CVT_FP32_2FLOAT(NEGATIVE_CUTOFF_VAL<float>);
+            }
+        }
+        return values;
+    }
+}
+
+template <typename T, unsigned int BOUND, bool IS_CONTIGUOUS>
+__forceinline__ __device__ static void
+store(unsigned long i, const unsigned long i_offset, T* __restrict__ dst, vec_t<T>& data)
+{
+    if(IS_CONTIGUOUS && i + load_factor<T> < BOUND)
+    {
+        *reinterpret_cast<load_t*>(&dst[i + i_offset]) = *reinterpret_cast<load_t*>(&data);
+    }
+    else
+    {
+#pragma unroll
+        for(int k = 0; k < load_factor<T>; ++k)
+        {
+            if(i + k < BOUND)
+            {
+                dst[i + k + i_offset] = data.data[k];
+            }
+        }
+    }
+}
+
 template <typename T>
 __device__ T logaddexp(T x, T y)
 {
@@ -96,8 +178,8 @@ __device__ void loop(const unsigned int lid, LAMBDA&& lambda)
     }
 }
 
-template <bool IS_CONTIGUOUS, int OFFSET>
-__forceinline__ __device__ int get_index(int n, int i, int s, int s0, int s1)
+template <bool IS_CONTIGUOUS, unsigned long OFFSET>
+__forceinline__ __device__ unsigned long get_index(int n, int i, int s, int s0, int s1)
 {
     auto idx = OFFSET;
     if constexpr(IS_CONTIGUOUS)
@@ -118,22 +200,22 @@ __forceinline__ __device__ int get_index(int n, int i, int s, int s0, int s1)
     return idx;
 }
 
-__forceinline__ __device__ int get_x_index(int n, int i, int s, int s0, int s1)
+__forceinline__ __device__ unsigned long get_x_index(int n, int i, int s, int s0, int s1)
 {
     return get_index<IS_INPUT_CONTIGUOUS, X_OFFSET>(n, i, s, s0, s1);
 }
 
-__forceinline__ __device__ int get_y_index(int n, int i, int s, int s0, int s1)
+__forceinline__ __device__ unsigned long get_y_index(int n, int i, int s, int s0, int s1)
 {
     return get_index<IS_OUTPUT_CONTIGUOUS, Y_OFFSET>(n, i, s, s0, s1);
 }
 
-__forceinline__ __device__ int get_dx_index(int n, int i, int s, int s0, int s1)
+__forceinline__ __device__ unsigned long get_dx_index(int n, int i, int s, int s0, int s1)
 {
     return get_index<IS_DINPUT_CONTIGUOUS, DX_OFFSET>(n, i, s, s0, s1);
 }
 
-__forceinline__ __device__ int get_dy_index(int n, int i, int s, int s0, int s1)
+__forceinline__ __device__ unsigned long get_dy_index(int n, int i, int s, int s0, int s1)
 {
     return get_index<IS_DOUTPUT_CONTIGUOUS, DY_OFFSET>(n, i, s, s0, s1);
 }
@@ -175,10 +257,37 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 // Compute max per channel
                 // Iterate over all the channels one thread is supposed to loop over
                 // and compute max
-                loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                    auto x_idx = get_x_index(n, i, s, s0, s1);
-                    tmp        = max(CVT_FLOAT2ACCUM(x[x_idx]), tmp);
-                });
+                if constexpr(VECTORIZED_C_X)
+                {
+                    unsigned long i = lid * load_factor<T>;
+                    auto x_offset   = get_x_index(n, 0, s, s0, s1);
+                    auto tmpx       = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
+                    i += LOCAL_SIZE * load_factor<T>;
+                    for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
+                    {
+                        auto tmpdata = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
+                        __builtin_amdgcn_sched_barrier(0);
+#pragma unroll
+                        for(int k = 0; k < load_factor<T>; ++k)
+                        {
+                            tmp = max(CVT_FLOAT2ACCUM(tmpx.data[k]), tmp);
+                        }
+                        __builtin_amdgcn_sched_barrier(0);
+                        tmpx = tmpdata;
+                    }
+#pragma unroll
+                    for(int k = 0; k < load_factor<T>; ++k)
+                    {
+                        tmp = max(CVT_FLOAT2ACCUM(tmpx.data[k]), tmp);
+                    }
+                }
+                else
+                {
+                    loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
+                        auto x_idx = get_x_index(n, i, s, s0, s1);
+                        tmp        = max(CVT_FLOAT2ACCUM(x[x_idx]), tmp);
+                    });
+                }
 
                 reduce<LOCAL_SIZE>(ltmp, lid, lid, tmp, reduce_max);
 
@@ -195,66 +304,214 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 tmp = 0;
             }
 
-            // Subtract channel_max from each value
-            loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                auto x_idx        = get_x_index(n, i, s, s0, s1);
-                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]);
+            if constexpr(VECTORIZED_C_X)
+            {
+                // Subtract channel_max from each value
+                unsigned long i = lid * load_factor<T>;
+                auto x_offset   = get_x_index(n, 0, s, s0, s1);
+                auto tmpx       = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
+                i += LOCAL_SIZE * load_factor<T>;
+                for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
+                {
+                    auto tmpdata = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
+                    __builtin_amdgcn_sched_barrier(0);
+#pragma unroll
+                    for(int k = 0; k < load_factor<T>; ++k)
+                    {
+                        FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpx.data[k]);
 
-                // Compute exponent of each value
-                // Then sum all the values touched by this thread
-                if constexpr(USE_SOFTMAX_LOG)
-                {
-                    tmp = logaddexp(value - channel_max, tmp);
+                        // Compute exponent of each value
+                        // Then sum all the values touched by this thread
+                        if constexpr(USE_SOFTMAX_LOG)
+                        {
+                            tmp = logaddexp(value - channel_max, tmp);
+                        }
+                        else if constexpr(USE_SOFTMAX_FAST)
+                        {
+                            tmp += exp(value);
+                        }
+                        else
+                        {
+                            tmp += exp(value - channel_max);
+                        }
+                    }
+                    __builtin_amdgcn_sched_barrier(0);
+                    tmpx = tmpdata;
                 }
-                else if constexpr(USE_SOFTMAX_FAST)
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
                 {
-                    tmp += exp(value);
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpx.data[k]);
+
+                    // Compute exponent of each value
+                    // Then sum all the values touched by this thread
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        tmp = logaddexp(value - channel_max, tmp);
+                    }
+                    else if constexpr(USE_SOFTMAX_FAST)
+                    {
+                        tmp += exp(value);
+                    }
+                    else
+                    {
+                        tmp += exp(value - channel_max);
+                    }
                 }
-                else
-                {
-                    tmp += exp(value - channel_max);
-                }
-            });
+            }
+            else
+            {
+                // Subtract channel_max from each value
+                loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
+                    auto x_idx        = get_x_index(n, i, s, s0, s1);
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]);
+
+                    // Compute exponent of each value
+                    // Then sum all the values touched by this thread
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        tmp = logaddexp(value - channel_max, tmp);
+                    }
+                    else if constexpr(USE_SOFTMAX_FAST)
+                    {
+                        tmp += exp(value);
+                    }
+                    else
+                    {
+                        tmp += exp(value - channel_max);
+                    }
+                });
+            }
 
             reduce<LOCAL_SIZE>(ltmp, lid, lid, tmp, reduce_sum_log);
 
             FLOAT_ACCUM channel_sum = ltmp[0];
 
-            // Normalize each value in the channel by the channel_sum
-            loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                auto x_idx = get_x_index(n, i, s, s0, s1);
-                auto y_idx = get_y_index(n, i, s, s0, s1);
-
-                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]);
-
-                // Subtracting max again because we do not write the output of
-                // value-max to DRAM above. Doing a subtraction again is much
-                // faster than writing uncoalesced to DRAM
-                if constexpr(!USE_SOFTMAX_FAST)
+            if constexpr(VECTORIZED_C_X && VECTORIZED_C_Y)
+            {
+                // Normalize each value in the channel by the channel_sum
+                unsigned long i = lid * load_factor<T>;
+                auto x_offset   = get_x_index(n, 0, s, s0, s1);
+                auto y_offset   = get_y_index(n, 0, s, s0, s1);
+                auto tmpx       = load<T, VECTOR_SIZE, true>(i, x_offset, x);
+                auto tmpy       = load<T, VECTOR_SIZE, true>(i, y_offset, y);
+                i += LOCAL_SIZE * load_factor<T>;
+                for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
                 {
-                    value -= channel_max;
-                }
-                if constexpr(!USE_SOFTMAX_LOG)
-                {
-                    value = exp(value);
-                }
+                    auto tmpdata  = load<T, VECTOR_SIZE, true>(i, x_offset, x);
+                    auto tmpdata2 = load<T, VECTOR_SIZE, true>(i, y_offset, y);
+                    __builtin_amdgcn_sched_barrier(0);
+#pragma unroll
+                    for(int k = 0; k < load_factor<T>; ++k)
+                    {
+                        FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpx.data[k]);
 
-                if constexpr(USE_SOFTMAX_LOG)
-                {
-                    value -= channel_sum;
-                }
-                else
-                {
-                    // Multiply by approximate reciprocal of channel_sum. The approximate reciprocal
-                    // is somewhat less accurate (1 ULP) than a full division, but is noticeably
-                    // more performant.
-                    value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
-                }
+                        // Subtracting max again because we do not write the output of
+                        // value-max to DRAM above. Doing a subtraction again is much
+                        // faster than writing uncoalesced to DRAM
+                        if constexpr(!USE_SOFTMAX_FAST)
+                        {
+                            value -= channel_max;
+                        }
+                        if constexpr(!USE_SOFTMAX_LOG)
+                        {
+                            value = exp(value);
+                        }
 
-                value = value * CVT_FP32_2ACCUM(alpha) +
-                        CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
-                y[y_idx] = CVT_ACCUM2FLOAT(value);
-            });
+                        if constexpr(USE_SOFTMAX_LOG)
+                        {
+                            value -= channel_sum;
+                        }
+                        else
+                        {
+                            // Multiply by approximate reciprocal of channel_sum. The approximate
+                            // reciprocal is somewhat less accurate (1 ULP) than a full division,
+                            // but is noticeably more performant.
+                            value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                        }
+                        value = value * CVT_FP32_2ACCUM(alpha) +
+                                CVT_FLOAT2ACCUM(tmpy.data[k]) * CVT_FP32_2ACCUM(beta);
+                        tmpy.data[k] = CVT_ACCUM2FLOAT(value);
+                    }
+                    __builtin_amdgcn_sched_barrier(0);
+                    auto tmpyout = tmpy;
+                    tmpx         = tmpdata;
+                    tmpy         = tmpdata2;
+                    store<T, VECTOR_SIZE, true>(
+                        i - LOCAL_SIZE * load_factor<T>, y_offset, y, tmpyout);
+                }
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpx.data[k]);
+
+                    // Subtracting max again because we do not write the output of
+                    // value-max to DRAM above. Doing a subtraction again is much
+                    // faster than writing uncoalesced to DRAM
+                    if constexpr(!USE_SOFTMAX_FAST)
+                    {
+                        value -= channel_max;
+                    }
+                    if constexpr(!USE_SOFTMAX_LOG)
+                    {
+                        value = exp(value);
+                    }
+
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        value -= channel_sum;
+                    }
+                    else
+                    {
+                        // Multiply by approximate reciprocal of channel_sum. The approximate
+                        // reciprocal is somewhat less accurate (1 ULP) than a full division, but is
+                        // noticeably more performant.
+                        value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                    }
+                    value = value * CVT_FP32_2ACCUM(alpha) +
+                            CVT_FLOAT2ACCUM(tmpy.data[k]) * CVT_FP32_2ACCUM(beta);
+                    tmpy.data[k] = CVT_ACCUM2FLOAT(value);
+                }
+                store<T, VECTOR_SIZE, true>(i - LOCAL_SIZE * load_factor<T>, y_offset, y, tmpy);
+            }
+            else
+            {
+                // Normalize each value in the channel by the channel_sum
+                loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
+                    auto x_idx = get_x_index(n, i, s, s0, s1);
+                    auto y_idx = get_y_index(n, i, s, s0, s1);
+
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]);
+
+                    // Subtracting max again because we do not write the output of
+                    // value-max to DRAM above. Doing a subtraction again is much
+                    // faster than writing uncoalesced to DRAM
+                    if constexpr(!USE_SOFTMAX_FAST)
+                    {
+                        value -= channel_max;
+                    }
+                    if constexpr(!USE_SOFTMAX_LOG)
+                    {
+                        value = exp(value);
+                    }
+
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        value -= channel_sum;
+                    }
+                    else
+                    {
+                        // Multiply by approximate reciprocal of channel_sum. The approximate
+                        // reciprocal is somewhat less accurate (1 ULP) than a full division, but is
+                        // noticeably more performant.
+                        value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                    }
+
+                    value = value * CVT_FP32_2ACCUM(alpha) +
+                            CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
+                    y[y_idx] = CVT_ACCUM2FLOAT(value);
+                });
+            }
         }
     }
     else // CSR-Stream like approach
@@ -285,7 +542,10 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
             tmp       = -MAX_VAL_ACCUM;
         }
 
-        FLOAT_ACCUM values[U_BATCH_SIZE];
+        // Vectorizations in CSR-Stream are dependent on each other due to the layout of `values`
+        constexpr bool VECTORIZED_C_STREAM = VECTORIZED_C_X && VECTORIZED_C_Y;
+
+        FLOAT_ACCUM values[ADJUSTED_U_BATCH_SIZE<T, VECTORIZED_C_STREAM>];
         for(FLOAT_ACCUM& value : values)
         {
             value = -MAX_VAL_ACCUM;
@@ -295,19 +555,70 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         // BATCH_SIZE threads iterate over the channels
         const auto index0 = batch_lid / BATCH_SIZE;
         auto index        = index0;
-        loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
+        if constexpr(VECTORIZED_C_STREAM)
+        {
+            unsigned long i = batch_lid * load_factor<T>;
+            auto x_offset   = get_x_index(batch_n, 0, batch_s, batch_s0, batch_s1);
+            vec_t<T> tmpx;
             if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
             {
-                auto x_idx = get_x_index(batch_n, i, batch_s, batch_s0, batch_s1);
-
-                values[index] = CVT_FLOAT2ACCUM(x[x_idx]);
-                if constexpr(!USE_SOFTMAX_FAST)
-                {
-                    tmp = max(values[index], tmp);
-                }
+                tmpx = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
             }
-            ++index;
-        });
+            i += BATCH_SIZE * load_factor<T>;
+            for(; i < VECTOR_SIZE; i += BATCH_SIZE * load_factor<T>)
+            {
+                auto tmpdata = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
+                __builtin_amdgcn_sched_barrier(0);
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
+                           batch_s <
+                       VECTOR_SIZE * GRID_SIZE)
+                    {
+                        values[index] = CVT_FLOAT2ACCUM(tmpx.data[k]);
+                        if constexpr(!USE_SOFTMAX_FAST)
+                        {
+                            tmp = max(values[index], tmp);
+                        }
+                    }
+                    ++index;
+                }
+                __builtin_amdgcn_sched_barrier(0);
+                tmpx = tmpdata;
+            }
+#pragma unroll
+            for(int k = 0; k < load_factor<T>; ++k)
+            {
+                if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
+                       batch_s <
+                   VECTOR_SIZE * GRID_SIZE)
+                {
+                    values[index] = CVT_FLOAT2ACCUM(tmpx.data[k]);
+                    if constexpr(!USE_SOFTMAX_FAST)
+                    {
+                        tmp = max(values[index], tmp);
+                    }
+                }
+                ++index;
+            }
+        }
+        else
+        {
+            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
+                if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
+                {
+                    auto x_idx = get_x_index(batch_n, i, batch_s, batch_s0, batch_s1);
+
+                    values[index] = CVT_FLOAT2ACCUM(x[x_idx]);
+                    if constexpr(!USE_SOFTMAX_FAST)
+                    {
+                        tmp = max(values[index], tmp);
+                    }
+                }
+                ++index;
+            });
+        }
 
         FLOAT_ACCUM channel_max;
         if constexpr(!USE_SOFTMAX_FAST)
@@ -329,30 +640,70 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
 
         // Subtract channel_max from each value
         index = index0;
-        loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int) {
+        if constexpr(VECTORIZED_C_STREAM)
+        {
             // Compute exponent of each value
             // Then sum all the values touched by this thread
-            FLOAT_ACCUM value = values[index];
-            if constexpr(!USE_SOFTMAX_FAST)
+            for(unsigned long i = batch_lid * load_factor<T>; i < VECTOR_SIZE;
+                i += BATCH_SIZE * load_factor<T>)
             {
-                value -= channel_max;
-            }
-            if constexpr(!USE_SOFTMAX_LOG)
-            {
-                value = exp(value);
-            }
-            if constexpr(USE_SOFTMAX_LOG)
-            {
-                tmp = logaddexp(tmp, value);
-            }
-            else
-            {
-                tmp += value;
-            }
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    if((batch_n * VECTOR_SIZE + i + k) * SPATIAL_DIM + batch_s <
+                       VECTOR_SIZE * GRID_SIZE)
+                    {
+                        FLOAT_ACCUM value = values[index];
+                        if constexpr(!USE_SOFTMAX_FAST)
+                        {
+                            value -= channel_max;
+                        }
+                        if constexpr(!USE_SOFTMAX_LOG)
+                        {
+                            value = exp(value);
+                        }
+                        if constexpr(USE_SOFTMAX_LOG)
+                        {
+                            tmp = logaddexp(tmp, value);
+                        }
+                        else
+                        {
+                            tmp += value;
+                        }
 
-            values[index] = value;
-            ++index;
-        });
+                        values[index] = value;
+                    }
+                    ++index;
+                }
+            }
+        }
+        else
+        {
+            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
+                // Compute exponent of each value
+                // Then sum all the values touched by this thread
+                FLOAT_ACCUM value = values[index];
+                if constexpr(!USE_SOFTMAX_FAST)
+                {
+                    value -= channel_max;
+                }
+                if constexpr(!USE_SOFTMAX_LOG)
+                {
+                    value = exp(value);
+                }
+                if constexpr(USE_SOFTMAX_LOG)
+                {
+                    tmp = logaddexp(tmp, value);
+                }
+                else
+                {
+                    tmp += value;
+                }
+
+                values[index] = value;
+                ++index;
+            });
+        }
 
         reduce<BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_sum_log);
 
@@ -360,32 +711,108 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
 
         // Normalize each value in the channel by the channel_sum
         index = index0;
-        loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
+        if constexpr(VECTORIZED_C_STREAM)
+        {
+            unsigned long i = batch_lid * load_factor<T>;
+            auto y_offset   = get_y_index(batch_n, 0, batch_s, batch_s0, batch_s1);
+            vec_t<T> tmpy;
             if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
             {
-                auto y_idx = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1);
-
-                auto v_idx = index;
-
-                if constexpr(USE_SOFTMAX_LOG)
-                {
-                    values[v_idx] -= channel_sum;
-                }
-                else
-                {
-                    // Multiply by approximate reciprocal of channel_sum. The approximate reciprocal
-                    // is somewhat less accurate (1 ULP) than a full division, but is noticeably
-                    // more performant.
-                    values[v_idx] *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
-                }
-
-                values[v_idx] = values[v_idx] * CVT_FP32_2ACCUM(alpha) +
-                                CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
-
-                y[y_idx] = CVT_ACCUM2FLOAT(values[v_idx]);
+                tmpy = load<T, VECTOR_SIZE, true>(i, y_offset, y);
             }
-            ++index;
-        });
+            i += BATCH_SIZE * load_factor<T>;
+            for(; i < VECTOR_SIZE; i += BATCH_SIZE * load_factor<T>)
+            {
+                auto tmpdata    = load<T, VECTOR_SIZE, true>(i, y_offset, y);
+                vec_t<T> tmpout = {{}};
+                __builtin_amdgcn_sched_barrier(0);
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
+                           batch_s <
+                       VECTOR_SIZE * GRID_SIZE)
+                    {
+                        if constexpr(USE_SOFTMAX_LOG)
+                        {
+                            values[index] -= channel_sum;
+                        }
+                        else
+                        {
+                            // Multiply by approximate reciprocal of channel_sum. The approximate
+                            // reciprocal is somewhat less accurate (1 ULP) than a full division,
+                            // but is noticeably more performant.
+                            values[index] *=
+                                __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                        }
+
+                        values[index] = values[index] * CVT_FP32_2ACCUM(alpha) +
+                                        CVT_FLOAT2ACCUM(tmpy.data[k]) * CVT_FP32_2ACCUM(beta);
+
+                        tmpy.data[k] = CVT_ACCUM2FLOAT(values[index]);
+                    }
+                    ++index;
+                }
+                __builtin_amdgcn_sched_barrier(0);
+                auto tmpyout = tmpy;
+                tmpy         = tmpdata;
+                store<T, VECTOR_SIZE, true>(i - BATCH_SIZE * load_factor<T>, y_offset, y, tmpyout);
+            }
+#pragma unroll
+            for(int k = 0; k < load_factor<T>; ++k)
+            {
+                if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
+                       batch_s <
+                   VECTOR_SIZE * GRID_SIZE)
+                {
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        values[index] -= channel_sum;
+                    }
+                    else
+                    {
+                        // Multiply by approximate reciprocal of channel_sum. The approximate
+                        // reciprocal is somewhat less accurate (1 ULP) than a full division, but is
+                        // noticeably more performant.
+                        values[index] *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                    }
+
+                    values[index] = values[index] * CVT_FP32_2ACCUM(alpha) +
+                                    CVT_FLOAT2ACCUM(tmpy.data[k]) * CVT_FP32_2ACCUM(beta);
+
+                    tmpy.data[k] = CVT_ACCUM2FLOAT(values[index]);
+                }
+                ++index;
+            }
+            store<T, VECTOR_SIZE, true>(i - BATCH_SIZE * load_factor<T>, y_offset, y, tmpy);
+        }
+        else
+        {
+            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
+                if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
+                {
+                    auto y_idx = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1);
+
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        values[index] -= channel_sum;
+                    }
+                    else
+                    {
+                        // Multiply by approximate reciprocal of channel_sum. The approximate
+                        // reciprocal is somewhat less accurate (1 ULP) than a full division, but is
+                        // noticeably more performant.
+                        values[index] *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                    }
+
+                    values[index] = values[index] * CVT_FP32_2ACCUM(alpha) +
+                                    CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
+
+                    y[y_idx] = CVT_ACCUM2FLOAT(values[index]);
+                }
+                ++index;
+            });
+        }
     }
 }
 
@@ -414,41 +841,158 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
             // Iterate over all the channels one thread is supposed to loop over
             // and compute dot-product
             FLOAT_ACCUM channel_dot = static_cast<FLOAT_ACCUM>(0);
-            loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                auto dy_idx = get_dy_index(n, i, s, s0, s1);
-                auto y_idx  = get_y_index(n, i, s, s0, s1);
-
-                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
+            if constexpr(VECTORIZED_C_Y && VECTORIZED_C_DY)
+            {
+                unsigned long i = lid * load_factor<T>;
+                auto dy_offset  = get_dy_index(n, 0, s, s0, s1);
+                int y_offset;
                 if constexpr(!USE_SOFTMAX_LOG)
                 {
-                    value *= CVT_FLOAT2ACCUM(y[y_idx]);
+                    y_offset = get_y_index(n, 0, s, s0, s1);
                 }
-                channel_dot += value;
-            });
+                auto tmpdy = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
+                vec_t<T> tmpy;
+                if constexpr(!USE_SOFTMAX_LOG)
+                {
+                    tmpy = load<T, VECTOR_SIZE, true>(i, y_offset, y);
+                }
+                i += LOCAL_SIZE * load_factor<T>;
+                for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
+                {
+                    auto tmpdydata = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
+                    vec_t<T> tmpydata;
+                    if constexpr(!USE_SOFTMAX_LOG)
+                    {
+                        tmpydata = load<T, VECTOR_SIZE, true>(i, y_offset, y);
+                    }
+                    __builtin_amdgcn_sched_barrier(0);
+#pragma unroll
+                    for(int k = 0; k < load_factor<T>; ++k)
+                    {
+                        FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpdy.data[k]);
+                        if constexpr(!USE_SOFTMAX_LOG)
+                        {
+                            value *= CVT_FLOAT2ACCUM(tmpy.data[k]);
+                        }
+                        channel_dot += value;
+                    }
+                    __builtin_amdgcn_sched_barrier(0);
+                    tmpdy = tmpdydata;
+                    if constexpr(!USE_SOFTMAX_LOG)
+                    {
+                        tmpy = tmpydata;
+                    }
+                }
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpdy.data[k]);
+                    if constexpr(!USE_SOFTMAX_LOG)
+                    {
+                        value *= CVT_FLOAT2ACCUM(tmpy.data[k]);
+                    }
+                    channel_dot += value;
+                }
+            }
+            else
+            {
+                loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
+                    auto dy_idx = get_dy_index(n, i, s, s0, s1);
+                    auto y_idx  = get_y_index(n, i, s, s0, s1);
+
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
+                    if constexpr(!USE_SOFTMAX_LOG)
+                    {
+                        value *= CVT_FLOAT2ACCUM(y[y_idx]);
+                    }
+                    channel_dot += value;
+                });
+            }
 
             reduce<LOCAL_SIZE>(ltmp, lid, lid, channel_dot, reduce_sum);
 
             channel_dot = ltmp[0];
 
             // Subtract and element-wise multiplication
-            loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                auto dy_idx = get_dy_index(n, i, s, s0, s1);
-                auto y_idx  = get_y_index(n, i, s, s0, s1);
-                auto dx_idx = get_dx_index(n, i, s, s0, s1);
+            if constexpr(VECTORIZED_C_Y && VECTORIZED_C_DX && VECTORIZED_C_DY)
+            {
+                unsigned long i = lid * load_factor<T>;
+                auto dy_offset  = get_dy_index(n, 0, s, s0, s1);
+                auto y_offset   = get_y_index(n, 0, s, s0, s1);
+                auto dx_offset  = get_dx_index(n, 0, s, s0, s1);
+                auto tmpdy      = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
+                auto tmpy       = load<T, VECTOR_SIZE, true>(i, y_offset, y);
+                auto tmpdx      = load<T, VECTOR_SIZE, true>(i, dx_offset, dx);
+                i += LOCAL_SIZE * load_factor<T>;
+                for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
+                {
+                    auto tmpdydata = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
+                    auto tmpydata  = load<T, VECTOR_SIZE, true>(i, y_offset, y);
+                    auto tmpdxdata = load<T, VECTOR_SIZE, true>(i, dx_offset, dx);
+                    __builtin_amdgcn_sched_barrier(0);
+#pragma unroll
+                    for(int k = 0; k < load_factor<T>; ++k)
+                    {
+                        FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpdy.data[k]);
+                        if constexpr(USE_SOFTMAX_LOG)
+                        {
+                            value -= channel_dot * exp(CVT_FLOAT2ACCUM(tmpy.data[k]));
+                        }
+                        else
+                        {
+                            value = (value - channel_dot) * CVT_FLOAT2ACCUM(tmpy.data[k]);
+                        }
+                        value = value * CVT_FP32_2ACCUM(alpha) +
+                                CVT_FLOAT2ACCUM(tmpdx.data[k]) * CVT_FP32_2ACCUM(beta);
+                        tmpdx.data[k] = CVT_ACCUM2FLOAT(value);
+                    }
+                    __builtin_amdgcn_sched_barrier(0);
+                    auto tmpdxout = tmpdx;
+                    tmpdy         = tmpdydata;
+                    tmpy          = tmpydata;
+                    tmpdx         = tmpdxdata;
+                    store<T, VECTOR_SIZE, true>(
+                        i - LOCAL_SIZE * load_factor<T>, dx_offset, dx, tmpdxout);
+                }
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpdy.data[k]);
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        value -= channel_dot * exp(CVT_FLOAT2ACCUM(tmpy.data[k]));
+                    }
+                    else
+                    {
+                        value = (value - channel_dot) * CVT_FLOAT2ACCUM(tmpy.data[k]);
+                    }
+                    value = value * CVT_FP32_2ACCUM(alpha) +
+                            CVT_FLOAT2ACCUM(tmpdx.data[k]) * CVT_FP32_2ACCUM(beta);
+                    tmpdx.data[k] = CVT_ACCUM2FLOAT(value);
+                }
+                store<T, VECTOR_SIZE, true>(i - LOCAL_SIZE * load_factor<T>, dx_offset, dx, tmpdx);
+            }
+            else
+            {
+                loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
+                    auto dy_idx = get_dy_index(n, i, s, s0, s1);
+                    auto y_idx  = get_y_index(n, i, s, s0, s1);
+                    auto dx_idx = get_dx_index(n, i, s, s0, s1);
 
-                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
-                if constexpr(USE_SOFTMAX_LOG)
-                {
-                    value -= channel_dot * exp(CVT_FLOAT2ACCUM(y[y_idx]));
-                }
-                else
-                {
-                    value = (value - channel_dot) * CVT_FLOAT2ACCUM(y[y_idx]);
-                }
-                value = value * CVT_FP32_2ACCUM(alpha) +
-                        CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
-                dx[dx_idx] = CVT_ACCUM2FLOAT(value);
-            });
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        value -= channel_dot * exp(CVT_FLOAT2ACCUM(y[y_idx]));
+                    }
+                    else
+                    {
+                        value = (value - channel_dot) * CVT_FLOAT2ACCUM(y[y_idx]);
+                    }
+                    value = value * CVT_FP32_2ACCUM(alpha) +
+                            CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
+                    dx[dx_idx] = CVT_ACCUM2FLOAT(value);
+                });
+            }
         }
     }
     else // CSR-Stream like approach
@@ -466,32 +1010,98 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
         const auto batch_s1 = batch_s % WIDTH;
         FLOAT_ACCUM channel_dot = static_cast<FLOAT_ACCUM>(0);
 
+        // Vectorizations in CSR-Stream are dependent on each other due to the layout of `y_values`
+        // and `dy_values`
+        constexpr bool VECTORIZED_C_STREAM = VECTORIZED_C_Y && VECTORIZED_C_DX && VECTORIZED_C_DY;
+
         // stores all the values touched by one thread so that we do not have load
         // again as the CSR-Vector approach
-        FLOAT_ACCUM y_values[U_BATCH_SIZE]  = {0};
-        FLOAT_ACCUM dy_values[U_BATCH_SIZE] = {0};
+        FLOAT_ACCUM y_values[ADJUSTED_U_BATCH_SIZE<T, VECTORIZED_C_STREAM>]  = {0};
+        FLOAT_ACCUM dy_values[ADJUSTED_U_BATCH_SIZE<T, VECTORIZED_C_STREAM>] = {0};
 
         // Compute dot product per channel
         // BATCH_SIZE threads iterate over the channels
         const auto index0 = batch_lid / BATCH_SIZE;
         auto index        = index0;
-        loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
+        if constexpr(VECTORIZED_C_STREAM)
+        {
+            unsigned long i = batch_lid * load_factor<T>;
+            auto y_offset   = get_y_index(batch_n, 0, batch_s, batch_s0, batch_s1);
+            auto dy_offset  = get_dy_index(batch_n, 0, batch_s, batch_s0, batch_s1);
+            vec_t<T> tmpy;
+            vec_t<T> tmpdy;
             if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
             {
-                auto y_idx  = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1);
-                auto dy_idx = get_dy_index(batch_n, i, batch_s, batch_s0, batch_s1);
-
-                y_values[index]  = CVT_FLOAT2ACCUM(y[y_idx]);
-                dy_values[index] = CVT_FLOAT2ACCUM(dy[dy_idx]);
-                auto value       = dy_values[index];
-                if constexpr(!USE_SOFTMAX_LOG)
-                {
-                    value *= y_values[index];
-                }
-                channel_dot += value;
+                tmpy  = load<T, VECTOR_SIZE, true>(i, y_offset, y);
+                tmpdy = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
             }
-            ++index;
-        });
+            i += BATCH_SIZE * load_factor<T>;
+            for(; i < VECTOR_SIZE; i += BATCH_SIZE * load_factor<T>)
+            {
+                auto tmpydata  = load<T, VECTOR_SIZE, true>(i, y_offset, y);
+                auto tmpdydata = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
+                __builtin_amdgcn_sched_barrier(0);
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
+                           batch_s <
+                       VECTOR_SIZE * GRID_SIZE)
+                    {
+                        y_values[index]  = CVT_FLOAT2ACCUM(tmpy.data[k]);
+                        dy_values[index] = CVT_FLOAT2ACCUM(tmpdy.data[k]);
+                        auto value       = dy_values[index];
+                        if constexpr(!USE_SOFTMAX_LOG)
+                        {
+                            value *= y_values[index];
+                        }
+                        channel_dot += value;
+                    }
+                    ++index;
+                }
+                __builtin_amdgcn_sched_barrier(0);
+                tmpy  = tmpydata;
+                tmpdy = tmpdydata;
+            }
+#pragma unroll
+            for(int k = 0; k < load_factor<T>; ++k)
+            {
+                if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
+                       batch_s <
+                   VECTOR_SIZE * GRID_SIZE)
+                {
+                    y_values[index]  = CVT_FLOAT2ACCUM(tmpy.data[k]);
+                    dy_values[index] = CVT_FLOAT2ACCUM(tmpdy.data[k]);
+                    auto value       = dy_values[index];
+                    if constexpr(!USE_SOFTMAX_LOG)
+                    {
+                        value *= y_values[index];
+                    }
+                    channel_dot += value;
+                }
+                ++index;
+            }
+        }
+        else
+        {
+            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
+                if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
+                {
+                    auto y_idx  = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1);
+                    auto dy_idx = get_dy_index(batch_n, i, batch_s, batch_s0, batch_s1);
+
+                    y_values[index]  = CVT_FLOAT2ACCUM(y[y_idx]);
+                    dy_values[index] = CVT_FLOAT2ACCUM(dy[dy_idx]);
+                    auto value       = dy_values[index];
+                    if constexpr(!USE_SOFTMAX_LOG)
+                    {
+                        value *= y_values[index];
+                    }
+                    channel_dot += value;
+                }
+                ++index;
+            });
+        }
 
         reduce<BATCH_SIZE>(ltmp, lid, batch_lid, channel_dot, reduce_sum);
 
@@ -499,26 +1109,95 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
 
         // Subtract and element-wise multiplication
         index = index0;
-        loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
+        if constexpr(VECTORIZED_C_STREAM)
+        {
+            unsigned long i = batch_lid * load_factor<T>;
+            auto dx_offset  = get_dx_index(batch_n, 0, batch_s, batch_s0, batch_s1);
+            vec_t<T> tmpdx;
             if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
             {
-                auto dx_idx = get_dx_index(batch_n, i, batch_s, batch_s0, batch_s1);
-
-                if constexpr(USE_SOFTMAX_LOG)
-                {
-                    dy_values[index] -= channel_dot * exp(y_values[index]);
-                }
-                else
-                {
-                    dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
-                }
-
-                auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
-                             CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
-                dx[dx_idx] = CVT_ACCUM2FLOAT(value);
+                tmpdx = load<T, VECTOR_SIZE, true>(i, dx_offset, dx);
             }
-            ++index;
-        });
+            i += BATCH_SIZE * load_factor<T>;
+            for(; i < VECTOR_SIZE; i += BATCH_SIZE * load_factor<T>)
+            {
+                auto tmpdata = load<T, VECTOR_SIZE, true>(i, dx_offset, dx);
+                __builtin_amdgcn_sched_barrier(0);
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
+                           batch_s <
+                       VECTOR_SIZE * GRID_SIZE)
+                    {
+                        if constexpr(USE_SOFTMAX_LOG)
+                        {
+                            dy_values[index] -= channel_dot * exp(y_values[index]);
+                        }
+                        else
+                        {
+                            dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
+                        }
+
+                        auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                     CVT_FLOAT2ACCUM(tmpdx.data[k]) * CVT_FP32_2ACCUM(beta);
+                        tmpdx.data[k] = CVT_ACCUM2FLOAT(value);
+                    }
+                    ++index;
+                }
+                __builtin_amdgcn_sched_barrier(0);
+                auto tmpdxout = tmpdx;
+                tmpdx         = tmpdata;
+                store<T, VECTOR_SIZE, true>(
+                    i - BATCH_SIZE * load_factor<T>, dx_offset, dx, tmpdxout);
+            }
+#pragma unroll
+            for(int k = 0; k < load_factor<T>; ++k)
+            {
+                if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
+                       batch_s <
+                   VECTOR_SIZE * GRID_SIZE)
+                {
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        dy_values[index] -= channel_dot * exp(y_values[index]);
+                    }
+                    else
+                    {
+                        dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
+                    }
+
+                    auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                 CVT_FLOAT2ACCUM(tmpdx.data[k]) * CVT_FP32_2ACCUM(beta);
+                    tmpdx.data[k] = CVT_ACCUM2FLOAT(value);
+                }
+                ++index;
+            }
+            store<T, VECTOR_SIZE, true>(i - BATCH_SIZE * load_factor<T>, dx_offset, dx, tmpdx);
+        }
+        else
+        {
+            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
+                if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
+                {
+                    auto dx_idx = get_dx_index(batch_n, i, batch_s, batch_s0, batch_s1);
+
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        dy_values[index] -= channel_dot * exp(y_values[index]);
+                    }
+                    else
+                    {
+                        dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
+                    }
+
+                    auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                 CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
+                    dx[dx_idx] = CVT_ACCUM2FLOAT(value);
+                }
+                ++index;
+            });
+        }
     }
 }
 

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -25,10 +25,6 @@ template <typename T>
 constexpr static unsigned int load_factor = sizeof(load_t) / sizeof(T);
 
 template <typename T>
-constexpr static unsigned int VALUES_SIZE =
-    VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE;
-
-template <typename T>
 using vec_t = array<T, load_factor<T>>;
 
 template <typename T,
@@ -36,17 +32,19 @@ template <typename T,
           unsigned int BOUND               = INNER_SIZE,
           unsigned int I_STRIDE            = STRIDE>
 __forceinline__ __device__ static vec_t<T>
-load(unsigned long i, const unsigned long i_offset, const T* __restrict__ src)
+load(unsigned int i, const unsigned int i_offset, const T* __restrict__ src)
 {
     if(I_STRIDE == 1 && i + load_factor<T> < BOUND)
     {
+        __builtin_amdgcn_sched_barrier(1);
         const load_t value = *reinterpret_cast<const load_t*>(&src[i + i_offset]);
         const auto values  = *reinterpret_cast<const vec_t<T>*>(&value);
         return values;
     }
     else
     {
-        vec_t<T> values = {{}};
+        __builtin_amdgcn_sched_barrier(1);
+        vec_t<T> values{{}};
 #pragma unroll
         for(int k = 0; k < load_factor<T>; ++k)
         {
@@ -65,7 +63,7 @@ load(unsigned long i, const unsigned long i_offset, const T* __restrict__ src)
 
 template <typename T, unsigned int BOUND = INNER_SIZE, unsigned int I_STRIDE = STRIDE>
 __forceinline__ __device__ static void
-store(unsigned long i, const unsigned long i_offset, T* __restrict__ dst, vec_t<T>& data)
+store(unsigned int i, const unsigned int i_offset, T* __restrict__ dst, vec_t<T>& data)
 {
     if(I_STRIDE == 1 && i + load_factor<T> < BOUND)
     {
@@ -215,7 +213,7 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
 #pragma unroll
                     for(int k = 0; k < load_factor<T>; ++k)
                     {
-                        tmp = max(CVT_FLOAT2ACCUM(xtmp.data[k]), tmp);
+                        tmp = max(CVT_FLOAT2ACCUM(xdata.data[k]), tmp);
                     }
                     xdata = xtmp;
                 }
@@ -335,10 +333,9 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                             CVT_FLOAT2ACCUM(ydata.data[k]) * CVT_FP32_2ACCUM(beta);
                     ydata.data[k] = CVT_ACCUM2FLOAT(value);
                 }
-                auto ytmpout = ydata;
-                xdata        = xtmp;
-                ydata        = ytmp;
-                store(i - LOCAL_SIZE * load_factor<T>, offset + Y_OFFSET, y, ytmpout);
+                store(i - LOCAL_SIZE * load_factor<T>, offset + Y_OFFSET, y, ydata);
+                xdata = xtmp;
+                ydata = ytmp;
             }
 #pragma unroll
             for(int k = 0; k < load_factor<T>; ++k)
@@ -399,7 +396,7 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         const unsigned int s      = (NUM_BATCH * gid + batch) % STRIDE;
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM tmp           = -MAX_VAL_ACCUM;
-        FLOAT_ACCUM x_values[VALUES_SIZE<T>];
+        FLOAT_ACCUM x_values[U_BATCH_SIZE * load_factor<T>];
         for(FLOAT_ACCUM& x_value : x_values)
         {
             x_value = -MAX_VAL_ACCUM;
@@ -546,9 +543,8 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                     ydata.data[k] = CVT_ACCUM2FLOAT(x_values[index]);
                     ++index;
                 }
-                auto ytmpout = ydata;
-                ydata        = ytmp;
-                store(i - BATCH_SIZE * load_factor<T>, offset + Y_OFFSET, y, ytmpout);
+                store(i - BATCH_SIZE * load_factor<T>, offset + Y_OFFSET, y, ydata);
+                ydata = ytmp;
             }
 #pragma unroll
             for(int k = 0; k < load_factor<T>; ++k)
@@ -663,10 +659,10 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
             for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
             {
                 auto dy_idx       = i * STRIDE + offset + DY_OFFSET;
-                auto y_idx        = i * STRIDE + offset + Y_OFFSET;
                 FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
                 if constexpr(!USE_SOFTMAX_LOG)
                 {
+                    auto y_idx = i * STRIDE + offset + Y_OFFSET;
                     value *= CVT_FLOAT2ACCUM(y[y_idx]);
                 }
                 channel_dot += value;
@@ -681,6 +677,7 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
             auto dydata    = load(i, offset + DY_OFFSET, dy);
             auto ydata     = load(i, offset + Y_OFFSET, y);
             auto dxdata    = load(i, offset + DX_OFFSET, dx);
+            i += LOCAL_SIZE * load_factor<T>;
             for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
             {
                 auto dytmp = load(i, offset + DY_OFFSET, dy);
@@ -702,11 +699,10 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                             CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
                     dxdata.data[k] = CVT_ACCUM2FLOAT(value);
                 }
-                auto dxtmpout = dxdata;
-                dydata        = dytmp;
-                ydata         = ytmp;
-                dxdata        = dxtmp;
-                store(i - LOCAL_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxtmpout);
+                store(i - LOCAL_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
+                dydata = dytmp;
+                ydata  = ytmp;
+                dxdata = dxtmp;
             }
 #pragma unroll
             for(int k = 0; k < load_factor<T>; ++k)
@@ -760,12 +756,12 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
         const unsigned int s      = (NUM_BATCH * gid + batch) % STRIDE;
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM channel_dot   = 0;
-        FLOAT_ACCUM y_values[VALUES_SIZE<T>];
+        FLOAT_ACCUM y_values[U_BATCH_SIZE * load_factor<T>];
         for(FLOAT_ACCUM& y_value : y_values)
         {
             y_value = 0;
         }
-        FLOAT_ACCUM dy_values[VALUES_SIZE<T>];
+        FLOAT_ACCUM dy_values[U_BATCH_SIZE * load_factor<T>];
         for(FLOAT_ACCUM& dy_value : dy_values)
         {
             dy_value = 0;
@@ -786,12 +782,11 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 {
                     y_values[index]  = CVT_FLOAT2ACCUM(ydata.data[k]);
                     dy_values[index] = CVT_FLOAT2ACCUM(dydata.data[k]);
-                    auto value       = dy_values[index];
                     if constexpr(!USE_SOFTMAX_LOG)
                     {
-                        value *= y_values[index];
+                        dy_values[index] *= y_values[index];
                     }
-                    channel_dot += value;
+                    channel_dot += dy_values[index];
                     ++index;
                 }
                 ydata  = ytmp;
@@ -802,12 +797,11 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
             {
                 y_values[index]  = CVT_FLOAT2ACCUM(ydata.data[k]);
                 dy_values[index] = CVT_FLOAT2ACCUM(dydata.data[k]);
-                auto value       = dy_values[index];
                 if constexpr(!USE_SOFTMAX_LOG)
                 {
-                    value *= y_values[index];
+                    dy_values[index] *= y_values[index];
                 }
-                channel_dot += value;
+                channel_dot += dy_values[index];
                 ++index;
             }
         }
@@ -819,12 +813,11 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 auto dy_idx      = i * STRIDE + offset + DY_OFFSET;
                 y_values[index]  = CVT_FLOAT2ACCUM(y[y_idx]);
                 dy_values[index] = CVT_FLOAT2ACCUM(dy[dy_idx]);
-                auto value       = dy_values[index];
                 if constexpr(!USE_SOFTMAX_LOG)
                 {
-                    value *= y_values[index];
+                    dy_values[index] *= y_values[index];
                 }
-                channel_dot += value;
+                channel_dot += dy_values[index];
                 ++index;
             }
         }
@@ -849,16 +842,15 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                     }
                     else
                     {
-                        dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
+                        dy_values[index] -= channel_dot * y_values[index];
                     }
-                    auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
-                                 CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
-                    dxdata.data[k] = CVT_ACCUM2FLOAT(value);
+                    dxdata.data[k] =
+                        CVT_ACCUM2FLOAT(dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                        CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta));
                     ++index;
                 }
-                auto dxtmpout = dxdata;
-                dxdata        = dxtmp;
-                store(i - BATCH_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxtmpout);
+                store(i - BATCH_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
+                dxdata = dxtmp;
             }
 #pragma unroll
             for(int k = 0; k < load_factor<T>; ++k)
@@ -869,11 +861,11 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 }
                 else
                 {
-                    dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
+                    dy_values[index] -= channel_dot * y_values[index];
                 }
-                auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
-                             CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
-                dxdata.data[k] = CVT_ACCUM2FLOAT(value);
+                dxdata.data[k] =
+                    CVT_ACCUM2FLOAT(dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                    CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta));
                 ++index;
             }
             store(i - BATCH_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
@@ -889,11 +881,10 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 }
                 else
                 {
-                    dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
+                    dy_values[index] -= channel_dot * y_values[index];
                 }
-                auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
-                             CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
-                dx[dx_idx] = CVT_ACCUM2FLOAT(value);
+                dx[dx_idx] = CVT_ACCUM2FLOAT(dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                             CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta));
                 ++index;
             }
         }

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -441,7 +441,7 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         }
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM tmp           = -MAX_VAL_ACCUM;
-        FLOAT_ACCUM x_values[VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE];
+        FLOAT_ACCUM x_values[U_BATCH_SIZE];
         for(FLOAT_ACCUM& x_value : x_values)
         {
             x_value = -MAX_VAL_ACCUM;
@@ -820,12 +820,12 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
         s                         = (NUM_BATCH * gid + batch) % STRIDE;
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM channel_dot   = 0;
-        FLOAT_ACCUM y_values[VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE];
+        FLOAT_ACCUM y_values[U_BATCH_SIZE];
         for(FLOAT_ACCUM& y_value : y_values)
         {
             y_value = 0;
         }
-        FLOAT_ACCUM dy_values[VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE];
+        FLOAT_ACCUM dy_values[U_BATCH_SIZE];
         for(FLOAT_ACCUM& dy_value : dy_values)
         {
             dy_value = 0;

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -96,10 +96,10 @@ __device__ void loop(const unsigned int lid, LAMBDA&& lambda)
     }
 }
 
-template <bool IS_CONTIGUOUS>
-__forceinline__ __device__ int get_index(int n, int i, int s, int s0, int s1, const int offset)
+template <bool IS_CONTIGUOUS, int OFFSET>
+__forceinline__ __device__ int get_index(int n, int i, int s, int s0, int s1)
 {
-    auto idx = offset;
+    auto idx = OFFSET;
     if constexpr(IS_CONTIGUOUS)
     {
         idx += (n * VECTOR_SIZE + i) * SPATIAL_DIM + s;
@@ -118,35 +118,29 @@ __forceinline__ __device__ int get_index(int n, int i, int s, int s0, int s1, co
     return idx;
 }
 
-__forceinline__ __device__ int get_x_index(int n, int i, int s, int s0, int s1, const int x_offset)
+__forceinline__ __device__ int get_x_index(int n, int i, int s, int s0, int s1)
 {
-    return get_index<IS_INPUT_CONTIGUOUS>(n, i, s, s0, s1, x_offset);
+    return get_index<IS_INPUT_CONTIGUOUS, X_OFFSET>(n, i, s, s0, s1);
 }
 
-__forceinline__ __device__ int get_y_index(int n, int i, int s, int s0, int s1, const int y_offset)
+__forceinline__ __device__ int get_y_index(int n, int i, int s, int s0, int s1)
 {
-    return get_index<IS_OUTPUT_CONTIGUOUS>(n, i, s, s0, s1, y_offset);
+    return get_index<IS_OUTPUT_CONTIGUOUS, Y_OFFSET>(n, i, s, s0, s1);
 }
 
-__forceinline__ __device__ int
-get_dx_index(int n, int i, int s, int s0, int s1, const int dx_offset)
+__forceinline__ __device__ int get_dx_index(int n, int i, int s, int s0, int s1)
 {
-    return get_index<IS_DINPUT_CONTIGUOUS>(n, i, s, s0, s1, dx_offset);
+    return get_index<IS_DINPUT_CONTIGUOUS, DX_OFFSET>(n, i, s, s0, s1);
 }
 
-__forceinline__ __device__ int
-get_dy_index(int n, int i, int s, int s0, int s1, const int dy_offset)
+__forceinline__ __device__ int get_dy_index(int n, int i, int s, int s0, int s1)
 {
-    return get_index<IS_DOUTPUT_CONTIGUOUS>(n, i, s, s0, s1, dy_offset);
+    return get_index<IS_DOUTPUT_CONTIGUOUS, DY_OFFSET>(n, i, s, s0, s1);
 }
 
 template <typename T>
-__forceinline__ __device__ void softmaxfwd(const T* __restrict__ x,
-                                           T* __restrict__ y,
-                                           const int x_offset,
-                                           const int y_offset,
-                                           const float alpha,
-                                           const float beta)
+__forceinline__ __device__ void
+softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const float beta)
 {
     const auto lid = threadIdx.x;
 
@@ -182,7 +176,7 @@ __forceinline__ __device__ void softmaxfwd(const T* __restrict__ x,
                 // Iterate over all the channels one thread is supposed to loop over
                 // and compute max
                 loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                    auto x_idx = get_x_index(n, i, s, s0, s1, x_offset);
+                    auto x_idx = get_x_index(n, i, s, s0, s1);
                     tmp        = max(CVT_FLOAT2ACCUM(x[x_idx]), tmp);
                 });
 
@@ -203,7 +197,7 @@ __forceinline__ __device__ void softmaxfwd(const T* __restrict__ x,
 
             // Subtract channel_max from each value
             loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                auto x_idx        = get_x_index(n, i, s, s0, s1, x_offset);
+                auto x_idx        = get_x_index(n, i, s, s0, s1);
                 FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]);
 
                 // Compute exponent of each value
@@ -228,8 +222,8 @@ __forceinline__ __device__ void softmaxfwd(const T* __restrict__ x,
 
             // Normalize each value in the channel by the channel_sum
             loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                auto x_idx = get_x_index(n, i, s, s0, s1, x_offset);
-                auto y_idx = get_y_index(n, i, s, s0, s1, y_offset);
+                auto x_idx = get_x_index(n, i, s, s0, s1);
+                auto y_idx = get_y_index(n, i, s, s0, s1);
 
                 FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]);
 
@@ -238,7 +232,7 @@ __forceinline__ __device__ void softmaxfwd(const T* __restrict__ x,
                 // faster than writing uncoalesced to DRAM
                 if constexpr(!USE_SOFTMAX_FAST)
                 {
-                    value = value - channel_max;
+                    value -= channel_max;
                 }
                 if constexpr(!USE_SOFTMAX_LOG)
                 {
@@ -304,7 +298,7 @@ __forceinline__ __device__ void softmaxfwd(const T* __restrict__ x,
         loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
             if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
             {
-                auto x_idx = get_x_index(batch_n, i, batch_s, batch_s0, batch_s1, x_offset);
+                auto x_idx = get_x_index(batch_n, i, batch_s, batch_s0, batch_s1);
 
                 values[index] = CVT_FLOAT2ACCUM(x[x_idx]);
                 if constexpr(!USE_SOFTMAX_FAST)
@@ -369,7 +363,7 @@ __forceinline__ __device__ void softmaxfwd(const T* __restrict__ x,
         loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
             if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
             {
-                auto y_idx = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1, y_offset);
+                auto y_idx = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1);
 
                 auto v_idx = index;
 
@@ -399,9 +393,6 @@ template <typename T>
 __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                                            const T* __restrict__ dy,
                                            T* __restrict__ dx,
-                                           const int y_offset,
-                                           const int dy_offset,
-                                           const int dx_offset,
                                            const float alpha,
                                            const float beta)
 {
@@ -424,8 +415,8 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
             // and compute dot-product
             FLOAT_ACCUM channel_dot = static_cast<FLOAT_ACCUM>(0);
             loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                auto dy_idx = get_dy_index(n, i, s, s0, s1, dy_offset);
-                auto y_idx  = get_y_index(n, i, s, s0, s1, y_offset);
+                auto dy_idx = get_dy_index(n, i, s, s0, s1);
+                auto y_idx  = get_y_index(n, i, s, s0, s1);
 
                 FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
                 if constexpr(!USE_SOFTMAX_LOG)
@@ -441,9 +432,9 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
 
             // Subtract and element-wise multiplication
             loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                auto dy_idx = get_dy_index(n, i, s, s0, s1, dy_offset);
-                auto y_idx  = get_y_index(n, i, s, s0, s1, y_offset);
-                auto dx_idx = get_dx_index(n, i, s, s0, s1, dx_offset);
+                auto dy_idx = get_dy_index(n, i, s, s0, s1);
+                auto y_idx  = get_y_index(n, i, s, s0, s1);
+                auto dx_idx = get_dx_index(n, i, s, s0, s1);
 
                 FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
                 if constexpr(USE_SOFTMAX_LOG)
@@ -487,8 +478,8 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
         loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
             if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
             {
-                auto y_idx  = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1, y_offset);
-                auto dy_idx = get_dy_index(batch_n, i, batch_s, batch_s0, batch_s1, dy_offset);
+                auto y_idx  = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1);
+                auto dy_idx = get_dy_index(batch_n, i, batch_s, batch_s0, batch_s1);
 
                 y_values[index]  = CVT_FLOAT2ACCUM(y[y_idx]);
                 dy_values[index] = CVT_FLOAT2ACCUM(dy[dy_idx]);
@@ -511,7 +502,7 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
         loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
             if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
             {
-                auto dx_idx = get_dx_index(batch_n, i, batch_s, batch_s0, batch_s1, dx_offset);
+                auto dx_idx = get_dx_index(batch_n, i, batch_s, batch_s0, batch_s1);
 
                 if constexpr(USE_SOFTMAX_LOG)
                 {
@@ -533,22 +524,17 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
 
 extern "C" __global__ void SoftmaxFwd(const DATA_TYPE* __restrict__ x,
                                       DATA_TYPE* __restrict__ y,
-                                      const int x_offset,
-                                      const int y_offset,
                                       const float alpha,
                                       const float beta)
 {
-    softmaxfwd<DATA_TYPE>(x, y, x_offset, y_offset, alpha, beta);
+    softmaxfwd<DATA_TYPE>(x, y, alpha, beta);
 }
 
 extern "C" __global__ void SoftmaxBwd(const DATA_TYPE* __restrict__ y,
                                       const DATA_TYPE* __restrict__ dy,
                                       DATA_TYPE* __restrict__ dx,
-                                      const int y_offset,
-                                      const int dy_offset,
-                                      const int dx_offset,
                                       const float alpha,
                                       const float beta)
 {
-    softmaxbwd<DATA_TYPE>(y, dy, dx, y_offset, dy_offset, dx_offset, alpha, beta);
+    softmaxbwd<DATA_TYPE>(y, dy, dx, alpha, beta);
 }

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 #ifndef MIOPEN_HIP_RUNTIME_COMPILE
 #include <hip/hip_fp16.h>
@@ -13,17 +13,6 @@ constexpr T NEGATIVE_CUTOFF_VAL = T{-1e20};
 template <typename T>
 constexpr T EPSILON = T{1e-12};
 
-template <bool IS_CONTIGUOUS>
-constexpr bool VECTORIZED_C =
-    VECTORIZED &&
-    ((IS_CONTIGUOUS && SPATIAL_DIM == 1) ||
-     (!IS_CONTIGUOUS && USE_SOFTMAX_MODE_INSTANCE && HEIGHT * WIDTH == 1 && C_STRIDE == 1) ||
-     (!IS_CONTIGUOUS && USE_SOFTMAX_MODE_CHANNEL && C_STRIDE == 1));
-constexpr bool VECTORIZED_C_X  = VECTORIZED_C<IS_INPUT_CONTIGUOUS>;
-constexpr bool VECTORIZED_C_Y  = VECTORIZED_C<IS_OUTPUT_CONTIGUOUS>;
-constexpr bool VECTORIZED_C_DX = VECTORIZED_C<IS_DINPUT_CONTIGUOUS>;
-constexpr bool VECTORIZED_C_DY = VECTORIZED_C<IS_DOUTPUT_CONTIGUOUS>;
-
 using load_t = int4;
 
 template <typename T, unsigned int N>
@@ -35,21 +24,21 @@ struct array
 template <typename T>
 constexpr static unsigned int load_factor = sizeof(load_t) / sizeof(T);
 
-template <typename T, bool IS_VECTORIZED>
-constexpr static unsigned int ADJUSTED_U_BATCH_SIZE =
-    IS_VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE;
+template <typename T>
+constexpr static unsigned int VALUES_SIZE =
+    VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE;
 
 template <typename T>
 using vec_t = array<T, load_factor<T>>;
 
 template <typename T,
-          unsigned int BOUND,
-          bool IS_CONTIGUOUS,
-          bool DEFAULT_NEGATIVE_CUTOFF_VAL = false>
+          bool DEFAULT_NEGATIVE_CUTOFF_VAL = false,
+          unsigned int BOUND               = INNER_SIZE,
+          unsigned int I_STRIDE            = STRIDE>
 __forceinline__ __device__ static vec_t<T>
 load(unsigned long i, const unsigned long i_offset, const T* __restrict__ src)
 {
-    if(IS_CONTIGUOUS && i + load_factor<T> < BOUND)
+    if(I_STRIDE == 1 && i + load_factor<T> < BOUND)
     {
         const load_t value = *reinterpret_cast<const load_t*>(&src[i + i_offset]);
         const auto values  = *reinterpret_cast<const vec_t<T>*>(&value);
@@ -63,7 +52,7 @@ load(unsigned long i, const unsigned long i_offset, const T* __restrict__ src)
         {
             if(i + k < BOUND)
             {
-                values.data[k] = src[i + k + i_offset];
+                values.data[k] = src[(i + k) * I_STRIDE + i_offset];
             }
             else if constexpr(DEFAULT_NEGATIVE_CUTOFF_VAL)
             {
@@ -74,11 +63,11 @@ load(unsigned long i, const unsigned long i_offset, const T* __restrict__ src)
     }
 }
 
-template <typename T, unsigned int BOUND, bool IS_CONTIGUOUS>
+template <typename T, unsigned int BOUND = INNER_SIZE, unsigned int I_STRIDE = STRIDE>
 __forceinline__ __device__ static void
 store(unsigned long i, const unsigned long i_offset, T* __restrict__ dst, vec_t<T>& data)
 {
-    if(IS_CONTIGUOUS && i + load_factor<T> < BOUND)
+    if(I_STRIDE == 1 && i + load_factor<T> < BOUND)
     {
         *reinterpret_cast<load_t*>(&dst[i + i_offset]) = *reinterpret_cast<load_t*>(&data);
     }
@@ -89,31 +78,7 @@ store(unsigned long i, const unsigned long i_offset, T* __restrict__ dst, vec_t<
         {
             if(i + k < BOUND)
             {
-                dst[i + k + i_offset] = data.data[k];
-            }
-        }
-    }
-}
-
-template <typename T, unsigned int BOUND, bool IS_CONTIGUOUS, unsigned int I_COND_STRIDE = 1>
-__forceinline__ __device__ static void store_if(unsigned long i,
-                                                const unsigned long i_offset,
-                                                unsigned long i_cond,
-                                                T* __restrict__ dst,
-                                                vec_t<T>& data)
-{
-    if(IS_CONTIGUOUS && i_cond + I_COND_STRIDE * load_factor<T> < BOUND)
-    {
-        *reinterpret_cast<load_t*>(&dst[i + i_offset]) = *reinterpret_cast<load_t*>(&data);
-    }
-    else
-    {
-#pragma unroll
-        for(int k = 0; k < load_factor<T>; ++k)
-        {
-            if(i_cond + k * I_COND_STRIDE < BOUND)
-            {
-                dst[i + k + i_offset] = data.data[k];
+                dst[(i + k) * I_STRIDE + i_offset] = data.data[k];
             }
         }
     }
@@ -135,7 +100,6 @@ __device__ T logaddexp(T x, T y)
 template <int ARRAY_SIZE, typename FUNCTION>
 __device__ void reduce(FLOAT_ACCUM array[ARRAY_SIZE],
                        const unsigned int lid,
-                       const unsigned int batch_lid,
                        FLOAT_ACCUM value_lid,
                        FUNCTION&& function)
 {
@@ -144,6 +108,27 @@ __device__ void reduce(FLOAT_ACCUM array[ARRAY_SIZE],
 
 #pragma nounroll
     for(auto i = ARRAY_SIZE >> 1; i > 0; i >>= 1)
+    {
+        if(lid < i)
+        {
+            array[lid] = function(array[lid], array[lid + i]);
+        }
+        __syncthreads();
+    }
+}
+
+template <int ARRAY_SIZE, int BLOCK_SIZE, typename FUNCTION>
+__device__ void reduce_block(FLOAT_ACCUM array[ARRAY_SIZE],
+                             const unsigned int lid,
+                             const unsigned int batch_lid,
+                             FLOAT_ACCUM value_batch_lid,
+                             FUNCTION&& function)
+{
+    array[lid] = value_batch_lid;
+    __syncthreads();
+
+#pragma nounroll
+    for(auto i = BLOCK_SIZE >> 1; i > 0; i >>= 1)
     {
         if(batch_lid < i)
         {
@@ -202,285 +187,139 @@ __device__ void loop(const unsigned int lid, LAMBDA&& lambda)
     }
 }
 
-template <bool IS_CONTIGUOUS, unsigned long OFFSET>
-__forceinline__ __device__ unsigned long get_index(int n, int i, int s, int s0, int s1)
-{
-    auto idx = OFFSET;
-    if constexpr(IS_CONTIGUOUS)
-    {
-        idx += (n * VECTOR_SIZE + i) * SPATIAL_DIM + s;
-    }
-    else if constexpr(USE_SOFTMAX_MODE_INSTANCE)
-    {
-        auto i0 = i / (HEIGHT * WIDTH);
-        auto i1 = (i % (HEIGHT * WIDTH)) / WIDTH;
-        auto i2 = (i % (HEIGHT * WIDTH)) % WIDTH;
-        idx += n * N_STRIDE + i0 * C_STRIDE + i1 * H_STRIDE + i2 * W_STRIDE;
-    }
-    else
-    {
-        idx += n * N_STRIDE + i * C_STRIDE + s0 * H_STRIDE + s1 * W_STRIDE;
-    }
-    return idx;
-}
-
-__forceinline__ __device__ unsigned long get_x_index(int n, int i, int s, int s0, int s1)
-{
-    return get_index<IS_INPUT_CONTIGUOUS, X_OFFSET>(n, i, s, s0, s1);
-}
-
-__forceinline__ __device__ unsigned long get_y_index(int n, int i, int s, int s0, int s1)
-{
-    return get_index<IS_OUTPUT_CONTIGUOUS, Y_OFFSET>(n, i, s, s0, s1);
-}
-
-__forceinline__ __device__ unsigned long get_dx_index(int n, int i, int s, int s0, int s1)
-{
-    return get_index<IS_DINPUT_CONTIGUOUS, DX_OFFSET>(n, i, s, s0, s1);
-}
-
-__forceinline__ __device__ unsigned long get_dy_index(int n, int i, int s, int s0, int s1)
-{
-    return get_index<IS_DOUTPUT_CONTIGUOUS, DY_OFFSET>(n, i, s, s0, s1);
-}
-
 template <typename T>
 __forceinline__ __device__ void
 softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const float beta)
 {
-    const auto lid = threadIdx.x;
-
+    const unsigned int gid = blockIdx.x;
+    const unsigned int lid = threadIdx.x;
     __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE];
-    FLOAT_ACCUM tmp;
 
     if constexpr(NUM_BATCH == 1) // CSR-Vector like approach
     {
-        /* Entire workgroup works on one spatial_dim.
-         * We use logarithmic reductions to compute max and sum per channel.
-         * This approach reads in the same data thrice from DRAM but is still better
-         * than launching three different kernels.
-         * The workgroup begins by computing the nth image and s (spatial_dim) it
-         * is working on and iterates over the entire grid until finished.
-         */
-
-        // Total number of workgroups launched can be less than the gridsize, hence iterate over.
-        for(auto gid = blockIdx.x; gid < GRID_SIZE; gid += WORKGROUPS)
+        const unsigned int o      = gid / STRIDE;
+        const unsigned int s      = gid % STRIDE;
+        const unsigned int offset = o * INNER_SIZE * STRIDE + s;
+        FLOAT_ACCUM tmp           = -MAX_VAL_ACCUM;
+        FLOAT_ACCUM channel_max   = 0;
+        if constexpr(!USE_SOFTMAX_FAST)
         {
-            auto n  = gid / SPATIAL_DIM; // nth image
-            auto s  = gid % SPATIAL_DIM; // spatial dimension (h * w)
-            auto s0 = s / WIDTH;
-            auto s1 = s % WIDTH;
-
-            FLOAT_ACCUM channel_max;
-
-            if constexpr(!USE_SOFTMAX_FAST)
+            if constexpr(VECTORIZED)
             {
-                ltmp[lid] = -MAX_VAL_ACCUM;
-                tmp       = -MAX_VAL_ACCUM;
-
-                // Compute max per channel
-                // Iterate over all the channels one thread is supposed to loop over
-                // and compute max
-                if constexpr(VECTORIZED_C_X)
+                unsigned int i = lid * load_factor<T>;
+                auto xdata     = load<T, true>(i, offset + X_OFFSET, x);
+                i += LOCAL_SIZE * load_factor<T>;
+                for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
                 {
-                    unsigned long i = lid * load_factor<T>;
-                    auto x_offset   = get_x_index(n, 0, s, s0, s1);
-                    auto tmpx       = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
-                    i += LOCAL_SIZE * load_factor<T>;
-                    for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
-                    {
-                        auto tmpdata = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
-                        __builtin_amdgcn_sched_barrier(0);
-#pragma unroll
-                        for(int k = 0; k < load_factor<T>; ++k)
-                        {
-                            tmp = max(CVT_FLOAT2ACCUM(tmpx.data[k]), tmp);
-                        }
-                        __builtin_amdgcn_sched_barrier(0);
-                        tmpx = tmpdata;
-                    }
+                    auto xtmp = load<T, true>(i, offset + X_OFFSET, x);
 #pragma unroll
                     for(int k = 0; k < load_factor<T>; ++k)
                     {
-                        tmp = max(CVT_FLOAT2ACCUM(tmpx.data[k]), tmp);
+                        tmp = max(CVT_FLOAT2ACCUM(xtmp.data[k]), tmp);
                     }
+                    xdata = xtmp;
+                }
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    tmp = max(CVT_FLOAT2ACCUM(xdata.data[k]), tmp);
+                }
+            }
+            else
+            {
+                for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+                {
+                    auto x_idx = i * STRIDE + offset + X_OFFSET;
+                    tmp        = max(CVT_FLOAT2ACCUM(x[x_idx]), tmp);
+                }
+            }
+            reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_max);
+            channel_max = ltmp[0];
+            __syncthreads();
+        }
+
+        if constexpr(USE_SOFTMAX_LOG)
+        {
+            tmp = NEGATIVE_CUTOFF_VAL<FLOAT_ACCUM>;
+        }
+        else
+        {
+            tmp = 0;
+        }
+        if constexpr(VECTORIZED)
+        {
+            unsigned int i = lid * load_factor<T>;
+            auto xdata     = load<T, true>(i, offset + X_OFFSET, x);
+            i += LOCAL_SIZE * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
+            {
+                auto xtmp = load<T, true>(i, offset + X_OFFSET, x);
+#pragma unroll
+                for(int k = 0; k < load_factor<T>; ++k)
+                {
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(xdata.data[k]) - channel_max;
+                    if constexpr(USE_SOFTMAX_LOG)
+                    {
+                        tmp = logaddexp(value, tmp);
+                    }
+                    else
+                    {
+                        tmp += exp(value);
+                    }
+                }
+                xdata = xtmp;
+            }
+#pragma unroll
+            for(int k = 0; k < load_factor<T>; ++k)
+            {
+                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(xdata.data[k]) - channel_max;
+                if constexpr(USE_SOFTMAX_LOG)
+                {
+                    tmp = logaddexp(value, tmp);
                 }
                 else
                 {
-                    loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                        auto x_idx = get_x_index(n, i, s, s0, s1);
-                        tmp        = max(CVT_FLOAT2ACCUM(x[x_idx]), tmp);
-                    });
+                    tmp += exp(value);
                 }
-
-                reduce<LOCAL_SIZE>(ltmp, lid, lid, tmp, reduce_max);
-
-                channel_max = ltmp[0];
-                __syncthreads();
             }
-
-            if constexpr(USE_SOFTMAX_LOG)
+        }
+        else
+        {
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
             {
-                tmp = NEGATIVE_CUTOFF_VAL<FLOAT_ACCUM>;
-            }
-            else
-            {
-                tmp = 0;
-            }
-
-            if constexpr(VECTORIZED_C_X)
-            {
-                // Subtract channel_max from each value
-                unsigned long i = lid * load_factor<T>;
-                auto x_offset   = get_x_index(n, 0, s, s0, s1);
-                auto tmpx       = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
-                i += LOCAL_SIZE * load_factor<T>;
-                for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
+                auto x_idx        = i * STRIDE + offset + X_OFFSET;
+                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]) - channel_max;
+                if constexpr(USE_SOFTMAX_LOG)
                 {
-                    auto tmpdata = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
-                    __builtin_amdgcn_sched_barrier(0);
-#pragma unroll
-                    for(int k = 0; k < load_factor<T>; ++k)
-                    {
-                        FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpx.data[k]);
-
-                        // Compute exponent of each value
-                        // Then sum all the values touched by this thread
-                        if constexpr(USE_SOFTMAX_LOG)
-                        {
-                            tmp = logaddexp(value - channel_max, tmp);
-                        }
-                        else if constexpr(USE_SOFTMAX_FAST)
-                        {
-                            tmp += exp(value);
-                        }
-                        else
-                        {
-                            tmp += exp(value - channel_max);
-                        }
-                    }
-                    __builtin_amdgcn_sched_barrier(0);
-                    tmpx = tmpdata;
+                    tmp = logaddexp(value, tmp);
                 }
+                else
+                {
+                    tmp += exp(value);
+                }
+            }
+        }
+        reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_sum_log);
+        FLOAT_ACCUM channel_sum = ltmp[0];
+
+        if constexpr(VECTORIZED)
+        {
+            unsigned int i = lid * load_factor<T>;
+            auto xdata     = load<T, !USE_SOFTMAX_LOG>(i, offset + X_OFFSET, x);
+            auto ydata     = load(i, offset + Y_OFFSET, y);
+            i += LOCAL_SIZE * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
+            {
+                auto xtmp = load<T, !USE_SOFTMAX_LOG>(i, offset + X_OFFSET, x);
+                auto ytmp = load(i, offset + Y_OFFSET, y);
 #pragma unroll
                 for(int k = 0; k < load_factor<T>; ++k)
                 {
-                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpx.data[k]);
-
-                    // Compute exponent of each value
-                    // Then sum all the values touched by this thread
-                    if constexpr(USE_SOFTMAX_LOG)
-                    {
-                        tmp = logaddexp(value - channel_max, tmp);
-                    }
-                    else if constexpr(USE_SOFTMAX_FAST)
-                    {
-                        tmp += exp(value);
-                    }
-                    else
-                    {
-                        tmp += exp(value - channel_max);
-                    }
-                }
-            }
-            else
-            {
-                // Subtract channel_max from each value
-                loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                    auto x_idx        = get_x_index(n, i, s, s0, s1);
-                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]);
-
-                    // Compute exponent of each value
-                    // Then sum all the values touched by this thread
-                    if constexpr(USE_SOFTMAX_LOG)
-                    {
-                        tmp = logaddexp(value - channel_max, tmp);
-                    }
-                    else if constexpr(USE_SOFTMAX_FAST)
-                    {
-                        tmp += exp(value);
-                    }
-                    else
-                    {
-                        tmp += exp(value - channel_max);
-                    }
-                });
-            }
-
-            reduce<LOCAL_SIZE>(ltmp, lid, lid, tmp, reduce_sum_log);
-
-            FLOAT_ACCUM channel_sum = ltmp[0];
-
-            if constexpr(VECTORIZED_C_X && VECTORIZED_C_Y)
-            {
-                // Normalize each value in the channel by the channel_sum
-                unsigned long i = lid * load_factor<T>;
-                auto x_offset   = get_x_index(n, 0, s, s0, s1);
-                auto y_offset   = get_y_index(n, 0, s, s0, s1);
-                auto tmpx       = load<T, VECTOR_SIZE, true>(i, x_offset, x);
-                auto tmpy       = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-                i += LOCAL_SIZE * load_factor<T>;
-                for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
-                {
-                    auto tmpdata  = load<T, VECTOR_SIZE, true>(i, x_offset, x);
-                    auto tmpdata2 = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-                    __builtin_amdgcn_sched_barrier(0);
-#pragma unroll
-                    for(int k = 0; k < load_factor<T>; ++k)
-                    {
-                        FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpx.data[k]);
-
-                        // Subtracting max again because we do not write the output of
-                        // value-max to DRAM above. Doing a subtraction again is much
-                        // faster than writing uncoalesced to DRAM
-                        if constexpr(!USE_SOFTMAX_FAST)
-                        {
-                            value -= channel_max;
-                        }
-                        if constexpr(!USE_SOFTMAX_LOG)
-                        {
-                            value = exp(value);
-                        }
-
-                        if constexpr(USE_SOFTMAX_LOG)
-                        {
-                            value -= channel_sum;
-                        }
-                        else
-                        {
-                            // Multiply by approximate reciprocal of channel_sum. The approximate
-                            // reciprocal is somewhat less accurate (1 ULP) than a full division,
-                            // but is noticeably more performant.
-                            value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
-                        }
-                        value = value * CVT_FP32_2ACCUM(alpha) +
-                                CVT_FLOAT2ACCUM(tmpy.data[k]) * CVT_FP32_2ACCUM(beta);
-                        tmpy.data[k] = CVT_ACCUM2FLOAT(value);
-                    }
-                    __builtin_amdgcn_sched_barrier(0);
-                    auto tmpyout = tmpy;
-                    tmpx         = tmpdata;
-                    tmpy         = tmpdata2;
-                    store<T, VECTOR_SIZE, true>(
-                        i - LOCAL_SIZE * load_factor<T>, y_offset, y, tmpyout);
-                }
-#pragma unroll
-                for(int k = 0; k < load_factor<T>; ++k)
-                {
-                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpx.data[k]);
-
-                    // Subtracting max again because we do not write the output of
-                    // value-max to DRAM above. Doing a subtraction again is much
-                    // faster than writing uncoalesced to DRAM
-                    if constexpr(!USE_SOFTMAX_FAST)
-                    {
-                        value -= channel_max;
-                    }
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(xdata.data[k]) - channel_max;
                     if constexpr(!USE_SOFTMAX_LOG)
                     {
                         value = exp(value);
                     }
-
                     if constexpr(USE_SOFTMAX_LOG)
                     {
                         value -= channel_sum;
@@ -493,162 +332,128 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                         value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
                     }
                     value = value * CVT_FP32_2ACCUM(alpha) +
-                            CVT_FLOAT2ACCUM(tmpy.data[k]) * CVT_FP32_2ACCUM(beta);
-                    tmpy.data[k] = CVT_ACCUM2FLOAT(value);
+                            CVT_FLOAT2ACCUM(ydata.data[k]) * CVT_FP32_2ACCUM(beta);
+                    ydata.data[k] = CVT_ACCUM2FLOAT(value);
                 }
-                store<T, VECTOR_SIZE, true>(i - LOCAL_SIZE * load_factor<T>, y_offset, y, tmpy);
+                auto ytmpout = ydata;
+                xdata        = xtmp;
+                ydata        = ytmp;
+                store(i - LOCAL_SIZE * load_factor<T>, offset + Y_OFFSET, y, ytmpout);
             }
-            else
+#pragma unroll
+            for(int k = 0; k < load_factor<T>; ++k)
             {
-                // Normalize each value in the channel by the channel_sum
-                loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                    auto x_idx = get_x_index(n, i, s, s0, s1);
-                    auto y_idx = get_y_index(n, i, s, s0, s1);
-
-                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]);
-
-                    // Subtracting max again because we do not write the output of
-                    // value-max to DRAM above. Doing a subtraction again is much
-                    // faster than writing uncoalesced to DRAM
-                    if constexpr(!USE_SOFTMAX_FAST)
-                    {
-                        value -= channel_max;
-                    }
-                    if constexpr(!USE_SOFTMAX_LOG)
-                    {
-                        value = exp(value);
-                    }
-
-                    if constexpr(USE_SOFTMAX_LOG)
-                    {
-                        value -= channel_sum;
-                    }
-                    else
-                    {
-                        // Multiply by approximate reciprocal of channel_sum. The approximate
-                        // reciprocal is somewhat less accurate (1 ULP) than a full division, but is
-                        // noticeably more performant.
-                        value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
-                    }
-
-                    value = value * CVT_FP32_2ACCUM(alpha) +
-                            CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
-                    y[y_idx] = CVT_ACCUM2FLOAT(value);
-                });
+                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(xdata.data[k]) - channel_max;
+                if constexpr(USE_SOFTMAX_LOG)
+                {
+                    value -= channel_sum;
+                }
+                else
+                {
+                    value = exp(value);
+                    // Multiply by approximate reciprocal of channel_sum. The approximate reciprocal
+                    // is somewhat less accurate (1 ULP) than a full division, but is noticeably
+                    // more performant.
+                    value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                }
+                value = value * CVT_FP32_2ACCUM(alpha) +
+                        CVT_FLOAT2ACCUM(ydata.data[k]) * CVT_FP32_2ACCUM(beta);
+                ydata.data[k] = CVT_ACCUM2FLOAT(value);
+            }
+            store(i - LOCAL_SIZE * load_factor<T>, offset + Y_OFFSET, y, ydata);
+        }
+        else
+        {
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+            {
+                auto x_idx        = i * STRIDE + offset + X_OFFSET;
+                auto y_idx        = i * STRIDE + offset + Y_OFFSET;
+                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(x[x_idx]) - channel_max;
+                if constexpr(USE_SOFTMAX_LOG)
+                {
+                    value -= channel_sum;
+                }
+                else
+                {
+                    value = exp(value);
+                    // Multiply by approximate reciprocal of channel_sum. The approximate reciprocal
+                    // is somewhat less accurate (1 ULP) than a full division, but is noticeably
+                    // more performant.
+                    value *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                }
+                value = value * CVT_FP32_2ACCUM(alpha) +
+                        CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
+                y[y_idx] = CVT_ACCUM2FLOAT(value);
             }
         }
     }
     else // CSR-Stream like approach
     {
-        /* Each workgroup is computing the softmax for NUM_BATCH spatial_dims ala CSR-Stream.
-         * The number of threads iterating over channels to compute softmax for one batch is
-         * BATCH_SIZE. The number of values each thread works on is U_BATCH_SIZE (read micro batch
-         * size). Each batch in the workgroup works on its nth image and s (spatial_dim). E.g. a 256
-         * thread workgroup with c=31 has 8 batches and a batchsize of 32. The number of workgroups
-         * launched are exactly the number as required hence, there is no for-loop.
-         */
-
-        const auto gid = blockIdx.x;
-
-        // ID of the thread within the batch
-        const auto batch_lid = lid & (BATCH_SIZE - 1); // thread specific channel_st
-        const auto batch     = lid / BATCH_SIZE;       // which spatial_dim or pixel
-
-        // Batch specific n and s
-        const auto batch_n  = (NUM_BATCH * gid + batch) / SPATIAL_DIM; // nth image
-        const auto batch_s  = (NUM_BATCH * gid + batch) % SPATIAL_DIM; // which spatial_dim/pixel
-        const auto batch_s0 = batch_s / WIDTH;
-        const auto batch_s1 = batch_s % WIDTH;
-
-        if constexpr(!USE_SOFTMAX_FAST)
+        const unsigned int batch_lid = lid % BATCH_SIZE;
+        const unsigned int batch     = lid / BATCH_SIZE;
+        const unsigned int o         = (NUM_BATCH * gid + batch) / STRIDE;
+        if(o >= OUTER_SIZE)
         {
-            ltmp[lid] = -MAX_VAL_ACCUM;
-            tmp       = -MAX_VAL_ACCUM;
+            return;
         }
-
-        // Vectorizations in CSR-Stream are dependent on each other due to the layout of `values`
-        constexpr bool VECTORIZED_C_STREAM = VECTORIZED_C_X && VECTORIZED_C_Y;
-
-        FLOAT_ACCUM values[ADJUSTED_U_BATCH_SIZE<T, VECTORIZED_C_STREAM>];
-        for(FLOAT_ACCUM& value : values)
+        const unsigned int s      = (NUM_BATCH * gid + batch) % STRIDE;
+        const unsigned int offset = o * INNER_SIZE * STRIDE + s;
+        FLOAT_ACCUM tmp           = -MAX_VAL_ACCUM;
+        FLOAT_ACCUM x_values[VALUES_SIZE<T>];
+        for(FLOAT_ACCUM& x_value : x_values)
         {
-            value = -MAX_VAL_ACCUM;
+            x_value = -MAX_VAL_ACCUM;
         }
-
-        // Compute max per channel
-        // BATCH_SIZE threads iterate over the channels
-        const auto index0 = batch_lid / BATCH_SIZE;
-        auto index        = index0;
-        if constexpr(VECTORIZED_C_STREAM)
+        unsigned int index = 0;
+        if constexpr(VECTORIZED)
         {
-            unsigned long i = batch_lid * load_factor<T>;
-            auto x_offset   = get_x_index(batch_n, 0, batch_s, batch_s0, batch_s1);
-            vec_t<T> tmpx;
-            if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
-            {
-                tmpx = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
-            }
+            unsigned int i = batch_lid * load_factor<T>;
+            auto xdata     = load<T, true>(i, offset + X_OFFSET, x);
             i += BATCH_SIZE * load_factor<T>;
-            for(; i < VECTOR_SIZE; i += BATCH_SIZE * load_factor<T>)
+            for(; i < INNER_SIZE; i += BATCH_SIZE * load_factor<T>)
             {
-                auto tmpdata = load<T, VECTOR_SIZE, true, true>(i, x_offset, x);
-                __builtin_amdgcn_sched_barrier(0);
+                auto xtmp = load<T, true>(i, offset + X_OFFSET, x);
 #pragma unroll
                 for(int k = 0; k < load_factor<T>; ++k)
                 {
-                    if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
-                           batch_s <
-                       VECTOR_SIZE * GRID_SIZE)
+                    x_values[index] = CVT_FLOAT2ACCUM(xdata.data[k]);
+                    if constexpr(!USE_SOFTMAX_FAST)
                     {
-                        values[index] = CVT_FLOAT2ACCUM(tmpx.data[k]);
-                        if constexpr(!USE_SOFTMAX_FAST)
-                        {
-                            tmp = max(values[index], tmp);
-                        }
+                        tmp = max(x_values[index], tmp);
                     }
                     ++index;
                 }
-                __builtin_amdgcn_sched_barrier(0);
-                tmpx = tmpdata;
+                xdata = xtmp;
             }
 #pragma unroll
             for(int k = 0; k < load_factor<T>; ++k)
             {
-                if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
-                       batch_s <
-                   VECTOR_SIZE * GRID_SIZE)
+                x_values[index] = CVT_FLOAT2ACCUM(xdata.data[k]);
+                if constexpr(!USE_SOFTMAX_FAST)
                 {
-                    values[index] = CVT_FLOAT2ACCUM(tmpx.data[k]);
-                    if constexpr(!USE_SOFTMAX_FAST)
-                    {
-                        tmp = max(values[index], tmp);
-                    }
+                    tmp = max(x_values[index], tmp);
                 }
                 ++index;
             }
         }
         else
         {
-            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
-                if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
+            for(unsigned int i = batch_lid; i < INNER_SIZE; i += BATCH_SIZE)
+            {
+                auto x_idx      = i * STRIDE + offset + X_OFFSET;
+                x_values[index] = CVT_FLOAT2ACCUM(x[x_idx]);
+                if constexpr(!USE_SOFTMAX_FAST)
                 {
-                    auto x_idx = get_x_index(batch_n, i, batch_s, batch_s0, batch_s1);
-
-                    values[index] = CVT_FLOAT2ACCUM(x[x_idx]);
-                    if constexpr(!USE_SOFTMAX_FAST)
-                    {
-                        tmp = max(values[index], tmp);
-                    }
+                    tmp = max(x_values[index], tmp);
                 }
                 ++index;
-            });
+            }
         }
 
-        FLOAT_ACCUM channel_max;
+        FLOAT_ACCUM channel_max = 0;
         if constexpr(!USE_SOFTMAX_FAST)
         {
-            reduce<BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_max);
-
+            reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_max);
             channel_max = ltmp[batch * BATCH_SIZE];
             __syncthreads();
         }
@@ -661,41 +466,28 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         {
             tmp = 0;
         }
-
-        // Subtract channel_max from each value
-        index = index0;
-        if constexpr(VECTORIZED_C_STREAM)
+        index = 0;
+        if constexpr(VECTORIZED)
         {
-            // Compute exponent of each value
-            // Then sum all the values touched by this thread
-            for(unsigned long i = batch_lid * load_factor<T>; i < VECTOR_SIZE;
+            for(unsigned int i = batch_lid * load_factor<T>; i < INNER_SIZE;
                 i += BATCH_SIZE * load_factor<T>)
             {
 #pragma unroll
                 for(int k = 0; k < load_factor<T>; ++k)
                 {
-                    if((batch_n * VECTOR_SIZE + i + k) * SPATIAL_DIM + batch_s <
-                       VECTOR_SIZE * GRID_SIZE)
+                    FLOAT_ACCUM x_value = x_values[index] - channel_max;
+                    if constexpr(USE_SOFTMAX_LOG)
                     {
-                        FLOAT_ACCUM value = values[index];
-                        if constexpr(!USE_SOFTMAX_FAST)
-                        {
-                            value -= channel_max;
-                        }
-                        if constexpr(!USE_SOFTMAX_LOG)
-                        {
-                            value = exp(value);
-                        }
-                        if constexpr(USE_SOFTMAX_LOG)
-                        {
-                            tmp = logaddexp(tmp, value);
-                        }
-                        else
-                        {
-                            tmp += value;
-                        }
-
-                        values[index] = value;
+                        tmp = logaddexp(tmp, x_value);
+                    }
+                    else
+                    {
+                        x_value = exp(x_value);
+                        tmp += x_value;
+                    }
+                    if constexpr(!USE_SOFTMAX_FAST || !USE_SOFTMAX_LOG)
+                    {
+                        x_values[index] = x_value;
                     }
                     ++index;
                 }
@@ -703,149 +495,103 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         }
         else
         {
-            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
-                // Compute exponent of each value
-                // Then sum all the values touched by this thread
-                FLOAT_ACCUM value = values[index];
-                if constexpr(!USE_SOFTMAX_FAST)
-                {
-                    value -= channel_max;
-                }
-                if constexpr(!USE_SOFTMAX_LOG)
-                {
-                    value = exp(value);
-                }
+            for(unsigned int i = batch_lid; i < INNER_SIZE; i += BATCH_SIZE)
+            {
+                FLOAT_ACCUM x_value = x_values[index] - channel_max;
                 if constexpr(USE_SOFTMAX_LOG)
                 {
-                    tmp = logaddexp(tmp, value);
+                    tmp = logaddexp(tmp, x_value);
                 }
                 else
                 {
-                    tmp += value;
+                    x_value = exp(x_value);
+                    tmp += x_value;
                 }
-
-                values[index] = value;
+                if constexpr(!USE_SOFTMAX_FAST || !USE_SOFTMAX_LOG)
+                {
+                    x_values[index] = x_value;
+                }
                 ++index;
-            });
+            }
         }
-
-        reduce<BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_sum_log);
-
+        reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_sum_log);
         FLOAT_ACCUM channel_sum = ltmp[batch * BATCH_SIZE];
 
-        // Normalize each value in the channel by the channel_sum
-        index = index0;
-        if constexpr(VECTORIZED_C_STREAM)
+        index = 0;
+        if constexpr(VECTORIZED)
         {
-            unsigned long i = batch_lid * load_factor<T>;
-            auto y_offset   = get_y_index(batch_n, 0, batch_s, batch_s0, batch_s1);
-            vec_t<T> tmpy;
-            if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
-            {
-                tmpy = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-            }
+            unsigned int i = batch_lid * load_factor<T>;
+            auto ydata     = load(i, offset + Y_OFFSET, y);
             i += BATCH_SIZE * load_factor<T>;
-            for(; i < VECTOR_SIZE; i += BATCH_SIZE * load_factor<T>)
+            for(; i < INNER_SIZE; i += BATCH_SIZE * load_factor<T>)
             {
-                auto tmpdata    = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-                vec_t<T> tmpout = {{}};
-                __builtin_amdgcn_sched_barrier(0);
+                auto ytmp = load(i, offset + Y_OFFSET, y);
 #pragma unroll
                 for(int k = 0; k < load_factor<T>; ++k)
                 {
-                    if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
-                           batch_s <
-                       VECTOR_SIZE * GRID_SIZE)
+                    if constexpr(USE_SOFTMAX_LOG)
                     {
-                        if constexpr(USE_SOFTMAX_LOG)
-                        {
-                            values[index] -= channel_sum;
-                        }
-                        else
-                        {
-                            // Multiply by approximate reciprocal of channel_sum. The approximate
-                            // reciprocal is somewhat less accurate (1 ULP) than a full division,
-                            // but is noticeably more performant.
-                            values[index] *=
-                                __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
-                        }
-
-                        values[index] = values[index] * CVT_FP32_2ACCUM(alpha) +
-                                        CVT_FLOAT2ACCUM(tmpy.data[k]) * CVT_FP32_2ACCUM(beta);
-
-                        tmpy.data[k] = CVT_ACCUM2FLOAT(values[index]);
+                        x_values[index] -= channel_sum;
                     }
+                    else
+                    {
+                        // Multiply by approximate reciprocal of channel_sum. The approximate
+                        // reciprocal is somewhat less accurate (1 ULP) than a full division, but is
+                        // noticeably more performant.
+                        x_values[index] *=
+                            __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                    }
+                    x_values[index] = x_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                      CVT_FLOAT2ACCUM(ydata.data[k]) * CVT_FP32_2ACCUM(beta);
+                    ydata.data[k] = CVT_ACCUM2FLOAT(x_values[index]);
                     ++index;
                 }
-                __builtin_amdgcn_sched_barrier(0);
-                auto tmpyout = tmpy;
-                tmpy         = tmpdata;
-                store_if<T, VECTOR_SIZE * GRID_SIZE, true, SPATIAL_DIM>(
-                    i - BATCH_SIZE * load_factor<T>,
-                    y_offset,
-                    (batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T>)*SPATIAL_DIM + batch_s,
-                    y,
-                    tmpyout);
+                auto ytmpout = ydata;
+                ydata        = ytmp;
+                store(i - BATCH_SIZE * load_factor<T>, offset + Y_OFFSET, y, ytmpout);
             }
 #pragma unroll
             for(int k = 0; k < load_factor<T>; ++k)
             {
-                if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
-                       batch_s <
-                   VECTOR_SIZE * GRID_SIZE)
+                if constexpr(USE_SOFTMAX_LOG)
                 {
-                    if constexpr(USE_SOFTMAX_LOG)
-                    {
-                        values[index] -= channel_sum;
-                    }
-                    else
-                    {
-                        // Multiply by approximate reciprocal of channel_sum. The approximate
-                        // reciprocal is somewhat less accurate (1 ULP) than a full division, but is
-                        // noticeably more performant.
-                        values[index] *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
-                    }
-
-                    values[index] = values[index] * CVT_FP32_2ACCUM(alpha) +
-                                    CVT_FLOAT2ACCUM(tmpy.data[k]) * CVT_FP32_2ACCUM(beta);
-
-                    tmpy.data[k] = CVT_ACCUM2FLOAT(values[index]);
+                    x_values[index] -= channel_sum;
                 }
+                else
+                {
+                    // Multiply by approximate reciprocal of channel_sum. The approximate reciprocal
+                    // is somewhat less accurate (1 ULP) than a full division, but is noticeably
+                    // more performant.
+                    x_values[index] *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                }
+                x_values[index] = x_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                  CVT_FLOAT2ACCUM(ydata.data[k]) * CVT_FP32_2ACCUM(beta);
+                ydata.data[k] = CVT_ACCUM2FLOAT(x_values[index]);
                 ++index;
             }
-            store_if<T, VECTOR_SIZE * GRID_SIZE, true, SPATIAL_DIM>(
-                i - BATCH_SIZE * load_factor<T>,
-                y_offset,
-                (batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T>)*SPATIAL_DIM + batch_s,
-                y,
-                tmpy);
+            store(i - BATCH_SIZE * load_factor<T>, offset + Y_OFFSET, y, ydata);
         }
         else
         {
-            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
-                if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
+            for(unsigned int i = batch_lid; i < INNER_SIZE; i += BATCH_SIZE)
+            {
+                auto y_idx = i * STRIDE + offset + Y_OFFSET;
+                if constexpr(USE_SOFTMAX_LOG)
                 {
-                    auto y_idx = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1);
-
-                    if constexpr(USE_SOFTMAX_LOG)
-                    {
-                        values[index] -= channel_sum;
-                    }
-                    else
-                    {
-                        // Multiply by approximate reciprocal of channel_sum. The approximate
-                        // reciprocal is somewhat less accurate (1 ULP) than a full division, but is
-                        // noticeably more performant.
-                        values[index] *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
-                    }
-
-                    values[index] = values[index] * CVT_FP32_2ACCUM(alpha) +
-                                    CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
-
-                    y[y_idx] = CVT_ACCUM2FLOAT(values[index]);
+                    x_values[index] -= channel_sum;
                 }
+                else
+                {
+                    // Multiply by approximate reciprocal of channel_sum. The approximate reciprocal
+                    // is somewhat less accurate (1 ULP) than a full division, but is noticeably
+                    // more performant.
+                    x_values[index] *= __builtin_amdgcn_rcpf(channel_sum + EPSILON<FLOAT_ACCUM>);
+                }
+                x_values[index] = x_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                  CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
+                y[y_idx] = CVT_ACCUM2FLOAT(x_values[index]);
                 ++index;
-            });
+            }
         }
     }
 }
@@ -857,389 +603,299 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                                            const float alpha,
                                            const float beta)
 {
+    const unsigned int gid = blockIdx.x;
+    const unsigned int lid = threadIdx.x;
     __shared__ FLOAT_ACCUM ltmp[LOCAL_SIZE];
-
-    const auto lid = threadIdx.x;
 
     if constexpr(NUM_BATCH == 1) // CSR-Vector like approach
     {
-        // Total number of workgroups launched can be less than the gridsize, hence iterate over.
-        for(auto gid = blockIdx.x; gid < GRID_SIZE; gid += WORKGROUPS)
+        const unsigned int o      = gid / STRIDE;
+        const unsigned int s      = gid % STRIDE;
+        const unsigned int offset = o * INNER_SIZE * STRIDE + s;
+        FLOAT_ACCUM channel_dot   = 0;
+        if constexpr(VECTORIZED)
         {
-            auto n  = gid / SPATIAL_DIM; // nth image
-            auto s  = gid % SPATIAL_DIM; // spatial dimension (H * W)
-            auto s0 = s / WIDTH;
-            auto s1 = s % WIDTH;
-
-            // Compute dot product per channel
-            // Iterate over all the channels one thread is supposed to loop over
-            // and compute dot-product
-            FLOAT_ACCUM channel_dot = static_cast<FLOAT_ACCUM>(0);
-            if constexpr(VECTORIZED_C_Y && VECTORIZED_C_DY)
+            unsigned int i = lid * load_factor<T>;
+            auto dydata    = load(i, offset + DY_OFFSET, dy);
+            vec_t<T> ydata;
+            if constexpr(!USE_SOFTMAX_LOG)
             {
-                unsigned long i = lid * load_factor<T>;
-                auto dy_offset  = get_dy_index(n, 0, s, s0, s1);
-                int y_offset;
+                ydata = load(i, offset + Y_OFFSET, y);
+            }
+            i += LOCAL_SIZE * load_factor<T>;
+            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
+            {
+                auto dytmp = load(i, offset + DY_OFFSET, dy);
+                vec_t<T> ytmp;
                 if constexpr(!USE_SOFTMAX_LOG)
                 {
-                    y_offset = get_y_index(n, 0, s, s0, s1);
-                }
-                auto tmpdy = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
-                vec_t<T> tmpy;
-                if constexpr(!USE_SOFTMAX_LOG)
-                {
-                    tmpy = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-                }
-                i += LOCAL_SIZE * load_factor<T>;
-                for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
-                {
-                    auto tmpdydata = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
-                    vec_t<T> tmpydata;
-                    if constexpr(!USE_SOFTMAX_LOG)
-                    {
-                        tmpydata = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-                    }
-                    __builtin_amdgcn_sched_barrier(0);
-#pragma unroll
-                    for(int k = 0; k < load_factor<T>; ++k)
-                    {
-                        FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpdy.data[k]);
-                        if constexpr(!USE_SOFTMAX_LOG)
-                        {
-                            value *= CVT_FLOAT2ACCUM(tmpy.data[k]);
-                        }
-                        channel_dot += value;
-                    }
-                    __builtin_amdgcn_sched_barrier(0);
-                    tmpdy = tmpdydata;
-                    if constexpr(!USE_SOFTMAX_LOG)
-                    {
-                        tmpy = tmpydata;
-                    }
+                    ytmp = load(i, offset + Y_OFFSET, y);
                 }
 #pragma unroll
                 for(int k = 0; k < load_factor<T>; ++k)
                 {
-                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpdy.data[k]);
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dydata.data[k]);
                     if constexpr(!USE_SOFTMAX_LOG)
                     {
-                        value *= CVT_FLOAT2ACCUM(tmpy.data[k]);
+                        value *= CVT_FLOAT2ACCUM(ydata.data[k]);
                     }
                     channel_dot += value;
                 }
-            }
-            else
-            {
-                loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                    auto dy_idx = get_dy_index(n, i, s, s0, s1);
-                    auto y_idx  = get_y_index(n, i, s, s0, s1);
-
-                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
-                    if constexpr(!USE_SOFTMAX_LOG)
-                    {
-                        value *= CVT_FLOAT2ACCUM(y[y_idx]);
-                    }
-                    channel_dot += value;
-                });
-            }
-
-            reduce<LOCAL_SIZE>(ltmp, lid, lid, channel_dot, reduce_sum);
-
-            channel_dot = ltmp[0];
-
-            // Subtract and element-wise multiplication
-            if constexpr(VECTORIZED_C_Y && VECTORIZED_C_DX && VECTORIZED_C_DY)
-            {
-                unsigned long i = lid * load_factor<T>;
-                auto dy_offset  = get_dy_index(n, 0, s, s0, s1);
-                auto y_offset   = get_y_index(n, 0, s, s0, s1);
-                auto dx_offset  = get_dx_index(n, 0, s, s0, s1);
-                auto tmpdy      = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
-                auto tmpy       = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-                auto tmpdx      = load<T, VECTOR_SIZE, true>(i, dx_offset, dx);
-                i += LOCAL_SIZE * load_factor<T>;
-                for(; i < VECTOR_SIZE; i += LOCAL_SIZE * load_factor<T>)
+                dydata = dytmp;
+                if constexpr(!USE_SOFTMAX_LOG)
                 {
-                    auto tmpdydata = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
-                    auto tmpydata  = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-                    auto tmpdxdata = load<T, VECTOR_SIZE, true>(i, dx_offset, dx);
-                    __builtin_amdgcn_sched_barrier(0);
-#pragma unroll
-                    for(int k = 0; k < load_factor<T>; ++k)
-                    {
-                        FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpdy.data[k]);
-                        if constexpr(USE_SOFTMAX_LOG)
-                        {
-                            value -= channel_dot * exp(CVT_FLOAT2ACCUM(tmpy.data[k]));
-                        }
-                        else
-                        {
-                            value = (value - channel_dot) * CVT_FLOAT2ACCUM(tmpy.data[k]);
-                        }
-                        value = value * CVT_FP32_2ACCUM(alpha) +
-                                CVT_FLOAT2ACCUM(tmpdx.data[k]) * CVT_FP32_2ACCUM(beta);
-                        tmpdx.data[k] = CVT_ACCUM2FLOAT(value);
-                    }
-                    __builtin_amdgcn_sched_barrier(0);
-                    auto tmpdxout = tmpdx;
-                    tmpdy         = tmpdydata;
-                    tmpy          = tmpydata;
-                    tmpdx         = tmpdxdata;
-                    store<T, VECTOR_SIZE, true>(
-                        i - LOCAL_SIZE * load_factor<T>, dx_offset, dx, tmpdxout);
+                    ydata = ytmp;
                 }
+            }
+#pragma unroll
+            for(int k = 0; k < load_factor<T>; ++k)
+            {
+                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dydata.data[k]);
+                if constexpr(!USE_SOFTMAX_LOG)
+                {
+                    value *= CVT_FLOAT2ACCUM(ydata.data[k]);
+                }
+                channel_dot += value;
+            }
+        }
+        else
+        {
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+            {
+                auto dy_idx       = i * STRIDE + offset + DY_OFFSET;
+                auto y_idx        = i * STRIDE + offset + Y_OFFSET;
+                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
+                if constexpr(!USE_SOFTMAX_LOG)
+                {
+                    value *= CVT_FLOAT2ACCUM(y[y_idx]);
+                }
+                channel_dot += value;
+            }
+        }
+        reduce<LOCAL_SIZE>(ltmp, lid, channel_dot, reduce_sum);
+        channel_dot = ltmp[0];
+
+        if constexpr(VECTORIZED)
+        {
+            unsigned int i = lid * load_factor<T>;
+            auto dydata    = load(i, offset + DY_OFFSET, dy);
+            auto ydata     = load(i, offset + Y_OFFSET, y);
+            auto dxdata    = load(i, offset + DX_OFFSET, dx);
+            for(; i < INNER_SIZE; i += LOCAL_SIZE * load_factor<T>)
+            {
+                auto dytmp = load(i, offset + DY_OFFSET, dy);
+                auto ytmp  = load(i, offset + Y_OFFSET, y);
+                auto dxtmp = load(i, offset + DX_OFFSET, dx);
 #pragma unroll
                 for(int k = 0; k < load_factor<T>; ++k)
                 {
-                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(tmpdy.data[k]);
+                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dydata.data[k]);
                     if constexpr(USE_SOFTMAX_LOG)
                     {
-                        value -= channel_dot * exp(CVT_FLOAT2ACCUM(tmpy.data[k]));
+                        value -= channel_dot * exp(CVT_FLOAT2ACCUM(ydata.data[k]));
                     }
                     else
                     {
-                        value = (value - channel_dot) * CVT_FLOAT2ACCUM(tmpy.data[k]);
+                        value = (value - channel_dot) * CVT_FLOAT2ACCUM(ydata.data[k]);
                     }
                     value = value * CVT_FP32_2ACCUM(alpha) +
-                            CVT_FLOAT2ACCUM(tmpdx.data[k]) * CVT_FP32_2ACCUM(beta);
-                    tmpdx.data[k] = CVT_ACCUM2FLOAT(value);
+                            CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
+                    dxdata.data[k] = CVT_ACCUM2FLOAT(value);
                 }
-                store<T, VECTOR_SIZE, true>(i - LOCAL_SIZE * load_factor<T>, dx_offset, dx, tmpdx);
+                auto dxtmpout = dxdata;
+                dydata        = dytmp;
+                ydata         = ytmp;
+                dxdata        = dxtmp;
+                store(i - LOCAL_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxtmpout);
             }
-            else
+#pragma unroll
+            for(int k = 0; k < load_factor<T>; ++k)
             {
-                loop<VECTOR_SIZE, LOCAL_SIZE>(lid, [&](int i) {
-                    auto dy_idx = get_dy_index(n, i, s, s0, s1);
-                    auto y_idx  = get_y_index(n, i, s, s0, s1);
-                    auto dx_idx = get_dx_index(n, i, s, s0, s1);
-
-                    FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
-                    if constexpr(USE_SOFTMAX_LOG)
-                    {
-                        value -= channel_dot * exp(CVT_FLOAT2ACCUM(y[y_idx]));
-                    }
-                    else
-                    {
-                        value = (value - channel_dot) * CVT_FLOAT2ACCUM(y[y_idx]);
-                    }
-                    value = value * CVT_FP32_2ACCUM(alpha) +
-                            CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
-                    dx[dx_idx] = CVT_ACCUM2FLOAT(value);
-                });
+                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dydata.data[k]);
+                if constexpr(USE_SOFTMAX_LOG)
+                {
+                    value -= channel_dot * exp(CVT_FLOAT2ACCUM(ydata.data[k]));
+                }
+                else
+                {
+                    value = (value - channel_dot) * CVT_FLOAT2ACCUM(ydata.data[k]);
+                }
+                value = value * CVT_FP32_2ACCUM(alpha) +
+                        CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
+                dxdata.data[k] = CVT_ACCUM2FLOAT(value);
+            }
+            store(i - LOCAL_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
+        }
+        else
+        {
+            for(unsigned int i = lid; i < INNER_SIZE; i += LOCAL_SIZE)
+            {
+                auto dy_idx       = i * STRIDE + offset + DY_OFFSET;
+                auto y_idx        = i * STRIDE + offset + Y_OFFSET;
+                auto dx_idx       = i * STRIDE + offset + DX_OFFSET;
+                FLOAT_ACCUM value = CVT_FLOAT2ACCUM(dy[dy_idx]);
+                if constexpr(USE_SOFTMAX_LOG)
+                {
+                    value -= channel_dot * exp(CVT_FLOAT2ACCUM(y[y_idx]));
+                }
+                else
+                {
+                    value = (value - channel_dot) * CVT_FLOAT2ACCUM(y[y_idx]);
+                }
+                value = value * CVT_FP32_2ACCUM(alpha) +
+                        CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
+                dx[dx_idx] = CVT_ACCUM2FLOAT(value);
             }
         }
     }
     else // CSR-Stream like approach
     {
-        const auto gid = blockIdx.x;
-
-        // ID of the thread within the batch
-        const auto batch_lid = lid & (BATCH_SIZE - 1); // thread specific channel_st
-        const auto batch     = lid / BATCH_SIZE;       // which spatial_dim or pixel
-
-        // Batch specific n and s
-        const auto batch_n  = (NUM_BATCH * gid + batch) / SPATIAL_DIM; // nth image
-        const auto batch_s  = (NUM_BATCH * gid + batch) % SPATIAL_DIM; // which spatial_dim/pixel
-        const auto batch_s0 = batch_s / WIDTH;
-        const auto batch_s1 = batch_s % WIDTH;
-        FLOAT_ACCUM channel_dot = static_cast<FLOAT_ACCUM>(0);
-
-        // Vectorizations in CSR-Stream are dependent on each other due to the layout of `y_values`
-        // and `dy_values`
-        constexpr bool VECTORIZED_C_STREAM = VECTORIZED_C_Y && VECTORIZED_C_DX && VECTORIZED_C_DY;
-
-        // stores all the values touched by one thread so that we do not have load
-        // again as the CSR-Vector approach
-        FLOAT_ACCUM y_values[ADJUSTED_U_BATCH_SIZE<T, VECTORIZED_C_STREAM>]  = {0};
-        FLOAT_ACCUM dy_values[ADJUSTED_U_BATCH_SIZE<T, VECTORIZED_C_STREAM>] = {0};
-
-        // Compute dot product per channel
-        // BATCH_SIZE threads iterate over the channels
-        const auto index0 = batch_lid / BATCH_SIZE;
-        auto index        = index0;
-        if constexpr(VECTORIZED_C_STREAM)
+        const unsigned int batch_lid = lid % BATCH_SIZE;
+        const unsigned int batch     = lid / BATCH_SIZE;
+        const unsigned int o         = (NUM_BATCH * gid + batch) / STRIDE;
+        if(o >= OUTER_SIZE)
         {
-            unsigned long i = batch_lid * load_factor<T>;
-            auto y_offset   = get_y_index(batch_n, 0, batch_s, batch_s0, batch_s1);
-            auto dy_offset  = get_dy_index(batch_n, 0, batch_s, batch_s0, batch_s1);
-            vec_t<T> tmpy;
-            vec_t<T> tmpdy;
-            if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
-            {
-                tmpy  = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-                tmpdy = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
-            }
+            return;
+        }
+        const unsigned int s      = (NUM_BATCH * gid + batch) % STRIDE;
+        const unsigned int offset = o * INNER_SIZE * STRIDE + s;
+        FLOAT_ACCUM channel_dot   = 0;
+        FLOAT_ACCUM y_values[VALUES_SIZE<T>];
+        for(FLOAT_ACCUM& y_value : y_values)
+        {
+            y_value = 0;
+        }
+        FLOAT_ACCUM dy_values[VALUES_SIZE<T>];
+        for(FLOAT_ACCUM& dy_value : dy_values)
+        {
+            dy_value = 0;
+        }
+        unsigned int index = 0;
+        if constexpr(VECTORIZED)
+        {
+            unsigned int i = batch_lid * load_factor<T>;
+            auto ydata     = load(i, offset + Y_OFFSET, y);
+            auto dydata    = load(i, offset + DY_OFFSET, dy);
             i += BATCH_SIZE * load_factor<T>;
-            for(; i < VECTOR_SIZE; i += BATCH_SIZE * load_factor<T>)
+            for(; i < INNER_SIZE; i += BATCH_SIZE * load_factor<T>)
             {
-                auto tmpydata  = load<T, VECTOR_SIZE, true>(i, y_offset, y);
-                auto tmpdydata = load<T, VECTOR_SIZE, true>(i, dy_offset, dy);
-                __builtin_amdgcn_sched_barrier(0);
+                auto ytmp  = load(i, offset + Y_OFFSET, y);
+                auto dytmp = load(i, offset + DY_OFFSET, dy);
 #pragma unroll
                 for(int k = 0; k < load_factor<T>; ++k)
                 {
-                    if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
-                           batch_s <
-                       VECTOR_SIZE * GRID_SIZE)
-                    {
-                        y_values[index]  = CVT_FLOAT2ACCUM(tmpy.data[k]);
-                        dy_values[index] = CVT_FLOAT2ACCUM(tmpdy.data[k]);
-                        auto value       = dy_values[index];
-                        if constexpr(!USE_SOFTMAX_LOG)
-                        {
-                            value *= y_values[index];
-                        }
-                        channel_dot += value;
-                    }
-                    ++index;
-                }
-                __builtin_amdgcn_sched_barrier(0);
-                tmpy  = tmpydata;
-                tmpdy = tmpdydata;
-            }
-#pragma unroll
-            for(int k = 0; k < load_factor<T>; ++k)
-            {
-                if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
-                       batch_s <
-                   VECTOR_SIZE * GRID_SIZE)
-                {
-                    y_values[index]  = CVT_FLOAT2ACCUM(tmpy.data[k]);
-                    dy_values[index] = CVT_FLOAT2ACCUM(tmpdy.data[k]);
+                    y_values[index]  = CVT_FLOAT2ACCUM(ydata.data[k]);
+                    dy_values[index] = CVT_FLOAT2ACCUM(dydata.data[k]);
                     auto value       = dy_values[index];
                     if constexpr(!USE_SOFTMAX_LOG)
                     {
                         value *= y_values[index];
                     }
                     channel_dot += value;
+                    ++index;
                 }
+                ydata  = ytmp;
+                dydata = dytmp;
+            }
+#pragma unroll
+            for(int k = 0; k < load_factor<T>; ++k)
+            {
+                y_values[index]  = CVT_FLOAT2ACCUM(ydata.data[k]);
+                dy_values[index] = CVT_FLOAT2ACCUM(dydata.data[k]);
+                auto value       = dy_values[index];
+                if constexpr(!USE_SOFTMAX_LOG)
+                {
+                    value *= y_values[index];
+                }
+                channel_dot += value;
                 ++index;
             }
         }
         else
         {
-            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
-                if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
+            for(unsigned int i = batch_lid; i < INNER_SIZE; i += BATCH_SIZE)
+            {
+                auto y_idx       = i * STRIDE + offset + Y_OFFSET;
+                auto dy_idx      = i * STRIDE + offset + DY_OFFSET;
+                y_values[index]  = CVT_FLOAT2ACCUM(y[y_idx]);
+                dy_values[index] = CVT_FLOAT2ACCUM(dy[dy_idx]);
+                auto value       = dy_values[index];
+                if constexpr(!USE_SOFTMAX_LOG)
                 {
-                    auto y_idx  = get_y_index(batch_n, i, batch_s, batch_s0, batch_s1);
-                    auto dy_idx = get_dy_index(batch_n, i, batch_s, batch_s0, batch_s1);
-
-                    y_values[index]  = CVT_FLOAT2ACCUM(y[y_idx]);
-                    dy_values[index] = CVT_FLOAT2ACCUM(dy[dy_idx]);
-                    auto value       = dy_values[index];
-                    if constexpr(!USE_SOFTMAX_LOG)
-                    {
-                        value *= y_values[index];
-                    }
-                    channel_dot += value;
+                    value *= y_values[index];
                 }
+                channel_dot += value;
                 ++index;
-            });
+            }
         }
-
-        reduce<BATCH_SIZE>(ltmp, lid, batch_lid, channel_dot, reduce_sum);
-
+        reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, channel_dot, reduce_sum);
         channel_dot = ltmp[batch * BATCH_SIZE];
 
-        // Subtract and element-wise multiplication
-        index = index0;
-        if constexpr(VECTORIZED_C_STREAM)
+        index = 0;
+        if constexpr(VECTORIZED)
         {
-            unsigned long i = batch_lid * load_factor<T>;
-            auto dx_offset  = get_dx_index(batch_n, 0, batch_s, batch_s0, batch_s1);
-            vec_t<T> tmpdx;
-            if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
-            {
-                tmpdx = load<T, VECTOR_SIZE, true>(i, dx_offset, dx);
-            }
+            unsigned int i = batch_lid * load_factor<T>;
+            auto dxdata    = load(i, offset + DX_OFFSET, dx);
             i += BATCH_SIZE * load_factor<T>;
-            for(; i < VECTOR_SIZE; i += BATCH_SIZE * load_factor<T>)
+            for(; i < INNER_SIZE; i += BATCH_SIZE * load_factor<T>)
             {
-                auto tmpdata = load<T, VECTOR_SIZE, true>(i, dx_offset, dx);
-                __builtin_amdgcn_sched_barrier(0);
+                auto dxtmp = load(i, offset + DX_OFFSET, dx);
 #pragma unroll
                 for(int k = 0; k < load_factor<T>; ++k)
                 {
-                    if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
-                           batch_s <
-                       VECTOR_SIZE * GRID_SIZE)
+                    if constexpr(USE_SOFTMAX_LOG)
                     {
-                        if constexpr(USE_SOFTMAX_LOG)
-                        {
-                            dy_values[index] -= channel_dot * exp(y_values[index]);
-                        }
-                        else
-                        {
-                            dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
-                        }
-
-                        auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
-                                     CVT_FLOAT2ACCUM(tmpdx.data[k]) * CVT_FP32_2ACCUM(beta);
-                        tmpdx.data[k] = CVT_ACCUM2FLOAT(value);
+                        dy_values[index] -= channel_dot * exp(y_values[index]);
                     }
+                    else
+                    {
+                        dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
+                    }
+                    auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                                 CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
+                    dxdata.data[k] = CVT_ACCUM2FLOAT(value);
                     ++index;
                 }
-                __builtin_amdgcn_sched_barrier(0);
-                auto tmpdxout = tmpdx;
-                tmpdx         = tmpdata;
-                store_if<T, VECTOR_SIZE * GRID_SIZE, true, SPATIAL_DIM>(
-                    i - BATCH_SIZE * load_factor<T>,
-                    dx_offset,
-                    (batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T>)*SPATIAL_DIM + batch_s,
-                    dx,
-                    tmpdx);
+                auto dxtmpout = dxdata;
+                dxdata        = dxtmp;
+                store(i - BATCH_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxtmpout);
             }
 #pragma unroll
             for(int k = 0; k < load_factor<T>; ++k)
             {
-                if((batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T> + k) * SPATIAL_DIM +
-                       batch_s <
-                   VECTOR_SIZE * GRID_SIZE)
+                if constexpr(USE_SOFTMAX_LOG)
                 {
-                    if constexpr(USE_SOFTMAX_LOG)
-                    {
-                        dy_values[index] -= channel_dot * exp(y_values[index]);
-                    }
-                    else
-                    {
-                        dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
-                    }
-
-                    auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
-                                 CVT_FLOAT2ACCUM(tmpdx.data[k]) * CVT_FP32_2ACCUM(beta);
-                    tmpdx.data[k] = CVT_ACCUM2FLOAT(value);
+                    dy_values[index] -= channel_dot * exp(y_values[index]);
                 }
+                else
+                {
+                    dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
+                }
+                auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                             CVT_FLOAT2ACCUM(dxdata.data[k]) * CVT_FP32_2ACCUM(beta);
+                dxdata.data[k] = CVT_ACCUM2FLOAT(value);
                 ++index;
             }
-            store_if<T, VECTOR_SIZE * GRID_SIZE, true, SPATIAL_DIM>(
-                i - BATCH_SIZE * load_factor<T>,
-                dx_offset,
-                (batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T>)*SPATIAL_DIM + batch_s,
-                dx,
-                tmpdx);
+            store(i - BATCH_SIZE * load_factor<T>, offset + DX_OFFSET, dx, dxdata);
         }
         else
         {
-            loop<VECTOR_SIZE, BATCH_SIZE>(batch_lid, [&](int i) {
-                if((batch_n * VECTOR_SIZE + i) * SPATIAL_DIM + batch_s < VECTOR_SIZE * GRID_SIZE)
+            for(unsigned int i = batch_lid; i < INNER_SIZE; i += BATCH_SIZE)
+            {
+                auto dx_idx = i * STRIDE + offset + DX_OFFSET;
+                if constexpr(USE_SOFTMAX_LOG)
                 {
-                    auto dx_idx = get_dx_index(batch_n, i, batch_s, batch_s0, batch_s1);
-
-                    if constexpr(USE_SOFTMAX_LOG)
-                    {
-                        dy_values[index] -= channel_dot * exp(y_values[index]);
-                    }
-                    else
-                    {
-                        dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
-                    }
-
-                    auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
-                                 CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
-                    dx[dx_idx] = CVT_ACCUM2FLOAT(value);
+                    dy_values[index] -= channel_dot * exp(y_values[index]);
                 }
+                else
+                {
+                    dy_values[index] = (dy_values[index] - channel_dot) * y_values[index];
+                }
+                auto value = dy_values[index] * CVT_FP32_2ACCUM(alpha) +
+                             CVT_FLOAT2ACCUM(dx[dx_idx]) * CVT_FP32_2ACCUM(beta);
+                dx[dx_idx] = CVT_ACCUM2FLOAT(value);
                 ++index;
-            });
+            }
         }
     }
 }

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -95,6 +95,30 @@ store(unsigned long i, const unsigned long i_offset, T* __restrict__ dst, vec_t<
     }
 }
 
+template <typename T, unsigned int BOUND, bool IS_CONTIGUOUS, unsigned int I_COND_STRIDE = 1>
+__forceinline__ __device__ static void store_if(unsigned long i,
+                                                const unsigned long i_offset,
+                                                unsigned long i_cond,
+                                                T* __restrict__ dst,
+                                                vec_t<T>& data)
+{
+    if(IS_CONTIGUOUS && i_cond + I_COND_STRIDE * load_factor<T> < BOUND)
+    {
+        *reinterpret_cast<load_t*>(&dst[i + i_offset]) = *reinterpret_cast<load_t*>(&data);
+    }
+    else
+    {
+#pragma unroll
+        for(int k = 0; k < load_factor<T>; ++k)
+        {
+            if(i_cond + k * I_COND_STRIDE < BOUND)
+            {
+                dst[i + k + i_offset] = data.data[k];
+            }
+        }
+    }
+}
+
 template <typename T>
 __device__ T logaddexp(T x, T y)
 {
@@ -756,7 +780,12 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 __builtin_amdgcn_sched_barrier(0);
                 auto tmpyout = tmpy;
                 tmpy         = tmpdata;
-                store<T, VECTOR_SIZE, true>(i - BATCH_SIZE * load_factor<T>, y_offset, y, tmpyout);
+                store_if<T, VECTOR_SIZE * GRID_SIZE, true, SPATIAL_DIM>(
+                    i - BATCH_SIZE * load_factor<T>,
+                    y_offset,
+                    (batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T>)*SPATIAL_DIM + batch_s,
+                    y,
+                    tmpyout);
             }
 #pragma unroll
             for(int k = 0; k < load_factor<T>; ++k)
@@ -784,7 +813,12 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 }
                 ++index;
             }
-            store<T, VECTOR_SIZE, true>(i - BATCH_SIZE * load_factor<T>, y_offset, y, tmpy);
+            store_if<T, VECTOR_SIZE * GRID_SIZE, true, SPATIAL_DIM>(
+                i - BATCH_SIZE * load_factor<T>,
+                y_offset,
+                (batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T>)*SPATIAL_DIM + batch_s,
+                y,
+                tmpy);
         }
         else
         {
@@ -1148,8 +1182,12 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 __builtin_amdgcn_sched_barrier(0);
                 auto tmpdxout = tmpdx;
                 tmpdx         = tmpdata;
-                store<T, VECTOR_SIZE, true>(
-                    i - BATCH_SIZE * load_factor<T>, dx_offset, dx, tmpdxout);
+                store_if<T, VECTOR_SIZE * GRID_SIZE, true, SPATIAL_DIM>(
+                    i - BATCH_SIZE * load_factor<T>,
+                    dx_offset,
+                    (batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T>)*SPATIAL_DIM + batch_s,
+                    dx,
+                    tmpdx);
             }
 #pragma unroll
             for(int k = 0; k < load_factor<T>; ++k)
@@ -1173,7 +1211,12 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 }
                 ++index;
             }
-            store<T, VECTOR_SIZE, true>(i - BATCH_SIZE * load_factor<T>, dx_offset, dx, tmpdx);
+            store_if<T, VECTOR_SIZE * GRID_SIZE, true, SPATIAL_DIM>(
+                i - BATCH_SIZE * load_factor<T>,
+                dx_offset,
+                (batch_n * VECTOR_SIZE + i - BATCH_SIZE * load_factor<T>)*SPATIAL_DIM + batch_s,
+                dx,
+                tmpdx);
         }
         else
         {

--- a/projects/miopen/src/kernels/MIOpenSoftmax.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmax.cpp
@@ -189,19 +189,20 @@ __forceinline__ __device__ void get_indices(unsigned int& gid, unsigned int& o, 
 {
     if constexpr(SEPARATE_STRIDE)
     {
-        o = blockIdx.x;
-        s = blockIdx.y;
+        o   = blockIdx.x;
+        s   = blockIdx.y;
         gid = o * STRIDE + s;
     }
     else
     {
         gid = blockIdx.x;
-        o = blockIdx.x / STRIDE;
-        s = blockIdx.x % STRIDE;
+        o   = blockIdx.x / STRIDE;
+        s   = blockIdx.x % STRIDE;
     }
 }
 
-__forceinline__ __device__ void get_indices_stream(unsigned int& o, unsigned int& s, const unsigned int batch)
+__forceinline__ __device__ void
+get_indices_stream(unsigned int& o, unsigned int& s, const unsigned int batch)
 {
     if constexpr(SEPARATE_STRIDE)
     {
@@ -260,9 +261,16 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                     tmp        = max(CVT_FLOAT2ACCUM(x[x_idx]), tmp);
                 }
             }
-            reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_max);
-            channel_max = ltmp[0];
-            __syncthreads();
+            if constexpr(LOCAL_SIZE > 1)
+            {
+                reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_max);
+                channel_max = ltmp[0];
+                __syncthreads();
+            }
+            else
+            {
+                channel_max = tmp;
+            }
         }
 
         if constexpr(USE_SOFTMAX_LOG)
@@ -326,9 +334,16 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 }
             }
         }
-        // TODO: if constexpr(LOCAL_SIZE > 1)
-        reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_sum_log);
-        FLOAT_ACCUM channel_sum = ltmp[0];
+        FLOAT_ACCUM channel_sum;
+        if constexpr(LOCAL_SIZE > 1)
+        {
+            reduce<LOCAL_SIZE>(ltmp, lid, tmp, reduce_sum_log);
+            channel_sum = ltmp[0];
+        }
+        else
+        {
+            channel_sum = tmp;
+        }
 
         if constexpr(VECTORIZED)
         {
@@ -426,7 +441,7 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         }
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM tmp           = -MAX_VAL_ACCUM;
-        FLOAT_ACCUM x_values[U_BATCH_SIZE * load_factor<T>]; // TODO: VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE
+        FLOAT_ACCUM x_values[VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE];
         for(FLOAT_ACCUM& x_value : x_values)
         {
             x_value = -MAX_VAL_ACCUM;
@@ -480,10 +495,16 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
         FLOAT_ACCUM channel_max = 0;
         if constexpr(!USE_SOFTMAX_FAST)
         {
-            // TODO: if constexpr(BATCH_SIZE > 1)
-            reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_max);
-            channel_max = ltmp[batch * BATCH_SIZE];
-            __syncthreads();
+            if constexpr(BATCH_SIZE > 1)
+            {
+                reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_max);
+                channel_max = ltmp[batch * BATCH_SIZE];
+                __syncthreads();
+            }
+            else
+            {
+                channel_max = tmp;
+            }
         }
 
         if constexpr(USE_SOFTMAX_LOG)
@@ -542,9 +563,16 @@ softmaxfwd(const T* __restrict__ x, T* __restrict__ y, const float alpha, const 
                 ++index;
             }
         }
-        // TODO: if constexpr(BATCH_SIZE > 1)
-        reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_sum_log);
-        FLOAT_ACCUM channel_sum = ltmp[batch * BATCH_SIZE];
+        FLOAT_ACCUM channel_sum;
+        if constexpr(BATCH_SIZE > 1)
+        {
+            reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, tmp, reduce_sum_log);
+            channel_sum = ltmp[batch * BATCH_SIZE];
+        }
+        else
+        {
+            channel_sum = tmp;
+        }
 
         index = 0;
         if constexpr(VECTORIZED)
@@ -699,9 +727,11 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 channel_dot += value;
             }
         }
-        // TODO: if constexpr(LOCAL_SIZE > 1)
-        reduce<LOCAL_SIZE>(ltmp, lid, channel_dot, reduce_sum);
-        channel_dot = ltmp[0];
+        if constexpr(LOCAL_SIZE > 1)
+        {
+            reduce<LOCAL_SIZE>(ltmp, lid, channel_dot, reduce_sum);
+            channel_dot = ltmp[0];
+        }
 
         if constexpr(VECTORIZED)
         {
@@ -782,20 +812,20 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
         get_indices(gid, o, s);
         const unsigned int batch_lid = lid % BATCH_SIZE;
         const unsigned int batch     = lid / BATCH_SIZE;
-        o         = (NUM_BATCH * gid + batch) / STRIDE;
+        o                            = (NUM_BATCH * gid + batch) / STRIDE;
         if(o >= OUTER_SIZE)
         {
             return;
         }
-        s      = (NUM_BATCH * gid + batch) % STRIDE;
+        s                         = (NUM_BATCH * gid + batch) % STRIDE;
         const unsigned int offset = o * INNER_SIZE * STRIDE + s;
         FLOAT_ACCUM channel_dot   = 0;
-        FLOAT_ACCUM y_values[U_BATCH_SIZE * load_factor<T>];
+        FLOAT_ACCUM y_values[VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE];
         for(FLOAT_ACCUM& y_value : y_values)
         {
             y_value = 0;
         }
-        FLOAT_ACCUM dy_values[U_BATCH_SIZE * load_factor<T>];
+        FLOAT_ACCUM dy_values[VECTORIZED ? U_BATCH_SIZE * load_factor<T> : U_BATCH_SIZE];
         for(FLOAT_ACCUM& dy_value : dy_values)
         {
             dy_value = 0;
@@ -855,8 +885,11 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
                 ++index;
             }
         }
-        reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, channel_dot, reduce_sum);
-        channel_dot = ltmp[batch * BATCH_SIZE];
+        if constexpr(BATCH_SIZE > 1)
+        {
+            reduce_block<LOCAL_SIZE, BATCH_SIZE>(ltmp, lid, batch_lid, channel_dot, reduce_sum);
+            channel_dot = ltmp[batch * BATCH_SIZE];
+        }
 
         index = 0;
         if constexpr(VECTORIZED)
@@ -926,18 +959,19 @@ __forceinline__ __device__ void softmaxbwd(const T* __restrict__ y,
 }
 
 extern "C" __global__ __launch_bounds__(LOCAL_SIZE) void SoftmaxFwd(const DATA_TYPE* __restrict__ x,
-                                      DATA_TYPE* __restrict__ y,
-                                      const float alpha,
-                                      const float beta)
+                                                                    DATA_TYPE* __restrict__ y,
+                                                                    const float alpha,
+                                                                    const float beta)
 {
     softmaxfwd<DATA_TYPE>(x, y, alpha, beta);
 }
 
-extern "C" __global__ __launch_bounds__(LOCAL_SIZE) void SoftmaxBwd(const DATA_TYPE* __restrict__ y,
-                                      const DATA_TYPE* __restrict__ dy,
-                                      DATA_TYPE* __restrict__ dx,
-                                      const float alpha,
-                                      const float beta)
+extern "C" __global__
+__launch_bounds__(LOCAL_SIZE) void SoftmaxBwd(const DATA_TYPE* __restrict__ y,
+                                              const DATA_TYPE* __restrict__ dy,
+                                              DATA_TYPE* __restrict__ dx,
+                                              const float alpha,
+                                              const float beta)
 {
     softmaxbwd<DATA_TYPE>(y, dy, dx, alpha, beta);
 }

--- a/projects/miopen/src/kernels/MIOpenSoftmaxNoncontiguous.cpp
+++ b/projects/miopen/src/kernels/MIOpenSoftmaxNoncontiguous.cpp
@@ -301,7 +301,7 @@ __forceinline__ __device__ void softmaxfwd(const T* __restrict__ x,
                 value = value * CVT_FP32_2ACCUM(alpha);
                 if constexpr(!ZERO_BETA)
                 {
-                    value += CVT_FLOAT2ACCUM(y) * CVT_FP32_2ACCUM(beta);
+                    value += CVT_FLOAT2ACCUM(y[y_idx]) * CVT_FP32_2ACCUM(beta);
                 }
                 y[y_idx] = CVT_ACCUM2FLOAT(value);
             });

--- a/projects/miopen/src/softmax.cpp
+++ b/projects/miopen/src/softmax.cpp
@@ -104,10 +104,10 @@ miopenStatus_t SoftmaxForward(const Handle& handle,
         MIOPEN_THROW(miopenStatusBadParm, "Null pointer for tensor.");
     }
 
-    const auto problem = softmax::ProblemDescription{alpha, beta, xDesc, yDesc, algorithm, mode};
-    const auto invoke_params =
-        softmax::InvokeParams{alpha, beta, xDesc, x, yDesc, y, algorithm, mode, x_offset, y_offset};
-    const auto algo = AlgorithmName{"Softmax"};
+    const auto problem =
+        softmax::ProblemDescription{alpha, beta, xDesc, yDesc, algorithm, mode, x_offset, y_offset};
+    const auto invoke_params = softmax::InvokeParams{alpha, beta, xDesc, x, yDesc, y};
+    const auto algo          = AlgorithmName{"Softmax"};
     const auto solvers =
         solver::SolverContainer<solver::softmax::AttnSoftmax, solver::softmax::Softmax>{};
     solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
@@ -135,21 +135,9 @@ miopenStatus_t SoftmaxBackward(const Handle& handle,
         MIOPEN_THROW(miopenStatusBadParm, "Null pointer for tensor.");
     }
 
-    const auto problem =
-        softmax::ProblemDescription{alpha, beta, yDesc, dyDesc, dxDesc, algorithm, mode};
-    const auto invoke_params = softmax::InvokeParams{alpha,
-                                                     beta,
-                                                     yDesc,
-                                                     y,
-                                                     dyDesc,
-                                                     dy,
-                                                     dxDesc,
-                                                     dx,
-                                                     algorithm,
-                                                     mode,
-                                                     y_offset,
-                                                     dy_offset,
-                                                     dx_offset};
+    const auto problem = softmax::ProblemDescription{
+        alpha, beta, yDesc, dyDesc, dxDesc, algorithm, mode, y_offset, dy_offset, dx_offset};
+    const auto invoke_params = softmax::InvokeParams{alpha, beta, yDesc, y, dyDesc, dy, dxDesc, dx};
     const auto algo          = AlgorithmName{"Softmax"};
     const auto solvers       = solver::SolverContainer<solver::softmax::Softmax>{};
     solvers.ExecutePrimitive(handle, problem, algo, invoke_params);

--- a/projects/miopen/src/softmax/problem_description.cpp
+++ b/projects/miopen/src/softmax/problem_description.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
+#include "miopen/miopen.h"
+#include "miopen/tensor.hpp"
 #include <miopen/datatype.hpp>
 #include <miopen/softmax/problem_description.hpp>
 #include <miopen/names.hpp>
@@ -12,15 +14,52 @@ namespace miopen {
 
 namespace softmax {
 
+size_t GetStride(const TensorDescriptor& desc, miopenSoftmaxMode_t mode)
+{
+    size_t stride = 1;
+    auto layout   = desc.GetLayoutEnum();
+    auto lengths  = desc.GetLengths();
+    if(layout.has_value() && layout.value() == miopenTensorNCHW &&
+       mode == MIOPEN_SOFTMAX_MODE_CHANNEL)
+    {
+        stride = lengths[2] * lengths[3]; // stride = H * W
+    }
+    return stride;
+}
+
+size_t GetOuterSize(const TensorDescriptor& desc, miopenSoftmaxMode_t mode)
+{
+    auto lengths      = desc.GetLengths();
+    size_t outer_size = lengths[0]; // outer_size = N
+    auto layout       = desc.GetLayoutEnum();
+    if(layout.has_value() && layout.value() == miopenTensorNHWC &&
+       mode == MIOPEN_SOFTMAX_MODE_CHANNEL)
+    {
+        outer_size *= lengths[2] * lengths[3]; // outer_size = N * H * W
+    }
+    return outer_size;
+}
+
+size_t GetInnerSize(const TensorDescriptor& desc, miopenSoftmaxMode_t mode)
+{
+    auto lengths      = desc.GetLengths();
+    size_t inner_size = lengths[1]; // inner_size = C
+    if(mode == MIOPEN_SOFTMAX_MODE_INSTANCE)
+    {
+        inner_size *= lengths[2] * lengths[3]; // inner_size = C * H * W
+    }
+    return inner_size;
+}
+
 NetworkConfig ProblemDescription::MakeNetworkConfig() const
 {
     std::ostringstream ss(isForward ? "sfmfwd-" : "sfmbwd-");
 
     // all the tensors must be the same size and types
     // so we can use only one set of values
-    const auto& desc            = isForward ? xdxDesc : yDesc;
-    const auto [sn, sc, sh, sw] = tien<4>(desc.GetLengths());
-    ss << "n" << sn << "c" << sc << "h" << sh << "w" << sw;
+    const auto& desc = isForward ? xdxDesc : yDesc;
+    ss << "forward" << isForward;
+    ss << "outer_size" << outer_size << "inner_size" << inner_size << "stride" << stride;
     ss << GetDataType(desc.GetType());
     ss << "a" << alpha;
     ss << "b" << beta;
@@ -30,23 +69,6 @@ NetworkConfig ProblemDescription::MakeNetworkConfig() const
     ss << "y_offset" << y_offset;
     ss << "dx_offset" << dx_offset;
     ss << "dy_offset" << dy_offset;
-
-    auto printStrides = [&ss](std::string_view name, const miopen::TensorDescriptor& d) {
-        const auto [n, c, h, w] = tien<4>(d.GetStrides());
-        ss << name << "strides" << n << "x" << c << "x" << h << "x" << w;
-    };
-
-    if(isForward)
-    {
-        printStrides("x", xdxDesc);
-        printStrides("y", yDesc);
-    }
-    else
-    {
-        printStrides("y", yDesc);
-        printStrides("dy", dyDesc);
-        printStrides("dx", xdxDesc);
-    }
 
     return NetworkConfig{ss.str()};
 }

--- a/projects/miopen/src/softmax/problem_description.cpp
+++ b/projects/miopen/src/softmax/problem_description.cpp
@@ -26,6 +26,10 @@ NetworkConfig ProblemDescription::MakeNetworkConfig() const
     ss << "b" << beta;
     ss << "algo" << static_cast<int>(algorithm);
     ss << "mode" << static_cast<int>(mode);
+    ss << "x_offset" << x_offset;
+    ss << "y_offset" << y_offset;
+    ss << "dx_offset" << dx_offset;
+    ss << "dy_offset" << dy_offset;
 
     auto printStrides = [&ss](std::string_view name, const miopen::TensorDescriptor& d) {
         const auto [n, c, h, w] = tien<4>(d.GetStrides());

--- a/projects/miopen/src/solution.cpp
+++ b/projects/miopen/src/solution.cpp
@@ -472,10 +472,8 @@ void Solution::RunImpl(const Handle& handle,
 
     const softmax::ProblemDescription problem_description = problem_casted.AsSoftmax();
 
-    float alpha                        = softmax_desc.GetAlpha();
-    float beta                         = softmax_desc.GetBeta();
-    miopenSoftmaxAlgorithm_t algorithm = softmax_desc.GetAlgorithm();
-    miopenSoftmaxMode_t mode           = softmax_desc.GetMode();
+    float alpha = softmax_desc.GetAlpha();
+    float beta  = softmax_desc.GetBeta();
 
     const auto invoke_ctx = [&]() -> AnyInvokeParams {
         switch(problem_casted.GetDirection())
@@ -485,7 +483,7 @@ void Solution::RunImpl(const Handle& handle,
             auto y = get_input_checked(miopenTensorSoftmaxY, "miopenTensorSoftmaxY");
 
             return softmax::InvokeParams(
-                &alpha, &beta, *x.descriptor, x.buffer, *y.descriptor, y.buffer, algorithm, mode);
+                &alpha, &beta, *x.descriptor, x.buffer, *y.descriptor, y.buffer);
         }
         case miopenProblemDirectionBackward: {
             auto y  = get_input_checked(miopenTensorSoftmaxY, "miopenTensorSoftmaxY");
@@ -499,9 +497,7 @@ void Solution::RunImpl(const Handle& handle,
                                          *dy.descriptor,
                                          dy.buffer,
                                          *dx.descriptor,
-                                         dx.buffer,
-                                         algorithm,
-                                         mode);
+                                         dx.buffer);
         }
 
         default: MIOPEN_THROW(miopenStatusNotImplemented);

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -97,8 +97,8 @@ Softmax::GetDefaultPerformanceConfig(const ExecutionContext&,
 {
     PerformanceConfigSoftmax config;
     config.HeuristicInit(problem);
-    config.local_size = PerformanceConfigSoftmax::default_local_size;
-    config.vectorized = PerformanceConfigSoftmax::default_vectorized(problem);
+    config.local_size      = PerformanceConfigSoftmax::default_local_size;
+    config.vectorized      = PerformanceConfigSoftmax::default_vectorized(problem);
     config.separate_stride = PerformanceConfigSoftmax::default_separate_stride;
     MIOPEN_LOG_I(config.ToString());
     return config;
@@ -125,19 +125,18 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     size_t grid_size, xlocalsize, ygridsize;
     if(config.separate_stride)
     {
-        grid_size = problem.outer_size;
+        grid_size  = problem.outer_size;
         xlocalsize = config.local_size;
-        ygridsize = problem.stride;
+        ygridsize  = problem.stride;
     }
     else
     {
-        grid_size = problem.outer_size * problem.stride;
+        grid_size  = problem.outer_size * problem.stride;
         xlocalsize = config.local_size;
         ygridsize  = 1;
     }
-    auto num_batch        = problem.inner_size < xlocalsize
-                                ? nextPow2(xlocalsize / problem.inner_size)
-                                : 1;
+    auto num_batch =
+        problem.inner_size < xlocalsize ? nextPow2(xlocalsize / problem.inner_size) : 1;
     auto batch_size       = xlocalsize / num_batch;
     auto vectorized_count = dtype == miopenFloat ? 4 : 8;
     if(config.vectorized && num_batch > 1 && batch_size >= vectorized_count)
@@ -147,8 +146,8 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     }
     auto u_batch_size =
         batch_size < problem.inner_size ? nextPow2(problem.inner_size / batch_size) : 1;
-    auto workgroups = (grid_size + num_batch - 1) / num_batch;
-    size_t xgridsize = workgroups * xlocalsize;
+    auto workgroups   = (grid_size + num_batch - 1) / num_batch;
+    size_t xgridsize  = workgroups * xlocalsize;
     size_t ylocalsize = 1;
     size_t zlocalsize = 1;
     size_t zgridsize  = 1;
@@ -265,10 +264,11 @@ bool PerformanceConfigSoftmax::SetNextValue(const miopen::softmax::ProblemDescri
         local_size = start_local_size;
         vectorized = !start_vectorized;
     }
-    if(separate_stride == start_separate_stride && vectorized != start_vectorized && local_size > max_local_size)
+    if(separate_stride == start_separate_stride && vectorized != start_vectorized &&
+       local_size > max_local_size)
     {
-        local_size = start_local_size;
-        vectorized = start_vectorized;
+        local_size      = start_local_size;
+        vectorized      = start_vectorized;
         separate_stride = !start_separate_stride;
     }
     return local_size <= max_local_size;
@@ -305,7 +305,8 @@ bool PerformanceConfigSoftmax::IsValid(const ExecutionContext&,
 
 bool PerformanceConfigSoftmax::operator==(const PerformanceConfigSoftmax& other) const
 {
-    return local_size == other.local_size && vectorized == other.vectorized && separate_stride == other.separate_stride;
+    return local_size == other.local_size && vectorized == other.vectorized &&
+           separate_stride == other.separate_stride;
 }
 
 } // namespace softmax

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -98,6 +98,7 @@ Softmax::GetDefaultPerformanceConfig(const ExecutionContext&,
     PerformanceConfigSoftmax config;
     config.HeuristicInit(problem);
     config.local_size = PerformanceConfigSoftmax::default_local_size;
+    config.vectorized = PerformanceConfigSoftmax::default_vectorized;
     MIOPEN_LOG_I(config.ToString());
     return config;
 }
@@ -173,6 +174,7 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
         {"NUM_BATCH", num_batch},
         {"BATCH_SIZE", batch_size},
         {"U_BATCH_SIZE", u_batch_size},
+        {"VECTORIZED", config.vectorized},
         {"IS_INPUT_CONTIGUOUS", problem.IsForward() && problem.GetXDesc().IsContiguous()},
         {"IS_OUTPUT_CONTIGUOUS", problem.GetYDesc().IsContiguous()},
         {"IS_DINPUT_CONTIGUOUS", !problem.IsForward() && problem.GetdXDesc().IsContiguous()},
@@ -225,7 +227,10 @@ void PerformanceConfigSoftmax::HeuristicInit(const miopen::softmax::ProblemDescr
     {
     case miopenHalf:
     case miopenFloat:
-    case miopenBFloat16: local_size = PerformanceConfigSoftmax::start_local_size; break;
+    case miopenBFloat16:
+        local_size = PerformanceConfigSoftmax::start_local_size;
+        vectorized = PerformanceConfigSoftmax::start_vectorized;
+        break;
     case miopenDouble:
     case miopenFloat8_fnuz:
     case miopenBFloat8_fnuz:
@@ -248,11 +253,16 @@ bool PerformanceConfigSoftmax::SetNextValue(const miopen::softmax::ProblemDescri
     {
         HeuristicInit(problem);
     }
-    if(local_size <= 0)
+    if(local_size < start_local_size)
     {
-        MIOPEN_THROW(miopenStatusInvalidValue, "Local size zero or negative");
+        MIOPEN_THROW(miopenStatusInvalidValue, "Local size below valid value");
     }
     local_size *= 2;
+    if(vectorized == start_vectorized && local_size > max_local_size)
+    {
+        local_size = start_local_size;
+        vectorized = !start_vectorized;
+    }
     return local_size <= max_local_size;
 #endif
 }

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -100,7 +100,6 @@ Softmax::GetDefaultPerformanceConfig(const ExecutionContext&,
     config.local_size = PerformanceConfigSoftmax::default_local_size;
     config.vectorized = PerformanceConfigSoftmax::default_vectorized(problem);
     config.separate_stride = PerformanceConfigSoftmax::default_separate_stride;
-    config.stride_in_local_size = PerformanceConfigSoftmax::default_stride_in_local_size;
     MIOPEN_LOG_I(config.ToString());
     return config;
 }
@@ -123,19 +122,17 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     auto algorithm  = problem.GetAlgorithm();
     auto mode       = problem.GetMode();
 
-    size_t grid_size, xlocalsize, ylocalsize, ygridsize;
+    size_t grid_size, xlocalsize, ygridsize;
     if(config.separate_stride)
     {
         grid_size = problem.outer_size;
-        xlocalsize = problem.stride <= config.local_size && config.stride_in_local_size ? config.local_size >> mloLg2(problem.stride) : config.local_size;
-        ylocalsize = problem.stride <= config.local_size && config.stride_in_local_size ? problem.stride : 1;
+        xlocalsize = config.local_size;
         ygridsize = problem.stride;
     }
     else
     {
         grid_size = problem.outer_size * problem.stride;
         xlocalsize = config.local_size;
-        ylocalsize = 1;
         ygridsize  = 1;
     }
     auto num_batch        = problem.inner_size < xlocalsize
@@ -152,6 +149,7 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
         batch_size < problem.inner_size ? nextPow2(problem.inner_size / batch_size) : 1;
     auto workgroups = (grid_size + num_batch - 1) / num_batch;
     size_t xgridsize = workgroups * xlocalsize;
+    size_t ylocalsize = 1;
     size_t zlocalsize = 1;
     size_t zgridsize  = 1;
 
@@ -177,8 +175,7 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
                               {"OUTER_SIZE", problem.outer_size},
                               {"INNER_SIZE", problem.inner_size},
                               {"STRIDE", problem.stride},
-                              {"LOCAL_SIZE_X", xlocalsize},
-                              {"LOCAL_SIZE_Y", ylocalsize},
+                              {"LOCAL_SIZE", xlocalsize},
                               {"NUM_BATCH", num_batch},
                               {"BATCH_SIZE", batch_size},
                               {"U_BATCH_SIZE", u_batch_size},
@@ -274,13 +271,6 @@ bool PerformanceConfigSoftmax::SetNextValue(const miopen::softmax::ProblemDescri
         vectorized = start_vectorized;
         separate_stride = !start_separate_stride;
     }
-    if(stride_in_local_size == start_stride_in_local_size && separate_stride == !start_separate_stride && vectorized == !start_vectorized && local_size > max_local_size)
-    {
-        local_size = start_local_size;
-        vectorized = start_vectorized;
-        separate_stride = start_separate_stride;
-        stride_in_local_size = !start_stride_in_local_size;
-    }
     return local_size <= max_local_size;
 #endif
 }
@@ -301,7 +291,7 @@ bool PerformanceConfigSoftmax::IsValid(const ExecutionContext&,
     {
     case miopenHalf:
     case miopenFloat:
-    case miopenBFloat16: return !(stride_in_local_size && problem.stride > local_size) && !((separate_stride || stride_in_local_size) && problem.stride == 1) && !(!separate_stride && stride_in_local_size) && IsValidValue();
+    case miopenBFloat16: return !(separate_stride && problem.stride == 1) && IsValidValue();
     case miopenDouble:
     case miopenFloat8_fnuz:
     case miopenBFloat8_fnuz:
@@ -315,7 +305,7 @@ bool PerformanceConfigSoftmax::IsValid(const ExecutionContext&,
 
 bool PerformanceConfigSoftmax::operator==(const PerformanceConfigSoftmax& other) const
 {
-    return local_size == other.local_size && vectorized == other.vectorized && separate_stride == other.separate_stride && stride_in_local_size == other.stride_in_local_size;
+    return local_size == other.local_size && vectorized == other.vectorized && separate_stride == other.separate_stride;
 }
 
 } // namespace softmax

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -155,6 +155,10 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
         {"USE_SOFTMAX_LOG", algorithm == MIOPEN_SOFTMAX_LOG},
         {"USE_SOFTMAX_MODE_INSTANCE", mode == MIOPEN_SOFTMAX_MODE_INSTANCE},
         {"USE_SOFTMAX_MODE_CHANNEL", mode == MIOPEN_SOFTMAX_MODE_CHANNEL},
+        {"X_OFFSET", problem.GetXOffset()},
+        {"Y_OFFSET", problem.GetYOffset()},
+        {"DX_OFFSET", problem.GetdXOffset()},
+        {"DY_OFFSET", problem.GetdYOffset()},
         {"HEIGHT", lengths[2]},
         {"WIDTH", lengths[3]},
         {"N_STRIDE", strides[0]},
@@ -193,12 +197,7 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
                 decltype(auto) kernel_ = handle_.Run(kernels.front());
                 decltype(auto) params  = raw_params.CastTo<miopen::softmax::InvokeParams>();
 
-                kernel_(params.x,
-                        params.forward_y,
-                        params.xdx_offset,
-                        params.y_offset,
-                        params.alpha,
-                        params.beta);
+                kernel_(params.x, params.forward_y, params.alpha, params.beta);
             };
         };
     }
@@ -209,14 +208,7 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
                 decltype(auto) kernel_ = handle_.Run(kernels.front());
                 decltype(auto) params  = raw_params.CastTo<miopen::softmax::InvokeParams>();
 
-                kernel_(params.backward_y,
-                        params.dy,
-                        params.dx,
-                        params.y_offset,
-                        params.dy_offset,
-                        params.xdx_offset,
-                        params.alpha,
-                        params.beta);
+                kernel_(params.backward_y, params.dy, params.dx, params.alpha, params.beta);
             };
         };
     }

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -98,7 +98,9 @@ Softmax::GetDefaultPerformanceConfig(const ExecutionContext&,
     PerformanceConfigSoftmax config;
     config.HeuristicInit(problem);
     config.local_size = PerformanceConfigSoftmax::default_local_size;
-    config.vectorized = PerformanceConfigSoftmax::default_vectorized;
+    config.vectorized = PerformanceConfigSoftmax::default_vectorized(problem);
+    config.separate_stride = PerformanceConfigSoftmax::default_separate_stride;
+    config.stride_in_local_size = PerformanceConfigSoftmax::default_stride_in_local_size;
     MIOPEN_LOG_I(config.ToString());
     return config;
 }
@@ -121,25 +123,35 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     auto algorithm  = problem.GetAlgorithm();
     auto mode       = problem.GetMode();
 
-    auto grid_size        = problem.outer_size * problem.stride;
-    auto num_batch        = problem.inner_size < config.local_size
-                                ? nextPow2(config.local_size / problem.inner_size)
+    size_t grid_size, xlocalsize, ylocalsize, ygridsize;
+    if(config.separate_stride)
+    {
+        grid_size = problem.outer_size;
+        xlocalsize = problem.stride <= config.local_size && config.stride_in_local_size ? config.local_size >> mloLg2(problem.stride) : config.local_size;
+        ylocalsize = problem.stride <= config.local_size && config.stride_in_local_size ? problem.stride : 1;
+        ygridsize = problem.stride;
+    }
+    else
+    {
+        grid_size = problem.outer_size * problem.stride;
+        xlocalsize = config.local_size;
+        ylocalsize = 1;
+        ygridsize  = 1;
+    }
+    auto num_batch        = problem.inner_size < xlocalsize
+                                ? nextPow2(xlocalsize / problem.inner_size)
                                 : 1;
-    auto batch_size       = config.local_size / num_batch;
+    auto batch_size       = xlocalsize / num_batch;
     auto vectorized_count = dtype == miopenFloat ? 4 : 8;
-    if(num_batch > 1 && batch_size >= vectorized_count)
+    if(config.vectorized && num_batch > 1 && batch_size >= vectorized_count)
     {
         num_batch *= vectorized_count;
         batch_size /= vectorized_count;
     }
-    auto workgroups = (grid_size + num_batch - 1) / num_batch;
     auto u_batch_size =
         batch_size < problem.inner_size ? nextPow2(problem.inner_size / batch_size) : 1;
-
-    size_t xlocalsize = config.local_size;
-    size_t xgridsize  = workgroups * xlocalsize;
-    size_t ylocalsize = 1;
-    size_t ygridsize  = 1;
+    auto workgroups = (grid_size + num_batch - 1) / num_batch;
+    size_t xgridsize = workgroups * xlocalsize;
     size_t zlocalsize = 1;
     size_t zgridsize  = 1;
 
@@ -165,11 +177,13 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
                               {"OUTER_SIZE", problem.outer_size},
                               {"INNER_SIZE", problem.inner_size},
                               {"STRIDE", problem.stride},
-                              {"LOCAL_SIZE", config.local_size},
+                              {"LOCAL_SIZE_X", xlocalsize},
+                              {"LOCAL_SIZE_Y", ylocalsize},
                               {"NUM_BATCH", num_batch},
                               {"BATCH_SIZE", batch_size},
                               {"U_BATCH_SIZE", u_batch_size},
-                              {"VECTORIZED", config.vectorized}};
+                              {"VECTORIZED", config.vectorized},
+                              {"SEPARATE_STRIDE", config.separate_stride}};
 
     kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
 
@@ -254,6 +268,19 @@ bool PerformanceConfigSoftmax::SetNextValue(const miopen::softmax::ProblemDescri
         local_size = start_local_size;
         vectorized = !start_vectorized;
     }
+    if(separate_stride == start_separate_stride && vectorized != start_vectorized && local_size > max_local_size)
+    {
+        local_size = start_local_size;
+        vectorized = start_vectorized;
+        separate_stride = !start_separate_stride;
+    }
+    if(stride_in_local_size == start_stride_in_local_size && separate_stride == !start_separate_stride && vectorized == !start_vectorized && local_size > max_local_size)
+    {
+        local_size = start_local_size;
+        vectorized = start_vectorized;
+        separate_stride = start_separate_stride;
+        stride_in_local_size = !start_stride_in_local_size;
+    }
     return local_size <= max_local_size;
 #endif
 }
@@ -274,7 +301,7 @@ bool PerformanceConfigSoftmax::IsValid(const ExecutionContext&,
     {
     case miopenHalf:
     case miopenFloat:
-    case miopenBFloat16: return true;
+    case miopenBFloat16: return !(stride_in_local_size && problem.stride > local_size) && !((separate_stride || stride_in_local_size) && problem.stride == 1) && !(!separate_stride && stride_in_local_size) && IsValidValue();
     case miopenDouble:
     case miopenFloat8_fnuz:
     case miopenBFloat8_fnuz:
@@ -288,7 +315,7 @@ bool PerformanceConfigSoftmax::IsValid(const ExecutionContext&,
 
 bool PerformanceConfigSoftmax::operator==(const PerformanceConfigSoftmax& other) const
 {
-    return local_size == other.local_size;
+    return local_size == other.local_size && vectorized == other.vectorized && separate_stride == other.separate_stride && stride_in_local_size == other.stride_in_local_size;
 }
 
 } // namespace softmax

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -139,13 +139,17 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
         problem.inner_size < xlocalsize ? nextPow2(xlocalsize / problem.inner_size) : 1;
     auto batch_size       = xlocalsize / num_batch;
     auto vectorized_count = dtype == miopenFloat ? 4 : 8;
-    if(config.vectorized && num_batch > 1 && batch_size >= vectorized_count)
-    {
-        num_batch *= vectorized_count;
-        batch_size /= vectorized_count;
-    }
     auto u_batch_size =
         batch_size < problem.inner_size ? nextPow2(problem.inner_size / batch_size) : 1;
+    if(config.vectorized)
+    {
+        if(num_batch > 1 && batch_size >= vectorized_count)
+        {
+            num_batch *= vectorized_count;
+            batch_size /= vectorized_count;
+        }
+        u_batch_size *= vectorized_count;
+    }
     auto workgroups   = (grid_size + num_batch - 1) / num_batch;
     size_t xgridsize  = workgroups * xlocalsize;
     size_t ylocalsize = 1;

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -121,12 +121,18 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     auto algorithm  = problem.GetAlgorithm();
     auto mode       = problem.GetMode();
 
-    auto grid_size  = problem.outer_size * problem.stride;
-    auto num_batch  = problem.inner_size < config.local_size
-                          ? nextPow2(config.local_size / problem.inner_size)
-                          : 1;
+    auto grid_size        = problem.outer_size * problem.stride;
+    auto num_batch        = problem.inner_size < config.local_size
+                                ? nextPow2(config.local_size / problem.inner_size)
+                                : 1;
+    auto batch_size       = config.local_size / num_batch;
+    auto vectorized_count = dtype == miopenFloat ? 4 : 8;
+    if(num_batch > 1 && batch_size >= vectorized_count)
+    {
+        num_batch *= vectorized_count;
+        batch_size /= vectorized_count;
+    }
     auto workgroups = (grid_size + num_batch - 1) / num_batch;
-    auto batch_size = config.local_size / num_batch;
     auto u_batch_size =
         batch_size < problem.inner_size ? nextPow2(problem.inner_size / batch_size) : 1;
 

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -116,23 +116,19 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
-    auto lengths    = problem.GetXDesc().GetLengths();
-    auto strides    = problem.GetXDesc().GetStrides();
     auto dtype      = problem.GetXDesc().GetType();
-    auto data_dtype = miopen::GetDataType(problem.GetXDesc().GetType());
+    auto data_dtype = miopen::GetDataType(dtype);
     auto algorithm  = problem.GetAlgorithm();
     auto mode       = problem.GetMode();
 
-    auto grid_size =
-        mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? lengths[0] : lengths[0] * lengths[2] * lengths[3];
-    auto spatial_dim = mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? 1 : lengths[2] * lengths[3];
-    auto vector_size =
-        mode == MIOPEN_SOFTMAX_MODE_INSTANCE ? lengths[1] * lengths[2] * lengths[3] : lengths[1];
-    auto num_batch =
-        vector_size < config.local_size ? nextPow2(config.local_size / vector_size) : 1;
-    auto workgroups   = num_batch == 1 ? grid_size : (grid_size + num_batch - 1) / num_batch;
-    auto batch_size   = config.local_size / num_batch;
-    auto u_batch_size = vector_size > batch_size ? nextPow2(vector_size / batch_size) : 1;
+    auto grid_size  = problem.outer_size * problem.stride;
+    auto num_batch  = problem.inner_size < config.local_size
+                          ? nextPow2(config.local_size / problem.inner_size)
+                          : 1;
+    auto workgroups = (grid_size + num_batch - 1) / num_batch;
+    auto batch_size = config.local_size / num_batch;
+    auto u_batch_size =
+        batch_size < problem.inner_size ? nextPow2(problem.inner_size / batch_size) : 1;
 
     size_t xlocalsize = config.local_size;
     size_t xgridsize  = workgroups * xlocalsize;
@@ -146,39 +142,28 @@ ConvSolution Softmax::GetSolution([[maybe_unused]] const ExecutionContext& conte
     kernel.kernel_file = "MIOpenSoftmax.cpp";
     kernel.kernel_name = problem.IsForward() ? "SoftmaxFwd" : "SoftmaxBwd";
 
-    const auto build_params = KernelBuildParameters{
-        {"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
-        {"MIOPEN_USE_FP32", static_cast<int>(dtype == miopenFloat)},
-        {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
-        {"DATA_TYPE", data_dtype == "bfloat16" ? "ushort" : data_dtype},
-        {"USE_SOFTMAX_FAST", algorithm == MIOPEN_SOFTMAX_FAST},
-        {"USE_SOFTMAX_ACCURATE", algorithm == MIOPEN_SOFTMAX_ACCURATE},
-        {"USE_SOFTMAX_LOG", algorithm == MIOPEN_SOFTMAX_LOG},
-        {"USE_SOFTMAX_MODE_INSTANCE", mode == MIOPEN_SOFTMAX_MODE_INSTANCE},
-        {"USE_SOFTMAX_MODE_CHANNEL", mode == MIOPEN_SOFTMAX_MODE_CHANNEL},
-        {"X_OFFSET", problem.GetXOffset()},
-        {"Y_OFFSET", problem.GetYOffset()},
-        {"DX_OFFSET", problem.GetdXOffset()},
-        {"DY_OFFSET", problem.GetdYOffset()},
-        {"HEIGHT", lengths[2]},
-        {"WIDTH", lengths[3]},
-        {"N_STRIDE", strides[0]},
-        {"C_STRIDE", strides[1]},
-        {"H_STRIDE", strides[2]},
-        {"W_STRIDE", strides[3]},
-        {"LOCAL_SIZE", config.local_size},
-        {"WORKGROUPS", workgroups},
-        {"GRID_SIZE", grid_size},
-        {"SPATIAL_DIM", spatial_dim},
-        {"VECTOR_SIZE", vector_size},
-        {"NUM_BATCH", num_batch},
-        {"BATCH_SIZE", batch_size},
-        {"U_BATCH_SIZE", u_batch_size},
-        {"VECTORIZED", config.vectorized},
-        {"IS_INPUT_CONTIGUOUS", problem.IsForward() && problem.GetXDesc().IsContiguous()},
-        {"IS_OUTPUT_CONTIGUOUS", problem.GetYDesc().IsContiguous()},
-        {"IS_DINPUT_CONTIGUOUS", !problem.IsForward() && problem.GetdXDesc().IsContiguous()},
-        {"IS_DOUTPUT_CONTIGUOUS", !problem.IsForward() && problem.GetdYDesc().IsContiguous()}};
+    const auto build_params =
+        KernelBuildParameters{{"MIOPEN_USE_FP16", static_cast<int>(dtype == miopenHalf)},
+                              {"MIOPEN_USE_FP32", static_cast<int>(dtype == miopenFloat)},
+                              {"MIOPEN_USE_BFP16", static_cast<int>(dtype == miopenBFloat16)},
+                              {"DATA_TYPE", data_dtype == "bfloat16" ? "ushort" : data_dtype},
+                              {"USE_SOFTMAX_FAST", algorithm == MIOPEN_SOFTMAX_FAST},
+                              {"USE_SOFTMAX_ACCURATE", algorithm == MIOPEN_SOFTMAX_ACCURATE},
+                              {"USE_SOFTMAX_LOG", algorithm == MIOPEN_SOFTMAX_LOG},
+                              {"USE_SOFTMAX_MODE_INSTANCE", mode == MIOPEN_SOFTMAX_MODE_INSTANCE},
+                              {"USE_SOFTMAX_MODE_CHANNEL", mode == MIOPEN_SOFTMAX_MODE_CHANNEL},
+                              {"X_OFFSET", problem.GetXOffset()},
+                              {"Y_OFFSET", problem.GetYOffset()},
+                              {"DX_OFFSET", problem.GetdXOffset()},
+                              {"DY_OFFSET", problem.GetdYOffset()},
+                              {"OUTER_SIZE", problem.outer_size},
+                              {"INNER_SIZE", problem.inner_size},
+                              {"STRIDE", problem.stride},
+                              {"LOCAL_SIZE", config.local_size},
+                              {"NUM_BATCH", num_batch},
+                              {"BATCH_SIZE", batch_size},
+                              {"U_BATCH_SIZE", u_batch_size},
+                              {"VECTORIZED", config.vectorized}};
 
     kernel.comp_options = build_params.GenerateFor(kbp::HIP{});
 

--- a/projects/miopen/src/solver/softmax/softmax.cpp
+++ b/projects/miopen/src/solver/softmax/softmax.cpp
@@ -66,7 +66,7 @@ bool Softmax::IsApplicable(
         {
             return false;
         }
-        if(!problem.GetXDesc().IsPacked() && !problem.GetYDesc().IsPacked())
+        if(!problem.GetXDesc().IsPacked() || !problem.GetYDesc().IsPacked())
         {
             return false;
         }

--- a/projects/miopen/test/gtest/soft_max.cpp
+++ b/projects/miopen/test/gtest/soft_max.cpp
@@ -687,15 +687,18 @@ struct GPU_Softmax_NonContiguous_FP32
     : public testing::TestWithParam<std::tuple<std::tuple<std::vector<size_t>, std::vector<size_t>>,
                                                miopenSoftmaxAlgorithm_t,
                                                miopenSoftmaxMode_t,
+                                               std::tuple<float, float>,
                                                int,
                                                int,
                                                int>>
 {
     void RunForward()
     {
-        auto&& handle                                                         = get_handle();
-        auto [tensorDimsStrides, algo, mode, xdx_offset, y_offset, dy_offset] = GetParam();
-        auto [dims, strides]                                                  = tensorDimsStrides;
+        auto&& handle = get_handle();
+        auto [tensorDimsStrides, algo, mode, alphaBeta, xdx_offset, y_offset, dy_offset] =
+            GetParam();
+        auto [dims, strides] = tensorDimsStrides;
+        auto [alpha, beta]   = alphaBeta;
 
         auto in_host   = tensor<float>{dims, strides}.generate(tensor_elem_gen_integer{5});
         size_t n_elems = dims[0] * strides[0];
@@ -716,7 +719,6 @@ struct GPU_Softmax_NonContiguous_FP32
                         xbuf[off(n, c, h, w) + xdx_offset] =
                             static_cast<float>((n * 13 + c * 7 + h * 3 + w + 1) % 5);
 
-        const float alpha = 1.0f, beta = 0.0f;
         auto in_dev  = handle.Write(xbuf);
         auto out_dev = handle.Write(ybuf);
 
@@ -784,6 +786,7 @@ struct GPU_Softmax_NonContiguous_FP32
                                 algo == MIOPEN_SOFTMAX_LOG
                                     ? xbuf[off(n, c, h, w) + xdx_offset] - mx - sum
                                     : std::exp(xbuf[off(n, c, h, w) + xdx_offset] - mx) / sum;
+                            ref        = alpha * ref + beta * ybuf[off(n, c, h, w) + y_offset];
                             double err = std::abs(ref - res[off(n, c, h, w) + y_offset]);
                             if(ref != 0.0)
                             {
@@ -829,6 +832,7 @@ struct GPU_Softmax_NonContiguous_FP32
                                 algo == MIOPEN_SOFTMAX_LOG
                                     ? xbuf[off(n, c, h, w) + xdx_offset] - mx - sum
                                     : std::exp(xbuf[off(n, c, h, w) + xdx_offset] - mx) / sum;
+                            ref        = alpha * ref + beta * ybuf[off(n, c, h, w) + y_offset];
                             double err = std::abs(ref - res[off(n, c, h, w) + y_offset]);
                             if(ref != 0.0)
                             {
@@ -847,9 +851,11 @@ struct GPU_Softmax_NonContiguous_FP32
 
     void RunBackward()
     {
-        auto&& handle                                                         = get_handle();
-        auto [tensorDimsStrides, algo, mode, xdx_offset, y_offset, dy_offset] = GetParam();
-        auto [dims, strides]                                                  = tensorDimsStrides;
+        auto&& handle = get_handle();
+        auto [tensorDimsStrides, algo, mode, alphaBeta, xdx_offset, y_offset, dy_offset] =
+            GetParam();
+        auto [dims, strides] = tensorDimsStrides;
+        auto [alpha, beta]   = alphaBeta;
 
         auto in_host   = tensor<float>{dims, strides}.generate(tensor_elem_gen_integer{5});
         size_t n_elems = dims[0] * strides[0];
@@ -881,7 +887,6 @@ struct GPU_Softmax_NonContiguous_FP32
             }
         }
 
-        const float alpha = 1.0f, beta = 0.0f;
         auto dy_dev = handle.Write(dybuf);
         auto y_dev  = handle.Write(ybuf);
         auto dx_dev = handle.Write(dxbuf);
@@ -939,6 +944,7 @@ struct GPU_Softmax_NonContiguous_FP32
                             {
                                 ref = (ref - channel_dot) * ybuf[off(n, c, h, w) + y_offset];
                             }
+                            ref        = alpha * ref + beta * dxbuf[off(n, c, h, w) + xdx_offset];
                             double err = std::abs(ref - res[off(n, c, h, w) + xdx_offset]);
                             if(ref != 0.0)
                             {
@@ -976,6 +982,7 @@ struct GPU_Softmax_NonContiguous_FP32
                             {
                                 ref = (ref - channel_dot) * ybuf[off(n, c, h, w) + y_offset];
                             }
+                            ref        = alpha * ref + beta * dxbuf[off(n, c, h, w) + xdx_offset];
                             double err = std::abs(ref - res[off(n, c, h, w) + xdx_offset]);
                             if(ref != 0.0)
                             {
@@ -1008,17 +1015,67 @@ std::vector<std::tuple<std::vector<size_t>, std::vector<size_t>>> nonContiguousT
 
 } // namespace
 
-INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_Softmax_NonContiguous_FP32,
-                         testing::Combine(testing::ValuesIn(nonContiguousTestCases()),
-                                          testing::Values(MIOPEN_SOFTMAX_FAST,
-                                                          MIOPEN_SOFTMAX_ACCURATE,
-                                                          MIOPEN_SOFTMAX_LOG),
-                                          testing::Values(MIOPEN_SOFTMAX_MODE_INSTANCE,
-                                                          MIOPEN_SOFTMAX_MODE_CHANNEL),
-                                          testing::Values(0, 11),
-                                          testing::Values(0, 13),
-                                          testing::Values(0, 17)));
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    GPU_Softmax_NonContiguous_FP32,
+    testing::Combine(
+        testing::ValuesIn(nonContiguousTestCases()),
+        testing::Values(MIOPEN_SOFTMAX_FAST, MIOPEN_SOFTMAX_ACCURATE, MIOPEN_SOFTMAX_LOG),
+        testing::Values(MIOPEN_SOFTMAX_MODE_INSTANCE, MIOPEN_SOFTMAX_MODE_CHANNEL),
+        testing::ValuesIn(std::vector<std::tuple<float, float>>{{1.0f, 0.0f}, {0.5f, 0.5f}}),
+        testing::Values(0, 11),
+        testing::Values(0, 13),
+        testing::Values(0, 17)));
+
+// --- Mixed packing (packed x, non-packed/strided y) --------------------
+// No forward softmax solver actually supports mixed packing, so the correct
+// behavior is to fail cleanly (miopenStatusNotImplemented) rather than silently
+// mis-address memory.
+// Parameterized (with a single trivial value) so the test's full name is
+// "Smoke/GPU_Softmax_MixedPacking_FP32.ForwardPackedXStridedY/0" -- the
+// leading "Smoke/" prefix (from INSTANTIATE_TEST_SUITE_P) is required for
+// TheRock CI's "*/GPU_Softmax*" filter (see test_categories.yaml) to select
+// it; a bare TEST_F would not match that glob (no "Prefix/" component).
+struct GPU_Softmax_MixedPacking_FP32 : public testing::TestWithParam<int>
+{
+};
+
+TEST_P(GPU_Softmax_MixedPacking_FP32, ForwardPackedXStridedY)
+{
+    auto&& handle = get_handle();
+
+    const std::vector<size_t> dims = {2, 32, 1, 1};
+    // Packed would be {32, 1, 1, 1}; pad the N stride so y is non-packed.
+    const std::vector<size_t> strided_strides = {40, 1, 1, 1};
+
+    auto x_host = tensor<float>{miopenTensorNCHW, dims}.generate(tensor_elem_gen_integer{5});
+    auto y_host = tensor<float>{dims, strided_strides};
+
+    ASSERT_TRUE(x_host.desc.IsPacked()) << "test setup: x must be packed";
+    ASSERT_FALSE(y_host.desc.IsPacked()) << "test setup: y must be non-packed";
+
+    const size_t n_elems_y = dims[0] * strided_strides[0];
+
+    std::vector<float> ybuf(n_elems_y, -42.0f);
+
+    const float alpha = 1.0f, beta = 0.0f;
+    auto x_dev = handle.Write(x_host.data);
+    auto y_dev = handle.Write(ybuf);
+
+    // No forward solver supports mixed packing -> SoftmaxForward must throw
+    // (miopenStatusNotImplemented)
+    EXPECT_ANY_THROW(miopen::SoftmaxForward(handle,
+                                            &alpha,
+                                            &beta,
+                                            x_host.desc,
+                                            x_dev.get(),
+                                            y_host.desc,
+                                            y_dev.get(),
+                                            MIOPEN_SOFTMAX_ACCURATE,
+                                            MIOPEN_SOFTMAX_MODE_INSTANCE));
+}
+
+INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Softmax_MixedPacking_FP32, testing::Values(0));
 
 // --- Extra coverage: non-zero x/y offsets --
 // Findings from the tests below (both DISABLED -- see caveats):
@@ -1097,65 +1154,61 @@ TEST_F(GPU_Softmax_Offset_FP32, DISABLED_ForwardNonZeroOffset_FindRace)
 }
 
 // --- Divergent __syncthreads() deadlock ----------------------------
-// CSR-Stream path (NUM_BATCH>1) with grid_size not a multiple of num_batch:
-// whole wavefronts hit `if(o >= OUTER_SIZE) return;` and skip the block-wide
-// __syncthreads() inside reduce_block(), while surviving lanes wait on it
-// forever. {3,8,1,1} INSTANCE ACCURATE: inner=8 (aligned, so no fault masks the
-// hang), outer=3, local=1024 -> num_batch=512; batches 3..511 (waves 1..15)
-// early-return while wave 0 reaches the barrier -> hang.
-//
-// DISABLED because it WILL WEDGE THE GPU. Run intentionally only, under an
-// external timeout:
-//   ./bin/test_soft_max --gtest_also_run_disabled_tests \
-//       --gtest_filter='*Softmax_Deadlock*'
-struct GPU_Softmax_Deadlock_FP32 : public testing::Test
+// Since a
+// bare TEST_F's name ("GPU_Softmax_Deadlock_FP32.*") has no "Prefix/" and so
+// would NOT match test_categories.yaml's "*/GPU_Softmax*" glob (nor would
+// TheRock ever pass --gtest_also_run_disabled_tests), converted to a
+// Smoke-prefixed parameterized suite via INSTANTIATE_TEST_SUITE_P so its full
+// name becomes "Smoke/GPU_Softmax_Deadlock_FP32.CsrStreamPartialBlock/<N>" and
+// is selected by CI like the other Smoke/GPU_Softmax_* suites in this file.
+struct SoftmaxDeadlockCand
+{
+    std::vector<size_t> dims;
+    miopenSoftmaxMode_t mode;
+};
+
+struct GPU_Softmax_Deadlock_FP32 : public testing::TestWithParam<SoftmaxDeadlockCand>
 {
 };
 
-TEST_F(GPU_Softmax_Deadlock_FP32, DISABLED_CsrStreamPartialBlock)
+TEST_P(GPU_Softmax_Deadlock_FP32, CsrStreamPartialBlock)
 {
-    auto&& handle = get_handle();
+    auto&& handle    = get_handle();
+    const auto& cand = GetParam();
 
-    // Each candidate is a CSR-Stream config (inner<local, BATCH_SIZE>1) whose
-    // grid is not a multiple of num_batch, so the last block mixes surviving
-    // lanes (which reach reduce_block's __syncthreads) with early-returning
-    // lanes / whole wavefronts.
-    struct Cand
-    {
-        std::vector<size_t> dims;
-        miopenSoftmaxMode_t mode;
-    };
-    const std::vector<Cand> cands = {
-        {{3, 8, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE}, // 15/16 waves return, 1 survives
-        {{7, 8, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE},
-        {{70, 8, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE},  // ~2 waves survive, rest return
-        {{100, 8, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE}, // multiple surviving waves
-        {{5, 16, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE},
-        {{2, 8, 3, 3}, MIOPEN_SOFTMAX_MODE_CHANNEL}, // stride=H*W=9 path
-    };
+    auto input  = tensor<float>{miopenTensorNCHW, cand.dims}.generate(tensor_elem_gen_integer{5});
+    auto output = tensor<float>{miopenTensorNCHW, cand.dims};
 
-    for(const auto& cand : cands)
-    {
-        auto input =
-            tensor<float>{miopenTensorNCHW, cand.dims}.generate(tensor_elem_gen_integer{5});
-        auto output = tensor<float>{miopenTensorNCHW, cand.dims};
+    const float alpha = 1.0f, beta = 0.0f;
+    auto in_dev  = handle.Write(input.data);
+    auto out_dev = handle.Write(output.data);
 
-        const float alpha = 1.0f, beta = 0.0f;
-        auto in_dev  = handle.Write(input.data);
-        auto out_dev = handle.Write(output.data);
-
-        miopen::SoftmaxForward(handle,
-                               &alpha,
-                               &beta,
-                               input.desc,
-                               in_dev.get(),
-                               output.desc,
-                               out_dev.get(),
-                               MIOPEN_SOFTMAX_ACCURATE,
-                               cand.mode);
-        handle.Finish(); // a hang would manifest here
-        auto res = handle.Read<float>(out_dev, output.data.size());
-        for(auto v : res)
-            EXPECT_TRUE(std::isfinite(v));
-    }
+    miopen::SoftmaxForward(handle,
+                           &alpha,
+                           &beta,
+                           input.desc,
+                           in_dev.get(),
+                           output.desc,
+                           out_dev.get(),
+                           MIOPEN_SOFTMAX_ACCURATE,
+                           cand.mode);
+    handle.Finish(); // a hang would manifest here
+    auto res = handle.Read<float>(out_dev, output.data.size());
+    for(auto v : res)
+        EXPECT_TRUE(std::isfinite(v));
 }
+
+// Each candidate is a CSR-Stream config (inner<local, BATCH_SIZE>1) whose
+// grid is not a multiple of num_batch, so the last block mixes surviving
+// lanes (which reach reduce_block's __syncthreads) with early-returning
+// lanes / whole wavefronts.
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_Softmax_Deadlock_FP32,
+    testing::Values(
+        SoftmaxDeadlockCand{{3, 8, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE}, // 15/16 waves return
+        SoftmaxDeadlockCand{{7, 8, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE},
+        SoftmaxDeadlockCand{{70, 8, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE},  // ~2 waves survive
+        SoftmaxDeadlockCand{{100, 8, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE}, // multiple survive
+        SoftmaxDeadlockCand{{5, 16, 1, 1}, MIOPEN_SOFTMAX_MODE_INSTANCE},
+        SoftmaxDeadlockCand{{2, 8, 3, 3}, MIOPEN_SOFTMAX_MODE_CHANNEL})); // stride=H*W=9 path


### PR DESCRIPTION
## Motivation

This PR provides performance improvements to the softmax kernels via optimizations and additional tuning options, including an option for vectorized loading and storing of data, similar to #4888. Closes #10167.

## Technical Details

- Add tuning options for vectorized loading and storing of data, and for scheduling strides in a different dimension.
- Update heuristics using new tuning options.
- Miscellaneous optimizations.

## Test Plan

Build and run the test targets `test_soft_max` and `test_softmax_find20`.

## Test Result

All tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
