### PR TITLE
[hipblaslt][tensilelite] Disable hwmonitor and timer for CI runs

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/ClientWriter.py
+++ b/projects/hipblaslt/tensilelite/Tensile/ClientWriter.py
@@ -669,6 +669,7 @@ def writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs
         param("skip-slow-solution-ratio", globalParameters["SkipSlowSolutionRatio"])
         param("use-gpu-timer",            globalParameters["KernelTime"])
         param("hardware-monitor",         globalParameters["HardwareMonitor"])
+        param("benchmark-timer",          globalParameters["BenchmarkTimer"])
         param("num-warmups",              globalParameters["NumWarmups"])
         param("min-flops-per-sync",       globalParameters["MinFlopsPerSync"])
         param("sleep-percent",            globalParameters["SleepPercent"])

--- a/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/GlobalParameters.py
@@ -60,6 +60,7 @@ globalParameters["PinClocks"] = False  # T=pin gpu clocks and fan, F=don't
 globalParameters["HardwareMonitor"] = (
     True  # False: disable benchmarking client monitoring clocks using rocm-smi.
 )
+globalParameters["BenchmarkTimer"] = True  # False: disable benchmark timing for correctness-only runs.
 globalParameters["MinFlopsPerSync"] = (
     1  # Minimum number of flops per sync to increase stability for small problems
 )

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/benchmark_timer.yaml
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/gemm/benchmark_timer.yaml
@@ -1,0 +1,79 @@
+# This file is a direct copy of fp32_nt.yaml. For use in ensuring the hwmonitor and timer work correctly.
+TestParameters:
+  marks: [skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported yet
+
+GlobalParameters:
+  MinimumRequiredVersion: 5.0.0
+  SleepPercent: 50
+  NumElementsToValidate: 128
+  DataInitTypeBeta: 0
+  DataInitTypeAlpha: 1
+  NewClient: 2
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  Device: 0
+
+BenchmarkProblems:
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      Batched: True
+      UseBias: 1
+      Batched: True
+      Activation: True
+      UseScaleAlphaVec: 1
+
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16,16,4, 1, 1, 2, 3, 2, 2] # 64 x 96
+
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [32]
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1]
+        - GlobalReadVectorWidthA: [-1]
+        - GlobalReadVectorWidthB: [-1]
+        - LocalReadVectorWidth: [-1]
+        - TransposeLDS: [-1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - StaggerU: [16]
+        - StaggerUStride: [-1]
+        - WorkGroupMapping: [1]
+        - StaggerUMapping: [0]
+        - 1LDSBuffer: [-1]
+        - WorkGroupMappingXCC: [8]
+        - WorkGroupMappingXCCGroup: [-1]
+        - GlobalSplitU: [1]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - GlobalReadPerMfma: [1]
+        - LocalWritePerMfma: [-1]
+        - StoreRemapVectorWidth: [0]
+        - StoreVectorWidth: [-1]
+        - SourceSwap: [1]
+        - NumElementsPerBatchStore: [16]
+        - ClusterLocalRead: [1]
+        - NonTemporalA: [0]
+        - NonTemporalB: [0]
+        - DirectToVgprA: [1]
+        - DirectToVgprB: [0]
+        - WorkGroup: [[32,4,4]]
+
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [255, 255, 1, 255]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/common/test_config.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/common/test_config.py
@@ -22,6 +22,7 @@
 #
 ################################################################################
 
+import glob
 import os
 import pytest
 import subprocess
@@ -228,6 +229,75 @@ def findConfigs(rootDir=None):
                     params.append(pytest.param(filepath, marks=marks, id=relpath))
     return params
 
+def _disable_timer_and_hwmonitor(args):
+    """Append --global-parameters to disable BenchmarkTimer and HardwareMonitor.
+
+    Inserts the overrides after the existing --global-parameters flag if present,
+    otherwise appends it. Modifies args in place.
+    """
+    try:
+        idx = args.index("--global-parameters")
+    except ValueError:
+        args.append("--global-parameters")
+        idx = len(args) - 1
+    args.insert(idx + 1, "BenchmarkTimer=0")
+    args.insert(idx + 2, "HardwareMonitor=0")
+
+
+def _parse_ini_value(ini_path, key):
+    """Parse a key=value from a Tensile client .ini file. Returns None if not found."""
+    with open(ini_path) as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith(key + "="):
+                return line.split("=", 1)[1]
+    return None
+
+
+def _verify_timer_and_hwmonitor(output_dir, expect_disabled):
+    """Verify benchmark-timer and hardware-monitor values in generated .ini files.
+
+    Args:
+        output_dir: The Tensile output directory to search for .ini files.
+        expect_disabled: If True, assert both parameters are disabled.
+            If False, assert benchmark-timer is enabled (hardware-monitor
+            is only checked for presence since some architectures like
+            gfx950 force-disable it).
+    """
+    ini_files = glob.glob(os.path.join(output_dir, "**", "*.ini"), recursive=True)
+    assert ini_files, "Expected at least one .ini file in the output directory"
+
+    # Values that indicate the feature is disabled (int 0 from CLI override,
+    # or bool False from code).
+    disabled_values = {"0", "False"}
+
+    for ini_file in ini_files:
+        bt_value = _parse_ini_value(ini_file, "benchmark-timer")
+        hm_value = _parse_ini_value(ini_file, "hardware-monitor")
+
+        assert bt_value is not None, \
+            f"benchmark-timer not found in {ini_file}"
+        assert hm_value is not None, \
+            f"hardware-monitor not found in {ini_file}"
+
+        if expect_disabled:
+            assert bt_value in disabled_values, \
+                f"Expected benchmark-timer disabled in {ini_file}, got {bt_value}"
+            assert hm_value in disabled_values, \
+                f"Expected hardware-monitor disabled in {ini_file}, got {hm_value}"
+        else:
+            assert bt_value not in disabled_values, \
+                f"Expected benchmark-timer enabled in {ini_file}, got {bt_value}"
+
+
 @pytest.mark.parametrize("config", findConfigs())
 def test_config(tensile_args, config, tmpdir):
-    Tensile.Tensile([config, tmpdir.strpath, *tensile_args])
+    args = [config, tmpdir.strpath, *tensile_args]
+    is_benchmark_timer_config = "benchmark_timer" in os.path.basename(config)
+    # Disable timer and hwmonitor for CI correctness-only runs.
+    # benchmark_timer tests retain timing to verify it works.
+    if not is_benchmark_timer_config:
+        _disable_timer_and_hwmonitor(args)
+    Tensile.Tensile(args)
+
+    _verify_timer_and_hwmonitor(tmpdir.strpath, expect_disabled=not is_benchmark_timer_config)

--- a/projects/hipblaslt/tensilelite/client/include/BenchmarkTimer.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/BenchmarkTimer.hpp
@@ -104,6 +104,7 @@ namespace TensileLite
             const size_t m_minFlopsPerSync = 0;
 
             const bool m_useGPUTimer;
+            const bool m_timerActive;
             const bool m_syncAfterWarmups = true;
             const int  m_sleepPercent;
 

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -1194,26 +1194,48 @@ int main(int argc, const char* argv[])
                                             TimingEvents startEvents(enq, eventCount);
                                             TimingEvents stopEvents(enq, eventCount);
 
-                                            listeners.preEnqueues(stream);
-
-                                            for(int j = 0; j < enq; j++)
                                             {
-                                                size_t kIdx = ((i * enq) + j) % kernels.size();
-                                                HIP_CHECK_EXC(adapter.launchKernels(
-                                                    kernels[kIdx], stream, nullptr, nullptr));
+                                                ScopedTimer t("benchmark_runs.pre_enqueues");
+                                                listeners.preEnqueues(stream);
+                                            }
 
-                                                if(icacheFlush)
+                                            {
+                                                ScopedTimer t("benchmark_runs.launch_kernels");
+                                                for(int j = 0; j < enq; j++)
                                                 {
-                                                    hipLaunchKernelGGL(
-                                                        flush_icache, flushGridSize, 64, 0, stream);
+                                                    size_t kIdx
+                                                        = ((i * enq) + j) % kernels.size();
+                                                    HIP_CHECK_EXC(adapter.launchKernels(
+                                                        kernels[kIdx], stream, nullptr, nullptr));
+
+                                                    if(icacheFlush)
+                                                    {
+                                                        hipLaunchKernelGGL(flush_icache,
+                                                                          flushGridSize,
+                                                                          64,
+                                                                          0,
+                                                                          stream);
+                                                    }
                                                 }
                                             }
 
-                                            listeners.postEnqueues(startEvents, stopEvents, stream);
-                                            listeners.validateEnqueues(inputs, startEvents, stopEvents);
+                                            {
+                                                ScopedTimer t("benchmark_runs.post_enqueues");
+                                                listeners.postEnqueues(
+                                                    startEvents, stopEvents, stream);
+                                            }
+                                            {
+                                                ScopedTimer t(
+                                                    "benchmark_runs.validate_enqueues");
+                                                listeners.validateEnqueues(
+                                                    inputs, startEvents, stopEvents);
+                                            }
                                         }
 
