### PR TITLE
[hipblaslt] disable mxDataGenerator for windows builds

### DIFF
--- a/projects/hipblaslt/CMakeLists.txt
+++ b/projects/hipblaslt/CMakeLists.txt
@@ -86,6 +86,10 @@ if(HIPBLASLT_ENABLE_HOST)
     option(HIPBLASLT_ENABLE_HIPBLAS_DIRECT "Use the hipblas header directly." OFF)
 endif()
 
+# mxDataGenerator is used by hipblaslt clients and tensilelite client; default OFF on Windows
+cmake_dependent_option(HIPBLASLT_ENABLE_MXDATAGENERATOR "Use mxDataGenerator for MX format data generation (clients/tests)." ON "NOT WIN32" OFF)
+message(STATUS "Enable mxDataGenerator for MX format data generation: ${HIPBLASLT_ENABLE_MXDATAGENERATOR}")
+
 set(CMAKE_SKIP_BUILD_RPATH FALSE CACHE BOOL "Skip build RPATH")
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE CACHE BOOL "Build with install RPATH")
 set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../llvm/lib" CACHE STRING "Install RPATH")

--- a/projects/hipblaslt/clients/CMakeLists.txt
+++ b/projects/hipblaslt/clients/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(hipblaslt-clients-common
         hip::device
 )
 
-if(NOT ROCM_LIBS_SUPERBUILD)
+if(HIPBLASLT_ENABLE_MXDATAGENERATOR AND NOT ROCM_LIBS_SUPERBUILD)
     if(HIPBLASLT_ENABLE_THEROCK)
         find_package(mxDataGenerator REQUIRED)
     else()
@@ -36,7 +36,10 @@ if(NOT ROCM_LIBS_SUPERBUILD)
     endif()
 endif()
 target_compile_features(hipblaslt-clients-common PRIVATE cxx_std_20)
-target_link_libraries(hipblaslt-clients-common PRIVATE roc::mxDataGenerator)
+if(HIPBLASLT_ENABLE_MXDATAGENERATOR)
+    target_compile_definitions(hipblaslt-clients-common PRIVATE HIPBLASLT_ENABLE_MXDATAGENERATOR)
+    target_link_libraries(hipblaslt-clients-common PRIVATE roc::mxDataGenerator)
+endif()
 
 if(HIPBLASLT_ENABLE_ROCROLLER)
     target_compile_definitions(hipblaslt-clients-common PRIVATE HIPBLASLT_USE_ROCROLLER)

--- a/projects/hipblaslt/clients/common/include/mxDataGen.hpp
+++ b/projects/hipblaslt/clients/common/include/mxDataGen.hpp
@@ -30,6 +30,7 @@
 
 #include <vector>
 
