### PR TITLE
Add sdpa-kernel-provider to hipDNN superbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(AVAILABLE_COMPONENTS
     hipdnn
     miopen-provider
     hipblaslt-provider
+    sdpa-kernel-provider
 )
 
 set(UNSUPPORTED_COMPONENTS
@@ -184,6 +185,14 @@ if("hipblaslt-provider" IN_LIST ROCM_LIBS_ENABLE_COMPONENTS)
         COMPONENT hipblaslt-provider
         PREFIX_PATH dnn-providers
         EXPECT_TARGET hipblaslt_plugin
+    )
+endif()
+
+if("sdpa-kernel-provider" IN_LIST ROCM_LIBS_ENABLE_COMPONENTS)
+    add_subdirectory_with_message(
+        COMPONENT sdpa-kernel-provider
+        PREFIX_PATH dnn-providers
+        EXPECT_TARGET sdpa_kernel_plugin
     )
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -81,6 +81,14 @@
             "cacheVariables": {
                 "ROCM_LIBS_ENABLE_COMPONENTS": "hipdnn;hipblaslt-provider"
             }
+        },
+        {
+            "name": "sdpa-kernel-provider",
+            "description": "Build hipdnn and sdpa-kernel-provider",
+            "inherits": ["default:release"],
+            "cacheVariables": {
+                "ROCM_LIBS_ENABLE_COMPONENTS": "hipdnn;sdpa-kernel-provider"
+            }
         }
     ],
     "buildPresets": [

--- a/dnn-providers/sdpa-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/sdpa-kernel-provider/CMakeLists.txt
@@ -36,8 +36,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib
      ${HIP_DIR}/cmake
 )
 
-option(HIPDNN_SKIP_TESTS "Skip building tests" OFF)
-option(SDPAKERNELPROVIDER_ENABLE_TESTS "Build tests" ON)
+option(SDPAKERNELPROVIDER_SKIP_TESTS "Skip building tests" OFF)
 
 option(BUILD_ADDRESS_SANITIZER "Build with Address Sanitizer enabled" OFF)
 option(ENABLE_CLANG_FORMAT "Enable Clang-Format checks" ON)
@@ -54,9 +53,9 @@ if(SDPAKERNELPROVIDER_ENABLE_COVERAGE)
     add_link_options(-fprofile-instr-generate -fcoverage-mapping)
 endif()
 
-# In superbuild mode, HIPDNN_SKIP_TESTS overrides the local test option
+# HIPDNN_SKIP_TESTS is the superbuild-level variable that controls test skipping
 if(HIPDNN_SKIP_TESTS)
-    set(SDPAKERNELPROVIDER_ENABLE_TESTS OFF)
+    set(SDPAKERNELPROVIDER_SKIP_TESTS ON)
 endif()
 
 list(
@@ -105,9 +104,7 @@ include(ClangTidy)
 
 # Setup testing dependencies
 include(Dependencies)
-if(NOT HIPDNN_SKIP_TESTS)
-    include(Tests)
-endif()
+include(Tests)
 
 if(WIN32)
     set(HIPDNN_PLUGIN_ENGINE_ROOTDIR "bin")

--- a/dnn-providers/sdpa-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/sdpa-kernel-provider/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.25.2)
 add_compile_definitions(__HIP_PLATFORM_AMD__)
 
-set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/ClangToolChain.cmake"
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ClangToolChain.cmake"
     CACHE STRING "Toolchain file"
 )
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -36,6 +36,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib
      ${HIP_DIR}/cmake
 )
 
+option(HIPDNN_SKIP_TESTS "Skip building tests" OFF)
 option(SDPAKERNELPROVIDER_ENABLE_TESTS "Build tests" ON)
 
 option(BUILD_ADDRESS_SANITIZER "Build with Address Sanitizer enabled" OFF)
@@ -51,6 +52,11 @@ if(SDPAKERNELPROVIDER_ENABLE_COVERAGE)
     message(VERBOSE "Enabling compile flags for coverage-mapping")
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
     add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+endif()
