### PR TITLE
Add ConvolutionBwd (dgrad) support to Fusilli plugin

### DIFF
--- a/dnn-providers/fusilli-provider/include/graph_import.h
+++ b/dnn-providers/fusilli-provider/include/graph_import.h
@@ -15,6 +15,7 @@
 #define FUSILLI_PLUGIN_SRC_GRAPH_IMPORT_H
 
 #include <fusilli.h>
+#include <hipdnn_data_sdk/data_objects/convolution_bwd_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/convolution_wrw_attributes_generated.h>
 #include <hipdnn_data_sdk/data_objects/data_types_generated.h>
 #include <hipdnn_data_sdk/data_objects/matmul_attributes_generated.h>
@@ -155,6 +156,11 @@ private:
       FUSILLI_CHECK_ERROR(
           importConvWGradAttr(node.attributes_as_ConvolutionWrwAttributes()));
       break;
+    case hipdnn_data_sdk::data_objects::NodeAttributes::
+        ConvolutionBwdAttributes:
+      FUSILLI_CHECK_ERROR(
+          importConvDGradAttr(node.attributes_as_ConvolutionBwdAttributes()));
+      break;
     case hipdnn_data_sdk::data_objects::NodeAttributes::PointwiseAttributes:
       FUSILLI_CHECK_ERROR(
           importPointwiseAttr(node.attributes_as_PointwiseAttributes()));
@@ -230,6 +236,38 @@ private:
     // Import node output.
     FUSILLI_CHECK_ERROR(
         importNodeOutput(hipDnnConvWrwAttr->dw_tensor_uid(), "dw", dw));
+
+    return fusilli::ok();
+  }
+
+  fusilli::ErrorObject importConvDGradAttr(
+      const hipdnn_data_sdk::data_objects::ConvolutionBwdAttributes
+          *hipDnnConvBwdAttr) {
+    // Import node inputs.
+    FUSILLI_ASSIGN_OR_RETURN(
+        std::shared_ptr<fusilli::TensorAttr> dy,
+        importNodeInput(hipDnnConvBwdAttr->dy_tensor_uid(), "dy"));
+    FUSILLI_ASSIGN_OR_RETURN(
+        std::shared_ptr<fusilli::TensorAttr> w,
+        importNodeInput(hipDnnConvBwdAttr->w_tensor_uid(), "w"));
+
+    // Fusilli only supports symmetric padding.
+    if (!std::ranges::equal(*hipDnnConvBwdAttr->pre_padding(),
+                            *hipDnnConvBwdAttr->post_padding())) // C++20
+      return fusilli::error(fusilli::ErrorCode::AttributeNotSet,
+                            "Conv dgrad node with asymmetric padding found.");
+    // Import node.
+    auto fusilliConvDGradAttr =
+        fusilli::ConvDGradAttr()
+            .setPadding(*hipDnnConvBwdAttr->post_padding())
+            .setStride(*hipDnnConvBwdAttr->stride())
+            .setDilation(*hipDnnConvBwdAttr->dilation());
+    std::shared_ptr<fusilli::TensorAttr> dx =
+        fusilliGraph.convDGrad(dy, w, fusilliConvDGradAttr);
+
+    // Import node output.
+    FUSILLI_CHECK_ERROR(
+        importNodeOutput(hipDnnConvBwdAttr->dx_tensor_uid(), "dx", dx));
 
     return fusilli::ok();
   }

--- a/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
+++ b/dnn-providers/fusilli-provider/test/integration/CMakeLists.txt
@@ -154,3 +154,18 @@ add_fusilli_plugin_test(
   COMPILE_DEFS
     FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
 )
+
+add_fusilli_plugin_test(
+  NAME fusilli_plugin_simple_conv_dgrad_test
+  SRCS convolution/simple_conv_dgrad.cpp
+  DEPS
+    GTest::gtest_main
+    hip::host
+    hipdnn_frontend
+    hipdnn_plugin_sdk
+    hipdnn_data_sdk
+    hipdnn_test_sdk
+    Threads::Threads
+  COMPILE_DEFS
+    FUSILLI_PLUGIN_PATH="../${FUSILLI_PLUGIN_RELATIVE_PATH}"
+)