+#if HIPBLASLT_ENABLE_MXDATAGENERATOR
 std::vector<float> generateMXInput(hipDataType                dataType,
                                    void*                      data,
                                    void*                      scale,
@@ -45,3 +46,4 @@ std::vector<float> generateMXInput(hipDataType                dataType,
                                    std::string_view const     initMethod = "Bounded",
                                    float                      min_val    = -1.0f,
                                    float                      max_val    = 1.0f);
+#endif

--- a/projects/hipblaslt/clients/common/include/testing_matmul.hpp
+++ b/projects/hipblaslt/clients/common/include/testing_matmul.hpp
@@ -38,7 +38,9 @@
 #include "hipblaslt_random.hpp"
 #include "hipblaslt_test.hpp"
 #include "hipblaslt_vector.hpp"
+#if HIPBLASLT_ENABLE_MXDATAGENERATOR
 #include "mxDataGen.hpp"
+#endif
 #include "near.hpp"
 #include "norm.hpp"
 #include "unit.hpp"
@@ -1901,6 +1903,10 @@ void testing_matmul_with_bias(const Arguments& arg,
 
         if(isBlockScaling(arg.scaleA))
         {
+#if !HIPBLASLT_ENABLE_MXDATAGENERATOR
+            hipblaslt_cout << "MX format (block scaling) is not supported when mxDataGenerator is disabled." << std::endl;
+            return;
+#else
             if(arg.initialization != hipblaslt_initialization::hpl
                && arg.initialization != hipblaslt_initialization::trig_float
                && arg.initialization != hipblaslt_initialization::uniform_01)
@@ -1940,6 +1946,7 @@ void testing_matmul_with_bias(const Arguments& arg,
             // Copy data and scale to device buffers
             CHECK_HIP_ERROR(synchronize(dA[i], hA[i], block_count));
             CHECK_HIP_ERROR(synchronize(dScaleA[i], hScaleA[i], block_count));
+#endif
         }
         else
         {
@@ -1957,6 +1964,10 @@ void testing_matmul_with_bias(const Arguments& arg,
         }
         if(isBlockScaling(arg.scaleB))
         {
+#if !HIPBLASLT_ENABLE_MXDATAGENERATOR
+            hipblaslt_cout << "MX format (block scaling) is not supported when mxDataGenerator is disabled." << std::endl;
+            return;
+#else
             if(arg.initialization != hipblaslt_initialization::hpl
                && arg.initialization != hipblaslt_initialization::trig_float
                && arg.initialization != hipblaslt_initialization::uniform_01)
@@ -1994,6 +2005,7 @@ void testing_matmul_with_bias(const Arguments& arg,
             // Copy data and scale to device buffers
             CHECK_HIP_ERROR(synchronize(dB[i], hB[i], block_count));
             CHECK_HIP_ERROR(synchronize(dScaleB[i], hScaleB[i], block_count));
+#endif
         }
         else
         {

--- a/projects/hipblaslt/clients/common/src/CMakeLists.txt
+++ b/projects/hipblaslt/clients/common/src/CMakeLists.txt
@@ -14,7 +14,9 @@ target_sources(hipblaslt-clients-common
         "${CMAKE_CURRENT_SOURCE_DIR}/hipblaslt_init_device.cpp"
 )
 
-target_sources(hipblaslt-clients-common PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/mxDataGen.cpp")
+if(HIPBLASLT_ENABLE_MXDATAGENERATOR)
+    target_sources(hipblaslt-clients-common PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/mxDataGen.cpp")
+endif()
 
 if(HIPBLASLT_ENABLE_BLIS)
     target_sources(hipblaslt-clients-common

--- a/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/projects/hipblaslt/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -2075,13 +2075,22 @@ namespace
         // push 2 activation arguments
         std::visit(
             [&inputs, &prob](auto val) {
-                inputs.activationArgs.push_back((decltype(val))prob.act0);
-                inputs.activationArgs.push_back((decltype(val))prob.act1);
+                using ValType = decltype(val);
+                if constexpr (std::is_constructible_v<ValType, float>)
+                {
+                    inputs.activationArgs.push_back(static_cast<ValType>(prob.act0));
+                    inputs.activationArgs.push_back(static_cast<ValType>(prob.act1));
+                }
+                else
+                {
+                    inputs.activationArgs.push_back(prob.act0);
+                    inputs.activationArgs.push_back(prob.act1);
+                }
                 if(prob.k)
-                    inputs.alpha = *(decltype(val)*)(prob.alpha);
+                    inputs.alpha = *(ValType*)(prob.alpha);
                 else
                     inputs.alpha = val;
-                inputs.beta = *(decltype(val)*)(prob.beta);
+                inputs.beta = *(ValType*)(prob.beta);
             },
             argument_vals.at(compute_type));
 

--- a/projects/hipblaslt/tensilelite/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/CMakeLists.txt
@@ -54,14 +54,16 @@ if(TENSILELITE_ENABLE_HOST)
     add_subdirectory(include)
 
     if(TENSILELITE_ENABLE_CLIENT)
-        # Add mxDataGenerator if it hasn't been added by clients build
-        if(NOT TARGET roc::mxDataGenerator)
-            if(NOT ROCM_LIBS_SUPERBUILD)
-                if(HIPBLASLT_ENABLE_THEROCK)
-                    find_package(mxDataGenerator REQUIRED)
-                else()
-                    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../../shared/mxdatagenerator"
-                                   "${CMAKE_CURRENT_BINARY_DIR}/mxdatagenerator")
+        if(HIPBLASLT_ENABLE_MXDATAGENERATOR)
+            # Add mxDataGenerator if it hasn't been added by clients build
+            if(NOT TARGET roc::mxDataGenerator)
+                if(NOT ROCM_LIBS_SUPERBUILD)
+                    if(HIPBLASLT_ENABLE_THEROCK)
+                        find_package(mxDataGenerator REQUIRED)
+                    else()
+                        add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../../../shared/mxdatagenerator"
+                                       "${CMAKE_CURRENT_BINARY_DIR}/mxdatagenerator")
+                    endif()
                 endif()
             endif()
         endif()

--- a/projects/hipblaslt/tensilelite/Tensile/Common/DataType.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Common/DataType.py
@@ -25,6 +25,7 @@
 from rocisa.enum import DataTypeEnum
 from functools import lru_cache
 import functools
+import platform
 
 @lru_cache
 def _is8bitFloat(value):
@@ -225,9 +226,9 @@ class DataType:
             'nameAbbrev': 'fp6',
             'miOutTypeNameAbbrev': 'f32',
             'reg': 0.1875,
-            'hip': 'tensile_float6x32',
+            'hip': 'ERROR' if platform.system() == 'Windows' else 'tensile_float6x32',
             'isComplex': False,
-            'packing': 32,
+            'packing': 1 if platform.system() == 'Windows' else 32,
         },
         {
             'enum': DataTypeEnum.BFloat6,
@@ -235,9 +236,9 @@ class DataType:
             'nameAbbrev': 'bf6',
             'miOutTypeNameAbbrev': 'f32',
             'reg': 0.1875,
-            'hip': 'tensile_bfloat6x32',
+            'hip': 'ERROR' if platform.system() == 'Windows' else 'tensile_bfloat6x32',
             'isComplex': False,
-            'packing': 32,
+            'packing': 1 if platform.system() == 'Windows' else 32,
         },
         {
             'enum': DataTypeEnum.Float4,
@@ -245,9 +246,9 @@ class DataType:
             'nameAbbrev': 'fp4',
             'miOutTypeNameAbbrev': 'f32',
             'reg': 0.125,
-            'hip': 'tensile_float4x2',
+            'hip': 'ERROR' if platform.system() == 'Windows' else 'tensile_float4x2',
             'isComplex': False,
-            'packing': 2,
+            'packing': 1 if platform.system() == 'Windows' else 2,
         },
     ]
     lookup = {}

--- a/projects/hipblaslt/tensilelite/client/CMakeLists.txt
+++ b/projects/hipblaslt/tensilelite/client/CMakeLists.txt
@@ -13,8 +13,12 @@ set(COMMON_CLIENT_LIBS
     OpenMP::OpenMP_CXX
 )
 
-target_link_libraries(tensilelite-client PRIVATE roc::mxDataGenerator)
-target_link_libraries(cpu-gemm-driver PRIVATE roc::mxDataGenerator)
+if(TARGET roc::mxDataGenerator)
+    target_compile_definitions(tensilelite-client PRIVATE HIPBLASLT_ENABLE_MXDATAGENERATOR)
+    target_link_libraries(tensilelite-client PRIVATE roc::mxDataGenerator)
+    target_compile_definitions(cpu-gemm-driver PRIVATE HIPBLASLT_ENABLE_MXDATAGENERATOR)
+    target_link_libraries(cpu-gemm-driver PRIVATE roc::mxDataGenerator)
+endif()
 
 if(NOT WIN32)
     find_package(amd_smi REQUIRED)

--- a/projects/hipblaslt/tensilelite/client/include/DataInitialization.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/DataInitialization.hpp
@@ -437,6 +437,7 @@ namespace TensileLite
                     initArray<BFloat8_fnuz>(
                         initMode, static_cast<BFloat8_fnuz*>(array), descriptor);
                     break;
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
                 case rocisa::DataType::Float6:
                     initArray<Float6x32>(initMode, static_cast<Float6x32*>(array), descriptor);
@@ -452,6 +453,7 @@ namespace TensileLite
                     initArray<Float4x2>(initMode, static_cast<Float4x2*>(array), descriptor);
                     break;
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
                 case rocisa::DataType::MXScale:
                     initArray<MXScale>(initMode, static_cast<MXScale*>(array), descriptor);
                     break;
@@ -468,7 +470,13 @@ namespace TensileLite
                 case rocisa::DataType::Float8BFloat8:
                 case rocisa::DataType::BFloat8Float8:
                 case rocisa::DataType::Float8BFloat8_fnuz:
-                case rocisa::DataType::BFloat8Float8_fnuz:;
+                case rocisa::DataType::BFloat8Float8_fnuz:
+#ifdef _WIN32
+                case rocisa::DataType::Float6:
+                case rocisa::DataType::BFloat6:
+                case rocisa::DataType::Float4:
+#endif // _WIN32
+                ;
                 }
             }
 
@@ -2180,6 +2188,7 @@ namespace TensileLite
         {
             return std::numeric_limits<int8_t>::min();
         }
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
         template <>
         inline Float6x32 DataInitialization::getValue<Float6x32, InitMode::Zero>()
@@ -2502,6 +2511,7 @@ namespace TensileLite
             throw std::runtime_error("BadOutput not available for float4.");
         }
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
 
         template <>
         inline MXScale DataInitialization::getValue<MXScale, InitMode::Zero>()
@@ -2642,6 +2652,7 @@ namespace TensileLite
             return value == DataInitialization::getValue<int8_t, InitMode::BadInput>();
         }
 
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
         template <>
         inline bool DataInitialization::isBadInput<Float6x32>(Float6x32 value)
@@ -2665,6 +2676,7 @@ namespace TensileLite
             return false;
         }
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
 
         template <>
         inline bool DataInitialization::isBadInput<MXScale>(MXScale value)
