### PR TITLE
[MIOpen] Fix Jenkins pipeline stage duplicate name

### DIFF
--- a/projects/miopen/Jenkinsfile
+++ b/projects/miopen/Jenkinsfile
@@ -658,7 +658,7 @@ pipeline {
                     }
                 }
                 // GFX90A Tests
-                stage('Fp32 Hip Debug gfx90a') {
+                stage('Fp32 Hip Debug CTEST gfx90a') {
                     when {
                         beforeAgent true
                         expression { params.TARGET_GFX90A }


### PR DESCRIPTION
## Motivation

Jenkins pipeline stalled since the pipeline has duplicate stage names (lines 661 and 830) - [example ](http://micimaster.amd.com/blue/organizations/jenkins/rocm-libraries-folder%2fMIOpen/detail/develop/733/pipeline/)
```
[2026-03-14T05:00:00.966Z] Started by timer with parameters: {NONCRITICAL_HW_NIGHTLY=true, BUILD_PACKAGE_AND_CHECKS=false, BUILD_FULL_TESTS=false, TARGET_GFX908=true, TARGET_NAVI35=true, TARGET_GFX90A=false, TARGET_GFX942=false}

[2026-03-14T05:00:01.120Z] Connecting to https://api.github.com/ using 1011671/******

[2026-03-14T05:00:01.958Z] Obtained projects/miopen/Jenkinsfile from 1207592af6830306da9b4689b425dec13b4391cc

[2026-03-14T05:00:03.170Z] org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:

[2026-03-14T05:00:03.170Z] WorkflowScript: 643: Duplicate stage name: "Fp32 Hip Debug gfx90a" @ line 643, column 13.

[2026-03-14T05:00:03.170Z]                parallel{

[2026-03-14T05:00:03.170Z]                ^

[2026-03-14T05:00:03.170Z] 

[2026-03-14T05:00:03.170Z] WorkflowScript: 643: Duplicate stage name: "Fp32 Hip Debug gfx90a" @ line 643, column 13.

[2026-03-14T05:00:03.170Z]                parallel{

[2026-03-14T05:00:03.170Z]                ^

[2026-03-14T05:00:03.170Z] 

[2026-03-14T05:00:03.170Z] 2 errors
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

CI should trigger and run jenkins pipeline

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
