### PR TITLE
[hipDNN] Fix type warning when compiling with MSVC.

### DIFF
--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Tensor.hpp
@@ -520,7 +520,7 @@ protected:
             std::inner_product(dims.begin(),
                                dims.end(),
                                strides.begin(),
-                               1,
+                               size_t{1},
                                std::plus<>(),
                                [](size_t len, size_t stride) { return (len - 1) * stride; }));
     }
@@ -533,7 +533,7 @@ protected:
         }
 
         return static_cast<size_t>(
-            std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>()));
+            std::accumulate(dims.begin(), dims.end(), int64_t{1}, std::multiplies<>()));
     }
 };
 


### PR DESCRIPTION
## Motivation

Fix warning in hipDNN frontend header files when using the MSVC 2022 compiler with warnings enabled; generates potential-data-loss warning that occurs when (`int`) literals are used with int64_t and size_t types.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
