### PR TITLE
[CK][CK_TILE] Compile time reduction: get_num_of_hidden_dimension

### DIFF
--- a/projects/composablekernel/include/ck/tensor_description/tensor_adaptor.hpp
+++ b/projects/composablekernel/include/ck/tensor_description/tensor_adaptor.hpp
@@ -121,11 +121,22 @@ struct TensorAdaptor
 
         constexpr auto all_dim_ids = merge_sequences(all_low_dim_ids, all_up_dim_ids);
 
-        using unique_sort_all_dim_ids = typename sequence_unique_sort<decltype(all_dim_ids),
-                                                                      math::less<index_t>,
-                                                                      math::equal<index_t>>::type;
+        // Fast path: all ids must be in the 0..63 range
+        constexpr index_t count = sequence_unique_count(all_dim_ids);
+        if constexpr(count >= 0)
+        {
+            return count;
+        }
+        else
+        {
+            // Fallback for theoretically possible ids > 63: use sorting
+            using unique_sort_all_dim_ids =
+                typename sequence_unique_sort<decltype(all_dim_ids),
+                                              math::less<index_t>,
+                                              math::equal<index_t>>::type;
 
-        return unique_sort_all_dim_ids::Size();
+            return unique_sort_all_dim_ids::Size();
+        }
     }
 
     constexpr static index_t ntransform_  = GetNumOfTransform();

--- a/projects/composablekernel/include/ck/tensor_description/tensor_adaptor.hpp
+++ b/projects/composablekernel/include/ck/tensor_description/tensor_adaptor.hpp
@@ -121,22 +121,7 @@ struct TensorAdaptor
 
         constexpr auto all_dim_ids = merge_sequences(all_low_dim_ids, all_up_dim_ids);
 
-        // Fast path: all ids must be in the 0..63 range
-        constexpr index_t count = sequence_unique_count(all_dim_ids);
-        if constexpr(count >= 0)
-        {
-            return count;
-        }
-        else
-        {
-            // Fallback for theoretically possible ids > 63: use sorting
-            using unique_sort_all_dim_ids =
-                typename sequence_unique_sort<decltype(all_dim_ids),
-                                              math::less<index_t>,
-                                              math::equal<index_t>>::type;
-
-            return unique_sort_all_dim_ids::Size();
-        }
+        return sequence_unique_count(all_dim_ids);
     }
 
     constexpr static index_t ntransform_  = GetNumOfTransform();

--- a/projects/composablekernel/include/ck/tensor_description/tensor_descriptor.hpp
+++ b/projects/composablekernel/include/ck/tensor_description/tensor_descriptor.hpp
@@ -44,11 +44,22 @@ struct TensorDescriptor
 
         constexpr auto all_dim_ids = merge_sequences(all_low_dim_ids, all_up_dim_ids);
 
-        using unique_sort_all_dim_ids = typename sequence_unique_sort<decltype(all_dim_ids),
-                                                                      math::less<index_t>,
-                                                                      math::equal<index_t>>::type;
+        // Fast path: all ids must be in the 0..63 range
+        constexpr index_t count = sequence_unique_count(all_dim_ids);
+        if constexpr(count >= 0)
+        {
+            return count;
+        }
+        else
+        {
+            // Fallback for theoretically possible ids > 63: use sorting
+            using unique_sort_all_dim_ids =
+                typename sequence_unique_sort<decltype(all_dim_ids),
+                                              math::less<index_t>,
+                                              math::equal<index_t>>::type;
 
-        return unique_sort_all_dim_ids::Size();
+            return unique_sort_all_dim_ids::Size();
+        }
     }
 
     __host__ __device__ static constexpr auto InitializeElementSize(const Transforms& transforms)

--- a/projects/composablekernel/include/ck/tensor_description/tensor_descriptor.hpp
+++ b/projects/composablekernel/include/ck/tensor_description/tensor_descriptor.hpp
@@ -44,22 +44,7 @@ struct TensorDescriptor
 
         constexpr auto all_dim_ids = merge_sequences(all_low_dim_ids, all_up_dim_ids);
 
