### PR TITLE
reducing the problem size to improve the overall execution time for t…

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/cgemm.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/cgemm.yaml
@@ -81,17 +81,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          # - Exact: [32, 32, 1, 8]
-          # - Exact: [16, 16, 1, 2]
-          # - Exact: [2048, 2048, 1, 256] #128x128(times16)
-          # - Exact: [1024, 1024, 1, 64] #64x64(times16)
-          # - Exact: [512, 512, 1, 32] #32x32
-          # - Exact: [64, 64, 1, 16]
-          # - Exact: [64, 64, 1, 128]
-          # - Exact: [4096, 4096, 1, 8192]
-
-          # - Range: [[16,37, 512],[16,57,512],[1],[1,1,64]]
-          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
+          - Exact: [127, 0, 2, 63] 
 
   - # cgemm NT
     - # ProblemType
@@ -129,12 +119,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          # - Exact: [16, 16, 1, 2]
-          # - Exact: [2048, 2048, 1, 256] #128x128(times16)
-          # - Exact: [1024, 1024, 1, 64] #64x64(times16)
-          # - Exact: [512, 512, 1, 32] #32x32
-
-          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
+          - Exact: [127, 0, 2, 64] 
 
   - # cgemm TN
     - # ProblemType
@@ -172,12 +157,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          # - Exact: [16, 16, 1, 2]
-          # - Exact: [2048, 2048, 1, 256] #128x128(times16)
-          # - Exact: [1024, 1024, 1, 64] #64x64(times16)
-          # - Exact: [512, 512, 1, 32] #32x32
-
-          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
+          - Exact: [128, 0, 2, 63] 
 
   - # cgemm TT
     - # ProblemType
@@ -215,12 +195,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          # - Exact: [16, 16, 1, 2]
-          # - Exact: [2048, 2048, 1, 256] #128x128(times16)
-          # - Exact: [1024, 1024, 1, 64] #64x64(times16)
-          # - Exact: [512, 512, 1, 32] #32x32
-
-          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
+          - Exact: [129, 0, 2, 63] 
 
   - # cgemm NC
     - # ProblemType
@@ -258,12 +233,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          # - Exact: [16, 16, 1, 2]
-          # - Exact: [2048, 2048, 1, 256] #128x128(times16)
-          # - Exact: [1024, 1024, 1, 64] #64x64(times16)
-          # - Exact: [512, 512, 1, 32] #32x32
-
-          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
+          - Exact: [127, 0, 2, 64] 
 
   - # cgemm CN
     - # ProblemType
@@ -301,12 +271,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          # - Exact: [16, 16, 1, 2]
-          # - Exact: [2048, 2048, 1, 256] #128x128(times16)
-          # - Exact: [1024, 1024, 1, 64] #64x64(times16)
-          # - Exact: [512, 512, 1, 32] #32x32
-
-          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
+          - Exact: [128, 0, 2, 63] 
 
   - # cgemm TC
     - # ProblemType
@@ -344,12 +309,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          # - Exact: [16, 16, 1, 2]
-          # - Exact: [2048, 2048, 1, 256] #128x128(times16)
-          # - Exact: [1024, 1024, 1, 64] #64x64(times16)
-          # - Exact: [512, 512, 1, 32] #32x32
-
-          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
+          - Exact: [129, 0, 2, 63] 
 
   - # cgemm CT
     - # ProblemType
@@ -387,12 +347,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          # - Exact: [16, 16, 1, 2]
-          # - Exact: [2048, 2048, 1, 256] #128x128(times16)
-          # - Exact: [1024, 1024, 1, 64] #64x64(times16)
-          # - Exact: [512, 512, 1, 32] #32x32
-
-          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
+          - Exact: [127, 0, 2, 64] 
 
   - # cgemm CC
     - # ProblemType
@@ -430,9 +385,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          # - Exact: [16, 16, 1, 2]
-          # - Exact: [2048, 2048, 1, 256] #128x128(times16)
-          # - Exact: [1024, 1024, 1, 64] #64x64(times16)
-          # - Exact: [512, 512, 1, 32] #32x32
-
-          - Range: [ [127,1,129], 0, [2], [63,1,64] ]
+          - Exact: [127, 0, 2, 63] 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
@@ -38,17 +38,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16, 16, 1,  1,   2, 2,  4,1 ]
-        #  - [16, 16, 16, 1,  1,   4, 1,  4,1 ]
-        #  - [16, 16, 16, 1,  1,   8, 1,  4,1 ]
-        #  - [32, 32,  8, 1,  1,   1, 4,  4,1 ]
-        #  - [32, 32,  8, 1,  1,   2, 2,  4,1 ]
-        #  - [32, 32,  8, 1,  1,   4, 1,  4,1 ]
-        #  - [16, 16,  4, 4,  4,   1, 4,  4,1 ]
-        #  - [ 4,  4,  4,16, 16,   2, 2,  4,1 ]
-        #  - [16, 16,  4, 4,  4,   2, 2,  4,1 ]
-        #  - [32, 32,  4, 2,  2,   2, 2,  4,1 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [2,4,8]
@@ -76,9 +65,6 @@ BenchmarkProblems:
         - LdsPadB: [-1]
         - 1LDSBuffer: [1]
         - GlobalSplitU: [1,2]
-        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
-        #- SourceSwap: [0, 1]
-        #- LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
         - TransposeLDS: [0,1]
@@ -107,18 +93,8 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
           - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
           - Exact: [255,   255, 1, 255]
-          - Exact: [255,   255, 1, 256]
 
   ########################################
   # HHS NT DTVA pack
@@ -139,15 +115,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16, 16, 1,  1,   2, 1,  4,1 ]
-        #  - [16, 16, 16, 1,  1,   4, 1,  4,1 ]
-        #  - [16, 16, 16, 1,  1,   8, 1,  4,1 ]
-        #  - [32, 32,  8, 1,  1,   1, 1,  4,1 ]
-        #  - [32, 32,  8, 1,  1,   2, 1,  4,1 ]
-        #  - [32, 32,  8, 1,  1,   4, 1,  4,1 ]
-        #  - [16, 16,  4, 4,  4,   2, 2,  4,1 ]
-        #  - [ 4,  4,  4,16, 16,   2, 2,  4,1 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [2,4,8]
@@ -165,7 +132,6 @@ BenchmarkProblems:
         - StaggerUStride: [256]
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
-        #- ExpandPointerSwap: [0,1]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -175,9 +141,7 @@ BenchmarkProblems:
         - LdsPadB: [-1]
         - 1LDSBuffer: [1]
         - GlobalSplitU: [1,2]
-        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [0, 1]
-        #- LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
         - TransposeLDS: [0,1]
@@ -206,18 +170,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
           - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
           - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
-          - Exact: [255,   255, 1, 255]
           - Exact: [255,   255, 1, 256]
 
   ########################################
@@ -239,15 +193,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16, 16, 1,  1,   1, 2,  1,4 ]
-        #  - [16, 16, 16, 1,  1,   1, 4,  1,4 ]
-        #  - [16, 16, 16, 1,  1,   1, 8,  1,4 ]
-        #  - [32, 32,  8, 1,  1,   1, 1,  1,4 ]
-        #  - [32, 32,  8, 1,  1,   1, 2,  1,4 ]
-        #  - [32, 32,  8, 1,  1,   1, 4,  1,4 ]
-        #  - [16, 16,  4, 4,  4,   2, 2,  1,4 ]
-        #  - [ 4,  4,  4,16, 16,   2, 2,  1,4 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [4,8]
@@ -274,7 +219,6 @@ BenchmarkProblems:
         - LdsPadB: [-1]
         - 1LDSBuffer: [1]
         - GlobalSplitU: [1,2]
