### PR TITLE
Adding a missing CheckXnackDisabled() in one of the tests to avoid failed tests with HSA_XNACK=1

### DIFF
--- a/projects/miopen/test/gtest/unit_conv_solver_ConvWinoRageRxS.cpp
+++ b/projects/miopen/test/gtest/unit_conv_solver_ConvWinoRageRxS.cpp
@@ -66,6 +66,7 @@ const auto& GetTestParams()
 {
     static const auto params = [] {
         auto p = miopen::unit_tests::UnitTestConvSolverParams(Gpu::gfx94X);
+        p.CheckXnackDisabled();
         return p;
     }();
     return params;


### PR DESCRIPTION
This is used in several other existing tests, but was missed in this case.

## Motivation

There were 17 failed tests from 4 test suites:
```
[==========] 17 tests from 4 test suites ran. (203 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 17 tests, listed below:
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/0, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {1,16,135,240}, {}), w:(0, none, {16,16,3,3}, {}), type_y:0), conv:({1,1}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/1, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {2,4,64,64}, {}), w:(0, none, {16,4,3,3}, {}), type_y:0), conv:({1,1}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/2, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {1,16,135,240}, {}), w:(0, none, {16,16,5,5}, {}), type_y:0), conv:({2,2}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/3, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {2,4,64,64}, {}), w:(0, none, {16,4,5,5}, {}), type_y:0), conv:({2,2}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/4, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {2,15,28,28}, {}), w:(0, none, {15,3,3,3}, {}), type_y:0), conv:({1,1}, {1,1}, {1,1}, 5)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/5, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {2,15,28,28}, {}), w:(0, none, {15,3,5,5}, {}), type_y:0), conv:({2,2}, {1,1}, {1,1}, 5)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/0, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {1,16,135,240}, {}), w:(0, none, {16,16,3,3}, {}), type_y:0), conv:({1,1}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/1, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {2,4,64,64}, {}), w:(0, none, {16,4,3,3}, {}), type_y:0), conv:({1,1}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/2, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {1,16,135,240}, {}), w:(0, none, {16,16,5,5}, {}), type_y:0), conv:({2,2}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/3, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {2,4,64,64}, {}), w:(0, none, {16,4,5,5}, {}), type_y:0), conv:({2,2}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/4, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {2,15,28,28}, {}), w:(0, none, {15,3,3,3}, {}), type_y:0), conv:({1,1}, {1,1}, {1,1}, 5)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/5, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {2,15,28,28}, {}), w:(0, none, {15,3,5,5}, {}), type_y:0), conv:({2,2}, {1,1}, {1,1}, 5)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Wrw_FP16.ConvWinoRageRxSf2x3/0, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {1,16,5,5}, {}), w:(0, none, {16,16,3,3}, {}), type_y:0), conv:({0,0}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Wrw_FP16.ConvWinoRageRxSf2x3/1, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {1,32,7,7}, {}), w:(0, none, {4,32,3,3}, {}), type_y:0), conv:({0,0}, {1,1}, {1,1}, 1)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Wrw_FP16.ConvWinoRageRxSf2x3/2, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {1,16,5,5}, {}), w:(0, none, {16,1,3,3}, {}), type_y:0), conv:({0,0}, {1,1}, {1,1}, 16)))
[  FAILED  ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Wrw_FP16.ConvWinoRageRxSf2x3/3, where GetParam() = ((Devs:0x10, Tolerances:()), 3, (x:(0, none, {2,16,28,28}, {}), w:(0, none, {16,1,5,5}, {}), type_y:0), conv:({2,2}, {1,1}, {1,1}, 16)))
[  FAILED  ] Smoke/CPU_UnitTestConvSolverWinoRage2x3DevApplicabilityFwd_NONE.ConvWinoRageRxSf2x3/0, where GetParam() = ((Devs:0x10, Tolerances:()), (x:(0, none, {1,16,135,240}, {}), w:(0, none, {16,16,3,3}, {}), type_y:0), conv:({1,1}, {1,1}, {1,1}, 1)))

17 FAILED TESTS
```

## Technical Details

The failures were occurring due to a test framework design issue rather than actual solver bugs.

The test framework has a built-in XNACK detection mechanism:

- `get_handle_xnack()` function checks if XNACK is enabled on the GPU handle
- When `params.check_xnack_disabled` is true and XNACK is detected, tests are skipped with `GTEST_SKIP()`
- However, the ConvWinoRageRxS tests didn't have `check_xnack_disabled` enabled in their test parameters

## Test Plan

Execute the failing tests after the fix and make sure they are skipped or pass.

## Test Result

```
[==========] 17 tests from 4 test suites ran. (418 ms total)
[  PASSED  ] 1 test.
[  SKIPPED ] 16 tests, listed below:
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/0
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/1
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/2
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/3
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/4
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Fwd_FP16.ConvWinoRageRxSf2x3/5
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/0
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/1
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/2
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/3
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/4
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Bwd_FP16.ConvWinoRageRxSf2x3/5
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Wrw_FP16.ConvWinoRageRxSf2x3/0
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Wrw_FP16.ConvWinoRageRxSf2x3/1
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Wrw_FP16.ConvWinoRageRxSf2x3/2
[  SKIPPED ] Smoke/GPU_UnitTestConvSolverWinoRage2x3Wrw_FP16.ConvWinoRageRxSf2x3/3
```
