### PR TITLE
[HIPDNN] Fix inconsistent tensor dimensions between layernorm defintion and layernorm CPU reference

### DIFF
--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/layernorm_attributes_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v24_12_23/hipdnn_data_sdk/data_objects/layernorm_attributes_generated.h
@@ -32,6 +32,7 @@ struct LayernormAttributesT : public ::flatbuffers::NativeTable {
   int64_t bias_tensor_uid = 0;
   int64_t epsilon_tensor_uid = 0;
   int64_t y_tensor_uid = 0;
+  int64_t normalized_dim_count = 0;
   ::flatbuffers::Optional<int64_t> mean_tensor_uid = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<int64_t> inv_variance_tensor_uid = ::flatbuffers::nullopt;
   hipdnn_data_sdk::data_objects::NormFwdPhase forward_phase = hipdnn_data_sdk::data_objects::NormFwdPhase::NOT_SET;
@@ -46,9 +47,10 @@ struct LayernormAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
     VT_BIAS_TENSOR_UID = 8,
     VT_EPSILON_TENSOR_UID = 10,
     VT_Y_TENSOR_UID = 12,
-    VT_MEAN_TENSOR_UID = 14,
-    VT_INV_VARIANCE_TENSOR_UID = 16,
-    VT_FORWARD_PHASE = 18
+    VT_NORMALIZED_DIM_COUNT = 14,
+    VT_MEAN_TENSOR_UID = 16,
+    VT_INV_VARIANCE_TENSOR_UID = 18,
+    VT_FORWARD_PHASE = 20
   };
   int64_t x_tensor_uid() const {
     return GetField<int64_t>(VT_X_TENSOR_UID, 0);
@@ -80,6 +82,12 @@ struct LayernormAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
   bool mutate_y_tensor_uid(int64_t _y_tensor_uid = 0) {
     return SetField<int64_t>(VT_Y_TENSOR_UID, _y_tensor_uid, 0);
   }
+  int64_t normalized_dim_count() const {
+    return GetField<int64_t>(VT_NORMALIZED_DIM_COUNT, 0);
+  }
+  bool mutate_normalized_dim_count(int64_t _normalized_dim_count = 0) {
+    return SetField<int64_t>(VT_NORMALIZED_DIM_COUNT, _normalized_dim_count, 0);
+  }
   ::flatbuffers::Optional<int64_t> mean_tensor_uid() const {
     return GetOptional<int64_t, int64_t>(VT_MEAN_TENSOR_UID);
   }
@@ -105,6 +113,7 @@ struct LayernormAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
            VerifyField<int64_t>(verifier, VT_BIAS_TENSOR_UID, 8) &&
            VerifyField<int64_t>(verifier, VT_EPSILON_TENSOR_UID, 8) &&
            VerifyField<int64_t>(verifier, VT_Y_TENSOR_UID, 8) &&
+           VerifyField<int64_t>(verifier, VT_NORMALIZED_DIM_COUNT, 8) &&
            VerifyField<int64_t>(verifier, VT_MEAN_TENSOR_UID, 8) &&
            VerifyField<int64_t>(verifier, VT_INV_VARIANCE_TENSOR_UID, 8) &&
            VerifyField<int8_t>(verifier, VT_FORWARD_PHASE, 1) &&
@@ -134,6 +143,9 @@ struct LayernormAttributesBuilder {
   void add_y_tensor_uid(int64_t y_tensor_uid) {
     fbb_.AddElement<int64_t>(LayernormAttributes::VT_Y_TENSOR_UID, y_tensor_uid, 0);
   }
+  void add_normalized_dim_count(int64_t normalized_dim_count) {
+    fbb_.AddElement<int64_t>(LayernormAttributes::VT_NORMALIZED_DIM_COUNT, normalized_dim_count, 0);
+  }
   void add_mean_tensor_uid(int64_t mean_tensor_uid) {
     fbb_.AddElement<int64_t>(LayernormAttributes::VT_MEAN_TENSOR_UID, mean_tensor_uid);
   }
@@ -161,12 +173,14 @@ inline ::flatbuffers::Offset<LayernormAttributes> CreateLayernormAttributes(
     int64_t bias_tensor_uid = 0,
     int64_t epsilon_tensor_uid = 0,
     int64_t y_tensor_uid = 0,
+    int64_t normalized_dim_count = 0,
     ::flatbuffers::Optional<int64_t> mean_tensor_uid = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<int64_t> inv_variance_tensor_uid = ::flatbuffers::nullopt,
     hipdnn_data_sdk::data_objects::NormFwdPhase forward_phase = hipdnn_data_sdk::data_objects::NormFwdPhase::NOT_SET) {
   LayernormAttributesBuilder builder_(_fbb);
   if(inv_variance_tensor_uid) { builder_.add_inv_variance_tensor_uid(*inv_variance_tensor_uid); }
   if(mean_tensor_uid) { builder_.add_mean_tensor_uid(*mean_tensor_uid); }
+  builder_.add_normalized_dim_count(normalized_dim_count);
   builder_.add_y_tensor_uid(y_tensor_uid);
   builder_.add_epsilon_tensor_uid(epsilon_tensor_uid);
   builder_.add_bias_tensor_uid(bias_tensor_uid);
@@ -186,6 +200,7 @@ inline bool operator==(const LayernormAttributesT &lhs, const LayernormAttribute
       (lhs.bias_tensor_uid == rhs.bias_tensor_uid) &&
       (lhs.epsilon_tensor_uid == rhs.epsilon_tensor_uid) &&
       (lhs.y_tensor_uid == rhs.y_tensor_uid) &&
+      (lhs.normalized_dim_count == rhs.normalized_dim_count) &&
       (lhs.mean_tensor_uid == rhs.mean_tensor_uid) &&
       (lhs.inv_variance_tensor_uid == rhs.inv_variance_tensor_uid) &&
       (lhs.forward_phase == rhs.forward_phase);
@@ -210,6 +225,7 @@ inline void LayernormAttributes::UnPackTo(LayernormAttributesT *_o, const ::flat
   { auto _e = bias_tensor_uid(); _o->bias_tensor_uid = _e; }
   { auto _e = epsilon_tensor_uid(); _o->epsilon_tensor_uid = _e; }
   { auto _e = y_tensor_uid(); _o->y_tensor_uid = _e; }
+  { auto _e = normalized_dim_count(); _o->normalized_dim_count = _e; }
   { auto _e = mean_tensor_uid(); _o->mean_tensor_uid = _e; }
   { auto _e = inv_variance_tensor_uid(); _o->inv_variance_tensor_uid = _e; }
   { auto _e = forward_phase(); _o->forward_phase = _e; }
@@ -228,6 +244,7 @@ inline ::flatbuffers::Offset<LayernormAttributes> CreateLayernormAttributes(::fl
   auto _bias_tensor_uid = _o->bias_tensor_uid;
   auto _epsilon_tensor_uid = _o->epsilon_tensor_uid;
   auto _y_tensor_uid = _o->y_tensor_uid;
+  auto _normalized_dim_count = _o->normalized_dim_count;
   auto _mean_tensor_uid = _o->mean_tensor_uid;
   auto _inv_variance_tensor_uid = _o->inv_variance_tensor_uid;
   auto _forward_phase = _o->forward_phase;
@@ -238,6 +255,7 @@ inline ::flatbuffers::Offset<LayernormAttributes> CreateLayernormAttributes(::fl
       _bias_tensor_uid,
       _epsilon_tensor_uid,
       _y_tensor_uid,
+      _normalized_dim_count,
       _mean_tensor_uid,
       _inv_variance_tensor_uid,
       _forward_phase);

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v25_9_23/hipdnn_data_sdk/data_objects/layernorm_attributes_generated.h
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/data_objects/v25_9_23/hipdnn_data_sdk/data_objects/layernorm_attributes_generated.h
@@ -32,6 +32,7 @@ struct LayernormAttributesT : public ::flatbuffers::NativeTable {
   int64_t bias_tensor_uid = 0;
   int64_t epsilon_tensor_uid = 0;
   int64_t y_tensor_uid = 0;
+  int64_t normalized_dim_count = 0;
   ::flatbuffers::Optional<int64_t> mean_tensor_uid = ::flatbuffers::nullopt;
   ::flatbuffers::Optional<int64_t> inv_variance_tensor_uid = ::flatbuffers::nullopt;
   hipdnn_data_sdk::data_objects::NormFwdPhase forward_phase = hipdnn_data_sdk::data_objects::NormFwdPhase::NOT_SET;
@@ -46,9 +47,10 @@ struct LayernormAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
     VT_BIAS_TENSOR_UID = 8,
     VT_EPSILON_TENSOR_UID = 10,
     VT_Y_TENSOR_UID = 12,
-    VT_MEAN_TENSOR_UID = 14,
-    VT_INV_VARIANCE_TENSOR_UID = 16,
-    VT_FORWARD_PHASE = 18
+    VT_NORMALIZED_DIM_COUNT = 14,
+    VT_MEAN_TENSOR_UID = 16,
+    VT_INV_VARIANCE_TENSOR_UID = 18,
+    VT_FORWARD_PHASE = 20
   };
   int64_t x_tensor_uid() const {
     return GetField<int64_t>(VT_X_TENSOR_UID, 0);
@@ -80,6 +82,12 @@ struct LayernormAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
   bool mutate_y_tensor_uid(int64_t _y_tensor_uid = 0) {
     return SetField<int64_t>(VT_Y_TENSOR_UID, _y_tensor_uid, 0);
   }
+  int64_t normalized_dim_count() const {
+    return GetField<int64_t>(VT_NORMALIZED_DIM_COUNT, 0);
+  }
+  bool mutate_normalized_dim_count(int64_t _normalized_dim_count = 0) {
+    return SetField<int64_t>(VT_NORMALIZED_DIM_COUNT, _normalized_dim_count, 0);
+  }
   ::flatbuffers::Optional<int64_t> mean_tensor_uid() const {
     return GetOptional<int64_t, int64_t>(VT_MEAN_TENSOR_UID);
   }
@@ -105,6 +113,7 @@ struct LayernormAttributes FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Tabl
            VerifyField<int64_t>(verifier, VT_BIAS_TENSOR_UID, 8) &&
            VerifyField<int64_t>(verifier, VT_EPSILON_TENSOR_UID, 8) &&
            VerifyField<int64_t>(verifier, VT_Y_TENSOR_UID, 8) &&
+           VerifyField<int64_t>(verifier, VT_NORMALIZED_DIM_COUNT, 8) &&
            VerifyField<int64_t>(verifier, VT_MEAN_TENSOR_UID, 8) &&
            VerifyField<int64_t>(verifier, VT_INV_VARIANCE_TENSOR_UID, 8) &&
            VerifyField<int8_t>(verifier, VT_FORWARD_PHASE, 1) &&
@@ -134,6 +143,9 @@ struct LayernormAttributesBuilder {
   void add_y_tensor_uid(int64_t y_tensor_uid) {
     fbb_.AddElement<int64_t>(LayernormAttributes::VT_Y_TENSOR_UID, y_tensor_uid, 0);
   }
+  void add_normalized_dim_count(int64_t normalized_dim_count) {
+    fbb_.AddElement<int64_t>(LayernormAttributes::VT_NORMALIZED_DIM_COUNT, normalized_dim_count, 0);
+  }
   void add_mean_tensor_uid(int64_t mean_tensor_uid) {
     fbb_.AddElement<int64_t>(LayernormAttributes::VT_MEAN_TENSOR_UID, mean_tensor_uid);
   }
@@ -161,12 +173,14 @@ inline ::flatbuffers::Offset<LayernormAttributes> CreateLayernormAttributes(
     int64_t bias_tensor_uid = 0,
     int64_t epsilon_tensor_uid = 0,
     int64_t y_tensor_uid = 0,
+    int64_t normalized_dim_count = 0,
     ::flatbuffers::Optional<int64_t> mean_tensor_uid = ::flatbuffers::nullopt,
     ::flatbuffers::Optional<int64_t> inv_variance_tensor_uid = ::flatbuffers::nullopt,
     hipdnn_data_sdk::data_objects::NormFwdPhase forward_phase = hipdnn_data_sdk::data_objects::NormFwdPhase::NOT_SET) {
   LayernormAttributesBuilder builder_(_fbb);
   if(inv_variance_tensor_uid) { builder_.add_inv_variance_tensor_uid(*inv_variance_tensor_uid); }
   if(mean_tensor_uid) { builder_.add_mean_tensor_uid(*mean_tensor_uid); }
+  builder_.add_normalized_dim_count(normalized_dim_count);
   builder_.add_y_tensor_uid(y_tensor_uid);
   builder_.add_epsilon_tensor_uid(epsilon_tensor_uid);
   builder_.add_bias_tensor_uid(bias_tensor_uid);
@@ -186,6 +200,7 @@ inline bool operator==(const LayernormAttributesT &lhs, const LayernormAttribute
       (lhs.bias_tensor_uid == rhs.bias_tensor_uid) &&
       (lhs.epsilon_tensor_uid == rhs.epsilon_tensor_uid) &&
       (lhs.y_tensor_uid == rhs.y_tensor_uid) &&
+      (lhs.normalized_dim_count == rhs.normalized_dim_count) &&
       (lhs.mean_tensor_uid == rhs.mean_tensor_uid) &&
       (lhs.inv_variance_tensor_uid == rhs.inv_variance_tensor_uid) &&
       (lhs.forward_phase == rhs.forward_phase);
@@ -210,6 +225,7 @@ inline void LayernormAttributes::UnPackTo(LayernormAttributesT *_o, const ::flat
   { auto _e = bias_tensor_uid(); _o->bias_tensor_uid = _e; }
   { auto _e = epsilon_tensor_uid(); _o->epsilon_tensor_uid = _e; }
   { auto _e = y_tensor_uid(); _o->y_tensor_uid = _e; }
+  { auto _e = normalized_dim_count(); _o->normalized_dim_count = _e; }
   { auto _e = mean_tensor_uid(); _o->mean_tensor_uid = _e; }
   { auto _e = inv_variance_tensor_uid(); _o->inv_variance_tensor_uid = _e; }
   { auto _e = forward_phase(); _o->forward_phase = _e; }
@@ -228,6 +244,7 @@ inline ::flatbuffers::Offset<LayernormAttributes> CreateLayernormAttributes(::fl
   auto _bias_tensor_uid = _o->bias_tensor_uid;
   auto _epsilon_tensor_uid = _o->epsilon_tensor_uid;
   auto _y_tensor_uid = _o->y_tensor_uid;
+  auto _normalized_dim_count = _o->normalized_dim_count;
   auto _mean_tensor_uid = _o->mean_tensor_uid;
   auto _inv_variance_tensor_uid = _o->inv_variance_tensor_uid;
   auto _forward_phase = _o->forward_phase;
@@ -238,6 +255,7 @@ inline ::flatbuffers::Offset<LayernormAttributes> CreateLayernormAttributes(::fl
       _bias_tensor_uid,
       _epsilon_tensor_uid,
       _y_tensor_uid,
+      _normalized_dim_count,
       _mean_tensor_uid,
       _inv_variance_tensor_uid,
       _forward_phase);

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Constants.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/Constants.hpp
@@ -6,4 +6,5 @@
 namespace hipdnn_data_sdk::utilities
 {
 constexpr double BATCHNORM_DEFAULT_EPSILON = 1e-5;
+constexpr double LAYERNORM_DEFAULT_EPSILON = 1e-5;
 } // namespace hipdnn_data_sdk::utilities

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/LayernormAttributes.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/LayernormAttributes.hpp
@@ -22,6 +22,7 @@ inline void to_json(nlohmann::json& layernormJson, const LayernormAttributes& ln
     outputs["mean_tensor_uid"] = ln.mean_tensor_uid();
     outputs["inv_variance_tensor_uid"] = ln.inv_variance_tensor_uid();
 
+    layernormJson["normalized_dim_count"] = ln.normalized_dim_count();
     layernormJson["forward_phase"] = static_cast<int8_t>(ln.forward_phase());
 }
 
@@ -35,6 +36,8 @@ inline auto to<data_objects::LayernormAttributes>(flatbuffers::FlatBufferBuilder
 {
     auto& inputs = entry.at("inputs");
     auto& outputs = entry.at("outputs");
+
+    int64_t normalizedDimCount = entry.at("normalized_dim_count").get<int64_t>();
 
     auto forwardPhase = data_objects::NormFwdPhase::NOT_SET;
     if(entry.contains("forward_phase"))
@@ -50,6 +53,7 @@ inline auto to<data_objects::LayernormAttributes>(flatbuffers::FlatBufferBuilder
         inputs.at("bias_tensor_uid").get<int64_t>(),
         inputs.at("epsilon_tensor_uid").get<int64_t>(),
         outputs.at("y_tensor_uid").get<int64_t>(),
+        normalizedDimCount,
         outputs.at("mean_tensor_uid").get<std::optional<int64_t>>(),
         outputs.at("inv_variance_tensor_uid").get<std::optional<int64_t>>(),
         forwardPhase);

--- a/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/LayernormAttributes.hpp
+++ b/projects/hipdnn/data_sdk/include/hipdnn_data_sdk/utilities/json/LayernormAttributes.hpp
@@ -37,7 +37,7 @@ inline auto to<data_objects::LayernormAttributes>(flatbuffers::FlatBufferBuilder
     auto& inputs = entry.at("inputs");
     auto& outputs = entry.at("outputs");
 
-    int64_t normalizedDimCount = entry.at("normalized_dim_count").get<int64_t>();
+    const int64_t normalizedDimCount = entry.at("normalized_dim_count").get<int64_t>();
 
     auto forwardPhase = data_objects::NormFwdPhase::NOT_SET;
     if(entry.contains("forward_phase"))

--- a/projects/hipdnn/data_sdk/schemas/layernorm_attributes.fbs
+++ b/projects/hipdnn/data_sdk/schemas/layernorm_attributes.fbs
@@ -11,6 +11,7 @@ table LayernormAttributes {
     bias_tensor_uid:           long;
     epsilon_tensor_uid:        long;
     y_tensor_uid:              long;
+    normalized_dim_count:      long;
     mean_tensor_uid:           long = null;
     inv_variance_tensor_uid:   long = null;
     forward_phase:             NormFwdPhase = NOT_SET;

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Utilities.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Utilities.hpp
@@ -120,6 +120,21 @@ inline TensorAttributes makeTensorAttributes(const std::string& name,
 }
 
 /**
+ * @brief Create TensorAttributes from a single constant value
+ *
+ * The data type will be set from the type of the value. Useful for tensors that contain single constants, for example an epsilon.
+ *
+ * @param name Human-readable name for debugging and serialization
+ * @param value Constant value to be inserted into the tensor
+ * @return Configured TensorAttributes ready to pass to Graph operations
+ */
+template <typename T>
+inline TensorAttributes makeTensorAttributes(const std::string& name, const T value)
+{
+    return TensorAttributes().set_name(name).set_value(value);
+}
+
+/**
  * @brief Allocate a Data SDK ITensor that matches the given attributes
  *
  * Creates an actual tensor object (with host/device storage) from a

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/LayernormAttributes.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/attributes/LayernormAttributes.hpp
@@ -16,7 +16,6 @@
 #include <hipdnn_data_sdk/data_objects/layernorm_attributes_generated.h>
 #include <memory>
 #include <unordered_map>
-#include <vector>
 
 namespace hipdnn_frontend::graph
 {
@@ -197,6 +196,19 @@ public:
         return _forwardPhase;
     }
 
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    LayernormAttributes& set_normalized_dim_count(int64_t value)
+    {
+        _normalizedDimCount = value;
+        return *this;
+    }
+
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    int64_t get_normalized_dim_count() const
+    {
+        return _normalizedDimCount;
+    }
+
     flatbuffers::Offset<hipdnn_data_sdk::data_objects::LayernormAttributes>
         pack_attributes(flatbuffers::FlatBufferBuilder& builder) const // NOLINT
     {
@@ -210,6 +222,7 @@ public:
             get_bias()->get_uid(),
             get_epsilon()->get_uid(),
             get_y()->get_uid(),
+            _normalizedDimCount,
             mean ? flatbuffers::Optional<int64_t>(mean->get_uid())
                  : flatbuffers::Optional<int64_t>(flatbuffers::nullopt),
             invVariance ? flatbuffers::Optional<int64_t>(invVariance->get_uid())
@@ -228,6 +241,7 @@ public:
         attr.set_bias(tensorMap.at(fb->bias_tensor_uid()));
         attr.set_epsilon(tensorMap.at(fb->epsilon_tensor_uid()));
         attr.set_y(tensorMap.at(fb->y_tensor_uid()));
+        attr.set_normalized_dim_count(fb->normalized_dim_count());
         attr.set_forward_phase(fromSdkType(fb->forward_phase()));
 
         if(fb->mean_tensor_uid().has_value())
@@ -243,6 +257,7 @@ public:
     }
 
 private:
+    int64_t _normalizedDimCount = 0;
     NormFwdPhase _forwardPhase = NormFwdPhase::NOT_SET;
 };
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/node/LayerNormNode.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/node/LayerNormNode.hpp
@@ -269,6 +269,35 @@ public:
             }
         }
 
+        // Infer normalized dimension count if not available
+        if(attributes.get_normalized_dim_count() <= 0)
+        {
+            if(attributes.get_x()->get_dim().size()
+               == attributes.get_scale()
+                      ->get_dim()
+                      .size()) // Dimensions not used by scale have been set to 1
+            {
+                int64_t normalizedDimCount = 1;
+                for(int64_t i = static_cast<int64_t>(attributes.get_scale()->get_dim().size()) - 1;
+                    i >= 0;
+                    --i)
+                {
+                    if(attributes.get_scale()->get_dim()[static_cast<size_t>(i)] == 1)
+                    {
+                        break;
+                    }
+                    normalizedDimCount
+                        = static_cast<int64_t>(attributes.get_scale()->get_dim().size()) - i;
+                }
+                attributes.set_normalized_dim_count(normalizedDimCount);
+            }
+            else // Dimensions not used by scale have been omitted
+            {
+                attributes.set_normalized_dim_count(
+                    static_cast<int64_t>(attributes.get_scale()->get_dim().size()));
+            }
+        }
+
         return {};
     }
 

--- a/projects/hipdnn/frontend/tests/TestLayerNormNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestLayerNormNode.cpp
@@ -414,7 +414,7 @@ TEST(TestLayerNormNode, InferPropertiesSetsNormalizedDimCount)
     attrs.set_scale(scale);
     attrs.set_bias(bias);
 
-    GraphAttributes graphAttrs;
+    const GraphAttributes graphAttrs;
     LayerNormNode node(std::move(attrs), graphAttrs);
     auto err = node.infer_properties_node();
     EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
@@ -434,7 +434,7 @@ TEST(TestLayerNormNode, InferPropertiesSetsAmbiguousNormalizedDimCount)
     attrs.set_scale(scale);
     attrs.set_bias(bias);
 
-    GraphAttributes graphAttrs;
+    const GraphAttributes graphAttrs;
     LayerNormNode node(std::move(attrs), graphAttrs);
     auto err = node.infer_properties_node();
     EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
@@ -454,7 +454,7 @@ TEST(TestLayerNormNode, InferPropertiesSetsNormalizedDimCountWithAlternativeLayo
     attrs.set_scale(scale);
     attrs.set_bias(bias);
 
-    GraphAttributes graphAttrs;
+    const GraphAttributes graphAttrs;
     LayerNormNode node(std::move(attrs), graphAttrs);
     auto err = node.infer_properties_node();
     EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;

--- a/projects/hipdnn/frontend/tests/TestLayerNormNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestLayerNormNode.cpp
@@ -401,6 +401,66 @@ TEST(TestLayerNormNode, InferPropertiesNhwcScaleStridesMatchX)
     EXPECT_EQ(bias->get_stride(), (std::vector<int64_t>{8192, 1, 512, 32}));
 }
 
+TEST(TestLayerNormNode, InferPropertiesSetsNormalizedDimCount)
+{
+    auto x = makeTensor({2, 3, 5, 7}, {105, 35, 7, 1});
+
+    // normalizedDimCount = 3
+    auto scale = makeTensor({1, 3, 5, 7}, {105, 35, 7, 1});
+    auto bias = makeTensor({1, 3, 5, 7}, {105, 35, 7, 1});
+
+    auto attrs = makeMinimalAttrs(x);
+    attrs.set_scale(scale);
+    attrs.set_bias(bias);
+
+    GraphAttributes graphAttrs;
+    LayerNormNode node(std::move(attrs), graphAttrs);
+    auto err = node.infer_properties_node();
+    EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
+
+    EXPECT_EQ(node.attributes.get_normalized_dim_count(), 3);
+}
+
+TEST(TestLayerNormNode, InferPropertiesSetsAmbiguousNormalizedDimCount)
+{
+    auto x = makeTensor({2, 1, 5, 7}, {35, 35, 7, 1});
+
+    // normalizedDimCount = 2
+    auto scale = makeTensor({1, 1, 5, 7}, {35, 35, 7, 1});
+    auto bias = makeTensor({1, 1, 5, 7}, {35, 35, 7, 1});
+
+    auto attrs = makeMinimalAttrs(x);
+    attrs.set_scale(scale);
+    attrs.set_bias(bias);
+
+    GraphAttributes graphAttrs;
+    LayerNormNode node(std::move(attrs), graphAttrs);
+    auto err = node.infer_properties_node();
+    EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
+
+    EXPECT_EQ(node.attributes.get_normalized_dim_count(), 2);
+}
+
+TEST(TestLayerNormNode, InferPropertiesSetsNormalizedDimCountWithAlternativeLayoutConvention)
+{
+    auto x = makeTensor({2, 3, 5, 7}, {105, 35, 7, 1});
+
+    // normalizedDimCount = 3
+    auto scale = makeTensor({3, 5, 7}, {35, 7, 1});
+    auto bias = makeTensor({3, 5, 7}, {35, 7, 1});
+
+    auto attrs = makeMinimalAttrs(x);
+    attrs.set_scale(scale);
+    attrs.set_bias(bias);
+
+    GraphAttributes graphAttrs;
+    LayerNormNode node(std::move(attrs), graphAttrs);
+    auto err = node.infer_properties_node();
+    EXPECT_EQ(err.code, error_code_t::OK) << err.err_msg;
+
+    EXPECT_EQ(node.attributes.get_normalized_dim_count(), 3);
+}
+
 TEST(TestLayerNormNode, InferPropertiesStatsSkippedInInferenceMode)
 {
     // Stats should NOT be inferred during inference phase, even if tensors are provided

--- a/projects/hipdnn/frontend/tests/TestLayerNormNode.cpp
+++ b/projects/hipdnn/frontend/tests/TestLayerNormNode.cpp
@@ -1,6 +1,7 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier:  MIT
 
+#include "hipdnn_data_sdk/utilities/Constants.hpp"
 #include <gtest/gtest.h>
 #include <hipdnn_frontend/Error.hpp>
 #include <hipdnn_frontend/attributes/GraphAttributes.hpp>
@@ -33,7 +34,7 @@ LayernormAttributes makeMinimalAttrs(const std::shared_ptr<TensorAttributes>& x)
     attrs.set_forward_phase(NormFwdPhase::INFERENCE);
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
 
@@ -106,7 +107,7 @@ TEST(TestLayerNormNode, PreValidateFailsForwardPhaseNotSet)
     attrs.set_x(x);
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
     attrs.set_scale(makeTensor({512}));
@@ -125,7 +126,7 @@ TEST(TestLayerNormNode, PreValidateFailsMissingX)
     attrs.set_forward_phase(NormFwdPhase::INFERENCE);
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
     attrs.set_scale(makeTensor({512}));
@@ -144,7 +145,7 @@ TEST(TestLayerNormNode, PreValidateFailsMissingY)
     auto x = makeTensor({32, 512});
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_x(x);
     attrs.set_epsilon(epsilon);
     attrs.set_scale(makeTensor({512}));
@@ -179,7 +180,7 @@ TEST(TestLayerNormNode, PreValidateFailsMissingScale)
     auto x = makeTensor({32, 512});
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_x(x);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
@@ -198,7 +199,7 @@ TEST(TestLayerNormNode, PreValidateFailsMissingBias)
     auto x = makeTensor({32, 512});
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_x(x);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
@@ -271,7 +272,7 @@ TEST(TestLayerNormNode, InferPropertiesInfersScaleDimsFromX)
     attrs.set_x(x);
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
 
@@ -303,7 +304,7 @@ TEST(TestLayerNormNode, InferPropertiesInfersScaleDimsFromX4D)
     attrs.set_x(x);
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
 
@@ -334,7 +335,7 @@ TEST(TestLayerNormNode, InferPropertiesPreservesNhwcStrideOrder)
     attrs.set_x(x);
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
 
@@ -379,7 +380,7 @@ TEST(TestLayerNormNode, InferPropertiesNhwcScaleStridesMatchX)
     attrs.set_x(x);
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
 
@@ -528,7 +529,7 @@ TEST(TestLayerNormNode, InferPropertiesPreservesExplicitOutputShape)
     attrs.set_x(x);
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_scale(makeTensor({512}));
     attrs.set_bias(makeTensor({512}));
@@ -582,7 +583,7 @@ TEST(TestLayerNormNode, PreValidateFailsXWithNoDimensions)
 
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_y(std::make_shared<TensorAttributes>());
     attrs.set_scale(makeTensor({512}));
@@ -607,7 +608,7 @@ TEST(TestLayerNormNode, PreValidateFailsEpsilonNotScalar)
     // Epsilon with more than one element.
     // set_value must be called before set_dim because set_value resets dim to {1}.
     auto epsilon = std::make_shared<TensorAttributes>();
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     epsilon->set_dim({2});
     attrs.set_epsilon(epsilon);
 
@@ -668,7 +669,7 @@ TEST(TestLayerNormNode, PreValidateFailsXYShapeMismatch)
 
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
 
     // Y has different shape than X
@@ -716,7 +717,7 @@ TEST(TestLayerNormNode, InferPropertiesFailsMissingX)
 
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_scale(makeTensor({512}));
     attrs.set_bias(makeTensor({512}));
@@ -735,7 +736,7 @@ TEST(TestLayerNormNode, InferPropertiesFailsMissingY)
 
     auto epsilon = std::make_shared<TensorAttributes>();
     epsilon->set_dim({1});
-    epsilon->set_value(1e-5f);
+    epsilon->set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
     attrs.set_epsilon(epsilon);
     attrs.set_scale(makeTensor({512}));
     attrs.set_bias(makeTensor({512}));
@@ -889,7 +890,8 @@ TEST(TestLayerNormNode, GatherHipdnnTensors)
     bias->set_uid(4).set_name("Bias");
 
     auto epsilon = std::make_shared<TensorAttributes>();
-    epsilon->set_uid(5).set_name("Epsilon").set_value(1e-5f);
+    epsilon->set_uid(5).set_name("Epsilon").set_value(
+        hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
 
     auto mean = std::make_shared<TensorAttributes>();
     mean->set_uid(6).set_name("Mean");
@@ -937,7 +939,7 @@ TEST(TestLayerNormNode, GatherHipdnnTensorsRequired)
     bias->set_uid(4);
 
     auto epsilon = std::make_shared<TensorAttributes>();
-    epsilon->set_uid(5).set_value(1e-5f);
+    epsilon->set_uid(5).set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
 
     LayernormAttributes attrs;
     attrs.set_x(x);

--- a/projects/hipdnn/frontend/tests/TestLayernormAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestLayernormAttributes.cpp
@@ -56,7 +56,7 @@ TEST(TestLayernormAttributes, SetNormalizedDimCount)
 {
     LayernormAttributes attrs;
 
-    int64_t normalizedDimCount = 3;
+    const int64_t normalizedDimCount = 3;
     attrs.set_normalized_dim_count(normalizedDimCount);
 
     EXPECT_EQ(attrs.get_normalized_dim_count(), normalizedDimCount);

--- a/projects/hipdnn/frontend/tests/TestLayernormAttributes.cpp
+++ b/projects/hipdnn/frontend/tests/TestLayernormAttributes.cpp
@@ -16,6 +16,7 @@ TEST(TestLayernormAttributes, DefaultValues)
     EXPECT_EQ(attrs.get_bias(), nullptr);
     EXPECT_EQ(attrs.get_epsilon(), nullptr);
     EXPECT_EQ(attrs.get_y(), nullptr);
+    EXPECT_EQ(attrs.get_normalized_dim_count(), 0);
     EXPECT_EQ(attrs.get_mean(), nullptr);
     EXPECT_EQ(attrs.get_inv_variance(), nullptr);
     EXPECT_EQ(attrs.get_forward_phase(), NormFwdPhase::NOT_SET);
@@ -49,6 +50,16 @@ TEST(TestLayernormAttributes, SetRequiredTensors)
     EXPECT_EQ(attrs.get_y(), y);
     EXPECT_EQ(attrs.get_mean(), nullptr);
     EXPECT_EQ(attrs.get_inv_variance(), nullptr);
+}
+
+TEST(TestLayernormAttributes, SetNormalizedDimCount)
+{
+    LayernormAttributes attrs;
+
+    int64_t normalizedDimCount = 3;
+    attrs.set_normalized_dim_count(normalizedDimCount);
+
+    EXPECT_EQ(attrs.get_normalized_dim_count(), normalizedDimCount);
 }
 
 TEST(TestLayernormAttributes, SetOptionalMean)
@@ -110,6 +121,7 @@ TEST(TestLayernormAttributes, PackAttributes)
     attrs.set_bias(bias);
     attrs.set_epsilon(epsilon);
     attrs.set_y(y);
+    attrs.set_normalized_dim_count(3);
     attrs.set_mean(mean);
     attrs.set_inv_variance(invVariance);
     attrs.set_forward_phase(NormFwdPhase::TRAINING);
@@ -126,6 +138,7 @@ TEST(TestLayernormAttributes, PackAttributes)
     EXPECT_EQ(fb->bias_tensor_uid(), 3);
     EXPECT_EQ(fb->epsilon_tensor_uid(), 4);
     EXPECT_EQ(fb->y_tensor_uid(), 5);
+    EXPECT_EQ(fb->normalized_dim_count(), 3);
     ASSERT_TRUE(fb->mean_tensor_uid().has_value());
     EXPECT_EQ(*fb->mean_tensor_uid(), 6);
     ASSERT_TRUE(fb->inv_variance_tensor_uid().has_value());
@@ -181,6 +194,7 @@ TEST(TestLayernormAttributes, FromFlatBuffer)
         30,
         40,
         50,
+        3,
         flatbuffers::Optional<int64_t>(60),
         flatbuffers::Optional<int64_t>(70),
         hipdnn_data_sdk::data_objects::NormFwdPhase::TRAINING);
@@ -210,6 +224,7 @@ TEST(TestLayernormAttributes, FromFlatBuffer)
     EXPECT_EQ(attrs.get_epsilon()->get_uid(), 40);
     ASSERT_NE(attrs.get_y(), nullptr);
     EXPECT_EQ(attrs.get_y()->get_uid(), 50);
+    EXPECT_EQ(attrs.get_normalized_dim_count(), 3);
     ASSERT_NE(attrs.get_mean(), nullptr);
     EXPECT_EQ(attrs.get_mean()->get_uid(), 60);
     ASSERT_NE(attrs.get_inv_variance(), nullptr);
@@ -221,7 +236,8 @@ TEST(TestLayernormAttributes, FromFlatBufferNoOptionals)
 {
     // Build a FlatBuffer without optional fields
     flatbuffers::FlatBufferBuilder builder;
-    auto packed = hipdnn_data_sdk::data_objects::CreateLayernormAttributes(builder, 1, 2, 3, 4, 5);
+    auto packed
+        = hipdnn_data_sdk::data_objects::CreateLayernormAttributes(builder, 1, 2, 3, 4, 5, 3);
     builder.Finish(packed);
 
     auto buf = builder.GetBufferPointer();

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceLayernorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceLayernorm.hpp
@@ -65,6 +65,11 @@ public:
                 "normalizedDimCount must be between 1 and the number of tensor dimensions.");
         }
 
+        if(scale != nullptr && bias != nullptr && scale->dims().size() != bias->dims().size())
+        {
+            throw std::runtime_error("Scale and bias tensors must have the same rank.");
+        }
+
         // Split dimensions into batch dims and normalized dims
         std::vector<int64_t> batchDims;
         std::vector<int64_t> normalizedDims;

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceLayernorm.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceLayernorm.hpp
@@ -66,8 +66,32 @@ public:
         }
 
         // Split dimensions into batch dims and normalized dims
-        std::vector<int64_t> batchDims(dims.begin(), dims.begin() + (ndim - normalizedDimCount));
-        std::vector<int64_t> normalizedDims(dims.begin() + (ndim - normalizedDimCount), dims.end());
+        std::vector<int64_t> batchDims;
+        std::vector<int64_t> normalizedDims;
+        if((scale != nullptr && scale->dims().size() == dims.size())
+           || (bias != nullptr && bias->dims().size() == dims.size())) // Pad with ones
+        {
+            batchDims = std::vector<int64_t>(dims.size(), 1);
+            normalizedDims = std::vector<int64_t>(dims.size(), 1);
+            for(size_t i = 0; i < dims.size(); ++i)
+            {
+                if(static_cast<int64_t>(i) < ndim - normalizedDimCount)
+                {
+                    batchDims[i] = dims[i];
+                }
+                else
+                {
+                    normalizedDims[i] = dims[i];
+                }
+            }
+        }
+        else // Don't pad with ones
+        {
+            batchDims
+                = std::vector<int64_t>(dims.begin(), dims.begin() + (ndim - normalizedDimCount));
+            normalizedDims
+                = std::vector<int64_t>(dims.begin() + (ndim - normalizedDimCount), dims.end());
+        }
 
         for(auto d : normalizedDims)
         {
@@ -173,13 +197,27 @@ private:
         std::vector<int64_t> fullIndices;
         fullIndices.reserve(static_cast<size_t>(ndim));
 
-        // If batchDimCount is 0, the batch iteration was over a padded [1] dim, skip it
-        if(batchDimCount > 0)
+        if(batchIndices.size() == static_cast<size_t>(ndim)
+           && normIndices.size() == static_cast<size_t>(ndim)) // Padded with 1
         {
-            fullIndices.insert(fullIndices.end(), batchIndices.begin(), batchIndices.end());
+            fullIndices.insert(fullIndices.end(),
+                               batchIndices.begin(),
+                               batchIndices.begin() + ndim - normalizedDimCount);
+            fullIndices.insert(fullIndices.end(),
+                               normIndices.begin() + ndim - normalizedDimCount,
+                               normIndices.end());
+        }
+        else // Not padded with 1
+        {
+            // If batchDimCount is 0, the batch iteration was over a padded [1] dim, skip it
+            if(batchDimCount > 0)
+            {
+                fullIndices.insert(fullIndices.end(), batchIndices.begin(), batchIndices.end());
+            }
+
+            fullIndices.insert(fullIndices.end(), normIndices.begin(), normIndices.end());
         }
 
-        fullIndices.insert(fullIndices.end(), normIndices.begin(), normIndices.end());
         return fullIndices;
     }
 };

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/TestTolerances.hpp
@@ -289,4 +289,34 @@ constexpr float getTolerance()
 
 } // namespace pointwise
 
+namespace layernorm
+{
+
+template <typename T>
+constexpr float getTolerance()
+{
+    if constexpr(std::is_same_v<T, double>)
+    {
+        return 1e-5f;
+    }
+    else if constexpr(std::is_same_v<T, float>)
+    {
+        return 1e-4f;
+    }
+    else if constexpr(std::is_same_v<T, half>)
+    {
+        return 1e-3f;
+    }
+    else if constexpr(std::is_same_v<T, bfloat16>)
+    {
+        return 1e-2f;
+    }
+    else
+    {
+        static_assert(false, "Type not supported");
+    }
+}
+
+} // namespace layernorm
+
 } // namespace hipdnn_test_sdk::utilities

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp
@@ -108,7 +108,24 @@ public:
         }
 
         // Determine normalizedDimCount from scale tensor shape
-        auto normalizedDimCount = static_cast<int64_t>(scaleTensor->dims().size());
+        int64_t normalizedDimCount;
+        if(shallowXTensor->dims().size()
+           == scaleTensor->dims().size()) // Dimensions not used by scale have been set to 1
+        {
+            normalizedDimCount = 0;
+            for(size_t i = scaleTensor->dims().size() - 1; i >= 0; --i)
+            {
+                if(scaleTensor->dims()[i] == 1 && shallowXTensor->dims()[i] > 1)
+                {
+                    break;
+                }
+                normalizedDimCount = static_cast<int64_t>(scaleTensor->dims().size() - i);
+            }
+        }
+        else // Dimensions not used by scale have been omitted
+        {
+            normalizedDimCount = static_cast<int64_t>(scaleTensor->dims().size());
+        }
 
         utilities::CpuFpReferenceLayernorm::fprop(*shallowXTensor,
                                                   scaleTensor.get(),

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp
@@ -113,13 +113,14 @@ public:
            == scaleTensor->dims().size()) // Dimensions not used by scale have been set to 1
         {
             normalizedDimCount = 0;
-            for(size_t i = scaleTensor->dims().size() - 1; i >= 0; --i)
+            for(int64_t i = static_cast<int64_t>(scaleTensor->dims().size()) - 1; i >= 0; --i)
             {
-                if(scaleTensor->dims()[i] == 1 && shallowXTensor->dims()[i] > 1)
+                if(scaleTensor->dims()[static_cast<size_t>(i)] == 1
+                   && shallowXTensor->dims()[static_cast<size_t>(i)] > 1)
                 {
                     break;
                 }
-                normalizedDimCount = static_cast<int64_t>(scaleTensor->dims().size() - i);
+                normalizedDimCount = static_cast<int64_t>(scaleTensor->dims().size()) - i;
             }
         }
         else // Dimensions not used by scale have been omitted

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp
@@ -27,6 +27,7 @@ struct LayernormFpropParams
         const hipdnn_data_sdk::data_objects::TensorAttributes& epsilonAttributes,
         const hipdnn_data_sdk::data_objects::TensorAttributes& scaleAttributes,
         const hipdnn_data_sdk::data_objects::TensorAttributes& biasAttributes,
+        const int64_t normalizedDimCount,
         const hipdnn_data_sdk::data_objects::TensorAttributes* meanAttributes = nullptr,
         const hipdnn_data_sdk::data_objects::TensorAttributes* invVarianceAttributes = nullptr)
         : xTensor(unpackTensorAttributes(xAttributes))
@@ -34,6 +35,7 @@ struct LayernormFpropParams
         , epsilonTensor(unpackTensorAttributes(epsilonAttributes))
         , scaleTensor(unpackTensorAttributes(scaleAttributes))
         , biasTensor(unpackTensorAttributes(biasAttributes))
+        , normalizedDimCount(normalizedDimCount)
         , meanTensor(meanAttributes != nullptr
                          ? std::make_optional(unpackTensorAttributes(*meanAttributes))
                          : std::nullopt)
@@ -48,6 +50,7 @@ struct LayernormFpropParams
     hipdnn_data_sdk::data_objects::TensorAttributesT epsilonTensor;
     hipdnn_data_sdk::data_objects::TensorAttributesT scaleTensor;
     hipdnn_data_sdk::data_objects::TensorAttributesT biasTensor;
+    int64_t normalizedDimCount;
     std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> meanTensor;
     std::optional<hipdnn_data_sdk::data_objects::TensorAttributesT> invVarianceTensor;
 };
@@ -107,33 +110,12 @@ public:
             invVariancePtr = invVarianceTensor.get();
         }
 
-        // Determine normalizedDimCount from scale tensor shape
-        int64_t normalizedDimCount;
-        if(shallowXTensor->dims().size()
-           == scaleTensor->dims().size()) // Dimensions not used by scale have been set to 1
-        {
-            normalizedDimCount = 0;
-            for(int64_t i = static_cast<int64_t>(scaleTensor->dims().size()) - 1; i >= 0; --i)
-            {
-                if(scaleTensor->dims()[static_cast<size_t>(i)] == 1
-                   && shallowXTensor->dims()[static_cast<size_t>(i)] > 1)
-                {
-                    break;
-                }
-                normalizedDimCount = static_cast<int64_t>(scaleTensor->dims().size()) - i;
-            }
-        }
-        else // Dimensions not used by scale have been omitted
-        {
-            normalizedDimCount = static_cast<int64_t>(scaleTensor->dims().size());
-        }
-
         utilities::CpuFpReferenceLayernorm::fprop(*shallowXTensor,
                                                   scaleTensor.get(),
                                                   biasTensor.get(),
                                                   *shallowYTensor,
                                                   epsilon,
-                                                  normalizedDimCount,
+                                                  _params.normalizedDimCount,
                                                   meanPtr,
                                                   invVariancePtr);
     }
@@ -232,6 +214,7 @@ public:
                                     *tensorMap.at(nodeAttributes->epsilon_tensor_uid()),
                                     *tensorMap.at(nodeAttributes->scale_tensor_uid()),
                                     *tensorMap.at(nodeAttributes->bias_tensor_uid()),
+                                    nodeAttributes->normalized_dim_count(),
                                     mean,
                                     invVariance);
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceLayernorm.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceLayernorm.cpp
@@ -1,11 +1,13 @@
 // Copyright © Advanced Micro Devices, Inc., or its affiliates.
 // SPDX-License-Identifier: MIT
 
+#include "hipdnn_data_sdk/utilities/Constants.hpp"
 #include <cmath>
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceLayernorm.hpp>
+#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_data_sdk::utilities;
@@ -53,9 +55,9 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropSanityValidation2D)
         bias.setHostValue(0.5, i);
     }
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     // Sample 0 statistics
     EXPECT_NEAR(mean.getHostValue(0), 2.5, tolerance);
@@ -108,9 +110,9 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropSanityValidation3D)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 2, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 2, &mean, &rstd);
 
-    auto tolerance = 1e-5;
+    auto tolerance = layernorm::getTolerance<double>();
 
     EXPECT_NEAR(mean.getHostValue(0), 3.5, tolerance);
 
@@ -155,10 +157,10 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropAllZeros)
         bias.setHostValue(3.0, i);
     }
 
-    double const epsilon = 1e-5;
+    double const epsilon = LAYERNORM_DEFAULT_EPSILON;
     CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, epsilon, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
     // rstd = 1/sqrt(eps) is large, so float precision causes larger absolute error
     auto rstdTolerance = 1e-3;
 
@@ -196,10 +198,10 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropAllOnes)
     scale.fillWithValue(1.5);
     bias.fillWithValue(0.25);
 
-    double const epsilon = 1e-5;
+    double const epsilon = LAYERNORM_DEFAULT_EPSILON;
     CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, epsilon, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
     // rstd = 1/sqrt(eps) is large, so float precision causes larger absolute error
     auto rstdTolerance = 1e-3;
 
@@ -236,10 +238,10 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropConstantInput)
     scale.fillWithValue(1.0);
     bias.fillWithValue(-1.0);
 
-    double const epsilon = 1e-5;
+    double const epsilon = LAYERNORM_DEFAULT_EPSILON;
     CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, epsilon, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     for(int b = 0; b < 2; b++)
     {
@@ -275,10 +277,10 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropSingleFeature)
     scale.setHostValue(2.0, 0);
     bias.setHostValue(1.0, 0);
 
-    double const epsilon = 1e-5;
+    double const epsilon = LAYERNORM_DEFAULT_EPSILON;
     CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, epsilon, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     // Each sample has 1 feature, so mean=x, var=0, xhat=0, y=bias
     EXPECT_NEAR(mean.getHostValue(0), 5.0, tolerance);
@@ -317,9 +319,9 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropIdentityTransform)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
-    auto tolerance = 1e-5;
+    auto tolerance = layernorm::getTolerance<double>();
 
     EXPECT_NEAR(mean.getHostValue(0), 35.0, tolerance);
 
@@ -370,9 +372,9 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropNegativeAndMixedValues)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     EXPECT_NEAR(mean.getHostValue(0), 0.0, tolerance);
 
@@ -419,7 +421,7 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropLargeEpsilon)
     double const largeEpsilon = 100.0;
     CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, largeEpsilon, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     EXPECT_NEAR(mean.getHostValue(0), 2.5, tolerance);
 
@@ -465,9 +467,9 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropLargeValueNumericalStability)
     bias.fillWithValue(0.0);
 
     CpuFpReferenceLayernorm::fprop<double, double, double, double, double>(
-        x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+        x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     EXPECT_NEAR(mean.getHostValue(0), offset + 2.5, tolerance);
 
@@ -512,7 +514,7 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropWithoutScaleBias)
         &mean,
         &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     double const expectedRstd = 1.0 / std::sqrt(1.25 + 1e-5);
     EXPECT_NEAR(mean.getHostValue(0), 2.5, tolerance);
@@ -542,12 +544,12 @@ TEST(TestCpuFpReferenceLayernormFp32, FpropTypicalTransformerShape)
     scale.fillWithValue(1.0f);
     bias.fillWithValue(0.0f);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
     // With identity scale/bias, verify output properties per normalized group:
     // - output mean ≈ 0
     // - output variance ≈ 1
-    auto tolerance = 1e-4f;
+    auto tolerance = layernorm::getTolerance<float>();
 
     for(int b = 0; b < 2; b++)
     {
@@ -613,7 +615,7 @@ TYPED_TEST(CpuFpReferenceLayernormFpropTyped, FpropRunsWithoutError)
     bias.fillWithValue(static_cast<ScaleType>(0.0));
 
     // Should not throw
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
     // All identical values -> all normalized to 0 -> y = bias = 0
     for(int b = 0; b < 2; b++)
@@ -666,9 +668,9 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropNormalizeLastTwoDims)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 2, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 2, &mean, &rstd);
 
-    auto tolerance = 1e-5;
+    auto tolerance = layernorm::getTolerance<double>();
 
     // Batch 0: mean = (1+2+...+12)/12 = 78/12 = 6.5
     EXPECT_NEAR(mean.getHostValue(0), 6.5, tolerance);
@@ -719,9 +721,9 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropOneHotRows)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     // All rows have same mean = 1/3
     double const expectedMean = 1.0 / 3.0;
@@ -776,9 +778,9 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropPerFeatureScaleBias)
     bias.setHostValue(20.0, 2);
     bias.setHostValue(30.0, 3);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     // mean=2.5, var=1.25, rstd=1/sqrt(1.25+1e-5)
     double const expectedMean = 2.5;
@@ -822,10 +824,10 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropWithoutMeanRstdOutputs)
     bias.fillWithValue(0.5);
 
     // Call without mean/rstd pointers — should work fine
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1);
 
     // Verify same results as the golden test (Sample 0)
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
     EXPECT_NEAR(y.getHostValue(0, 0), -2.18327084, tolerance);
     EXPECT_NEAR(y.getHostValue(0, 1), -0.39442361, tolerance);
     EXPECT_NEAR(y.getHostValue(0, 2), 1.39442361, tolerance);
@@ -844,10 +846,12 @@ TEST(TestCpuFpReferenceLayernormFp32, FpropThrowsOnInvalidNormalizedDimCount)
     Tensor<float> bias({4});
 
     // normalizedDimCount = 0 is invalid
-    EXPECT_THROW(CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 0), std::runtime_error);
+    EXPECT_THROW(CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 0),
+                 std::runtime_error);
 
     // normalizedDimCount > ndim is invalid
-    EXPECT_THROW(CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 3), std::runtime_error);
+    EXPECT_THROW(CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 3),
+                 std::runtime_error);
 }
 
 // ============================================================================
@@ -861,7 +865,8 @@ TEST(TestCpuFpReferenceLayernormFp32, FpropThrowsOnScalarTensor)
     Tensor<float> scale({});
     Tensor<float> bias({});
 
-    EXPECT_THROW(CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1), std::runtime_error);
+    EXPECT_THROW(CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1),
+                 std::runtime_error);
 }
 
 // ============================================================================
@@ -891,9 +896,9 @@ TEST(TestCpuFpReferenceLayernormFp64, Fprop1D)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
-    auto tolerance = 1e-6;
+    auto tolerance = layernorm::getTolerance<double>();
 
     EXPECT_NEAR(mean.getHostValue(0), 6.0, tolerance);
 
@@ -952,9 +957,9 @@ TEST(TestCpuFpReferenceLayernormFp64, Fprop4DNormalizeLast1)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 1, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 1, &mean, &rstd);
 
-    auto tolerance = 1e-5;
+    auto tolerance = layernorm::getTolerance<double>();
 
     // Verify each of the 12 groups has zero-mean, unit-variance output
     for(int b = 0; b < 2; b++)
@@ -1019,9 +1024,9 @@ TEST(TestCpuFpReferenceLayernormFp64, Fprop4DNormalizeLast3)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 3, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 3, &mean, &rstd);
 
-    auto tolerance = 1e-5;
+    auto tolerance = layernorm::getTolerance<double>();
 
     // Batch 0: mean = (1+2+...+24)/24 = 300/24 = 12.5
     EXPECT_NEAR(mean.getHostValue(0), 12.5, tolerance);
@@ -1073,7 +1078,7 @@ TEST(TestCpuFpReferenceLayernormFp64, FpropFullTensorNormalization)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 2);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 2);
 
     // Verify output has zero mean (sum to 0)
     double sum = 0.0;
@@ -1118,9 +1123,9 @@ TEST(TestCpuFpReferenceLayernormFp64, Fprop5DNormalizeLast2)
     scale.fillWithValue(1.0);
     bias.fillWithValue(0.0);
 
-    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, 1e-5, 2, &mean, &rstd);
+    CpuFpReferenceLayernorm::fprop(x, &scale, &bias, y, LAYERNORM_DEFAULT_EPSILON, 2, &mean, &rstd);
 
-    auto tolerance = 1e-5;
+    auto tolerance = layernorm::getTolerance<double>();
 
     // Verify each of the 12 groups has zero-mean, unit-variance output
     for(int b0 = 0; b0 < 2; b0++)

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/LayernormGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/LayernormGraphUtils.hpp
@@ -19,16 +19,34 @@ inline std::shared_ptr<hipdnn_frontend::graph::Graph>
                              const std::vector<int64_t>& dims,
                              const int64_t normalizedDimCount,
                              const hipdnn_data_sdk::utilities::TensorLayout& layout,
-                             bool useTrainingPhase = false)
+                             bool useTrainingPhase = false,
+                             bool onePadded = false)
 {
     auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
     graph->set_name("LayernormFpropTest");
 
     auto strides = hipdnn_data_sdk::utilities::generateStrides(dims, layout.strideOrder);
 
-    // Scale/bias shape = normalized dims (last N-1 dims for NCHW, i.e., dims[1:])
-    std::vector<int64_t> const normalizedDims(
-        dims.begin() + (static_cast<int64_t>(dims.size()) - normalizedDimCount), dims.end());
+    // Scale/bias shape = normalized dims (last normalizedDimCount dims for NCHW)
+    std::vector<int64_t> normalizedDims;
+    if(onePadded)
+    {
+        normalizedDims = std::vector<int64_t>(dims.size(), 1);
+        for(size_t i = static_cast<size_t>(
+                std::max(static_cast<int64_t>(dims.size()) - normalizedDimCount, int64_t{0}));
+            i < dims.size();
+            ++i)
+        {
+            normalizedDims[i] = dims[i];
+        }
+    }
+    else
+    {
+        normalizedDims = std::vector<int64_t>(
+            dims.begin()
+                + std::max(static_cast<int64_t>(dims.size()) - normalizedDimCount, int64_t{0}),
+            dims.end());
+    }
     auto normalizedStrides = hipdnn_data_sdk::utilities::generateStrides(normalizedDims);
 
     int64_t uid = 1;
@@ -58,7 +76,7 @@ inline std::shared_ptr<hipdnn_frontend::graph::Graph>
         .set_data_type(hipdnn_frontend::DataType::DOUBLE)
         .set_dim({1})
         .set_stride({1})
-        .set_value(hipdnn_data_sdk::utilities::BATCHNORM_DEFAULT_EPSILON);
+        .set_value(hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON);
 
     hipdnn_frontend::graph::LayernormAttributes lnAttrs;
     lnAttrs.set_name("layernorm_fprop");
@@ -90,9 +108,14 @@ inline std::shared_ptr<hipdnn_frontend::graph::Graph>
 
     if(useTrainingPhase)
     {
-        // Mean shape = batch dims (e.g., [N, 1, 1, 1] for input [N, C, H, W])
+        // Mean shape = batch dims (e.g., [N, 1, 1, 1] for input [N, C, H, W] and normalizedDimCount 3)
         std::vector<int64_t> statsDims(dims.size(), 1);
-        statsDims[0] = dims[0];
+        for(size_t i = 0; i < static_cast<size_t>(std::max(
+                              static_cast<int64_t>(dims.size()) - normalizedDimCount, int64_t{0}));
+            ++i)
+        {
+            statsDims[i] = dims[i];
+        }
         auto statsStrides = hipdnn_data_sdk::utilities::generateStrides(statsDims);
 
         auto& meanTensorAttr = outputTensorsAttr[1];

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/LayernormGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/LayernormGraphUtils.hpp
@@ -17,6 +17,7 @@ inline std::shared_ptr<hipdnn_frontend::graph::Graph>
                              hipdnn_data_sdk::data_objects::DataType meanInvVarianceDataType,
                              hipdnn_data_sdk::data_objects::DataType computeDataType,
                              const std::vector<int64_t>& dims,
+                             const int64_t normalizedDimCount,
                              const hipdnn_data_sdk::utilities::TensorLayout& layout,
                              bool useTrainingPhase = false)
 {
@@ -26,7 +27,8 @@ inline std::shared_ptr<hipdnn_frontend::graph::Graph>
     auto strides = hipdnn_data_sdk::utilities::generateStrides(dims, layout.strideOrder);
 
     // Scale/bias shape = normalized dims (last N-1 dims for NCHW, i.e., dims[1:])
-    std::vector<int64_t> const normalizedDims(dims.begin() + 1, dims.end());
+    std::vector<int64_t> const normalizedDims(
+        dims.begin() + (static_cast<int64_t>(dims.size()) - normalizedDimCount), dims.end());
     auto normalizedStrides = hipdnn_data_sdk::utilities::generateStrides(normalizedDims);
 
     int64_t uid = 1;

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
@@ -28,7 +28,7 @@ class TestLayernormFpropPlan : public ::testing::Test
 
 TEST_F(TestLayernormFpropPlan, ExecutePlan)
 {
-    auto tolerance = batchnorm::getToleranceInference<float>();
+    auto tolerance = layernorm::getTolerance<float>();
     std::vector<int64_t> const dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 3;
     unsigned int const seed = getGlobalTestSeed();
@@ -86,7 +86,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
 
 TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
 {
-    auto tolerance = batchnorm::getToleranceInference<float>();
+    auto tolerance = layernorm::getTolerance<float>();
     std::vector<int64_t> dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 2;
     unsigned int seed = getGlobalTestSeed();
@@ -146,7 +146,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
 
 TEST_F(TestLayernormFpropPlan, ExecutePlanTrainingPhase)
 {
-    auto tolerance = batchnorm::getToleranceInference<float>();
+    auto tolerance = layernorm::getTolerance<float>();
     std::vector<int64_t> const dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 3;
     unsigned int const seed = getGlobalTestSeed();

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
@@ -30,12 +30,14 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
 {
     auto tolerance = batchnorm::getToleranceInference<float>();
     std::vector<int64_t> const dims = {6, 3, 32, 32};
+    const int64_t normalizedDimCount = 3;
     unsigned int const seed = getGlobalTestSeed();
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           dims,
+                                          normalizedDimCount,
                                           TensorLayout::NHWC);
     auto flatbufferGraph = graph->buildFlatbufferOperationGraph();
     GraphWrapper const graphWrapper(flatbufferGraph.data(), flatbufferGraph.size());
@@ -65,7 +67,62 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
     auto shallowYTensor = createShallowTensor<float>(
         params.yTensor, directTensorBundle.getTensor(attributes.y_tensor_uid()).rawHostData());
 
-    auto normalizedDimCount = static_cast<int64_t>(shallowScaleTensor->dims().size());
+    CpuFpReferenceLayernorm::fprop(*shallowXTensor,
+                                   shallowScaleTensor.get(),
+                                   shallowBiasTensor.get(),
+                                   *shallowYTensor,
+                                   hipdnn_data_sdk::utilities::BATCHNORM_DEFAULT_EPSILON,
+                                   normalizedDimCount);
+
+    LayernormFpropPlan<float, float, float, float, float> fpropPlan(std::move(params));
+    fpropPlan.execute(variantPack);
+
+    CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
+    EXPECT_TRUE(
+        cpuRefOutputValidation.allClose(directTensorBundle.getTensor(attributes.y_tensor_uid()),
+                                        planTensorBundle.getTensor(attributes.y_tensor_uid())));
+}
+
+TEST_F(TestLayernormFpropPlan, ExecutePlanNormalizedDimCount2)
+{
+    auto tolerance = batchnorm::getToleranceInference<float>();
+    std::vector<int64_t> dims = {6, 3, 32, 32};
+    const int64_t normalizedDimCount = 2;
+    unsigned int seed = getGlobalTestSeed();
+    auto graph = buildLayernormFpropGraph(DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          dims,
+                                          normalizedDimCount,
+                                          TensorLayout::NHWC);
+    auto flatbufferGraph = graph->buildFlatbufferOperationGraph();
+    GraphWrapper graphWrapper(flatbufferGraph.data(), flatbufferGraph.size());
+    const INodeWrapper& node = graphWrapper.getNodeWrapper(0);
+    LayernormFpropTensorBundle planTensorBundle(node, graphWrapper.getTensorMap(), seed);
+    LayernormFpropTensorBundle directTensorBundle(node, graphWrapper.getTensorMap(), seed);
+
+    const auto& attributes
+        = node.attributesAs<hipdnn_data_sdk::data_objects::LayernormAttributes>();
+    const auto& tensorMap = graphWrapper.getTensorMap();
+    LayernormFpropParams params(*tensorMap.at(attributes.x_tensor_uid()),
+                                *tensorMap.at(attributes.y_tensor_uid()),
+                                *tensorMap.at(attributes.epsilon_tensor_uid()),
+                                *tensorMap.at(attributes.scale_tensor_uid()),
+                                *tensorMap.at(attributes.bias_tensor_uid()));
+
+    std::unordered_map<int64_t, void*> variantPack = planTensorBundle.toHostVariantPack();
+
+    auto shallowXTensor = createShallowTensor<float>(
+        params.xTensor, directTensorBundle.getTensor(attributes.x_tensor_uid()).rawHostData());
+    auto shallowScaleTensor = createShallowTensor<float>(
+        params.scaleTensor,
+        directTensorBundle.getTensor(attributes.scale_tensor_uid()).rawHostData());
+    auto shallowBiasTensor = createShallowTensor<float>(
+        params.biasTensor,
+        directTensorBundle.getTensor(attributes.bias_tensor_uid()).rawHostData());
+    auto shallowYTensor = createShallowTensor<float>(
+        params.yTensor, directTensorBundle.getTensor(attributes.y_tensor_uid()).rawHostData());
 
     CpuFpReferenceLayernorm::fprop(*shallowXTensor,
                                    shallowScaleTensor.get(),
@@ -87,12 +144,14 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanTrainingPhase)
 {
     auto tolerance = batchnorm::getToleranceInference<float>();
     std::vector<int64_t> const dims = {6, 3, 32, 32};
+    const int64_t normalizedDimCount = 3;
     unsigned int const seed = getGlobalTestSeed();
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           dims,
+                                          normalizedDimCount,
                                           TensorLayout::NHWC,
                                           true);
     auto flatbufferGraph = graph->buildFlatbufferOperationGraph();
@@ -158,8 +217,6 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanTrainingPhase)
         invVariancePtr = shallowInvVarianceTensor.get();
     }
 
-    auto normalizedDimCount = static_cast<int64_t>(shallowScaleTensor->dims().size());
-
     CpuFpReferenceLayernorm::fprop(*shallowXTensor,
                                    shallowScaleTensor.get(),
                                    shallowBiasTensor.get(),
@@ -195,11 +252,13 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanTrainingPhase)
 TEST(TestLayernormFpropPlanBuilder, PlanConstruction)
 {
     std::vector<int64_t> const dims = {1, 1, 1, 1};
+    const int64_t normalizedDimCount = 3;
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           dims,
+                                          normalizedDimCount,
                                           TensorLayout::NHWC);
     auto flatbufferGraph = graph->buildFlatbufferOperationGraph();
     GraphWrapper const graphWrapper(flatbufferGraph.data(), flatbufferGraph.size());
@@ -221,11 +280,13 @@ TEST(TestLayernormFpropPlanBuilder, PlanConstruction)
 TEST(TestLayernormFpropPlanBuilder, IsApplicable)
 {
     std::vector<int64_t> const dims = {1, 1, 1, 1};
+    const int64_t normalizedDimCount = 3;
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           dims,
+                                          normalizedDimCount,
                                           TensorLayout::NHWC);
     auto flatbufferGraph = graph->buildFlatbufferOperationGraph();
     GraphWrapper const graphWrapper(flatbufferGraph.data(), flatbufferGraph.size());
@@ -255,11 +316,13 @@ TEST(TestLayernormFpropPlanBuilder, IsApplicable)
 TEST(TestLayernormFpropPlanBuilder, PlanConstructionTrainingPhase)
 {
     std::vector<int64_t> const dims = {1, 1, 1, 1};
+    const int64_t normalizedDimCount = 3;
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           dims,
+                                          normalizedDimCount,
                                           TensorLayout::NHWC,
                                           true);
     auto flatbufferGraph = graph->buildFlatbufferOperationGraph();
@@ -282,11 +345,13 @@ TEST(TestLayernormFpropPlanBuilder, PlanConstructionTrainingPhase)
 TEST(TestLayernormFpropPlanBuilder, IsApplicableTrainingPhase)
 {
     std::vector<int64_t> const dims = {1, 1, 1, 1};
+    const int64_t normalizedDimCount = 3;
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           dims,
+                                          normalizedDimCount,
                                           TensorLayout::NHWC,
                                           true);
     auto flatbufferGraph = graph->buildFlatbufferOperationGraph();

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
@@ -78,7 +78,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
     LayernormFpropPlan<float, float, float, float, float> fpropPlan(std::move(params));
     fpropPlan.execute(variantPack);
 
-    CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
+    const CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
     EXPECT_TRUE(
         cpuRefOutputValidation.allClose(directTensorBundle.getTensor(attributes.y_tensor_uid()),
                                         planTensorBundle.getTensor(attributes.y_tensor_uid())));
@@ -87,9 +87,9 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
 TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
 {
     auto tolerance = layernorm::getTolerance<float>();
-    std::vector<int64_t> dims = {6, 3, 32, 32};
+    std::vector<int64_t> const dims = {6, 3, 32, 32};
     const int64_t normalizedDimCount = 2;
-    unsigned int seed = getGlobalTestSeed();
+    const unsigned int seed = getGlobalTestSeed();
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
@@ -100,7 +100,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
                                           false,
                                           true);
     auto flatbufferGraph = graph->buildFlatbufferOperationGraph();
-    GraphWrapper graphWrapper(flatbufferGraph.data(), flatbufferGraph.size());
+    const GraphWrapper graphWrapper(flatbufferGraph.data(), flatbufferGraph.size());
     const INodeWrapper& node = graphWrapper.getNodeWrapper(0);
     LayernormFpropTensorBundle planTensorBundle(node, graphWrapper.getTensorMap(), seed);
     LayernormFpropTensorBundle directTensorBundle(node, graphWrapper.getTensorMap(), seed);
@@ -115,7 +115,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
                                 *tensorMap.at(attributes.bias_tensor_uid()),
                                 normalizedDimCount);
 
-    std::unordered_map<int64_t, void*> variantPack = planTensorBundle.toHostVariantPack();
+    const std::unordered_map<int64_t, void*> variantPack = planTensorBundle.toHostVariantPack();
 
     auto shallowXTensor = createShallowTensor<float>(
         params.xTensor, directTensorBundle.getTensor(attributes.x_tensor_uid()).rawHostData());

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
@@ -52,7 +52,8 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
                                 *tensorMap.at(attributes.y_tensor_uid()),
                                 *tensorMap.at(attributes.epsilon_tensor_uid()),
                                 *tensorMap.at(attributes.scale_tensor_uid()),
-                                *tensorMap.at(attributes.bias_tensor_uid()));
+                                *tensorMap.at(attributes.bias_tensor_uid()),
+                                normalizedDimCount);
 
     std::unordered_map<int64_t, void*> const variantPack = planTensorBundle.toHostVariantPack();
 
@@ -111,7 +112,8 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
                                 *tensorMap.at(attributes.y_tensor_uid()),
                                 *tensorMap.at(attributes.epsilon_tensor_uid()),
                                 *tensorMap.at(attributes.scale_tensor_uid()),
-                                *tensorMap.at(attributes.bias_tensor_uid()));
+                                *tensorMap.at(attributes.bias_tensor_uid()),
+                                normalizedDimCount);
 
     std::unordered_map<int64_t, void*> variantPack = planTensorBundle.toHostVariantPack();
 
@@ -182,6 +184,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanTrainingPhase)
                                 *tensorMap.at(attributes.epsilon_tensor_uid()),
                                 *tensorMap.at(attributes.scale_tensor_uid()),
                                 *tensorMap.at(attributes.bias_tensor_uid()),
+                                normalizedDimCount,
                                 meanAttr,
                                 invVarianceAttr);
 

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropPlan.cpp
@@ -71,7 +71,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
                                    shallowScaleTensor.get(),
                                    shallowBiasTensor.get(),
                                    *shallowYTensor,
-                                   hipdnn_data_sdk::utilities::BATCHNORM_DEFAULT_EPSILON,
+                                   hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON,
                                    normalizedDimCount);
 
     LayernormFpropPlan<float, float, float, float, float> fpropPlan(std::move(params));
@@ -83,7 +83,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlan)
                                         planTensorBundle.getTensor(attributes.y_tensor_uid())));
 }
 
-TEST_F(TestLayernormFpropPlan, ExecutePlanNormalizedDimCount2)
+TEST_F(TestLayernormFpropPlan, ExecutePlanOnePaddedNormalizedDimCount2)
 {
     auto tolerance = batchnorm::getToleranceInference<float>();
     std::vector<int64_t> dims = {6, 3, 32, 32};
@@ -95,7 +95,9 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanNormalizedDimCount2)
                                           DataType::FLOAT,
                                           dims,
                                           normalizedDimCount,
-                                          TensorLayout::NHWC);
+                                          TensorLayout::NHWC,
+                                          false,
+                                          true);
     auto flatbufferGraph = graph->buildFlatbufferOperationGraph();
     GraphWrapper graphWrapper(flatbufferGraph.data(), flatbufferGraph.size());
     const INodeWrapper& node = graphWrapper.getNodeWrapper(0);
@@ -128,7 +130,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanNormalizedDimCount2)
                                    shallowScaleTensor.get(),
                                    shallowBiasTensor.get(),
                                    *shallowYTensor,
-                                   hipdnn_data_sdk::utilities::BATCHNORM_DEFAULT_EPSILON,
+                                   hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON,
                                    normalizedDimCount);
 
     LayernormFpropPlan<float, float, float, float, float> fpropPlan(std::move(params));
@@ -221,7 +223,7 @@ TEST_F(TestLayernormFpropPlan, ExecutePlanTrainingPhase)
                                    shallowScaleTensor.get(),
                                    shallowBiasTensor.get(),
                                    *shallowYTensor,
-                                   hipdnn_data_sdk::utilities::BATCHNORM_DEFAULT_EPSILON,
+                                   hipdnn_data_sdk::utilities::LAYERNORM_DEFAULT_EPSILON,
                                    normalizedDimCount,
                                    meanPtr,
                                    invVariancePtr);

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestLayernormFpropSignatureKey.cpp
@@ -105,11 +105,13 @@ TEST(TestLayernormFpropSignatureKey, CreateFromNodeAndTensorMap)
     LayernormFpropSignatureKey const expectedKey{
         DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
     std::vector<int64_t> const dims = {1, 1, 1, 1};
+    const int64_t normalizedDimCount = 3;
     auto graph = buildLayernormFpropGraph(DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           DataType::FLOAT,
                                           dims,
+                                          normalizedDimCount,
                                           TensorLayout::NHWC);
     auto flatbufferGraph = graph->buildFlatbufferOperationGraph();
     auto graphWrap = hipdnn_data_sdk::flatbuffer_utilities::GraphWrapper(flatbufferGraph.data(),

--- a/projects/hipdnn/tests/frontend/IntegrationLayernormForward.cpp
+++ b/projects/hipdnn/tests/frontend/IntegrationLayernormForward.cpp
@@ -194,12 +194,8 @@ protected:
         }
         tensors.bias = std::make_shared<TensorAttributes>(std::move(biasAttr));
 
-        tensors.epsilon = std::make_shared<TensorAttributes>();
-        tensors.epsilon->set_name("Epsilon")
-            .set_data_type(DataType::FLOAT)
-            .set_dim({1})
-            .set_stride({1})
-            .set_value(1e-5);
+        auto epsilonAttr = makeTensorAttributes("epsilon", 1e-5f);
+        tensors.epsilon = std::make_shared<TensorAttributes>(std::move(epsilonAttr));
         if(useManualUids)
         {
             tensors.epsilon->set_uid(uid++);


### PR DESCRIPTION
## Motivation

This PR aims to fix an inconsistency between how the affine tensors of forward layernorm are defined in the defintion and the CPU reference.

## Technical Details

Currently, `LayerNormNode.hpp:202-222` defines that the dimension vector of affine tensors is the same length as that of the IO tensors, but with the unnormalized dimensions set to 1. However, in `LayernormFpropPlan.hpp:111`, the CPU reference clearly assumes that the dimension vector of affine tensors only contain the normalized dimensions and that the other dimensions are omitted.

This PR fixes this inconsistency by adapting the CPU reference to accept affine tensor dimension vectors where the unnormalized dimensions have been set to 1.

## Test Plan

Build and run `ninja check`.

## Test Result

All tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
