### PR TITLE
[hipDNN] fp8_e8m0: Fix numeric_limits round_style and improve test coverage

### DIFF
--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/types/Fp8E8M0.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/types/Fp8E8M0.hpp
@@ -287,7 +287,7 @@ public:
     static constexpr bool has_signaling_NaN = false;
     static constexpr std::float_denorm_style has_denorm = std::denorm_absent;
     static constexpr bool has_denorm_loss = false;
-    static constexpr std::float_round_style round_style = std::round_to_nearest;
+    static constexpr std::float_round_style round_style = std::round_toward_zero;
     static constexpr bool is_iec559 = false;
     static constexpr bool is_bounded = true;
     static constexpr bool is_modulo = false;

--- a/projects/hipdnn/data_sdk/tests/types/TestFp8E8M0.cpp
+++ b/projects/hipdnn/data_sdk/tests/types/TestFp8E8M0.cpp
@@ -61,13 +61,6 @@ TEST(TestFp8E8M0, ConstructFromFloatBitPatterns)
     EXPECT_EQ(four.data, E8M0_BITS_FOUR);
 }
 
-TEST(TestFp8E8M0, FromBitsMinValue)
-{
-    // scale=0 is 2^-127, NOT zero (E8M0-specific)
-    fp8_e8m0 minVal = fp8_e8m0::from_bits(0x00);
-    EXPECT_EQ(static_cast<float>(minVal), 0x1p-127f);
-}
-
 TEST(TestFp8E8M0, CopyAssignment)
 {
     fp8_e8m0 a(2.0f);
@@ -93,15 +86,16 @@ TEST(TestFp8E8M0, RoundTripConversion)
     }
 }
 
-TEST(TestFp8E8M0, NonPowerOfTwoRounding)
+TEST(TestFp8E8M0, NonPowerOfTwoTruncation)
 {
-    // Non-power-of-2 values should be rounded to nearest power of 2
-    // 3.0 is between 2 (2^1) and 4 (2^2), closer to 4
-    // But E8M0 only stores exponent, so 3.0 -> exponent of 3.0 = 128 (for 2.0 since floor)
+    // E8M0 truncates to the lower power of 2 (floor behavior, not rounding)
+    // 3.0 is between 2 (2^1) and 4 (2^2) - truncates to 2.0
     fp8_e8m0 three(3.0f);
-    auto result = static_cast<float>(three);
-    // 3.0 has exponent 128 in float (for values in [2,4)), so E8M0 stores 128, giving 2.0
-    EXPECT_EQ(result, 2.0f);
+    EXPECT_EQ(static_cast<float>(three), 2.0f);
+
+    // 3.9 is very close to 4.0 but still truncates to 2.0
+    fp8_e8m0 almostFour(3.9f);
+    EXPECT_EQ(static_cast<float>(almostFour), 2.0f);
 }
 
 TEST(TestFp8E8M0, MaximumValue)
@@ -117,16 +111,16 @@ TEST(TestFp8E8M0, MaximumValue)
 
 TEST(TestFp8E8M0, MinimumValue)
 {
-    // E8M0 has no zero - scale=0 represents min
+    // E8M0 has no zero - scale=0 represents min (2^-127)
     fp8_e8m0 minVal = fp8_e8m0::from_bits(0x00);
     EXPECT_EQ(minVal.data, E8M0_BITS_MIN);
-    EXPECT_EQ(static_cast<float>(minVal), 0x1p-127f);
-}
 
-TEST(TestFp8E8M0, NaNValue)
-{
-    fp8_e8m0 nan = fp8_e8m0::from_bits(E8M0_BITS_NAN);
-    EXPECT_TRUE(isnan(nan));
+    auto minFloat = static_cast<float>(minVal);
+    EXPECT_EQ(minFloat, 0x1p-127f);
+
+    // Round-trip: convert float back to fp8_e8m0
+    fp8_e8m0 roundTrip(minFloat);
+    EXPECT_EQ(roundTrip.data, E8M0_BITS_MIN);
 }
 
 TEST(TestFp8E8M0, Signbit)


### PR DESCRIPTION
## Motivation

The `fp8_e8m0` type's `std::numeric_limits` specialization incorrectly specified `round_style = std::round_to_nearest`. However, the actual implementation truncates to the lower power of 2 (floor behavior), producing $2^{\lfloor \log_2(x) \rfloor}$. This is because `float_to_fp8_e8m0_bits` extracts the IEEE 754 exponent directly, which inherently floors the logarithm.

Additionally, the test file contained duplicate tests and misleading comments that described "rounding" behavior when the actual behavior is truncation.

## Technical Details

### Changes to `Fp8E8M0.hpp`

- Changed `round_style` from `std::round_to_nearest` to `std::round_toward_zero` in `std::numeric_limits<fp8_e8m0>` to accurately reflect the truncation behavior

### Changes to `TestFp8E8M0.cpp`

- Removed duplicate test `FromBitsMinValue` (functionality already covered by `MinimumValue`)
- Removed duplicate test `NaNValue` (functionality already covered by `QuietNaN` in `TestPortableTypes.cpp`)
- Renamed `NonPowerOfTwoRounding` to `NonPowerOfTwoTruncation` with corrected comments
- Added test case for `3.9f` to demonstrate truncation behavior (very close to 4.0 but truncates to 2.0)
- Added round-trip verification to `MinimumValue` test

## Test Plan

- Run unit tests for `fp8_e8m0` type
- Verify all existing and new tests pass

## Test Result

All tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
