### PR TITLE
[hipblaslt] Fix tailLoop errors in GLOBAL_OFFSET_{A or B} for fp16_gfx12.yaml

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/KernelWriterAssembly.py
@@ -8632,6 +8632,8 @@ class KernelWriterAssembly(KernelWriter):
       module.add(VSubU32(dst=vgpr(tmp2), src0=vgpr(tmp2), src1=1, comment="GLTr%s: unroll idx - 1"%(tc)))
       bfArgs = (maxGroVgpr, maxGroVgpr, tmp2, tmp)
       module.add(MacroInstruction(name="GLOBAL_OFFSET_%s"%tc, args=bfArgs))
+      # Convert element offset to byte offset (GLOBAL_OFFSET macro computes in elements)
+      module.add(vectorMultiplyBpe(vgpr(maxGroVgpr), vgpr(maxGroVgpr), tP["bpeGR"]))
 
       module.addSpaceLine()
 


### PR DESCRIPTION
## Motivation

- CI test `tox -e py3 -- Tensile/Tests -k  Tensile/Tests -k Tensile/Tests/common/gemm/gfx12/fp16_gfx12.yaml` always failed in gfx12 machines
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- The test passed when K = 256 (multiple of 32), but failed with K=255 and K=257
- So the problem occurred in TailLoop
- Look at the TailLoop asm code:
<img width="2796" height="290" alt="image" src="https://github.com/user-attachments/assets/ca974c71-6e65-45c1-8cd0-5ce6680454a9" />

- Every time we use GLOBAL_OFFSET_{A or B}, we have to add the `v_lshlrev_b32` back, but I found there is some mismatch between GLOBAL_OFFSET_* which is in the TailLoop.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Script: `tox -e py3 -- Tensile/Tests -k Tensile/Tests/common/gemm/gfx12/fp16_gfx12.yaml`.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

The test passed.
[fp16_gfx12_debug.log](https://github.com/user-attachments/files/25963352/fp16_gfx12_debug.log)


<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