-        #- SourceSwap: [0, 1]
         - DirectToVgprB: [1]
         - UseSgprForGRO: [0,1]
         - StreamK: [0,1]
@@ -300,18 +244,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
           - Exact: [255,   255, 1, 255]
-          - Exact: [255,   255, 1, 256]
 
   ########################################
   # HHS TN DTVA
@@ -332,15 +265,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16, 16, 1,  1,   2, 1,  4,1 ]
-        #  - [16, 16, 16, 1,  1,   4, 1,  4,1 ]
-        #  - [16, 16, 16, 1,  1,   8, 1,  4,1 ]
-        #  - [32, 32,  8, 1,  1,   1, 1,  4,1 ]
-        #  - [32, 32,  8, 1,  1,   2, 1,  4,1 ]
-        #  - [32, 32,  8, 1,  1,   4, 1,  4,1 ]
-        #  - [16, 16,  4, 4,  4,   2, 2,  4,1 ]
-        #  - [ 4,  4,  4,16, 16,   2, 2,  4,1 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [4,8]
@@ -359,7 +283,6 @@ BenchmarkProblems:
         - StaggerUMapping: [2]
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
-        #- ExpandPointerSwap: [0,1]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -398,18 +321,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
           - Exact: [255,   255, 1, 255]
-          - Exact: [255,   255, 1, 256]
 
   ########################################
   # HHS TN DTVA + BIAS + Activation
@@ -474,8 +386,6 @@ BenchmarkProblems:
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - 1LDSBuffer: [1]
-        #- GlobalSplitU: [1,2]
-        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [0, 1]
         - LocalReadVectorWidth: [2,4,8]
         - DirectToVgprA: [1]
@@ -486,9 +396,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [127,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
           - Exact: [256,   255, 1, 1101]
-          - Exact: [256,   257, 1, 1101]
           - Exact: [512,   128, 1, 256]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
@@ -513,15 +421,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16, 16, 1,  1,   1, 2,  1,4 ]
-        #  - [16, 16, 16, 1,  1,   1, 4,  1,4 ]
-        #  - [16, 16, 16, 1,  1,   1, 8,  1,4 ]
-        #  - [32, 32,  8, 1,  1,   1, 1,  1,4 ]
-        #  - [32, 32,  8, 1,  1,   1, 2,  1,4 ]
-        #  - [32, 32,  8, 1,  1,   1, 4,  1,4 ]
-        #  - [16, 16,  4, 4,  4,   4, 1,  1,4 ]
-        #  - [ 4,  4,  4,16, 16,   2, 2,  1,4 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [4,8]
@@ -540,7 +439,6 @@ BenchmarkProblems:
         - StaggerUMapping: [2]
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
-        #- ExpandPointerSwap: [0,1]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -550,7 +448,6 @@ BenchmarkProblems:
         - LdsPadB: [-1]
         - 1LDSBuffer: [1]
         - GlobalSplitU: [1,2]
-        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [0, 1]
         - LocalReadVectorWidth: [4,8]
         - DirectToVgprB: [1]
@@ -577,17 +474,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
-          - Exact: [255,   255, 1, 255]
           - Exact: [255,   255, 1, 256]
 
   ########################################
@@ -665,11 +551,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [127,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
-          - Exact: [256,   255, 1, 1101]
           - Exact: [256,   257, 1, 1101]
-          - Exact: [128,   512, 1, 256]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: relu]
@@ -693,15 +576,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16, 16, 1,  1,   2, 2,  1,4 ]
-        #  - [16, 16, 16, 1,  1,   1, 4,  1,4 ]
-        #  - [16, 16, 16, 1,  1,   1, 8,  1,4 ]
-        #  - [32, 32,  8, 1,  1,   2, 2,  1,4 ]
-        #  - [32, 32,  8, 1,  1,   1, 4,  1,4 ]
-        #  - [ 4,  4,  4,16,  1,   2, 2,  1,4 ]
-        #  - [16, 16,  4, 4,  1,   2, 2,  1,4 ]
-        #  - [32, 32,  4, 2,  1,   2, 2,  1,4 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [4,8]
@@ -753,17 +627,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
           - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
           - Exact: [255,   255, 1, 256]
 
   ########################################
@@ -784,13 +648,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16,  4, 1,  1,   1, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   2, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   4, 1,  4,1 ]
-        #  - [32, 32,  2, 1,  1,   1, 1,  4,1 ]
-        #  - [32, 32,  2, 1,  1,   2, 1,  4,1 ]
-        #  - [ 4,  4,  1,16, 16,   1, 8,  4,1 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2,4]
@@ -819,7 +676,6 @@ BenchmarkProblems:
         - 1LDSBuffer: [1]
         - GlobalSplitU: [1,2]
         - GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
-        #- SourceSwap: [0, 1]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
         - TransposeLDS: [0,1]
@@ -839,16 +695,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
           - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
           - Exact: [255,   255, 1, 128]
 
   ########################################
@@ -869,13 +716,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16,  4, 1,  1,   1, 1,  1,4 ]
-        #  - [16, 16,  4, 1,  1,   1, 2,  1,4 ]
-        #  - [16, 16,  4, 1,  1,   1, 4,  1,4 ]
-        #  - [32, 32,  2, 1,  1,   1, 1,  1,4 ]
-        #  - [32, 32,  2, 1,  1,   1, 2,  1,4 ]
-        #  - [ 4,  4,  1,16,  1,   8, 1,  1,4 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2]
@@ -889,11 +729,8 @@ BenchmarkProblems:
         - MIArchVgpr: [0]
         - LocalWritePerMfma: [-1]
         - StaggerU: [0]
-        #- StaggerUStride: [256]
-        #- StaggerUMapping: [2]
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
-        #- ExpandPointerSwap: [0,1]
         - TransposeLDS: [0]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
@@ -903,8 +740,6 @@ BenchmarkProblems:
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - 1LDSBuffer: [1]
-        #- GlobalSplitU: [1,2]
-        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [0, 1]
         - DirectToVgprB: [1]
         - UseSgprForGRO: [0,1]
@@ -924,17 +759,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
           - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
           - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 128]
 
   ########################################
   # SGEMM NN DTVA
@@ -954,14 +780,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16,  4, 1,  1,   1, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   2, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   4, 1,  4,1 ]
-        #  - [32, 32,  2, 1,  1,   1, 1,  4,1 ]
-        #  - [32, 32,  2, 1,  1,   2, 1,  4,1 ]
-        #  - [ 4,  4,  1,16, 16,   1, 8,  4,1 ]
-        #  - [32, 32,  1, 2,  2,   1, 1,  4,1 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2,4]
@@ -1012,15 +830,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
           - Exact: [255,   255, 1, 128]
 
   ########################################
@@ -1041,14 +850,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16,  4, 1,  1,   1, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   2, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   4, 1,  4,1 ]
-        #  - [32, 32,  2, 1,  1,   1, 1,  4,1 ]
-        #  - [32, 32,  2, 1,  1,   2, 1,  4,1 ]
-        #  - [ 4,  4,  1,16, 16,   1, 8,  4,1 ]
-        #  - [32, 32,  1, 2,  2,   1, 1,  4,1 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2,4]
@@ -1098,15 +899,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
           - Exact: [255,   255, 1, 128]
 
   ########################################
@@ -1127,11 +919,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16,  4, 1,  1,   1, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   2, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   4, 1,  4,1 ]
-        #  - [ 4,  4,  4, 4,  4,   2, 2,  4,1 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2]
@@ -1178,16 +965,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
           - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
           - Exact: [255,   255, 1, 128]
 
   ########################################
