### PR TITLE
reducing the problem size to improve the overall execution time for tensile common folder

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/mx32f4_tn.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/mx32f4_tn.yaml
@@ -110,38 +110,12 @@ BenchmarkProblems:
           # - Exact: [16, 16, 1, 128]
           - Exact: [32, 16, 1, 1024]
           - Exact: [256, 256, 1, 128]
-          - Exact: [1025, 513, 1, 2048]
-#          - Exact: [1026, 514, 1, 2048]
-#          - Exact: [1027, 515, 1, 2048]
-#          - Exact: [1028, 516, 1, 2048]
-#          - Exact: [1029, 517, 1, 2048]
-#          - Exact: [1030, 518, 1, 2048]
-#          - Exact: [1031, 519, 1, 2048]
-#          - Exact: [1032, 520, 1, 2048]
-#          - Exact: [1033, 521, 1, 2048]
-#          - Exact: [1034, 522, 1, 2048]
-#          - Exact: [1035, 523, 1, 2048]
-#          - Exact: [1036, 524, 1, 2048]
-#          - Exact: [1037, 525, 1, 2048]
-#          - Exact: [1038, 526, 1, 2048]
-#          - Exact: [1039, 527, 1, 2048]
-#          - Exact: [1040, 528, 1, 2048]
-#          - Exact: [1041, 529, 1, 2048]
-#          - Exact: [1042, 530, 1, 2048]
-#          - Exact: [1043, 531, 1, 2048]
           - Exact: [1044, 532, 1, 2048]
           - Exact: [127, 127, 1, 640] #special cleanup case
-          - Exact: [128, 128, 1, 128]
-          - Exact: [129, 129, 1, 640]
-          # - Exact: [128, 128, 1, 127]
-          # - Exact: [128, 128, 1, 129]
-          # - Exact: [111, 111, 1, 111]
-          # - Exact: [777, 777, 1, 777]
           - Exact: [128, 128, 1, 512]
-          #- Range: [[128], [128], [1], [1024,32,1280]]
           - Range: [[128], [128], [1], [1024,128,1280]] #make K value is multiple of DepthU
-          - Range: [[128,1,256], [128], [1], [1024]]
-          - Range: [[128], [128,1,256], [1], [1024]]
+          - Range: [[128,64,256], [128], [1], [1024]]
+          - Range: [[128], [128,64,256], [1], [1024]]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
@@ -170,16 +144,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [1025, 513, 1, 2048]
           - Exact: [127, 127, 1, 640] #special cleanup case
-          - Exact: [129, 129, 1, 640]
-          - Exact: [128, 128, 1, 512]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
 
-# LibraryLogic:
-#     ScheduleName: "aquavanjaram"
-#     DeviceNames: ["Device 0049"]
-#     ArchitectureName: "gfx950"
-#     LibraryType: "GridBased"
-#
-# LibraryClient:

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/mx32f8_tn.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/gfx950/mx32f8_tn.yaml
@@ -111,45 +111,14 @@ BenchmarkProblems:
           - Exact: [32, 16, 1, 1024]
           #- Exact: [256, 256, 1, 64]   # TODO: this fails as currently tailloop is not supported for MX types.
           - Exact: [1025, 513, 1, 2048]
-#          - Exact: [1026, 514, 1, 2048]
-#          - Exact: [1027, 515, 1, 2048]
-#          - Exact: [1028, 516, 1, 2048]
-#          - Exact: [1029, 517, 1, 2048]
-#          - Exact: [1030, 518, 1, 2048]
-#          - Exact: [1031, 519, 1, 2048]
-#          - Exact: [1032, 520, 1, 2048]
-#          - Exact: [1033, 521, 1, 2048]
-#          - Exact: [1034, 522, 1, 2048]
-#          - Exact: [1035, 523, 1, 2048]
-#          - Exact: [1036, 524, 1, 2048]
-#          - Exact: [1037, 525, 1, 2048]
-#          - Exact: [1038, 526, 1, 2048]
-#          - Exact: [1039, 527, 1, 2048]
-#          - Exact: [1040, 528, 1, 2048]
-#          - Exact: [1041, 529, 1, 2048]
-#          - Exact: [1042, 530, 1, 2048]
-#          - Exact: [1043, 531, 1, 2048]
           - Exact: [1044, 532, 1, 2048]
           - Exact: [127, 127, 1, 640] #special cleanup case
           - Exact: [128, 128, 1, 128]
           - Exact: [129, 129, 1, 640]
-          # - Exact: [128, 128, 1, 127]
-          # - Exact: [128, 128, 1, 129]
-          # - Exact: [111, 111, 1, 111]
-          # - Exact: [777, 777, 1, 777]
           - Exact: [128, 128, 1, 512]
-          #- Range: [[128], [128], [1], [1024,32,1280]]
-          #- Range: [[128], [128], [1], [1024,64,1280]] # TODO: passed for DepthU = 64 but failed for DepthU = 128 since we currently don't support tailloop in MX feature.
-          - Range: [[128,1,256], [128], [1], [1024]]
-          - Range: [[128], [128,1,256], [1], [1024]]
+          - Range: [[128,33,256], [128], [1], [1024]]
+          - Range: [[128], [128,33,256], [1], [1024]]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: none]
 
-# LibraryLogic:
-#     ScheduleName: "aquavanjaram"
-#     DeviceNames: ["Device 0049"]
-#     ArchitectureName: "gfx950"
-#     LibraryType: "GridBased"
-#
-# LibraryClient:


### PR DESCRIPTION
## Motivation

Current execution time for tensile common folder takes ~45 minutes on 1 GPU. reducing unnecessary problem size to improve the execution time

## Technical Details

Reduce the problem size which is duplicate/redundant

https://github.com/ROCm/rocm-libraries/commit/fd3ed4e8fdc0bfcd1ea48a0827a4e61a09fc8ca9

## Test Plan

N/A

## Test Result

```
OLD      NEW
133.96s 77.91s  Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/mx32f8_tn.yaml]
131.84s 38.27s  Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/gemm/gfx950/mx32f4_tn.yaml]
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