-        // Fast path: all ids must be in the 0..63 range
-        constexpr index_t count = sequence_unique_count(all_dim_ids);
-        if constexpr(count >= 0)
-        {
-            return count;
-        }
-        else
-        {
-            // Fallback for theoretically possible ids > 63: use sorting
-            using unique_sort_all_dim_ids =
-                typename sequence_unique_sort<decltype(all_dim_ids),
-                                              math::less<index_t>,
-                                              math::equal<index_t>>::type;
-
-            return unique_sort_all_dim_ids::Size();
-        }
+        return sequence_unique_count(all_dim_ids);
     }
 
     __host__ __device__ static constexpr auto InitializeElementSize(const Transforms& transforms)

--- a/projects/composablekernel/include/ck/utility/sequence.hpp
+++ b/projects/composablekernel/include/ck/utility/sequence.hpp
@@ -672,29 +672,61 @@ struct sequence_unique_sort
     using sorted2unsorted_map = typename sorted_seqs::ids_type;
 };
 
+namespace detail {
+
+// All values must be in range [0, 63], otherwise returns -1
+template <index_t... Is>
+__host__ __device__ constexpr index_t sequence_unique_count_impl(Sequence<Is...>)
+{
+    constexpr index_t size = sizeof...(Is);
+    if constexpr(size == 0)
+    {
+        return 0;
+    }
+    else
+    {
+        constexpr index_t input[] = {Is...};
+
+        uint64_t set = 0;
+        for(index_t i = 0; i < size; ++i)
+        {
+            const index_t v = input[i];
+            if(v >= 0 && v < 64)
+            {
+                set |= (uint64_t{1} << v);
+            }
+            else
+            {
+                return -1;
+            }
+        }
+        return __builtin_popcountll(set);
+    }
+}
+
+} // namespace detail
+
 /**
- * @brief Count the number of unique values in a sequence, all values must be in range [0, 63]
- * otherwise returns -1. For such cases use sequence_unique_sort.
- * @tparam Seq sequence.
- * @return the number of unique values or -1 if any of values is not in range [0, 63].
+ * @brief Count the number of unique values in a sequence.
+ * @tparam Seq The input sequence.
+ * @return The number of unique values.
  */
 template <typename Seq>
 __host__ __device__ constexpr index_t sequence_unique_count(Seq)
 {
-    uint64_t set = 0;
-    for(index_t i = 0; i < Seq::Size(); ++i)
+    // Fast path when all values are in range [0, 63]
+    constexpr index_t count = detail::sequence_unique_count_impl(Seq{});
+    if constexpr(count >= 0)
     {
-        const index_t v = Seq::At(i);
-        if(v >= 0 && v < 64)
-        {
-            set |= (1ull << v);
-        }
-        else
-        {
-            return -1;
-        }
+        return count;
     }
-    return __builtin_popcountll(set);
+    else
+    {
+        // Use sorting as a universal fallback
+        using unique_sort =
+            typename sequence_unique_sort<Seq, math::less<index_t>, math::equal<index_t>>::type;
+        return unique_sort::Size();
+    }
 }
 
 template <typename SeqMap>

--- a/projects/composablekernel/include/ck/utility/sequence.hpp
+++ b/projects/composablekernel/include/ck/utility/sequence.hpp
@@ -672,6 +672,31 @@ struct sequence_unique_sort
     using sorted2unsorted_map = typename sorted_seqs::ids_type;
 };
 
