### PR TITLE
[TensileLite] Migrate unit tests to pytest from unittest

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/cms_validation_base.py
@@ -24,15 +24,13 @@
 ################################################################################
 from collections.abc import Callable
 from typing import Any, Optional
-import unittest
-
 from test_CustomSchedule import create_base_kernel, update_kernel, ScheduleInfo
 from Tensile.Components.CMSValidator import (
     create_unified_timeline, ValidatorPassContext, validate_timeline,
 )
 
 
-class CMSValidationTestBase(unittest.TestCase):
+class CMSValidationTestBase:
     """
     Base class for CMS validation tests that provides common setup and helper methods.
 
@@ -81,8 +79,15 @@ class CMSValidationTestBase(unittest.TestCase):
             return False, message
         return True, ""
     
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None):
-        """Initialize kernel and compute number of VMFMAs."""
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None):
+        """Initialize kernel and compute number of VMFMAs.
+
+        Args:
+            method: The test method about to run (passed by pytest automatically).
+                    Defaulted to None so subclasses can call super().setup_method(method)
+                    even when invoked without it.
+            kernel_updates: Optional dict of kernel config overrides.
+        """
         self.kernel = create_base_kernel()
         if kernel_updates:
             update_kernel(self.kernel, kernel_updates)

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_EstimateQuadCyclesForValidator.py
@@ -23,8 +23,6 @@
 # SPDX-License-Identifier: MIT
 ################################################################################
 
-import unittest
-
 from Tensile.Components.CMSValidator import estimate_quad_cycles_precomputed, MFMA, MFMAPack, Pack, precompute_issue_times, SchedulePosition, SNop, ValidatorInstruction
 
 
@@ -32,7 +30,7 @@ def _pos(vmfma_index: int, sub_index: int) -> SchedulePosition:
     return SchedulePosition(loop_index=0, vmfma_index=vmfma_index, sub_index=sub_index)
 
 
-class TestEstimateQuadCyclesValidator(unittest.TestCase):
+class TestEstimateQuadCyclesValidator:
     def validate(self, instruction: ValidatorInstruction, expected_quad_cycles: int, all_instructions: list[ValidatorInstruction]):
         """
         Helper method to validate quad-cycle estimation.

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_GRMustStartAfterGRInc.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_GRMustStartAfterGRInc.py
@@ -41,9 +41,6 @@ class TestGRMustStartAfterGRInc(CMSValidationTestBase):
     """
     validator_passes = [add_gr_not_too_early_constraints]
 
-    def setUp(self):
-        super().setUp()
-
     def test_basic_grinc_before_gr(self):
         """
         GRIncA finishes well before GRA.

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
@@ -37,9 +37,6 @@ class TestValidateGlobalReadsNotTooEarly(CMSValidationTestBase):
     """
     validator_passes = [add_gr_not_too_early_constraints]
 
-    def setUp(self):
-        super().setUp()
-
     def test_basic(self):
         """
         LRA0 at 0, LRB0 at 1. SWaitCnt(dscnt=0) at 3, SBarrier at 4.
@@ -729,8 +726,8 @@ class TestValidateGlobalReadsNotTooEarlyDtlPlusLdsBuf(CMSValidationTestBase):
     """
     validator_passes = [add_gr_not_too_early_constraints]
 
-    def setUp(self):
-        super().setUp()
+    def setup_method(self, method=None):
+        super().setup_method(method)
         self.kernel["DtlPlusLdsBuf"] = True
 
     def test_basic(self):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateGlobalReadsNotTooEarly.py
@@ -20,6 +20,7 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
+from typing import Any, Optional
 from Tensile.Components.CMSValidator import add_gr_not_too_early_constraints
 from rocisa.instruction import SBarrier, SWaitCnt
 from cms_validation_base import CMSValidationTestBase
@@ -726,9 +727,10 @@ class TestValidateGlobalReadsNotTooEarlyDtlPlusLdsBuf(CMSValidationTestBase):
     """
     validator_passes = [add_gr_not_too_early_constraints]
 
-    def setup_method(self, method=None):
-        super().setup_method(method)
-        self.kernel["DtlPlusLdsBuf"] = True
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None):
+        kernel_updates = kernel_updates.copy() if kernel_updates else {}
+        kernel_updates.update({"DtlPlusLdsBuf": True})
+        super().setup_method(method, kernel_updates=kernel_updates)
 
     def test_basic(self):
         """

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -267,7 +267,7 @@ class TestValidateLRsCompleteBeforeVMFMA(CMSValidationTestBase):
         Case where each LR reads more than 1 WaveTile worth of data.
         Even though there are 4 tiles of A and 4 of B there are only 2 LRAs and 2 LRBs, each loading 2 tiles of A and B respectively.
         """
