### PR TITLE
[rocBLAS] skip with reporting gemm get solution holes

### DIFF
--- a/projects/rocblas/clients/gtest/get_solutions_gtest.yaml
+++ b/projects/rocblas/clients/gtest/get_solutions_gtest.yaml
@@ -96,7 +96,7 @@ Tests:
   transA: N
   transB: T
   precision : *real_precisions
-  solution_index: -2 # do get solutions and repeat for all
+  solution_index: *c_gemm_test_all_solutions_returned
   algo: 1
   pointer_mode_device: false
   gpu_arch: ['90a','942','950','12??']

--- a/projects/rocblas/clients/include/blas_ex/testing_gemm_batched_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_gemm_batched_ex.hpp
@@ -662,7 +662,7 @@ void testing_gemm_batched_ex_run(const Arguments& arg)
 template <typename Ti, typename To, typename Tc>
 void testing_gemm_batched_ex(const Arguments& arg)
 {
-    bool                     compare_solutions = arg.solution_index == -2;
+    bool                     compare_solutions = arg.solution_index == c_rocblas_test_all_solutions;
     const Arguments*         arguments         = &arg;
     Arguments                run_arg(arg);
     std::vector<rocblas_int> solutions_that_solve(1, 0);
@@ -707,6 +707,10 @@ void testing_gemm_batched_ex(const Arguments& arg)
 
             // append default
             solutions_that_solve.push_back(0);
+        }
+        else
+        {
+            GTEST_SKIP() << "Backend returning 0 valid solutions";
         }
     }
 #endif

--- a/projects/rocblas/clients/include/blas_ex/testing_gemm_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_gemm_ex.hpp
@@ -805,7 +805,7 @@ void testing_gemm_ex_run(const Arguments& arg)
 template <typename Ti, typename To, typename Tc>
 void testing_gemm_ex(const Arguments& arg)
 {
-    bool                     compare_solutions = arg.solution_index == -2;
+    bool                     compare_solutions = arg.solution_index == c_rocblas_test_all_solutions;
     const Arguments*         arguments         = &arg;
     Arguments                run_arg(arg);
     std::vector<rocblas_int> solutions_that_solve(1, 0);
@@ -850,6 +850,10 @@ void testing_gemm_ex(const Arguments& arg)
 
             // append default
             solutions_that_solve.push_back(0);
+        }
+        else
+        {
+            GTEST_SKIP() << "Backend returning 0 valid solutions";
         }
     }
 #endif

--- a/projects/rocblas/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
+++ b/projects/rocblas/clients/include/blas_ex/testing_gemm_strided_batched_ex.hpp
@@ -686,7 +686,7 @@ void testing_gemm_strided_batched_ex_run(const Arguments& arg)
 template <typename Ti, typename To, typename Tc>
 void testing_gemm_strided_batched_ex(const Arguments& arg)
 {
-    bool                     compare_solutions = arg.solution_index == -2;
+    bool                     compare_solutions = arg.solution_index == c_rocblas_test_all_solutions;
     const Arguments*         arguments         = &arg;
     Arguments                run_arg(arg);
     std::vector<rocblas_int> solutions_that_solve(1, 0);
@@ -734,6 +734,10 @@ void testing_gemm_strided_batched_ex(const Arguments& arg)
 
             // append default
             solutions_that_solve.push_back(0);
+        }
+        else
+        {
+            GTEST_SKIP() << "Backend returning 0 valid solutions";
         }
     }
 #endif

--- a/projects/rocblas/clients/include/rocblas_common.yaml
+++ b/projects/rocblas/clients/include/rocblas_common.yaml
@@ -488,6 +488,10 @@ Definitions:
   - &c_scan_value_2
     - [-998]
 
+  # scan extension applied by Arguments class
+  - &c_gemm_test_all_solutions_returned
+    - [-3] # match definitions.hpp
+
   # int64 API testing constants
   - &c_pos_overflow_int32
     - [4294967296]
@@ -503,7 +507,7 @@ Definitions:
     - [67108865] # (67108865 - 1) x 32 will overflow to sign bit
 
   - &c_grid_yz_require_passes
-    - [65539] # force looping over y/z chunks 65536.  TODO track constant c_i64_grid_YZ_chunk in int64_helpers.hpp
+    - [65539] # force looping over y/z chunks near grid limit.  TODO track constant c_i64_grid_YZ_chunk in int64_helpers.hpp
 
   - &c_grid_x_require_passes
     - [268435459] # force looping over x chunks 268435456.  TODO track constant c_i64_grid_X_chunk in int64_helpers.hpp

--- a/projects/rocblas/library/src/include/definitions.hpp
+++ b/projects/rocblas/library/src/include/definitions.hpp
@@ -30,6 +30,7 @@
  ******************************************************************************/
 const int c_rocblas_default_solution   = 0; // either backend -1 is equivalent
 const int c_rocblas_source_solution    = -2;
+const int c_rocblas_test_all_solutions = -3; // reserved for testing
 const int c_rocblas_solutions_reserved = 10;
 const int c_rocblas_bad_solution_index = 0x7fffffff; // maxint
 


### PR DESCRIPTION
## Motivation
This pull request introduces a new reserved constant for testing all GEMM solutions, updates the related YAML and C++ code to use this constant, and improves test robustness by skipping tests when no valid solutions are returned. The changes are primarily focused on enhancing clarity and maintainability in solution selection logic for GEMM tests.

**Constants and Definitions Updates:**
* Added `c_rocblas_test_all_solutions = -3` as a reserved constant for testing all GEMM solutions in `definitions.hpp`, and referenced it in YAML definitions (`rocblas_common.yaml`). 

**Test Logic Improvements:**
* Updated GEMM test YAML (`get_solutions_gtest.yaml`) to use the new constant for solution selection instead of `-2`.
* Modified solution comparison logic in GEMM test runners (`testing_gemm_ex.hpp`, `testing_gemm_batched_ex.hpp`, `testing_gemm_strided_batched_ex.hpp`) to use the new constant for identifying "compare all solutions" mode.
* Improved test robustness by skipping tests when the backend returns zero valid solutions in all GEMM test runners. 

**Minor Definition Clarification:**
* Updated a comment in `rocblas_common.yaml` for `c_grid_yz_require_passes` to clarify grid chunk limits.