### PR TITLE
[rocroller] Fetch ROCmCMakeBuildTools if it is available

### DIFF
--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -18,7 +18,7 @@ option(ROCROLLER_ENABLE_FETCH "Enable fetch content for dependencies if find_pac
 find_package(ROCmCMakeBuildTools CONFIG QUIET)
 if(NOT ROCmCMakeBuildTools_FOUND)
     if(ROCROLLER_ENABLE_FETCH)
-        message(STATUS "ROCm CMake not found. Fetching...")
+        message(STATUS "ROCmCMakeBuildTools not found. Fetching...")
         FetchContent_Declare(
             ROCmCMakeBuildTools
             GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git
@@ -31,7 +31,7 @@ if(NOT ROCmCMakeBuildTools_FOUND)
             ${rocmcmakebuildtools_SOURCE_DIR}/share/rocmcmakebuildtools/cmake
         )
     else()
-        message(FATAL_ERROR "Failed to find ROCmCMakeBuildTools (rocm-cmake)")
+        message(FATAL_ERROR "Failed to find ROCmCMakeBuildTools")
     endif()
 endif()
 include(ROCMInstallTargets)

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -13,17 +13,27 @@ include(FetchContent)
 include(CMakeDependentOption)
 include(rocroller_target_configure_sanitizers)
 
-FetchContent_Declare(
-    ROCmCMakeBuildTools
-    GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git
-    GIT_TAG rocm-6.3.0
-    SOURCE_SUBDIR "DISABLE ADDING TO BUILD"
-)
-FetchContent_MakeAvailable(ROCmCMakeBuildTools)
-list(
-    APPEND CMAKE_MODULE_PATH
-    ${rocmcmakebuildtools_SOURCE_DIR}/share/rocmcmakebuildtools/cmake
-)
+option(ROCROLLER_ENABLE_FETCH "Enable fetch content for dependencies if find_package fails." OFF)
+
+find_package(ROCmCMakeBuildTools CONFIG QUIET)
+if(NOT ROCmCMakeBuildTools_FOUND)
+    if(ROCROLLER_ENABLE_FETCH)
+        message(STATUS "ROCm CMake not found. Fetching...")
+        FetchContent_Declare(
+            ROCmCMakeBuildTools
+            GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git
+            GIT_TAG rocm-6.3.0
+            SOURCE_SUBDIR "DISABLE ADDING TO BUILD"
+        )
+        FetchContent_MakeAvailable(ROCmCMakeBuildTools)
+        list(
+            APPEND CMAKE_MODULE_PATH
+            ${rocmcmakebuildtools_SOURCE_DIR}/share/rocmcmakebuildtools/cmake
+        )
+    else()
+        message(FATAL_ERROR "Failed to find ROCmCMakeBuildTools (rocm-cmake)")
+    endif()
+endif()
 include(ROCMInstallTargets)
 include(ROCMSetupVersion)
 
@@ -40,7 +50,6 @@ option(ROCROLLER_ENABLE_COVERAGE "Build code coverage." OFF)
 cmake_dependent_option(ROCROLLER_ENABLE_SLOW_TESTS "Disable slow running tests." ON "NOT ROCROLLER_ENABLE_COVERAGE" OFF)
 option(ROCROLLER_EMBED_ARCH_DEF "Embed msgpack architecture data in library." ON)
 option(ROCROLLER_BUILD_SHARED_LIBS "Build rocRoller as a shared library." ON)
-option(ROCROLLER_ENABLE_FETCH "Enable fetch content for dependencies if find_package fails." OFF)
 option(ROCROLLER_ENABLE_TIMERS "Enable rocRoller timer code." OFF)
 option(ROCROLLER_ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(ROCROLLER_ENABLE_ASAN "Enable addresss sanitizers." OFF)

--- a/shared/rocroller/CMakeLists.txt
+++ b/shared/rocroller/CMakeLists.txt
@@ -13,29 +13,7 @@ include(FetchContent)
 include(CMakeDependentOption)
 include(rocroller_target_configure_sanitizers)
 
-option(ROCROLLER_ENABLE_FETCH "Enable fetch content for dependencies if find_package fails." OFF)
-
-find_package(ROCmCMakeBuildTools CONFIG QUIET)
-if(NOT ROCmCMakeBuildTools_FOUND)
-    if(ROCROLLER_ENABLE_FETCH)
-        message(STATUS "ROCmCMakeBuildTools not found. Fetching...")
-        FetchContent_Declare(
-            ROCmCMakeBuildTools
-            GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git
-            GIT_TAG rocm-6.3.0
-            SOURCE_SUBDIR "DISABLE ADDING TO BUILD"
-        )
-        FetchContent_MakeAvailable(ROCmCMakeBuildTools)
-        list(
-            APPEND CMAKE_MODULE_PATH
-            ${rocmcmakebuildtools_SOURCE_DIR}/share/rocmcmakebuildtools/cmake
-        )
-    else()
-        message(FATAL_ERROR "Failed to find ROCmCMakeBuildTools")
-    endif()
-endif()
-include(ROCMInstallTargets)
-include(ROCMSetupVersion)
+include(fetch_rocm_cmake)
 
 option(ROCROLLER_ENABLE_CLIENT "Build the rocRoller client." ON)
 option(ROCROLLER_ENABLE_YAML_CPP "Enable yaml-cpp backend." ON)
@@ -50,6 +28,7 @@ option(ROCROLLER_ENABLE_COVERAGE "Build code coverage." OFF)
 cmake_dependent_option(ROCROLLER_ENABLE_SLOW_TESTS "Disable slow running tests." ON "NOT ROCROLLER_ENABLE_COVERAGE" OFF)
 option(ROCROLLER_EMBED_ARCH_DEF "Embed msgpack architecture data in library." ON)
 option(ROCROLLER_BUILD_SHARED_LIBS "Build rocRoller as a shared library." ON)
+option(ROCROLLER_ENABLE_FETCH "Enable fetch content for dependencies if find_package fails." OFF)
 option(ROCROLLER_ENABLE_TIMERS "Enable rocRoller timer code." OFF)
 option(ROCROLLER_ENABLE_CPPCHECK "Enable cppcheck." OFF)
 option(ROCROLLER_ENABLE_ASAN "Enable addresss sanitizers." OFF)

--- a/shared/rocroller/cmake/fetch_rocm_cmake.cmake
+++ b/shared/rocroller/cmake/fetch_rocm_cmake.cmake
@@ -1,0 +1,31 @@
+# Copyright Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier: MIT
+
+# Attempt to find ROCmCMakeBuildTools in the system, if not found, fetch from source. To install
+# ROCmCMakeBuildTools from source, see: https://github.com/ROCm/rocm-cmake
+
+find_package(ROCmCMakeBuildTools QUIET CONFIG)
+
+if(NOT ROCmCMakeBuildTools_FOUND)
+    message(STATUS "ROCmCMakeBuildTools not found. Fetching from source...")
+    include(FetchContent)
+    fetchcontent_declare(
+        rocm-cmake
+        GIT_REPOSITORY https://github.com/ROCm/rocm-cmake.git
+        GIT_TAG c01b4f1fd36a94d26c76e7f617b57577b3b84275
+        GIT_SHALLOW TRUE
+    )
+
+    fetchcontent_getproperties(rocm-cmake)
+    if(NOT rocm-cmake_POPULATED)
+        fetchcontent_populate(rocm-cmake)
+        message(
+            STATUS
+                "Added ROCm CMake modules path: ${rocm-cmake_SOURCE_DIR}/share/rocmcmakebuildtools/cmake"
+        )
+        list(APPEND CMAKE_MODULE_PATH ${rocm-cmake_SOURCE_DIR}/share/rocmcmakebuildtools/cmake)
+    endif()
+endif()
+
+include(ROCMInstallTargets)
+include(ROCMSetupVersion)


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/rocm-libraries/issues/4954

rocroller unconditionally fetches `rocm-cmake` even when it is already installed on the system, or when `ROCROLLER_ENABLE_FETCH=OFF`. 

## Technical Details

Use `find_package(ROCmCMakeBuildTools CONFIG QUIET)` before falling back to `FetchContent`, matching the pattern already used by rocroller's other dependencies (`fmt`, `spdlog`, `libdivide`).

The `ROCROLLER_ENABLE_FETCH` option declaration was moved earlier in the file (before the `rocm-cmake` resolution block) since it is now needed there.

## Test Plan

Tested three cmake configure scenarios:

1. `ROCROLLER_ENABLE_FETCH=OFF`, system `rocm-cmake` available via `CMAKE_PREFIX_PATH`: `find_package` succeeds, no fetch, configure proceeds.
2. `ROCROLLER_ENABLE_FETCH=OFF`, no system `rocm-cmake`: `FATAL_ERROR: Failed to find ROCmCMakeBuildTools (rocm-cmake)`.
3. `ROCROLLER_ENABLE_FETCH=ON`, no system `rocm-cmake`: fetches `rocm-cmake` from GitHub.

## Test Result

All three scenarios behave as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.