-        self.setUp({
+        self.setup_method(kernel_updates={
             "MIWaveTileA": 4,
             "MIWaveTileB": 4
         })
@@ -359,10 +359,10 @@ class TestValidateLRsCompleteBeforeVMFMA_tf32(CMSValidationTestBase):
     LRB3 needed at 12 (0 of next iter)
     LRA3 needed at 12 (0 of next iter)
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None):
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None):
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates.update({"UseF32XEmulation": True, "ISA": IsaVersion(9,5,0), "DepthU": 32, "ForceUnrollSubIter": True})
-        super().setUp(kernel_updates)
+        super().setup_method(method, kernel_updates=kernel_updates)
 
     validator_passes = [add_local_read_constraints]
 
@@ -528,7 +528,7 @@ class TestValidateLRsCompleteBeforeVMFMA_MfmaReorder(CMSValidationTestBase):
         - needed_by = 4
         """
         # Use 3x2 tile configuration
-        self.setUp({"MIWaveTileA": 3, "MIWaveTileB": 2})
+        self.setup_method(kernel_updates={"MIWaveTileA": 3, "MIWaveTileB": 2})
         assert self.num_vmfma == 12  # 2 * 3 * 2
         
         # Reorder: Reorder to row-major order.
@@ -576,7 +576,7 @@ class TestValidateLRsCompleteBeforeVMFMA_MfmaReorder(CMSValidationTestBase):
     def test_tf32(self):
         """
         """
-        self.setUp({"UseF32XEmulation": True, "ISA": IsaVersion(9,5,0), "DepthU": 32, "ForceUnrollSubIter": True})
+        self.setup_method(kernel_updates={"UseF32XEmulation": True, "ISA": IsaVersion(9,5,0), "DepthU": 32, "ForceUnrollSubIter": True})
         assert self.num_vmfma == 12
         
         # Row-major reordering: swap middle two groups
@@ -632,8 +632,8 @@ class TestValidateLRsCompleteBeforeVMFMA_ForceUnrollSubIter(CMSValidationTestBas
     NOTE:   These tests do not include the Pack commands which are REQUIRED for a valid kernel.
             Not including them here in order to test just the LR-VMFMA orderling logic.
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None):
-        super().setUp({"ForceUnrollSubIter": True, "MIWaveTileA": 4, "MIWaveTileB": 4, "DepthU": 32})
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None):
+        super().setup_method(method, kernel_updates={"ForceUnrollSubIter": True, "MIWaveTileA": 4, "MIWaveTileB": 4, "DepthU": 32})
 
     validator_passes = [add_local_read_constraints]
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateLRsCompleteBeforeVMFMA.py
@@ -633,7 +633,9 @@ class TestValidateLRsCompleteBeforeVMFMA_ForceUnrollSubIter(CMSValidationTestBas
             Not including them here in order to test just the LR-VMFMA orderling logic.
     """
     def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None):
-        super().setup_method(method, kernel_updates={"ForceUnrollSubIter": True, "MIWaveTileA": 4, "MIWaveTileB": 4, "DepthU": 32})
+        kernel_updates = kernel_updates.copy() if kernel_updates else {}
+        kernel_updates.update({"ForceUnrollSubIter": True, "MIWaveTileA": 4, "MIWaveTileB": 4, "DepthU": 32})
+        super().setup_method(method, kernel_updates=kernel_updates)
 
     validator_passes = [add_local_read_constraints]
 

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
@@ -37,9 +37,6 @@ class TestValidatePackBF16(CMSValidationTestBase):
     Validate the Pack instructions present in BF16 kernels.
     Here, the pack commands map to v_perm.
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
-        super().setUp(kernel_updates)
-    
     validator_passes = [add_local_read_constraints, add_pack_constraints]
 
     def test_passing(self):
@@ -138,8 +135,8 @@ class TestValidatePackBF16MFMAReorder(CMSValidationTestBase):
     | 4 6 | -> | 4 5 |
     | 5 7 | -> | 6 7 |
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
-        super().setUp(kernel_updates)
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
+        super().setup_method(method, kernel_updates=kernel_updates)
         self.mfma_reorder = [0, 2, 1, 3, 4, 6, 5, 7]
     
     validator_passes = [add_local_read_constraints, add_pack_constraints]
