### PR TITLE
[hipblaslt] Fix tox test fp8_gfx12 failed when dtva1=1 or dtvb1=1

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4372,7 +4372,7 @@ class KernelWriterAssembly(KernelWriter):
       if tP["isSwizzled"]:
         self.sgprPool.checkIn(tmp)
       elif isTr:
-        module.add(VBfeU32(dst=vgpr(tmp), src0=vgpr(dividendReg), src1=tP["bpeGR"]+1, src2=1, comment="%s: offset for the right half of the tile"%(swizzledOrTrName)))
+        module.add(VBfeU32(dst=vgpr(tmp), src0=vgpr(dividendReg), src1=int(tP["bpeGR"])+1, src2=1, comment="%s: offset for the right half of the tile"%(swizzledOrTrName)))
         module.add(VAddU32(dst=vgpr(qReg), src0=vgpr(tmp), src1=vgpr(qReg), comment="%s: wave_id += offset for the right half of the tile"%(swizzledOrTrName)))
         self.vgprPool.checkIn(tmp)
     elif isDTVAB:
@@ -8609,7 +8609,7 @@ class KernelWriterAssembly(KernelWriter):
         module.add(VLShiftRightB32(dst=vgpr(maxGroVgpr), shiftHex=log2(WvG_M), src=vgpr(maxGroVgpr), comment="GLTr%s: wave_id (along_N) /= MIWG[0]"%tc))
         module.add(VMulU32U24(dst=vgpr(maxGroVgpr), src0=numKr, src1=vgpr(maxGroVgpr), comment="GLTr%s: wave_id (along_N) *= numKr"%tc))
 
-      module.add(VBfeU32(dst=vgpr(tmp2), src0=vgpr("Serial"), src1=tP["bpeGR"]+1, src2=1, comment="GLTr%s: offset for the right half of the tile"%(tc)))
+      module.add(VBfeU32(dst=vgpr(tmp2), src0=vgpr("Serial"), src1=int(tP["bpeGR"])+1, src2=1, comment="GLTr%s: offset for the right half of the tile"%(tc)))
       module.add(VAddU32(dst=vgpr(maxGroVgpr), src0=vgpr(tmp2), src1=vgpr(maxGroVgpr), comment="GLTr%s: wave_id += offset for the right half of the tile"%(tc)))
 
       with self.allocTmpSgpr(1) as tmpSgprInfo:


### PR DESCRIPTION
## Motivation

- The tox test in CI failed with Tensile/Tests/common/gemm/gfx12/fp8_gfx12.yaml

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- When the kernels do the validation with host side, kernels with dtva1 or dtvb1 always/usually failed.
<img width="604" height="177" alt="image" src="https://github.com/user-attachments/assets/2409c81e-99b3-4cd2-8d5d-6ea1214af32d" />

- The reason behind that is v_bfe_u32 v4, v[Serial], 2.0, 1 → 2.0 encodes as 0x40000000 in IEEE 754, so the GPU shifts by 0x40000000 & 0x1F = 0 bits, extracting bit 0 instead of bit 2


<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

`tox -e py3 -- Tensile/Tests -k  Tensile/Tests/common/gemm/gfx12/fp8_gfx12.yaml  2>&1 | tee fp8_gfx12.log`

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Build succeed log: 
[fp8_gfx12_fixed.log](https://github.com/user-attachments/files/25933785/fp8_gfx12_fixed.log)

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