@@ -1208,11 +986,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16,  4, 1,  1,   1, 1,  1,4 ]
-        #  - [16, 16,  4, 1,  1,   1, 2,  1,4 ]
-        #  - [16, 16,  4, 1,  1,   1, 4,  1,4 ]
-        #  - [ 4,  4,  4, 4,  4,   2, 2,  4,1 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2]
@@ -1259,15 +1032,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
           - Exact: [255,   255, 1, 127]
           - Exact: [255,   255, 1, 128]
 
@@ -1289,11 +1053,6 @@ BenchmarkProblems:
       BenchmarkCommonParameters:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
-        #- MatrixInstruction:
-        #  - [16, 16,  4, 1,  1,   1, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   2, 1,  4,1 ]
-        #  - [16, 16,  4, 1,  1,   4, 1,  4,1 ]
-        #  - [ 4,  4,  4, 4,  4,   2, 2,  4,1 ]
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2]
@@ -1339,15 +1098,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  17]
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
           - Exact: [255,   255, 1, 127]
           - Exact: [255,   255, 1, 128]
 
@@ -1686,16 +1436,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  32]
           - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
-          - Exact: [255,   255, 1, 255]
           - Exact: [255,   255, 1, 256]
 
   ########################################
@@ -1774,16 +1515,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  15]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
           - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
-          - Exact: [255,   255, 1, 255]
           - Exact: [255,   255, 1, 256]
 
   ########################################
@@ -1867,16 +1599,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  32]
-          - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
           - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
-          - Exact: [255,   255, 1, 255]
           - Exact: [255,   255, 1, 256]
 
   ########################################
@@ -1958,16 +1681,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [255,   255, 1,  32]
           - Exact: [255,   255, 1,  33]
-          - Exact: [255,   255, 1,  47]
-          - Exact: [255,   255, 1,  63]
-          - Exact: [255,   255, 1,  79]
-          - Exact: [255,   255, 1,  95]
-          - Exact: [255,   255, 1, 111]
-          - Exact: [255,   255, 1, 127]
-          - Exact: [255,   255, 1, 191]
-          - Exact: [255,   255, 1, 255]
           - Exact: [255,   255, 1, 256]
 
   ########################################
@@ -2036,8 +1750,6 @@ BenchmarkProblems:
         - ProblemSizes:
           - Exact: [960, 1280, 1, 192]
           - Exact: [960, 1280, 1, 256] # no tail
-          - Exact: [1280, 1280, 1, 192]
-          - Exact: [1600, 1280, 1, 192]
 
   ########################################
   # HHS NN DTVB with/wo tail loop
@@ -2103,7 +1815,5 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [960, 1280, 1, 192]
           - Exact: [960, 1280, 1, 256]
           - Exact: [1280, 1280, 1, 192]
-          - Exact: [1600, 1280, 1, 192]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_hhs.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/fp8nfp16mix_hhs.yaml
@@ -70,18 +70,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,     127, 1, 127]
-          - Exact: [2,     127, 1, 127]
-          - Exact: [3,     127, 1, 127]
           - Exact: [1,     1,   1, 127]
-          - Exact: [127,   1,   1, 127]
-          - Exact: [127,   2,   1, 127]
-          - Exact: [127,   3,   1, 127]
-          - Exact: [127,   127, 1, 127]
-          - Exact: [128,   128, 1, 128]
-          - Exact: [129,   129, 1, 129]
-          - Exact: [127,   127, 1, 128]
-          - Exact: [127,   127, 1, 129]
-          - Exact: [127,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
@@ -137,20 +126,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [1,     127, 1, 127]
           - Exact: [2,     127, 1, 127]
-          - Exact: [3,     127, 1, 127]
-          - Exact: [1,     1,   1, 127]
-          - Exact: [127,   1,   1, 127]
-          - Exact: [127,   2,   1, 127]
           - Exact: [127,   3,   1, 127]
-          - Exact: [127,   127, 1, 127]
-          - Exact: [128,   128, 1, 128]
-          - Exact: [129,   129, 1, 129]
-          - Exact: [127,   127, 1, 128]
-          - Exact: [127,   127, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -207,7 +184,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 128]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
@@ -265,7 +241,6 @@ BenchmarkProblems:
         - ProblemSizes:
           - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 128]
-          - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -324,7 +299,6 @@ BenchmarkProblems:
         - ProblemSizes:
           - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 128]
-          - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -378,8 +352,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [127,   128, 1, 640]
-          - Exact: [128,   128, 1, 128]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
@@ -437,7 +409,6 @@ BenchmarkProblems:
         - ProblemSizes:
           - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 128]
-          - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -492,7 +463,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 128]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
@@ -551,7 +521,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 128]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
@@ -609,7 +578,6 @@ BenchmarkProblems:
         - ProblemSizes:
           - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 128]