@@ -218,10 +215,10 @@ class TestValidatePackBF16PLRPack(CMSValidationTestBase):
     Validate the Pack instructions present in BF16 kernels with UsePLRPack.
     Here, Pack commands map to v_perm.
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
-        super().setUp(kernel_updates)
+        super().setup_method(method, kernel_updates=kernel_updates)
     
     validator_passes = [add_local_read_constraints, add_pack_constraints]
 
@@ -363,14 +360,14 @@ class TestValidatePackTF32(CMSValidationTestBase):
     """
     Only tests with UsePLRPack since performance is better.
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
         kernel_updates["ForceUnrollSubIter"] = True
         kernel_updates["UseDirect32XEmulation"] = True
         kernel_updates["DepthU"] = 32
-        super().setUp(kernel_updates)
+        super().setup_method(method, kernel_updates=kernel_updates)
 
         self.q1s = 0
         self.q1e = self.num_vmfma // 4 - 1
@@ -544,7 +541,7 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
     
     MFMA reorder swaps Q2 and Q3 (indices 12-23 execute at 24-35 positions and vice versa).
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
@@ -553,7 +550,7 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
         kernel_updates["DepthU"] = 32
         kernel_updates["MIWaveTileA"] = 4  # Need >= 4 for n_tiles_quarter >= 1
         kernel_updates["MIWaveTileB"] = 4  # Need >= 4 for n_tiles_quarter >= 1
-        super().setUp(kernel_updates)
+        super().setup_method(method, kernel_updates=kernel_updates)
 
         self.q1s = 0
         self.q1e = self.num_vmfma // 4 - 1
@@ -626,7 +623,7 @@ class TestValidatePackTF32CrossPackInterleaving(CMSValidationTestBase):
     Tests for TF32 validation with PackA0 and PackB0 interleaving.
     Seperate class since more MFMAs are needed to allow for enough room to interleave.
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
@@ -635,7 +632,7 @@ class TestValidatePackTF32CrossPackInterleaving(CMSValidationTestBase):
         kernel_updates["DepthU"] = 32
         kernel_updates["MIWaveTileA"] = 4
         kernel_updates["MIWaveTileB"] = 4
-        super().setUp(kernel_updates)
+        super().setup_method(method, kernel_updates=kernel_updates)
     
     validator_passes = [add_local_read_constraints, add_pack_constraints]
     
@@ -732,7 +729,7 @@ class TestValidatePackTF32MultipleGroups(CMSValidationTestBase):
     The middle-16 packs (indices 4-19 within each group of 24) share a temporary register
     and must be scheduled as pairs without any other middle-16 pack between them.
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
@@ -743,7 +740,7 @@ class TestValidatePackTF32MultipleGroups(CMSValidationTestBase):
         # 4 A tiles to get 2 groups of 24 packs (48 total)
         kernel_updates["MIWaveTileA"] = 4
         kernel_updates["MIWaveTileB"] = 2
-        super().setUp(kernel_updates)
+        super().setup_method(method, kernel_updates=kernel_updates)
 
         self.q1s = 0
         self.q1e = self.num_vmfma // 4 - 1
@@ -871,7 +868,7 @@ class TestValidatePackTF32MFMA4x4x4(CMSValidationTestBase):
     """
     Tests for TF32 validation with 4x4x4 MFMA.
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
@@ -881,7 +878,7 @@ class TestValidatePackTF32MFMA4x4x4(CMSValidationTestBase):
         kernel_updates["DepthU"] = 32
         kernel_updates["MIWaveTileA"] = 4
         kernel_updates["MIWaveTileB"] = 4
-        super().setUp(kernel_updates)
+        super().setup_method(method, kernel_updates=kernel_updates)
 
         self.q1s = 0
         self.q1e = self.num_vmfma // 4 - 1
@@ -1170,7 +1167,7 @@ class TestValidatePackTF32MFMA4x4x4MultipleTiles(CMSValidationTestBase):
     - Tile 2 (packs 20-29): needed by MFMAs at base_offset + 6
     - Tile 3 (packs 30-39): needed by MFMAs at base_offset + 9
     """
-    def setUp(self, kernel_updates: Optional[dict[str, Any]] = None) -> None:
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
         kernel_updates["UsePLRPack"] = True
         kernel_updates["UseF32XEmulation"] = True
@@ -1180,7 +1177,7 @@ class TestValidatePackTF32MFMA4x4x4MultipleTiles(CMSValidationTestBase):
         kernel_updates["DepthU"] = 32
         kernel_updates["MIWaveTileA"] = 4
         kernel_updates["MIWaveTileB"] = 2
-        super().setUp(kernel_updates)
+        super().setup_method(method, kernel_updates=kernel_updates)
 
         # With 4 A tiles, 2 B tiles, 3 MFMAs per tile = 24 vmfmas
         self.q1s = 0

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidatePack.py
@@ -217,7 +217,7 @@ class TestValidatePackBF16PLRPack(CMSValidationTestBase):
     """
     def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
