### PR TITLE
Make the usage side’s logic consistent with allocation side (tPackM)

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/LocalRead.py
@@ -634,6 +634,13 @@ class LocalReadMFMA(LocalRead):
             needPack = False
         needPack |= (kernel["ConvertAfterDS"] and (tP["bpe"] != tP["bpeDS"]))
         needPack |= kernel["UseF32XEmulation"]
+
+        # Metadata pack SGPR prefix: "M" when both 16-bit (A/B) and 8-bit (metadata) packing coexist
+        # Must match tPackM logic in KernelWriterAssembly.py
+        tPackM = ""
+        if (kernel["ProblemType"]["MacDataTypeA"].isHalf() or kernel["ProblemType"]["MacDataTypeA"].isBFloat16()):
+            if (writer.states.lrvwTileA > 1 or writer.states.lrvwTileB > 1) and writer.states.lrvwTileMetadata > 1:
+                tPackM = "M"
         pack     = Module("pack%s_I%s"%(tc,iui))
         packPre = Module("pack%s_I%s Pre"%(tc,iui))
 
@@ -1028,13 +1035,13 @@ class LocalReadMFMA(LocalRead):
                                                             packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
                                                                             src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 1, i+vIdx*numVgpr)), \
                                                                             src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr)), \
-                                                                            src2=sgpr("PackKForV%u"%vgprOffset), \
-                                                                            comment="1 select K=%u%u for vector=%u"%(0, 1, vgprOffset)))
+                                                                            src2=sgpr("PackKFor%sV%u"%(tPackM, elementIdx)), \
+                                                                            comment="1 select K=%u%u for vector=%u"%(0, 1, elementIdx)))
                                                             packCodeT.add(VPermB32(dst=vgpr("PackTemp"), \
                                                                             src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 3, i+vIdx*numVgpr)), \
                                                                             src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 2, i+vIdx*numVgpr)), \
-                                                                            src2=sgpr("PackKForV%u"%vgprOffset), \
-                                                                            comment="1 select K=%u%u for vector=%u"%(2, 3, vgprOffset)))
+                                                                            src2=sgpr("PackKFor%sV%u"%(tPackM, elementIdx)), \
+                                                                            comment="1 select K=%u%u for vector=%u"%(2, 3, elementIdx)))
                                                             packCodeT.add(VLShiftLeftOrB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
                                                                             src0=vgpr("PackTemp"), shiftHex=16, \
                                                                             src1=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
@@ -1048,14 +1055,14 @@ class LocalReadMFMA(LocalRead):
                                                             packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx)), \
                                                                                     src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 1, i+vIdx*numVgpr)), \
                                                                                     src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr)), \
-                                                                                    src2=sgpr("PackKForV%u"%vgprOffset), \
-                                                                                    comment="select K=%u%u for vector=%u"%(0, 1, vgprOffset)))
+                                                                                    src2=sgpr("PackKFor%sV%u"%(tPackM, elementIdx)), \
+                                                                                    comment="select K=%u%u for vector=%u"%(0, 1, elementIdx)))
                                                             vgprOffset += 1
                                                 elif kernel["MIInputPerThread%s"%tc] == 1:
                                                     vgprIdx_ = vgprIdx+vIdx*(numSplitMetadata+1)
-                                                    packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_)), src=destVgpr))
+                                                    packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_)), src=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr))))
                                                     for elementIdx in range(1, numSplitMetadata+1):
-                                                        packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_ + elementIdx)), src=destVgpr, \
+                                                        packCodeT.add(VMovB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_ + elementIdx)), src=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, 0, i+vIdx*numVgpr)), \
                                                                             comment="another VGPR storing lshr 8-bit value %d %d" %(vgprIdx, elementIdx)))
                                                         packCodeT.add(VLShiftRightB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx_+elementIdx)), \
                                                                                     shiftHex=hex(8*elementIdx), \
@@ -1069,7 +1076,7 @@ class LocalReadMFMA(LocalRead):
                                                     packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+elementIdx+vIdx*2)), \
                                                                         src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, vgprOffset*2 + 1 , i+vIdx*numVgpr)), \
                                                                         src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, vgprOffset*2, i+vIdx*numVgpr)), \
-                                                                        src2=sgpr("PackKForV%u"%elementIdx), \
+                                                                        src2=sgpr("PackKFor%sV%u"%(tPackM, elementIdx % 2)), \
                                                                         comment="select K=%u%u for vector=%u"%(vgprOffset*2+1, vgprOffset*2, elementIdx)))
                                                     vgprOffset += (1 if elementIdx % 2 == 1 else 0)
                                             elif kernel["ProblemType"]["MacDataTypeA"].isHalf() or kernel["MFMA_BF16_1K"] or kernel["ProblemType"]["MacDataTypeA"].isBFloat16():
