### PR TITLE
[ci] Build therock-archives and therock-dist together

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -95,11 +95,8 @@ jobs:
         run: |
           python3 TheRock/build_tools/github_actions/build_configure.py
 
-      - name: Build therock-dist
-        run: cmake --build TheRock/build --target therock-dist
-
-      - name: Build therock-archives
-        run: cmake --build TheRock/build --target therock-archives
+      - name: Build therock-archives and therock-dist
+        run: cmake --build TheRock/build --target therock-archives therock-dist -- -k 0
 
       - name: Report
         if: ${{ !cancelled() }}

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -109,11 +109,8 @@ jobs:
           ccache -z
           python3 TheRock/build_tools/github_actions/build_configure.py
 
-      - name: Build therock-dist
-        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-dist
-
-      - name: Build therock-archives
-        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives
+      - name: Build therock-archives and therock-dist
+        run: cmake --build "${{ env.BUILD_DIR }}" --target therock-archives therock-dist -- -k 0
 
       - name: Report
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Motivation

Incorporating https://github.com/ROCm/TheRock/pull/1523 into these forked workflows.

This should fix "report" step errors like `ls: cannot access 'B:\build/artifacts/*.tar.xz': No such file or directory` on https://github.com/ROCm/rocm-libraries/actions/runs/22953229409/job/66623069364?pr=5202 when the build fails, leading to more clear error attribution.

## Technical Details

* Also adding `-k 0` to keep going through errors
* We originally split these steps because archive generation was very slow on Windows (on the order of 1h for a 1h build).
* The "report" step should still be moved to a Python script that gracefully handles missing directories/files.
* Eventually these workflows will be de-dup'd with those in TheRock

## Test Plan

* CI on this PR should succeed, check the logs for archive generation and step timing

## Test Result

CI runs passed as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