-        kernel_updates["UsePLRPack"] = True
+        kernel_updates.update({"UsePLRPack": True})
         super().setup_method(method, kernel_updates=kernel_updates)
     
     validator_passes = [add_local_read_constraints, add_pack_constraints]
@@ -362,11 +362,7 @@ class TestValidatePackTF32(CMSValidationTestBase):
     """
     def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
-        kernel_updates["UsePLRPack"] = True
-        kernel_updates["UseF32XEmulation"] = True
-        kernel_updates["ForceUnrollSubIter"] = True
-        kernel_updates["UseDirect32XEmulation"] = True
-        kernel_updates["DepthU"] = 32
+        kernel_updates.update({"UsePLRPack": True, "UseF32XEmulation": True, "ForceUnrollSubIter": True, "UseDirect32XEmulation": True, "DepthU": 32})
         super().setup_method(method, kernel_updates=kernel_updates)
 
         self.q1s = 0
@@ -543,13 +539,12 @@ class TestValidatePackTF32MFMAReorder(CMSValidationTestBase):
     """
     def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
-        kernel_updates["UsePLRPack"] = True
-        kernel_updates["UseF32XEmulation"] = True
-        kernel_updates["UseDirect32XEmulation"] = True
-        kernel_updates["ForceUnrollSubIter"] = True
-        kernel_updates["DepthU"] = 32
-        kernel_updates["MIWaveTileA"] = 4  # Need >= 4 for n_tiles_quarter >= 1
-        kernel_updates["MIWaveTileB"] = 4  # Need >= 4 for n_tiles_quarter >= 1
+        kernel_updates.update(
+            {
+                "UsePLRPack": True, "UseF32XEmulation": True, "UseDirect32XEmulation": True, "ForceUnrollSubIter": True, "DepthU": 32, 
+                "MIWaveTileA": 4, "MIWaveTileB": 4  # Need >= 4 for n_tiles_quarter >= 1
+            }
+        )
         super().setup_method(method, kernel_updates=kernel_updates)
 
         self.q1s = 0
@@ -625,13 +620,7 @@ class TestValidatePackTF32CrossPackInterleaving(CMSValidationTestBase):
     """
     def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
-        kernel_updates["UsePLRPack"] = True
-        kernel_updates["UseF32XEmulation"] = True
-        kernel_updates["UseDirect32XEmulation"] = True
-        kernel_updates["ForceUnrollSubIter"] = True
-        kernel_updates["DepthU"] = 32
-        kernel_updates["MIWaveTileA"] = 4
-        kernel_updates["MIWaveTileB"] = 4
+        kernel_updates.update({"UsePLRPack": True, "UseF32XEmulation": True, "UseDirect32XEmulation": True, "ForceUnrollSubIter": True, "DepthU": 32, "MIWaveTileA": 4, "MIWaveTileB": 4})
         super().setup_method(method, kernel_updates=kernel_updates)
     
     validator_passes = [add_local_read_constraints, add_pack_constraints]
@@ -731,15 +720,12 @@ class TestValidatePackTF32MultipleGroups(CMSValidationTestBase):
     """
     def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
-        kernel_updates["UsePLRPack"] = True
-        kernel_updates["UseF32XEmulation"] = True
-        kernel_updates["UseDirect32XEmulation"] = True
-        kernel_updates["ForceUnrollSubIter"] = True
-        kernel_updates["DepthU"] = 32
-
-        # 4 A tiles to get 2 groups of 24 packs (48 total)
-        kernel_updates["MIWaveTileA"] = 4
-        kernel_updates["MIWaveTileB"] = 2
+        kernel_updates.update(
+            {
+                "UsePLRPack": True, "UseF32XEmulation": True, "UseDirect32XEmulation": True, "ForceUnrollSubIter": True, "DepthU": 32, 
+                "MIWaveTileA": 4, "MIWaveTileB": 2  # 4 A tiles to get 2 groups of 24 packs (48 total)
+            }
+        )
         super().setup_method(method, kernel_updates=kernel_updates)
 
         self.q1s = 0