-                                    listeners.postSyncs();
+                                    {
+                                        ScopedTimer t("benchmark_runs.post_syncs");
+                                        listeners.postSyncs();
+                                    }
                                 }
 
                                 if(useUserArgs)

--- a/projects/hipblaslt/tensilelite/client/main.cpp
+++ b/projects/hipblaslt/tensilelite/client/main.cpp
@@ -280,6 +280,7 @@ namespace TensileLite
                 ("use-gpu-timer",            po::value<bool>()->default_value(true), "Use GPU timer")
                 ("sleep-percent",            po::value<int>()->default_value(0), "Sleep percentage")
                 ("hardware-monitor",         po::value<bool>()->default_value(true), "Use hardware monitor.")
+                ("benchmark-timer",          po::value<bool>()->default_value(true), "Enable benchmark timing. Disable for correctness-only runs.")
 
                 ("perf-l2-read-hits",        po::value<double>()->default_value(0.0), "L2 read hits")
                 ("perf-l2-write-hits",       po::value<double>()->default_value(0.5), "L2 write hits")
@@ -532,6 +533,7 @@ namespace TensileLite
             DUMP_OPT("use-gpu-timer", bool);
             DUMP_OPT("sleep-percent", int);
             DUMP_OPT("hardware-monitor", bool);