+/**
+ * @brief Count the number of unique values in a sequence, all values must be in range [0, 63]
+ * otherwise returns -1. For such cases use sequence_unique_sort.
+ * @tparam Seq sequence.
+ * @return the number of unique values or -1 if any of values is not in range [0, 63].
+ */
+template <typename Seq>
+__host__ __device__ constexpr index_t sequence_unique_count(Seq)
+{
+    uint64_t set = 0;
+    for(index_t i = 0; i < Seq::Size(); ++i)
+    {
+        const index_t v = Seq::At(i);
+        if(v >= 0 && v < 64)
+        {
+            set |= (1ull << v);
+        }
+        else
+        {
+            return -1;
+        }
+    }
+    return __builtin_popcountll(set);
+}
+
 template <typename SeqMap>
 struct is_valid_sequence_map : is_same<typename arithmetic_sequence_gen<0, SeqMap::Size(), 1>::type,
                                        typename sequence_sort<SeqMap, math::less<index_t>>::type>

--- a/projects/composablekernel/include/ck_tile/core/container/sequence.hpp
+++ b/projects/composablekernel/include/ck_tile/core/container/sequence.hpp
@@ -782,29 +782,60 @@ struct sequence_unique_sort
     using sorted2unsorted_map = typename uniquify::uniquified_ids;
 };
 
+namespace detail {
+
+// All values must be in range [0, 63], otherwise returns -1
+template <index_t... Is>
+CK_TILE_HOST_DEVICE constexpr index_t sequence_unique_count_impl(sequence<Is...>)
+{
+    constexpr index_t size = sizeof...(Is);
+    if constexpr(size == 0)
+    {
+        return 0;
+    }
+    else
+    {
+        constexpr index_t input[] = {Is...};
+
+        uint64_t set = 0;
+        for(index_t i = 0; i < size; ++i)
+        {
+            const index_t v = input[i];
+            if(v >= 0 && v < 64)
+            {
+                set |= (uint64_t{1} << v);
+            }
+            else
+            {
+                return -1;
+            }
+        }
+        return __builtin_popcountll(set);
+    }
+}
+
+} // namespace detail
+
 /**
- * @brief Count the number of unique values in a sequence, all values must be in range [0, 63]
- * otherwise returns -1. For such cases use sequence_unique_sort.
- * @tparam Seq sequence.
- * @return the number of unique values or -1 if any of values is not in range [0, 63].
+ * @brief Count the number of unique values in a sequence.
+ * @tparam Seq The input sequence.
+ * @return The number of unique values.
  */
 template <typename Seq>
 CK_TILE_HOST_DEVICE constexpr index_t sequence_unique_count(Seq)
 {
-    uint64_t set = 0;
-    for(index_t i = 0; i < Seq::size(); ++i)
+    // Fast path when all values are in range [0, 63]
+    constexpr index_t count = detail::sequence_unique_count_impl(Seq{});
+    if constexpr(count >= 0)
     {
-        const index_t v = Seq::at(i);
-        if(v >= 0 && v < 64)
-        {
-            set |= (1ull << v);
-        }
-        else
-        {
-            return -1;
-        }
+        return count;
     }
-    return __builtin_popcountll(set);
+    else
+    {
+        // Use sorting as a universal fallback
+        using unique_sort = typename sequence_unique_sort<Seq, less<index_t>, equal<index_t>>::type;
+        return unique_sort::size();
+    }
 }
 
 template <typename SeqMap>

--- a/projects/composablekernel/include/ck_tile/core/container/sequence.hpp
+++ b/projects/composablekernel/include/ck_tile/core/container/sequence.hpp
@@ -782,6 +782,31 @@ struct sequence_unique_sort
     using sorted2unsorted_map = typename uniquify::uniquified_ids;
 };
 
+/**
+ * @brief Count the number of unique values in a sequence, all values must be in range [0, 63]
+ * otherwise returns -1. For such cases use sequence_unique_sort.
+ * @tparam Seq sequence.
+ * @return the number of unique values or -1 if any of values is not in range [0, 63].
+ */
+template <typename Seq>
+CK_TILE_HOST_DEVICE constexpr index_t sequence_unique_count(Seq)
+{
+    uint64_t set = 0;
+    for(index_t i = 0; i < Seq::size(); ++i)
+    {
+        const index_t v = Seq::at(i);
+        if(v >= 0 && v < 64)
+        {
+            set |= (1ull << v);
+        }
+        else
+        {
+            return -1;
+        }
+    }
+    return __builtin_popcountll(set);
+}
+
 template <typename SeqMap>
 struct is_valid_sequence_map
     : std::is_same<typename arithmetic_sequence_gen<0, SeqMap::size(), 1>::type,

