### PR TITLE
[CK_BUILDER] Added testing support for bwd data conv kernels

### DIFF
--- a/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/bwd_data.hpp
+++ b/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/bwd_data.hpp
@@ -1,0 +1,70 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "ck_tile/builder/testing/tensor_initialization.hpp"
+#include "ck_tile/builder/testing/testing_reflect.hpp"
+#include "ck_tile/builder/testing/conv/args.hpp"
+#include "ck_tile/builder/testing/error.hpp"
+
+/// This file deals with the backward data-specific details of running grouped
+/// convolution backwards data operations. It mainly defines the data
+/// structures (`Input` and `Output`), initialization, and validation.
+/// Note that for this operation specifically, many of the operations are
+/// implemented automatically via testing_reflect.hpp.
+
+namespace ck_tile::builder::test {
+
+/// @brief `Inputs` specialization for backwards data convolution.
+///
+/// @tparam SIGNATURE Backwards data convolution signature.
+///
+/// @see Inputs
+template <auto SIGNATURE>
+    requires ValidConvSignature<SIGNATURE> && ConvDirectionIsBackwardData<SIGNATURE>
+struct Inputs<SIGNATURE>
+{
+    void* weight;
+    void* output;
+
+    // See testing_reflect.hpp
+    static void reflect(const Args<SIGNATURE>& args, const auto& inspect)
+    {
+        inspect("weight", args.make_weight_descriptor(), &Inputs<SIGNATURE>::weight);
+        inspect("output", args.make_output_descriptor(), &Inputs<SIGNATURE>::output);
+    }
+};
+
+/// @brief `Outputs` specialization for backwards data convolution.
+///
+/// @tparam SIGNATURE Backwards data convolution signature.
+///
+/// @see Outputs
+template <auto SIGNATURE>
+    requires ValidConvSignature<SIGNATURE> && ConvDirectionIsBackwardData<SIGNATURE>
+struct Outputs<SIGNATURE>
+{
+    void* input;
+
+    // See testing_reflect.hpp
+    static void reflect(const Args<SIGNATURE>& args, const auto& inspect)
+    {
+        inspect("input", args.make_input_descriptor(), &Outputs<SIGNATURE>::input);
+    }
+};
+
+/// @brief `init_inputs()` specialization for backwards convolution.
+///
+/// @tparam SIGNATURE Backwards data convolution signature.
+///
+/// @see init_inputs()
+template <auto SIGNATURE>
+    requires ValidConvSignature<SIGNATURE> && ConvDirectionIsBackwardData<SIGNATURE>
+void init_inputs(const Args<SIGNATURE>& args, Inputs<SIGNATURE> inputs)
+{
+    init_tensor_buffer_uniform_fp(inputs.weight, args.make_weight_descriptor(), -2.0f, 2.0f);
+    init_tensor_buffer_uniform_fp(inputs.output, args.make_output_descriptor(), -2.0f, 2.0f);
+}
+
+} // namespace ck_tile::builder::test

