### PR TITLE
[hipDNN] Fix conv fprop/dgrad tolerance issues

### DIFF
--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuConvBackwardData.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuConvBackwardData.cpp
@@ -54,7 +54,12 @@ protected:
             testCase.wDims);
     }
 
-    void runGraphTest(float tolerance, const TensorLayout& layout = TensorLayout::NCHW)
+    // Fixed small rtol; dynamic atol already accounts for accumulation error.
+    static constexpr float RELATIVE_TOLERANCE = 0.01f;
+
+    void runGraphTest(float absoluteTolerance,
+                      float relativeTolerance,
+                      const TensorLayout& layout = TensorLayout::NCHW)
     {
         // Skipping until CK is working on Windows
         SKIP_IF_WINDOWS();
@@ -91,7 +96,7 @@ protected:
         dxTensorAttr->set_dim(testCase.xDims);
         dxTensorAttr->set_stride(generateStrides(testCase.xDims, layout.strideOrder));
 
-        this->registerValidator(dxTensorAttr, tolerance);
+        this->registerValidator(dxTensorAttr, absoluteTolerance, relativeTolerance);
         this->verifyGraph(graphObj, testCase.seed);
     }
 
@@ -121,62 +126,76 @@ using IntegrationGpuConvBwdDataNdhwcFp16 = ConvBackwardData<half>;
 
 TEST_P(IntegrationGpuConvBwdDataNchwFp32, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<float, float, float>(), TensorLayout::NCHW);
+    runGraphTest(
+        getConvDgradTolerance<float, float, float>(), RELATIVE_TOLERANCE, TensorLayout::NCHW);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNcdhwFp32, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<float, float, float>(), TensorLayout::NCDHW);
+    runGraphTest(
+        getConvDgradTolerance<float, float, float>(), RELATIVE_TOLERANCE, TensorLayout::NCDHW);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNchwBfp16, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<bfloat16, bfloat16, float>(), TensorLayout::NCHW);
+    runGraphTest(
+        getConvDgradTolerance<bfloat16, bfloat16, float>(), RELATIVE_TOLERANCE, TensorLayout::NCHW);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNcdhwBfp16, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<bfloat16, bfloat16, float>(), TensorLayout::NCDHW);
+    runGraphTest(getConvDgradTolerance<bfloat16, bfloat16, float>(),
+                 RELATIVE_TOLERANCE,
+                 TensorLayout::NCDHW);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNchwFp16, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<half, half, float>(), TensorLayout::NCHW);
+    runGraphTest(
+        getConvDgradTolerance<half, half, float>(), RELATIVE_TOLERANCE, TensorLayout::NCHW);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNcdhwFp16, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<half, half, float>(), TensorLayout::NCDHW);
+    runGraphTest(
+        getConvDgradTolerance<half, half, float>(), RELATIVE_TOLERANCE, TensorLayout::NCDHW);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNhwcFp32, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<float, float, float>(), TensorLayout::NHWC);
+    runGraphTest(
+        getConvDgradTolerance<float, float, float>(), RELATIVE_TOLERANCE, TensorLayout::NHWC);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNdhwcFp32, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<float, float, float>(), TensorLayout::NDHWC);
+    runGraphTest(
+        getConvDgradTolerance<float, float, float>(), RELATIVE_TOLERANCE, TensorLayout::NDHWC);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNhwcBfp16, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<bfloat16, bfloat16, float>(), TensorLayout::NHWC);
+    runGraphTest(
+        getConvDgradTolerance<bfloat16, bfloat16, float>(), RELATIVE_TOLERANCE, TensorLayout::NHWC);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNdhwcBfp16, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<bfloat16, bfloat16, float>(), TensorLayout::NDHWC);
+    runGraphTest(getConvDgradTolerance<bfloat16, bfloat16, float>(),
+                 RELATIVE_TOLERANCE,
+                 TensorLayout::NDHWC);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNhwcFp16, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<half, half, float>(), TensorLayout::NHWC);
+    runGraphTest(
+        getConvDgradTolerance<half, half, float>(), RELATIVE_TOLERANCE, TensorLayout::NHWC);
 }
 
 TEST_P(IntegrationGpuConvBwdDataNdhwcFp16, Correctness)
 {
-    runGraphTest(getConvDgradTolerance<half, half, float>(), TensorLayout::NDHWC);
+    runGraphTest(
+        getConvDgradTolerance<half, half, float>(), RELATIVE_TOLERANCE, TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,

--- a/dnn-providers/miopen-provider/integration_tests/IntegrationGpuConvForward.cpp
+++ b/dnn-providers/miopen-provider/integration_tests/IntegrationGpuConvForward.cpp
@@ -27,7 +27,9 @@ template <typename DataType>
 class ConvForward : public IntegrationGraphVerificationHarness<DataType, ConvTestCase>
 {
 protected:
-    void runGraphTest(float tolerance, const TensorLayout& layout = TensorLayout::NCHW)
+    void runGraphTest(float absoluteTolerance,
+                      float relativeTolerance,
+                      const TensorLayout& layout = TensorLayout::NCHW)
     {
         // Skipping until CK is working on Windows
         SKIP_IF_WINDOWS();
@@ -60,7 +62,7 @@ protected:
 
         yAttr->set_output(true);
 
-        this->registerValidator(yAttr, tolerance);
+        this->registerValidator(yAttr, absoluteTolerance, relativeTolerance);
 
         this->verifyGraph(graphObj, testCase.seed);
     }
@@ -88,62 +90,79 @@ using IntegrationGpuConvFwdNdhwcFp16 = ConvForward<half>;
 
 TEST_P(IntegrationGpuConvFwdNchwFp32, Correctness)
 {
-    runGraphTest(4e-6f, TensorLayout::NCHW);
+    runGraphTest(4e-6f, conv::getRelativeToleranceFwd<float>(), TensorLayout::NCHW);
 }
 
 TEST_P(IntegrationGpuConvFwdNcdhwFp32, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<float>(), TensorLayout::NCDHW);
+    runGraphTest(conv::getToleranceFwd<float>(),
+                 conv::getRelativeToleranceFwd<float>(),
+                 TensorLayout::NCDHW);
 }
 
 TEST_P(IntegrationGpuConvFwdNchwBfp16, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<bfloat16>(), TensorLayout::NCHW);
+    runGraphTest(conv::getToleranceFwd<bfloat16>(),
+                 conv::getRelativeToleranceFwd<bfloat16>(),
+                 TensorLayout::NCHW);
 }
 
 TEST_P(IntegrationGpuConvFwdNcdhwBfp16, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<bfloat16>(), TensorLayout::NCDHW);
+    runGraphTest(conv::getToleranceFwd<bfloat16>(),
+                 conv::getRelativeToleranceFwd<bfloat16>(),
+                 TensorLayout::NCDHW);
 }
 
 TEST_P(IntegrationGpuConvFwdNchwFp16, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<half>(), TensorLayout::NCHW);
