### PR TITLE
[CK][Test] Moving device_op creation before data initialization.

### DIFF
--- a/projects/composablekernel/profiler/include/profiler/profile_batched_contraction_multiple_d_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_batched_contraction_multiple_d_impl.hpp
@@ -99,6 +99,23 @@ bool profile_batched_contraction_multiple_d_impl(int do_verification,
     std::cout << "d_gs_ms_ns: " << d_gs_ms_ns.mDesc << std::endl;
     std::cout << "e_gs_ms_ns: " << e_gs_ms_ns_host_result.mDesc << std::endl;
 
+    // get device op instances
+    using DeviceOp     = ck::tensor_operation::device::DeviceBatchedContractionMultipleD<NumDimG,
+                                                                                         NumDimM,
+                                                                                         NumDimN,
+                                                                                         NumDimK,
+                                                                                         ADataType,
+                                                                                         BDataType,
+                                                                                         DsDataType,
+                                                                                         EDataType,
+                                                                                         AElementOp,
+                                                                                         BElementOp,
+                                                                                         CDEElementOp>;
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
+
     switch(init_method)
     {
     case 0: break;
@@ -180,23 +197,6 @@ bool profile_batched_contraction_multiple_d_impl(int do_verification,
             }
         }
     }
-
-    // get device op instances
-    using DeviceOp     = ck::tensor_operation::device::DeviceBatchedContractionMultipleD<NumDimG,
-                                                                                         NumDimM,
-                                                                                         NumDimN,
-                                                                                         NumDimK,
-                                                                                         ADataType,
-                                                                                         BDataType,
-                                                                                         DsDataType,
-                                                                                         EDataType,
-                                                                                         AElementOp,
-                                                                                         BElementOp,
-                                                                                         CDEElementOp>;
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
 
     std::string best_op_name;
     float best_ave_time   = 0;