@@ -2751,6 +2763,7 @@ namespace TensileLite
             return value == DataInitialization::getValue<int8_t, InitMode::BadOutput>();
         }
 
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
         template <>
         inline bool DataInitialization::isBadOutput<Float6x32>(Float6x32 value)
@@ -2774,6 +2787,7 @@ namespace TensileLite
             return false;
         }
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
 
         template <>
         inline float DataInitialization::getTrigValue<float>(int idx, bool useCos, bool useAbs)
@@ -2850,6 +2864,7 @@ namespace TensileLite
             throw std::runtime_error("Trig not available for Int8.");
         }
 
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
         template <>
         inline Float6x32 DataInitialization::getTrigValue<Float6x32>(int idx, bool useCos, bool useAbs)
@@ -2947,6 +2962,7 @@ namespace TensileLite
             return Float4x2(val0, val1);
         }
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
 
         template <>
         inline MXScale DataInitialization::getTrigValue<MXScale>(int idx, bool useCos, bool useAbs)
@@ -3221,6 +3237,7 @@ namespace TensileLite
             return getValue<int8_t, InitMode::Random>();
         }
 
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
         template <>
         inline Float6x32 DataInitialization::getValue<Float6x32, InitMode::RandomNarrow>()
@@ -3316,6 +3333,7 @@ namespace TensileLite
             return getValue<Float4x2, InitMode::Random>();
         }
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
 
         template <>
         inline MXScale DataInitialization::getValue<MXScale, InitMode::RandomNarrow>()