+    runGraphTest(
+        conv::getToleranceFwd<half>(), conv::getRelativeToleranceFwd<half>(), TensorLayout::NCHW);
 }
 
 TEST_P(IntegrationGpuConvFwdNcdhwFp16, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<half>(), TensorLayout::NCDHW);
+    runGraphTest(
+        conv::getToleranceFwd<half>(), conv::getRelativeToleranceFwd<half>(), TensorLayout::NCDHW);
 }
 
 TEST_P(IntegrationGpuConvFwdNhwcFp32, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<float>(), TensorLayout::NHWC);
+    runGraphTest(
+        conv::getToleranceFwd<float>(), conv::getRelativeToleranceFwd<float>(), TensorLayout::NHWC);
 }
 
 TEST_P(IntegrationGpuConvFwdNdhwcFp32, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<float>(), TensorLayout::NDHWC);
+    runGraphTest(conv::getToleranceFwd<float>(),
+                 conv::getRelativeToleranceFwd<float>(),
+                 TensorLayout::NDHWC);
 }
 
 TEST_P(IntegrationGpuConvFwdNhwcBfp16, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<bfloat16>(), TensorLayout::NHWC);
+    runGraphTest(conv::getToleranceFwd<bfloat16>(),
+                 conv::getRelativeToleranceFwd<bfloat16>(),
+                 TensorLayout::NHWC);
 }
 
 TEST_P(IntegrationGpuConvFwdNdhwcBfp16, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<bfloat16>(), TensorLayout::NDHWC);
+    runGraphTest(conv::getToleranceFwd<bfloat16>(),
+                 conv::getRelativeToleranceFwd<bfloat16>(),
+                 TensorLayout::NDHWC);
 }
 
 TEST_P(IntegrationGpuConvFwdNhwcFp16, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<half>(), TensorLayout::NHWC);