--- a/projects/composablekernel/include/ck_tile/core/tensor/tensor_adaptor.hpp
+++ b/projects/composablekernel/include/ck_tile/core/tensor/tensor_adaptor.hpp
@@ -132,21 +132,7 @@ struct tensor_adaptor
 
         constexpr auto all_dim_ids = merge_sequences(all_low_dim_ids, all_up_dim_ids);
 
-        // Fast path: all ids must be in the 0..63 range
-        constexpr index_t count = sequence_unique_count(all_dim_ids);
-        if constexpr(count >= 0)
-        {
-            return count;
-        }
-        else
-        {
-            // Fallback for theoretically possible ids > 63: use sorting
-            using unique_sort_all_dim_ids = typename sequence_unique_sort<decltype(all_dim_ids),
-                                                                          less<index_t>,
-                                                                          equal<index_t>>::type;
-
-            return unique_sort_all_dim_ids::size();
-        }
+        return sequence_unique_count(all_dim_ids);
     }
 
     constexpr static index_t ntransform_  = get_num_of_transform();

--- a/projects/composablekernel/include/ck_tile/core/tensor/tensor_adaptor.hpp
+++ b/projects/composablekernel/include/ck_tile/core/tensor/tensor_adaptor.hpp
@@ -132,11 +132,21 @@ struct tensor_adaptor
 
         constexpr auto all_dim_ids = merge_sequences(all_low_dim_ids, all_up_dim_ids);
 
-        using unique_sort_all_dim_ids = typename sequence_unique_sort<decltype(all_dim_ids),
-                                                                      less<index_t>,
-                                                                      equal<index_t>>::type;
+        // Fast path: all ids must be in the 0..63 range
+        constexpr index_t count = sequence_unique_count(all_dim_ids);
+        if constexpr(count >= 0)
+        {
+            return count;
+        }
+        else
+        {
+            // Fallback for theoretically possible ids > 63: use sorting
+            using unique_sort_all_dim_ids = typename sequence_unique_sort<decltype(all_dim_ids),
+                                                                          less<index_t>,
+                                                                          equal<index_t>>::type;
 
-        return unique_sort_all_dim_ids::size();
+            return unique_sort_all_dim_ids::size();
+        }
     }
 
     constexpr static index_t ntransform_  = get_num_of_transform();

--- a/projects/composablekernel/test/ck_tile/core/container/unit_sequence.cpp
+++ b/projects/composablekernel/test/ck_tile/core/container/unit_sequence.cpp
@@ -380,6 +380,32 @@ TEST(SequenceUniqueSort, UniqueSortAllSame)
     EXPECT_TRUE((std::is_same<Result, Expected>::value));
 }
 
