### PR TITLE
[rocsparse] Add missing calls to hipFree in some documentation examples and add mixed precision to SpMV and SpMM

### DIFF
--- a/projects/rocsparse/clients/samples/documentation_examples/conversion/example_rocsparse_dense2csr.cpp
+++ b/projects/rocsparse/clients/samples/documentation_examples/conversion/example_rocsparse_dense2csr.cpp
@@ -86,10 +86,11 @@ int main()
     ROCSPARSE_CHECK(rocsparse_sdense2csr(
         handle, m, n, descr, ddense_A, m, dnnz_per_row, dcsr_val, dcsr_row_ptr, dcsr_col_ind));
 
+    HIP_CHECK(hipFree(ddense_A));
+    HIP_CHECK(hipFree(dnnz_per_row));
     HIP_CHECK(hipFree(dcsr_row_ptr));
     HIP_CHECK(hipFree(dcsr_col_ind));
     HIP_CHECK(hipFree(dcsr_val));
-    HIP_CHECK(hipFree(dnnz_per_row));
 
     rocsparse_destroy_mat_descr(descr);
     rocsparse_destroy_handle(handle);

--- a/projects/rocsparse/clients/samples/documentation_examples/extra/example_rocsparse_bsrgeam.cpp
+++ b/projects/rocsparse/clients/samples/documentation_examples/extra/example_rocsparse_bsrgeam.cpp
@@ -175,6 +175,9 @@ int main()
     HIP_CHECK(hipFree(d_bsr_row_ptr_B));
     HIP_CHECK(hipFree(d_bsr_col_ind_B));
     HIP_CHECK(hipFree(d_bsr_val_B));
+    HIP_CHECK(hipFree(d_bsr_row_ptr_C));
+    HIP_CHECK(hipFree(d_bsr_col_ind_C));
+    HIP_CHECK(hipFree(d_bsr_val_C));
 
     return 0;
 }

--- a/projects/rocsparse/clients/samples/documentation_examples/generic/example_rocsparse_dense_to_sparse.cpp
+++ b/projects/rocsparse/clients/samples/documentation_examples/generic/example_rocsparse_dense_to_sparse.cpp
@@ -162,6 +162,7 @@ int main()
     HIP_CHECK(hipFree(dcsr_col_ind));
     HIP_CHECK(hipFree(dcsr_val));
     HIP_CHECK(hipFree(ddense));
+    HIP_CHECK(hipFree(temp_buffer));
 
     return 0;
 }

--- a/projects/rocsparse/clients/samples/documentation_examples/generic/example_rocsparse_sparse_to_dense.cpp
+++ b/projects/rocsparse/clients/samples/documentation_examples/generic/example_rocsparse_sparse_to_dense.cpp
@@ -131,6 +131,7 @@ int main()
     HIP_CHECK(hipFree(dcsr_col_ind));
     HIP_CHECK(hipFree(dcsr_val));
     HIP_CHECK(hipFree(ddense));
+    HIP_CHECK(hipFree(temp_buffer));
 
     return 0;
 }

--- a/projects/rocsparse/clients/samples/documentation_examples/generic/example_rocsparse_spitsv.cpp
+++ b/projects/rocsparse/clients/samples/documentation_examples/generic/example_rocsparse_spitsv.cpp
@@ -179,6 +179,7 @@ int main()
     HIP_CHECK(hipFree(dcsr_val));
     HIP_CHECK(hipFree(dx));
     HIP_CHECK(hipFree(dy));
+    HIP_CHECK(hipFree(temp_buffer));
 
     return 0;
 }

--- a/projects/rocsparse/clients/samples/documentation_examples/level2/example_rocsparse_bsrsv.cpp
+++ b/projects/rocsparse/clients/samples/documentation_examples/level2/example_rocsparse_bsrsv.cpp
@@ -173,6 +173,8 @@ int main()
     HIP_CHECK(hipFree(dbsr_row_ptr));
     HIP_CHECK(hipFree(dbsr_col_ind));
     HIP_CHECK(hipFree(dbsr_val));
+    HIP_CHECK(hipFree(dx));
+    HIP_CHECK(hipFree(dy));
     HIP_CHECK(hipFree(temp_buffer));
 
     return 0;