@@ -3428,6 +3446,7 @@ namespace TensileLite
             return getValueWithUpperLowerBoundInteger<int8_t>();
         }
 
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
         template <>
         inline Float6x32 DataInitialization::getValue<Float6x32, InitMode::RandomNegPosLimited>()
@@ -3525,6 +3544,7 @@ namespace TensileLite
                             getValueWithUpperLowerBoundFP<float>());
         }
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
 
         template <>
         inline MXScale DataInitialization::getValue<MXScale, InitMode::RandomNegPosLimited>()
@@ -3613,6 +3633,7 @@ namespace TensileLite
             return static_cast<int8_t>(i);
         }
 
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
         template <>
         inline Float6x32 DataInitialization::ConvertTo<Float6x32>(size_t i)
@@ -3708,6 +3729,7 @@ namespace TensileLite
             return Float4x2(float(i), float(i));
         }
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
 
         template <>
         inline MXScale DataInitialization::ConvertTo<MXScale>(size_t i)
@@ -3794,6 +3816,7 @@ namespace TensileLite
         {
             return static_cast<BFloat8_fnuz>(value);
         }
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
         template <>
         inline Float6x32 DataInitialization::convertDoubleTo<Float6x32>(double value)
@@ -3889,6 +3912,7 @@ namespace TensileLite
             return Float4x2(float(value), float(value));
         }
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
 
         template <>
         inline MXScale DataInitialization::convertDoubleTo<MXScale>(double value)

