### PR TITLE
[hipblaslt] Fix fail with gfx942+dtv/dtl.yaml

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4414,7 +4414,7 @@ class KernelWriterAssembly(KernelWriter):
 
       if lrvwOther >= 2 and (not tluOther) and tP["tlu"]:
         # DirectToVgpr + LocalReadVectorWidth>=2 case, multiply qReg by lrvwOther
-        dtvKInterval = lrvwOther
+        dtvKInterval = int(lrvwOther)
       if  tluOther and tP["tlu"]:
         # DirectToVgpr + both TLU case, multiply qReg by kernel["MIInputPerThread"]
         dtvKInterval = kernel["MIInputPerThread"]


### PR DESCRIPTION
## Motivation

Fix dtv/dtl.yaml fail on gfx942

## Technical Details

Add int cast to avoid using float value in const field

## Test Plan

Run dtv/dtl.yaml on gfx942

## Test Result

dtv/dtl.yaml padded on gfx942

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
