### PR TITLE
[CK] [CK_TILE] Improve build and test time of CI with smart dependency parser

### DIFF
--- a/projects/composablekernel/script/dependency-parser/README.md
+++ b/projects/composablekernel/script/dependency-parser/README.md
@@ -479,6 +479,30 @@ ctest --output-on-failure -R "^(test_atomic|test_ck_tile_.*|...)$"
 | Tests Run | ~10,000 (all) | 1,261 (affected) | 87% reduction |
 | Estimated Time | 4-6 hours | 30-45 minutes | 85% faster |
 
+**Method Validation (Commit 5ccc1387ea):**
+
+Validated that new pre-build method produces identical test selection as legacy post-build method:
+
+**Commit:** 5ccc1387ea - "Proof of concept for removing forward declarations (#5135)"
+- **Modified files:** 6 files in `experimental/builder/` and `include/ck/` (grouped conv bwd weight)
+- **Legacy method** (`ninja -t deps`): 7 executables selected
+- **New method** (`clang -MM`): 7 executables selected
+- **Result:** ✅ **100% match** - Both methods selected identical executables:
+  ```
+  bin/ckProfiler
+  bin/example_grouped_conv_bwd_weight_xdl_bf16
+  bin/example_grouped_conv_bwd_weight_xdl_fp16
+  bin/example_grouped_conv_bwd_weight_xdl_fp16_comp_bf8_fp8
+  bin/test_grouped_convnd_bwd_weight
+  bin/test_grouped_convnd_bwd_weight_dataset_xdl
+  bin/test_grouped_convnd_bwd_weight_interface_xdl
+  ```
+
+**Key Difference:**
+- Legacy method requires building affected tests first (~30 min), then extracting dependencies
+- New method extracts dependencies during CMake configure (~5-6 min), no build needed
+- **Total time savings:** ~25 minutes per commit analysis
+
 **Bugs Fixed During Validation:**
 
 1. **Test Prefix Filter Bug**: Filter checked `exe.startswith("test_")` but executables have `bin/` prefix (e.g., `bin/test_gemm`). Fixed by checking `"test_" in exe`.
@@ -487,7 +511,7 @@ ctest --output-on-failure -R "^(test_atomic|test_ck_tile_.*|...)$"
 
 3. **Git Path Filter Bug**: Using `git diff -- projects/composablekernel/` from build directory returned empty results. Fixed by removing git path filtering.
 
-**Conclusion:** ✅ Smart build system validated and ready for production deployment.
+**Conclusion:** ✅ New smart build method validated - produces identical test selection as legacy method with significantly faster dependency analysis!
 
 ## Development
 


### PR DESCRIPTION
## Motivation

Existing dependency parser needs full build of tests to determine which tests are affected by code changes in a PR. This still takes 2-4 hours for building the tests which slows down the CI as the number of tests grow. To resolve this issue we implemented a smart dependency parser which uses CMake Configure to parse dependencies and build only the affected test cases.  We have ensured that two approaches are available 1) CMake pre-build analysis for each PR to ensure fast build and test. 2) Ninja post-build analysis to enable full build for nightly tests.  

## Technical Details

```bash
### 1. Configure the project with CMake
cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..

### 2. Analyze dependencies (no build required!)
python3 ../script/dependency-parser/main.py cmake-parse compile_commands.json build.ninja \
  --workspace-root .. --output cmake_dependency_mapping.json --parallel 8

### 3. Find tests affected by changes
python3 ../script/dependency-parser/main.py select cmake_dependency_mapping.json origin/develop \
  HEAD --test-prefix --output tests_to_run.json

### 4. Build only affected tests
ninja $(jq -r '.executables[]' tests_to_run.json | tr '\n' ' ')

### 5. Run affected tests
ctest -R "$(jq -r '.regex' tests_to_run.json)"
```

### Jenkins Integration
- Added `buildMode` to jenkinsfile to integrate both `selective` and `full` build methods

### Known Limitations

### 1. Build-Time Generated Headers (HIGH RISK)

**Problem:** Files generated during the build process (e.g., via `add_custom_command`) cannot be analyzed before building.

**Example:**
```cmake
add_custom_command(
  OUTPUT ${CMAKE_BINARY_DIR}/generated/config.hpp
  COMMAND generate_config.sh
  DEPENDS template.hpp.in
)
```

**Impact:** If a source file includes `generated/config.hpp`, the dependency won't be detected until after building.

**Mitigation:**
- CK analysis shows **no generated headers** currently used
- If generated headers are added in the future, they must be built first
- Recommendation: Generate headers in CMake configure phase (not build phase) when possible


## Test Plan
**1. Modified Files:**
```
include/ck_tile/ops/common.hpp
include/ck_tile/ops/gemm.hpp
include/ck_tile/ops/gemm/warp/warp_gemm.hpp
```
**2. Compare tests selected between `build.ninja` and `cmake-parse` methods


## Test Result
- 1. The test completed in 5-6 minutes finding about 8000+ executables that should be built.
- 2. We selected a commit 5ccc1387ea which resulted in same 7 tests with both legacy and new methods.
- Please check projects/composablekernel/script/dependency-parser/README.md for more test results



## Submission Checklist

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