@@ -870,14 +856,12 @@ class TestValidatePackTF32MFMA4x4x4(CMSValidationTestBase):
     """
     def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
-        kernel_updates["UsePLRPack"] = True
-        kernel_updates["UseF32XEmulation"] = True
-        kernel_updates["UseMFMAF32XEmulation"] = True
-        kernel_updates["UseDirect32XEmulation"] = True
-        kernel_updates["ForceUnrollSubIter"] = True
-        kernel_updates["DepthU"] = 32
-        kernel_updates["MIWaveTileA"] = 4
-        kernel_updates["MIWaveTileB"] = 4
+        kernel_updates.update(
+            {
+                "UsePLRPack": True, "UseF32XEmulation": True, "UseMFMAF32XEmulation": True, "UseDirect32XEmulation": True, "ForceUnrollSubIter": True, "DepthU": 32, 
+                "MIWaveTileA": 4, "MIWaveTileB": 4  # 4 A tiles, 4 B tiles, 3 MFMAs per tile = 48 vmfmas
+            }
+        )
         super().setup_method(method, kernel_updates=kernel_updates)
 
         self.q1s = 0
@@ -1169,14 +1153,12 @@ class TestValidatePackTF32MFMA4x4x4MultipleTiles(CMSValidationTestBase):
     """
     def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None) -> None:
         kernel_updates = kernel_updates.copy() if kernel_updates else {}
-        kernel_updates["UsePLRPack"] = True
-        kernel_updates["UseF32XEmulation"] = True
-        kernel_updates["UseMFMAF32XEmulation"] = True
-        kernel_updates["UseDirect32XEmulation"] = True
-        kernel_updates["ForceUnrollSubIter"] = True
-        kernel_updates["DepthU"] = 32
-        kernel_updates["MIWaveTileA"] = 4
-        kernel_updates["MIWaveTileB"] = 2
+        kernel_updates.update(
+            {
+                "UsePLRPack": True, "UseF32XEmulation": True, "UseMFMAF32XEmulation": True, "UseDirect32XEmulation": True, "ForceUnrollSubIter": True, "DepthU": 32, 
+                "MIWaveTileA": 4, "MIWaveTileB": 2  # 4 A tiles, 2 B tiles, 3 MFMAs per tile = 24 vmfmas
+            }
+        )
         super().setup_method(method, kernel_updates=kernel_updates)
 
         # With 4 A tiles, 2 B tiles, 3 MFMAs per tile = 24 vmfmas

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateSCCoverlap.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateSCCoverlap.py
@@ -33,8 +33,8 @@ class TestValidateSCCOverlap(CMSValidationTestBase):
     def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
         return verify_scc_overlap(sched, kernel_dict, codePathIdx)
 
-    def setUp(self):
-        super().setUp()
+    def setup_method(self, method=None):
+        super().setup_method(method)
         self.kernel["MIWaveTileA"] = 4
         self.kernel["MIWaveTileB"] = 4
         

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateSCCoverlap.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_ValidateSCCoverlap.py
@@ -22,6 +22,7 @@
 #
 # SPDX-License-Identifier: MIT
 ################################################################################
+from typing import Any, Optional
 from rocisa.instruction import SWaitCnt
 
 from Tensile.Components.CMSValidator import verify_scc_overlap
@@ -33,13 +34,10 @@ class TestValidateSCCOverlap(CMSValidationTestBase):
     def validation_function(self, sched, kernel_dict, codePathIdx, timeline=None):
         return verify_scc_overlap(sched, kernel_dict, codePathIdx)
 
-    def setup_method(self, method=None):
-        super().setup_method(method)
-        self.kernel["MIWaveTileA"] = 4
-        self.kernel["MIWaveTileB"] = 4
-        
-        self.kernel["DirectToLds"] = 1
-        self.num_vmfma = 2 * self.kernel["MIWaveTileA"] * self.kernel["MIWaveTileB"]
+    def setup_method(self, method=None, *, kernel_updates: Optional[dict[str, Any]] = None):
+        kernel_updates = kernel_updates.copy() if kernel_updates else {}
+        kernel_updates.update({"MIWaveTileA": 4, "MIWaveTileB": 4, "DirectToLds": 1})
+        super().setup_method(method, kernel_updates=kernel_updates)
 
     
     def test_gr_simple(self):


### PR DESCRIPTION
## Motivation
All of these tests were already expcted to be pytests and were run using pytest, the inheritence and functions should reflect this.

## Technical Details

Replace unittest helper ufnction with equivalent pytest one.

## Test Plan

Run existing tests.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.