### PR TITLE
[rocSOLVER] Consolidate latrd_forsytrd kernels

### DIFF
--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_latrd_forsytrd.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_latrd_forsytrd.hpp
@@ -304,9 +304,6 @@ ROCSOLVER_KERNEL void latrd_computeW_gemvt_kernel(rocblas_fill uplo,
     T* yw = load_ptr_batch<T>(yA, bid, shiftY, strideY);
     T* ywork = workA + bid * strideblk;
 
-    int n, lda1, lda2, it, ld, i0;
-    T *a, *x, *y;
-
     /* -----------------------------
     formulate gemv problem:
         upper:
@@ -332,7 +329,7 @@ ROCSOLVER_KERNEL void latrd_computeW_gemvt_kernel(rocblas_fill uplo,
                 A1 = W(c+1:mm-1, 0:c-1)
                 A2 = A(c+1:mm-1, :)
                 x = A(c+1,mm-1, c)
-                yw = W(:, cw)
+                yw = W(:, c)
                 ywork = work (temp buffer)
 
             operation:
@@ -344,6 +341,9 @@ ROCSOLVER_KERNEL void latrd_computeW_gemvt_kernel(rocblas_fill uplo,
             Notes:
                 1. Here A2(:, c+1:mm-1) is full/general matrix (data below and above diagonal)
     ------------------------------ */
+    int n, lda1, lda2, it, ld, i0;
+    T *a, *x, *y;
+
     if(upper)
     {
         n = c;
@@ -427,21 +427,22 @@ ROCSOLVER_KERNEL void latrd_computeW_gemvt_kernel(rocblas_fill uplo,
 /***** Kernels to update column of W *****/
 /*****************************************/
 template <typename T, typename U>
-ROCSOLVER_KERNEL void latrd_upper_updateW_kernel(const rocblas_int mm,
-                                                 const rocblas_int k,
-                                                 const rocblas_int c,
-                                                 U AA,
-                                                 const rocblas_int shiftA,
-                                                 const rocblas_int lda,
-                                                 const rocblas_stride strideA,
-                                                 T* WA,
-                                                 const rocblas_int shiftW,
-                                                 const rocblas_int ldw,
-                                                 const rocblas_stride strideW,
-                                                 T* workA,
-                                                 const rocblas_stride strideblk,
-                                                 T* tauA,
-                                                 const rocblas_stride strideP)
+ROCSOLVER_KERNEL void latrd_updateW_kernel(rocblas_fill uplo,
+                                           const rocblas_int mm,
+                                           const rocblas_int k,
+                                           const rocblas_int c,
+                                           U AA,
+                                           const rocblas_int shiftA,
+                                           const rocblas_int lda,
+                                           const rocblas_stride strideA,
+                                           T* WA,
+                                           const rocblas_int shiftW,
+                                           const rocblas_int ldw,
+                                           const rocblas_stride strideW,
+                                           T* workA,
+                                           const rocblas_stride strideblk,
+                                           T* tauA,
+                                           const rocblas_stride strideP)
 {
     int bid = hipBlockIdx_z;
     int bidr = hipBlockIdx_x;
@@ -458,6 +459,7 @@ ROCSOLVER_KERNEL void latrd_upper_updateW_kernel(const rocblas_int mm,
     int idr = bidr * threadsr + tidr;
 
     // select batch instance
+    bool upper = (uplo == rocblas_fill_upper);
     T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
     T* W = load_ptr_batch<T>(WA, bid, shiftW, strideW);
     T* work = workA + bid * strideblk;
@@ -465,145 +467,61 @@ ROCSOLVER_KERNEL void latrd_upper_updateW_kernel(const rocblas_int mm,
 
     /* ------------------------
     formulate gemv problem:
+        upper:
+            components:
+                cw = c - mm + k
+                y = W(0:c-1, cw)
+                A1 = A(0:c-1, c+1:mm-1)
+                A2 = W(0:c-1, cw+1:k-1)
+                x1 = work (temp buffer)
+                x2 = W(c+1:mm-1, cw)
+                t = tau(c-1)
 
-        components:
-            cw = c - mm + k
-            y = W(0:c-1, cw)
-            A1 = A(0:c-1, c+1:mm-1)
-            A2 = W(0:c-1, cw+1:k-1)
-            x1 = work (temp buffer)
-            x2 = W(c+1:mm-1, cw)
-            t = tau(c-1)
+            operation:
+                y = t * (y - A1 * x1 - A2 * x2)
 
-        operation:
-            y = t * (y - A1 * x1 - A2 * x2)
+        lower:
+            components:
+                y = W(c+1:mm-1, c)
+                A1 = A(c+1:mm-1, 0:c-1)
+                A2 = W(c+1:mm-1, 0:c-1)
+                x1 = work (temp buffer)
+                x2 = W(0:c-1, c)
+                t = tau(c)
+
+            operation:
+                y = t * (y - A1 * x1 - A2 * x2)
     ------------------------ */
-    int n = mm - c - 1;
-    int m = c;
-    int cw = c - mm + k;
-    T* y = W + idx2D(0, cw, ldw);
-    T* A1 = A + idx2D(0, c + 1, lda);
-    int lda1 = lda;
-    T* A2 = W + idx2D(0, cw + 1, ldw);
-    int lda2 = ldw;
-    T* x1 = work;
-    T* x2 = W + idx2D(c + 1, cw, ldw);
-    T* t = tau + c - 1;
+    int n, m;
+    T *y, *A1, *A2, *x2, *t;
 
-    // rpgr and rpgc are the number of rounds a group should run
-    // to cover all the rows and columns, respectively
-    int ngrp = (m - 1) / threadsr + 1;
-    int rpgr = (ngrp - 1) / groupsr + 1;
-    ngrp = (n - 1) / threadsc + 1;
-    int rpgc = (ngrp - 1) / groupsc + 1;
-    int i, j;
-
-    // Registers/LDS:
-    // ac, acs -> accumulator
-    // sx -> hold the elements of 'x'
-    extern __shared__ double smem[]; //min size should be threadsr x threadsc
-    T* acs = reinterpret_cast<T*>(smem);
-    T ac;
-    T sx1, sx2;
-
-    for(int ii = 0; ii < rpgr; ++ii)
+    if(upper)
     {
-        i = ii * totalthsr + idr;
+        n = mm - c - 1;
+        m = c;
 
-        // read y
-        ac = (idc == 0 && i < m) ? y[i] : 0;
-
-        for(int jj = 0; jj < rpgc; ++jj)
-        {
-            // read x
-            j = jj * totalthsc + idc;
-            sx1 = (j < n) ? x1[j] : 0;
-            sx2 = (j < n) ? x2[j] : 0;
-
-            // operation for all rows
-            if(i < m && j < n)
-                ac -= A1[i + j * lda1] * sx1 + A2[i + j * lda2] * sx2;
-        }
-        acs[tidr + tidc * threadsr] = ac;
-        __syncthreads();
-
-        // group reduction
-        for(int r = threadsc / 2; r > 0; r /= 2)
-        {
-            if(tidc < r)
-            {
-                ac += acs[tidr + (tidc + r) * threadsr];
-                acs[tidr + tidc * threadsr] = ac;
-            }
-            __syncthreads();
-        }
-
-        // write groups results in temp array for further reduction
-        if(tidc == 0 && i < m)
-            y[i] = ac * t[0];
+        int cw = c - mm + k;
+        y = W + idx2D(0, cw, ldw);
+        A1 = A + idx2D(0, c + 1, lda);
+        A2 = W + idx2D(0, cw + 1, ldw);
+        x2 = W + idx2D(c + 1, cw, ldw);
+        t = tau + c - 1;
     }
-}
+    else
+    {
+        m = mm - c - 1;
+        n = c;
 
-template <typename T, typename U>
-ROCSOLVER_KERNEL void latrd_lower_updateW_kernel(const rocblas_int mm,
-                                                 const rocblas_int c,
-                                                 U AA,
-                                                 const rocblas_int shiftA,
-                                                 const rocblas_int lda,
-                                                 const rocblas_stride strideA,
-                                                 T* WA,
-                                                 const rocblas_int shiftW,
-                                                 const rocblas_int ldw,
-                                                 const rocblas_stride strideW,
-                                                 T* workA,
-                                                 const rocblas_stride strideblk,
-                                                 T* tauA,
-                                                 const rocblas_stride strideP)
-{
-    int bid = hipBlockIdx_z;
-    int bidr = hipBlockIdx_x;
-    int bidc = hipBlockIdx_y;
-    int tidr = hipThreadIdx_x;
-    int tidc = hipThreadIdx_y;
-    int threadsr = hipBlockDim_x;
-    int threadsc = hipBlockDim_y;
-    int groupsr = hipGridDim_x;
-    int groupsc = hipGridDim_y;
-    int totalthsr = groupsr * threadsr;
-    int totalthsc = groupsc * threadsc;
-    int idc = bidc * threadsc + tidc;
-    int idr = bidr * threadsr + tidr;
+        y = W + idx2D(c + 1, c, ldw);
+        A1 = A + idx2D(c + 1, 0, lda);
+        A2 = W + idx2D(c + 1, 0, ldw);
+        x2 = W + idx2D(0, c, ldw);
+        t = tau + c;
+    }
 
-    // select batch instance
-    T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
-    T* W = load_ptr_batch<T>(WA, bid, shiftW, strideW);
-    T* work = workA + bid * strideblk;
-    T* tau = tauA + bid * strideP;
-
-    /* ------------------------
-    formulate gemv problem:
-
-        components:
-            y = W(c+1:mm-1, c)
-            A1 = A(c+1:mm-1, 0:c-1)
-            A2 = W(c+1:mm-1, 0:c-1)
-            x1 = work (temp buffer)
-            x2 = W(0:c-1, c)
-            t = tau(c)
-
-        operation:
-            y = t * (y - A1 * x1 - A2 * x2)
-    ------------------------ */
-    int m = mm - c - 1;
-    int n = c;
-    T* y = W + idx2D(c + 1, c, ldw);
-    T* A1 = A + idx2D(c + 1, 0, lda);
     int lda1 = lda;
-    T* A2 = W + idx2D(c + 1, 0, ldw);
     int lda2 = ldw;
     T* x1 = work;
-    T* x2 = W + idx2D(0, c, ldw);
-    T* t = tau + c;
 
     // rpgr and rpgc are the number of rounds a group should run
     // to cover all the rows and columns, respectively
@@ -832,9 +750,9 @@ rocblas_status rocsolver_latrd_forsytrd_template(rocblas_handle handle,
             // update column j of W
             //--------------------------------------------------------------
             ROCSOLVER_LAUNCH_KERNEL(
-                latrd_lower_updateW_kernel<T>, dim3(grr_updates, grc_updates, batch_count),
-                dim3(thr_updates, thc_updates, 1), lmemsize_updates, stream, n, j, A, shiftA, lda,
-                strideA, W, shiftW, ldw, strideW, work, strideblk, tau, strideP);
+                latrd_updateW_kernel<T>, dim3(grr_updates, grc_updates, batch_count),
+                dim3(thr_updates, thc_updates, 1), lmemsize_updates, stream, uplo, n, k, j, A,
+                shiftA, lda, strideA, W, shiftW, ldw, strideW, work, strideblk, tau, strideP);
 
             ROCSOLVER_LAUNCH_KERNEL((latrd_dot_scale_axpy<1024, T>), dim3(1, 1, batch_count),
                                     dim3(1024, 1, 1), 0, stream, n - 1 - j, A,
@@ -882,9 +800,9 @@ rocblas_status rocsolver_latrd_forsytrd_template(rocblas_handle handle,
             // update column j of W
             //--------------------------------------------------------------
             ROCSOLVER_LAUNCH_KERNEL(
-                latrd_upper_updateW_kernel<T>, dim3(grr_updates, grc_updates, batch_count),
-                dim3(thr_updates, thc_updates, 1), lmemsize_updates, stream, n, k, j, A, shiftA,
-                lda, strideA, W, shiftW, ldw, strideW, work, strideblk, tau, strideP);
+                latrd_updateW_kernel<T>, dim3(grr_updates, grc_updates, batch_count),
+                dim3(thr_updates, thc_updates, 1), lmemsize_updates, stream, uplo, n, k, j, A,
+                shiftA, lda, strideA, W, shiftW, ldw, strideW, work, strideblk, tau, strideP);
 
             ROCSOLVER_LAUNCH_KERNEL((latrd_dot_scale_axpy<1024, T>), dim3(1, 1, batch_count),
                                     dim3(1024, 1, 1), 0, stream, j, A, shiftA + idx2D(0, j, lda),

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_latrd_forsytrd.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_latrd_forsytrd.hpp
@@ -130,17 +130,18 @@ ROCSOLVER_KERNEL void latrd_reduce_kernel(const rocblas_fill uplo,
 /***** Kernels to update column of A *****/
 /*****************************************/
 template <typename T, typename U>
-ROCSOLVER_KERNEL void latrd_upper_updateA_kernel(const rocblas_int mm,
-                                                 const rocblas_int k,
-                                                 const rocblas_int c,
-                                                 U AA,
-                                                 const rocblas_int shiftA,
-                                                 const rocblas_int lda,
-                                                 const rocblas_stride strideA,
-                                                 T* WA,
-                                                 const rocblas_int shiftW,
-                                                 const rocblas_int ldw,
-                                                 const rocblas_stride strideW)
+ROCSOLVER_KERNEL void latrd_updateA_kernel(rocblas_fill uplo,
+                                           const rocblas_int mm,
+                                           const rocblas_int k,
+                                           const rocblas_int c,
+                                           U AA,
+                                           const rocblas_int shiftA,
+                                           const rocblas_int lda,
+                                           const rocblas_stride strideA,
+                                           T* WA,
+                                           const rocblas_int shiftW,
+                                           const rocblas_int ldw,
+                                           const rocblas_stride strideW)
 {
     int bid = hipBlockIdx_z;
     int bidr = hipBlockIdx_x;
@@ -157,143 +158,63 @@ ROCSOLVER_KERNEL void latrd_upper_updateA_kernel(const rocblas_int mm,
     int idr = bidr * threadsr + tidr;
 
     // select batch instance
+    bool upper = (uplo == rocblas_fill_upper);
     T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
     T* W = load_ptr_batch<T>(WA, bid, shiftW, strideW);
 
     /* ------------------------
     formulate gemv problem:
+        upper:
+            components:
+                cw = c - mm + k
+                y = A(0:c, c)
+                A1 = A(0:c, c+1:mm-1)
+                A2 = W(0:c, cw+1:k-1)
+                x1 = W(c, cw+1:k-1)
+                x2 = A(c, c+1:mm-1)
 
-        components:
-            cw = c - mm + k
-            y = A(0:c, c)
-            A1 = A(0:c, c+1:mm-1)
-            A2 = W(0:c, cw+1:k-1)
-            x1 = W(c, cw+1:k-1)
-            x2 = A(c, c+1:mm-1)
+            operation:
+                y = y - A1 * x1' - A2 * x2'
 
-        operation:
-            y = y - A1 * x1' - A2 * x2'
+        lower:
+            components:
+                y = A(c:mm-1, c)
+                A1 = A(c:mm-1, 0:c-1)
+                A2 = W(c:mm-1, 0:c-1)
+                x1 = W(c, 0:c-1)
+                x2 = A(c, 0:c-1)
+
+            operation:
+                y = y - A1 * x1' - A2 * x2'
     ------------------------ */
-    int n = mm - c - 1;
-    int m = c + 1;
-    int cw = c - mm + k;
-    T* y = A + idx2D(0, c, lda);
-    T* A1 = A + idx2D(0, c + 1, lda);
-    int lda1 = lda;
-    T* A2 = W + idx2D(0, cw + 1, ldw);
-    int lda2 = ldw;
-    T* x1 = W + idx2D(c, cw + 1, ldw);
-    int incx1 = ldw;
-    T* x2 = A + idx2D(c, c + 1, lda);
-    int incx2 = lda;
+    int n, m;
+    T *y, *A1, *A2, *x1, *x2;
 
-    // rpgr and rpgc are the number of rounds a group should run
-    // to cover all the rows and columns, respectively
-    int ngrp = (m - 1) / threadsr + 1;
-    int rpgr = (ngrp - 1) / groupsr + 1;
-    ngrp = (n - 1) / threadsc + 1;
-    int rpgc = (ngrp - 1) / groupsc + 1;
-    int i, j;
-
-    // Registers/LDS:
-    // ac, acs -> accumulator
-    // sx -> hold the elements of 'x'
-    extern __shared__ double smem[]; //min size should be threadsr x threadsc
-    T* acs = reinterpret_cast<T*>(smem);
-    T ac;
-    T sx1, sx2;
-
-    for(int ii = 0; ii < rpgr; ++ii)
+    if(upper)
     {
-        i = ii * totalthsr + idr;
-
-        // read y
-        ac = (idc == 0 && i < m) ? y[i] : 0;
-
-        for(int jj = 0; jj < rpgc; ++jj)
-        {
-            // read x
-            j = jj * totalthsc + idc;
-            sx1 = (j < n) ? conj(x1[j * incx1]) : 0;
-            sx2 = (j < n) ? conj(x2[j * incx2]) : 0;
-
-            // operation for all rows
-            if(i < m && j < n)
-                ac -= A1[i + j * lda1] * sx1 + A2[i + j * lda2] * sx2;
-        }
-        acs[tidr + tidc * threadsr] = ac;
-        __syncthreads();
-
-        // group reduction
-        for(int r = threadsc / 2; r > 0; r /= 2)
-        {
-            if(tidc < r)
-            {
-                ac += acs[tidr + (tidc + r) * threadsr];
-                acs[tidr + tidc * threadsr] = ac;
-            }
-            __syncthreads();
-        }
-
-        // write results
-        if(tidc == 0 && i < m)
-            y[i] = ac;
+        int cw = c - mm + k;
+        n = mm - c - 1;
+        m = c + 1;
+        y = A + idx2D(0, c, lda);
+        A1 = A + idx2D(0, c + 1, lda);
+        A2 = W + idx2D(0, cw + 1, ldw);
+        x1 = W + idx2D(c, cw + 1, ldw);
+        x2 = A + idx2D(c, c + 1, lda);
     }
-}
+    else
+    {
+        m = mm - c;
+        n = c;
+        y = A + idx2D(c, c, lda);
+        A1 = A + idx2D(c, 0, lda);
+        A2 = W + idx2D(c, 0, ldw);
+        x1 = W + idx2D(c, 0, ldw);
+        x2 = A + idx2D(c, 0, lda);
+    }
 
-template <typename T, typename U>
-ROCSOLVER_KERNEL void latrd_lower_updateA_kernel(const rocblas_int mm,
-                                                 const rocblas_int c,
-                                                 U AA,
-                                                 const rocblas_int shiftA,
-                                                 const rocblas_int lda,
-                                                 const rocblas_stride strideA,
-                                                 T* WA,
-                                                 const rocblas_int shiftW,
-                                                 const rocblas_int ldw,
-                                                 const rocblas_stride strideW)
-{
-    int bid = hipBlockIdx_z;
-    int bidr = hipBlockIdx_x;
-    int bidc = hipBlockIdx_y;
-    int tidr = hipThreadIdx_x;
-    int tidc = hipThreadIdx_y;
-    int threadsr = hipBlockDim_x;
-    int threadsc = hipBlockDim_y;
-    int groupsr = hipGridDim_x;
-    int groupsc = hipGridDim_y;
-    int totalthsr = groupsr * threadsr;
-    int totalthsc = groupsc * threadsc;
-    int idc = bidc * threadsc + tidc;
-    int idr = bidr * threadsr + tidr;
-
-    // select batch instance
-    T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
-    T* W = load_ptr_batch<T>(WA, bid, shiftW, strideW);
-
-    /* ------------------------
-    formulate gemv problem:
-
-        components:
-            y = A(c:mm-1, c)
-            A1 = A(c:mm-1, 0:c-1)
-            A2 = W(c:mm-1, 0:c-1)
-            x1 = W(c, 0:c-1)
-            x2 = A(c, 0:c-1)
-
-        operation:
-            y = y - A1 * x1' - A2 * x2'
-    ------------------------ */
-    int m = mm - c;
-    int n = c;
-    T* y = A + idx2D(c, c, lda);
-    T* A1 = A + idx2D(c, 0, lda);
     int lda1 = lda;
-    T* A2 = W + idx2D(c, 0, ldw);
     int lda2 = ldw;
-    T* x1 = W + idx2D(c, 0, ldw);
     int incx1 = ldw;
-    T* x2 = A + idx2D(c, 0, lda);
     int incx2 = lda;
 
     // rpgr and rpgc are the number of rounds a group should run
@@ -905,10 +826,10 @@ rocblas_status rocsolver_latrd_forsytrd_template(rocblas_handle handle,
         {
             // update column j of A with reflector computed in step j-1
             //----------------------------------------------------------
-            ROCSOLVER_LAUNCH_KERNEL(latrd_lower_updateA_kernel<T>,
+            ROCSOLVER_LAUNCH_KERNEL(latrd_updateA_kernel<T>,
                                     dim3(grr_updates, grc_updates, batch_count),
-                                    dim3(thr_updates, thc_updates, 1), lmemsize_updates, stream, n,
-                                    j, A, shiftA, lda, strideA, W, shiftW, ldw, strideW);
+                                    dim3(thr_updates, thc_updates, 1), lmemsize_updates, stream,
+                                    uplo, n, k, j, A, shiftA, lda, strideA, W, shiftW, ldw, strideW);
             //-------------------------------------------------------------
 
             // reduce column j of A with new reflector, then copy off-diagonal element
@@ -955,10 +876,10 @@ rocblas_status rocsolver_latrd_forsytrd_template(rocblas_handle handle,
 
             // update column j of A with reflector computed in step j-1
             //----------------------------------------------------------
-            ROCSOLVER_LAUNCH_KERNEL(latrd_upper_updateA_kernel<T>,
+            ROCSOLVER_LAUNCH_KERNEL(latrd_updateA_kernel<T>,
                                     dim3(grr_updates, grc_updates, batch_count),
-                                    dim3(thr_updates, thc_updates, 1), lmemsize_updates, stream, n,
-                                    k, j, A, shiftA, lda, strideA, W, shiftW, ldw, strideW);
+                                    dim3(thr_updates, thc_updates, 1), lmemsize_updates, stream,
+                                    uplo, n, k, j, A, shiftA, lda, strideA, W, shiftW, ldw, strideW);
             //-------------------------------------------------------------
 
             // reduce column j of A with new reflector, then copy off-diagonal element

--- a/projects/rocsolver/library/src/auxiliary/rocauxiliary_latrd_forsytrd.hpp
+++ b/projects/rocsolver/library/src/auxiliary/rocauxiliary_latrd_forsytrd.hpp
@@ -274,47 +274,111 @@ ROCSOLVER_KERNEL void latrd_updateA_kernel(rocblas_fill uplo,
 /***** Kernels to compute column of W *****/
 /******************************************/
 template <int NB_X, typename T, typename U>
-ROCSOLVER_KERNEL void latrd_upper_computeW_gemvt_kernel(const rocblas_int mm,
-                                                        const rocblas_int k,
-                                                        const rocblas_int c,
-                                                        U AA,
-                                                        const rocblas_int shiftA,
-                                                        const rocblas_int lda,
-                                                        const rocblas_stride strideA,
-                                                        T* WA,
-                                                        const rocblas_int shiftW,
-                                                        const rocblas_int ldw,
-                                                        const rocblas_stride strideW,
-                                                        T* yA,
-                                                        const rocblas_int shiftY,
-                                                        const rocblas_int ldy,
-                                                        const rocblas_stride strideY,
-                                                        T* workA,
-                                                        const rocblas_stride strideblk)
+ROCSOLVER_KERNEL void latrd_computeW_gemvt_kernel(rocblas_fill uplo,
+                                                  const rocblas_int mm,
+                                                  const rocblas_int k,
+                                                  const rocblas_int c,
+                                                  U AA,
+                                                  const rocblas_int shiftA,
+                                                  const rocblas_int lda,
+                                                  const rocblas_stride strideA,
+                                                  T* WA,
+                                                  const rocblas_int shiftW,
+                                                  const rocblas_int ldw,
+                                                  const rocblas_stride strideW,
+                                                  T* yA,
+                                                  const rocblas_int shiftY,
+                                                  const rocblas_int ldy,
+                                                  const rocblas_stride strideY,
+                                                  T* workA,
+                                                  const rocblas_stride strideblk)
 {
     rocblas_int bid = blockIdx.z;
     rocblas_int tx = threadIdx.x;
     rocblas_int i = blockIdx.x;
 
+    // select batch instance
+    bool upper = (uplo == rocblas_fill_upper);
     T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
     T* W = load_ptr_batch<T>(WA, bid, shiftW, strideW);
-    T* y1 = load_ptr_batch<T>(yA, bid, shiftY, strideY);
-    T* y2 = workA + bid * strideblk;
+    T* yw = load_ptr_batch<T>(yA, bid, shiftY, strideY);
+    T* ywork = workA + bid * strideblk;
 
-    int n = c;
-    int cc = mm - c - 1;
-    // int m = mm + cc;
-    int cw = c - mm + k;
-    T* A1 = A;
-    T* A2 = W + idx2D(0, cw + 1, ldw);
-    int lda1 = lda;
-    int lda2 = ldw;
-    T* x = A + idx2D(0, c, lda);
+    int n, lda1, lda2, it, ld, i0;
+    T *a, *x, *y;
 
-    int it = (i < mm) ? i : i - mm;
-    T* a = (i < mm) ? A1 : A2;
-    int ld = (i < mm) ? lda1 : lda2;
-    T* y = (i < mm) ? y1 : y2;
+    /* -----------------------------
+    formulate gemv problem:
+        upper:
+            components:
+                cw = c - mm + k
+                A1 = A(0:c-1, :)
+                A2 = W(0:c-1, cw+1:k-1)
+                x = A(0:c-1, c)
+                yw = W(:, cw)
+                ywork = work (temp buffer)
+
+            operation:
+                        [   A1(:, 0:c-1)   ]
+                yw =    [        0         ] * x
+                        [ A1(:, c+1:mm-1)' ]
+                ywork = [        A2'       ] * x
+
+            Notes:
+                1. Here A1(:, 0:c-1) is full/general matrix (data below and above diagonal)
+
+        lower:
+            components:
+                A1 = W(c+1:mm-1, 0:c-1)
+                A2 = A(c+1:mm-1, :)
+                x = A(c+1,mm-1, c)
+                yw = W(:, cw)
+                ywork = work (temp buffer)
+
+            operation:
+                ywork = [       A1'       ] * x
+                        [  A2(:, 0:c-1)'  ]
+                yw =    [        0        ] * x
+                        [ A2(:, c+1:mm-1) ]
+
+            Notes:
+                1. Here A2(:, c+1:mm-1) is full/general matrix (data below and above diagonal)
+    ------------------------------ */
+    if(upper)
+    {
+        n = c;
+        lda1 = lda;
+        lda2 = ldw;
+
+        int cw = c - mm + k;
+        T* A1 = A;
+        T* A2 = W + idx2D(0, cw + 1, ldw);
+
+        x = A + idx2D(0, c, lda);
+
+        it = (i < mm) ? i : i - mm;
+        a = (i < mm) ? A1 : A2;
+        ld = (i < mm) ? lda1 : lda2;
+        y = (i < mm) ? yw : ywork;
+        i0 = c;
+    }
+    else
+    {
+        n = mm - c - 1;
+        lda1 = ldw;
+        lda2 = lda;
+
+        T* A1 = W + idx2D(c + 1, 0, ldw);
+        T* A2 = A + idx2D(c + 1, 0, lda);
+
+        x = A + idx2D(c + 1, c, lda);
+
+        it = (i < c) ? i : i - c;
+        a = (i < c) ? A1 : A2;
+        ld = (i < c) ? lda1 : lda2;
+        y = (i < c) ? ywork : yw;
+        i0 = 2 * c;
+    }
 
     if(tx < n)
         a += tx;
@@ -328,92 +392,7 @@ ROCSOLVER_KERNEL void latrd_upper_computeW_gemvt_kernel(const rocblas_int mm,
     // partial sums
     rocblas_int n_full = (n / NB_X) * NB_X;
 
-    if(i != c)
-    {
-        for(rocblas_int j = 0; j < n_full; j += NB_X)
-            res += conj(a[j]) * x[tx + j];
-
-        if(tx + n_full < n)
-            res += conj(a[n_full]) * x[tx + n_full];
-
-        // reduction of partial sums
-        res += shift_left(res, 1);
-        res += shift_left(res, 2);
-        res += shift_left(res, 4);
-        res += shift_left(res, 8);
-        res += shift_left(res, 16);
-        if(warpSize > 32)
-            res += shift_left(res, 32);
-        if(tx % warpSize == 0)
-            sdata[tx / warpSize] = res;
-        __syncthreads();
-        if(tx == 0)
-        {
-            for(rocblas_int k = 1; k < NB_X / warpSize; k++)
-                res += sdata[k];
-        }
-    }
-
-    if(tx == 0)
-    {
-        y[it] = res;
-    }
-}
-
-template <int NB_X, typename T, typename U>
-ROCSOLVER_KERNEL void latrd_lower_computeW_gemvt_kernel(const rocblas_int mm,
-                                                        const rocblas_int c,
-                                                        U AA,
-                                                        const rocblas_int shiftA,
-                                                        const rocblas_int lda,
-                                                        const rocblas_stride strideA,
-                                                        T* WA,
-                                                        const rocblas_int shiftW,
-                                                        const rocblas_int ldw,
-                                                        const rocblas_stride strideW,
-                                                        T* yA,
-                                                        const rocblas_int shiftY,
-                                                        const rocblas_int ldy,
-                                                        const rocblas_stride strideY,
-                                                        T* workA,
-                                                        const rocblas_stride strideblk)
-{
-    rocblas_int bid = blockIdx.z;
-    rocblas_int tx = threadIdx.x;
-    rocblas_int i = blockIdx.x;
-
-    T* A = load_ptr_batch<T>(AA, bid, shiftA, strideA);
-    T* W = load_ptr_batch<T>(WA, bid, shiftW, strideW);
-    T* y1 = workA + bid * strideblk;
-    T* y2 = load_ptr_batch<T>(yA, bid, shiftY, strideY);
-
-    int n = mm - c - 1;
-    // int m = mm + c;
-    T* A1 = W + idx2D(c + 1, 0, ldw);
-    T* A2 = A + idx2D(c + 1, 0, lda);
-    int lda1 = ldw;
-    int lda2 = lda;
-    T* x = A + idx2D(c + 1, c, lda);
-
-    int it = (i < c) ? i : i - c;
-    T* a = (i < c) ? A1 : A2;
-    int ld = (i < c) ? lda1 : lda2;
-    int it2 = it - c - 1;
-    T* y = (i < c) ? y1 : y2;
-
-    if(tx < n)
-        a += tx;
-
-    a += it * size_t(ld);
-
-    T res = 0;
-
-    __shared__ T sdata[NB_X];
-
-    // partial sums
-    rocblas_int n_full = (n / NB_X) * NB_X;
-
-    if(it != c)
+    if(i != i0)
     {
         for(rocblas_int j = 0; j < n_full; j += NB_X)
             res += conj(a[j]) * x[tx + j];
@@ -845,10 +824,10 @@ rocblas_status rocsolver_latrd_forsytrd_template(rocblas_handle handle,
             static constexpr int NB = 256;
             dim3 gemvt_grid(n + j, 1, batch_count);
             dim3 gemvt_threads(NB);
-            ROCSOLVER_LAUNCH_KERNEL((latrd_lower_computeW_gemvt_kernel<NB, T>), gemvt_grid,
-                                    gemvt_threads, 0, stream, n, j, A, shiftA, lda, strideA, W,
-                                    shiftW, ldw, strideW, W, shiftW + idx2D(0, j, ldw), ldw,
-                                    strideW, work, strideblk);
+            ROCSOLVER_LAUNCH_KERNEL((latrd_computeW_gemvt_kernel<NB, T>), gemvt_grid, gemvt_threads,
+                                    0, stream, uplo, n, k, j, A, shiftA, lda, strideA, W, shiftW,
+                                    ldw, strideW, W, shiftW + idx2D(0, j, ldw), ldw, strideW, work,
+                                    strideblk);
 
             // update column j of W
             //--------------------------------------------------------------
@@ -895,10 +874,10 @@ rocblas_status rocsolver_latrd_forsytrd_template(rocblas_handle handle,
             static constexpr int NB = 256;
             dim3 gemvt_grid(n + n - j - 1, 1, batch_count);
             dim3 gemvt_threads(NB);
-            ROCSOLVER_LAUNCH_KERNEL((latrd_upper_computeW_gemvt_kernel<NB, T>), gemvt_grid,
-                                    gemvt_threads, 0, stream, n, k, j, A, shiftA, lda, strideA, W,
-                                    shiftW, ldw, strideW, W, shiftW + idx2D(0, jw, ldw), ldw,
-                                    strideW, work, strideblk);
+            ROCSOLVER_LAUNCH_KERNEL((latrd_computeW_gemvt_kernel<NB, T>), gemvt_grid, gemvt_threads,
+                                    0, stream, uplo, n, k, j, A, shiftA, lda, strideA, W, shiftW,
+                                    ldw, strideW, W, shiftW + idx2D(0, jw, ldw), ldw, strideW, work,
+                                    strideblk);
 
             // update column j of W
             //--------------------------------------------------------------


### PR DESCRIPTION
## Motivation
Reduce duplicate code and aid LATRD optimization efforts by combining separate upper and lower kernels into one.

## Technical Details
Combine separate upper and lower latrd_forsytrd kernels into one and move branching inside the kernels. Additionally, document computeW kernel for maintainability.

## Test Plan
Validate locally and with CI tests.

## Test Results
Local tests passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