-          - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -664,7 +632,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 128]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
@@ -721,7 +688,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 128]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml
@@ -74,7 +74,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[255], [255], [1], [1, 148, 192]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -108,7 +108,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[255], [255], [1], [1, 148, 192]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -179,8 +179,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[160], [256], [1], [1,17,64]]
-          - Range: [[160], [256], [1], [32, 64, 256]]
+          - Range: [[160], [256], [1], [1,34,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -218,8 +217,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [160], [1], [1,17,64]]
-          - Range: [[256], [160], [1], [32, 64, 256]]
+          - Range: [[256], [160], [1], [1,34,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -253,8 +251,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [240], [1], [1, 17, 64]]
-          - Range: [[256], [240], [1], [32, 64, 256]]
+          - Range: [[256], [240], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -292,8 +289,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [208], [1], [1, 17, 64]]
-          - Range: [[256], [208], [1], [32, 64, 256]]
+          - Range: [[256], [208], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -331,8 +327,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[320], [192], [1], [1, 17, 64]]
-          - Range: [[320], [192], [1], [32, 64, 256]]
+          - Range: [[320], [192], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -366,8 +361,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [320], [1], [1, 17, 64]]
-          - Range: [[192], [320], [1], [32, 64, 256]]
+          - Range: [[192], [320], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -405,8 +399,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [32, 64, 256]]
-          - Range: [[256], [192], [1], [1,17,64]]
+          - Range: [[256], [192], [1], [1,34,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -440,8 +433,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[208], [256], [1], [1, 17, 64]]
-          - Range: [[208], [256], [1], [32, 64, 256]]
+          - Range: [[208], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -514,8 +506,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[240], [256], [1], [64, 64, 256]]
-          - Range: [[240], [256], [1], [1, 17, 256]]  
+          - Range: [[240], [256], [1], [64, 128, 256]]
           - Exact: [3840, 4096, 1, 8192]
         - BiasTypeArgs: ['b']          
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -548,8 +539,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [224], [1], [1,17,64]]
-          - Range: [[128], [224], [1], [32, 64, 256]]
+          - Range: [[128], [224], [1], [1,34,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -579,9 +569,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [256], [1], [64, 64, 256]]
-          - Range: [[128], [256], [1], [1,1,64]]
-          - Range: [[128], [256], [1], [32, 64, 256]]          
+          - Range: [[128], [256], [1], [1,26,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -616,9 +604,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [96], [1], [64, 64, 256]]
-          - Range: [[256], [96], [1], [1, 1, 64]]
-          - Range: [[256], [96], [1], [32, 64, 256]]
+          - Range: [[256], [96], [1], [1, 29, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -650,9 +636,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [128], [1], [64, 64, 256]]
-          - Range: [[224], [128], [1], [1,1,64]]
-          - Range: [[224], [128], [1], [32, 64, 256]]
+          - Range: [[224], [128], [1], [1,33,64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 256x224x64 NN
       InitialSolutionParameters:
@@ -682,8 +666,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [224], [1], [ 1, 17,  64]]
-          - Range: [[256], [224], [1], [32, 64, 256]]
+          - Range: [[256], [224], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 256x224x64 NN
       InitialSolutionParameters:
@@ -713,8 +696,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [256], [1], [ 1, 17,  64]]
-          - Range: [[224], [256], [1], [32, 64, 256]]
+          - Range: [[224], [256], [1], [ 1, 33,  64]]
         - BiasTypeArgs: ['b']        
   ########################################
   # HHS NN - standard
@@ -761,7 +743,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[257], [257], [1], [1, 148, 192]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -794,7 +776,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[257], [257], [1], [1, 148, 192]]
     - # BenchmarkProblemSizeGroup - 96x256x64 NN (CMS)
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -826,8 +808,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[96], [256], [1], [1, 17, 64]]
-          - Range: [[96], [256], [1], [32, 64, 256]]
+          - Range: [[96], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -882,8 +863,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
-          - Range: [[613], [612], [1], [1, 1, 64]]
+          - Range: [[613], [612], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -931,7 +911,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[255], [257], [1], [1, 148, 192]]
 
   ########################################
   # BBS TN - standard
@@ -986,8 +966,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
-          - Range: [[613], [612], [1], [1, 1, 64]]
+          - Range: [[613], [612], [1], [1, 27, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 192x128x64 TN (CMS)
       InitialSolutionParameters:
@@ -1022,8 +1001,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [128], [1], [1, 17, 64]]
-          - Range: [[192], [128], [1], [32, 64, 256]]
+          - Range: [[192], [128], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 256x160x64 TN (match cms-tn.yaml)
       InitialSolutionParameters:
@@ -1057,8 +1035,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [160], [1], [1, 17, 64]]
-          - Range: [[256], [160], [1], [32, 64, 256]]
+          - Range: [[256], [160], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1091,8 +1068,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [256], [1], [1, 17, 64]]
-          - Range: [[192], [256], [1], [32, 64, 256]]
+          - Range: [[192], [256], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 96x256x64 TN
       InitialSolutionParameters:
@@ -1126,9 +1102,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1536, 4096, 1, 8192]
-          - Range: [[96], [256], [1], [64, 64, 256]]
-          - Range: [[96], [256], [1], [32, 64, 256]]
-          - Range: [[96], [256], [1], [1, 1, 64]]
+          - Range: [[96], [256], [1], [1, 33, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1161,8 +1135,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [240], [1], [1, 17, 64]]
-          - Range: [[256], [240], [1], [32, 64, 256]]
+          - Range: [[256], [240], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1195,8 +1168,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [208], [1], [1, 17, 64]]
-          - Range: [[256], [208], [1], [32, 64, 256]]
+          - Range: [[256], [208], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1230,8 +1202,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [128], [1], [1, 17, 64]]
-          - Range: [[224], [128], [1], [32, 64, 256]]
+          - Range: [[224], [128], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1264,8 +1235,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [256], [1], [1, 17, 64]]
-          - Range: [[224], [256], [1], [32, 64, 256]]
+          - Range: [[224], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1298,8 +1268,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [224], [1], [1, 17, 64]]
-          - Range: [[256], [224], [1], [32, 64, 256]]
+          - Range: [[256], [224], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1332,8 +1301,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [1, 17, 64]]
-          - Range: [[256], [192], [1], [32, 64, 256]]
+          - Range: [[256], [192], [1], [1, 34, 64]]
           - Exact: [4096, 3072, 1, 8192]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
@@ -1369,8 +1337,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [96], [1], [1, 17, 64]]
-          - Range: [[256], [96], [1], [32, 64, 256]]
+          - Range: [[256], [96], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1403,8 +1370,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[160], [256], [1], [1, 17, 64]]
-          - Range: [[160], [256], [1], [32, 64, 256]]
+          - Range: [[160], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1437,8 +1403,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [1, 17, 64]]
-          - Range: [[256], [192], [1], [32, 64, 256]]
+          - Range: [[256], [192], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1519,8 +1484,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[240], [256], [1], [1, 17, 64]]
-          - Range: [[240], [256], [1], [32, 64, 256]]
+          - Range: [[240], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1567,8 +1531,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[208], [256], [1], [1, 17, 64]]
-          - Range: [[208], [256], [1], [32, 64, 256]]
+          - Range: [[208], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1602,8 +1565,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [256], [1], [1, 17, 64]]
-          - Range: [[192], [256], [1], [32, 64, 256]]
+          - Range: [[192], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1629,8 +1591,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
       - ProblemSizes:
-        - Range: [[192], [320], [1], [1, 17, 64]]
-        - Range: [[192], [320], [1], [32, 64, 256]]
+        - Range: [[192], [320], [1], [1, 34, 64]]
       - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1663,8 +1624,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [224], [1], [1, 17, 64]]
-          - Range: [[128], [224], [1], [32, 64, 256]]
+          - Range: [[128], [224], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1698,8 +1658,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[320], [192], [1], [1, 17, 64]]
-          - Range: [[320], [192], [1], [32, 64, 256]]
+          - Range: [[320], [192], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 128x192x64 TN (CMS)
       InitialSolutionParameters:
@@ -1734,8 +1693,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [192], [1], [ 1, 17,  64]]
-          - Range: [[128], [192], [1], [32, 64, 256]]
+          - Range: [[128], [192], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 352x192x64 TN (CMS)
       InitialSolutionParameters:
@@ -1770,8 +1728,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[352], [192], [1], [1, 17,  64]]
-          - Range: [[352], [192], [1], [32, 64, 256]]
+          - Range: [[352], [192], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -1805,8 +1762,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [320], [1], [1, 17, 64]]
-          - Range: [[224], [320], [1], [32, 64, 256]]
+          - Range: [[224], [320], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -1854,7 +1810,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[255], [257], [1], [1, 148, 192]]
 
   ########################################
   # F8BS TN - standard
@@ -1909,8 +1865,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[17, 235, 750], [2, 127, 400], [1], [4, 4, 400]]
-          - Range: [[613], [612], [1], [1, 1, 128]]
+          - Range: [[17, 470, 750], [2, 254, 400], [1], [4, 128, 400]]
         #- BiasTypeArgs: ['b']
 
   ########################################
@@ -1965,8 +1920,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
-          - Range: [[613], [612], [1], [1, 1, 128]]
+          - Range: [[613], [612], [1], [1, 32, 128]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 224x128x64 NT
       InitialSolutionParameters:
@@ -2002,8 +1956,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [3584, 2048, 1, 8192]
-          - Range: [[224], [128], [1], [1, 16, 64]]
-          - Range: [[224], [128], [1], [32, 64, 256]]
+          - Range: [[224], [128], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - 128x224x64 NT
       InitialSolutionParameters:
@@ -2038,8 +1991,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[128], [224], [1], [1, 17, 64]]
-          - Range: [[128], [224], [1], [32, 64, 256]]
+          - Range: [[128], [224], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2106,8 +2058,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[96], [256], [1], [1, 17, 64]]
-          - Range: [[96], [256], [1], [32, 64, 256]]
+          - Range: [[96], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2145,8 +2096,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[160], [256], [1], [1,17,64]]
-          - Range: [[160], [256], [1], [32, 64, 256]]
+          - Range: [[160], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2179,8 +2129,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [256], [1], [1, 17, 64]]
-          - Range: [[192], [256], [1], [32, 64, 256]]
+          - Range: [[192], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2218,8 +2167,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [160], [1], [1,17,64]]
-          - Range: [[256], [160], [1], [32, 64, 256]]
+          - Range: [[256], [160], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2253,8 +2201,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [240], [1], [1, 17, 64]]
-          - Range: [[256], [240], [1], [32, 64, 256]]
+          - Range: [[256], [240], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2327,8 +2274,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[240], [256], [1], [1, 17, 256]]
-          - Range: [[240], [256], [1], [32, 64, 256]]
+          - Range: [[240], [256], [1], [1, 34, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2362,8 +2308,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[320], [192], [1], [1, 17, 64]]
-          - Range: [[320], [192], [1], [32, 64, 256]]
+          - Range: [[320], [192], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2396,8 +2341,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[208], [256], [1], [1, 17, 64]]
-          - Range: [[208], [256], [1], [32, 64, 256]]
+          - Range: [[208], [256], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2431,8 +2375,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [192], [1], [1, 17, 64]]
-          - Range: [[256], [192], [1], [32, 64, 256]]
+          - Range: [[256], [192], [1], [1, 34, 64]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2465,8 +2408,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[192], [320], [1], [1, 17, 64]]
-          - Range: [[192], [320], [1], [32, 64, 256]]
+          - Range: [[192], [320], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2500,8 +2442,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[224], [256], [1], [1, 17, 256]]
-          - Range: [[224], [256], [1], [32, 64, 256]]
+          - Range: [[224], [256], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2531,8 +2472,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [224], [1], [1, 17, 64]]
-          - Range: [[256], [224], [1], [32, 64, 256]]
+          - Range: [[256], [224], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
@@ -2567,8 +2507,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [96], [1], [1, 17, 256]]
-          - Range: [[256], [96], [1], [32, 64, 256]]
+          - Range: [[256], [96], [1], [32, 128, 256]]
         - BiasTypeArgs: ['b']
 
   ########################################
@@ -2615,4 +2554,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 192]]
+          - Range: [[257], [255], [1], [1, 148, 192]]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -59,7 +59,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[1,67,300], [1,93,300], [1], [1,76,192]]
+          - Range: [[300], [1], [1], [152]]
     - # Check DTL+nonDTL tuning
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -132,7 +132,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[1,67,300], [1,93,300], [1], [1,76,192]]
+          - Range: [[170], [186], [1], [152]]
 
   ########################################
   # F8HS TN DTL
@@ -195,10 +195,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[19], [19], [1], [1,3,12]]
-          - Range: [[31], [31], [1], [1,7,72]]
-          - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13], [17], [1], [258, 9, 384]]
+          - Range: [[19], [19], [1], [1,6,12]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -268,10 +265,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[19], [19], [1], [1,3,12]]
-          - Range: [[31], [31], [1], [1,7,72]]
-          - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13], [17], [1], [258, 9, 384]]
+          - Range: [[19], [19], [1], [1,6,12]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -316,12 +310,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,1,32],[28,1,29],[1],[1,1,64]]
-          - Range: [[16,1,32],[28,1,29],[1],[66,4,129]]
-          - Range: [[16,1,32],[28,1,29],[1],[65,4,129]]
-          - Range: [[28,1,29],[16,1,32],[1],[1,1,64]]
-          - Range: [[28,1,29],[16,1,32],[1],[66,4,129]]
-          - Range: [[28,1,29],[16,1,32],[1],[65,4,129]]
+          - Range: [[16,8,32],[28,1,29],[1],[1,31,64]]
+          - Range: [[28,1,29],[16,8,32],[1],[1,31,64]]
 
   ########################################
   # F8HHS TT DTL
