### PR TITLE
[rocthrust] Fix a few compilation warnings

### DIFF
--- a/projects/rocthrust/test/generate_resource_spec.cpp
+++ b/projects/rocthrust/test/generate_resource_spec.cpp
@@ -97,8 +97,8 @@ int main(int argc, char* argv[])
   out_file.open(argv[1]);
 
   // Figure out how many devices are in the system.
-  int dev_count = 0;
-  hipGetDeviceCount(&dev_count);
+  int dev_count;
+  HIP_CHECK(hipGetDeviceCount(&dev_count));
 
   // There could be more than one device of each type.
   // Build a mapping of gfxID (string) to a vector of device IDs (unsigned ints).

--- a/projects/rocthrust/thrust/system/hip/detail/future.inl
+++ b/projects/rocthrust/thrust/system/hip/detail/future.inl
@@ -698,7 +698,7 @@ public:
     thrust::hip_rocprim::throw_on_error(hipGetDevice(&device_));
   }
 
-  THRUST_HOST virtual ~unique_eager_event()
+  THRUST_HOST ~unique_eager_event()
   {
     // FIXME: If we could asynchronously handle destruction of keep alives, we
     // could avoid doing this.

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -23,6 +23,18 @@
 #include <type_traits>
 #include <utility>
 
+// Define a portable macro for the no_unique_address attribute
+// - MSVC provides msvc::no_unique_address as a vendor extension
+// - Standard [[no_unique_address]] is available in C++20
+// - For C++17, we omit the attribute (safe, but may increase size with stateful deleters)
+#if defined(_MSC_VER) && !defined(__clang__)
+#  define THRUST_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#elif __cplusplus >= 202002L
+#  define THRUST_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#  define THRUST_NO_UNIQUE_ADDRESS
+#endif
+
 THRUST_NAMESPACE_BEGIN
 
 /*! \addtogroup memory_management Memory Management
@@ -337,7 +349,7 @@ public:
 
 private:
   pointer m_ptr;
-  [[no_unique_address]] deleter_type m_deleter;
+  THRUST_NO_UNIQUE_ADDRESS deleter_type m_deleter;
 
   using DeleterSFINAE = thrust::detail::unique_ptr_deleter_sfinae<D>;
 
@@ -701,7 +713,7 @@ private:
   friend class unique_ptr;
 
   pointer m_ptr;
-  [[no_unique_address]] deleter_type m_deleter;
+  THRUST_NO_UNIQUE_ADDRESS deleter_type m_deleter;
 
   using DeleterSFINAE = thrust::detail::unique_ptr_deleter_sfinae<D>;
 

--- a/projects/rocthrust/thrust/unique_ptr.h
+++ b/projects/rocthrust/thrust/unique_ptr.h
@@ -24,15 +24,12 @@
 #include <utility>
 
 // Define a portable macro for the no_unique_address attribute
-// - MSVC provides msvc::no_unique_address as a vendor extension
-// - Standard [[no_unique_address]] is available in C++20
-// - For C++17, we omit the attribute (safe, but may increase size with stateful deleters)
-#if defined(_MSC_VER) && !defined(__clang__)
+// - MSVC and clang with -fms-compatibility use [[msvc::no_unique_address]]
+// - Other compilers use standard [[no_unique_address]]
+#if defined(_MSC_VER)
 #  define THRUST_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
-#elif __cplusplus >= 202002L
-#  define THRUST_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #else
-#  define THRUST_NO_UNIQUE_ADDRESS
+#  define THRUST_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 
 THRUST_NAMESPACE_BEGIN


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR fixes a few compilation warnings for rocThrust.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
At the normal warning level of rocThrust, `-Wall -Wextra`, a few compiler warnings were generated. This PR fixes them for both Linux and Windows.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Build rucThrust on both Linux and Windows. No compilation warnings should be generated.

## Test Result

<!-- Briefly summarize test outcomes. -->
Verified that the build logs do not contain warnings.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