--- a/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/bwd_data_ck.hpp
+++ b/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/bwd_data_ck.hpp
@@ -1,0 +1,169 @@
+// Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "ck_tile/builder/testing/testing.hpp"
+#include "ck_tile/builder/testing/conv/bwd_data.hpp"
+#include "ck_tile/builder/factory/helpers/ck/conv_elementwise_op.hpp"
+#include "ck_tile/builder/factory/helpers/ck/conv_tensor_type.hpp"
+#include <type_traits>
+#include <array>
+
+/// This file contains the implementation details for invoking/testing
+/// bwd data grouped convolution operations in old CK. The main item is
+/// the `run()` function, which is the main implementation used to invoke
+/// CK grouped backward data convolution kernels.
+
+namespace ck_tile::builder::test {
+
+namespace detail {
+
+/// @brief Concept for checking whether a bwd data convolution is invoked like old CK.
+///
+/// This is the same as `::ck_tile::builder::test::CkConvBwdDataInstance`, except
+/// with some utility aliases. For that reason, its moved to this detail
+/// namespace.
+template <typename Conv,
+          auto SIGNATURE,
+          size_t SPATIAL_DIM = SIGNATURE.spatial_dim,
+          // TODO: We shouldn't need to call into an internal namespace here.
+          typename Types = factory::internal::ConvTensorDataTypes<SIGNATURE>,
+          typename Ops   = factory::internal::ConvElementwiseOps<SIGNATURE>>
+concept CkConvBwdDataInstance =
+    requires(Conv& conv,
+             const Types::OutDataType* p_output, // A (output image)
+             const Types::WeiDataType* p_weight, // B (weight)
+             std::array<const void*, 0> p_ds,    // empty Ds (bias)
+             Types::InDataType* p_input,         // E (input image)
+             std::array<index_t, SPATIAL_DIM + 3> out_lengths,
+             std::array<index_t, SPATIAL_DIM + 3> out_strides,
+             std::array<index_t, SPATIAL_DIM + 3> wei_lengths,
+             std::array<index_t, SPATIAL_DIM + 3> wei_strides,
+             std::array<std::array<index_t, SPATIAL_DIM + 3>, 0> ds_lengths,
+             std::array<std::array<index_t, SPATIAL_DIM + 3>, 0> ds_strides,
+             std::array<index_t, SPATIAL_DIM + 3> in_lengths,
+             std::array<index_t, SPATIAL_DIM + 3> in_strides,
+             std::array<index_t, SPATIAL_DIM> filter,
+             Ops::OutElementwiseOp elementwise_a,  // output image op
+             Ops::WeiElementwiseOp elementwise_b,  // weight op
+             Ops::InElementwiseOp elementwise_cde, // input image op
+             ck::index_t split_k) {
+        requires ValidConvSignature<SIGNATURE>;
+        requires ConvDirectionIsBackwardData<SIGNATURE>;
+
+        {
+            // backward-data CK kernels: output (A), weight (B), bias (Ds, empty), input (E)
+            conv.MakeArgument(p_output,
+                              p_weight,
+                              p_ds,
+                              p_input,
+                              // output image lengths/strides (A)
+                              out_lengths,
+                              out_strides,
+                              // weight lengths/strides (B)
+                              wei_lengths,
+                              wei_strides,
+                              // bias lengths/strides (Ds - empty)
+                              ds_lengths,
+                              ds_strides,
+                              // input image lengths/strides (E)
+                              in_lengths,
+                              in_strides,
+                              // convolution strides/dilations/pads
+                              filter,
+                              filter,
+                              filter,
+                              filter,
+                              // element-wise operations
+                              elementwise_a,
+                              elementwise_b,
+                              elementwise_cde,
+                              split_k)
+        };
+    };
+
+} // namespace detail
+
+/// @brief Concept for checking whether a bwd data convolution is invoked like old CK.
+///
+/// - Conv The convolution type.
+/// - SIGNATURE The convolution signature.
+///
+/// @see detail::CkConvBwdDataInstance
+template <typename Conv, auto SIGNATURE>
+concept CkConvBwdDataInstance = detail::CkConvBwdDataInstance<Conv, SIGNATURE>;
+
+/// @brief `run()` specialization for backward data convolution and old CK.
+///
+/// @tparam SIGNATURE Backward data convolution signature.
+/// @returns RunResult about how the operation completed (or not).
+///
+/// @see run()
+template <auto SIGNATURE>
+    requires ValidConvSignature<SIGNATURE> && ConvDirectionIsBackwardData<SIGNATURE>
+[[nodiscard]] RunResult run(CkConvBwdDataInstance<SIGNATURE> auto& conv,
+                            const Args<SIGNATURE>& args,
+                            const Inputs<SIGNATURE>& inputs,
+                            const Outputs<SIGNATURE>& outputs)
+{
+    using Types = factory::internal::ConvTensorDataTypes<SIGNATURE>;
+
+    constexpr auto spatial_dim = SIGNATURE.spatial_dim;
+
+    const auto copy = [](const auto& src, auto& dst) {
+        std::copy(src.begin(), src.end(), dst.begin());
+    };
+
+    const auto to_ck_extent = [&](const auto& extent) {
+        std::array<ck::index_t, spatial_dim> result;
+        copy(extent, result);
+        return result;
+    };
+
+    const auto param = args.to_ck_conv_param();
+
+    const auto input_desc  = args.make_input_descriptor();
+    const auto weight_desc = args.make_weight_descriptor();
+    const auto output_desc = args.make_output_descriptor();
+
+    // For backward data: convert descriptor data to CK format
+    auto to_ck_lengths_from_vec = [](const auto& vec) {
+        std::array<ck::index_t, spatial_dim + 3> result;
+        std::copy(vec.begin(), vec.end(), result.begin());
+        return result;
+    };
+
+    // Create empty Ds array - for backward data, no bias tensors
+    const std::array<std::array<ck::index_t, spatial_dim + 3>, 0> ds_lengths{};
+    const std::array<std::array<ck::index_t, spatial_dim + 3>, 0> ds_strides{};
+
+    auto ck_args = conv.MakeArgument(
+        static_cast<const Types::OutDataType*>(inputs.output), // p_a (output image A)
+        static_cast<const Types::WeiDataType*>(inputs.weight), // p_b (weight B)
+        std::array<const void*, 0>{},                          // p_ds (empty - no bias)
+        static_cast<Types::InDataType*>(outputs.input),        // p_e (input image E - result)
+        to_ck_lengths_from_vec(output_desc.get_lengths()),     // a_g_n_k_wos_lengths
+        to_ck_lengths_from_vec(output_desc.get_strides()),     // a_g_n_k_wos_strides
+        to_ck_lengths_from_vec(weight_desc.get_lengths()),     // b_g_k_c_xs_lengths
+        to_ck_lengths_from_vec(weight_desc.get_strides()),     // b_g_k_c_xs_strides
+        ds_lengths,                                            // ds_g_n_c_wis_lengths (empty)
+        ds_strides,                                            // ds_g_n_c_wis_strides (empty)
+        to_ck_lengths_from_vec(input_desc.get_lengths()),      // e_g_n_c_wis_lengths
+        to_ck_lengths_from_vec(input_desc.get_strides()),      // e_g_n_c_wis_strides
+        to_ck_extent(param.conv_filter_strides_),
+        to_ck_extent(param.conv_filter_dilations_),
+        to_ck_extent(param.input_left_pads_),
+        to_ck_extent(param.input_right_pads_),
+        args.a_elementwise_op,
+        args.b_elementwise_op,
+        args.cde_elementwise_op,
+        args.k_batch);
+
+    if(!conv.IsSupportedArgument(ck_args))
+        return RunResult::not_supported("invalid ck arguments");
+
+    return RunResult::from_runtime(conv.MakeInvoker().Run(ck_args));
+}
+
+} // namespace ck_tile::builder::test

