### PR TITLE
Fix: add MacDataTypeA to mock kernel

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_SolutionStructsUtilities.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_SolutionStructsUtilities.py
@@ -37,7 +37,7 @@ def _build_kernel(*, enable_f32_xdl_math_op=False, use_f32x_emulation=False,
         "EnableF32XdlMathOp": enable_f32_xdl_math_op,
         "UseF32XEmulation": use_f32x_emulation,
         "ProblemType": {
-            "DataType": data_type or DataType(DataTypeEnum.Float),
+            "MacDataTypeA": data_type or DataType(DataTypeEnum.Float),
             "F32XdlMathOp": f32_xdl_math_op or DataType(DataTypeEnum.XFloat32),
         },
     }


### PR DESCRIPTION
## Motivation

Fix the unit test now that we use `MacDataTypeA` to get the datatype for a matrix instruction.


## Test Plan

Unit tests

## Test Result

pass