+
+# In superbuild mode, HIPDNN_SKIP_TESTS overrides the local test option
+if(HIPDNN_SKIP_TESTS)
+    set(SDPAKERNELPROVIDER_ENABLE_TESTS OFF)
 endif()
 
 list(
@@ -81,16 +87,27 @@ list(
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/llvm ${ROCM_PATH} ${ROCM_PATH}/hip)
 
 find_package(hip REQUIRED)
-find_package(hipdnn_data_sdk CONFIG REQUIRED)
-find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+
+# SDK dependencies - use targets directly in superbuild, find_package otherwise
+if(NOT TARGET hipdnn_data_sdk)
+    find_package(hipdnn_data_sdk CONFIG REQUIRED)
+endif()
+
+if(NOT TARGET hipdnn_plugin_sdk)
+    find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+endif()
 
 include(CheckToolVersion)
-include(ClangCheck)
+if(ENABLE_CLANG_FORMAT)
+    include(ClangCheck)
+endif()
 include(ClangTidy)
 
 # Setup testing dependencies
 include(Dependencies)
-include(Tests)
+if(NOT HIPDNN_SKIP_TESTS)
+    include(Tests)
+endif()
 
 if(WIN32)
     set(HIPDNN_PLUGIN_ENGINE_ROOTDIR "bin")

--- a/dnn-providers/sdpa-kernel-provider/CMakeLists.txt
+++ b/dnn-providers/sdpa-kernel-provider/CMakeLists.txt
@@ -177,12 +177,19 @@ if(SDPAKERNELPROVIDER_ENABLE_COVERAGE)
         # cmake-format: on
     endfunction()
 
-    add_custom_coverage_target(code_coverage check)
-    add_custom_coverage_target(unit-coverage unit-check)
-    add_custom_coverage_target(integration-coverage integration-check)
+    if(SDPAKERNELPROVIDER_SKIP_TESTS)
+        message(
+            WARNING
+                "\nThe code coverage targets depend on test targets but test targets don't exist because SDPAKERNELPROVIDER_SKIP_TESTS is enabled."
+        )
+    else()
+        add_custom_coverage_target(code_coverage check)
+        add_custom_coverage_target(unit-coverage unit-check)
+        add_custom_coverage_target(integration-coverage integration-check)
 
-    # Alias target
-    add_custom_target(coverage DEPENDS code_coverage COMMENT "Alias for code_coverage")
+        # Alias target
+        add_custom_target(coverage DEPENDS code_coverage COMMENT "Alias for code_coverage")
+    endif()
 
     # Standalone coverage report from existing profdata (does not run tests)
     add_custom_coverage_target(current-coverage "")

--- a/dnn-providers/sdpa-kernel-provider/cmake/ClangCheck.cmake
+++ b/dnn-providers/sdpa-kernel-provider/cmake/ClangCheck.cmake
@@ -54,7 +54,7 @@ if(ENABLE_CLANG_FORMAT)
         COMMAND find . ${CLANG_FORMAT_PRUNE}
                 \( -name "*.cpp" -o -name "*.hpp" -o -name "*.c" -o -name "*.h" \)
                 -exec ${CLANG_FORMAT_BINARY} --dry-run --Werror {} +
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         VERBATIM
         COMMENT "Checking code format (${PROJECT_NAME})"
     )
@@ -64,7 +64,7 @@ if(ENABLE_CLANG_FORMAT)
         COMMAND find . ${CLANG_FORMAT_PRUNE}
                 \( -name "*.cpp" -o -name "*.hpp" -o -name "*.c" -o -name "*.h" \)
                 -exec ${CLANG_FORMAT_BINARY} --verbose -i {} +
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         VERBATIM
         COMMENT "Formatting code (${PROJECT_NAME})"
     )

--- a/dnn-providers/sdpa-kernel-provider/cmake/ClangCheck.cmake
+++ b/dnn-providers/sdpa-kernel-provider/cmake/ClangCheck.cmake
@@ -40,23 +40,44 @@ if(ENABLE_CLANG_FORMAT)
     # Find and check clang-format version using unified function
     findandcheckclangformat()
 
+    # Use prefixed target names in superbuild to avoid collisions
+    if(ROCM_LIBS_SUPERBUILD)
+        set(_CHECK_FORMAT_TARGET ${PROJECT_NAME}_check_format)
+        set(_FORMAT_TARGET ${PROJECT_NAME}_format)
+    else()
+        set(_CHECK_FORMAT_TARGET check_format)
+        set(_FORMAT_TARGET format)
+    endif()
+
     add_custom_target(
-        check_format
+        ${_CHECK_FORMAT_TARGET}
         COMMAND find . ${CLANG_FORMAT_PRUNE}
                 \( -name "*.cpp" -o -name "*.hpp" -o -name "*.c" -o -name "*.h" \)
                 -exec ${CLANG_FORMAT_BINARY} --dry-run --Werror {} +
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         VERBATIM
-        COMMENT "Checking code format"
+        COMMENT "Checking code format (${PROJECT_NAME})"
     )
 
     add_custom_target(
-        format
+        ${_FORMAT_TARGET}
         COMMAND find . ${CLANG_FORMAT_PRUNE}
                 \( -name "*.cpp" -o -name "*.hpp" -o -name "*.c" -o -name "*.h" \)
                 -exec ${CLANG_FORMAT_BINARY} --verbose -i {} +
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         VERBATIM
-        COMMENT "Formatting code"
+        COMMENT "Formatting code (${PROJECT_NAME})"
+    )
+
+    # Alias targets with consistent hyphenated naming
+    add_custom_target(
+        ${PROJECT_NAME}-check-format
+        DEPENDS ${_CHECK_FORMAT_TARGET}
+        COMMENT "Alias for ${_CHECK_FORMAT_TARGET}"
+    )
+    add_custom_target(
+        ${PROJECT_NAME}-format
+        DEPENDS ${_FORMAT_TARGET}
+        COMMENT "Alias for ${_FORMAT_TARGET}"
     )
 endif() # ENABLE_CLANG_FORMAT