--- a/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/bwd_weight_ck.hpp
+++ b/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/bwd_weight_ck.hpp
@@ -10,9 +10,9 @@
 #include <array>
 
 /// This file contains the implementation details for invoking/testing
-/// bwd grouped convolution operations in old CK. The main item is the
-/// `run()` function, which is the main implementation used to invoke
-/// CK grouped forward convolution kernels.
+/// bwd weight grouped convolution operations in old CK. The main item
+/// is the `run()` function, which is the main implementation used to
+/// invoke CK backward weight grouped convolution kernels.
 
 namespace ck_tile::builder::test {
 
@@ -146,7 +146,7 @@ concept CkConvBwdWeightMultipleDInstance =
 
 /// @brief `run()` specialization for backward weight convolution and old CK.
 ///
-/// @tparam SIGNATURE Forward convolution signature.
+/// @tparam SIGNATURE Backward weight convolution signature.
 /// @returns RunResult about how the operation completed (or not).
 ///
 /// @see run()
@@ -210,7 +210,7 @@ template <auto SIGNATURE>
 ///
 /// This overload is specialized for Multiple-D.
 ///
-/// @tparam SIGNATURE Forward convolution signature.
+/// @tparam SIGNATURE Backward weight convolution signature.
 /// @returns RunResult about how the operation completed (or not).
 ///
 /// @see run()

--- a/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/ck_tile.hpp
+++ b/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/ck_tile.hpp
@@ -132,7 +132,29 @@ template <auto SIGNATURE>
     return detail::run(conv,
                        args,
                        static_cast<const void*>(inputs.input),
-                       static_cast<void*>(outputs.weight),
+                       static_cast<const void*>(outputs.weight),
+                       static_cast<void*>(inputs.output),
+                       s_conf);
+}
+
+/// @brief `run()` specialization for backwards data convolution and CK Tile.
+///
+/// @tparam SIGNATURE Backwards data convolution signature.
+/// @returns RunResult about how the operation completed (or not).
+///
+/// @see run()
+template <auto SIGNATURE>
+    requires ConvDirectionIsBackwardData<SIGNATURE>
+[[nodiscard]] RunResult run(CkTileConvInstance<SIGNATURE> auto& conv,
+                            const Args<SIGNATURE>& args,
+                            const Inputs<SIGNATURE>& inputs,
+                            const Outputs<SIGNATURE>& outputs,
+                            const ck_tile::stream_config s_conf = {})
+{
+    return detail::run(conv,
+                       args,
+                       static_cast<void*>(outputs.input),
+                       static_cast<const void*>(inputs.weight),
                        static_cast<const void*>(inputs.output),
                        s_conf);
 }

--- a/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/reference.hpp
+++ b/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/reference.hpp
@@ -118,7 +118,7 @@ concept RefConvBwdWeightInstance =
     detail::RefConvInstance<Conv, SIGNATURE, const void*, void*, const void*> &&
     ConvDirectionIsBackwardWeight<SIGNATURE>;
 
-/// @brief `run()` specialization for forward convolution and the reference
+/// @brief `run()` specialization for backward weight convolution and the reference
 /// backward weight implementation.
 ///
 /// @tparam SIGNATURE The signature of the operation to perform. Must be backwards weight.

--- a/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/reference.hpp
+++ b/projects/composablekernel/experimental/builder/include/ck_tile/builder/testing/conv/reference.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "ck_tile/builder/conv_signature_concepts.hpp"
 #include "ck_tile/builder/testing/testing.hpp"
 #include "ck/library/utility/convolution_parameter.hpp"
 #include <stdexcept>
