### PR TITLE
[hipDNN] Update EngineNames.hpp path in plugin development docs

### DIFF
--- a/projects/hipdnn/docs/PluginDevelopment.md
+++ b/projects/hipdnn/docs/PluginDevelopment.md
@@ -124,7 +124,7 @@ To add your engine name to the official registry:
    - Use UPPER_CASE with underscores
    - Make the name match the value.
 
-2. **Add to Registry**: Submit a PR to add your engine name to [`plugin_sdk/include/hipdnn_plugin_sdk/EngineNames.hpp`](../plugin_sdk/include/hipdnn_plugin_sdk/EngineNames.hpp):
+2. **Add to Registry**: Submit a PR to add your engine name to [`data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp`](../data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp):
    ```cpp
    HIPDNN_REGISTER_ENGINE(MY_NEW_ENGINE, "MY_NEW_ENGINE")
    ```


### PR DESCRIPTION
The EngineNames.hpp file was moved from plugin_sdk to data_sdk/utilities. Update the documentation link to reflect the new location.

## Motivation

The `EngineNames.hpp` file was moved from `plugin_sdk/include/hipdnn_plugin_sdk/` to `data_sdk/include/hipdnn_data_sdk/utilities/` but the documentation still referenced the old path.

## Technical Details

Updated the file path reference in `projects/hipdnn/docs/PluginDevelopment.md` (line 127) to point to the new location:
- **Old path**: `plugin_sdk/include/hipdnn_plugin_sdk/EngineNames.hpp`
- **New path**: `data_sdk/include/hipdnn_data_sdk/utilities/EngineNames.hpp`

## Test Plan

Documentation-only change. Verify the link resolves correctly to the new file location.

## Test Result

N/A - Documentation update only

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