--- a/dnn-providers/sdpa-kernel-provider/cmake/ClangTidy.cmake
+++ b/dnn-providers/sdpa-kernel-provider/cmake/ClangTidy.cmake
@@ -10,7 +10,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Sets up clang-tidy command variables with appropriate compiler flags for C++ and HIP files
 function(setClangTidyVars)
-    set(CLANG_TIDY_COMMAND ${CLANG_TIDY_EXE} -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy -p
+    set(CLANG_TIDY_COMMAND ${CLANG_TIDY_EXE} -config-file=${PROJECT_SOURCE_DIR}/.clang-tidy -p
                            ${CMAKE_BINARY_DIR} PARENT_SCOPE
     )
     if(NOT CLANG_TIDY_HIP_ARGS)
@@ -58,9 +58,9 @@ function(add_clang_tidy_custom_target)
             tidy
             COMMAND
                 ${RUN_CLANG_TIDY_EXE} -p ${CMAKE_BINARY_DIR}
-                -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy -source-filter "^(?!.*_deps/).*" -quiet
+                -config-file=${PROJECT_SOURCE_DIR}/.clang-tidy -source-filter "^(?!.*_deps/).*" -quiet
                 -j ${CLANG_TIDY_JOBS} ${CLANG_TIDY_HIP_ARGS}
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT
                 "Running clang-tidy on all source files and headers (${CLANG_TIDY_JOBS} parallel jobs)..."
             VERBATIM
@@ -71,9 +71,9 @@ function(add_clang_tidy_custom_target)
             tidy-cxx
             COMMAND
                 ${RUN_CLANG_TIDY_EXE} -p ${CMAKE_BINARY_DIR}
-                -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy -source-filter
+                -config-file=${PROJECT_SOURCE_DIR}/.clang-tidy -source-filter
                 "^(?!.*(_deps/)).*" -quiet -j ${CLANG_TIDY_JOBS}
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT "Running clang-tidy on C++ files (${CLANG_TIDY_JOBS} parallel jobs)..."
             VERBATIM
         )

--- a/dnn-providers/sdpa-kernel-provider/cmake/ClangTidy.cmake
+++ b/dnn-providers/sdpa-kernel-provider/cmake/ClangTidy.cmake
@@ -53,29 +53,50 @@ function(add_clang_tidy_custom_target)
             set(CLANG_TIDY_JOBS 1)
         endif()
 