@@ -132,6 +133,34 @@ template <auto SIGNATURE>
                             const Outputs<SIGNATURE>& outputs)
 {
     return detail::run(conv, args, inputs.input, outputs.weight, inputs.output);
+}
+
+/// @brief Concept for checking whether this is the reference convolution
+/// backward data implementation.
+template <typename Conv, auto SIGNATURE>
+concept RefConvBwdDataInstance =
+    detail::RefConvInstance<Conv, SIGNATURE, const void*, void*, const void*> &&
+    ConvDirectionIsBackwardData<SIGNATURE>;
+
+/// @brief `run()` specialization for backward data convolution and the reference
+/// backward data implementation.
+///
+/// @tparam SIGNATURE The signature of the operation to perform. Must be backwards data.
+/// @returns RunResult about how the operation completed (or not).
+///
+/// @see run()
+template <auto SIGNATURE>
+[[nodiscard]] RunResult run(RefConvBwdDataInstance<SIGNATURE> auto& conv,
+                            const Args<SIGNATURE>& args,
+                            const Inputs<SIGNATURE>& inputs,
+                            const Outputs<SIGNATURE>& outputs)
+{
+    if(false)
+    {
+        return {};
+    }
+    // For backward-data the reference expects (dX, W, dY)
+    return detail::run(conv, args, outputs.input, inputs.weight, inputs.output);
 }
 
 } // namespace ck_tile::builder::test

--- a/projects/composablekernel/experimental/builder/test/conv/ck/test_ckb_conv_bwd_data_multi_d_wmma_cshuffle.cpp
+++ b/projects/composablekernel/experimental/builder/test/conv/ck/test_ckb_conv_bwd_data_multi_d_wmma_cshuffle.cpp
@@ -4,7 +4,11 @@
 #include "utils/ckb_conv_test_configs.hpp"
 #include "utils/ckb_conv_test_utils.hpp"
 #include "utils/conv_algorithm_type_utils.hpp"
-#include "ck_tile/host/device_prop.hpp"
+#include "ck_tile/builder/testing/conv/bwd_data_ck.hpp"
+#include "ck_tile/builder/testing/conv/reference.hpp"
+#include "testing_utils.hpp"
+
+namespace {
 
 namespace ckb = ck_tile::builder;
 namespace ckt = ck_tile::builder::test;
@@ -22,13 +26,17 @@ constexpr auto SIGNATURE =
 constexpr auto ALGORITHM = cku::ConvAlgorithm_DeviceGroupedConvBwdDataMultipleD_Wmma_CShuffle{}
                                .with_thread_block(cku::ThreadBlock_64_32x32x32)
                                .with_gemm_config(cku::GemmParams_Wmma_16x16_2x1_per_wave)
-                               .with_transfer(cku::BwdTransfer_4x8x1_4x16x1_v3)
+                               .with_transfer(cku::BwdTransfer_4x16x1_4x16x1_v3)
                                .with_bwd_data_specialization(ckb::ConvSpecialization::DEFAULT)
                                .with_prefetch_config(1, ckb::PipelineScheduler::DEFAULT)
                                .with_gridwise_gemm_pipeline(ckb::PipelineVersion::V1);
 
 using Builder  = ckb::ConvBuilder<SIGNATURE, ALGORITHM>;
 using Instance = Builder::Instance;
+
+using Reference = ckb::ConvBuilder<SIGNATURE, ckt::ConvAlgorithm_Reference{}>::Instance;
+
+} // namespace
 
 TEST(BwdData_2DFp16_MultiD_Wmma_CShuffle_GNHWC, Create)
 {
@@ -40,4 +48,46 @@ TEST(BwdData_2DFp16_MultiD_Wmma_CShuffle_GNHWC, Create)
                             "GNHWK,GKYXC,EmptyTuple,GNHWC",
                             "PassThrough,PassThrough,PassThrough",
                             "fp16,fp16"}); // check compute types
+}
+
+TEST(BwdData_2DFp16_MultiD_Wmma_CShuffle_GNHWC, Exec)
+{
+    if(!(ck::is_gfx11_supported() || ck::is_gfx12_supported()))
+    {
+        // Note: See device_grouped_conv_bwd_data_multiple_d_wmma_cshuffle.hpp `IsSupportedArgument`
+        GTEST_SKIP() << "unsupported architecture";
+    }
+    ckt::Args<SIGNATURE> args = {
+        .lengths =
+            {
+                .batch_size      = 2,
+                .groups          = 4,
+                .input_channels  = 32,
+                .output_channels = 48,
+                .image           = {.width = 32, .height = 56},
+                .filter          = {.width = 3, .height = 3},
+            },
+        .filter_strides     = {.width = 1, .height = 1},
+        .filter_dilation    = {.width = 1, .height = 1},
+        .input_left_pad     = {.width = 0, .height = 0},
+        .input_right_pad    = {.width = 0, .height = 0},
+        .a_elementwise_op   = {},
+        .b_elementwise_op   = {},
+        .cde_elementwise_op = {},
+    };
+
+    auto inputs    = ckt::alloc_inputs(args);
+    auto outputs   = ckt::alloc_outputs(args);
+    auto reference = ckt::alloc_outputs(args);
+
+    ckt::init_inputs(args, inputs.get());
+
+    using namespace ck_tile::test;
+    auto conv = Instance{};
+    EXPECT_THAT(ckt::run(conv, args, inputs.get(), outputs.get()), SuccessfulRun());
+
+    auto ref_conv = Reference{};
+    EXPECT_THAT(ckt::run(ref_conv, args, inputs.get(), reference.get()), SuccessfulRun());
+
+    EXPECT_THAT(outputs.get(), MatchesReference(args, reference.get()));
 }