--- a/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/LogReporter.hpp
@@ -335,6 +335,7 @@ namespace TensileLite
                                        reinterpret_cast<BFloat8_fnuz const*>(data),
                                        tensor,
                                        reinterpret_cast<BFloat8_fnuz const*>(ptrVal));
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
                     else if(tensor.dataType() == rocisa::DataType::Float6)
                         logTensorTyped(level,
@@ -359,6 +360,7 @@ namespace TensileLite
                                        tensor,
                                        reinterpret_cast<Float4x2 const*>(ptrVal));
 #endif // #ifdef TENSILE_USE_FP4
+#endif // !_WIN32
                     else if(tensor.dataType() == rocisa::DataType::ComplexFloat)
                         logTensorTyped(level,
                                        name,

--- a/projects/hipblaslt/tensilelite/client/include/TypedId.hpp
+++ b/projects/hipblaslt/tensilelite/client/include/TypedId.hpp
@@ -285,6 +285,7 @@ namespace TensileLite
 #endif // TENSILE_USE_HALF
 #endif // TENSILE_USE_FP8_BF8
 
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
     using TypedGemm_F6_S_S = TypedGemm<Float6x32, Float6x32, float, float>;
     using TypedGemm_F8F6_S_S
@@ -320,4 +321,5 @@ namespace TensileLite
     using TypedGemm_F4B6_S_S
         = TypedGemm<Float4x2, BFloat6x32, float, float, float, float, Float4x2, BFloat6x32>;
 #endif // defined(TENSILE_USE_BF6) && defined(TENSILE_USE_FP4)
+#endif // !_WIN32
 } // namespace TensileLite

--- a/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/DataInitialization.cpp
@@ -1925,6 +1925,10 @@ namespace TensileLite
                     case rocisa::DataType::BFloat8_fnuz:
                         prop.value = getValue<BFloat8_fnuz>(prop.init, prop.freeValue);
                         break;
+                    case rocisa::DataType::MXScale:
+                        prop.value = getValue<MXScale>(prop.init, prop.freeValue);
+                        break;
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
                     case rocisa::DataType::Float6:
                         prop.value = getValue<Float6x32>(prop.init, prop.freeValue);
@@ -1940,16 +1944,20 @@ namespace TensileLite
                         prop.value = getValue<Float4x2>(prop.init, prop.freeValue);
                         break;
 #endif // #ifdef TENSILE_USE_FP4
-                    case rocisa::DataType::MXScale:
-                        prop.value = getValue<MXScale>(prop.init, prop.freeValue);
-                        break;
+#endif // !_WIN32
                     case rocisa::DataType::Int64:
                     case rocisa::DataType::XFloat32:
                     case rocisa::DataType::Count:
                     case rocisa::DataType::Float8BFloat8:
                     case rocisa::DataType::BFloat8Float8:
                     case rocisa::DataType::Float8BFloat8_fnuz:
-                    case rocisa::DataType::BFloat8Float8_fnuz:;
+                    case rocisa::DataType::BFloat8Float8_fnuz:
+#ifdef _WIN32
+                    case rocisa::DataType::Float6:
+                    case rocisa::DataType::BFloat6:
+                    case rocisa::DataType::Float4:
+#endif // _WIN32
+                    ;
                     }
                 }
                 if(Debug::Instance().printTensorInfo() && prop.dataType != rocisa::DataType::None)

--- a/projects/hipblaslt/tensilelite/client/src/Reference.cpp
+++ b/projects/hipblaslt/tensilelite/client/src/Reference.cpp
@@ -813,6 +813,17 @@ namespace TensileLite
             throw std::runtime_error("Unsupported input type.");
         }
 
+#ifdef _WIN32
+        template <typename Accumulator,
+                  typename MathOpAccum,
+                  typename Type,
+                  typename ComputeInputType>
+        inline Accumulator getElement(ContractionProblemGemm const& problem,
+                                      Type const*                   ptr,
+                                      const size_t                  idx,
+                                      void const*                   scalePtr,
+                                      const bool                    conjugate)
+#else // _WIN32
         template <typename Accumulator,
                   typename MathOpAccum,
                   typename Type,
