### PR TITLE
[Tensilelite][CMS] Test helper function to auto-update derived values

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
@@ -26,7 +26,7 @@ from collections.abc import Callable
 from typing import Any, Optional
 import unittest
 
-from test_CustomSchedule import create_base_kernel, ScheduleInfo
+from test_CustomSchedule import create_base_kernel, update_kernel, ScheduleInfo
 from Tensile.Components.CMSValidator import (
     create_unified_timeline, ValidatorPassContext, validate_timeline,
 )
@@ -85,14 +85,7 @@ class CMSValidationTestBase(unittest.TestCase):
         """Initialize kernel and compute number of VMFMAs."""
         self.kernel = create_base_kernel()
         if kernel_updates:
-            # Handle nested ProblemType updates
-            if "ProblemType" in kernel_updates:
-                self.kernel["ProblemType"].update(kernel_updates["ProblemType"])
-                # Create a copy without ProblemType for top-level update
-                remaining_updates = {k: v for k, v in kernel_updates.items() if k != "ProblemType"}
-                self.kernel.update(remaining_updates)
-            else:
-                self.kernel.update(kernel_updates)
+            update_kernel(self.kernel, kernel_updates)
         
         self.num_vmfma = self.kernel["MIWaveTileA"] * self.kernel["MIWaveTileB"]
         self.num_vmfma *= self.kernel["DepthU"] // self.kernel["MatrixInstruction"][2]

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -51,6 +51,8 @@ def create_base_kernel():
             "DataTypeB": _mock_dtype(),
             "TransposeA": False,
             "TransposeB": False,
+            "TLUA": True,
+            "TLUB": False,
         },
         "MacroTile0": 0, "MacroTile1": 0, "DepthU": 64,
         "PrefetchGlobalRead": 0, "PrefetchLocalRead": 0, "DirectToLds": 1,  "DtlPlusLdsBuf": False,
@@ -71,6 +73,26 @@ def create_base_kernel():
         "MIWaveTileB": 2,
     }
     return kernel
+
+def update_kernel(kernel, updates):
+    """Update kernel dict, auto-deriving TLUA/TLUB from TransposeA/TransposeB.
+
+    Args:
+        kernel: kernel dict to modify in-place
+        updates: dict mirroring the kernel structure. "ProblemType" key (if present)
+                 is applied via kernel["ProblemType"].update(); all other keys are
+                 applied via kernel.update(). If TransposeA or TransposeB appear in
+                 the ProblemType sub-dict, TLUA and TLUB are auto-derived.
+    """
+    if "ProblemType" in updates:
+        pt = updates.pop("ProblemType")
+        if "TransposeA" in pt or "TransposeB" in pt:
+            transA = pt.get("TransposeA", kernel["ProblemType"]["TransposeA"])
+            transB = pt.get("TransposeB", kernel["ProblemType"]["TransposeB"])
+            pt["TLUA"] = not transA
+            pt["TLUB"] = transB
+        kernel["ProblemType"].update(pt)
+    kernel.update(updates)
 
 class TestCustomScheduleBF16:
     @staticmethod
@@ -98,11 +120,11 @@ class TestCustomScheduleBF16:
 
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 256, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -140,11 +162,11 @@ class TestCustomScheduleBF16:
 
         kernel = create_base_kernel()
         dtype_8bit = _mock_dtype(is_8bit=True, num_bytes=1)