+// Test sequence_unique_count
+TEST(SequenceUniqueCount, UniqueCount)
+{
+    EXPECT_TRUE(sequence_unique_count(sequence<>{}) == 0);
+    EXPECT_TRUE(sequence_unique_count(sequence<3, 1, 4, 1, 5, 9, 2, 6, 5>{}) == 7);
+    EXPECT_TRUE(sequence_unique_count(sequence<31, 33, 31, 33>{}) == 2);
+}
+
+TEST(SequenceUniqueCount, UniqueCountNoDuplicates)
+{
+    EXPECT_TRUE(sequence_unique_count(sequence<5, 2, 8, 1, 9>{}) == 5);
+    EXPECT_TRUE(sequence_unique_count(sequence<0, 5, 2, 8, 1, 9, 11, 7, 34>{}) == 9);
+}
+
+TEST(SequenceUniqueCount, UniqueCountAllSame)
+{
+    EXPECT_TRUE(sequence_unique_count(sequence<5, 5, 5, 5>{}) == 1);
+    EXPECT_TRUE(sequence_unique_count(sequence<63, 63, 63>{}) == 1);
+}
+
+TEST(SequenceUniqueCount, UniqueCountOutOfRange)
+{
+    EXPECT_TRUE(sequence_unique_count(sequence<1, 2, -5, 3>{}) == -1);
+    EXPECT_TRUE(sequence_unique_count(sequence<100, 102>{}) == -1);
+}
+
 // Test is_valid_sequence_map
 TEST(SequenceMap, ValidMap)
 {

--- a/projects/composablekernel/test/ck_tile/core/container/unit_sequence.cpp
+++ b/projects/composablekernel/test/ck_tile/core/container/unit_sequence.cpp
@@ -385,25 +385,22 @@ TEST(SequenceUniqueCount, UniqueCount)
 {
     EXPECT_TRUE(sequence_unique_count(sequence<>{}) == 0);
     EXPECT_TRUE(sequence_unique_count(sequence<3, 1, 4, 1, 5, 9, 2, 6, 5>{}) == 7);
-    EXPECT_TRUE(sequence_unique_count(sequence<31, 33, 31, 33>{}) == 2);
+    EXPECT_TRUE(sequence_unique_count(sequence<63, 65, 63, 65>{}) == 2);
+    EXPECT_TRUE(sequence_unique_count(sequence<1, -3, 2, -3, 3>{}) == 4);
 }
 
 TEST(SequenceUniqueCount, UniqueCountNoDuplicates)
 {
     EXPECT_TRUE(sequence_unique_count(sequence<5, 2, 8, 1, 9>{}) == 5);
     EXPECT_TRUE(sequence_unique_count(sequence<0, 5, 2, 8, 1, 9, 11, 7, 34>{}) == 9);
+    EXPECT_TRUE(sequence_unique_count(sequence<-3, 2>{}) == 2);
+    EXPECT_TRUE(sequence_unique_count(sequence<60, 80>{}) == 2);
 }
 
 TEST(SequenceUniqueCount, UniqueCountAllSame)
 {
     EXPECT_TRUE(sequence_unique_count(sequence<5, 5, 5, 5>{}) == 1);
-    EXPECT_TRUE(sequence_unique_count(sequence<63, 63, 63>{}) == 1);
-}
-
-TEST(SequenceUniqueCount, UniqueCountOutOfRange)
-{
-    EXPECT_TRUE(sequence_unique_count(sequence<1, 2, -5, 3>{}) == -1);
-    EXPECT_TRUE(sequence_unique_count(sequence<100, 102>{}) == -1);
+    EXPECT_TRUE(sequence_unique_count(sequence<123, 123>{}) == 1);
 }
 
 // Test is_valid_sequence_map

--- a/projects/composablekernel/test/util/unit_sequence.cpp
+++ b/projects/composablekernel/test/util/unit_sequence.cpp
@@ -519,6 +519,32 @@ TEST(SequenceUniqueSort, UniqueSortAllSame)
     EXPECT_TRUE((is_same<Result, Expected>::value));
 }
 