@@ -835,6 +846,7 @@ namespace TensileLite
                                       const size_t                  idx,
                                       void const*                   scalePtr,
                                       const bool                    conjugate)
+#endif // _WIN32
         {
             // case I8/I32/I32, I8 be implicitly cast to int.
             constexpr bool needAccumCast
@@ -867,6 +879,7 @@ namespace TensileLite
             return static_cast<Accumulator>(static_cast<MultT>(static_cast<MathOpMultT>(val)));
         }
 
+#ifndef _WIN32
         template <typename Accumulator,
                   typename MathOpAccum,
                   typename Type,
@@ -895,6 +908,7 @@ namespace TensileLite
 
             return static_cast<Accumulator>(ptr[packIdx].getElement(elemIdx));
         }
+#endif // !_WIN32
 
         template <typename Inputs,
                   typename Accumulator,
@@ -2350,6 +2364,7 @@ namespace TensileLite
 #endif // TENSILE_USE_HALF
 #endif // TENSILE_USE_FP8_BF8
 
+#ifndef _WIN32
 #ifdef TENSILE_USE_FP6
             case TypedGemm_F6_S_S::TypeId():
             {
@@ -2428,6 +2443,7 @@ namespace TensileLite
                     problem, inputs, elementsToValidate);
             }
 #endif // defined(TENSILE_USE_BF6) && defined(TENSILE_USE_FP4)
+#endif // !_WIN32
             default:;
             }
 

--- a/projects/hipblaslt/tensilelite/include/Tensile/DataTypes.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/DataTypes.hpp
@@ -302,6 +302,20 @@ namespace TensileLite
     {
     };
 
+#ifdef _WIN32
+    template <>
+    struct TypeInfo<Float6> : public BaseTypeInfo<Float6, rocisa::DataType::Float6, 1, false, false>
+    {
+    };
+    template <>
+    struct TypeInfo<BFloat6> : public BaseTypeInfo<BFloat6, rocisa::DataType::BFloat6, 1, false, false>
+    {
+    };
+    template <>
+    struct TypeInfo<Float4> : public BaseTypeInfo<Float4, rocisa::DataType::Float4, 1, false, false>
+    {
+    };
+#else // _WIN32
     template <>
     struct TypeInfo<Float6x32> : public BaseTypeInfo<Float6x32, rocisa::DataType::Float6, 32, false, false>
     {
@@ -314,6 +328,7 @@ namespace TensileLite
     struct TypeInfo<Float4x2> : public BaseTypeInfo<Float4x2, rocisa::DataType::Float4, 2, false, false>
     {
     };
+#endif // _WIN32
     template <>
     struct TypeInfo<MXScale>
         : public BaseTypeInfo<MXScale, rocisa::DataType::MXScale, 1, false, false>
@@ -335,9 +350,11 @@ namespace TensileLite
                                          Float8_fnuz,
                                          BFloat8_fnuz,
                                          int8_t,
+#ifndef _WIN32
                                          Float6x32,
                                          BFloat6x32,
                                          Float4x2,
+#endif // !_WIN32
                                          MXScale
                                         >;
 
@@ -407,6 +424,7 @@ namespace TensileLite
         return static_cast<T>(*std::get_if<Int8x4>(&val));
     }
 
+#ifndef _WIN32
     // Convert variants to type T
     template <typename T>
     typename std::enable_if<std::is_same<Float6x32, T>::value, T>::type
@@ -448,6 +466,7 @@ namespace TensileLite
             throw std::runtime_error("Unsupported variant cast type.");
         }
     }
+#endif // !_WIN32
 
     std::string ToString(ConstantVariant d);
     bool        CompareValue(const ConstantVariant& d, double value);

--- a/projects/hipblaslt/tensilelite/include/Tensile/DataTypes_BFloat6.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/DataTypes_BFloat6.hpp
@@ -30,6 +30,17 @@
 
 #ifdef TENSILE_USE_BF6
 
+#ifdef _WIN32
+
+#include <cstdint>
+
+namespace TensileLite
+{
+    typedef struct BFloat6{ uint8_t data;} BFloat6;
+} // end of namespace TensileLite
+
+#else // _WIN32
+
 #ifdef TENSILE_USE_HIP
 #include <hip/hip_runtime.h>
 #endif
@@ -295,5 +306,7 @@ namespace std
         return stream << to_string(a);
     }
 } // namespace std