--- a/projects/composablekernel/profiler/include/profiler/profile_batched_gemm_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_batched_gemm_impl.hpp
@@ -85,6 +85,12 @@ bool profile_batched_gemm_impl(int do_verification,
     std::cout << "b_g_k_n: " << b_g_k_n.mDesc << std::endl;
     std::cout << "c_g_m_n: " << c_g_m_n_host_result.mDesc << std::endl;
 
+    // get device op instances
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
+
     switch(init_method)
     {
     case 0: break;
@@ -128,12 +134,6 @@ bool profile_batched_gemm_impl(int do_verification,
     a_device_buf.ToDevice(a_g_m_k.mData.data());
     b_device_buf.ToDevice(b_g_k_n.mData.data());
     c_device_buf.ToDevice(c_g_m_n_device_result.mData.data());
-
-    // get device op instances
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
 
     std::string best_op_name;
     float best_ave_time   = 0;

--- a/projects/composablekernel/profiler/include/profiler/profile_batchnorm_backward_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_batchnorm_backward_impl.hpp
@@ -63,6 +63,27 @@ bool profile_batchnorm_backward_impl(bool do_verification,
         };
     }
 
+    using PassThroughOp = ck::tensor_operation::element_wise::PassThrough;
+
+    // add device batchnorm-backward instances
+    using DeviceOp = ck::tensor_operation::device::DeviceBatchNormBwd<XDataType,
+                                                                      DxDataType,
+                                                                      DxDataType,
+                                                                      AccDataType,
+                                                                      ScaleDataType,
+                                                                      DscaleDbiasDataType,
+                                                                      MeanVarDataType,
+                                                                      PassThroughOp,
+                                                                      Rank,
+                                                                      NumBatchNormReduceDim>;
+
+    // get device op instances
+    const auto instance_ptrs =
+        ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+            DeviceOp>::GetInstances();
+
+    std::cout << "found " << instance_ptrs.size() << " instances" << std::endl;
+
     // input data of the batchnorm backward algorithm
     Tensor<XDataType> x(inOutLengths);
     Tensor<DyDataType> dy(inOutLengths);
@@ -190,27 +211,6 @@ bool profile_batchnorm_backward_impl(bool do_verification,
               arrScaleBiasMeanVarStrides.begin());
 
     std::copy(reduceDims.begin(), reduceDims.end(), arrReduceDims.begin());
-
-    using PassThroughOp = ck::tensor_operation::element_wise::PassThrough;
-
-    // add device batchnorm-backward instances
-    using DeviceOp = ck::tensor_operation::device::DeviceBatchNormBwd<XDataType,
-                                                                      DxDataType,
-                                                                      DxDataType,
-                                                                      AccDataType,
-                                                                      ScaleDataType,
-                                                                      DscaleDbiasDataType,
-                                                                      MeanVarDataType,
-                                                                      PassThroughOp,
-                                                                      Rank,
-                                                                      NumBatchNormReduceDim>;
-
-    // get device op instances
-    const auto instance_ptrs =
-        ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-            DeviceOp>::GetInstances();
-
-    std::cout << "found " << instance_ptrs.size() << " instances" << std::endl;
 
     std::string best_instance_name;
     float best_avg_time   = std::numeric_limits<float>::max();

--- a/projects/composablekernel/profiler/include/profiler/profile_conv_bwd_data_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_conv_bwd_data_impl.hpp
@@ -111,6 +111,23 @@ bool profile_conv_bwd_data_impl(int do_verification,
     std::cout << "weight: " << weight.mDesc << std::endl;
     std::cout << "output: " << output.mDesc << std::endl;
 
+    using DeviceOp = ck::tensor_operation::device::DeviceConvBwdData<NDimSpatial,
+                                                                     InLayout,
+                                                                     WeiLayout,
+                                                                     OutLayout,
+                                                                     InDataType,
+                                                                     WeiDataType,
+                                                                     OutDataType,
+                                                                     InElementOp,
+                                                                     WeiElementOp,
+                                                                     OutElementOp>;
+
+    // get device op instances
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
+
     switch(init_method)
     {
     case 0: break;
@@ -178,23 +195,6 @@ bool profile_conv_bwd_data_impl(int do_verification,
         hip_check_error(hipDeviceSynchronize());
         gpu_ref_in_dev.FromDevice(gpu_ref_input.mData.data());
     }
-
-    using DeviceOp = ck::tensor_operation::device::DeviceConvBwdData<NDimSpatial,
-                                                                     InLayout,
-                                                                     WeiLayout,
-                                                                     OutLayout,
-                                                                     InDataType,
-                                                                     WeiDataType,
-                                                                     OutDataType,
-                                                                     InElementOp,
-                                                                     WeiElementOp,
-                                                                     OutElementOp>;
-
-    // get device op instances
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
 
     std::string best_op_name;
     float best_avg_time   = 0;

--- a/projects/composablekernel/profiler/include/profiler/profile_conv_fwd_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_conv_fwd_impl.hpp
@@ -89,6 +89,23 @@ bool profile_conv_fwd_impl(int do_verification,
     std::cout << "weight: " << weight.mDesc << std::endl;
     std::cout << "output: " << host_output.mDesc << std::endl;
 
+    using DeviceOp = ck::tensor_operation::device::DeviceConvFwd<NDimSpatial,
+                                                                 InLayout,
+                                                                 WeiLayout,
+                                                                 OutLayout,
+                                                                 InDataType,
+                                                                 WeiDataType,
+                                                                 OutDataType,
+                                                                 InElementOp,
+                                                                 WeiElementOp,
+                                                                 OutElementOp>;
+
+    // get device op instances
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
+
     switch(init_method)
     {
     case 0: break;
@@ -157,23 +174,6 @@ bool profile_conv_fwd_impl(int do_verification,
         hip_check_error(hipDeviceSynchronize());
         gpu_ref_out_dev.FromDevice(gpu_ref_output.mData.data());
     }
-
-    using DeviceOp = ck::tensor_operation::device::DeviceConvFwd<NDimSpatial,
-                                                                 InLayout,
-                                                                 WeiLayout,
-                                                                 OutLayout,
-                                                                 InDataType,
-                                                                 WeiDataType,
-                                                                 OutDataType,
-                                                                 InElementOp,
-                                                                 WeiElementOp,
-                                                                 OutElementOp>;
-
-    // get device op instances
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
 
     std::string best_op_name;
     float best_avg_time   = 0;

--- a/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_bwd_data_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_bwd_data_impl.hpp
@@ -115,6 +115,28 @@ bool profile_grouped_conv_bwd_data_impl(int do_verification,
     std::cout << "wei: " << wei_g_k_c_xs_desc << std::endl;
     std::cout << "in: " << in_g_n_c_wis_desc << std::endl;
 
+    using DeviceOp =
+        ck::tensor_operation::device::DeviceGroupedConvBwdDataMultipleD<NDimSpatial,
+                                                                        OutLayout,
+                                                                        WeiLayout,
+                                                                        ck::Tuple<>,
+                                                                        InLayout,
+                                                                        OutDataType,
+                                                                        WeiDataType,
+                                                                        ck::Tuple<>,
+                                                                        InDataType,
+                                                                        OutElementOp,
+                                                                        WeiElementOp,
+                                                                        InElementOp,
+                                                                        ComputeDataType,
+                                                                        ComputeDataType>;
+
+    // get device op instances
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
+
     // Create host tensors
     Tensor<OutDataType> out(out_g_n_k_wos_desc);
     Tensor<WeiDataType> wei(wei_g_k_c_xs_desc);
@@ -438,26 +460,6 @@ bool profile_grouped_conv_bwd_data_impl(int do_verification,
     };
 
     // do GEMM
-    using DeviceOp =
-        ck::tensor_operation::device::DeviceGroupedConvBwdDataMultipleD<NDimSpatial,
-                                                                        OutLayout,
-                                                                        WeiLayout,
-                                                                        ck::Tuple<>,
-                                                                        InLayout,
-                                                                        OutDataType,
-                                                                        WeiDataType,
-                                                                        ck::Tuple<>,
-                                                                        InDataType,
-                                                                        OutElementOp,
-                                                                        WeiElementOp,
-                                                                        InElementOp,
-                                                                        ComputeDataType,
-                                                                        ComputeDataType>;
-
-    // get device op instances
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
     std::array<ck::index_t, NDimSpatial + 3> out_lengths{};
     std::array<ck::index_t, NDimSpatial + 3> out_strides{};
     std::array<ck::index_t, NDimSpatial + 3> wei_lengths{};

--- a/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_bwd_weight_impl.hpp
@@ -118,6 +118,25 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
     std::cout << "weight: " << wei_g_k_c_xs_desc << std::endl;
     std::cout << "output: " << out_g_n_k_wos_desc << std::endl;
 
+    using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvBwdWeight<NDimSpatial,
+                                                                              InLayout,
+                                                                              WeiLayout,
+                                                                              OutLayout,
+                                                                              InDataType,
+                                                                              WeiDataType,
+                                                                              OutDataType,
+                                                                              InElementOp,
+                                                                              WeiElementOp,
+                                                                              OutElementOp,
+                                                                              ComputeTypeA,
+                                                                              ComputeTypeB>;
+
+    // get device op instances
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
+
     // Create host tensors
     Tensor<InDataType> input(in_g_n_c_wis_desc);
     Tensor<WeiDataType> weight_host_result(wei_g_k_c_xs_desc);
@@ -243,25 +262,6 @@ bool profile_grouped_conv_bwd_weight_impl(int do_verification,
                 out_element_op);
         }
     }
-
-    using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvBwdWeight<NDimSpatial,
-                                                                              InLayout,
-                                                                              WeiLayout,
-                                                                              OutLayout,
-                                                                              InDataType,
-                                                                              WeiDataType,
-                                                                              OutDataType,
-                                                                              InElementOp,
-                                                                              WeiElementOp,
-                                                                              OutElementOp,
-                                                                              ComputeTypeA,
-                                                                              ComputeTypeB>;
-
-    // get device op instances
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
 
     std::string best_op_name;
     float best_avg_time   = 0;

--- a/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_fwd_bias_clamp_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_fwd_bias_clamp_impl.hpp
@@ -129,6 +129,28 @@ bool profile_grouped_conv_fwd_bias_clamp_impl(int do_verification,
     std::cout << "output: " << host_output.mDesc << std::endl;
     std::cout << "bias: " << bias.mDesc << std::endl;
 
+    using DeviceOp =
+        ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NDimSpatial,
+                                                                      InLayout,
+                                                                      WeiLayout,
+                                                                      ck::Tuple<OutLayout>,
+                                                                      OutLayout,
+                                                                      InDataType,
+                                                                      WeiDataType,
+                                                                      ck::Tuple<OutDataType>,
+                                                                      OutDataType,
+                                                                      InElementOp,
+                                                                      WeiElementOp,
+                                                                      OutElementOp,
+                                                                      AComputeType,
+                                                                      BComputeType>;
+
+    // get device op instances
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "ckProfiler found " << op_ptrs.size() << " instances" << std::endl;
+
     switch(init_method)
     {
     case 0: break;
@@ -338,28 +360,6 @@ bool profile_grouped_conv_fwd_bias_clamp_impl(int do_verification,
             std::cout << op_ptr->GetTypeString() << " does not support this problem" << std::endl;
         }
     };
-
-    using DeviceOp =
-        ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NDimSpatial,
-                                                                      InLayout,
-                                                                      WeiLayout,
-                                                                      ck::Tuple<OutLayout>,
-                                                                      OutLayout,
-                                                                      InDataType,
-                                                                      WeiDataType,
-                                                                      ck::Tuple<OutDataType>,
-                                                                      OutDataType,
-                                                                      InElementOp,
-                                                                      WeiElementOp,
-                                                                      OutElementOp,
-                                                                      AComputeType,
-                                                                      BComputeType>;
-
-    // get device op instances
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "ckProfiler found " << op_ptrs.size() << " instances" << std::endl;
 
     if constexpr(BiasGK)
     {

--- a/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_fwd_bilinear_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_fwd_bilinear_impl.hpp
@@ -107,6 +107,27 @@ bool profile_grouped_conv_fwd_bilinear_impl(
     std::cout << "d_tensor: " << d_tensor.mDesc << std::endl;
     std::cout << "output: " << host_output.mDesc << std::endl;
 
+    using DeviceOp =
+        ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NDimSpatial,
+                                                                      InLayout,
+                                                                      WeiLayout,
+                                                                      ck::Tuple<DLayout>,
+                                                                      OutLayout,
+                                                                      InDataType,
+                                                                      WeiDataType,
+                                                                      ck::Tuple<DDataType>,
+                                                                      OutDataType,
+                                                                      InElementOp,
+                                                                      WeiElementOp,
+                                                                      OutElementOp,
+                                                                      AComputeType,
+                                                                      BComputeType>;
+
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
+
     switch(init_method)
     {
     case 0: break;
@@ -230,27 +251,6 @@ bool profile_grouped_conv_fwd_bilinear_impl(
     float best_tflops     = 0;
     float best_gb_per_sec = 0;
     int valids            = 0;
-
-    using DeviceOp =
-        ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NDimSpatial,
-                                                                      InLayout,
-                                                                      WeiLayout,
-                                                                      ck::Tuple<DLayout>,
-                                                                      OutLayout,
-                                                                      InDataType,
-                                                                      WeiDataType,
-                                                                      ck::Tuple<DDataType>,
-                                                                      OutDataType,
-                                                                      InElementOp,
-                                                                      WeiElementOp,
-                                                                      OutElementOp,
-                                                                      AComputeType,
-                                                                      BComputeType>;
-
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
 
     for(std::size_t i = 0; i < op_ptrs.size(); ++i)
     {

--- a/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_fwd_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_fwd_impl.hpp
@@ -133,6 +133,27 @@ bool profile_grouped_conv_fwd_impl(int do_verification,
     std::cout << "weight: " << wei_g_k_c_xs_desc << std::endl;
     std::cout << "output: " << out_g_n_k_wos_desc << std::endl;
 
+    using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NDimSpatial,
+                                                                                   InLayout,
+                                                                                   WeiLayout,
+                                                                                   ck::Tuple<>,
+                                                                                   OutLayout,
+                                                                                   InDataType,
+                                                                                   WeiDataType,
+                                                                                   ck::Tuple<>,
+                                                                                   OutDataType,
+                                                                                   InElementOp,
+                                                                                   WeiElementOp,
+                                                                                   OutElementOp,
+                                                                                   AComputeType,
+                                                                                   BComputeType>;
+
+    // get device op instances
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "ckProfiler found " << op_ptrs.size() << " instances" << std::endl;
+
     // Create host tensors
     Tensor<InDataType> input(in_g_n_c_wis_desc);
     Tensor<WeiDataType> weight(wei_g_k_c_xs_desc);
@@ -393,27 +414,6 @@ bool profile_grouped_conv_fwd_impl(int do_verification,
             std::cout << op_ptr->GetTypeString() << " does not support this problem" << std::endl;
         }
     };
-
-    using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NDimSpatial,
-                                                                                   InLayout,
-                                                                                   WeiLayout,
-                                                                                   ck::Tuple<>,
-                                                                                   OutLayout,
-                                                                                   InDataType,
-                                                                                   WeiDataType,
-                                                                                   ck::Tuple<>,
-                                                                                   OutDataType,
-                                                                                   InElementOp,
-                                                                                   WeiElementOp,
-                                                                                   OutElementOp,
-                                                                                   AComputeType,
-                                                                                   BComputeType>;
-
-    // get device op instances
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "ckProfiler found " << op_ptrs.size() << " instances" << std::endl;
 
     if(list_instances)
     {

--- a/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_fwd_outelementop_impl.hpp
+++ b/projects/composablekernel/profiler/include/profiler/profile_grouped_conv_fwd_outelementop_impl.hpp
@@ -151,6 +151,27 @@ bool profile_grouped_conv_fwd_outelementop_impl(int do_verification,
     std::cout << "scale_wei: " << scale_wei << std::endl;
     std::cout << "scale_out: " << scale_out << std::endl;
 
+    using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NDimSpatial,
+                                                                                   InLayout,
+                                                                                   WeiLayout,
+                                                                                   ck::Tuple<>,
+                                                                                   OutLayout,
+                                                                                   InDataType,
+                                                                                   WeiDataType,
+                                                                                   ck::Tuple<>,
+                                                                                   OutDataType,
+                                                                                   InElementOp,
+                                                                                   WeiElementOp,
+                                                                                   OutElementOp,
+                                                                                   AComputeType,
+                                                                                   BComputeType>;
+
+    // get device op instances
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "ckProfiler found " << op_ptrs.size() << " instances" << std::endl;
+
     // run reference op
     if(do_verification == 1)
     {
@@ -339,27 +360,6 @@ bool profile_grouped_conv_fwd_outelementop_impl(int do_verification,
             std::cout << op_ptr->GetTypeString() << " does not support this problem" << std::endl;
         }
     };
-
-    using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<NDimSpatial,
-                                                                                   InLayout,
-                                                                                   WeiLayout,
-                                                                                   ck::Tuple<>,
-                                                                                   OutLayout,
-                                                                                   InDataType,
-                                                                                   WeiDataType,
-                                                                                   ck::Tuple<>,
-                                                                                   OutDataType,
-                                                                                   InElementOp,
-                                                                                   WeiElementOp,
-                                                                                   OutElementOp,
-                                                                                   AComputeType,
-                                                                                   BComputeType>;
-
-    // get device op instances
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "ckProfiler found " << op_ptrs.size() << " instances" << std::endl;
 
     for(auto& op_ptr : op_ptrs)
     {

--- a/projects/composablekernel/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_bilinear.cpp
+++ b/projects/composablekernel/test/grouped_convnd_bwd_weight/test_grouped_convnd_bwd_weight_bilinear.cpp
@@ -140,6 +140,25 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
         std::cout << "wei: " << wei_host.mDesc << std::endl;
         std::cout << "out: " << out.mDesc << std::endl;
 
+        using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvBwdWeightMultipleD<
+            NDimSpatial,
+            InLayout,
+            WeiLayout,
+            OutLayout,
+            ck::Tuple<WeiLayout>,
+            InDataType,
+            WeiDataType,
+            OutDataType,
+            ck::Tuple<WeiDataType>,
+            InElementOp,
+            WeiElementOp,
+            OutElementOp>;
+
+        // get device op instances
+        const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+            DeviceOp>::GetInstances();
+        std::cout << "found " << op_ptrs.size() << " instances" << std::endl;
+
         in.GenerateTensorValue(GeneratorTensor_2<InDataType>{-5, 5});
         out.GenerateTensorValue(GeneratorTensor_2<OutDataType>{-5, 5});
         d.GenerateTensorValue(GeneratorTensor_2<WeiDataType>{-5, 5});
@@ -179,23 +198,6 @@ class TestGroupedConvndBwdWeight : public ::testing::Test
 
         RunReference(conv_param, in, wei_host, out, d);
 
-        using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvBwdWeightMultipleD<
-            NDimSpatial,
-            InLayout,
-            WeiLayout,
-            OutLayout,
-            ck::Tuple<WeiLayout>,
-            InDataType,
-            WeiDataType,
-            OutDataType,
-            ck::Tuple<WeiDataType>,
-            InElementOp,
-            WeiElementOp,
-            OutElementOp>;
-
-        // get device op instances
-        const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-            DeviceOp>::GetInstances();
         int num_kernel = 0;
 
         for(std::size_t i = 0; i < op_ptrs.size(); ++i)

--- a/projects/composablekernel/test/grouped_convnd_fwd/test_grouped_convnd_fwd_scaleadd_ab.cpp
+++ b/projects/composablekernel/test/grouped_convnd_fwd/test_grouped_convnd_fwd_scaleadd_ab.cpp
@@ -104,6 +104,27 @@ bool profile_grouped_conv_fwd_scaleadd_ab_impl(int do_verification,
     std::cout << "weight: " << weight.mDesc << std::endl;
     std::cout << "output: " << host_output.mDesc << std::endl;
 
+    // InDataType and WeiDataType must be tuple, inLayout and weiLayout are single.
+    using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<
+        NDimSpatial,
+        InLayout,
+        WeiLayout,
+        ck::Tuple<>,
+        OutLayout,
+        ck::Tuple<InDataType, InDataType>,
+        ck::Tuple<WeiDataType, WeiDataType>,
+        ck::Tuple<>,
+        OutDataType,
+        InElementOp,
+        WeiElementOp,
+        OutElementOp>;
+
+    // get device op instances
+    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
+        DeviceOp>::GetInstances();
+
+    std::cout << "ckProfiler found " << op_ptrs.size() << " instances" << std::endl;
+
     switch(init_method)
     {
     case 0: break;
@@ -245,27 +266,6 @@ bool profile_grouped_conv_fwd_scaleadd_ab_impl(int do_verification,
             std::cout << op_ptr->GetTypeString() << " does not support this problem" << std::endl;
         }
     };
-
-    // InDataType and WeiDataType must be tuple, inLayout and weiLayout are single.
-    using DeviceOp = ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<
-        NDimSpatial,
-        InLayout,
-        WeiLayout,
-        ck::Tuple<>,
-        OutLayout,
-        ck::Tuple<InDataType, InDataType>,
-        ck::Tuple<WeiDataType, WeiDataType>,
-        ck::Tuple<>,
-        OutDataType,
-        InElementOp,
-        WeiElementOp,
-        OutElementOp>;
-
-    // get device op instances
-    const auto op_ptrs = ck::tensor_operation::device::instance::DeviceOperationInstanceFactory<
-        DeviceOp>::GetInstances();
-
-    std::cout << "ckProfiler found " << op_ptrs.size() << " instances" << std::endl;
 
     std::array<const void*, NumAs> as{in_device_buf.GetDeviceBuffer(),
                                       in_bias_device_buf.GetDeviceBuffer()};


### PR DESCRIPTION
## Motivation

We want to have information about how many instances are found as fast as possible for our internal testing framework.

## Technical Details

Nothing changes, just creating deviceOp earlier.

## Test Plan

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