--- a/projects/composablekernel/experimental/builder/test/conv/ck/test_ckb_conv_bwd_data_multi_d_wmma_cshuffle_v3.cpp
+++ b/projects/composablekernel/experimental/builder/test/conv/ck/test_ckb_conv_bwd_data_multi_d_wmma_cshuffle_v3.cpp
@@ -4,7 +4,11 @@
 #include "utils/ckb_conv_test_configs.hpp"
 #include "utils/ckb_conv_test_utils.hpp"
 #include "utils/conv_algorithm_type_utils.hpp"
-#include "ck_tile/host/device_prop.hpp"
+#include "ck_tile/builder/testing/conv/bwd_data_ck.hpp"
+#include "ck_tile/builder/testing/conv/reference.hpp"
+#include "testing_utils.hpp"
+
+namespace {
 
 namespace ckb = ck_tile::builder;
 namespace ckt = ck_tile::builder::test;
@@ -22,7 +26,7 @@ constexpr auto SIGNATURE =
 constexpr auto ALGORITHM = cku::ConvAlgorithm_DeviceGroupedConvBwdDataMultipleD_Wmma_CShuffle_V3{}
                                .with_thread_block(cku::ThreadBlock_64_32x32x32)
                                .with_gemm_config(cku::GemmParamsABK1_Wmma_16x16_2x1_per_wave)
-                               .with_transfer(cku::BwdTransfer_4x8x1_4x16x1_v3)
+                               .with_transfer(cku::BwdTransfer_4x16x1_4x16x1_v3)
                                .with_bwd_data_specialization(ckb::ConvSpecialization::DEFAULT)
                                .with_prefetch_config(1, ckb::PipelineScheduler::DEFAULT)
                                .with_gemm_pad_params(0, 0)
@@ -31,6 +35,10 @@ constexpr auto ALGORITHM = cku::ConvAlgorithm_DeviceGroupedConvBwdDataMultipleD_
 
 using Builder  = ckb::ConvBuilder<SIGNATURE, ALGORITHM>;
 using Instance = Builder::Instance;
+
+using Reference = ckb::ConvBuilder<SIGNATURE, ckt::ConvAlgorithm_Reference{}>::Instance;
+
+} // namespace
 
 TEST(BwdData_2DFp16_MultiD_Wmma_CShuffle_V3_GNHWC, Create)
 {
@@ -42,4 +50,48 @@ TEST(BwdData_2DFp16_MultiD_Wmma_CShuffle_V3_GNHWC, Create)
                             "GNHWK,GKYXC,EmptyTuple,GNHWC",
                             "PassThrough,PassThrough,PassThrough",
                             "fp16,fp16"}); // check compute types
+}
+
+TEST(BwdData_2DFp16_MultiD_Wmma_CShuffle_V3_GNHWC, Exec)
+{
+    if(!(ck::is_gfx11_supported() || ck::is_gfx12_supported()))
+    {
+        // Note: See device_grouped_conv_bwd_data_multiple_d_wmma_cshuffle_v3.hpp
+        // `IsSupportedArgument`
+        GTEST_SKIP() << "unsupported architecture";
+    }
+
+    ckt::Args<SIGNATURE> args = {
+        .lengths =
+            {
+                .batch_size      = 2,
+                .groups          = 4,
+                .input_channels  = 128,
+                .output_channels = 48,
+                .image           = {.width = 128, .height = 32},
+                .filter          = {.width = 3, .height = 3},
+            },
+        .filter_strides     = {.width = 1, .height = 1},
+        .filter_dilation    = {.width = 1, .height = 1},
+        .input_left_pad     = {.width = 0, .height = 0},
+        .input_right_pad    = {.width = 0, .height = 0},
+        .a_elementwise_op   = {},
+        .b_elementwise_op   = {},
+        .cde_elementwise_op = {},
+    };
+
+    auto inputs    = ckt::alloc_inputs(args);
+    auto outputs   = ckt::alloc_outputs(args);
+    auto reference = ckt::alloc_outputs(args);
+
+    ckt::init_inputs(args, inputs.get());
+
+    using namespace ck_tile::test;
+    auto conv = Instance{};
+    EXPECT_THAT(ckt::run(conv, args, inputs.get(), outputs.get()), SuccessfulRun());
+
+    auto ref_conv = Reference{};
+    EXPECT_THAT(ckt::run(ref_conv, args, inputs.get(), reference.get()), SuccessfulRun());
+
+    EXPECT_THAT(outputs.get(), MatchesReference(args, reference.get()));
 }