+        # Use prefixed target names in superbuild to avoid collisions
+        if(ROCM_LIBS_SUPERBUILD)
+            set(_TIDY_TARGET ${PROJECT_NAME}_tidy)
+            set(_TIDY_CXX_TARGET ${PROJECT_NAME}_tidy-cxx)
+        else()
+            set(_TIDY_TARGET tidy)
+            set(_TIDY_CXX_TARGET tidy-cxx)
+        endif()
+
         # Target for running tidy on all files using HIP args for all files.
         add_custom_target(
-            tidy
+            ${_TIDY_TARGET}
             COMMAND
                 ${RUN_CLANG_TIDY_EXE} -p ${CMAKE_BINARY_DIR}
                 -config-file=${PROJECT_SOURCE_DIR}/.clang-tidy -source-filter "^(?!.*_deps/).*" -quiet
                 -j ${CLANG_TIDY_JOBS} ${CLANG_TIDY_HIP_ARGS}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             COMMENT
-                "Running clang-tidy on all source files and headers (${CLANG_TIDY_JOBS} parallel jobs)..."
+                "Running clang-tidy on ${PROJECT_NAME} source files (${CLANG_TIDY_JOBS} parallel jobs)..."
             VERBATIM
         )
 
         # Target for running tidy on all C++ language files (no HIP args)
         add_custom_target(
-            tidy-cxx
+            ${_TIDY_CXX_TARGET}
             COMMAND
                 ${RUN_CLANG_TIDY_EXE} -p ${CMAKE_BINARY_DIR}
                 -config-file=${PROJECT_SOURCE_DIR}/.clang-tidy -source-filter
                 "^(?!.*(_deps/)).*" -quiet -j ${CLANG_TIDY_JOBS}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-            COMMENT "Running clang-tidy on C++ files (${CLANG_TIDY_JOBS} parallel jobs)..."
+            COMMENT "Running clang-tidy on ${PROJECT_NAME} C++ files (${CLANG_TIDY_JOBS} parallel jobs)..."
             VERBATIM
+        )
+
+        # Alias targets with consistent hyphenated naming
+        add_custom_target(
+            ${PROJECT_NAME}-tidy
+            DEPENDS ${_TIDY_TARGET}
+            COMMENT "Alias for ${_TIDY_TARGET}"
+        )
+        add_custom_target(
+            ${PROJECT_NAME}-tidy-cxx
+            DEPENDS ${_TIDY_CXX_TARGET}
+            COMMENT "Alias for ${_TIDY_CXX_TARGET}"
         )
     else()
         message(${_not_found_log_level}

--- a/dnn-providers/sdpa-kernel-provider/cmake/Tests.cmake
+++ b/dnn-providers/sdpa-kernel-provider/cmake/Tests.cmake
@@ -1,29 +1,154 @@
 # Copyright © Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
-if(NOT SDPAKERNELPROVIDER_ENABLE_TESTS)
-    return()
-endif()
-
 include(GoogleTest)
+
+find_package(Python3 COMPONENTS Interpreter)
 
 set(CHECK_DEPENDS_GLOBAL "" CACHE INTERNAL "Accumulated global dependencies for test name validation" FORCE)
 set(CHECK_EXECUTABLE_PATHS_GLOBAL "" CACHE INTERNAL "Accumulated global check executable paths" FORCE)
 
+# Builds the test environment list with optional code coverage support
+# ~~~
+# Parameters:
+#   OUT_VAR - The name of the variable to store the result in (will be set in PARENT_SCOPE)
+# ~~~
+function(_build_test_environment_list_internal OUT_VAR)
+    set(ENVIRONMENT_LIST "")
+    if(DEFINED TEST_ENVIRONMENT)
+        set(ENVIRONMENT_LIST ${TEST_ENVIRONMENT})
+    endif()
+
+    if(SDPAKERNELPROVIDER_ENABLE_COVERAGE)
+        # Ensure coverage report directory exists
+        file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/coverage-report/profraw")
+
+        # For code coverage builds, we want each profraw file to have a unique name. The %m in the
+        # LLVM_PROFILE_FILE environment variable will auto generate a unique id.
+        list(APPEND ENVIRONMENT_LIST
+             "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage-report/profraw/%m.profraw"
+        )
+    endif()
+
+    set(${OUT_VAR} ${ENVIRONMENT_LIST} PARENT_SCOPE)
+endfunction() # _build_test_environment_list_internal
+
+# Creates a dummy target for test name validation
+function(_create_test_name_validation_target_internal prefix_name)
+    add_custom_target(
+        ${prefix_name}-validate_test_names COMMAND ${CMAKE_COMMAND} -E echo
+                                    "Test name validation skipped for sdpa-kernel-provider"
+        COMMENT "Skipping test name validation"
+    )
+endfunction() # _create_test_name_validation_target_internal
+
 enable_testing() # Cmake wont discover or run tests without this line
 
-if(SDPAKERNELPROVIDER_ENABLE_COVERAGE)
-    # Ensure coverage report directory exists
-    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/coverage-report/profraw")
+# Internal helper function to create a ctest target
+# ~~~
+# Parameters:
+#   PREFIX_NAME - Prefix for target names
+#   TARGET_NAME - Name of the ctest target to create (will be prefixed)
+#   LABEL - Optional label filter for ctest (empty string for no filter)
+#   VERBOSE - Set to TRUE to add --verbose flag, FALSE otherwise
+#   COMMENT - Comment describing the target
+# ~~~
+function(_add_ctest_target_internal PREFIX_NAME TARGET_NAME LABEL VERBOSE COMMENT)
+    # Build the ctest command
+    set(CTEST_CMD ${CMAKE_COMMAND} -E env ${CTEST_ENV} ${CMAKE_CTEST_COMMAND})
 
-    # For code coverage builds, we want each profraw file to have a unique name. The %m in the
-    # LLVM_PROFILE_FILE environment variable will auto generate a unique id.
-    set(COVERAGE_ENVIRONMENT
-        "LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/coverage-report/profraw/%m.profraw"
-    )
-endif()
+    # Add label filter if specified
+    if(NOT "${LABEL}" STREQUAL "")
+        list(APPEND CTEST_CMD -L "${LABEL}")
+    endif()
 
+    # Always add --output-on-failure
+    list(APPEND CTEST_CMD --output-on-failure)
+
+    # Add --verbose if requested
+    if(VERBOSE)
+        list(APPEND CTEST_CMD --verbose)
+    endif()
+
+    # Add configuration
+    list(APPEND CTEST_CMD -C ${CMAKE_CFG_INTDIR})
+
+    # Create the target with prefix
+    set(FULL_TARGET_NAME "${PREFIX_NAME}-${TARGET_NAME}")
+    add_custom_target(${FULL_TARGET_NAME} COMMAND ${CTEST_CMD} COMMENT "${COMMENT}" USES_TERMINAL)
+    add_dependencies(${FULL_TARGET_NAME} ${PREFIX_NAME}-validate_test_names)
+    message(VERBOSE "Created ${FULL_TARGET_NAME} target")
+endfunction() # _add_ctest_target_internal
+
+# Internal helper function to create the check targets for running tests via ctest
+function(_create_ctest_targets_internal prefix_name)
+    # cmake-format: off
+    # Build test environment once for all ctest targets
+    _build_test_environment_list_internal(CTEST_ENV)
+
+    # Regular targets (without --verbose)
+    _add_ctest_target_internal(${prefix_name} "check_ctest" "" FALSE "Running all tests via ctest")
+    _add_ctest_target_internal(${prefix_name} "unit-check_ctest" "unit_test" FALSE "Running unit tests via ctest")
+    _add_ctest_target_internal(${prefix_name} "integration-check_ctest" "integration_test" FALSE "Running integration tests via ctest")
+
+    # Verbose targets (with --verbose)
+    _add_ctest_target_internal(${prefix_name} "check_ctest-verbose" "" TRUE "Running all tests via ctest (verbose)")
+    _add_ctest_target_internal(${prefix_name} "unit-check_ctest-verbose" "unit_test" TRUE "Running unit tests via ctest (verbose)")
+    _add_ctest_target_internal(${prefix_name} "integration-check_ctest-verbose" "integration_test" TRUE "Running integration tests via ctest (verbose)")
+    # cmake-format: on
+endfunction() # _create_ctest_targets_internal
+
+# Finalizes and creates all of the test targets
+#
+# Arguments:
+#   prefix_name - Prefix to add to all target names (e.g., "sdpa-kernel-provider" creates "sdpa-kernel-provider-check")
+#
+# Creates prefixed targets (e.g., "sdpa-kernel-provider-check", "sdpa-kernel-provider-unit-check", etc.)
+# In standalone builds (non-superbuild), also creates unprefixed aliases for backward compatibility
+function(finalize_test_targets prefix_name)
+    _create_test_name_validation_target_internal(${prefix_name})
+
+    _create_ctest_targets_internal(${prefix_name})
+
+    # cmake-format: off
+    # Determine if we should create legacy aliases (only in standalone builds)
+    set(CREATE_ALIASES FALSE)
+    if(NOT ROCM_LIBS_SUPERBUILD)
+        set(CREATE_ALIASES TRUE)
+    endif()
+
+    # Create prefixed test targets that depend on the prefixed _ctest targets
+    # Regular targets (without --verbose)
+    add_custom_target(${prefix_name}-check DEPENDS ${prefix_name}-check_ctest COMMENT "Running all tests via ctest")
+    add_custom_target(${prefix_name}-unit-check DEPENDS ${prefix_name}-unit-check_ctest COMMENT "Running unit tests via ctest")
+    add_custom_target(${prefix_name}-integration-check DEPENDS ${prefix_name}-integration-check_ctest COMMENT "Running integration tests via ctest")
+    message(STATUS "Created ctest targets: ${prefix_name}-check, ${prefix_name}-unit-check, ${prefix_name}-integration-check")
+    # Verbose targets (with --verbose)
+    add_custom_target(${prefix_name}-check-verbose DEPENDS ${prefix_name}-check_ctest-verbose COMMENT "Running all tests via ctest (verbose)")
+    add_custom_target(${prefix_name}-unit-check-verbose DEPENDS ${prefix_name}-unit-check_ctest-verbose COMMENT "Running unit tests via ctest (verbose)")
+    add_custom_target(${prefix_name}-integration-check-verbose DEPENDS ${prefix_name}-integration-check_ctest-verbose COMMENT "Running integration tests via ctest (verbose)")
+    message(STATUS "Created ctest verbose targets: ${prefix_name}-check-verbose, ${prefix_name}-unit-check-verbose, ${prefix_name}-integration-check-verbose")
+
+    # Create legacy unprefixed aliases for backward compatibility (standalone builds only)
+    if(CREATE_ALIASES)
+        add_custom_target(check DEPENDS ${prefix_name}-check COMMENT "Alias for ${prefix_name}-check")
+        add_custom_target(unit-check DEPENDS ${prefix_name}-unit-check COMMENT "Alias for ${prefix_name}-unit-check")
+        add_custom_target(integration-check DEPENDS ${prefix_name}-integration-check COMMENT "Alias for ${prefix_name}-integration-check")
+        add_custom_target(check-verbose DEPENDS ${prefix_name}-check-verbose COMMENT "Alias for ${prefix_name}-check-verbose")
+        add_custom_target(unit-check-verbose DEPENDS ${prefix_name}-unit-check-verbose COMMENT "Alias for ${prefix_name}-unit-check-verbose")
+        add_custom_target(integration-check-verbose DEPENDS ${prefix_name}-integration-check-verbose COMMENT "Alias for ${prefix_name}-integration-check-verbose")
+        message(STATUS "Created legacy alias targets for backward compatibility")
+    endif()
+    # cmake-format: on
+endfunction() # finalize_test_targets
+
+# ~~~
 # Internal helper function to record, configure, and register a ctest test target.
+# Parameters:
+#   APPEND_FUNCTION_SUFFIX - Label to apply to the test (e.g., "unit_test", "integration_test")
+#   TARGET - Name of the test executable target (must already exist)
+#   WORKING_DIR - Working directory for test execution
+# ~~~
 function(_add_test_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
     set(TARGET_EXE ${TARGET})
 
@@ -33,19 +158,24 @@ function(_add_test_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
 
     message(STATUS "Appending ${APPEND_FUNCTION_SUFFIX} check target: ${TARGET} -> ${TARGET_EXE} in working directory: ${WORKING_DIR}")
 
+    # Track the dependencies for test name validation
     set(CHECK_DEPENDS_GLOBAL ${CHECK_DEPENDS_GLOBAL} ${TARGET}
         CACHE INTERNAL "Accumulated global dependencies for test name validation" FORCE
     )
+    # Track the binary paths for test name validation
     set(CHECK_EXECUTABLE_PATHS_GLOBAL ${CHECK_EXECUTABLE_PATHS_GLOBAL} "${CMAKE_INSTALL_BINDIR}/${TARGET_EXE}"
         CACHE INTERNAL "Accumulated global check executable paths" FORCE
     )
 
+    # Track this test target for later use in generating installed CTestTestfile.cmake
     set_property(GLOBAL APPEND PROPERTY SDPA_KERNEL_PLUGIN_TEST_TARGETS ${TARGET})
 
     set_target_properties(
         ${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}"
     )
 
+    # Make test executables relocatable so they can find libraries when build directory is moved
+    # Include both the main lib directory and the engine plugin directories
     set_target_properties(
         ${TARGET}
         PROPERTIES
@@ -55,54 +185,35 @@ function(_add_test_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
             BUILD_RPATH_USE_ORIGIN TRUE
     )
 
+    # Install test executables to bin directory
     install(TARGETS ${TARGET} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     add_test(NAME ${TARGET} COMMAND ${TARGET} WORKING_DIRECTORY ${WORKING_DIR})
     set_tests_properties(${TARGET} PROPERTIES LABELS ${APPEND_FUNCTION_SUFFIX})
 
-    if(COVERAGE_ENVIRONMENT)
-        set_tests_properties(${TARGET} PROPERTIES ENVIRONMENT "${COVERAGE_ENVIRONMENT}")
+    if(SDPAKERNELPROVIDER_ENABLE_COVERAGE)
+        _build_test_environment_list_internal(COVERAGE_ENV)
+        set_tests_properties(${TARGET} PROPERTIES ENVIRONMENT "${COVERAGE_ENV}")
     endif()
-endfunction()
+endfunction() # _add_test_target_internal
 
 # Adds a unit test target
 function(add_unit_test_target TARGET WORKING_DIR)
     _add_test_target_internal(unit_test ${TARGET} ${WORKING_DIR})
-endfunction()
+endfunction() # add_unit_test_target
 
 # Adds an integration test target
 function(add_integration_test_target TARGET WORKING_DIR)
     _add_test_target_internal(integration_test ${TARGET} ${WORKING_DIR})
-endfunction()
-
-# Finalizes and creates all of the test targets
-function(finalize_test_targets)
-    # cmake-format: off
-    add_custom_target(check
-        COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR}
-        COMMENT "Running all tests via ctest"
-        USES_TERMINAL
-    )
-
-    add_custom_target(unit-check
-        COMMAND ${CMAKE_CTEST_COMMAND} -L unit_test --output-on-failure -C ${CMAKE_CFG_INTDIR}
-        COMMENT "Running unit tests via ctest"
-        USES_TERMINAL
-    )
-
-    add_custom_target(integration-check
-        COMMAND ${CMAKE_CTEST_COMMAND} -L integration_test --output-on-failure -C ${CMAKE_CFG_INTDIR}
-        COMMENT "Running integration tests via ctest"
-        USES_TERMINAL
-    )
-    # cmake-format: on
-    message(STATUS "Created ctest targets: check, unit-check, integration-check")
-endfunction()
+endfunction() # add_integration_test_target
 
 # Install CTest configuration files for direct test execution
+# This should be called once at the end of the main CMakeLists.txt after all tests are registered
 function(install_sdpa_kernel_plugin_ctest_files)
+    # Define the CTest installation directory
     set(SDPA_KERNEL_PLUGIN_CTEST_FILE_INSTALL_PATH "${CMAKE_INSTALL_BINDIR}/sdpa_kernel_plugin")
 
+    # Generate a new CTestTestfile.cmake that references installed test executables
     set(INSTALLED_CTEST_FILE "${CMAKE_CURRENT_BINARY_DIR}/CTestTestfile.cmake.install")
 
     file(WRITE "${INSTALLED_CTEST_FILE}"
@@ -110,13 +221,15 @@ function(install_sdpa_kernel_plugin_ctest_files)
     )
     file(APPEND "${INSTALLED_CTEST_FILE}" "# Generated by sdpa_kernel_plugin build system\n\n")
 
+    # Get all test targets that were registered
     get_property(all_tests GLOBAL PROPERTY SDPA_KERNEL_PLUGIN_TEST_TARGETS)
 
     foreach(test_target ${all_tests})
         file(APPEND "${INSTALLED_CTEST_FILE}" "add_test(${test_target} \"../${test_target}\")\n")
     endforeach()
 
+    # Install the generated CTestTestfile.cmake to SDPA_KERNEL_PLUGIN_CTEST_FILE_INSTALL_PATH
     install(FILES "${INSTALLED_CTEST_FILE}"
             DESTINATION ${SDPA_KERNEL_PLUGIN_CTEST_FILE_INSTALL_PATH} RENAME CTestTestfile.cmake
     )
-endfunction()
+endfunction() # install_sdpa_kernel_plugin_ctest_files

--- a/dnn-providers/sdpa-kernel-provider/cmake/Tests.cmake
+++ b/dnn-providers/sdpa-kernel-provider/cmake/Tests.cmake
@@ -1,9 +1,11 @@
 # Copyright © Advanced Micro Devices, Inc., or its affiliates.
 # SPDX-License-Identifier:  MIT
 
-include(GoogleTest)
+if(SDPAKERNELPROVIDER_SKIP_TESTS)
+    return()
+endif()
 
-find_package(Python3 COMPONENTS Interpreter)
+include(GoogleTest)
 
 set(CHECK_DEPENDS_GLOBAL "" CACHE INTERNAL "Accumulated global dependencies for test name validation" FORCE)
 set(CHECK_EXECUTABLE_PATHS_GLOBAL "" CACHE INTERNAL "Accumulated global check executable paths" FORCE)
@@ -190,11 +192,6 @@ function(_add_test_target_internal APPEND_FUNCTION_SUFFIX TARGET WORKING_DIR)
 
     add_test(NAME ${TARGET} COMMAND ${TARGET} WORKING_DIRECTORY ${WORKING_DIR})
     set_tests_properties(${TARGET} PROPERTIES LABELS ${APPEND_FUNCTION_SUFFIX})
-
-    if(SDPAKERNELPROVIDER_ENABLE_COVERAGE)
-        _build_test_environment_list_internal(COVERAGE_ENV)
-        set_tests_properties(${TARGET} PROPERTIES ENVIRONMENT "${COVERAGE_ENV}")
-    endif()
 endfunction() # _add_test_target_internal
 
 # Adds a unit test target

--- a/dnn-providers/sdpa-kernel-provider/src/CMakeLists.txt
+++ b/dnn-providers/sdpa-kernel-provider/src/CMakeLists.txt
@@ -53,7 +53,11 @@ if(SDPAKERNELPROVIDER_ENABLE_TESTS)
 
     # Keep this after all build folders have been added so they have a chance to register their tests
     # using add_*_test_target()
-    finalize_test_targets()
+    # Finalize test targets with prefix to avoid collisions in superbuild mode
+    finalize_test_targets("${PROJECT_NAME}")
 
-    install_sdpa_kernel_plugin_ctest_files()
+    # For standalone builds we need to install the ctest files
+    if(NOT ROCM_LIBS_SUPERBUILD)
+        install_sdpa_kernel_plugin_ctest_files()
+    endif()
 endif()

--- a/dnn-providers/sdpa-kernel-provider/src/CMakeLists.txt
+++ b/dnn-providers/sdpa-kernel-provider/src/CMakeLists.txt
@@ -47,16 +47,16 @@ set_target_properties(
 # ============================================================================
 # Tests
 # ============================================================================
-if(SDPAKERNELPROVIDER_ENABLE_TESTS)
+if(NOT SDPAKERNELPROVIDER_SKIP_TESTS)
     add_subdirectory(tests)
     add_subdirectory(integration_tests)
 
     # Keep this after all build folders have been added so they have a chance to register their tests
     # using add_*_test_target()
-    # Finalize test targets with prefix to avoid collisions in superbuild mode
+    # Test targets are prefixed with PROJECT_NAME to allow coexistence in superbuild
     finalize_test_targets("${PROJECT_NAME}")
 
-    # For standalone builds we need to install the ctest files
+    # Install ctest files for standalone (non-superbuild) builds
     if(NOT ROCM_LIBS_SUPERBUILD)
         install_sdpa_kernel_plugin_ctest_files()
     endif()

--- a/dnn-providers/sdpa-kernel-provider/src/integration_tests/CMakeLists.txt
+++ b/dnn-providers/sdpa-kernel-provider/src/integration_tests/CMakeLists.txt
@@ -3,8 +3,14 @@
 
 find_package(Threads REQUIRED)
 
-find_package(hipdnn_test_sdk CONFIG REQUIRED)
-find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+# SDK dependencies - use targets directly in superbuild, find_package otherwise
+if(NOT TARGET hipdnn_test_sdk)
+    find_package(hipdnn_test_sdk CONFIG REQUIRED)
+endif()
+
+if(NOT TARGET hipdnn_plugin_sdk)
+    find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+endif()
 
 add_executable(
     sdpa_kernel_plugin_integration_tests

--- a/dnn-providers/sdpa-kernel-provider/src/integration_tests/main.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/integration_tests/main.cpp
@@ -7,13 +7,15 @@ SPDX-License-Identifier: MIT
 
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
-#include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
+#include <hipdnn_test_sdk/utilities/LogRecorder.hpp>
 
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
+
+    auto callback = hipdnn_test_sdk::utilities::initializeTestLogRecordingShared();
     hipdnn_plugin_sdk::logging::initializeCallbackLogging(
-        "sdpa_kernel_plugin_integration_tests", hipdnn_test_sdk::utilities::testLoggingCallback);
+        "sdpa_kernel_plugin_integration_tests", callback);
 
     // Register HipErrorHandler to check and clear HIP errors after each test
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();

--- a/dnn-providers/sdpa-kernel-provider/src/tests/CMakeLists.txt
+++ b/dnn-providers/sdpa-kernel-provider/src/tests/CMakeLists.txt
@@ -5,8 +5,14 @@ add_compile_definitions(__HIP_PLATFORM_AMD__)
 find_package(hip REQUIRED)
 find_package(Threads REQUIRED)
 
-find_package(hipdnn_test_sdk CONFIG REQUIRED)
-find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+# SDK dependencies - use targets directly in superbuild, find_package otherwise
+if(NOT TARGET hipdnn_test_sdk)
+    find_package(hipdnn_test_sdk CONFIG REQUIRED)
+endif()
+
+if(NOT TARGET hipdnn_plugin_sdk)
+    find_package(hipdnn_plugin_sdk CONFIG REQUIRED)
+endif()
 
 add_executable(
     sdpa_kernel_plugin_tests

--- a/dnn-providers/sdpa-kernel-provider/src/tests/main.cpp
+++ b/dnn-providers/sdpa-kernel-provider/src/tests/main.cpp
@@ -7,13 +7,14 @@ SPDX-License-Identifier: MIT
 
 #include <hipdnn_plugin_sdk/PluginLogging.hpp>
 #include <hipdnn_test_sdk/utilities/HipErrorHandler.hpp>
-#include <hipdnn_test_sdk/utilities/LoggingUtils.hpp>
+#include <hipdnn_test_sdk/utilities/LogRecorder.hpp>
 
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
-    hipdnn_plugin_sdk::logging::initializeCallbackLogging(
-        "sdpa_kernel_plugin_tests", hipdnn_test_sdk::utilities::testLoggingCallback);
+
+    auto callback = hipdnn_test_sdk::utilities::initializeTestLogRecordingShared();
+    hipdnn_plugin_sdk::logging::initializeCallbackLogging("sdpa_kernel_plugin_tests", callback);
 
     // Register HipErrorHandler to check and clear HIP errors after each test
     testing::TestEventListeners& listeners = testing::UnitTest::GetInstance()->listeners();


### PR DESCRIPTION
## Motivation

The SDPA kernel provider could only be built as a standalone project. This PR integrates it into the hipDNN superbuild so it can be configured, built, and tested alongside the rest of the hipDNN components in a single CMake invocation.

## Technical Details

- **Superbuild registration**: Added `sdpa-kernel-provider` to the top-level `CMakeLists.txt` component list and `CMakePresets.json` with a dedicated preset.
- **SDK dependency resolution**: Changed `find_package()` calls for `hipdnn_data_sdk`, `hipdnn_plugin_sdk`, and `hipdnn_test_sdk` to first check if the target already exists (as it would in a superbuild), falling back to `find_package()` for standalone builds.
- **Target name prefixing**: Prefixed all custom targets (`check`, `unit-check`, `tidy`, `format`, etc.) with `${PROJECT_NAME}` when built under the superbuild to avoid collisions with identically-named targets from other components. Unprefixed aliases are still created in standalone builds for backward compatibility.
- **Path fixes**: Replaced `CMAKE_SOURCE_DIR` with `CMAKE_CURRENT_SOURCE_DIR` / `PROJECT_SOURCE_DIR` throughout so paths resolve correctly when the provider is added as a subdirectory.
- **Test infrastructure refactor**: Reworked `Tests.cmake` — extracted helpers into named functions (`_build_test_environment_list_internal`, `_add_ctest_target_internal`, `_create_ctest_targets_internal`), added prefix support to `finalize_test_targets()`, and flipped the test gate from `SDPAKERNELPROVIDER_ENABLE_TESTS` (opt-in) to `SDPAKERNELPROVIDER_SKIP_TESTS` (opt-out) to match the superbuild's `HIPDNN_SKIP_TESTS` convention.
- **Logging API update**: Updated test `main.cpp` files to use the renamed `LogRecorder.hpp` header and `initializeTestLogRecordingShared()` API (matching changes on the base branch).

## Test Plan

- Configure and build with the new `sdpa-kernel-provider` CMake preset (superbuild mode) and verify all targets compile without collisions.
- Configure and build the provider standalone to verify backward-compatible alias targets still work.
- Run `ninja sdpa-kernel-provider-unit-check` and `ninja sdpa-kernel-provider-integration-check` in the superbuild.
- Run `ninja unit-check` and `ninja integration-check` in a standalone build.
- Verify `ninja sdpa-kernel-provider-tidy` and `ninja sdpa-kernel-provider-check-format` work without interfering with hipDNN's own `tidy`/`check_format` targets.

## Test Result

Superbuild configures and compiles successfully with `--preset sdpa-kernel-provider`. All prefixed test, format, and tidy targets are created without collisions alongside hipDNN's own targets. Standalone build continues to work with unprefixed alias targets.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