-        kernel["ProblemType"].update({
-            "DataType": dtype_8bit, "DataTypeA": dtype_8bit, "DataTypeB": dtype_8bit,
-            "TransposeA": True, "TransposeB": False
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_8bit, "DataTypeA": dtype_8bit, "DataTypeB": dtype_8bit,
+                "TransposeA": True, "TransposeB": False,
+            },
             "MacroTile0": 256, "MacroTile1": 256, "DepthU": 128,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 0,
             "GlobalReadVectorWidthA": 16, "GlobalReadVectorWidthB": 16, "LocalReadVectorWidthA": 16, "LocalReadVectorWidthB": 16,
@@ -171,11 +193,11 @@ class TestCustomScheduleBF16:
         """Tests the 256x96x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB,
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 256, "MacroTile1": 96, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -209,11 +231,11 @@ class TestCustomScheduleBF16:
         """Tests the 96x256x64 16-bit schedules."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 96, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -236,11 +258,11 @@ class TestCustomScheduleBF16:
         NT = not transA and transB
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 192, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -271,11 +293,11 @@ class TestCustomScheduleBF16:
         """Tests the 256x192x64 16-bit TN schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 256, "MacroTile1": 192, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -296,11 +318,11 @@ class TestCustomScheduleBF16:
         """Tests the 160x256x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 160, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -321,11 +343,11 @@ class TestCustomScheduleBF16:
         """Tests the 256x160x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 256, "MacroTile1": 160, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -352,11 +374,11 @@ class TestCustomScheduleBF16:
         """Tests the 256x240x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 256, "MacroTile1": 240, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 2, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -377,11 +399,11 @@ class TestCustomScheduleBF16:
         """Tests the 256x208x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 256, "MacroTile1": 208, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 2, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -409,11 +431,11 @@ class TestCustomScheduleBF16:
         """Tests the 224x256x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 224, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -441,11 +463,11 @@ class TestCustomScheduleBF16:
         """Tests the 192x320x64 16-bit NN schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 192, "MacroTile1": 320, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -481,11 +503,11 @@ class TestCustomScheduleBF16:
         NT = (not transA and transB)
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": mt0, "MacroTile1": mt1, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -514,11 +536,11 @@ class TestCustomScheduleBF16:
         """Tests the 256x224x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 256, "MacroTile1": 224, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -546,11 +568,11 @@ class TestCustomScheduleBF16:
         """Tests the 320x192x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 320, "MacroTile1": 192, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -583,11 +605,11 @@ class TestCustomScheduleBF16:
         TN = transA and not transB
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 240, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 2, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -615,11 +637,11 @@ class TestCustomScheduleBF16:
         """Tests the 208x256x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 208, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 2, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -646,11 +668,11 @@ class TestCustomScheduleBF16:
         """Tests the 208x256x64 16-bit schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 128, "MacroTile1": 224, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -683,11 +705,11 @@ class TestCustomScheduleBF16:
         mi_wave_tile = (mt0 // (mi[0] * mi_wave_group[0]), mt1 // (mi[1] * mi_wave_group[1]))
 
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": True, "TransposeB": False
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": True, "TransposeB": False,
+            },
             "MacroTile0": mt0, "MacroTile1": mt1, "DepthU": du,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -706,12 +728,11 @@ class TestCustomScheduleBF16:
         """Tests the 128x256x64  NN schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": False, "TransposeB": False
-        })
-
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": False, "TransposeB": False,
+            },
             "MacroTile0": 128, "MacroTile1": 256, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "DirectToLds": True,