+// Test sequence_unique_count
+TEST(SequenceUniqueCount, UniqueCount)
+{
+    EXPECT_TRUE(sequence_unique_count(Sequence<>{}) == 0);
+    EXPECT_TRUE(sequence_unique_count(Sequence<3, 1, 4, 1, 5, 9, 2, 6, 5>{}) == 7);
+    EXPECT_TRUE(sequence_unique_count(Sequence<31, 33, 31, 33>{}) == 2);
+}
+
+TEST(SequenceUniqueCount, UniqueCountNoDuplicates)
+{
+    EXPECT_TRUE(sequence_unique_count(Sequence<5, 2, 8, 1, 9>{}) == 5);
+    EXPECT_TRUE(sequence_unique_count(Sequence<0, 5, 2, 8, 1, 9, 11, 7, 34>{}) == 9);
+}
+
+TEST(SequenceUniqueCount, UniqueCountAllSame)
+{
+    EXPECT_TRUE(sequence_unique_count(Sequence<5, 5, 5, 5>{}) == 1);
+    EXPECT_TRUE(sequence_unique_count(Sequence<63, 63, 63>{}) == 1);
+}
+
+TEST(SequenceUniqueCount, UniqueCountOutOfRange)
+{
+    EXPECT_TRUE(sequence_unique_count(Sequence<1, 2, -5, 3>{}) == -1);
+    EXPECT_TRUE(sequence_unique_count(Sequence<100, 102>{}) == -1);
+}
+
 // Test is_valid_sequence_map
 TEST(SequenceMap, ValidMap)
 {

--- a/projects/composablekernel/test/util/unit_sequence.cpp
+++ b/projects/composablekernel/test/util/unit_sequence.cpp
@@ -524,25 +524,22 @@ TEST(SequenceUniqueCount, UniqueCount)
 {
     EXPECT_TRUE(sequence_unique_count(Sequence<>{}) == 0);
     EXPECT_TRUE(sequence_unique_count(Sequence<3, 1, 4, 1, 5, 9, 2, 6, 5>{}) == 7);
-    EXPECT_TRUE(sequence_unique_count(Sequence<31, 33, 31, 33>{}) == 2);
+    EXPECT_TRUE(sequence_unique_count(Sequence<63, 65, 63, 65>{}) == 2);
+    EXPECT_TRUE(sequence_unique_count(Sequence<1, -3, 2, -3, 3>{}) == 4);
 }
 
 TEST(SequenceUniqueCount, UniqueCountNoDuplicates)
 {
     EXPECT_TRUE(sequence_unique_count(Sequence<5, 2, 8, 1, 9>{}) == 5);
     EXPECT_TRUE(sequence_unique_count(Sequence<0, 5, 2, 8, 1, 9, 11, 7, 34>{}) == 9);
+    EXPECT_TRUE(sequence_unique_count(Sequence<-3, 2>{}) == 2);
+    EXPECT_TRUE(sequence_unique_count(Sequence<60, 80>{}) == 2);
 }
 
 TEST(SequenceUniqueCount, UniqueCountAllSame)
 {
     EXPECT_TRUE(sequence_unique_count(Sequence<5, 5, 5, 5>{}) == 1);
-    EXPECT_TRUE(sequence_unique_count(Sequence<63, 63, 63>{}) == 1);
-}
-
-TEST(SequenceUniqueCount, UniqueCountOutOfRange)
-{
-    EXPECT_TRUE(sequence_unique_count(Sequence<1, 2, -5, 3>{}) == -1);
-    EXPECT_TRUE(sequence_unique_count(Sequence<100, 102>{}) == -1);
+    EXPECT_TRUE(sequence_unique_count(Sequence<123, 123>{}) == 1);
 }
 
 // Test is_valid_sequence_map


### PR DESCRIPTION
## Motivation

Reduce compilation time of various CK and CK Tile kernels.

## Technical Details

`sequence_unique_sort` is used in these function:
 * `tensor_adaptor::get_num_of_hidden_dimension()`
 * `TensorAdaptor::GetNumOfHiddenDimension()`
 * `TensorDescriptor::GetNumOfHiddenDimension()`

These constexpr functions are called for every instance of tensor adaptor/descriptor, `sequence_unique_sort` is a heavy type requiring multiple instantiations of various other types and functions.  
However, only size of the sorted sequence of unique values is used, not the actual values.
When possible (potentially always) `sequence_unique_sort` calls are replaced with a special contextpr function `sequence_unique_count`.

For CK Tile FMHA this change reduces compile time by 5% (fwd instances) and 9% (bwd instances) for gfx950.
Other parts of CK and CK Tile still need a proper measurement of compile time.

## Test Plan

```
ninja ck_tile_unit_sequence && bin/ck_tile_unit_sequence
ninja unit_sequence && bin/unit_sequence
```
and basically all CK/CK tile instances/tests/examples depend on these functions internally.

## Test Result

All tests must pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
