### PR TITLE
[ci] disabling mi325 test runners

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -148,7 +148,8 @@ jobs:
     name: Test (${{ inputs.amdgpu_families }})
     needs: [therock-build-linux]
     # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
-    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu'}}
+    # Due to migrating MI325s, we have lost capacity as of 3/13/2026 11:41am PST
+    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' && inputs.amdgpu_families != 'gfx94X-dcgpu' }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: ${{ inputs.projects_to_test }}


### PR DESCRIPTION
As DigitalOcean MI325 machines are being migrated, we have lost capacity. this PR will disable them until we get capacity (so we can continue to get signal and no infinite hangs)