@@ -738,11 +759,11 @@ class TestCustomScheduleBF16:
         """Tests the 352x192x64 16-bit TN schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 352, "MacroTile1": 192, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -768,11 +789,11 @@ class TestCustomScheduleBF16:
         """Tests the 224x320x64 16-bit TN schedule."""
         kernel = create_base_kernel()
         dtype_16bit = _mock_dtype(is_16bit=True, num_bytes=2)
-        kernel["ProblemType"].update({
-            "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "DataType": dtype_16bit, "DataTypeA": dtype_16bit, "DataTypeB": dtype_16bit,
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "MacroTile0": 224, "MacroTile1": 320, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
             "GlobalReadVectorWidthA": 8, "GlobalReadVectorWidthB": 8, "LocalReadVectorWidthA": 8, "LocalReadVectorWidthB": 8,
@@ -802,12 +823,12 @@ class TestCustomScheduleTF32:
         (False, False, 1),
         ])
     def test_schedule_192x256x32_TF32(self, transA, transB, vwa):
-        """Tests the 192x256x32 TF32 schedule."""        
+        """Tests the 192x256x32 TF32 schedule."""
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 192, "MacroTile1": 256, "DepthU": 32,
@@ -832,10 +853,10 @@ class TestCustomScheduleTF32:
     def test_schedule_128x192x32_TF32(self):
         """Tests the 128x192x32 TF32 TN schedule."""
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": True, "TransposeB": False
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": True, "TransposeB": False,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 128, "MacroTile1": 192, "DepthU": 32,
@@ -858,10 +879,10 @@ class TestCustomScheduleTF32:
     def test_schedule_192x128x32_TF32(self):
         """Tests the 192x128x32 TF32 TN schedule."""
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": True, "TransposeB": False
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": True, "TransposeB": False,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 192, "MacroTile1": 128, "DepthU": 32,
@@ -891,10 +912,10 @@ class TestCustomScheduleTF32:
     def test_schedule_256x256x32_TF32(self,transA, transB, lds_tr_inst, tr_lds, vwa, vwb):
         """Tests the 256x256x32 TF32 TN schedule."""
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 256, "MacroTile1": 256, "DepthU": 32,
@@ -929,10 +950,10 @@ class TestCustomScheduleTF32:
     def test_schedule_256x192x32_TF32(self, transA, transB, vwa):
         """Tests the 256x192x32 TF32 TN schedule."""
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 256, "MacroTile1": 192, "DepthU": 32,
@@ -959,10 +980,10 @@ class TestCustomScheduleTF32:
     def test_schedule_128x256x32_TF32(self):
         """Tests the 128x256x32 TF32 TN schedule."""
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": True, "TransposeB": False
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": True, "TransposeB": False,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": True,
             "MacroTile0": 128, "MacroTile1": 256, "DepthU": 32,
@@ -995,14 +1016,14 @@ class TestCustomScheduleTF32:
     def test_schedule_128x128x32(self, transA, transB, lds_tr_inst, tr_lds, plr, vwa, vwb, mi, ncp):
         """Tests the 128x128x32 TF32 schedule."""
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": transA, "TransposeB": transB
-        })
         macro_tile = (128,128,32)
         mi_wave_group = (2,2)
         mi_wave_tile = (macro_tile[0] // (mi[0] * mi_wave_group[0]), macro_tile[1] // (mi[1] * mi_wave_group[1]))
 
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "ForceUnrollSubIter": (macro_tile[2] == mi[2]), # production sets True when DU == matrixInstK (Solution.py:1442)
             "MacroTile0": macro_tile[0], "MacroTile1": macro_tile[1], "DepthU": macro_tile[2],
@@ -1040,10 +1061,10 @@ class TestCustomScheduleTF32:
     def test_schedule_128x128x64(self, transA, transB, lds_tr_inst, tr_lds, vwa):
         """Tests the 128x128x64 TF32 TN schedule."""
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": transA, "TransposeB": transB
-        })
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "MacroTile0": 128, "MacroTile1": 128, "DepthU": 64,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
@@ -1079,16 +1100,16 @@ class TestCustomScheduleTF32:
         """Tests the 128x160x64, 160x128x64 TF32 TN schedule and 160x128x64 TF32 NN."""
 
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": transA, "TransposeB": transB
-        })
 
         du = 64
         mi = [16,16,32,1]
         mi_wave_group = [2, 2]
         mi_wave_tile = (mt0 // (mi[0] * mi_wave_group[0]), mt1 // (mi[1] * mi_wave_group[1]))
 
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "MacroTile0": mt0, "MacroTile1": mt1, "DepthU": du,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,
@@ -1114,16 +1135,15 @@ class TestCustomScheduleTF32:
     def test_schedule_64x128x64_128x64x64(self, transA, transB, lds_tr_inst, tr_lds, mt0, mt1):
         """Tests the 64x128x64 & 128x64x64 TF32 TN schedules."""
         kernel = create_base_kernel()
-        kernel["ProblemType"].update({
-            "TransposeA": transA, "TransposeB": transB
-        })
         du = 64
         mi = [16,16,32,1]
         mi_wave_group = [2, 2]
         mi_wave_tile = (mt0 // (mi[0] * mi_wave_group[0]), mt1 // (mi[1] * mi_wave_group[1]))
 
-
-        kernel.update({
+        update_kernel(kernel, {
+            "ProblemType": {
+                "TransposeA": transA, "TransposeB": transB,
+            },
             "UseF32XEmulation": True, "UseDirect32XEmulation": True,
             "MacroTile0": mt0, "MacroTile1": mt1, "DepthU": du,
             "PrefetchGlobalRead": 2, "PrefetchLocalRead": 1,


### PR DESCRIPTION
## Motivation

Current test setup requires manually specifying certain internal parameters put into the kernel object which should not be manually specified and can be derived from the input kernel. This pr adds helper function to do that.

## Technical Details

Create a helper function for updating the base kernel which derives required values (e.g. TLUA/TLUB) based on the updated kernel.

## Test Plan

Run exisiting tests

## Test Result

Tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.