### PR TITLE
[CK] Add Filter1x1Stride1Pad0 WMMA backward weight conv instances

### DIFF
--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/grouped_conv2d_bwd_weight/wmma/nhwgc_gkyxc_nhwgk/device_grouped_conv2d_bwd_weight_two_stage_wmma_nhwgc_gkyxc_nhwgk_bf16_pipev1_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/grouped_conv2d_bwd_weight/wmma/nhwgc_gkyxc_nhwgk/device_grouped_conv2d_bwd_weight_two_stage_wmma_nhwgc_gkyxc_nhwgk_bf16_pipev1_instance.cpp
@@ -33,6 +33,17 @@ void add_device_grouped_conv2d_bwd_weight_two_stage_wmma_nhwgc_gkyxc_nhwgk_bf16_
             ConvBwdWeightDefault,
             BlockGemmPipelineScheduler::Intrawave,
             BlockGemmPipelineVersion::v1>{});
+    // 2. Filter1x1Stride1Pad0
+    add_device_operation_instances(
+        instances,
+        device_grouped_conv_bwd_weight_two_stage_nhwgc_wmma_c_shuffle_bf16_instances<
+            2,
+            NHWGC,
+            GKYXC,
+            NHWGK,
+            ConvBwdWeightFilter1x1Stride1Pad0,
+            BlockGemmPipelineScheduler::Intrawave,
+            BlockGemmPipelineVersion::v1>{});
 }
 
 } // namespace instance

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/grouped_conv2d_bwd_weight/wmma/nhwgc_gkyxc_nhwgk/device_grouped_conv2d_bwd_weight_two_stage_wmma_nhwgc_gkyxc_nhwgk_f16_pipev1_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/grouped_conv2d_bwd_weight/wmma/nhwgc_gkyxc_nhwgk/device_grouped_conv2d_bwd_weight_two_stage_wmma_nhwgc_gkyxc_nhwgk_f16_pipev1_instance.cpp
@@ -33,6 +33,17 @@ void add_device_grouped_conv2d_bwd_weight_two_stage_wmma_nhwgc_gkyxc_nhwgk_f16_p
             ConvBwdWeightDefault,
             BlockGemmPipelineScheduler::Intrawave,
             BlockGemmPipelineVersion::v1>{});
+    // 2. Filter1x1Stride1Pad0
+    add_device_operation_instances(
+        instances,
+        device_grouped_conv_bwd_weight_two_stage_nhwgc_wmma_c_shuffle_f16_instances<
+            2,
+            NHWGC,
+            GKYXC,
+            NHWGK,
+            ConvBwdWeightFilter1x1Stride1Pad0,
+            BlockGemmPipelineScheduler::Intrawave,
+            BlockGemmPipelineVersion::v1>{});
 }
 
 } // namespace instance

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/grouped_conv2d_bwd_weight/wmma/nhwgc_gkyxc_nhwgk/device_grouped_conv2d_bwd_weight_wmma_nhwgc_gkyxc_nhwgk_bf16_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/grouped_conv2d_bwd_weight/wmma/nhwgc_gkyxc_nhwgk/device_grouped_conv2d_bwd_weight_wmma_nhwgc_gkyxc_nhwgk_bf16_instance.cpp
@@ -30,6 +30,14 @@ void add_device_grouped_conv2d_bwd_weight_wmma_nhwgc_gkyxc_nhwgk_bf16_instances(
                                                                         GKYXC,
                                                                         NHWGK,
                                                                         ConvBwdWeightDefault>{});
+    // 2. Filter1x1Stride1Pad0
+    add_device_operation_instances(
+        instances,
+        device_grouped_conv_bwd_weight_v3_wmma_c_shuffle_bf16_instances<2,
+                                                                        NHWGC,
+                                                                        GKYXC,
+                                                                        NHWGK,
+                                                                        ConvBwdWeightFilter1x1Stride1Pad0>{});
 }
 
 } // namespace instance

--- a/projects/composablekernel/library/src/tensor_operation_instance/gpu/grouped_conv2d_bwd_weight/wmma/nhwgc_gkyxc_nhwgk/device_grouped_conv2d_bwd_weight_wmma_nhwgc_gkyxc_nhwgk_f16_instance.cpp
+++ b/projects/composablekernel/library/src/tensor_operation_instance/gpu/grouped_conv2d_bwd_weight/wmma/nhwgc_gkyxc_nhwgk/device_grouped_conv2d_bwd_weight_wmma_nhwgc_gkyxc_nhwgk_f16_instance.cpp
@@ -30,6 +30,14 @@ void add_device_grouped_conv2d_bwd_weight_wmma_nhwgc_gkyxc_nhwgk_f16_instances(
                                                                        GKYXC,
                                                                        NHWGK,
                                                                        ConvBwdWeightDefault>{});
+    // 2. Filter1x1Stride1Pad0
+    add_device_operation_instances(
+        instances,
+        device_grouped_conv_bwd_weight_v3_wmma_c_shuffle_f16_instances<2,
+                                                                       NHWGC,
+                                                                       GKYXC,
+                                                                       NHWGK,
+                                                                       ConvBwdWeightFilter1x1Stride1Pad0>{});
 }
 
 } // namespace instance


### PR DESCRIPTION
## Proposed changes

Add the `Filter1x1Stride1Pad0` convolution specialization to all 4 WMMA backward weight instance files. The XDL instances already have both `ConvBwdWeightDefault` and `Filter1x1Stride1Pad0`, but the WMMA instances only had `Default`.

This causes 1x1 convolution backward weight to use the generic path with unnecessary padding/stride logic when running on WMMA-capable GPUs (gfx11xx, gfx12xx).

### Changes

4 files, each adds one `add_device_operation_instances()` call with `ConvBwdWeightFilter1x1Stride1Pad0`:
- `device_grouped_conv2d_bwd_weight_wmma_nhwgc_gkyxc_nhwgk_f16_instance.cpp`
- `device_grouped_conv2d_bwd_weight_wmma_nhwgc_gkyxc_nhwgk_bf16_instance.cpp`
- `device_grouped_conv2d_bwd_weight_two_stage_wmma_nhwgc_gkyxc_nhwgk_f16_pipev1_instance.cpp`
- `device_grouped_conv2d_bwd_weight_two_stage_wmma_nhwgc_gkyxc_nhwgk_bf16_pipev1_instance.cpp`

### Benchmark (RX 9070 XT gfx1201, WSL2 32/64 CUs)

**1x1 Conv BwdWrW FP16 batch=64:**

| Layer | Without Filter1x1 (TFLOPS) | With Filter1x1 (TFLOPS) | Improvement |
|-------|---------------------------|------------------------|-------------|
| 512→128 @ 28×28 | 13.8 | **16.4** | +19% |
| 256→64 @ 56×56 | 8.5 | **9.6** | +13% |
| 2048→512 @ 7×7 | 23.7 | **24.0** | +1% |

**PyTorch ResNet50 FP16 training:** 538.2 → **557.3 img/sec** (+3.5%)

## Checklist

- [x] Follows existing XDL instance pattern
- [x] No regressions — additive instances only
- [x] Benchmarked on real hardware

Related: #5455