+    runGraphTest(
+        conv::getToleranceFwd<half>(), conv::getRelativeToleranceFwd<half>(), TensorLayout::NHWC);
 }
 
 TEST_P(IntegrationGpuConvFwdNdhwcFp16, Correctness)
 {
-    runGraphTest(conv::getToleranceFwd<half>(), TensorLayout::NDHWC);
+    runGraphTest(
+        conv::getToleranceFwd<half>(), conv::getRelativeToleranceFwd<half>(), TensorLayout::NDHWC);
 }
 
 INSTANTIATE_TEST_SUITE_P(Smoke,

--- a/projects/hipdnn/samples/convolution/ConvDgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvDgrad.cpp
@@ -10,7 +10,7 @@
 #include <hipdnn_frontend.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
-#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
 
 #include "../utils/Helpers.hpp"
 
@@ -107,10 +107,13 @@ bool SampleRunner::operator()(const TensorLayout& layout)
         hipdnn_test_sdk::utilities::CpuFpReferenceConvolution::dgrad(
             dxRefTensor, wTensor, dyTensor, {u, v}, {dilH, dilW}, {padH, padW});
 
-        auto tolerance = hipdnn_test_sdk::utilities::conv::getToleranceBwd<InputType>();
+        auto absoluteTolerance = hipdnn_test_sdk::utilities::conv::
+            calculateConvDgradTolerance<InputType, InputType, float>(
+                0.0, 1.0, 0.0, 1.0, wAttr->get_dim());
+        constexpr float relativeTolerance = 0.01f;
 
-        auto dxValidator
-            = hipdnn_test_sdk::utilities::CpuFpReferenceValidation<InputType>(tolerance, tolerance);
+        auto dxValidator = hipdnn_test_sdk::utilities::CpuFpReferenceValidation<InputType>(
+            absoluteTolerance, relativeTolerance);
 
         bool dxValid = dxValidator.allClose(dxRefTensor, dxTensor);
 

--- a/projects/hipdnn/samples/convolution/ConvWgrad.cpp
+++ b/projects/hipdnn/samples/convolution/ConvWgrad.cpp
@@ -11,7 +11,6 @@
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceConvolution.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
-#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
 
 #include "../utils/Helpers.hpp"
 
@@ -108,12 +107,13 @@ bool SampleRunner::operator()(const TensorLayout& layout)
         hipdnn_test_sdk::utilities::CpuFpReferenceConvolution::wgrad(
             xTensor, dwRefTensor, dyTensor, {u, v}, {dilH, dilW}, {padH, padW});
 
-        auto tolerance
-            = hipdnn_test_sdk::utilities::conv::calculateConvWrwTolerance<InputType, float>(
+        auto absoluteTolerance = hipdnn_test_sdk::utilities::conv::
+            calculateConvWrwTolerance<InputType, InputType, float>(
                 0.0, 1.0, 0.0, 1.0, dyAttr->get_dim());
+        constexpr float relativeTolerance = 0.01f;
 
-        auto dwValidator
-            = hipdnn_test_sdk::utilities::CpuFpReferenceValidation<InputType>(tolerance, tolerance);
+        auto dwValidator = hipdnn_test_sdk::utilities::CpuFpReferenceValidation<InputType>(
+            absoluteTolerance, relativeTolerance);
 
         bool dwValid = dwValidator.allClose(dwRefTensor, dwTensor);
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
@@ -167,7 +167,32 @@ constexpr float getToleranceFwd()
     }
     else if constexpr(std::is_same_v<T, bfloat16>)
     {
+        // Relaxed from 1e-2f to account for Winograd solvers (e.g. ConvWinoRageRxS),
+        // which introduce higher absolute error (~1-3 ULP) for bfloat16.
+        // See: https://github.com/ROCm/rocm-libraries/issues/5286
+        return 1e-1f;
+    }
+    else
+    {
+        static_assert(false, "Type not supported");
+    }
+}
+
+template <typename T>
+constexpr float getRelativeToleranceFwd()
+{
+    if constexpr(std::is_same_v<T, float>)
+    {
+        return 1e-5f;
+    }
+    else if constexpr(std::is_same_v<T, half>)
+    {
         return 1e-2f;
+    }
+    else if constexpr(std::is_same_v<T, bfloat16>)
+    {
+        // See: https://github.com/ROCm/rocm-libraries/issues/5286
+        return 2e-2f;
     }
     else
     {


### PR DESCRIPTION
## Motivation

#2429 added Bfp16 winograd support to MIOpen which causes breaks in existing test tolerances.
As a workaround we are bumping tolerances to unbreak CI.
Adding issue #5286 to track this.

## Technical Details

- Split rtol / atol functions since it's representing different values.
- Update bprop to set an atol, since it was using the dynamic tolerance for both (override does this for single value).
- Add updated rtol / atol for verification
- Add bprop dynamic tolerance for samples

## Test Plan

Tests and samples are passing now without errors

## Test Result

Waiting on CI, tests passing locally.