--- a/projects/composablekernel/experimental/builder/test/conv/ck/test_ckb_conv_bwd_data_multi_d_xdl_cshuffle.cpp
+++ b/projects/composablekernel/experimental/builder/test/conv/ck/test_ckb_conv_bwd_data_multi_d_xdl_cshuffle.cpp
@@ -1,10 +1,16 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
+
 #include "gmock/gmock.h"
+
+#include "ck_tile/builder/testing/conv/bwd_data_ck.hpp"
+#include "ck_tile/builder/testing/conv/reference.hpp"
 #include "utils/ckb_conv_test_configs.hpp"
 #include "utils/ckb_conv_test_utils.hpp"
 #include "utils/conv_algorithm_type_utils.hpp"
-#include "ck_tile/host/device_prop.hpp"
+#include "testing_utils.hpp"
+
+namespace {
 
 namespace ckb = ck_tile::builder;
 namespace ckt = ck_tile::builder::test;
@@ -22,7 +28,7 @@ constexpr auto SIGNATURE =
 constexpr auto ALGORITHM = cku::ConvAlgorithm_DeviceGroupedConvBwdDataMultipleD_Xdl_CShuffle{}
                                .with_thread_block(cku::ThreadBlock_256_256x128x32)
                                .with_gemm_config(cku::BwdDataGemmParams_Xdl_4x4_per_wave)
-                               .with_transfer(cku::Transfer_4x64x1)
+                               .with_transfer(cku::BwdTransfer_4x64x1_Xdl)
                                .with_prefetch_config(1, ckb::PipelineScheduler::DEFAULT)
                                .with_bwd_data_specialization(ckb::ConvSpecialization::DEFAULT)
                                .with_gemm_pad_params(0, 0)
@@ -30,6 +36,10 @@ constexpr auto ALGORITHM = cku::ConvAlgorithm_DeviceGroupedConvBwdDataMultipleD_
 
 using Builder  = ckb::ConvBuilder<SIGNATURE, ALGORITHM>;
 using Instance = Builder::Instance;
+
+using Reference = ckb::ConvBuilder<SIGNATURE, ckt::ConvAlgorithm_Reference{}>::Instance;
+
+} // namespace
 
 TEST(BwdData_2DFp16_MultiD_Xdl_CShuffle_GNHWC, Create)
 {
@@ -41,4 +51,41 @@ TEST(BwdData_2DFp16_MultiD_Xdl_CShuffle_GNHWC, Create)
                             "GNHWK,GKYXC,EmptyTuple,GNHWC",
                             "PassThrough,PassThrough,PassThrough",
                             "fp16,fp16"}); // check compute types
+}
+
+TEST(BwdData_2DFp16_MultiD_Xdl_CShuffle_GNHWC, Exec)
+{
+    ckt::Args<SIGNATURE> args = {
+        .lengths =
+            {
+                .batch_size      = 2,
+                .groups          = 4,
+                .input_channels  = 128,
+                .output_channels = 48,
+                .image           = {.width = 32, .height = 56},
+                .filter          = {.width = 3, .height = 3},
+            },
+        .filter_strides     = {.width = 1, .height = 1},
+        .filter_dilation    = {.width = 1, .height = 1},
+        .input_left_pad     = {.width = 0, .height = 0},
+        .input_right_pad    = {.width = 0, .height = 0},
+        .a_elementwise_op   = {},
+        .b_elementwise_op   = {},
+        .cde_elementwise_op = {},
+    };
+
+    auto inputs    = ckt::alloc_inputs(args);
+    auto outputs   = ckt::alloc_outputs(args);
+    auto reference = ckt::alloc_outputs(args);
+
+    ckt::init_inputs(args, inputs.get());
+
+    using namespace ck_tile::test;
+    auto conv = Instance{};
+    EXPECT_THAT(ckt::run(conv, args, inputs.get(), outputs.get()), SuccessfulRun());
+
+    auto ref_conv = Reference{};
+    EXPECT_THAT(ckt::run(ref_conv, args, inputs.get(), reference.get()), SuccessfulRun());
+
+    EXPECT_THAT(outputs.get(), MatchesReference(args, reference.get()));
 }

--- a/projects/composablekernel/experimental/builder/test/conv/ck_tile/test_ckb_conv_bwd_data_2d_fp16_v3.cpp
+++ b/projects/composablekernel/experimental/builder/test/conv/ck_tile/test_ckb_conv_bwd_data_2d_fp16_v3.cpp
@@ -1,35 +1,48 @@
 // Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
+#include "ck_tile/builder/testing/conv/bwd_data.hpp"
+#include "ck_tile/builder/testing/conv/ck_tile.hpp"
+#include "ck_tile/builder/testing/conv/reference.hpp"
 #include "utils/ckb_conv_tile_test_configs.hpp"
 #include "utils/ckb_conv_test_utils.hpp"
