### PR TITLE
[hipDNN] add matmul dynamic tolerance

### DIFF
--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -558,7 +558,7 @@ double computeMatrixInfNorm(ITensor& tensor)
     using hipdnn_data_sdk::utilities::iterateAlongDimensions;
 
     const auto& dims = tensor.dims();
-    TensorView<T> view(tensor);
+    const TensorView<T> view(tensor);
 
     auto cols = dims.back();
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -44,7 +44,7 @@ inline double computeGamma(uint64_t k, double epsilon)
 {
     constexpr double NU_THRESHOLD = 0.01;
 
-    double nU = 2.0 * static_cast<double>(k) * epsilon;
+    const double nU = 2.0 * static_cast<double>(k) * epsilon;
 
     if(nU < NU_THRESHOLD)
     {
@@ -638,8 +638,8 @@ float calculateMatmulTolerance(ITensor& a, ITensor& b)
     }
 
     // Extract reduction dimension K (last dim of A, second-to-last dim of B)
-    int64_t k = aDims[aDims.size() - 1];
-    int64_t bRows = bDims[bDims.size() - 2];
+    const int64_t k = aDims[aDims.size() - 1];
+    const int64_t bRows = bDims[bDims.size() - 2];
 
     if(k != bRows)
     {
@@ -655,12 +655,12 @@ float calculateMatmulTolerance(ITensor& a, ITensor& b)
     auto numberOfAccumulations = static_cast<uint64_t>(k);
 
     // Compute infinity-norms of input matrices (max absolute row sum)
-    double normA = computeMatrixInfNorm<InputType>(a);
-    double normB = computeMatrixInfNorm<InputType>(b);
+    const double normA = computeMatrixInfNorm<InputType>(a);
+    const double normB = computeMatrixInfNorm<InputType>(b);
 
     // Apply Higham's error bound: max_ij |error_ij| <= γ_k * ||A||_inf * ||B||_inf
     auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
-    double gamma = hipdnn_test_sdk::utilities::computeGamma(numberOfAccumulations, epsilon);
+    const double gamma = hipdnn_test_sdk::utilities::computeGamma(numberOfAccumulations, epsilon);
 
     constexpr double GAMMA_MAX = 0.5;
     if(gamma >= GAMMA_MAX)
@@ -683,7 +683,7 @@ float calculateMatmulTolerance(ITensor& a, ITensor& b)
         // Each element loses precision proportional to epsilon when cast.
         // Worst-case error contribution from input casting:
         //   Error ≈ 2 * ||A||_inf * ||B||_inf * epsilon
-        double castingError = 2.0 * normA * normB * epsilon;
+        const double castingError = 2.0 * normA * normB * epsilon;
         accumulatedTolerance += castingError;
     }
 
@@ -697,12 +697,12 @@ float calculateMatmulTolerance(ITensor& a, ITensor& b)
     {
         // The error is bounded by the precision of the OutputType at the final accumulated value.
         // Maximum possible output magnitude: ||A||_inf * ||B||_inf
-        double maxPossibleOutputValue = normA * normB;
+        const double maxPossibleOutputValue = normA * normB;
         castTolerance = maxPossibleOutputValue * outputEpsilon;
     }
 
     // Total tolerance is the sum of accumulation error and casting errors
-    double totalTolerance = accumulatedTolerance + castTolerance;
+    const double totalTolerance = accumulatedTolerance + castTolerance;
 
     // Check if totalTolerance exceeds the maximum representable value of OutputType
     if(totalTolerance > static_cast<double>(std::numeric_limits<OutputType>::max()))

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -11,6 +11,50 @@
 #include <vector>
 
 #include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_data_sdk/utilities/TensorView.hpp>
+
+namespace hipdnn_test_sdk::utilities
+{
+
+/**
+ * @brief Computes Higham's error growth factor γ_k for floating-point accumulation.
+ *
+ * For k accumulations with machine epsilon u:
+ *   - Linear (when nU < 0.01):     γ_k = (2*k*u) / (1 - 2*k*u)  [deterministic worst-case]
+ *   - Statistical (when nU >= 0.01): γ_k = K_SIGMA * sqrt(2*k) * u [probabilistic, K_SIGMA=6]
+ *
+ * where nU = 2*k*u.
+ *
+ * The switch at nU = 0.01 is chosen because the linear bound inflates noticeably
+ * above this point (at nU=0.01 the overshoot is ~1%, at nU=0.1 it's ~11%).
+ *
+ * This is a pure math function that never throws. Callers are responsible for
+ * checking if the returned gamma is too large for their use case (e.g., gamma >= 0.5
+ * means the error bound exceeds 50% of the signal).
+ *
+ * Reusable across conv, matmul, and any operation that accumulates k products.
+ *
+ * @param k Number of accumulations (reduction dimension).
+ * @param epsilon Machine epsilon for the compute type.
+ * @return The error growth factor γ_k as a double.
+ */
+inline double computeGamma(uint64_t k, double epsilon)
+{
+    constexpr double NU_THRESHOLD = 0.01;
+
+    double nU = 2.0 * static_cast<double>(k) * epsilon;
+
+    if(nU < NU_THRESHOLD)
+    {
+        return nU / (1.0 - nU);
+    }
+
+    constexpr double K_SIGMA = 6.0;
+    return K_SIGMA * std::sqrt(2.0 * static_cast<double>(k)) * epsilon;
+}
+
+} // namespace hipdnn_test_sdk::utilities
 
 namespace hipdnn_test_sdk::utilities::conv
 {
@@ -481,3 +525,177 @@ float calculateConvFpropTolerance(
 }
 
 } // namespace hipdnn_test_sdk::utilities::conv
+
+namespace hipdnn_test_sdk::utilities::matmul
+{
+using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::half;
+using hipdnn_data_sdk::utilities::ITensor;
+using hipdnn_data_sdk::utilities::TensorView;
+
+/**
+ * @brief Computes the 1-norm (sum of absolute values) of a tensor.
+ *
+ * The 1-norm is defined as: ||A||_1 = sum_{i,j} |A[i,j]|
+ *
+ * Uses TensorView's iterator which correctly handles both packed
+ * and non-packed (strided) tensor layouts.
+ *
+ * @tparam T The data type of the tensor elements.
+ * @param tensor The input tensor.
+ * @return The 1-norm as a double.
+ */
+template <typename T>
+double compute1Norm(ITensor& tensor)
+{
+    TensorView<T> view(tensor);
+    double norm = 0.0;
+
+    for(auto it = view.begin(); it != view.end(); ++it)
+    {
+        norm += static_cast<double>(hipdnn_data_sdk::types::fabs(*it));
+    }
+
+    return norm;
+}
+
+/**
+ * @brief Calculates the expected tolerance for Matrix Multiplication operations.
+ *
+ * This function estimates the maximum expected error due to floating-point accumulation during the
+ * computation of C = A × B using Higham's error analysis for matrix multiplication.
+ *
+ * Norm Selection: 1-norm vs Frobenius norm
+ * ==========================================
+ * We use the 1-norm (sum of absolute values) instead of the Frobenius norm for the following reasons:
+ *
+ * 1. Computational Efficiency:
+ *    - 1-norm:      ||A||_1 = sum_{i,j} |A[i,j]|            (cost: 1 pass, abs + sum)
+ *    - Frobenius:   ||A||_F = sqrt(sum_{i,j} |A[i,j]|^2)   (cost: 1 pass, abs + square + sum + sqrt)
+ *    The 1-norm is approximately 2× faster (no squaring, no square root).
+ *
+ * 2. Tightness Trade-off:
+ *    Both norms provide rigorous error bounds based on Higham's analysis. While the Frobenius norm
+ *    can give slightly tighter bounds, the difference is typically small in practice, especially
+ *    compared to the much looser max-norm approach (which can overestimate by sqrt(m*k)).
+ *
+ * 3. Practical Validation:
+ *    For testing purposes, having a slightly looser but still rigorous bound is acceptable,
+ *    especially given the significant computational savings.
+ *
+ * Error Bound (Higham's Analysis):
+ * =================================
+ * For C = A*B where A is m×k and B is k×n:
+ *   ||fl(A*B) - A*B|| ≤ γ_k * ||A||_1 * ||B||_1
+ *
+ * where γ_k is the error growth factor:
+ *   - High Precision (FP32, FP64): γ_k = (2*k*u) / (1 - 2*k*u)  (linear worst-case bound)
+ *   - Low Precision (FP16, BF16):  γ_k = K_SIGMA * sqrt(2*k) * u  (statistical bound, K_SIGMA=6)
+ *   - u = machine epsilon for ComputeType
+ *
+ * The function also accounts for precision loss from input/output casting if needed.
+ *
+ * @tparam OutputType The data type of the output matrix C.
+ * @tparam InputType The data type of the input matrices A and B.
+ * @tparam ComputeType The data type used for accumulation (default: float).
+ * @param a The input matrix A.
+ * @param b The input matrix B.
+ * @return The calculated tolerance value as float.
+ */
+template <typename OutputType, typename InputType, typename ComputeType = float>
+float calculateMatmulTolerance(ITensor& a, ITensor& b)
+{
+    // Validate ComputeType
+    static_assert(std::is_same_v<ComputeType, float> || std::is_same_v<ComputeType, double>
+                      || std::is_same_v<ComputeType, half> || std::is_same_v<ComputeType, bfloat16>,
+                  "ComputeType must be float, double, half, or bfloat16");
+
+    // Validate tensor dimensions for matmul compatibility
+    const auto& aDims = a.dims();
+    const auto& bDims = b.dims();
+
+    if(aDims.size() < 2 || bDims.size() < 2)
+    {
+        throw std::invalid_argument("Matrices must have at least 2 dimensions for matmul.");
+    }
+
+    // Extract reduction dimension K (last dim of A, second-to-last dim of B)
+    int64_t k = aDims[aDims.size() - 1];
+    int64_t bRows = bDims[bDims.size() - 2];
+
+    if(k != bRows)
+    {
+        throw std::invalid_argument(
+            "Matrix dimensions incompatible for multiplication: A columns != B rows.");
+    }
+
+    if(k <= 0)
+    {
+        throw std::invalid_argument("Reduction dimension k must be positive.");
+    }
+
+    auto numberOfAccumulations = static_cast<uint64_t>(k);
+
+    // Compute 1-norms of input matrices
+    // Note: Using 1-norm instead of Frobenius norm for computational efficiency (~2× faster)
+    // while still maintaining rigorous error bounds (see detailed comments above).
+    double normA = compute1Norm<InputType>(a);
+    double normB = compute1Norm<InputType>(b);
+
+    // Apply Higham's error bound: ||error|| ≤ γ_k * ||A||_1 * ||B||_1
+    auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+    double gamma = hipdnn_test_sdk::utilities::computeGamma(numberOfAccumulations, epsilon);
+
+    constexpr double GAMMA_MAX = 0.5;
+    if(gamma >= GAMMA_MAX)
+    {
+        throw std::overflow_error(
+            "Error growth factor gamma >= 0.5: the accumulation error exceeds 50% of the signal. "
+            "The computation may be numerically meaningless at this precision and reduction size.");
+    }
+
+    double accumulatedTolerance = gamma * normA * normB;
+
+    // Calculate input casting error
+    // If InputType has higher precision (smaller epsilon) than ComputeType, we lose precision
+    // when loading inputs (downcasting). Example: double -> float.
+    // If InputType has lower precision than ComputeType, no additional error (upcasting).
+    auto inputEpsilon = static_cast<double>(std::numeric_limits<InputType>::epsilon());
+    if(inputEpsilon < epsilon)
+    {
+        // Input precision is higher than compute precision, so we have casting error.
+        // Each element loses precision proportional to epsilon when cast.
+        // Worst-case error contribution from input casting:
+        //   Error ≈ 2 * ||A||_1 * ||B||_1 * epsilon
+        double castingError = 2.0 * normA * normB * epsilon;
+        accumulatedTolerance += castingError;
+    }
+
+    // Calculate output casting error
+    // If OutputType has lower precision (larger epsilon) than ComputeType, we lose precision
+    // when storing the result (downcasting). Example: float -> half.
+    auto outputEpsilon = static_cast<double>(std::numeric_limits<OutputType>::epsilon());
+    double castTolerance = 0.0;
+
+    if(outputEpsilon > epsilon)
+    {
+        // The error is bounded by the precision of the OutputType at the final accumulated value.
+        // Maximum possible output magnitude: ||A||_1 * ||B||_1
+        double maxPossibleOutputValue = normA * normB;
+        castTolerance = maxPossibleOutputValue * outputEpsilon;
+    }
+
+    // Total tolerance is the sum of accumulation error and casting errors
+    double totalTolerance = accumulatedTolerance + castTolerance;
+
+    // Check if totalTolerance exceeds the maximum representable value of OutputType
+    if(totalTolerance > static_cast<double>(std::numeric_limits<OutputType>::max()))
+    {
+        throw std::overflow_error(
+            "Calculated tolerance exceeds the maximum representable value of the output type.");
+    }
+
+    return static_cast<float>(totalTolerance);
+}
+
+} // namespace hipdnn_test_sdk::utilities::matmul

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -534,59 +534,76 @@ using hipdnn_data_sdk::utilities::ITensor;
 using hipdnn_data_sdk::utilities::TensorView;
 
 /**
- * @brief Computes the 1-norm (sum of absolute values) of a tensor.
+ * @brief Computes the infinity-norm (max absolute row sum) of a matrix tensor.
  *
- * The 1-norm is defined as: ||A||_1 = sum_{i,j} |A[i,j]|
+ * The infinity-norm is defined as: ||A||_inf = max_i (sum_j |A[i,j]|)
  *
- * Uses TensorView's iterator which correctly handles both packed
- * and non-packed (strided) tensor layouts.
+ * This is the appropriate subordinate matrix norm for element-wise error bounds
+ * via Higham's analysis: max_ij |error_ij| <= gamma_k * ||A||_inf * ||B||_inf.
+ *
+ * Uses strides to correctly handle both packed and non-packed tensor layouts.
  *
  * @tparam T The data type of the tensor elements.
- * @param tensor The input tensor.
- * @return The 1-norm as a double.
+ * @param tensor The input tensor (must have at least 2 dimensions).
+ * @return The infinity-norm as a double.
  */
 template <typename T>
-double compute1Norm(ITensor& tensor)
+double computeMatrixInfNorm(ITensor& tensor)
 {
-    TensorView<T> view(tensor);
-    double norm = 0.0;
+    const auto& dims = tensor.dims();
+    const auto& strides = tensor.strides();
 
-    for(auto it = view.begin(); it != view.end(); ++it)
+    auto rows = dims[dims.size() - 2];
+    auto cols = dims[dims.size() - 1];
+
+    auto rowStride = strides[strides.size() - 2];
+    auto colStride = strides[strides.size() - 1];
+
+    const auto* data = static_cast<const T*>(tensor.rawHostData());
+
+    // For tensors with batch dimensions, compute across all batches
+    auto batchCount = static_cast<int64_t>(tensor.elementCount()) / (rows * cols);
+
+    double maxRowSum = 0.0;
+
+    for(int64_t batch = 0; batch < batchCount; ++batch)
     {
-        norm += static_cast<double>(hipdnn_data_sdk::types::fabs(*it));
+        auto batchOffset = batch * rows * rowStride;
+
+        for(int64_t i = 0; i < rows; ++i)
+        {
+            double rowSum = 0.0;
+            for(int64_t j = 0; j < cols; ++j)
+            {
+                auto idx = batchOffset + i * rowStride + j * colStride;
+                rowSum += static_cast<double>(hipdnn_data_sdk::types::fabs(data[idx]));
+            }
+            maxRowSum = std::max(maxRowSum, rowSum);
+        }
     }
 
-    return norm;
+    return maxRowSum;
 }
 
 /**
  * @brief Calculates the expected tolerance for Matrix Multiplication operations.
  *
- * This function estimates the maximum expected error due to floating-point accumulation during the
- * computation of C = A × B using Higham's error analysis for matrix multiplication.
+ * This function estimates the maximum expected element-wise error due to floating-point
+ * accumulation during the computation of C = A × B using Higham's error analysis.
  *
- * Norm Selection: 1-norm vs Frobenius norm
- * ==========================================
- * We use the 1-norm (sum of absolute values) instead of the Frobenius norm for the following reasons:
+ * Norm Selection: Infinity-norm (max absolute row sum)
+ * =====================================================
+ * We use the infinity-norm ||A||_inf = max_i (sum_j |A[i,j]|) because Higham's element-wise
+ * error bound for matrix multiplication gives:
+ *   max_ij |fl(C)_ij - C_ij| <= gamma_k * ||A||_inf * ||B||_inf
  *
- * 1. Computational Efficiency:
- *    - 1-norm:      ||A||_1 = sum_{i,j} |A[i,j]|            (cost: 1 pass, abs + sum)
- *    - Frobenius:   ||A||_F = sqrt(sum_{i,j} |A[i,j]|^2)   (cost: 1 pass, abs + square + sum + sqrt)
- *    The 1-norm is approximately 2× faster (no squaring, no square root).
- *
- * 2. Tightness Trade-off:
- *    Both norms provide rigorous error bounds based on Higham's analysis. While the Frobenius norm
- *    can give slightly tighter bounds, the difference is typically small in practice, especially
- *    compared to the much looser max-norm approach (which can overestimate by sqrt(m*k)).
- *
- * 3. Practical Validation:
- *    For testing purposes, having a slightly looser but still rigorous bound is acceptable,
- *    especially given the significant computational savings.
+ * This is the correct subordinate matrix norm for bounding the maximum element-wise error,
+ * which is what allClose-style validation checks.
  *
  * Error Bound (Higham's Analysis):
  * =================================
  * For C = A*B where A is m×k and B is k×n:
- *   ||fl(A*B) - A*B|| ≤ γ_k * ||A||_1 * ||B||_1
+ *   max_ij |error_ij| <= γ_k * ||A||_inf * ||B||_inf
  *
  * where γ_k is the error growth factor:
  *   - High Precision (FP32, FP64): γ_k = (2*k*u) / (1 - 2*k*u)  (linear worst-case bound)
@@ -636,13 +653,11 @@ float calculateMatmulTolerance(ITensor& a, ITensor& b)
 
     auto numberOfAccumulations = static_cast<uint64_t>(k);
 
-    // Compute 1-norms of input matrices
-    // Note: Using 1-norm instead of Frobenius norm for computational efficiency (~2× faster)
-    // while still maintaining rigorous error bounds (see detailed comments above).
-    double normA = compute1Norm<InputType>(a);
-    double normB = compute1Norm<InputType>(b);
+    // Compute infinity-norms of input matrices (max absolute row sum)
+    double normA = computeMatrixInfNorm<InputType>(a);
+    double normB = computeMatrixInfNorm<InputType>(b);
 
-    // Apply Higham's error bound: ||error|| ≤ γ_k * ||A||_1 * ||B||_1
+    // Apply Higham's error bound: max_ij |error_ij| <= γ_k * ||A||_inf * ||B||_inf
     auto epsilon = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
     double gamma = hipdnn_test_sdk::utilities::computeGamma(numberOfAccumulations, epsilon);
 
@@ -666,7 +681,7 @@ float calculateMatmulTolerance(ITensor& a, ITensor& b)
         // Input precision is higher than compute precision, so we have casting error.
         // Each element loses precision proportional to epsilon when cast.
         // Worst-case error contribution from input casting:
-        //   Error ≈ 2 * ||A||_1 * ||B||_1 * epsilon
+        //   Error ≈ 2 * ||A||_inf * ||B||_inf * epsilon
         double castingError = 2.0 * normA * normB * epsilon;
         accumulatedTolerance += castingError;
     }
@@ -680,7 +695,7 @@ float calculateMatmulTolerance(ITensor& a, ITensor& b)
     if(outputEpsilon > epsilon)
     {
         // The error is bounded by the precision of the OutputType at the final accumulated value.
-        // Maximum possible output magnitude: ||A||_1 * ||B||_1
+        // Maximum possible output magnitude: ||A||_inf * ||B||_inf
         double maxPossibleOutputValue = normA * normB;
         castTolerance = maxPossibleOutputValue * outputEpsilon;
     }

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_data_sdk/utilities/TensorView.hpp>
 
@@ -541,7 +542,11 @@ using hipdnn_data_sdk::utilities::TensorView;
  * This is the appropriate subordinate matrix norm for element-wise error bounds
  * via Higham's analysis: max_ij |error_ij| <= gamma_k * ||A||_inf * ||B||_inf.
  *
- * Uses strides to correctly handle both packed and non-packed tensor layouts.
+ * For batched tensors (>2D), the infinity-norm is computed across all batches,
+ * returning the maximum row sum over all rows in all batches.
+ *
+ * Uses iterateAlongDimensions + ConstTensorView to correctly handle padded
+ * and non-packed tensor layouts via stride-aware indexing.
  *
  * @tparam T The data type of the tensor elements.
  * @param tensor The input tensor (must have at least 2 dimensions).
@@ -550,37 +555,33 @@ using hipdnn_data_sdk::utilities::TensorView;
 template <typename T>
 double computeMatrixInfNorm(ITensor& tensor)
 {
+    using hipdnn_data_sdk::utilities::iterateAlongDimensions;
+
     const auto& dims = tensor.dims();
-    const auto& strides = tensor.strides();
+    TensorView<T> view(tensor);
 
-    auto rows = dims[dims.size() - 2];
-    auto cols = dims[dims.size() - 1];
+    auto cols = dims.back();
 
-    auto rowStride = strides[strides.size() - 2];
-    auto colStride = strides[strides.size() - 1];
-
-    const auto* data = static_cast<const T*>(tensor.rawHostData());
-
-    // For tensors with batch dimensions, compute across all batches
-    auto batchCount = static_cast<int64_t>(tensor.elementCount()) / (rows * cols);
+    // outerDims = [batch..., rows] — everything except the last dim (cols)
+    auto outerDims = std::vector<int64_t>(dims.begin(), dims.end() - 1);
 
     double maxRowSum = 0.0;
 
-    for(int64_t batch = 0; batch < batchCount; ++batch)
-    {
-        auto batchOffset = batch * rows * rowStride;
+    iterateAlongDimensions(outerDims, [&](const std::vector<int64_t>& outerIndices) {
+        double rowSum = 0.0;
 
-        for(int64_t i = 0; i < rows; ++i)
+        auto fullIndices = outerIndices;
+        fullIndices.push_back(0);
+
+        for(int64_t j = 0; j < cols; ++j)
         {
-            double rowSum = 0.0;
-            for(int64_t j = 0; j < cols; ++j)
-            {
-                auto idx = batchOffset + i * rowStride + j * colStride;
-                rowSum += static_cast<double>(hipdnn_data_sdk::types::fabs(data[idx]));
-            }
-            maxRowSum = std::max(maxRowSum, rowSum);
+            fullIndices.back() = j;
+            rowSum += static_cast<double>(
+                hipdnn_data_sdk::types::fabs(view.getHostValue(fullIndices)));
         }
-    }
+
+        maxRowSum = std::max(maxRowSum, rowSum);
+    });
 
     return maxRowSum;
 }

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
@@ -1139,8 +1139,8 @@ struct MatmulToleranceTestCase
 {
     std::vector<int64_t> aDims;
     std::vector<int64_t> bDims;
-    double aValue;
-    double bValue;
+    std::vector<double> aRowValues;
+    std::vector<double> bRowValues;
     double expectedTolerance;
     bool expectThrow = false;
 
@@ -1156,25 +1156,43 @@ struct MatmulToleranceTestCase
         {
             os << tc.bDims[i] << (i < tc.bDims.size() - 1 ? ", " : "");
         }
-        os << "], aValue: " << tc.aValue << ", bValue: " << tc.bValue
-           << ", expectedTolerance: " << tc.expectedTolerance
+        os << "], aRowValues: [";
+        for(size_t i = 0; i < tc.aRowValues.size(); ++i)
+        {
+            os << tc.aRowValues[i] << (i < tc.aRowValues.size() - 1 ? ", " : "");
+        }
+        os << "], bRowValues: [";
+        for(size_t i = 0; i < tc.bRowValues.size(); ++i)
+        {
+            os << tc.bRowValues[i] << (i < tc.bRowValues.size() - 1 ? ", " : "");
+        }
+        os << "], expectedTolerance: " << tc.expectedTolerance
            << ", expectThrow: " << (tc.expectThrow ? "true" : "false");
         return os;
     }
 };
 
-// Helper to create a tensor filled with a constant value
+// Helper to create a tensor where each row is filled with a per-row constant value.
+// rowValues[i] specifies the constant value for all elements in row i.
+// This ensures different rows have different sums, exercising the max-row-sum logic
+// in computeMatrixInfNorm.
 template <typename T>
-hipdnn_data_sdk::utilities::Tensor<T> createConstantTensor(const std::vector<int64_t>& dims,
-                                                           double value)
+hipdnn_data_sdk::utilities::Tensor<T>
+    createTensorFromRowValues(const std::vector<int64_t>& dims,
+                              const std::vector<double>& rowValues)
 {
     hipdnn_data_sdk::utilities::Tensor<T> tensor(dims);
-    auto elementCount = tensor.elementCount();
     auto* data = static_cast<T*>(tensor.memory().hostData());
 
-    for(size_t i = 0; i < elementCount; ++i)
+    auto rows = dims[dims.size() - 2];
+    auto cols = dims[dims.size() - 1];
+
+    for(int64_t i = 0; i < rows; ++i)
     {
-        data[i] = static_cast<T>(value);
+        for(int64_t j = 0; j < cols; ++j)
+        {
+            data[i * cols + j] = static_cast<T>(rowValues[static_cast<size_t>(i)]);
+        }
     }
 
     return tensor;
@@ -1186,67 +1204,92 @@ template <typename T>
 std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases();
 
 // Float / Float / Float (High Precision: Linear)
-// Tolerance = gamma(K, u_float) * ||A||_1 * ||B||_1
-// All tensors filled with 1.0, so ||T||_1 = product(dims)
+// Tolerance = gamma(K, u_float) * ||A||_inf * ||B||_inf
+// Row-varying values ensure ||A||_inf != entry_sum / rows
 template <>
 std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<float, float, float>>()
 {
     auto u = hipdnn_data_sdk::types::pow(2.0, -23);
 
-    return {// K=1: A=2x1, B=1x2. ||A||=2, ||B||=2. Tol = gamma(1,u) * 4
-            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, u) * 2.0 * 2.0},
-            // K=3: A=2x3, B=3x4. ||A||=6, ||B||=12. Tol = gamma(3,u) * 72
-            {{2, 3}, {3, 4}, 1.0, 1.0, computeGamma(3, u) * 6.0 * 12.0},
-            // K=10: A=2x10, B=10x2. ||A||=20, ||B||=20. Tol = gamma(10,u) * 400
-            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, u) * 20.0 * 20.0},
-            // K=100: A=2x100, B=100x2. ||A||=200, ||B||=200. Tol = gamma(100,u) * 40000
-            {{2, 100}, {100, 2}, 1.0, 1.0, computeGamma(100, u) * 200.0 * 200.0}};
+    auto bRowValues100 = std::vector<double>(100, 1.0);
+
+    return {// K=1: A=2x1, rows={1,2}. ||A||_inf=2, B=1x2, rows={1}. ||B||_inf=2
+            {{2, 1}, {1, 2}, {1.0, 2.0}, {1.0}, computeGamma(1, u) * 2.0 * 2.0},
+            // K=3: A=2x3, rows={1,2}. ||A||_inf=6, B=3x4, rows={1,3,0.5}. ||B||_inf=12
+            {{2, 3}, {3, 4}, {1.0, 2.0}, {1.0, 3.0, 0.5}, computeGamma(3, u) * 6.0 * 12.0},
+            // K=10: A=2x10, rows={1,2}. ||A||_inf=20, B=10x2, rows={1..5,1..5}. ||B||_inf=10
+            {{2, 10},
+             {10, 2},
+             {1.0, 2.0},
+             {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
+             computeGamma(10, u) * 20.0 * 10.0},
+            // K=100: A=2x100, rows={1,2}. ||A||_inf=200, B=100x2, all 1.0. ||B||_inf=2
+            {{2, 100}, {100, 2}, {1.0, 2.0}, bRowValues100, computeGamma(100, u) * 200.0 * 2.0}};
 }
 
 // Float / Double / Float (Input casting error)
-// Tolerance = gamma(K, u_float) * ||A|| * ||B|| + 2 * ||A|| * ||B|| * u_float
+// Tolerance = gamma(K, u_float) * ||A||_inf * ||B||_inf + 2 * ||A||_inf * ||B||_inf * u_float
 template <>
 std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<float, double, float>>()
 {
     auto u = hipdnn_data_sdk::types::pow(2.0, -23);
 
-    return {// K=1: ||A||=2, ||B||=2. Tol = gamma(1,u)*4 + 2*4*u
-            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, u) * 4.0 + 2.0 * 4.0 * u},
-            // K=10: ||A||=20, ||B||=20. Tol = gamma(10,u)*400 + 2*400*u
-            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, u) * 400.0 + 2.0 * 400.0 * u}};
+    return {
+        // K=1: ||A||_inf=2, ||B||_inf=2. Tol = gamma(1,u)*4 + 2*4*u
+        {{2, 1}, {1, 2}, {1.0, 2.0}, {1.0}, computeGamma(1, u) * 2.0 * 2.0 + 2.0 * 2.0 * 2.0 * u},
+        // K=10: ||A||_inf=20, ||B||_inf=10. Tol = gamma(10,u)*200 + 2*200*u
+        {{2, 10},
+         {10, 2},
+         {1.0, 2.0},
+         {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
+         computeGamma(10, u) * 20.0 * 10.0 + 2.0 * 20.0 * 10.0 * u}};
 }
 
 // Half / Float / Float (Output casting error)
-// Tolerance = gamma(K, u_float) * ||A|| * ||B|| + ||A|| * ||B|| * u_half
+// Tolerance = gamma(K, u_float) * ||A||_inf * ||B||_inf + ||A||_inf * ||B||_inf * u_half
 template <>
 std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<half, float, float>>()
 {
     auto uFloat = hipdnn_data_sdk::types::pow(2.0, -23);
     auto uHalf = hipdnn_data_sdk::types::pow(2.0, -10);
 
-    return {// K=1: ||A||=2, ||B||=2. Tol = gamma(1,uFloat)*4 + 4*uHalf
-            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, uFloat) * 4.0 + 4.0 * uHalf},
-            // K=10: ||A||=20, ||B||=20. Tol = gamma(10,uFloat)*400 + 400*uHalf
-            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, uFloat) * 400.0 + 400.0 * uHalf}};
+    return {// K=1: ||A||_inf=2, ||B||_inf=2. Tol = gamma(1,uFloat)*4 + 4*uHalf
+            {{2, 1},
+             {1, 2},
+             {1.0, 2.0},
+             {1.0},
+             computeGamma(1, uFloat) * 2.0 * 2.0 + 2.0 * 2.0 * uHalf},
+            // K=10: ||A||_inf=20, ||B||_inf=10. Tol = gamma(10,uFloat)*200 + 200*uHalf
+            {{2, 10},
+             {10, 2},
+             {1.0, 2.0},
+             {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
+             computeGamma(10, uFloat) * 20.0 * 10.0 + 20.0 * 10.0 * uHalf}};
 }
 
 // Half / Half / Half (Low Precision: Statistical)
-// Tolerance = gamma(K, u_half) * ||A|| * ||B||
+// Tolerance = gamma(K, u_half) * ||A||_inf * ||B||_inf
 template <>
 std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<half, half, half>>()
 {
     auto u = hipdnn_data_sdk::types::pow(2.0, -10);
 
-    return {// K=1: ||A||=2, ||B||=2
-            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, u) * 4.0},
-            // K=10: ||A||=20, ||B||=20
-            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, u) * 400.0},
-            // K=100: ||A||=200, ||B||=200
-            {{2, 100}, {100, 2}, 1.0, 1.0, computeGamma(100, u) * 40000.0}};
+    auto bRowValues100 = std::vector<double>(100, 1.0);
+
+    return {// K=1: ||A||_inf=2, ||B||_inf=2
+            {{2, 1}, {1, 2}, {1.0, 2.0}, {1.0}, computeGamma(1, u) * 2.0 * 2.0},
+            // K=10: ||A||_inf=20, ||B||_inf=10
+            {{2, 10},
+             {10, 2},
+             {1.0, 2.0},
+             {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
+             computeGamma(10, u) * 20.0 * 10.0},
+            // K=100: ||A||_inf=200, ||B||_inf=2
+            {{2, 100}, {100, 2}, {1.0, 2.0}, bRowValues100, computeGamma(100, u) * 200.0 * 2.0}};
 }
 
 // Bfloat16 / Float / Float (Output casting error)
-// Tolerance = gamma(K, u_float) * ||A|| * ||B|| + ||A|| * ||B|| * u_bf16
+// Tolerance = gamma(K, u_float) * ||A||_inf * ||B||_inf + ||A||_inf * ||B||_inf * u_bf16
 template <>
 std::vector<MatmulToleranceTestCase>
     getMatmulToleranceTestCases<TypeTriple<bfloat16, float, float>>()
@@ -1254,26 +1297,40 @@ std::vector<MatmulToleranceTestCase>
     auto uFloat = hipdnn_data_sdk::types::pow(2.0, -23);
     auto uBf16 = hipdnn_data_sdk::types::pow(2.0, -7);
 
-    return {// K=1: ||A||=2, ||B||=2. Tol = gamma(1,uFloat)*4 + 4*uBf16
-            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, uFloat) * 4.0 + 4.0 * uBf16},
-            // K=10: ||A||=20, ||B||=20. Tol = gamma(10,uFloat)*400 + 400*uBf16
-            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, uFloat) * 400.0 + 400.0 * uBf16}};
+    return {// K=1: ||A||_inf=2, ||B||_inf=2. Tol = gamma(1,uFloat)*4 + 4*uBf16
+            {{2, 1},
+             {1, 2},
+             {1.0, 2.0},
+             {1.0},
+             computeGamma(1, uFloat) * 2.0 * 2.0 + 2.0 * 2.0 * uBf16},
+            // K=10: ||A||_inf=20, ||B||_inf=10. Tol = gamma(10,uFloat)*200 + 200*uBf16
+            {{2, 10},
+             {10, 2},
+             {1.0, 2.0},
+             {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
+             computeGamma(10, uFloat) * 20.0 * 10.0 + 20.0 * 10.0 * uBf16}};
 }
 
 // Bfloat16 / Bfloat16 / Bfloat16 (Low Precision: Statistical)
-// Tolerance = gamma(K, u_bf16) * ||A|| * ||B||
+// Tolerance = gamma(K, u_bf16) * ||A||_inf * ||B||_inf
 template <>
 std::vector<MatmulToleranceTestCase>
     getMatmulToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
 {
     auto u = hipdnn_data_sdk::types::pow(2.0, -7);
 
-    return {// K=1: ||A||=2, ||B||=2
-            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, u) * 4.0},
-            // K=10: ||A||=20, ||B||=20
-            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, u) * 400.0},
-            // K=50: ||A||=100, ||B||=100 (K=100 exceeds gamma>=0.5 for bf16)
-            {{2, 50}, {50, 2}, 1.0, 1.0, computeGamma(50, u) * 10000.0}};
+    auto bRowValues50 = std::vector<double>(50, 1.0);
+
+    return {// K=1: ||A||_inf=2, ||B||_inf=2
+            {{2, 1}, {1, 2}, {1.0, 2.0}, {1.0}, computeGamma(1, u) * 2.0 * 2.0},
+            // K=10: ||A||_inf=20, ||B||_inf=10
+            {{2, 10},
+             {10, 2},
+             {1.0, 2.0},
+             {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
+             computeGamma(10, u) * 20.0 * 10.0},
+            // K=50: ||A||_inf=100, ||B||_inf=2 (K=100 exceeds gamma>=0.5 for bf16)
+            {{2, 50}, {50, 2}, {1.0, 2.0}, bRowValues50, computeGamma(50, u) * 100.0 * 2.0}};
 }
 
 template <typename Out, typename In, typename Comp>
@@ -1286,15 +1343,15 @@ protected:
 
         if(tc.expectThrow)
         {
-            auto a = createConstantTensor<In>(tc.aDims, tc.aValue);
-            auto b = createConstantTensor<In>(tc.bDims, tc.bValue);
+            auto a = createTensorFromRowValues<In>(tc.aDims, tc.aRowValues);
+            auto b = createTensorFromRowValues<In>(tc.bDims, tc.bRowValues);
 
             EXPECT_THROW((calculateMatmulTolerance<Out, In, Comp>(a, b)), std::exception) << tc;
         }
         else
         {
-            auto a = createConstantTensor<In>(tc.aDims, tc.aValue);
-            auto b = createConstantTensor<In>(tc.bDims, tc.bValue);
+            auto a = createTensorFromRowValues<In>(tc.aDims, tc.aRowValues);
+            auto b = createTensorFromRowValues<In>(tc.bDims, tc.bRowValues);
 
             auto tolerance = calculateMatmulTolerance<Out, In, Comp>(a, b);
             EXPECT_NEAR(tolerance, static_cast<float>(tc.expectedTolerance), 1e-10f) << tc;
@@ -1369,8 +1426,8 @@ INSTANTIATE_TEST_SUITE_P(
 TEST(TestCalculateMatmulTolerance, ThrowsOnInvalidDimensions)
 {
     // Mismatched dimensions: A is 2x3, B is 4x5 (3 != 4)
-    auto a = createConstantTensor<float>({2, 3}, 1.0);
-    auto b = createConstantTensor<float>({4, 5}, 1.0);
+    auto a = createTensorFromRowValues<float>({2, 3}, {1.0, 2.0});
+    auto b = createTensorFromRowValues<float>({4, 5}, {1.0, 2.0, 3.0, 4.0});
 
     EXPECT_THROW((calculateMatmulTolerance<float, float, float>(a, b)), std::invalid_argument);
 }
@@ -1385,8 +1442,9 @@ TEST(TestCalculateMatmulTolerance, ThrowsOnSingularity)
     // For bfloat16, epsilon = 2^-7 ≈ 7.81e-3
     // K=100: nU = 2*100*7.81e-3 = 1.562 >= 0.01 → statistical bound
     // gamma = 6 * sqrt(200) * 7.81e-3 ≈ 0.663 >= 0.5 → overflow
-    auto a = createConstantTensor<bfloat16>({2, 100}, 1.0);
-    auto b = createConstantTensor<bfloat16>({100, 2}, 1.0);
+    auto bRowValues100 = std::vector<double>(100, 1.0);
+    auto a = createTensorFromRowValues<bfloat16>({2, 100}, {1.0, 2.0});
+    auto b = createTensorFromRowValues<bfloat16>({100, 2}, bRowValues100);
 
     EXPECT_THROW((calculateMatmulTolerance<bfloat16, bfloat16, bfloat16>(a, b)),
                  std::overflow_error);
@@ -1396,11 +1454,12 @@ TEST(TestCalculateMatmulTolerance, ThrowsOnSingularity)
 TEST(TestCalculateMatmulTolerance, ThrowsOnOutputOverflow)
 {
     // Create matrices with very large values that will cause tolerance > half::max
-    // A = 2x10 filled with 1e5, B = 10x2 filled with 1e5
-    // ||A||_1 = 20 * 1e5 = 2e6, ||B||_1 = 20 * 1e5 = 2e6
+    // A = 2x10, rows={1e5, 1e5}. ||A||_inf = 10 * 1e5 = 1e6
+    // B = 10x2, all rows 1e5. ||B||_inf = 2 * 1e5 = 2e5
     // Product will exceed half max (65504)
-    auto a = createConstantTensor<float>({2, 10}, 1.0e5);
-    auto b = createConstantTensor<float>({10, 2}, 1.0e5);
+    auto bRowValues10 = std::vector<double>(10, 1.0e5);
+    auto a = createTensorFromRowValues<float>({2, 10}, {1.0e5, 1.0e5});
+    auto b = createTensorFromRowValues<float>({10, 2}, bRowValues10);
 
     // OutputType = half, so max ≈ 65504
     EXPECT_THROW((calculateMatmulTolerance<half, float, float>(a, b)), std::overflow_error);

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
@@ -1128,3 +1128,280 @@ TEST(TestCalculateConvFpropTolerance, ThrowsOnOutputOverflow)
     EXPECT_THROW((calculateConvFpropTolerance<half, float, float>(-val, val, -val, val, dims)),
                  std::overflow_error);
 }
+
+// =================================================================================================
+// TestCalculateMatmulTolerance
+// =================================================================================================
+
+using namespace hipdnn_test_sdk::utilities::matmul;
+
+struct MatmulToleranceTestCase
+{
+    std::vector<int64_t> aDims;
+    std::vector<int64_t> bDims;
+    double aValue;
+    double bValue;
+    double expectedTolerance;
+    bool expectThrow = false;
+
+    friend std::ostream& operator<<(std::ostream& os, const MatmulToleranceTestCase& tc)
+    {
+        os << "aDims: [";
+        for(size_t i = 0; i < tc.aDims.size(); ++i)
+        {
+            os << tc.aDims[i] << (i < tc.aDims.size() - 1 ? ", " : "");
+        }
+        os << "], bDims: [";
+        for(size_t i = 0; i < tc.bDims.size(); ++i)
+        {
+            os << tc.bDims[i] << (i < tc.bDims.size() - 1 ? ", " : "");
+        }
+        os << "], aValue: " << tc.aValue << ", bValue: " << tc.bValue
+           << ", expectedTolerance: " << tc.expectedTolerance
+           << ", expectThrow: " << (tc.expectThrow ? "true" : "false");
+        return os;
+    }
+};
+
+// Helper to create a tensor filled with a constant value
+template <typename T>
+hipdnn_data_sdk::utilities::Tensor<T> createConstantTensor(const std::vector<int64_t>& dims,
+                                                           double value)
+{
+    hipdnn_data_sdk::utilities::Tensor<T> tensor(dims);
+    auto elementCount = tensor.elementCount();
+    auto* data = static_cast<T*>(tensor.memory().hostData());
+
+    for(size_t i = 0; i < elementCount; ++i)
+    {
+        data[i] = static_cast<T>(value);
+    }
+
+    return tensor;
+}
+
+using hipdnn_test_sdk::utilities::computeGamma;
+
+template <typename T>
+std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases();
+
+// Float / Float / Float (High Precision: Linear)
+// Tolerance = gamma(K, u_float) * ||A||_1 * ||B||_1
+// All tensors filled with 1.0, so ||T||_1 = product(dims)
+template <>
+std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<float, float, float>>()
+{
+    auto u = hipdnn_data_sdk::types::pow(2.0, -23);
+
+    return {// K=1: A=2x1, B=1x2. ||A||=2, ||B||=2. Tol = gamma(1,u) * 4
+            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, u) * 2.0 * 2.0},
+            // K=3: A=2x3, B=3x4. ||A||=6, ||B||=12. Tol = gamma(3,u) * 72
+            {{2, 3}, {3, 4}, 1.0, 1.0, computeGamma(3, u) * 6.0 * 12.0},
+            // K=10: A=2x10, B=10x2. ||A||=20, ||B||=20. Tol = gamma(10,u) * 400
+            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, u) * 20.0 * 20.0},
+            // K=100: A=2x100, B=100x2. ||A||=200, ||B||=200. Tol = gamma(100,u) * 40000
+            {{2, 100}, {100, 2}, 1.0, 1.0, computeGamma(100, u) * 200.0 * 200.0}};
+}
+
+// Float / Double / Float (Input casting error)
+// Tolerance = gamma(K, u_float) * ||A|| * ||B|| + 2 * ||A|| * ||B|| * u_float
+template <>
+std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<float, double, float>>()
+{
+    auto u = hipdnn_data_sdk::types::pow(2.0, -23);
+
+    return {// K=1: ||A||=2, ||B||=2. Tol = gamma(1,u)*4 + 2*4*u
+            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, u) * 4.0 + 2.0 * 4.0 * u},
+            // K=10: ||A||=20, ||B||=20. Tol = gamma(10,u)*400 + 2*400*u
+            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, u) * 400.0 + 2.0 * 400.0 * u}};
+}
+
+// Half / Float / Float (Output casting error)
+// Tolerance = gamma(K, u_float) * ||A|| * ||B|| + ||A|| * ||B|| * u_half
+template <>
+std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<half, float, float>>()
+{
+    auto uFloat = hipdnn_data_sdk::types::pow(2.0, -23);
+    auto uHalf = hipdnn_data_sdk::types::pow(2.0, -10);
+
+    return {// K=1: ||A||=2, ||B||=2. Tol = gamma(1,uFloat)*4 + 4*uHalf
+            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, uFloat) * 4.0 + 4.0 * uHalf},
+            // K=10: ||A||=20, ||B||=20. Tol = gamma(10,uFloat)*400 + 400*uHalf
+            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, uFloat) * 400.0 + 400.0 * uHalf}};
+}
+
+// Half / Half / Half (Low Precision: Statistical)
+// Tolerance = gamma(K, u_half) * ||A|| * ||B||
+template <>
+std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<half, half, half>>()
+{
+    auto u = hipdnn_data_sdk::types::pow(2.0, -10);
+
+    return {// K=1: ||A||=2, ||B||=2
+            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, u) * 4.0},
+            // K=10: ||A||=20, ||B||=20
+            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, u) * 400.0},
+            // K=100: ||A||=200, ||B||=200
+            {{2, 100}, {100, 2}, 1.0, 1.0, computeGamma(100, u) * 40000.0}};
+}
+
+// Bfloat16 / Float / Float (Output casting error)
+// Tolerance = gamma(K, u_float) * ||A|| * ||B|| + ||A|| * ||B|| * u_bf16
+template <>
+std::vector<MatmulToleranceTestCase>
+    getMatmulToleranceTestCases<TypeTriple<bfloat16, float, float>>()
+{
+    auto uFloat = hipdnn_data_sdk::types::pow(2.0, -23);
+    auto uBf16 = hipdnn_data_sdk::types::pow(2.0, -7);
+
+    return {// K=1: ||A||=2, ||B||=2. Tol = gamma(1,uFloat)*4 + 4*uBf16
+            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, uFloat) * 4.0 + 4.0 * uBf16},
+            // K=10: ||A||=20, ||B||=20. Tol = gamma(10,uFloat)*400 + 400*uBf16
+            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, uFloat) * 400.0 + 400.0 * uBf16}};
+}
+
+// Bfloat16 / Bfloat16 / Bfloat16 (Low Precision: Statistical)
+// Tolerance = gamma(K, u_bf16) * ||A|| * ||B||
+template <>
+std::vector<MatmulToleranceTestCase>
+    getMatmulToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
+{
+    auto u = hipdnn_data_sdk::types::pow(2.0, -7);
+
+    return {// K=1: ||A||=2, ||B||=2
+            {{2, 1}, {1, 2}, 1.0, 1.0, computeGamma(1, u) * 4.0},
+            // K=10: ||A||=20, ||B||=20
+            {{2, 10}, {10, 2}, 1.0, 1.0, computeGamma(10, u) * 400.0},
+            // K=50: ||A||=100, ||B||=100 (K=100 exceeds gamma>=0.5 for bf16)
+            {{2, 50}, {50, 2}, 1.0, 1.0, computeGamma(50, u) * 10000.0}};
+}
+
+template <typename Out, typename In, typename Comp>
+class TestCalculateMatmulTolerance : public ::testing::TestWithParam<MatmulToleranceTestCase>
+{
+protected:
+    void verifyTolerance()
+    {
+        const auto& tc = GetParam();
+
+        if(tc.expectThrow)
+        {
+            auto a = createConstantTensor<In>(tc.aDims, tc.aValue);
+            auto b = createConstantTensor<In>(tc.bDims, tc.bValue);
+
+            EXPECT_THROW((calculateMatmulTolerance<Out, In, Comp>(a, b)), std::exception) << tc;
+        }
+        else
+        {
+            auto a = createConstantTensor<In>(tc.aDims, tc.aValue);
+            auto b = createConstantTensor<In>(tc.bDims, tc.bValue);
+
+            auto tolerance = calculateMatmulTolerance<Out, In, Comp>(a, b);
+            EXPECT_NEAR(tolerance, static_cast<float>(tc.expectedTolerance), 1e-10f) << tc;
+        }
+    }
+};
+
+using TestCalculateMatmulToleranceFp32 = TestCalculateMatmulTolerance<float, float, float>;
+TEST_P(TestCalculateMatmulToleranceFp32, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateMatmulToleranceFp32,
+    ::testing::ValuesIn(getMatmulToleranceTestCases<TypeTriple<float, float, float>>()));
+
+using TestCalculateMatmulToleranceInputDouble = TestCalculateMatmulTolerance<float, double, float>;
+TEST_P(TestCalculateMatmulToleranceInputDouble, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateMatmulToleranceInputDouble,
+    ::testing::ValuesIn(getMatmulToleranceTestCases<TypeTriple<float, double, float>>()));
+
+using TestCalculateMatmulToleranceComputeFloatFp16
+    = TestCalculateMatmulTolerance<half, float, float>;
+TEST_P(TestCalculateMatmulToleranceComputeFloatFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateMatmulToleranceComputeFloatFp16,
+    ::testing::ValuesIn(getMatmulToleranceTestCases<TypeTriple<half, float, float>>()));
+
+using TestCalculateMatmulToleranceFp16 = TestCalculateMatmulTolerance<half, half, half>;
+TEST_P(TestCalculateMatmulToleranceFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateMatmulToleranceFp16,
+    ::testing::ValuesIn(getMatmulToleranceTestCases<TypeTriple<half, half, half>>()));
+
+using TestCalculateMatmulToleranceComputeFloatBfp16
+    = TestCalculateMatmulTolerance<bfloat16, float, float>;
+TEST_P(TestCalculateMatmulToleranceComputeFloatBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateMatmulToleranceComputeFloatBfp16,
+    ::testing::ValuesIn(getMatmulToleranceTestCases<TypeTriple<bfloat16, float, float>>()));
+
+using TestCalculateMatmulToleranceBfp16
+    = TestCalculateMatmulTolerance<bfloat16, bfloat16, bfloat16>;
+TEST_P(TestCalculateMatmulToleranceBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculateMatmulToleranceBfp16,
+    ::testing::ValuesIn(getMatmulToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()));
+
+// Test dimension validation
+TEST(TestCalculateMatmulTolerance, ThrowsOnInvalidDimensions)
+{
+    // Mismatched dimensions: A is 2x3, B is 4x5 (3 != 4)
+    auto a = createConstantTensor<float>({2, 3}, 1.0);
+    auto b = createConstantTensor<float>({4, 5}, 1.0);
+
+    EXPECT_THROW((calculateMatmulTolerance<float, float, float>(a, b)), std::invalid_argument);
+}
+
+// Note: K=0 validation test removed. Tensor constructor's validateAllPositive() rejects
+// dimension <= 0 before calculateMatmulTolerance is reached, so K=0 cannot be tested
+// through the public API with real tensors.
+
+// Test that large K with low-precision type causes gamma >= 0.5 overflow
+TEST(TestCalculateMatmulTolerance, ThrowsOnSingularity)
+{
+    // For bfloat16, epsilon = 2^-7 ≈ 7.81e-3
+    // K=100: nU = 2*100*7.81e-3 = 1.562 >= 0.01 → statistical bound
+    // gamma = 6 * sqrt(200) * 7.81e-3 ≈ 0.663 >= 0.5 → overflow
+    auto a = createConstantTensor<bfloat16>({2, 100}, 1.0);
+    auto b = createConstantTensor<bfloat16>({100, 2}, 1.0);
+
+    EXPECT_THROW((calculateMatmulTolerance<bfloat16, bfloat16, bfloat16>(a, b)),
+                 std::overflow_error);
+}
+
+// Test that extreme values cause output overflow
+TEST(TestCalculateMatmulTolerance, ThrowsOnOutputOverflow)
+{
+    // Create matrices with very large values that will cause tolerance > half::max
+    // A = 2x10 filled with 1e5, B = 10x2 filled with 1e5
+    // ||A||_1 = 20 * 1e5 = 2e6, ||B||_1 = 20 * 1e5 = 2e6
+    // Product will exceed half max (65504)
+    auto a = createConstantTensor<float>({2, 10}, 1.0e5);
+    auto b = createConstantTensor<float>({10, 2}, 1.0e5);
+
+    // OutputType = half, so max ≈ 65504
+    EXPECT_THROW((calculateMatmulTolerance<half, float, float>(a, b)), std::overflow_error);
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
@@ -1173,6 +1173,8 @@ struct MatmulToleranceTestCase
     }
 };
 
+namespace
+{
 // Helper to create a tensor where each row is filled with a per-row constant value.
 // rowValues[i] specifies the constant value for all elements in row i.
 // This ensures different rows have different sums, exercising the max-row-sum logic
@@ -1206,6 +1208,7 @@ hipdnn_data_sdk::utilities::Tensor<T>
 
     return tensor;
 }
+} // namespace
 
 using hipdnn_test_sdk::utilities::computeGamma;
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
@@ -1218,7 +1218,7 @@ std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases();
 template <>
 std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<float, float, float>>()
 {
-    auto u = hipdnn_data_sdk::types::pow(2.0, -23);
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
 
     auto bRowValues100 = std::vector<double>(100, 1.0);
 
@@ -1251,7 +1251,7 @@ std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<floa
 template <>
 std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<float, double, float>>()
 {
-    auto u = hipdnn_data_sdk::types::pow(2.0, -23);
+    auto u = static_cast<double>(std::numeric_limits<float>::epsilon());
 
     return {
         // K=1: ||A||_inf=2, ||B||_inf=2. Tol = gamma(1,u)*4 + 2*4*u
@@ -1269,8 +1269,8 @@ std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<floa
 template <>
 std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<half, float, float>>()
 {
-    auto uFloat = hipdnn_data_sdk::types::pow(2.0, -23);
-    auto uHalf = hipdnn_data_sdk::types::pow(2.0, -10);
+    auto uFloat = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
 
     return {// K=1: ||A||_inf=2, ||B||_inf=2. Tol = gamma(1,uFloat)*4 + 4*uHalf
             {{2, 1},
@@ -1291,7 +1291,7 @@ std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<half
 template <>
 std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<half, half, half>>()
 {
-    auto u = hipdnn_data_sdk::types::pow(2.0, -10);
+    auto u = static_cast<double>(std::numeric_limits<half>::epsilon());
 
     auto bRowValues100 = std::vector<double>(100, 1.0);
 
@@ -1313,8 +1313,8 @@ template <>
 std::vector<MatmulToleranceTestCase>
     getMatmulToleranceTestCases<TypeTriple<bfloat16, float, float>>()
 {
-    auto uFloat = hipdnn_data_sdk::types::pow(2.0, -23);
-    auto uBf16 = hipdnn_data_sdk::types::pow(2.0, -7);
+    auto uFloat = static_cast<double>(std::numeric_limits<float>::epsilon());
+    auto uBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
 
     return {// K=1: ||A||_inf=2, ||B||_inf=2. Tol = gamma(1,uFloat)*4 + 4*uBf16
             {{2, 1},
@@ -1336,7 +1336,7 @@ template <>
 std::vector<MatmulToleranceTestCase>
     getMatmulToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
 {
-    auto u = hipdnn_data_sdk::types::pow(2.0, -7);
+    auto u = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
 
     auto bRowValues50 = std::vector<double>(50, 1.0);
 

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <gtest/gtest.h>
 #include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
@@ -1176,24 +1177,32 @@ struct MatmulToleranceTestCase
 // rowValues[i] specifies the constant value for all elements in row i.
 // This ensures different rows have different sums, exercising the max-row-sum logic
 // in computeMatrixInfNorm.
+// Supports batched (>2D) tensors via iterateAlongDimensions.
 template <typename T>
 hipdnn_data_sdk::utilities::Tensor<T>
     createTensorFromRowValues(const std::vector<int64_t>& dims,
                               const std::vector<double>& rowValues)
 {
+    using hipdnn_data_sdk::utilities::iterateAlongDimensions;
+
     hipdnn_data_sdk::utilities::Tensor<T> tensor(dims);
-    auto* data = static_cast<T*>(tensor.memory().hostData());
 
-    auto rows = dims[dims.size() - 2];
-    auto cols = dims[dims.size() - 1];
+    auto cols = dims.back();
 
-    for(int64_t i = 0; i < rows; ++i)
-    {
+    // outerDims = [batch..., rows] — everything except the last dim (cols)
+    auto outerDims = std::vector<int64_t>(dims.begin(), dims.end() - 1);
+
+    iterateAlongDimensions(outerDims, [&](const std::vector<int64_t>& outerIndices) {
+        auto row = outerIndices.back();
+        auto fullIndices = outerIndices;
+        fullIndices.push_back(0);
+
         for(int64_t j = 0; j < cols; ++j)
         {
-            data[i * cols + j] = static_cast<T>(rowValues[static_cast<size_t>(i)]);
+            fullIndices.back() = j;
+            tensor.setHostValue(static_cast<T>(rowValues[static_cast<size_t>(row)]), fullIndices);
         }
-    }
+    });
 
     return tensor;
 }
@@ -1224,7 +1233,17 @@ std::vector<MatmulToleranceTestCase> getMatmulToleranceTestCases<TypeTriple<floa
              {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
              computeGamma(10, u) * 20.0 * 10.0},
             // K=100: A=2x100, rows={1,2}. ||A||_inf=200, B=100x2, all 1.0. ||B||_inf=2
-            {{2, 100}, {100, 2}, {1.0, 2.0}, bRowValues100, computeGamma(100, u) * 200.0 * 2.0}};
+            {{2, 100}, {100, 2}, {1.0, 2.0}, bRowValues100, computeGamma(100, u) * 200.0 * 2.0},
+            // Batched K=3: A={2,2,3}, B={2,3,4}. Same row values as 2D K=3 case.
+            // Batch dim doesn't change max row sum: ||A||_inf=6, ||B||_inf=12
+            {{2, 2, 3}, {2, 3, 4}, {1.0, 2.0}, {1.0, 3.0, 0.5}, computeGamma(3, u) * 6.0 * 12.0},
+            // Batched K=10: A={3,2,10}, B={3,10,2}. 3 batches.
+            // ||A||_inf=20, ||B||_inf=10 (same as 2D K=10)
+            {{3, 2, 10},
+             {3, 10, 2},
+             {1.0, 2.0},
+             {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
+             computeGamma(10, u) * 20.0 * 10.0}};
 }
 
 // Float / Double / Float (Input casting error)

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestMatmulPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestMatmulPlan.cpp
@@ -70,7 +70,7 @@ TEST_F(TestMatmulPlan, ExecutePlan)
         = hipdnn_test_sdk::utilities::matmul::calculateMatmulTolerance<float, float, float>(
             planTensorBundle.aTensor, planTensorBundle.bTensor);
 
-    CpuFpReferenceValidation<float> const cpuRefOutputValidation(tolerance, tolerance);
+    const CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
     EXPECT_TRUE(
         cpuRefOutputValidation.allClose(directTensorBundle.cTensor, planTensorBundle.cTensor));
 }

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestMatmulPlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestMatmulPlan.cpp
@@ -11,9 +11,9 @@
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceMatmul.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/Seeds.hpp>
-#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/MatmulPlan.hpp>
 
 using namespace hipdnn_sdk_test_utils;
@@ -66,8 +66,11 @@ TEST_F(TestMatmulPlan, ExecutePlan)
 
     patient.execute(variantPack);
 
-    const CpuFpReferenceValidation<float> cpuRefOutputValidation(matmul::getTolerance<float>(),
-                                                                 matmul::getTolerance<float>());
+    auto tolerance
+        = hipdnn_test_sdk::utilities::matmul::calculateMatmulTolerance<float, float, float>(
+            planTensorBundle.aTensor, planTensorBundle.bTensor);
+
+    CpuFpReferenceValidation<float> const cpuRefOutputValidation(tolerance, tolerance);
     EXPECT_TRUE(
         cpuRefOutputValidation.allClose(directTensorBundle.cTensor, planTensorBundle.cTensor));
 }


### PR DESCRIPTION
## Motivation
Enable dynamic tolerance calculations for matrix multiplications or different sizes and data type entries.

## Technical details

  - Add `calculateMatmulTolerance<Out, In, Comp>(ITensor&, ITensor&)` for computing
    element-wise error bounds on matrix multiplication using Higham's forward error analysis
  - Add shared `computeGamma(k, epsilon)` utility with automatic linear/statistical
    regime switching, reusable across conv and matmul
  - Replace static matmul tolerance in `TestMatmulPlan.cpp` with the dynamic calculation

  Uses the matrix infinity-norm `||A||_inf = max_i (sum_j |A[i,j]|)` (max absolute row sum).
  This is the correct subordinate norm for element-wise error bounds:

      `max_ij |fl(C)_ij - C_ij| <= gamma_k * ||A||_inf * ||B||_inf`

  which matches what `allClose` validates.

## Test Plan

19 unit tests covering 6 type combinations (float, double, half, bfloat16) across linear and statistical gamma regimes, with input/output casting error paths.                                     
Tests use non-uniform row data to validate the infinity-norm implementation.
Three edge case tests verify throws on dimension mismatch, gamma overflow (bf16/K=100), and output overflow (tolerance > half::max).