--- a/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_dgrad.cpp
+++ b/dnn-providers/fusilli-provider/test/integration/convolution/simple_conv_dgrad.cpp
@@ -1,0 +1,149 @@
+// Copyright 2026 Advanced Micro Devices, Inc.
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+#include <hipdnn_backend.h>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/attributes/ConvolutionDgradAttributes.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/TestUtilities.hpp>
+
+#include <cstdint>
+#include <memory>
+
+using namespace hipdnn_frontend;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_test_sdk::utilities;
+
+// Test: ConvDGrad 1x1.
+TEST(ConvDgradIntegrationTest, ConvDgrad) {
+  // Initialize HIP.
+  ASSERT_EQ(hipInit(0), hipSuccess);
+  ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+  hipStream_t stream = nullptr;
+  ASSERT_EQ(hipStreamCreate(&stream), hipSuccess);
+
+  // Set plugin path.
+  auto pluginPath = std::filesystem::canonical(getCurrentExecutableDirectory() /
+                                               FUSILLI_PLUGIN_PATH);
+  const std::array<const char *, 1> paths = {pluginPath.c_str()};
+  ASSERT_EQ(hipdnnSetEnginePluginPaths_ext(paths.size(), paths.data(),
+                                           HIPDNN_PLUGIN_LOADING_ABSOLUTE),
+            HIPDNN_STATUS_SUCCESS);
+
+  // Create handle.
+  hipdnnHandle_t handle;
+  ASSERT_EQ(hipdnnCreate(&handle), HIPDNN_STATUS_SUCCESS);
+  ASSERT_EQ(hipdnnSetStream(handle, stream), HIPDNN_STATUS_SUCCESS);
+
+  const int64_t n = 16;  // batch
+  const int64_t c = 128; // input channels
+  const int64_t h = 64;  // spatial height
+  const int64_t w = 32;  // spatial width
+  const int64_t k = 256; // output channels (gradient channels)
+  const int64_t r = 1;   // filter height
+  const int64_t s = 1;   // filter width
+
+  // UIDs.
+  const int64_t dyUID = 0;
+  const int64_t wUID = 1;
+  const int64_t dxUID = 2;
+
+  // Initialize tensors. Use NHWC strides for dy and dx, KRSC for w.
+  PinnedTensor<float> dyTensor({n, k, h, w}, {k * h * w, 1, k * w, k});
+  PinnedTensor<float> wTensor({k, c, r, s}, {c * r * s, 1, c * s, c});
+  PinnedTensor<float> dxTensor({n, c, h, w}, {c * h * w, 1, c * w, c});
+  dyTensor.fillWithValue(1.0f);
+  wTensor.fillWithValue(1.0f);
+  dxTensor.fillWithValue(-100.0f);
+
+  // Create graph.
+  auto graph = std::make_shared<graph::Graph>();
+  graph->set_name("simple_conv_dgrad_test");
+  graph->set_io_data_type(DataType_t::FLOAT)
+      .set_intermediate_data_type(DataType_t::FLOAT)
+      .set_compute_data_type(DataType_t::FLOAT);
+
+  // Create tensor attributes with NHWC strides.
+  auto dyAttr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("dy", DataType_t::FLOAT, dyTensor));
+  dyAttr->set_uid(dyUID);
+  auto wAttr = std::make_shared<graph::TensorAttributes>(
+      graph::makeTensorAttributes("w", DataType_t::FLOAT, wTensor));
+  wAttr->set_uid(wUID);
+
+  // Create conv dgrad attributes.
+  graph::ConvDgradAttributes convDgradAttr;
+  convDgradAttr.set_name("conv_dgrad")
+      .set_padding({0, 0})
+      .set_stride({1, 1})
+      .set_dilation({1, 1});
+
+  // Create conv dgrad node.
+  auto dxAttr = graph->conv_dgrad(dyAttr, wAttr, convDgradAttr);
+  dxAttr->set_uid(dxUID);
+  dxAttr->set_dim(dxTensor.dims())
+      .set_stride(dxTensor.strides())
+      .set_output(true);
+
+  // Build + validate + build plans for graph.
+  auto result = graph->validate();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->build_operation_graph(handle);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->create_execution_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->check_support();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  result = graph->build_plans();
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  // Query workspace size.
+  int64_t workspaceSize = 0;
+  result = graph->get_workspace_size(workspaceSize);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+
+  // Allocate workspace if needed.
+  void *workspace = nullptr;
+  if (workspaceSize > 0) {
+    ASSERT_EQ(hipMalloc(&workspace, static_cast<size_t>(workspaceSize)),
+              hipSuccess);
+  }
+
+  // Create variant pack.
+  std::unordered_map<int64_t, void *> variantPack;
+  variantPack[dyUID] = dyTensor.memory().deviceData();
+  variantPack[wUID] = wTensor.memory().deviceData();
+  variantPack[dxUID] = dxTensor.memory().deviceData();
+
+  // Execute graph with workspace.
+  result = graph->execute(handle, variantPack, workspace);
+  ASSERT_EQ(result.code, error_code_t::OK) << result.err_msg;
+  dxTensor.memory().markDeviceModified();
+
+  // Validate results. For 1x1 conv dgrad with all-ones inputs, stride=1,
+  // no padding: dx[n,c,h,w] = sum_{k} dy * w = k (number of output channels).
+  const float expected = static_cast<float>(k);
+  auto *dxData = dxTensor.memory().hostData();
+  for (size_t i = 0; i < static_cast<size_t>(n * c * h * w); ++i) {
+    EXPECT_FLOAT_EQ(dxData[i], expected) << "mismatch at index " << i;
+  }
+
+  // Clean up.
+  if (workspace != nullptr) {
+    ASSERT_EQ(hipFree(workspace), hipSuccess);
+  }
+  ASSERT_EQ(hipStreamDestroy(stream), HIPDNN_STATUS_SUCCESS);
+  ASSERT_EQ(hipdnnDestroy(handle), HIPDNN_STATUS_SUCCESS);
+}