+#include "testing_utils.hpp"
 
 namespace {
 
-using namespace ck_tile::builder::test_utils;
+namespace ckb = ck_tile::builder;
+namespace ckt = ck_tile::builder::test;
+namespace cku = ck_tile::builder::test_utils;
 
-TEST(BwdDataConvInstances, Create_ConvAlgorithm_Tile_GroupedConvolutionKernel_2D_FP16_NHWGC)
+using enum ck_tile::builder::TensorLayout;
+
+inline constexpr auto SIGNATURE = cku::ConvSignature{.spatial_dim = 2,
+                                                     .direction = ckb::ConvDirection::BACKWARD_DATA,
+                                                     .data_type = ckb::DataType::FP16,
+                                                     .accumulation_data_type = ckb::DataType::FP32,
+                                                     .input  = {.config = {.layout = NHWGC}},
+                                                     .weight = {.config = {.layout = GKYXC}},
+                                                     .output = {.config = {.layout = NHWGK}}};
+
+inline constexpr auto ALGORITHM =
+    cku::ConvAlgorithm_Tile_GroupedConvolutionKernel{}
+        .with_tile_specializations(ckb::TileConvSpecialization::DEFAULT)
+        .with_tile_thread_block(cku::TileThreadBlock_64x64x64)
+        .with_tile_block_gemm(cku::TileBlockGemmDesc_16x16_v3_intrawave)
+        .with_tile_transfer(cku::TileTransfer_4x4x4)
+        .with_tile_optimizations(ckt::TileOptimizations{
+            .num_groups_to_merge = 1, .split_image = false, .explicit_gemm = false});
+
+using Builder  = ckb::ConvBuilder<SIGNATURE, ALGORITHM>;
+using Instance = Builder::Instance;
+
+using Reference = ckb::ConvBuilder<SIGNATURE, ckt::ConvAlgorithm_Reference{}>::Instance;
+
+} // namespace
+
+TEST(BwdData_Tile_GroupedConv_2D_FP16_NHWGC, Create)
 {
-    constexpr ConvSignature BwdDataConvSignature{
-        .spatial_dim            = 2,
-        .direction              = ConvDirection::BACKWARD_DATA,
-        .data_type              = DataType::FP16,
-        .accumulation_data_type = DataType::FP32,
-        .input                  = {.config = {.layout = TensorLayout::NHWGC}},
-        .weight                 = {.config = {.layout = TensorLayout::GKYXC}},
-        .output                 = {.config = {.layout = TensorLayout::NHWGK}}};
-
-    constexpr auto BwdDataConvAlgorithm =
-        ConvAlgorithm_Tile_GroupedConvolutionKernel{}
-            .with_tile_specializations(TileConvSpecialization::DEFAULT)
-            .with_tile_thread_block(TileThreadBlock_64x64x64)
-            .with_tile_block_gemm(TileBlockGemmDesc_16x16_v3_intrawave)
-            .with_tile_transfer(TileTransfer_4x4x4)
-            .with_tile_optimizations(TileOptimizations{
-                .num_groups_to_merge = 1, .split_image = false, .explicit_gemm = false});
-
-    using Builder = ConvBuilder<BwdDataConvSignature, BwdDataConvAlgorithm>;
-    run_ck_tile_test<Builder>({
+    cku::run_ck_tile_test<Builder>({
         "grouped_convolution_backward_data",
         "fp16",
         "NHWGC_GKYXC_NHWGK",
@@ -49,4 +62,39 @@ TEST(BwdDataConvInstances, Create_ConvAlgorithm_Tile_GroupedConvolutionKernel_2D
     });
 }
 
-} // namespace
+TEST(BwdData_Tile_GroupedConv_2D_FP16_NHWGC, Exec)
+{
+    ckt::Args<SIGNATURE> args = {
+        .lengths =
+            {
+                .batch_size      = 2,
+                .groups          = 4,
+                .input_channels  = 32,
+                .output_channels = 48,
+                .image           = {.width = 32, .height = 56},
+                .filter          = {.width = 3, .height = 3},
+            },
+        .filter_strides     = {.width = 1, .height = 1},
+        .filter_dilation    = {.width = 1, .height = 1},
+        .input_left_pad     = {.width = 0, .height = 0},
+        .input_right_pad    = {.width = 0, .height = 0},
+        .a_elementwise_op   = {},
+        .b_elementwise_op   = {},
+        .cde_elementwise_op = {},
+    };
+
+    auto inputs    = ckt::alloc_inputs(args);
+    auto outputs   = ckt::alloc_outputs(args);
+    auto reference = ckt::alloc_outputs(args);
+
+    ckt::init_inputs(args, inputs.get());
+
+    using namespace ck_tile::test;
+    auto conv = Instance{};
+    EXPECT_THAT(ckt::run(conv, args, inputs.get(), outputs.get()), SuccessfulRun());
+
+    auto ref_conv = Reference{};
+    EXPECT_THAT(ckt::run(ref_conv, args, inputs.get(), reference.get()), SuccessfulRun());
+
+    EXPECT_THAT(outputs.get(), MatchesReference(args, reference.get()));
+}

--- a/projects/composablekernel/experimental/builder/test/utils/ckb_conv_test_configs.hpp
+++ b/projects/composablekernel/experimental/builder/test/utils/ckb_conv_test_configs.hpp
@@ -83,6 +83,39 @@ constexpr Transfer<> Transfer_4x64x1{
         },
 };
 
+constexpr Transfer<> BwdTransfer_4x64x1_Xdl{
+    .a =
+        {
+            .block_transfer               = {.k0 = 4, .m_n = 64, .k1 = 1},
+            .lds_transfer                 = {.src_vector_dim            = 2,
+                                             .src_scalar_per_vector     = 2,
+                                             .lds_dst_scalar_per_vector = 4,
+                                             .is_direct_load            = false,
+                                             .lds_padding               = false},
+            .thread_cluster_arrange_order = {1, 0, 2},
+            .src_access_order             = {1, 0, 2},
+        },
+    .b =
+        {
+            .block_transfer               = {.k0 = 4, .m_n = 64, .k1 = 1},
+            .lds_transfer                 = {.src_vector_dim            = 1,
+                                             .src_scalar_per_vector     = 2,
+                                             .lds_dst_scalar_per_vector = 4,
+                                             .is_direct_load            = false,
+                                             .lds_padding               = false},
+            .thread_cluster_arrange_order = {1, 0, 2},
+            .src_access_order             = {1, 0, 2},
+        },
+    .c =
+        {
+            .thread_cluster_dims =
+                {.m_block = 1, .m_wave_per_xdl = 32, .n_block = 1, .n_wave_per_xdl = 8},
+            .epilogue = {.m_xdl_per_wave_per_shuffle = 1,
+                         .n_xdl_per_wave_per_shuffle = 1,
+                         .scalar_per_vector          = 2},
+        },
+};
+
 constexpr Transfer<4> BwdTransfer_4x64x1{
     .a =
         {
@@ -121,6 +154,39 @@ constexpr Transfer<> BwdTransfer_4x8x1_4x16x1_v3{
         {
             .block_transfer               = {.k0 = 4, .m_n = 8, .k1 = 1},
             .lds_transfer                 = {.src_vector_dim            = 1,
+                                             .src_scalar_per_vector     = 2,
+                                             .lds_dst_scalar_per_vector = 2,
+                                             .is_direct_load            = false,
+                                             .lds_padding               = false},
+            .thread_cluster_arrange_order = {2, 0, 1},
+            .src_access_order             = {1, 0, 2},
+        },
+    .b =
+        {
+            .block_transfer               = {.k0 = 4, .m_n = 16, .k1 = 1},
+            .lds_transfer                 = {.src_vector_dim            = 1,
+                                             .src_scalar_per_vector     = 2,
+                                             .lds_dst_scalar_per_vector = 2,
+                                             .is_direct_load            = false,
+                                             .lds_padding               = false},
+            .thread_cluster_arrange_order = {2, 0, 1},
+            .src_access_order             = {1, 0, 2},
+        },
+    .c =
+        {
+            .thread_cluster_dims =
+                {.m_block = 1, .m_wave_per_xdl = 8, .n_block = 1, .n_wave_per_xdl = 8},
+            .epilogue = {.m_xdl_per_wave_per_shuffle = 1,
+                         .n_xdl_per_wave_per_shuffle = 1,
+                         .scalar_per_vector          = 2},
+        },
+};
+
+constexpr Transfer<> BwdTransfer_4x16x1_4x16x1_v3{
+    .a =
+        {
+            .block_transfer               = {.k0 = 4, .m_n = 16, .k1 = 1},
+            .lds_transfer                 = {.src_vector_dim            = 2,
                                              .src_scalar_per_vector     = 2,
                                              .lds_dst_scalar_per_vector = 2,
                                              .is_direct_load            = false,
@@ -286,7 +352,7 @@ constexpr Transfer<> Transfer_4x32x1{
 constexpr GridwiseBwdDataXdlGemm BwdDataGemmParams_Xdl_4x4_per_wave{
     .ak1        = 8,
     .bk1        = 8,
-    .xdl_params = {.m_per_xdl = 32, .n_per_xdl = 32, .m_xdl_per_wave = 4, .n_xdl_per_wave = 4}};
+    .xdl_params = {.m_per_xdl = 16, .n_per_xdl = 16, .m_xdl_per_wave = 4, .n_xdl_per_wave = 4}};
 
 constexpr GridwiseBwdDataXdlGemm BwdDataGemmParams_Xdl_4x2_per_wave{
     .ak1        = 8,


### PR DESCRIPTION
## Motivation

We need to test the ported bwd data kernels.

## Technical Details

Created functions to support `run` implementations for old CK, CK Tile and reference checking.

## Test Plan

Added `Exec` test cases for the bwd data kernels.

## Test Result
Tests should pass for all target architectures.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
