### PR TITLE
[hipBLASlt] Restore gfx12 guard in StreamK generateSingleCall (cherry-pick #5275)

### DIFF
--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -1316,7 +1316,8 @@ namespace TensileLite
             rv.numWorkGroups.z = 1;
         }
 
-        // Use arch from existing hardware to avoid repeated hipGetDeviceProperties (SWDEV-579719)
+        // Use arch from existing hardware to avoid repeated hipGetDeviceProperties (SWDEV-579719).
+        // On gfx12 (e.g. gfx1200, gfx1201) do not flatten workgroups; kernels expect unflattened grid.
         auto removePrefix = [](const std::string& s) {
             size_t pos = s.find("gfx");
             if(pos != std::string::npos)
@@ -1326,7 +1327,7 @@ namespace TensileLite
             return s;
         };
         auto gpu_arch_no_prefix = removePrefix(hardware.archName());
-        if(internalArgsSupport.version >= 1)
+        if(stoi(gpu_arch_no_prefix) / 100 != 12 && internalArgsSupport.version >= 1)
         {
             if(internalArgsSupport.version >= 1)
             {


### PR DESCRIPTION
Cherry-pick of [#5275](https://github.com/ROCm/rocm-libraries/pull/5275) (from commit `6d8ae1e10e` on develop) into `release/rocm-rel-7.2`.

## Summary

Restores the gfx12 architecture guard in `ContractionSolution::generateSingleCall` so that StreamK workgroup flattening is skipped on gfx1200/gfx1201. PR #5146 (cherry-pick of #4665) had removed this guard when switching to `hardware.archName()`; on gfx12 the kernels expect the unflattened grid, and running the flatten block there causes memory access issues. This cherry-pick brings the fix to ROCm 7.2.

## Rationale

On gfx1200/gfx1201, the StreamK path must not flatten the workgroup grid; the original pre-#4665 code used `stoi(gpu_arch_no_prefix) / 100 != 12` to skip flattening on gfx12xx. Restoring that condition fixes the regression while keeping the use of `hardware.archName()` (no repeated `hipGetDeviceProperties`).

## Test Plan

- Run hipBLASLt StreamK / matmul tests on gfx1200 or gfx1201 to confirm the regression is fixed.
- Run the same tests on other architectures (e.g. gfx942) to confirm no behavior change.

## References

- ROCM-19925
- #5275 (develop fix)
- #4665 / #5146 (original change and its 7.2 cherry-pick that introduced the regression)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