--- a/projects/rocsparse/clients/samples/documentation_examples/level2/example_rocsparse_csrsv.cpp
+++ b/projects/rocsparse/clients/samples/documentation_examples/level2/example_rocsparse_csrsv.cpp
@@ -163,6 +163,8 @@ int main()
     HIP_CHECK(hipFree(dcsr_row_ptr));
     HIP_CHECK(hipFree(dcsr_col_ind));
     HIP_CHECK(hipFree(dcsr_val));
+    HIP_CHECK(hipFree(dx));
+    HIP_CHECK(hipFree(dy));
     HIP_CHECK(hipFree(temp_buffer));
 
     return 0;

--- a/projects/rocsparse/clients/samples/documentation_examples/level3/example_rocsparse_csrsm.cpp
+++ b/projects/rocsparse/clients/samples/documentation_examples/level3/example_rocsparse_csrsm.cpp
@@ -192,6 +192,10 @@ int main()
     std::cout << "" << std::endl;
 
     // Clean up
+    HIP_CHECK(hipFree(dcsr_row_ptr));
+    HIP_CHECK(hipFree(dcsr_col_ind));
+    HIP_CHECK(hipFree(dcsr_val));
+    HIP_CHECK(hipFree(dB));
     HIP_CHECK(hipFree(temp_buffer));
     ROCSPARSE_CHECK(rocsparse_destroy_mat_info(info));
     ROCSPARSE_CHECK(rocsparse_destroy_mat_descr(descr));

--- a/projects/rocsparse/library/include/internal/generic/rocsparse_spmm.h
+++ b/projects/rocsparse/library/include/internal/generic/rocsparse_spmm.h
@@ -141,7 +141,9 @@ extern "C" {
 *  <tr><td>rocsparse_datatype_i8_r   <td>rocsparse_datatype_i32_r <td>rocsparse_datatype_i32_r
 *  <tr><td>rocsparse_datatype_i8_r   <td>rocsparse_datatype_f32_r <td>rocsparse_datatype_f32_r
 *  <tr><td>rocsparse_datatype_f16_r  <td>rocsparse_datatype_f32_r <td>rocsparse_datatype_f32_r
+*  <tr><td>rocsparse_datatype_f16_r  <td>rocsparse_datatype_f16_r <td>rocsparse_datatype_f32_r
 *  <tr><td>rocsparse_datatype_bf16_r <td>rocsparse_datatype_f32_r <td>rocsparse_datatype_f32_r
+*  <tr><td>rocsparse_datatype_bf16_r <td>rocsparse_datatype_bf16_r <td>rocsparse_datatype_f32_r
 *  </table>
 *
 *  \p rocsparse_spmm supports \ref rocsparse_indextype_i32 and \ref rocsparse_indextype_i64 index precisions

--- a/projects/rocsparse/library/include/internal/generic/rocsparse_v2_spmv.h
+++ b/projects/rocsparse/library/include/internal/generic/rocsparse_v2_spmv.h
@@ -159,6 +159,7 @@ rocsparse_status rocsparse_v2_spmv_buffer_size(rocsparse_handle            handl
 *  <tr><td>rocsparse_datatype_i8_r   <td>rocsparse_datatype_f32_r  <td>rocsparse_datatype_f32_r
 *  <tr><td>rocsparse_datatype_f16_r  <td>rocsparse_datatype_f32_r  <td>rocsparse_datatype_f32_r
 *  <tr><td>rocsparse_datatype_f16_r  <td>rocsparse_datatype_f16_r  <td>rocsparse_datatype_f32_r
+*  <tr><td>rocsparse_datatype_bf16_r <td>rocsparse_datatype_f32_r  <td>rocsparse_datatype_f32_r
 *  <tr><td>rocsparse_datatype_bf16_r <td>rocsparse_datatype_bf16_r <td>rocsparse_datatype_f32_r
 *  </table>
 *


### PR DESCRIPTION
## Motivation

Some of the documentation examples were missing some calls to `hipFree`. Additionally, in the documentation for `rocsparse_v2_spmv` and `rocsparse_spmm`, we were missing some half mixed precision support.
