### PR TITLE
[tensilelite][CMS] Add check to validate sub-iteration suffixes

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -503,6 +503,34 @@ class Timeline:
         has_lr3s = "LRA3" in available_keys or "LRB3" in available_keys
         assert not (has_lr1s and has_lr3s), "Can't mix LR1s and LR3s."
 
+        # Validate that sub-iteration suffixes are consistent with the kernel configuration.
+        # The valid suffixes depend on how numLoopIter is determined:
+        # - ForceUnrollSubIter=True: numLoopIter = numSubTiles² = 4 (KernelWriter.py:4592)
+        # - DepthU == matrixInstK (n_sub_iters == 1): split to numLoopIter = 2 (CustomSchedule.py:317)
+        # - DepthU > matrixInstK: numLoopIter = DepthU / matrixInstK
+        if "DepthU" in kernel and "MatrixInstruction" in kernel:
+            force_unroll = kernel.get("ForceUnrollSubIter", False)
+            if force_unroll:
+                valid_suffixes = {0, 1, 2, 3}
+            else:
+                n_sub_iters = kernel["DepthU"] // kernel["MatrixInstruction"][2]
+                if n_sub_iters == 1:
+                    valid_suffixes = {0, 1}
+                else:
+                    valid_suffixes = set(range(n_sub_iters))
+            for key in available_keys:
+                for prefix in ("LRA", "LRB", "PackA", "PackB"):
+                    if key.startswith(prefix):
+                        suffix_str = key[len(prefix):]
+                        if suffix_str.isdigit():
+                            suffix = int(suffix_str)
+                            assert suffix in valid_suffixes, (
+                                f"Schedule key '{key}' has sub-iteration index {suffix}, "
+                                f"but with DepthU={kernel['DepthU']} and matrixInstK={kernel['MatrixInstruction'][2]}, "
+                                f"valid sub-iteration indices are {sorted(valid_suffixes)}."
+                            )
+                        break
+
         self.num_vmfma = schedule_info.numMfma
         self.vlcnt_shift = defaultdict(int)
         self.vlcnt_shift[NO_GLOBAL_LOAD_LOOP] = schedule_info.nglshift

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -1004,7 +1004,7 @@ class TestCustomScheduleTF32:
 
         kernel.update({
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
-            "ForceUnrollSubIter": (True if plr == 0 else False), # internal state/config that needs to be set explicitly 
+            "ForceUnrollSubIter": (macro_tile[2] == mi[2]), # production sets True when DU == matrixInstK (Solution.py:1442)
             "MacroTile0": macro_tile[0], "MacroTile1": macro_tile[1], "DepthU": macro_tile[2],
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": plr,
             "GlobalReadVectorWidthA": 4, "GlobalReadVectorWidthB": 4, "LocalReadVectorWidthA": 4, "LocalReadVectorWidthB": 4,


### PR DESCRIPTION
## Motivation

Currently the validator accepts LRA{Y}s for any value of Y when creating the timeline, even invalid ones (e.g. LRA1 for a schedule that should have LRA3 based on kernel values).

When validating real schedules this is not a problem since the first validaiton pass asserts that the correct number of each instruction is passed based on `id_map`. However, unit tests do not create an `id_map`, and hench can create kernels and schedules with are not in agreement.

This PR add validation the ensure that the LRs/Packs provided fit the requirements of the provided kernel.

## Technical Details

Calculate which LR & Pack indices are valid for the current kernel and assert that all passed in LRs/Packs are valid.

## Test Plan

Run existing tests.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
