### PR TITLE
[hipBLASlt] Revert #5146 - missing dependency #2681

### DIFF
--- a/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
+++ b/projects/hipblaslt/tensilelite/src/ContractionSolution.cpp
@@ -1316,7 +1316,10 @@ namespace TensileLite
             rv.numWorkGroups.z = 1;
         }
 
-        // Use arch from existing hardware to avoid repeated hipGetDeviceProperties (SWDEV-579719)
+        //short-term workaround
+        int             deviceId;
+        hipDeviceProp_t deviceProperties;
+
         auto removePrefix = [](const std::string& s) {
             size_t pos = s.find("gfx");
             if(pos != std::string::npos)
@@ -1325,8 +1328,11 @@ namespace TensileLite
             }
             return s;
         };
-        auto gpu_arch_no_prefix = removePrefix(hardware.archName());
-        if(internalArgsSupport.version >= 1)
+
+        static_cast<void>(hipGetDevice(&deviceId));
+        static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
+        auto gpu_arch_no_prefix = removePrefix(deviceProperties.gcnArchName);
+        if(stoi(gpu_arch_no_prefix) / 100 != 12)
         {
             if(internalArgsSupport.version >= 1)
             {


### PR DESCRIPTION
## Revert incomplete cherry-pick #5146

This reverts PR #5146 (cherry-pick of #4665 from develop to release/rocm-rel-7.2).

### Problem

PR #4665 was written on develop AFTER PR #2681 merged. PR #2681:
- Removed the gfx12 guard that prevented workgroup flattening on gfx12
- Added kernel-side ttmp restoration to handle flattened workgroups on gfx12

PR #4665 assumes this infrastructure exists and was written for a codebase where #2681 had already been merged.

When #5146 cherry-picked #4665 to release/rocm-rel-7.2 without also bringing #2681, it created an incomplete state:
- **Host-side**: Workgroups are flattened on gfx12 (from #4665, no guard)
- **Kernel-side**: No ttmp restoration code (missing #2681)
- **Result**: Segfaults on gfx1200/gfx1201 systems

### Solution

Revert #5146 to restore the previous working state. The release branch returns to:
- Calling \`hipGetDeviceProperties\` (slight performance cost, but correct)
- Preserving the gfx12 guard that prevents workgroup flattening on gfx12
- Working behavior on all architectures

### Future Work

For ROCm 7.3 or later, we can bring both #2681 and #4665 together to get the complete feature:
- Large grid support on gfx12 (from #2681)
- Better performance via cached arch info (from #4665)

### References

- #5146 (cherry-pick being reverted)
- #4665 (original PR on develop - works correctly there)
- #2681 (missing dependency with kernel-side ttmp restoration)
- ROCM-19925 (reported segfault on gfx12)

### Test Plan

- Verify hipBLASLt matmul tests pass on gfx1200/gfx1201 (no segfaults)
- Verify tests still pass on other architectures (gfx942, etc.)
- Performance may be slightly lower than #5146 due to \`hipGetDeviceProperties\` calls, but correctness is restored

### Submission Checklist

- [x] Reverts problematic change cleanly
- [x] Explains root cause and dependency issue
- [x] Documents path forward for future releases