--- a/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
+++ b/dnn-providers/fusilli-provider/test/test_fusilli_plugin_api.cpp
@@ -288,6 +288,53 @@ TEST(TestFusilliPluginApi, GetApplicableEngineIds) {
   ASSERT_EQ(numEngines, 0);
 }
 
+TEST(TestFusilliPluginApi, GetApplicableEngineIdsConvDGrad) {
+  // Create plugin handle.
+  hipdnnEnginePluginHandle_t handle = nullptr;
+  ASSERT_EQ(hipdnnEnginePluginCreate(&handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+  ASSERT_NE(handle, nullptr);
+
+  std::array<int64_t, 5> engineIDs;
+  uint32_t numEngines = 0;
+
+  // Create a serialized hipDNN conv_bwd (dgrad) graph with symmetric padding.
+  auto builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph();
+  hipdnnPluginConstData_t opGraph;
+  opGraph.ptr = builder.GetBufferPointer();
+  opGraph.size = builder.GetSize();
+
+  // Fusilli plugin should offer to compile and execute single node conv_dgrad.
+  ASSERT_EQ(hipdnnEnginePluginGetApplicableEngineIds(
+                /*handle=*/handle, /*op_graph=*/&opGraph,
+                /*engine_ids=*/engineIDs.data(), /*max_engines=*/5,
+                /*num_engines=*/&numEngines),
+            HIPDNN_PLUGIN_STATUS_SUCCESS);
+  ASSERT_EQ(numEngines, 1);
+  ASSERT_EQ(engineIDs[0], hipdnn_data_sdk::utilities::FUSILLI_ENGINE_ID);
+
+  // Create a serialized hipDNN conv_bwd (dgrad) graph with asymmetric padding.
+  builder = hipdnn_test_sdk::utilities::createValidConvBwdGraph(
+      /*dxDims=*/{4, 4, 4, 4}, /*dxStrides=*/{64, 16, 4, 1},
+      /*wDims=*/{4, 4, 1, 1}, /*wStrides=*/{4, 1, 1, 1},
+      /*dyDims=*/{4, 4, 4, 4}, /*dyStrides=*/{64, 16, 4, 1},
+      /*convPrePadding=*/{1, 0},  // asymmetric: pre doesn't match post
+      /*convPostPadding=*/{2, 1}, // asymmetric: pre doesn't match post
+      /*convStrides=*/{1, 1}, /*convDilation=*/{1, 1});
+  opGraph.ptr = builder.GetBufferPointer();
+  opGraph.size = builder.GetSize();
+
+  // Fusilli plugin should not offer to compile and execute conv_dgrad with
+  // asymmetric padding.
+  ASSERT_EQ(hipdnnEnginePluginGetApplicableEngineIds(
+                /*handle=*/handle, /*op_graph=*/&opGraph,
+                /*engine_ids=*/engineIDs.data(), /*max_engines=*/5,
+                /*num_engines=*/&numEngines),
+            HIPDNN_PLUGIN_STATUS_SUCCESS);
+  ASSERT_EQ(numEngines, 0);
+
+  EXPECT_EQ(hipdnnEnginePluginDestroy(handle), HIPDNN_PLUGIN_STATUS_SUCCESS);
+}
+
 TEST(TestFusilliPluginApi, GetApplicableEngineIdsConvPointwise) {
   // Create plugin handle.
   hipdnnEnginePluginHandle_t handle = nullptr;


### PR DESCRIPTION
## Summary
- Add `ConvolutionBwdAttributes` (dgrad) case to the Fusilli plugin's graph importer, which previously only handled `ConvolutionFwd` and `ConvolutionWrw`
- Add unit test verifying the plugin accepts symmetric-padding dgrad graphs and rejects asymmetric ones
- Add integration test running a 1x1 conv dgrad end-to-end with numerical validation

## Test plan
- [ ] `fusilli_plugin_simple_conv_dgrad_test` integration test passes on MI325
- [ ] `GetApplicableEngineIdsConvDGrad` unit test passes
- [ ] Existing conv fprop/wgrad tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)