@@ -1078,7 +1085,7 @@ class LocalReadMFMA(LocalRead):
                                                     for elementIdx in range(0, int(tP["bpe"]*kernel["MIInputPerThread%s"%tc]//writer.states.bpr)):
                                                         packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+vgprOffset)), \
                                                                             src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg+1, i+vIdx*numVgpr)), \
-                                                                            src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg, i+vIdx*numVgpr)), src2=sgpr("PackKForV%u"%vectorIdx), \
+                                                                            src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg, i+vIdx*numVgpr)), src2=sgpr("PackKFor%sV%u"%(tPackM, vectorIdx)), \
                                                                             comment="select K=%u%u for vector=%u"%(elementIdx*numElementPerReg,  elementIdx*numElementPerReg+1, vectorIdx)))
                                                         vgprOffset += 1
                                             elif kernel["ProblemType"]["MacDataTypeA"].isInt8() or kernel["ProblemType"]["MacDataTypeA"].is8bitFloat():
@@ -1091,12 +1098,12 @@ class LocalReadMFMA(LocalRead):
                                                         packCodeT.add(VPermB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx+vgprOffset)), \
                                                                             src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg+1, i+vIdx*numVgpr)), \
                                                                             src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg, i+vIdx*numVgpr)), \
-                                                                            src2=sgpr("PackKForV%u"%vectorIdx), \
+                                                                            src2=sgpr("PackKFor%sV%u"%(tPackM, vectorIdx)), \
                                                                             comment="select K=%u%u for vector=%u"%(elementIdx*4,  elementIdx*4+1, vectorIdx)))
                                                         packCodeT.add(VPermB32(dst=vgpr("PackTemp"), \
                                                                             src0=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg+3, i+vIdx*numVgpr)), \
                                                                             src1=vgpr("Valu%s_X%u_I%u_D%u+%u"%(tc, bufferIdx, iui, elementIdx*numElementPerReg+2, i+vIdx*numVgpr)), \
-                                                                            src2=sgpr("PackKForV%u"%vectorIdx), \
+                                                                            src2=sgpr("PackKFor%sV%u"%(tPackM, vectorIdx)), \
                                                                             comment="select K=%u%u for vector=%u"%(elementIdx*4+2,  elementIdx*4+3, vectorIdx)))
                                                         packCodeT.add(VLShiftLeftOrB32(dst=vgpr("Valu%s_X%u_I%u+%u"%(tc, bufferIdx, iui, vgprIdx + vgprOffset)),
                                                                                     src0=vgpr("PackTemp"), \

--- a/projects/hipsparselt/library/src/hcc_detail/rocsparselt/src/tensile_host.cpp
+++ b/projects/hipsparselt/library/src/hcc_detail/rocsparselt/src/tensile_host.cpp
@@ -313,7 +313,8 @@ namespace
                                                        static_cast<double>(*prob.beta),
                                                        prob.workspaceSize);
 
-        tensileProblem.setComputeInputType(Tensile_Ti);
+        tensileProblem.setComputeInputTypeA(Tensile_Ti);
+        tensileProblem.setComputeInputTypeB(Tensile_Ti);
         tensileProblem.setAlphaType(Tensile_Tc);
         tensileProblem.setBetaType(Tensile_Tc);
 


### PR DESCRIPTION
## Motivation
- The error: [math-ci.amd.com/job/rocm-libraries/job/precheckin/job/hipsparselt/job/PR-5202/6/pipeline-overview/log?nodeId=628](https://math-ci.amd.com/job/rocm-libraries/job/precheckin/job/hipsparselt/job/PR-5202/6/pipeline-overview/log?nodeId=628)
- Fix the inconsistency between LocalRead.py and KernelWriterAssembly.py
- Change `setComputeInputType` to `setComputeInputTypeA` and `setComputeInputTypeB`, because `setComputeInputType` doesn't exist anymore.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- Inside the LocalRead side, it tries to reference the wrong names, which are non-set sgprs such as `sgprPackKForV2` and `sgprPackKForV3`. It shall reference `sgprPackKForMV2/sgprPackKForMV3`, so I have to make it reference the right ones.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

- Please use the attached file `setup_hipsparselt_build` to set the packages and env variables the same as the CI.
[setup_hipsparselt_build.sh](https://github.com/user-attachments/files/25870143/setup_hipsparselt_build.sh)
- `./install.sh -c`
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

- first build with errors: 
[build_hipsparselt_1st.log](https://github.com/user-attachments/files/25870212/build_hipsparselt_1st.log)

- final build WITHOUT errors: 
[build_hipsparselt_final.log](https://github.com/user-attachments/files/25870348/build_hipsparselt_final.log)


<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
