### PR TITLE
[fusilli-provider] Relicense from Apache-2.0 (with LLVM Exceptions) to MIT

### DIFF
--- a/dnn-providers/fusilli-provider/CMakeLists.txt
+++ b/dnn-providers/fusilli-provider/CMakeLists.txt
@@ -1,8 +1,5 @@
-# Copyright 2025 Advanced Micro Devices, Inc.
-#
-# Licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
 
 cmake_minimum_required(VERSION 3.24)
 

--- a/dnn-providers/fusilli-provider/build_tools/FusilliPluginTestUtils.cmake
+++ b/dnn-providers/fusilli-provider/build_tools/FusilliPluginTestUtils.cmake
@@ -1,8 +1,5 @@
-# Copyright 2025 Advanced Micro Devices, Inc.
-#
-# Licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
 
 #===------------------------------------------------------------------------===#
 #

--- a/dnn-providers/fusilli-provider/include/graph_import.h
+++ b/dnn-providers/fusilli-provider/include/graph_import.h
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 //===----------------------------------------------------------------------===//
 //

--- a/dnn-providers/fusilli-provider/include/hipdnn_engine_plugin_execution_context.h
+++ b/dnn-providers/fusilli-provider/include/hipdnn_engine_plugin_execution_context.h
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 //===----------------------------------------------------------------------===//
 //

--- a/dnn-providers/fusilli-provider/include/hipdnn_engine_plugin_handle.h
+++ b/dnn-providers/fusilli-provider/include/hipdnn_engine_plugin_handle.h
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 //===----------------------------------------------------------------------===//
 //

--- a/dnn-providers/fusilli-provider/include/utils.h
+++ b/dnn-providers/fusilli-provider/include/utils.h
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 //===----------------------------------------------------------------------===//
 //

--- a/dnn-providers/fusilli-provider/src/fusilli_plugin.cpp
+++ b/dnn-providers/fusilli-provider/src/fusilli_plugin.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 //===----------------------------------------------------------------------===//
 //

--- a/dnn-providers/fusilli-provider/test/CMakeLists.txt
+++ b/dnn-providers/fusilli-provider/test/CMakeLists.txt
@@ -1,8 +1,5 @@
-# Copyright 2025 Advanced Micro Devices, Inc.
-#
-# Licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
 
 find_package(Threads REQUIRED)
 

--- a/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
+++ b/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
@@ -1,8 +1,5 @@
-# Copyright 2025 Advanced Micro Devices, Inc.
-#
-# Licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
 
 find_package(Threads REQUIRED)
 

--- a/dnn-providers/fusilli-provider/test/integration/convolution/conv_fprop_parameterized_full.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/convolution/conv_fprop_parameterized_full.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>

--- a/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_fprop_parameterized_stream_device.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_fprop_parameterized_stream_device.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 // ----------------------------------------------------------------------
 //  Test for simple NCHW KCRS convfprop with parameterization for

--- a/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_fprop_with_relu_and_bias.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_fprop_with_relu_and_bias.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>

--- a/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_wgrad.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_wgrad.cpp
@@ -1,8 +1,5 @@
-// Copyright 2026 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>

--- a/dnn-providers/fusilli-provider/test/integration/matmul/batched_matmul_parameterized.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/matmul/batched_matmul_parameterized.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>

--- a/dnn-providers/fusilli-provider/test/integration/matmul/matmul_parameterized.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/matmul/matmul_parameterized.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>

--- a/dnn-providers/fusilli-provider/test/integration/matmul/simple_matmul.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/matmul/simple_matmul.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>

--- a/dnn-providers/fusilli-provider/test/integration/matmul/simple_scaled_matmul_accumulate.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/matmul/simple_scaled_matmul_accumulate.cpp
@@ -1,8 +1,5 @@
-// Copyright 2026 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>

--- a/dnn-providers/fusilli-provider/test/integration/plugin_load.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/plugin_load.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/utilities/PlatformUtils.hpp>

--- a/dnn-providers/fusilli-provider/test/integration/pointwise/simple_pointwise.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/pointwise/simple_pointwise.cpp
@@ -1,8 +1,5 @@
-// Copyright 2026 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>

--- a/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
+++ b/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include <flatbuffers/flatbuffer_builder.h>
 #include <fusilli.h>

--- a/dnn-providers/fusilli-provider/test/test_graph_import.cpp
+++ b/dnn-providers/fusilli-provider/test/test_graph_import.cpp
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 #include "graph_import.h"
 #include "utils.h"

--- a/dnn-providers/fusilli-provider/test/utils.h
+++ b/dnn-providers/fusilli-provider/test/utils.h
@@ -1,8 +1,5 @@
-// Copyright 2025 Advanced Micro Devices, Inc.
-//
-// Licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier:  MIT
 
 //===----------------------------------------------------------------------===//
 //


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

As part of moving fusilli into `rocm-libraies` https://github.com/ROCm/rocm-libraries/pull/5149 update the license to be MIT rather than Apache License v2.0 with LLVM Exceptions. I don't think we _need_ to change the license as both licenses are on the AMD approved license list, but everything else in `rocm-libraries` is MIT so it would be nice to keep it consistent.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

IANAL but as AMD holds the 100% of the copyright for the fusilli codebase I am given to understand that there are no legal hurdles relicensing this code.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

N/A

## Test Result

<!-- Briefly summarize test outcomes. -->

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