+            DUMP_OPT("benchmark-timer", bool);
             DUMP_OPT("perf-l2-read-hits", double);
             DUMP_OPT("perf-l2-write-hits", double);
             DUMP_OPT("perf-l2-read-bw-mul", double);

--- a/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
@@ -366,6 +366,7 @@ namespace TensileLite
                                               TimingEvents const&            startEvents,
                                               TimingEvents const&            stopEvents)
         {
+            ScopedTimer t("benchmark_runs.validate_enqueues.timer");
             double_millis totalTime(0.0);
 
             if(m_useGPUTimer)

--- a/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/BenchmarkTimer.cpp
@@ -56,6 +56,7 @@ namespace TensileLite
             , m_hardware(hardware)
             , m_numEnqueuesPerSolution(m_numEnqueuesPerSync * m_numSyncsPerBenchmark)
             , m_useGPUTimer(args["use-gpu-timer"].as<bool>())
+            , m_timerActive(args["benchmark-timer"].as<bool>())
             , m_sleepPercent(args["sleep-percent"].as<int>())
             , m_timeInSolution(0)
             , m_totalGPUTime(0)
@@ -167,7 +168,7 @@ namespace TensileLite
 
             {
                 ScopedTimer timer("post_solution_perf_calc");
-                bool   sol_is_skipped    = (m_skiprun_from_map || m_skip_slow_solution);
+                bool   sol_is_skipped    = (m_skiprun_from_map || m_skip_slow_solution || !m_timerActive);
                 timePerEnqueue_us = !sol_is_skipped ? double_micros(m_timeInSolution).count()
                                                                      / m_numEnqueuesInSolution
                                                                  - m_flushTimeUs
@@ -333,6 +334,9 @@ namespace TensileLite
 
         void BenchmarkTimer::preEnqueues(hipStream_t const& stream)
         {
+            if(!m_timerActive)
+                return;
+
             if(!m_useGPUTimer)
             {
                 HIP_CHECK_EXC(hipDeviceSynchronize());
@@ -350,6 +354,9 @@ namespace TensileLite
                                           TimingEvents const& stopEvents,
                                           hipStream_t const&  stream)
         {
+            if(!m_timerActive)
+                return;
+
             if(!m_useGPUTimer)
             {
                 HIP_CHECK_EXC(hipDeviceSynchronize());
@@ -366,6 +373,12 @@ namespace TensileLite
                                               TimingEvents const&            startEvents,
                                               TimingEvents const&            stopEvents)
         {
+            if(!m_timerActive)
+            {
+                m_numEnqueuesInSolution += startEvents->size();
+                return;
+            }
+
             ScopedTimer t("benchmark_runs.validate_enqueues.timer");
             double_millis totalTime(0.0);
 

--- a/projects/hipblaslt/tensilelite/client/src/HardwareMonitorListener.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/HardwareMonitorListener.cpp
@@ -27,6 +27,7 @@
 #include "HardwareMonitorListener.hpp"
 #include "HardwareMonitor.hpp"
 #include "ResultReporter.hpp"
+#include "TimingInstrumentation.hpp"
 #include <Tensile/hip/HipUtils.hpp>
 #include <hip/hip_runtime.h>
 #include <unistd.h>
@@ -86,6 +87,7 @@ namespace TensileLite
                                                        TimingEvents const&            startEvents,
                                                        TimingEvents const&            stopEvents)
         {
+            ScopedTimer t("benchmark_runs.validate_enqueues.hwmonitor");
             if(!m_active)
                 return;
 

--- a/projects/hipblaslt/tensilelite/client/src/ProgressListener.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/ProgressListener.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include <ProgressListener.hpp>
+#include "TimingInstrumentation.hpp"
 #include <rocisa/include/enum.hpp>
 
 #include <cstddef>
@@ -182,6 +183,7 @@ namespace TensileLite
                                                 TimingEvents const&            startEvents,
                                                 TimingEvents const&            stopEvents)
         {
+            ScopedTimer t("benchmark_runs.validate_enqueues.progress");
             struct timeval tmnow;
             struct tm*     tm;
             gettimeofday(&tmnow, NULL); // microsecond resolution

--- a/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
+++ b/projects/hipblaslt/tensilelite/scripts/analyze_timing.py
@@ -96,7 +96,18 @@ TIMING_HIERARCHY = {
             "pre_solution": {},
             "kernel_solving": {},
             "warmup_runs": {},
-            "benchmark_runs": {},
+            "benchmark_runs": {
+                "benchmark_runs.pre_syncs": {},
+                "benchmark_runs.pre_enqueues": {},
+                "benchmark_runs.launch_kernels": {},
+                "benchmark_runs.post_enqueues": {},
+                "benchmark_runs.validate_enqueues": {
+                    "benchmark_runs.validate_enqueues.timer": {},
+                    "benchmark_runs.validate_enqueues.progress": {},
+                    "benchmark_runs.validate_enqueues.hwmonitor": {},
+                },
+                "benchmark_runs.post_syncs": {},
+            },
             "gpu_kernel_execution": {},
             "post_solution": {
                 "post_solution_perf_calc": {},


### PR DESCRIPTION
## Motivation

For CI correctness-only runs, the benchmark timer overhead is unnecessary. `BenchmarkTimer::postEnqueues` calls `hipEventSynchronize` (or `hipDeviceSynchronize`) every iteration, and `validateEnqueues` computes elapsed time, together consuming ~5% of wall time for small kernels. Since CI only cares that kernels produce correct results (validated during warmups), these timing operations can be skipped entirely.

## Technical Details

Add a `--benchmark-timer` CLI flag (default `true`) that, when set to `false`, skips HIP event creation, GPU synchronization, and elapsed-time computation in `BenchmarkTimer`. The `preEnqueues`, `postEnqueues`, and `validateEnqueues` methods return early when the timer is inactive, while the enqueue counter still advances to preserve loop termination. In `postSolution`, the `sol_is_skipped` condition includes `!m_timerActive` so timing metrics report NaN instead of dividing by zero. The Python side adds a `BenchmarkTimer` global parameter and passes it through `ClientWriter` to the C++ client.

## Test Plan

Run `Tensile dtv_trim.yaml out --global-parameters=BenchmarkTimer=0,HardwareMonitor=0` and verify that correctness validation still passes, timing phases (`validate_enqueues.timer`, `pre_enqueues`, `post_enqueues`) drop to ~0, and the default behavior (without the flag) is unchanged.

## Test Result

With `BenchmarkTimer=0` and `HardwareMonitor=0`, all kernels produce correct results and the benchmark timing phases are eliminated from the timing report. Default runs with the flag omitted behave identically to the baseline.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