@@ -371,7 +361,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[63], [127], [1], [1,63,384]]
+          - Range: [[63], [127], [1], [1,175,384]]
 
   ########################################
   # F8B8HS TN DTL
@@ -434,7 +424,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,9,34], [16,9,34], [1], [1,3,12]]
+          - Range: [[34], [34], [1], [1,6,12]]
           - Exact: [256, 256, 1, 320]
 
   ########################################
@@ -496,10 +486,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[19], [19], [1], [1,3,12]]
-          - Range: [[31], [31], [1], [1,7,72]]
-          - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13],   [17], [1], [258, 9, 384]]
+          - Range: [[31], [31], [1], [1,27,72]]
+          - Range: [[13],   [17], [1], [258, 49, 384]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -554,7 +542,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[63], [127], [1], [1,31,384]]
+          - Range: [[63], [127], [1], [1,131,384]]
 
   ########################################
   # F8F8S TT DTL
@@ -615,10 +603,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[19], [19], [1], [1,3,12]]
-          - Range: [[31], [31], [1], [1,7,72]]
-          - Range: [[127], [127], [1], [128,4,140]]
-          - Range: [[13],   [17], [1], [258, 9, 384]]
+          - Range: [[31], [31], [1], [1,37,72]]
+          - Range: [[127], [127], [1], [128]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -679,7 +665,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[65], [123], [1], [1,71,192]]
+          - Range: [[65], [123], [1], [1,171,192]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -790,7 +776,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[47], [97], [1], [1,31,192]]
+          - Range: [[47], [97], [1], [1,131,192]]
     - # ASEM/AFEM check
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -820,7 +806,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,2,32],[16,2,32],[1],[1,1,32]]
+          - Range: [[16,12,32],[16,12,32],[1],[1,21,32]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -903,7 +889,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 512]
-          - Range: [[18], [99], [1], [1,31,192]]
+          - Range: [[18], [99], [1], [1,74,192]]
 
   ########################################
   # HHS TT DTL
@@ -951,7 +937,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[256], [512], [1], [64,64,192]]
+          - Range: [[256], [512], [1], [64,128,192]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -981,7 +967,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[4096], [8192], [1], [64,64,192]]
+          - Range: [[4096], [8192], [1], [64,128,192]]
 
   ########################################
   # HHS NT DTL
@@ -1066,7 +1052,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[65], [123], [1], [1,123,192]]
+          - Range: [[65], [123], [1], [192]]
     - # Check DTL for load width less than 32bits
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -1090,7 +1076,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[65], [123], [1], [1,63,192]]
+          - Range: [[65], [123], [1], [63]]
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -1119,7 +1105,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[4096], [8192], [1], [64,64,192]]
+          - Range: [[4096], [8192], [1], [64]]
 
 
   ########################################

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/plr_zero.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/plr_zero.yaml
@@ -117,7 +117,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [255], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -148,7 +148,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [257], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -173,7 +173,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [255], [1], [1, 64, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -251,7 +251,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [4096, 4096, 1, 16384]
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [257], [1], [1, 71, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -278,7 +278,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [255], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -304,7 +304,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [257], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -379,7 +379,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [4096, 4096, 1, 16384]
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [255], [1], [1, 81, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -406,7 +406,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [257], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -432,7 +432,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [255], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -508,7 +508,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           #- Exact: [4096, 4096, 1, 16384]
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[255], [257], [1], [1, 81, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -535,7 +535,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [255], [1], [1, 74, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -561,7 +561,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [1, 37, 128]]
+          - Range: [[257], [257], [1], [1, 73, 128]]
     - # BenchmarkProblemSizeGroup - Standard
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -638,4 +638,4 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[255, 1, 257], [255, 1, 257], [1], [2, 37, 512]]
+          - Range: [[257], [257], [1], [2, 148, 512]]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/hh_f8nhs.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/hh_f8nhs.yaml
@@ -74,7 +74,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 129]
           - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
@@ -135,9 +134,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 128, 1, 128]
           - Exact: [129, 129, 1, 129]
-          - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
           - [Enum: none]
@@ -197,8 +194,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 129]
           - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
@@ -260,7 +255,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 129]
           - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
@@ -322,9 +316,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 128, 1, 128]
           - Exact: [129, 129, 1, 129]
-          - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
           - [Enum: none]
@@ -384,8 +376,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 129]
           - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
@@ -447,7 +437,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 129]
           - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
@@ -508,8 +497,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 129]
           - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
