### PR TITLE
[HIPDNN] Fix Doxygen docs: exclude data_sdk Graph.hpp collision, document SDPA  enums and log levels

### DIFF
--- a/projects/hipdnn/Doxyfile
+++ b/projects/hipdnn/Doxyfile
@@ -1057,7 +1057,8 @@ RECURSIVE              = YES
 # run.
 
 EXCLUDE                = ./frontend/include/hipdnn_frontend/detail \
-                         ./frontend/include/hipdnn_frontend/node/detail
+                         ./frontend/include/hipdnn_frontend/node/detail \
+                         ./data_sdk/include/hipdnn_data_sdk/utilities/json/Graph.hpp
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -13,7 +13,9 @@
  *
  * The Graph class provides a fluent API for:
  * - Creating tensor descriptors (shape + dtype, no data yet)
- * - Adding operations (conv, batchnorm, layernorm, rmsnorm, pointwise, matmul)
+ * - Adding operations (convolution forward/dgrad/wgrad, batchnorm
+ *   forward/backward/inference, layernorm, rmsnorm, pointwise, matmul,
+ *   scaled dot-product attention, block-scale quantize/dequantize)
  * - Building (compiling) an execution plan for the GPU
  * - Executing the plan with real device pointers
  *

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Handle.hpp
@@ -181,22 +181,26 @@ using hipdnn_handle_deleter = HipdnnHandleDeleter;
 /// @brief snake_case alias for HipdnnHandlePtr
 using hipdnn_handle_ptr = HipdnnHandlePtr;
 
+/// @brief snake_case alias for createHipdnnHandle() (structured-binding style)
 inline auto create_hipdnn_handle(hipStream_t stream // NOLINT(readability-identifier-naming)
                                  = nullptr)
 {
     return createHipdnnHandle(stream);
 }
+/// @brief snake_case alias for createHipdnnHandle() (output-parameter style)
 inline Error create_hipdnn_handle(HipdnnHandlePtr& handle, // NOLINT(readability-identifier-naming)
                                   hipStream_t stream = nullptr)
 {
     return createHipdnnHandle(handle, stream);
 }
+/// @brief snake_case alias for setHipdnnHandleStream()
 inline Error
     set_hipdnn_handle_stream(const HipdnnHandlePtr& h, // NOLINT(readability-identifier-naming)
                              hipStream_t s)
 {
     return setHipdnnHandleStream(h, s);
 }
+/// @brief snake_case alias for getHipdnnHandleStream()
 inline Error
     get_hipdnn_handle_stream(const HipdnnHandlePtr& h, // NOLINT(readability-identifier-naming)
                              hipStream_t* s)

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Logging.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Logging.hpp
@@ -12,7 +12,16 @@
  * backend or plugin messages.
  *
  * Log verbosity is controlled by the `HIPDNN_LOG_LEVEL` environment