+
+#endif // _WIN32
 
 #endif // TENSILE_USE_BF6

--- a/projects/hipblaslt/tensilelite/include/Tensile/DataTypes_Float4.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/DataTypes_Float4.hpp
@@ -30,6 +30,15 @@
 
 #ifdef TENSILE_USE_FP4
 
+#ifdef _WIN32
+
+namespace TensileLite
+{
+    typedef struct Float4{ uint8_t data;} Float4;
+} // end of namespace TensileLite
+
+#else // _WIN32
+
 #ifdef TENSILE_USE_HIP
 #include <hip/hip_runtime.h>
 #endif
@@ -145,5 +154,7 @@ namespace std
         return stream << static_cast<float>(result[0]) << " " << static_cast<float>(result[1]);
     }
 } // namespace std
+
+#endif // _WIN32
 
 #endif // TENSILE_USE_FP4

--- a/projects/hipblaslt/tensilelite/include/Tensile/DataTypes_Float6.hpp
+++ b/projects/hipblaslt/tensilelite/include/Tensile/DataTypes_Float6.hpp
@@ -30,6 +30,17 @@
 
 #ifdef TENSILE_USE_FP6
 
+#ifdef _WIN32
+
+#include <cstdint>
+
+namespace TensileLite
+{
+    typedef struct Float6{ uint8_t data;} Float6;
+} // end of namespace TensileLite
+
+#else // _WIN32
+
 #ifdef TENSILE_USE_HIP
 #include <hip/hip_runtime.h>
 #endif
@@ -295,5 +306,7 @@ namespace std
         return stream << to_string(a);
     }
 } // namespace std
+
+#endif // _WIN32
 
 #endif // TENSILE_USE_FP6

--- a/projects/hipblaslt/tensilelite/src/DataTypes.cpp
+++ b/projects/hipblaslt/tensilelite/src/DataTypes.cpp
@@ -129,12 +129,21 @@ namespace rocisa
             return TensileLite::TypeInfo<Float8BFloat8_fnuz>::ElementSize;
         case rocisa::DataType::BFloat8Float8_fnuz:
             return TensileLite::TypeInfo<BFloat8Float8_fnuz>::ElementSize;
+#ifdef _WIN32
+        case rocisa::DataType::Float6:
+            return TensileLite::TypeInfo<TensileLite::Float6>::ElementSize;
+        case rocisa::DataType::BFloat6:
+            return TensileLite::TypeInfo<TensileLite::BFloat6>::ElementSize;
+        case rocisa::DataType::Float4:
+            return TensileLite::TypeInfo<TensileLite::Float4>::ElementSize;
+#else // _WIN32
         case rocisa::DataType::Float6:
             return TensileLite::TypeInfo<TensileLite::Float6x32>::ElementSize;
         case rocisa::DataType::BFloat6:
             return TensileLite::TypeInfo<TensileLite::BFloat6x32>::ElementSize;
         case rocisa::DataType::Float4:
             return TensileLite::TypeInfo<TensileLite::Float4x2>::ElementSize;
+#endif // _WIN32
         case rocisa::DataType::MXScale:
             return TensileLite::TypeInfo<TensileLite::MXScale>::ElementSize;
         case rocisa::DataType::Count:
@@ -257,9 +266,15 @@ namespace TensileLite
         registerTypeInfo<BFloat8Float8>();
         registerTypeInfo<Float8BFloat8_fnuz>();
         registerTypeInfo<BFloat8Float8_fnuz>();
+#ifdef _WIN32
+        registerTypeInfo<Float6>();
+        registerTypeInfo<BFloat6>();
+        registerTypeInfo<Float4>();
+#else // _WIN32
         registerTypeInfo<Float6x32>();
         registerTypeInfo<BFloat6x32>();
         registerTypeInfo<Float4x2>();
+#endif // _WIN32
         registerTypeInfo<MXScale>();
     }
 


### PR DESCRIPTION
## Motivation

Disable mxDataGenerator for Windows builds.

## Technical Details

Disable mxDataGenerator for Windows builds.

The original PR failed `Tensile/Tests/common/gemm/gfx950/mx32f4_tn.yaml` since we removed data types. restore the original implementation with OS specific build dispatch.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