@@ -572,7 +559,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 129]
           - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
@@ -633,9 +619,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 128, 1, 128]
           - Exact: [129, 129, 1, 129]
-          - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
           - [Enum: none]
@@ -695,9 +679,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 128, 1, 128]
           - Exact: [129, 129, 1, 129]
-          - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
           - [Enum: none]
@@ -758,8 +740,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 129]
-          - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s', 'h']
         - ActivationArgs:
           - [Enum: none]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/lsu_fnuz.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/lsu_fnuz.yaml
@@ -78,19 +78,9 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,     127, 1, 127]
-          - Exact: [2,     127, 1, 127]
-          - Exact: [3,     127, 1, 127]
           - Exact: [1,     1,   1, 127]
-          - Exact: [127,   1,   1, 127]
           - Exact: [127,   2,   1, 127]
-          - Exact: [127,   3,   1, 127]
-          - Exact: [127,   127, 1, 127]
-          - Exact: [128,   128, 1, 128]
           - Exact: [129,   129, 1, 129]
-          - Exact: [127,   127, 1, 128]
-          - Exact: [127,   127, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
   ########################################
   # LSU2 - 2 waves
   ########################################
@@ -155,20 +145,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [1,     127, 1, 127]
           - Exact: [2,     127, 1, 127]
-          - Exact: [3,     127, 1, 127]
-          - Exact: [1,     1,   1, 127]
           - Exact: [127,   1,   1, 127]
-          - Exact: [127,   2,   1, 127]
-          - Exact: [127,   3,   1, 127]
-          - Exact: [127,   127, 1, 127]
           - Exact: [128,   128, 1, 128]
-          - Exact: [129,   129, 1, 129]
-          - Exact: [127,   127, 1, 128]
-          - Exact: [127,   127, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
   ########################################
   # LSU2 - 4/8 waves
   ########################################
@@ -231,19 +210,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [1,     127, 1, 127]
-          - Exact: [2,     127, 1, 127]
           - Exact: [3,     127, 1, 127]
           - Exact: [1,     1,   1, 127]
-          - Exact: [127,   1,   1, 127]
-          - Exact: [127,   2,   1, 127]
-          - Exact: [127,   3,   1, 127]
-          - Exact: [127,   127, 1, 127]
-          - Exact: [128,   128, 1, 128]
-          - Exact: [129,   129, 1, 129]
-          - Exact: [127,   127, 1, 128]
-          - Exact: [127,   127, 1, 129]
-          - Exact: [127,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
   ########################################
   # LSU4 - 8 waves
@@ -307,19 +275,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,     127, 1, 127]
-          - Exact: [2,     127, 1, 127]
-          - Exact: [3,     127, 1, 127]
-          - Exact: [1,     1,   1, 127]
-          - Exact: [127,   1,   1, 127]
-          - Exact: [127,   2,   1, 127]
-          - Exact: [127,   3,   1, 127]
-          - Exact: [127,   127, 1, 127]
-          - Exact: [128,   128, 1, 128]
           - Exact: [129,   129, 1, 129]
-          - Exact: [127,   127, 1, 128]
-          - Exact: [127,   127, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
 
   ########################################
   # LSU4 + GSU
@@ -389,9 +345,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [127,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
           - Exact: [256,   255, 1, 1101]
-          - Exact: [256,   257, 1, 1101]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: relu]
@@ -509,18 +463,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,     127, 1, 127]
-          - Exact: [2,     127, 1, 127]
-          - Exact: [3,     127, 1, 127]
-          - Exact: [1,     1,   1, 127]
-          - Exact: [127,   1,   1, 127]
-          - Exact: [127,   2,   1, 127]
-          - Exact: [127,   3,   1, 127]
-          - Exact: [127,   127, 1, 127]
           - Exact: [128,   128, 1, 128]
-          - Exact: [129,   129, 1, 129]
-          - Exact: [127,   127, 1, 128]
-          - Exact: [127,   127, 1, 129]
-          - Exact: [127,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['h']
 
@@ -584,21 +527,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [1,     127, 1, 127]
-          - Exact: [2,     127, 1, 127]
           - Exact: [3,     127, 1, 127]
           - Exact: [1,     1,   1, 127]
-          - Exact: [127,   1,   1, 127]
-          - Exact: [127,   2,   1, 127]
-          - Exact: [127,   3,   1, 127]
           - Exact: [127,   127, 1, 127]
-          - Exact: [128,   128, 1, 128]
-          - Exact: [129,   129, 1, 129]
-          - Exact: [127,   127, 1, 128]
-          - Exact: [127,   127, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
-          - Exact: [512,   512, 1, 640]
 
   ########################################
   # LSU2 - 2 waves larger MT
@@ -668,17 +599,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,     127, 1, 127]
-          - Exact: [2,     127, 1, 127]
-          - Exact: [3,     127, 1, 127]
           - Exact: [1,     1,   1, 127]
-          - Exact: [127,   1,   1, 127]
-          - Exact: [127,   2,   1, 127]
           - Exact: [127,   3,   1, 127]
-          - Exact: [127,   127, 1, 127]
-          - Exact: [128,   128, 1, 128]
-          - Exact: [129,   129, 1, 129]
-          - Exact: [127,   127, 1, 128]
           - Exact: [127,   127, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
-          - Exact: [512,   512, 1, 640]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/mix_cvt_after_ds_fnuz.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/mix_cvt_after_ds_fnuz.yaml
@@ -85,15 +85,8 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,   128, 1, 640]
-          - Exact: [2,   128, 1, 640]
-          - Exact: [3,   128, 1, 640]
           - Exact: [1,   1, 1, 640]
-          - Exact: [127,   127, 1, 640]
-          - Exact: [129,   129, 1, 640]
           - Exact: [128,   128, 1, 127]
-          - Exact: [128,   128, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [128,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
@@ -165,15 +158,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,   128, 1, 640]
-          - Exact: [2,   128, 1, 640]
-          - Exact: [3,   128, 1, 640]
-          - Exact: [1,   1, 1, 640]
           - Exact: [127,   127, 1, 640]
-          - Exact: [129,   129, 1, 640]
-          - Exact: [128,   128, 1, 127]
-          - Exact: [128,   128, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [128,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
@@ -245,16 +230,8 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,   128, 1, 640]
-          - Exact: [2,   128, 1, 640]
-          - Exact: [3,   128, 1, 640]
-          - Exact: [1,   1, 1, 640]
-          - Exact: [127,   127, 1, 640]
-          - Exact: [129,   129, 1, 640]
-          - Exact: [128,   128, 1, 127]
-          - Exact: [128,   128, 1, 129]
           - Exact: [127,   128, 1, 640]
           - Exact: [128,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -325,15 +302,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,   128, 1, 640]
-          - Exact: [2,   128, 1, 640]
-          - Exact: [3,   128, 1, 640]
           - Exact: [1,   1, 1, 640]
-          - Exact: [127,   127, 1, 640]
-          - Exact: [129,   129, 1, 640]
-          - Exact: [128,   128, 1, 127]
-          - Exact: [128,   128, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [128,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
@@ -405,15 +374,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,   128, 1, 640]
-          - Exact: [2,   128, 1, 640]
-          - Exact: [3,   128, 1, 640]
-          - Exact: [1,   1, 1, 640]
-          - Exact: [127,   127, 1, 640]
-          - Exact: [129,   129, 1, 640]
           - Exact: [128,   128, 1, 127]
-          - Exact: [128,   128, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [128,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
@@ -485,15 +446,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,   128, 1, 640]
-          - Exact: [2,   128, 1, 640]
-          - Exact: [3,   128, 1, 640]
-          - Exact: [1,   1, 1, 640]
-          - Exact: [127,   127, 1, 640]
-          - Exact: [129,   129, 1, 640]
           - Exact: [128,   128, 1, 127]
-          - Exact: [128,   128, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [128,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
@@ -564,16 +517,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [1,   128, 1, 640]
-          - Exact: [2,   128, 1, 640]
-          - Exact: [3,   128, 1, 640]
           - Exact: [1,   1, 1, 640]
-          - Exact: [127,   127, 1, 640]
-          - Exact: [129,   129, 1, 640]
-          - Exact: [128,   128, 1, 127]
-          - Exact: [128,   128, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [128,   128, 1, 640]
           - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
@@ -645,16 +589,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [1,   128, 1, 640]
-          - Exact: [2,   128, 1, 640]
-          - Exact: [3,   128, 1, 640]
-          - Exact: [1,   1, 1, 640]
-          - Exact: [127,   127, 1, 640]
-          - Exact: [129,   129, 1, 640]
           - Exact: [128,   128, 1, 127]
-          - Exact: [128,   128, 1, 129]
-          - Exact: [127,   128, 1, 640]
-          - Exact: [128,   128, 1, 640]
-          - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_bf16.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_bf16.yaml
@@ -84,13 +84,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s', 'b']
         - FactorDimArgs: [0,1]
@@ -164,13 +158,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
           - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
@@ -244,14 +232,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
           - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
           - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
@@ -324,15 +306,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
           - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -403,20 +378,8 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
           - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
           - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
@@ -487,22 +450,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
           - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -571,28 +520,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
           - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [16, 16, 1, 16] # classic format
-          - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 48] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 192] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
           - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -661,22 +591,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
           - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f16.yaml
@@ -85,15 +85,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
           - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s', 'h']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -167,15 +160,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
           - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -248,13 +234,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
           - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
@@ -330,14 +310,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
           - Exact: [256, 256, 1, 32] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [1024, 1924, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -407,22 +380,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
           - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
           - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -492,22 +451,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
           - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -576,28 +521,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
-          - Exact: [8, 8, 1, 256] # classic format
           - Exact: [16, 16, 1, 16] # classic format
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 48] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 192] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
           - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:
@@ -666,22 +591,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [8, 8, 1, 16] # classic format
-          - Exact: [8, 8, 1, 32] # classic format
-          - Exact: [8, 8, 1, 48] # classic format
-          - Exact: [8, 8, 1, 64] # classic format
-          - Exact: [8, 8, 1, 128] # classic format
-          - Exact: [8, 8, 1, 192] # classic format
           - Exact: [8, 8, 1, 256] # classic format
-          - Exact: [128, 128, 1, 16] # classic format
-          - Exact: [128, 128, 1, 24] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 48] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 192] # classic format
           - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [1024, 1024, 1, 1024] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0, 1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_f8.yaml
@@ -83,15 +83,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
           - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
           - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
@@ -165,16 +157,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
           - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -247,16 +231,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
           - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -329,16 +305,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -410,17 +378,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -492,17 +450,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -573,18 +521,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
           - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -655,18 +593,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
           - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/sparse/gfx950/spmm_i8.yaml
@@ -84,15 +84,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -165,16 +157,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
           - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -247,16 +231,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
           - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
           - Exact: [256, 256, 1, 256] # classic format
-          - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -329,16 +305,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
           - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [256, 256, 1, 64] # classic format
-          - Exact: [256, 256, 1, 128] # classic format
-          - Exact: [256, 256, 1, 256] # classic format
           - Exact: [256, 256, 1, 384] # classic format
-          - Exact: [256, 256, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -409,17 +377,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
           - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
           - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
@@ -492,17 +450,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
           - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -573,18 +521,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
           - Exact: [16, 16, 1, 64] # classic format
-          - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
           - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
-          - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:
@@ -655,18 +593,8 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [16, 16, 1, 32] # classic format
-          - Exact: [16, 16, 1, 64] # classic format
           - Exact: [16, 16, 1, 128] # classic format
-          - Exact: [16, 16, 1, 256] # classic format
-          - Exact: [16, 16, 1, 384] # classic format
-          - Exact: [16, 16, 1, 512] # classic format
-          - Exact: [128, 128, 1, 32] # classic format
-          - Exact: [128, 128, 1, 64] # classic format
-          - Exact: [128, 128, 1, 128] # classic format
-          - Exact: [128, 128, 1, 256] # classic format
           - Exact: [128, 128, 1, 384] # classic format
-          - Exact: [128, 128, 1, 512] # classic format
         - BiasTypeArgs: ['s']
         - FactorDimArgs: [0,1]
         - ActivationArgs:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_f8ngemm_quick.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_f8ngemm_quick.yaml
@@ -79,19 +79,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [1024, 1024, 1, 1024]
-          # - Exact: [4096, 1024, 1, 1024]
-          # - Exact: [1024, 4096, 1, 1024]
-          # - Exact: [1024, 1024, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4096]
-          # - Exact: [4111, 4096, 1, 4096]
-          # - Exact: [4096, 4111, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4111]
-          - Exact: [4111, 4111, 1, 4111]
-          # - Exact: [1024, 1024, 1, 512]
-          # - Exact: [127,   128, 1, 640]
-          # - Exact: [128,   128, 1, 640]
-          # - Exact: [129,   128, 1, 640]
+          - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -156,19 +144,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [1024, 1024, 1, 1024]
-          # - Exact: [4096, 1024, 1, 1024]
-          # - Exact: [1024, 4096, 1, 1024]
-          # - Exact: [1024, 1024, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4096]
-          # - Exact: [4111, 4096, 1, 4096]
-          # - Exact: [4096, 4111, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4111]
           - Exact: [4111, 4111, 1, 4111]
-          # - Exact: [1024, 1024, 1, 512]
-          # - Exact: [127,   128, 1, 640]
-          # - Exact: [128,   128, 1, 640]
-          # - Exact: [129,   128, 1, 640]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -233,19 +209,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [1024, 1024, 1, 1024]
-          # - Exact: [4096, 1024, 1, 1024]
-          # - Exact: [1024, 4096, 1, 1024]
-          # - Exact: [1024, 1024, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4096]
-          # - Exact: [4111, 4096, 1, 4096]
-          # - Exact: [4096, 4111, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4111]
-          - Exact: [4111, 4111, 1, 4111]
-          # - Exact: [1024, 1024, 1, 512]
-          # - Exact: [127,   128, 1, 640]
-          # - Exact: [128,   128, 1, 640]
-          # - Exact: [129,   128, 1, 640]
+          - Exact: [255, 255, 1, 255]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -310,19 +274,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [1024, 1024, 1, 1024]
-          # - Exact: [4096, 1024, 1, 1024]
-          # - Exact: [1024, 4096, 1, 1024]
-          # - Exact: [1024, 1024, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4096]
-          # - Exact: [4111, 4096, 1, 4096]
-          # - Exact: [4096, 4111, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4111]
-          - Exact: [4111, 4111, 1, 4111]
-          # - Exact: [1024, 1024, 1, 512]
-          # - Exact: [127,   128, 1, 640]
-          # - Exact: [128,   128, 1, 640]
-          # - Exact: [129,   128, 1, 640]
+          - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -387,19 +339,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [1024, 1024, 1, 1024]
-          # - Exact: [4096, 1024, 1, 1024]
-          # - Exact: [1024, 4096, 1, 1024]
-          # - Exact: [1024, 1024, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4096]
-          # - Exact: [4111, 4096, 1, 4096]
-          # - Exact: [4096, 4111, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4111]
-          - Exact: [4111, 4111, 1, 4111]
-          # - Exact: [1024, 1024, 1, 512]
-          # - Exact: [127,   128, 1, 640]
-          # - Exact: [128,   128, 1, 640]
-          # - Exact: [129,   128, 1, 640]
+          - Exact: [31, 31, 1, 31]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -463,20 +403,7 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 128, 1, 128]
-          - Exact: [1024, 1024, 1, 1024]
-          # - Exact: [4096, 1024, 1, 1024]
-          # - Exact: [1024, 4096, 1, 1024]
-          # - Exact: [1024, 1024, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4096]
-          # - Exact: [4111, 4096, 1, 4096]
-          # - Exact: [4096, 4111, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4111]
-          - Exact: [4111, 4111, 1, 4111]
-          # - Exact: [1024, 1024, 1, 512]
-          # - Exact: [127,   128, 1, 640]
-          # - Exact: [128,   128, 1, 640]
-          # - Exact: [129,   128, 1, 640]
+          - Exact: [255, 255, 1, 255]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -542,19 +469,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [1024, 1024, 1, 1024]
-          # - Exact: [4096, 1024, 1, 1024]
-          # - Exact: [1024, 4096, 1, 1024]
-          # - Exact: [1024, 1024, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4096]
-          # - Exact: [4111, 4096, 1, 4096]
-          # - Exact: [4096, 4111, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4111]
-          - Exact: [4111, 4111, 1, 4111]
-          # - Exact: [1024, 1024, 1, 512]
-          # - Exact: [127,   128, 1, 640]
-          # - Exact: [128,   128, 1, 640]
-          # - Exact: [129,   128, 1, 640]
+          - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -619,19 +534,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [128, 128, 1, 128]
-          - Exact: [1024, 1024, 1, 1024]
-          # - Exact: [4096, 1024, 1, 1024]
-          # - Exact: [1024, 4096, 1, 1024]
-          # - Exact: [1024, 1024, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4096]
-          # - Exact: [4111, 4096, 1, 4096]
-          # - Exact: [4096, 4111, 1, 4096]
-          # - Exact: [4096, 4096, 1, 4111]
-          - Exact: [4111, 4111, 1, 4111]
-          # - Exact: [1024, 1024, 1, 512]
-          # - Exact: [127,   128, 1, 640]
-          # - Exact: [128,   128, 1, 640]
-          # - Exact: [129,   128, 1, 640]
+          - Exact: [127, 127, 1, 127]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_hgemm_quick.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_hgemm_quick.yaml
@@ -91,11 +91,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          - Exact: [4103, 4103, 1, 1031]
 
     - # HGEMM NT - Test DepthU, WGM, VW
       InitialSolutionParameters:
@@ -131,12 +126,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          # - Exact: [4103, 4103, 1, 1031]
           - Exact: [2055, 2055, 1, 1031]
 
     - # HGEMM NT - Test tuning params
@@ -179,12 +168,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          # - Exact: [4103, 4103, 1, 1031]
-          - Exact: [2055, 2055, 1, 1031]
 
   #   - # HGEMM NT - Test size range
   #     InitialSolutionParameters:
@@ -290,11 +273,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
           - Exact: [4103, 4103, 1, 1031]
 
     # - # HGEMM NN - Test DepthU, WGM, VW
@@ -532,12 +510,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          # - Exact: [4103, 4103, 1, 1031]
-          - Exact: [2055, 2055, 1, 1031]
 
     # - # HGEMM TN - Test tuning params
     #   InitialSolutionParameters:
@@ -779,12 +751,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          # - Exact: [4103, 4103, 1, 1031]
-          - Exact: [2055, 2055, 1, 1031]
 
   #   - # HGEMM TT - Test size range
   #     InitialSolutionParameters:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_sgemm_quick.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/streamk/sk_sgemm_quick.yaml
@@ -85,11 +85,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          - Exact: [4103, 4103, 1, 1031]
 
     - # SGEMM NT - Test DepthU, WGM, VW
       InitialSolutionParameters:
@@ -126,12 +121,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          # - Exact: [4103, 4103, 1, 1031]
-          - Exact: [2055, 2055, 1, 1031]
 
     - # SGEMM NT - Test tuning params
       InitialSolutionParameters:
@@ -173,12 +162,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          # - Exact: [4103, 4103, 1, 1031]
-          - Exact: [2055, 2055, 1, 1031]
+          - Exact: [355, 355, 1, 331]
 
     # - # SGEMM NT - Test size range
     #   InitialSolutionParameters:
@@ -279,11 +263,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          - Exact: [4103, 4103, 1, 1031]
 
     # - # SGEMM NN - Test DepthU, WGM, VW
     #   InitialSolutionParameters:
@@ -514,12 +493,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          # - Exact: [4103, 4103, 1, 1031]
-          - Exact: [2055, 2055, 1, 1031]
+          - Exact: [155, 155, 1, 131]
 
     # - # SGEMM TN - Test tuning params
     #   InitialSolutionParameters:
@@ -755,12 +729,6 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          # - Exact: [4096, 4096, 1, 1024]
-          # - Exact: [4103, 4096, 1, 1024]
-          # - Exact: [4096, 4103, 1, 1024]
-          # - Exact: [4096, 4096, 1, 1031]
-          # - Exact: [4103, 4103, 1, 1031]
-          - Exact: [2055, 2055, 1, 1031]
 
     # - # SGEMM TT - Test size range
     #   InitialSolutionParameters:
@@ -839,7 +807,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          - Exact: [2055, 2055, 1, 1031]
+          - Exact: [155, 155, 1, 131]
     
     - # SGEMM TT - Test autoWGM (WorkGroupMapping: [0])
       # WorkGroupMapping is set to default (sqrt(CU/XCD)) at runtime
@@ -881,7 +849,7 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          - Exact: [2055, 2055, 1, 1031]
+          - Exact: [155, 155, 1, 131]
     
     - # SGEMM TT - Test autoWGM + autoWGMXCC (WorkGroupMapping: [0] and WorkGroupMappingXCC: [-1])
       # WorkGroupMapping and WorkGroupMappingXCC values are predicted at runtime. (not default values)
@@ -923,4 +891,4 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Exact: [512, 512, 1, 512]
-          - Exact: [2055, 2055, 1, 1031]
+          - Exact: [155, 155, 1, 131]


### PR DESCRIPTION
## Motivation

Current execution time for tensile common folder takes ~45 minutes on 1 GPU. reducing unnecessary problem size to improve the execution time

## Technical Details

Reduce the problem size which is duplicate/redundant

https://github.com/ROCm/rocm-libraries/commit/7f788928e592739b8b9110a2bb3451ebe2cba24b

## Test Plan

N/A
## Test Result

On `gfx942` top 9 yaml
```
OLD           NEW
1071.55s   655.59s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/dtv.yaml]
268.13s    171.43s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/mix_cvt_after_ds_fnuz.yaml]
249.57s     61.79s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/streamk/sk_hgemm_quick.yaml]
214.43s     64.98s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/streamk/sk_f8ngemm_quick.yaml]
213.79s    145.25s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/hh_f8nhs.yaml]
201.91s    110.26s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/lsu_fnuz.yaml]
187.73s    120.06s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/cgemm.yaml]
184.18s     79.74s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/fp8nfp16mix_hhs.yaml]
179.08s     92.22s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/streamk/sk_sgemm_quick.yaml]
```

On `gfx950` 

```
OLD           NEW
986.90s   653.58s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/custom_mainloop_scheduling.yaml]
632.80s   324.20s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/dtl.yaml]
421.29s   221.51s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/plr_zero.yaml]
236.69s   194.92s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_f16.yaml]
161.22s   119.03s     Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_bf16.yaml]
140.42s   89.97s      Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_i8.yaml]
114.11s   88.79s      Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/sparse/gfx950/spmm_f8.yaml]
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