- * variable (e.g. `HIPDNN_LOG_LEVEL=info`).
+ * variable. Valid values (case-insensitive):
+ * | Value   | Effect                                      |
+ * |---------|---------------------------------------------|
+ * | `info`  | Informational messages and above             |
+ * | `warn`  | Warnings and above                          |
+ * | `error` | Errors and fatal messages only               |
+ * | `fatal` | Fatal messages only                          |
+ * | `off`   | Disable all logging (default)                |
+ *
+ * Example: `HIPDNN_LOG_LEVEL=warn`
  */
 
 #pragma once

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Logging.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Logging.hpp
@@ -3,13 +3,7 @@
 
 /**
  * @file Logging.hpp
- * @brief Frontend logging initialization and convenience macros
- *
- * hipDNN uses a callback-based logging system (similar to Python's
- * `logging` module). The macros in this file — HIPDNN_FE_LOG_INFO,
- * HIPDNN_FE_LOG_WARN, etc. — auto-initialize on first use and tag every
- * message with "hipdnn_frontend" so you can filter frontend output from
- * backend or plugin messages.
+ * @brief Frontend logging configuration and log-level control
  *
  * Log verbosity is controlled by the `HIPDNN_LOG_LEVEL` environment
  * variable. Valid values (case-insensitive):
@@ -33,19 +27,10 @@
 namespace hipdnn_frontend
 {
 
+/// @cond INTERNAL
 /// @brief Component name used for all frontend log messages
 inline constexpr const char* K_COMPONENT_NAME = "hipdnn_frontend";
 
-/**
- * @brief Initialize the frontend logging subsystem
- *
- * Registers a logging callback and reads the log level from the environment.
- * Subsequent calls are no-ops (initialization happens at most once per
- * shared object). The HIPDNN_FE_LOG_* macros call this automatically.
- *
- * @param fn Logging callback function (defaults to the backend-provided callback)
- * @return 0 on success or if already initialized, -1 if fn is null
- */
 HIPDNN_HIDDEN inline int32_t initializeFrontendLogging(hipdnnCallback_t fn
                                                        = hipdnnLoggingCallback_ext)
 {
@@ -74,21 +59,9 @@ HIPDNN_HIDDEN inline int32_t initializeFrontendLogging(hipdnnCallback_t fn
 
     return 0;
 }
+/// @endcond
 
-/**
- * @name Frontend Logging Macros
- * @brief Auto-initializing logging macros for the hipDNN frontend
- *
- * These macros initialize logging on first use and emit messages with
- * "hipdnn_frontend" as the component name. Supports streaming syntax:
- * @code{.cpp}
- * HIPDNN_FE_LOG_INFO("value = " << x);
- * @endcode
- * @{
- */
-
-/** @def HIPDNN_FE_LOG_INFO
- *  @brief Log an informational message */
+/// @cond INTERNAL
 #define HIPDNN_FE_LOG_INFO(msg)                                                     \
     do                                                                              \
     {                                                                               \
@@ -96,8 +69,6 @@ HIPDNN_HIDDEN inline int32_t initializeFrontendLogging(hipdnnCallback_t fn
         HIPDNN_SDK_LOG_INFO_WITH_COMPONENT(hipdnn_frontend::K_COMPONENT_NAME, msg); \
     } while(0)
 
-/** @def HIPDNN_FE_LOG_WARN
- *  @brief Log a warning message */
 #define HIPDNN_FE_LOG_WARN(msg)                                                     \
     do                                                                              \
     {                                                                               \
@@ -105,8 +76,6 @@ HIPDNN_HIDDEN inline int32_t initializeFrontendLogging(hipdnnCallback_t fn
         HIPDNN_SDK_LOG_WARN_WITH_COMPONENT(hipdnn_frontend::K_COMPONENT_NAME, msg); \
     } while(0)
 
-/** @def HIPDNN_FE_LOG_ERROR
- *  @brief Log an error message */
 #define HIPDNN_FE_LOG_ERROR(msg)                                                     \
     do                                                                               \
     {                                                                                \
@@ -114,15 +83,13 @@ HIPDNN_HIDDEN inline int32_t initializeFrontendLogging(hipdnnCallback_t fn
         HIPDNN_SDK_LOG_ERROR_WITH_COMPONENT(hipdnn_frontend::K_COMPONENT_NAME, msg); \
     } while(0)
 
-/** @def HIPDNN_FE_LOG_FATAL
- *  @brief Log a fatal error message */
 #define HIPDNN_FE_LOG_FATAL(msg)                                                     \
     do                                                                               \
     {                                                                                \
         hipdnn_frontend::initializeFrontendLogging();                                \
         HIPDNN_SDK_LOG_FATAL_WITH_COMPONENT(hipdnn_frontend::K_COMPONENT_NAME, msg); \
     } while(0)
-/** @} */ // end of Frontend Logging Macros group
+/// @endcond
 
 // === Logging Callback and Log Level APIs ===
 

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Types.hpp
@@ -13,6 +13,11 @@
  * | PointwiseMode | Activation / element-wise op | relu, gelu, add, mul, etc. |
  * | ConvolutionMode | Filter application method | Cross-correlation vs mathematical convolution |
  * | NormFwdPhase | Training vs inference | Whether to save stats for backward pass |
+ * | DiagonalAlignment | SDPA causal mask alignment | Top-left vs bottom-right diagonal |
+ * | AttentionImplementation | SDPA execution strategy | Auto, composite, or unified kernel |
+ * | HeuristicMode | Engine discovery mode | How engines are ranked |
+ * | BuildPlanPolicy | Plan selection policy | Heuristic choice vs build all |
+ * | KnobValueType | Engine knob data type | int64, float64, or string |
  *
  * This file also contains conversion utilities between frontend types and
  * the internal SDK/backend types.
@@ -149,20 +154,45 @@ enum class DataType
 };
 typedef DataType DataType_t; ///< @brief Type alias for DataType
 
+/**
+ * @enum DiagonalAlignment
+ * @brief Diagonal alignment mode for SDPA causal masking
+ *
+ * Controls which corner of the attention matrix the causal mask diagonal
+ * is anchored to. This affects how the triangular mask is positioned
+ * when query and key sequence lengths differ (S_q != S_kv).
+ *
+ * For equal-length sequences both modes produce the same mask. When
+ * S_q < S_kv, BOTTOM_RIGHT aligns the mask so that each query attends
+ * to the most recent keys rather than the earliest.
+ *
+ * @see SdpaAttributes::set_diagonal_alignment()
+ */
 enum class DiagonalAlignment
 {
-    TOP_LEFT = 0,
-    BOTTOM_RIGHT = 1,
+    TOP_LEFT = 0, ///< Anchor mask diagonal to the top-left corner of the attention matrix
+    BOTTOM_RIGHT = 1, ///< Anchor mask diagonal to the bottom-right corner of the attention matrix
 };
-typedef DiagonalAlignment DiagonalAlignment_t; // NOLINT(readability-identifier-naming)
+// NOLINTNEXTLINE(readability-identifier-naming)
+typedef DiagonalAlignment DiagonalAlignment_t; ///< @brief Type alias for DiagonalAlignment
 
+/**
+ * @enum AttentionImplementation
+ * @brief Execution strategy for scaled dot-product attention
+ *
+ * Selects how the SDPA computation is mapped to GPU kernels.
+ *
+ * @see SdpaAttributes::set_implementation()
+ */
 enum class AttentionImplementation
 {
-    AUTO = 0,
-    COMPOSITE = 1,
-    UNIFIED = 2,
+    AUTO = 0, ///< Let the backend choose the best strategy for the given configuration
+    COMPOSITE = 1, ///< Decompose attention into separate matmul, softmax, and matmul kernels
+    UNIFIED = 2, ///< Use a single fused kernel for the entire attention computation
 };
-typedef AttentionImplementation AttentionImplementation_t; // NOLINT(readability-identifier-naming)
+// NOLINTNEXTLINE(readability-identifier-naming)
+typedef AttentionImplementation
+    AttentionImplementation_t; ///< @brief Type alias for AttentionImplementation
 
 /**
  * @enum HeuristicMode
@@ -564,6 +594,7 @@ inline hipdnn_frontend::DataType fromSdkType(const hipdnn_data_sdk::data_objects
     }
 }
 
+/// @brief Convert frontend DiagonalAlignment to SDK DiagonalAlignment
 inline hipdnn_data_sdk::data_objects::DiagonalAlignment toSdkType(const DiagonalAlignment& type)
 {
     switch(type)
@@ -577,6 +608,7 @@ inline hipdnn_data_sdk::data_objects::DiagonalAlignment toSdkType(const Diagonal
     }
 }
 
+/// @brief Convert SDK DiagonalAlignment to frontend DiagonalAlignment
 inline hipdnn_frontend::DiagonalAlignment
     fromSdkType(const hipdnn_data_sdk::data_objects::DiagonalAlignment& type)
 {
@@ -591,6 +623,7 @@ inline hipdnn_frontend::DiagonalAlignment
     }
 }
 
+/// @brief Convert frontend AttentionImplementation to SDK AttentionImplementation
 inline hipdnn_data_sdk::data_objects::AttentionImplementation
     toSdkType(const AttentionImplementation& type)
 {
@@ -607,6 +640,7 @@ inline hipdnn_data_sdk::data_objects::AttentionImplementation
     }
 }
 
+/// @brief Convert SDK AttentionImplementation to frontend AttentionImplementation
 inline hipdnn_frontend::AttentionImplementation
     fromSdkType(const hipdnn_data_sdk::data_objects::AttentionImplementation& type)
 {


### PR DESCRIPTION
## Motivation
 
  These are all gaps visible on the public-facing Doxygen site. The `Graph.hpp` collision
  produced a broken link, the SDPA enums rendered without explanations (users have no way
  to choose between `TOP_LEFT`/`BOTTOM_RIGHT` or `AUTO`/`COMPOSITE`/`UNIFIED` without
  reading source), and the overview sections were incomplete — giving the impression that
  the API surface is smaller than it actually is. No functional code changes; docs only.