### PR TITLE
Improved CI infrastructure failure detection

### DIFF
--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -118,7 +118,7 @@ def sendFailureNotifications() {
     ]
     
     // Get the build log.
-    def buildLog = currentBuild.rawBuild.getLog(Integer.MAX_VALUE).join('\n')
+    def buildLog = sh(script: 'wget -q --no-check-certificate -O - ' + BUILD_URL + 'consoleText', returnStdout: true)
     echo "Checking for failure patterns..."
     // Check for patterns in the log.
     def foundPatterns = []

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -1452,16 +1452,11 @@ pipeline {
                     env.SHOULD_RUN_CI = String.valueOf(params.FORCE_CI.toBoolean() || shouldRunCICheck())
                     echo "SHOULD_RUN_CI: ${env.SHOULD_RUN_CI}"
 
-                    // TEST ONLY: Emit all failure patterns so sendFailureNotifications() can
-                    // detect and exercise every pattern branch, then force the build to fail.
-                    echo "login attempt to registry.example.com failed with status: 401 Unauthorized"
-                    echo "docker login failed"
-                    echo "HTTP request sent awaiting response... 404 Not Found"
+                    // TEST ONLY: Generate a large volume of dummy output to simulate a real
+                    // build log, then emit all failure patterns near the end to verify that
+                    // sendFailureNotifications() correctly detects patterns in a large log.
+                    sh 'for i in $(seq 1 80000); do echo "Dummy build log line $i: compiling and processing..."; done'
                     echo "cat: /dev/dri/renderD128: No such file or directory"
-                    echo "GPU not found"
-                    echo "Could not connect to Redis at 127.0.0.1:6379: Connection timed out"
-                    echo "unauthorized: your account must log in with a Personal Access Token"
-                    echo "sccache: error: Server startup failed: Address in use"
                     error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -1487,14 +1487,6 @@ pipeline {
                     checkoutComposableKernel()
                     env.SHOULD_RUN_CI = String.valueOf(params.FORCE_CI.toBoolean() || shouldRunCICheck())
                     echo "SHOULD_RUN_CI: ${env.SHOULD_RUN_CI}"
-
-                    // TEST ONLY: Generate a large volume of dummy output to simulate a real
-                    // build log, then emit all failure patterns near the end to verify that
-                    // sendFailureNotifications() correctly detects patterns in a large log.
-                    sh 'for i in $(seq 1 30000); do echo "Dummy build log line $i: compiling and processing..."; done'
-                    echo "cat: /dev/dri/renderD128: No such file or directory"
-                    sh 'for i in $(seq 1 50000); do echo "Dummy build log line $i: compiling and processing..."; done'
-                    error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }
         }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -1386,14 +1386,6 @@ pipeline {
                     checkoutComposableKernel()
                     env.SHOULD_RUN_CI = String.valueOf(params.FORCE_CI.toBoolean() || shouldRunCICheck())
                     echo "SHOULD_RUN_CI: ${env.SHOULD_RUN_CI}"
-
-                    // TEST ONLY: Generate a large volume of dummy output to simulate a real
-                    // build log, then emit all failure patterns near the end to verify that
-                    // sendFailureNotifications() correctly detects patterns in a large log.
-                    sh 'for i in $(seq 1 30000); do echo "Dummy build log line $i: compiling and processing..."; done'
-                    echo "cat: /dev/dri/renderD128: No such file or directory"
-                    sh 'for i in $(seq 1 50000); do echo "Dummy build log line $i: compiling and processing..."; done'
-                    error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }
         }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -1451,6 +1451,18 @@ pipeline {
                     checkoutComposableKernel()
                     env.SHOULD_RUN_CI = String.valueOf(params.FORCE_CI.toBoolean() || shouldRunCICheck())
                     echo "SHOULD_RUN_CI: ${env.SHOULD_RUN_CI}"
+
+                    // TEST ONLY: Emit all failure patterns so sendFailureNotifications() can
+                    // detect and exercise every pattern branch, then force the build to fail.
+                    echo "login attempt to registry.example.com failed with status: 401 Unauthorized"
+                    echo "docker login failed"
+                    echo "HTTP request sent awaiting response... 404 Not Found"
+                    echo "cat: /dev/dri/renderD128: No such file or directory"
+                    echo "GPU not found"
+                    echo "Could not connect to Redis at 127.0.0.1:6379: Connection timed out"
+                    echo "unauthorized: your account must log in with a Personal Access Token"
+                    echo "sccache: error: Server startup failed: Address in use"
+                    error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }
         }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -94,7 +94,7 @@ def sendFailureNotifications() {
         [pattern: 'GPU not found', description: "GPU not found"],
         [pattern: 'Could not connect to Redis at .* Connection timed out', description: "Redis connection timed out"],
         [pattern: 'unauthorized: your account must log in with a Personal Access Token', description: "Docker login failed"],
-        [pattern: 'sccache: error: Server startup failed: Address in use', description: "Sccache Error"]
+        [pattern: 'sccache: error: Server startup failed: Address in use', description: "Sccache Error"],
         [pattern: 'No space left on device', description: "Device space error"]
     ]
 

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -100,7 +100,7 @@ def sendFailureNotifications() {
 
     // Patterns where the node name is useful for triage — captured by extracting
     // NODE_NAME = <name> from the context block.
-    def gpuPatterns = ['cat: .* No such file or directory', 'GPU not found']
+    def nodePatterns = ['cat: .* No such file or directory', 'GPU not found', 'No space left on device']
 
     // Build a single combined grep -E pattern and stream the log through it.
     // grep does the scanning natively so the full log is never loaded into Groovy.
@@ -135,7 +135,7 @@ def sendFailureNotifications() {
         for (patternMap in failurePatterns) {
             if ((block =~ patternMap.pattern) && !foundPatterns.any { it.description == patternMap.description }) {
                 def nodeName = ""
-                if (gpuPatterns.contains(patternMap.pattern)) {
+                if (nodePatterns.contains(patternMap.pattern)) {
                     nodeName = sh(
                         script: """
                             set +x

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -1494,15 +1494,6 @@ pipeline {
                     checkoutComposableKernel()
                     env.SHOULD_RUN_CI = String.valueOf(params.FORCE_CI.toBoolean() || shouldRunCICheck())
                     echo "SHOULD_RUN_CI: ${env.SHOULD_RUN_CI}"
-
-                    // TEST ONLY: Generate a large volume of dummy output to simulate a real
-                    // build log, then emit all failure patterns near the end to verify that
-                    // sendFailureNotifications() correctly detects patterns in a large log.
-                    sh 'echo "NODE_NAME = \$NODE_NAME"'
-                    sh 'for i in $(seq 1 30000); do echo "Dummy build log line $i: compiling and processing..."; done'
-                    echo "cat: /dev/dri/renderD128: No such file or directory"
-                    sh 'for i in $(seq 1 50000); do echo "Dummy build log line $i: compiling and processing..."; done'
-                    error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }
         }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -95,6 +95,7 @@ def sendFailureNotifications() {
         [pattern: 'Could not connect to Redis at .* Connection timed out', description: "Redis connection timed out"],
         [pattern: 'unauthorized: your account must log in with a Personal Access Token', description: "Docker login failed"],
         [pattern: 'sccache: error: Server startup failed: Address in use', description: "Sccache Error"]
+        [pattern: 'No space left on device', description: "Device space error"]
     ]
 
     // Patterns where the node name is useful for triage — captured by extracting

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -104,16 +104,14 @@ def sendFailureNotifications() {
 
     // Build a single combined grep -E pattern and stream the log through it.
     // grep does the scanning natively so the full log is never loaded into Groovy.
-    // -B 10 captures enough preceding lines to include NODE_NAME = <name>, which
-    // appears 6 lines before the cat: failure line in the build log.
-    // -A 2 captures 2 lines of context after each match.
+    // -B 2 -A 2 captures 2 lines of context around each match.
     // || true prevents a non-zero grep exit code (no matches) from failing the stage.
     def combinedPattern = failurePatterns.collect { it.pattern }.join('|')
     echo "Checking for failure patterns..."
     def grepOutput = sh(
         script: """
             set +x
-            wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | grep -E -B 10 -A 2 '${combinedPattern}' || true
+            wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | grep -E -B 2 -A 2 '${combinedPattern}' || true
         """,
         returnStdout: true
     ).trim()
@@ -128,7 +126,9 @@ def sendFailureNotifications() {
     // Adjacent matches share one block (no '--' separator), so all patterns must
     // be checked against every block. Deduplication prevents double-notifying on
     // the same description if a pattern appears in multiple blocks.
-    // For GPU-related patterns, also extract the node name from the context block.
+    // For GPU-related patterns, the node name is extracted via a separate awk pass
+    // that tracks the most recent NODE_NAME seen and exits as soon as the failure
+    // line is hit, working reliably regardless of log size.
     def foundPatterns = []
     def blocks = grepOutput.split('\n--\n')
     for (block in blocks) {
@@ -136,10 +136,16 @@ def sendFailureNotifications() {
             if ((block =~ patternMap.pattern) && !foundPatterns.any { it.description == patternMap.description }) {
                 def nodeName = ""
                 if (gpuPatterns.contains(patternMap.pattern)) {
-                    def nodeNameMatcher = (block =~ /NODE_NAME\s*=\s*(\S+)/)
-                    if (nodeNameMatcher) {
-                        nodeName = nodeNameMatcher[0][1]
-                    }
+                    nodeName = sh(
+                        script: """
+                            set +x
+                            wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | awk '
+                                /NODE_NAME[[:space:]]*=/ { node = \$NF }
+                                /${patternMap.pattern}/ { print node; exit }
+                            '
+                        """,
+                        returnStdout: true
+                    ).trim()
                 }
                 foundPatterns.add([description: patternMap.description, context: block, nodeName: nodeName])
             }
@@ -1488,6 +1494,15 @@ pipeline {
                     checkoutComposableKernel()
                     env.SHOULD_RUN_CI = String.valueOf(params.FORCE_CI.toBoolean() || shouldRunCICheck())
                     echo "SHOULD_RUN_CI: ${env.SHOULD_RUN_CI}"
+
+                    // TEST ONLY: Generate a large volume of dummy output to simulate a real
+                    // build log, then emit all failure patterns near the end to verify that
+                    // sendFailureNotifications() correctly detects patterns in a large log.
+                    sh 'echo "NODE_NAME = \$NODE_NAME"'
+                    sh 'for i in $(seq 1 30000); do echo "Dummy build log line $i: compiling and processing..."; done'
+                    echo "cat: /dev/dri/renderD128: No such file or directory"
+                    sh 'for i in $(seq 1 50000); do echo "Dummy build log line $i: compiling and processing..."; done'
+                    error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }
         }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -1452,7 +1452,14 @@ pipeline {
                     // build log, then emit all failure patterns near the end to verify that
                     // sendFailureNotifications() correctly detects patterns in a large log.
                     sh 'for i in $(seq 1 80000); do echo "Dummy build log line $i: compiling and processing..."; done'
+                    echo "login attempt to registry.example.com failed with status: 401 Unauthorized"
+                    echo "docker login failed"
+                    echo "HTTP request sent awaiting response... 404 Not Found"
                     echo "cat: /dev/dri/renderD128: No such file or directory"
+                    echo "GPU not found"
+                    echo "Could not connect to Redis at 127.0.0.1:6379: Connection timed out"
+                    echo "unauthorized: your account must log in with a Personal Access Token"
+                    echo "sccache: error: Server startup failed: Address in use"
                     error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -117,14 +117,16 @@ def sendFailureNotifications() {
     }
 
     // grep separates non-adjacent match blocks with '--'. Split on that to get
-    // one context block per match, then identify which pattern each block hit.
+    // one context block per match, then identify which patterns each block hit.
+    // Adjacent matches share one block (no '--' separator), so all patterns must
+    // be checked against every block. Deduplication prevents double-notifying on
+    // the same description if a pattern appears in multiple blocks.
     def foundPatterns = []
     def blocks = grepOutput.split('\n--\n')
     for (block in blocks) {
         for (patternMap in failurePatterns) {
-            if (block =~ patternMap.pattern) {
+            if ((block =~ patternMap.pattern) && !foundPatterns.any { it.description == patternMap.description }) {
                 foundPatterns.add([description: patternMap.description, context: block])
-                break
             }
         }
     }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -81,11 +81,9 @@ def checkoutComposableKernel()
     checkout scm
 }
 
-// Given a pattern, check if the log contains the pattern and return the context.
 // Scan the build logs for failures and send notifications.
 def sendFailureNotifications() {
     // Error patterns to scan build logs for specific failure types and send detailed notifications.
-    // Patterns are plain strings so they can be passed directly to grep -E.
     def failurePatterns = [
         [pattern: 'login attempt to .* failed with status: 401 Unauthorized', description: "Docker registry authentication failed"],
         [pattern: 'docker login failed', description: "Docker login failed"],
@@ -98,8 +96,7 @@ def sendFailureNotifications() {
         [pattern: 'No space left on device', description: "Device space error"]
     ]
 
-    // Patterns where the node name is useful for triage — captured by extracting
-    // NODE_NAME = <name> from the context block.
+    // The patterns which we want to know the node's name.
     def nodePatterns = ['cat: .* No such file or directory', 'GPU not found', 'No space left on device']
 
     // Build a single combined grep -E pattern and stream the log through it.
@@ -127,8 +124,7 @@ def sendFailureNotifications() {
     // be checked against every block. Deduplication prevents double-notifying on
     // the same description if a pattern appears in multiple blocks.
     // For GPU-related patterns, the node name is extracted via a separate awk pass
-    // that tracks the most recent NODE_NAME seen and exits as soon as the failure
-    // line is hit, working reliably regardless of log size.
+    // that tracks the most recent NODE_NAME seen and exits as soon as the failure is observed.
     def foundPatterns = []
     def blocks = grepOutput.split('\n--\n')
     for (block in blocks) {
@@ -162,7 +158,6 @@ def sendFailureNotifications() {
             .replace('\n', '\\n')
         withCredentials([string(credentialsId: 'ck_ci_errors_webhook_url', variable: 'WEBHOOK_URL')]) {
         sh '''
-            # Create JSON payload with base64 data
             echo "Creating JSON payload..."
             {
                 printf '{\n'

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -2052,6 +2052,9 @@ pipeline {
                          status: 'FAILURE',
                          description: 'Some checks have failed'
             node(rocmnode("nogpu")) {
+                script {
+                    checkoutComposableKernel()
+                }
                 withCredentials([string(credentialsId: 'ck_ci_errors_webhook_url', variable: 'WEBHOOK_URL')]) {
                     sh 'bash projects/composablekernel/script/infra_helper/send_failure_notifications.sh'
                 }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -81,109 +81,6 @@ def checkoutComposableKernel()
     checkout scm
 }
 
-// Scan the build logs for failures and send notifications.
-def sendFailureNotifications() {
-    // Error patterns to scan build logs for specific failure types and send detailed notifications.
-    def failurePatterns = [
-        [pattern: 'login attempt to .* failed with status: 401 Unauthorized', description: "Docker registry authentication failed"],
-        [pattern: 'docker login failed', description: "Docker login failed"],
-        [pattern: 'HTTP request sent .* 404 Not Found', description: "HTTP request failed with 404"],
-        [pattern: 'cat: .* No such file or directory', description: "Missing drivers"],
-        [pattern: 'GPU not found', description: "GPU not found"],
-        [pattern: 'Could not connect to Redis at .* Connection timed out', description: "Redis connection timed out"],
-        [pattern: 'unauthorized: your account must log in with a Personal Access Token', description: "Docker login failed"],
-        [pattern: 'sccache: error: Server startup failed: Address in use', description: "Sccache Error"],
-        [pattern: 'No space left on device', description: "Device space error"]
-    ]
-
-    // The patterns which we want to know the node's name.
-    def nodePatterns = ['cat: .* No such file or directory', 'GPU not found', 'No space left on device']
-
-    // Build a single combined grep -E pattern and stream the log through it.
-    // grep does the scanning natively so the full log is never loaded into Groovy.
-    // -B 2 -A 2 captures 2 lines of context around each match.
-    // || true prevents a non-zero grep exit code (no matches) from failing the stage.
-    def combinedPattern = failurePatterns.collect { it.pattern }.join('|')
-    echo "Checking for failure patterns..."
-    def grepOutput = sh(
-        script: """
-            set +x
-            wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | grep -E -B 2 -A 2 '${combinedPattern}' || true
-        """,
-        returnStdout: true
-    ).trim()
-
-    if (!grepOutput) {
-        echo "No failure patterns found in build log"
-        return
-    }
-
-    // grep separates non-adjacent match blocks with '--'. Split on that to get
-    // one context block per match, then identify which patterns each block hit.
-    // Adjacent matches share one block (no '--' separator), so all patterns must
-    // be checked against every block. Deduplication prevents double-notifying on
-    // the same description if a pattern appears in multiple blocks.
-    // For GPU-related patterns, the node name is extracted via a separate awk pass
-    // that tracks the most recent NODE_NAME seen and exits as soon as the failure is observed.
-    def foundPatterns = []
-    def blocks = grepOutput.split('\n--\n')
-    for (block in blocks) {
-        for (patternMap in failurePatterns) {
-            if ((block =~ patternMap.pattern) && !foundPatterns.any { it.description == patternMap.description }) {
-                def nodeName = ""
-                if (nodePatterns.contains(patternMap.pattern)) {
-                    nodeName = sh(
-                        script: """
-                            set +x
-                            wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | awk '
-                                /NODE_NAME[[:space:]]*=/ { node = \$NF }
-                                /${patternMap.pattern}/ { print node; exit }
-                            '
-                        """,
-                        returnStdout: true
-                    ).trim()
-                }
-                foundPatterns.add([description: patternMap.description, context: block, nodeName: nodeName])
-            }
-        }
-    }
-    echo "Done checking for failure patterns..."
-    // Send a notification for each matched failure pattern.
-    for (patternMap in foundPatterns) {
-        // Escape the context string for safe embedding in a JSON value:
-        // backslashes first, then quotes, then convert real newlines to \n.
-        def escapedContext = patternMap.context
-            .replace('\\', '\\\\')
-            .replace('"', '\\"')
-            .replace('\n', '\\n')
-        withCredentials([string(credentialsId: 'ck_ci_errors_webhook_url', variable: 'WEBHOOK_URL')]) {
-        sh '''
-            echo "Creating JSON payload..."
-            {
-                printf '{\n'
-                printf '    "jobName": "%s",\n' "''' + env.JOB_NAME + '''"
-                printf '    "buildNumber": "%s",\n' "''' + env.BUILD_NUMBER + '''"
-                printf '    "jobUrl": "%s",\n' "''' + env.RUN_DISPLAY_URL + '''"
-                printf '    "detectedIssue": "%s",\n' "''' + patternMap.description + '''"
-                printf '    "logContext": "%s",\n' "''' + escapedContext + '''"
-                printf '    "nodeName": "%s",\n' "''' + (patternMap.nodeName ? patternMap.nodeName : "") + '''"
-                printf '}\n'
-            } > webhook_payload.json
-            
-            echo "JSON payload created, size: $(wc -c < webhook_payload.json) bytes"
-            
-            curl -X POST "${WEBHOOK_URL}" \
-            -H "Content-Type: application/json" \
-            -d @webhook_payload.json
-            
-            # Clean up temporary file
-            rm -f webhook_payload.json
-        '''
-        }
-    }
-    echo "Done failure pattern checking and notifications"
-}
-
 def generateAndArchiveBuildTraceVisualization(String buildTraceFileName) {
     try {
         checkoutComposableKernel()
@@ -1489,6 +1386,14 @@ pipeline {
                     checkoutComposableKernel()
                     env.SHOULD_RUN_CI = String.valueOf(params.FORCE_CI.toBoolean() || shouldRunCICheck())
                     echo "SHOULD_RUN_CI: ${env.SHOULD_RUN_CI}"
+
+                    // TEST ONLY: Generate a large volume of dummy output to simulate a real
+                    // build log, then emit all failure patterns near the end to verify that
+                    // sendFailureNotifications() correctly detects patterns in a large log.
+                    sh 'for i in $(seq 1 30000); do echo "Dummy build log line $i: compiling and processing..."; done'
+                    echo "cat: /dev/dri/renderD128: No such file or directory"
+                    sh 'for i in $(seq 1 50000); do echo "Dummy build log line $i: compiling and processing..."; done'
+                    error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }
         }
@@ -2147,8 +2052,8 @@ pipeline {
                          status: 'FAILURE',
                          description: 'Some checks have failed'
             node(rocmnode("nogpu")) {
-                script {
-                    sendFailureNotifications()
+                withCredentials([string(credentialsId: 'ck_ci_errors_webhook_url', variable: 'WEBHOOK_URL')]) {
+                    sh 'bash projects/composablekernel/script/infra_helper/send_failure_notifications.sh'
                 }
             }
         }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -90,7 +90,7 @@ def sendFailureNotifications() {
         [pattern: 'login attempt to .* failed with status: 401 Unauthorized', description: "Docker registry authentication failed"],
         [pattern: 'docker login failed', description: "Docker login failed"],
         [pattern: 'HTTP request sent .* 404 Not Found', description: "HTTP request failed with 404"],
-        [pattern: 'cat: .* No such file or directory', description: "GPU not found"],
+        [pattern: 'cat: .* No such file or directory', description: "Missing drivers"],
         [pattern: 'GPU not found', description: "GPU not found"],
         [pattern: 'Could not connect to Redis at .* Connection timed out', description: "Redis connection timed out"],
         [pattern: 'unauthorized: your account must log in with a Personal Access Token', description: "Docker login failed"],
@@ -1453,15 +1453,11 @@ pipeline {
                     // TEST ONLY: Generate a large volume of dummy output to simulate a real
                     // build log, then emit all failure patterns near the end to verify that
                     // sendFailureNotifications() correctly detects patterns in a large log.
-                    sh 'for i in $(seq 1 80000); do echo "Dummy build log line $i: compiling and processing..."; done'
-                    echo "login attempt to registry.example.com failed with status: 401 Unauthorized"
-                    echo "docker login failed"
-                    echo "HTTP request sent awaiting response... 404 Not Found"
+                    sh 'for i in $(seq 1 30000); do echo "Dummy build log line $i: compiling and processing..."; done'
                     echo "cat: /dev/dri/renderD128: No such file or directory"
+                    sh 'for i in $(seq 1 30000); do echo "Dummy build log line $i: compiling and processing..."; done'
                     echo "GPU not found"
-                    echo "Could not connect to Redis at 127.0.0.1:6379: Connection timed out"
-                    echo "unauthorized: your account must log in with a Personal Access Token"
-                    echo "sccache: error: Server startup failed: Address in use"
+                    sh 'for i in $(seq 1 20000); do echo "Dummy build log line $i: compiling and processing..."; done'
                     error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -108,30 +108,30 @@ def sendFailureNotifications() {
     // Error patterns to scan build logs for specific failure types and send detailed notifications.
     def failurePatterns = [
         [pattern: /login attempt to .* failed with status: 401 Unauthorized/, description: "Docker registry authentication failed"],
-        [pattern: /.*docker login failed.*/, description: "Docker login failed"],
+        [pattern: /docker login failed/, description: "Docker login failed"],
         [pattern: /HTTP request sent .* 404 Not Found/, description: "HTTP request failed with 404"],
         [pattern: /cat: .* No such file or directory/, description: "GPU not found"],
-        [pattern: /.*GPU not found.*/, description: "GPU not found"],
+        [pattern: /GPU not found/, description: "GPU not found"],
         [pattern: /Could not connect to Redis at .* Connection timed out/, description: "Redis connection timed out"],
-        [pattern: /.*unauthorized: your account must log in with a Personal Access Token.*/, description: "Docker login failed"],
-        [pattern: /.*sccache: error: Server startup failed: Address in use.*/, description: "Sccache Error"]
+        [pattern: /unauthorized: your account must log in with a Personal Access Token/, description: "Docker login failed"],
+        [pattern: /sccache: error: Server startup failed: Address in use/, description: "Sccache Error"]
     ]
     
     // Get the build log.
-    def buildLog = sh(script: 'wget -q --no-check-certificate -O - ' + BUILD_URL + 'consoleText', returnStdout: true)
+    def buildLog = currentBuild.rawBuild.getLog(Integer.MAX_VALUE).join('\n')
     echo "Checking for failure patterns..."
-    // Check for patterns in the log.
-    // def foundPatterns = []
-    // for (patternMap in failurePatterns) {
-    //     def result = checkForPattern(patternMap.pattern, buildLog)
-    //     if (result.found) {
-    //         foundPatterns.add([
-    //             description: patternMap.description,
-    //             matchedLine: result.matchedLine,
-    //             context: result.context
-    //         ])
-    //     }
-    // }
+    Check for patterns in the log.
+    def foundPatterns = []
+    for (patternMap in failurePatterns) {
+        def result = checkForPattern(patternMap.pattern, buildLog)
+        if (result.found) {
+            foundPatterns.add([
+                description: patternMap.description,
+                matchedLine: result.matchedLine,
+                context: result.context
+            ])
+        }
+    }
     echo "Done checking for failure patterns..."
     // Send a notification for each matched failure pattern.
     for (patternMap in foundPatterns) {

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -104,7 +104,10 @@ def sendFailureNotifications() {
     def combinedPattern = failurePatterns.collect { it.pattern }.join('|')
     echo "Checking for failure patterns..."
     def grepOutput = sh(
-        script: "wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | grep -E -B 2 -A 2 '${combinedPattern}' || true",
+        script: """
+            set +x
+            wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | grep -E -B 2 -A 2 '${combinedPattern}' || true
+        """,
         returnStdout: true
     ).trim()
 

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -147,6 +147,12 @@ def sendFailureNotifications() {
     echo "Done checking for failure patterns..."
     // Send a notification for each matched failure pattern.
     for (patternMap in foundPatterns) {
+        // Escape the context string for safe embedding in a JSON value:
+        // backslashes first, then quotes, then convert real newlines to \n.
+        def escapedContext = patternMap.context
+            .replace('\\', '\\\\')
+            .replace('"', '\\"')
+            .replace('\n', '\\n')
         withCredentials([string(credentialsId: 'ck_ci_errors_webhook_url', variable: 'WEBHOOK_URL')]) {
         sh '''
             # Create JSON payload with base64 data
@@ -157,7 +163,7 @@ def sendFailureNotifications() {
                 printf '    "buildNumber": "%s",\n' "''' + env.BUILD_NUMBER + '''"
                 printf '    "jobUrl": "%s",\n' "''' + env.RUN_DISPLAY_URL + '''"
                 printf '    "detectedIssue": "%s",\n' "''' + patternMap.description + '''"
-                printf '    "logContext": "%s",\n' "''' + patternMap.context + '''"
+                printf '    "logContext": "%s",\n' "''' + escapedContext + '''"
                 printf '    "nodeName": "%s",\n' "''' + (patternMap.nodeName ? patternMap.nodeName : "") + '''"
                 printf '}\n'
             } > webhook_payload.json

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -82,54 +82,47 @@ def checkoutComposableKernel()
 }
 
 // Given a pattern, check if the log contains the pattern and return the context.
-def checkForPattern(pattern, log) {
-    def lines = log.split('\n')
-    for (int i = 0; i < lines.size(); i++) {
-        if (lines[i] =~ pattern) {
-            echo "Found pattern match in log for ${pattern}"
-            
-            // Get the two lines before and after failure.
-            def contextStart = Math.max(0, i - 2)
-            def contextEnd = Math.min(lines.size() - 1, i + 2)
-            def contextLines = []
-            for (int j = contextStart; j <= contextEnd; j++) {
-                contextLines.add(lines[j])
-            }
-            
-            return [found: true, matchedLine: lines[i], context: contextLines.join('\n')]
-        }
-    }
-    echo "No pattern match found in log for ${pattern}"
-    return [found: false, matchedLine: "", context: ""]
-}
-
 // Scan the build logs for failures and send notifications.
 def sendFailureNotifications() {
     // Error patterns to scan build logs for specific failure types and send detailed notifications.
+    // Patterns are plain strings so they can be passed directly to grep -E.
     def failurePatterns = [
-        [pattern: /login attempt to .* failed with status: 401 Unauthorized/, description: "Docker registry authentication failed"],
-        [pattern: /docker login failed/, description: "Docker login failed"],
-        [pattern: /HTTP request sent .* 404 Not Found/, description: "HTTP request failed with 404"],
-        [pattern: /cat: .* No such file or directory/, description: "GPU not found"],
-        [pattern: /GPU not found/, description: "GPU not found"],
-        [pattern: /Could not connect to Redis at .* Connection timed out/, description: "Redis connection timed out"],
-        [pattern: /unauthorized: your account must log in with a Personal Access Token/, description: "Docker login failed"],
-        [pattern: /sccache: error: Server startup failed: Address in use/, description: "Sccache Error"]
+        [pattern: 'login attempt to .* failed with status: 401 Unauthorized', description: "Docker registry authentication failed"],
+        [pattern: 'docker login failed', description: "Docker login failed"],
+        [pattern: 'HTTP request sent .* 404 Not Found', description: "HTTP request failed with 404"],
+        [pattern: 'cat: .* No such file or directory', description: "GPU not found"],
+        [pattern: 'GPU not found', description: "GPU not found"],
+        [pattern: 'Could not connect to Redis at .* Connection timed out', description: "Redis connection timed out"],
+        [pattern: 'unauthorized: your account must log in with a Personal Access Token', description: "Docker login failed"],
+        [pattern: 'sccache: error: Server startup failed: Address in use', description: "Sccache Error"]
     ]
-    
-    // Get the build log.
-    def buildLog = sh(script: 'wget -q --no-check-certificate -O - ' + BUILD_URL + 'consoleText', returnStdout: true)
+
+    // Build a single combined grep -E pattern and stream the log through it.
+    // grep does the scanning natively so the full log is never loaded into Groovy.
+    // -B 2 -A 2 captures 2 lines of context around each match.
+    // || true prevents a non-zero grep exit code (no matches) from failing the stage.
+    def combinedPattern = failurePatterns.collect { it.pattern }.join('|')
     echo "Checking for failure patterns..."
-    // Check for patterns in the log.
+    def grepOutput = sh(
+        script: "wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | grep -E -B 2 -A 2 '${combinedPattern}' || true",
+        returnStdout: true
+    ).trim()
+
+    if (!grepOutput) {
+        echo "No failure patterns found in build log"
+        return
+    }
+
+    // grep separates non-adjacent match blocks with '--'. Split on that to get
+    // one context block per match, then identify which pattern each block hit.
     def foundPatterns = []
-    for (patternMap in failurePatterns) {
-        def result = checkForPattern(patternMap.pattern, buildLog)
-        if (result.found) {
-            foundPatterns.add([
-                description: patternMap.description,
-                matchedLine: result.matchedLine,
-                context: result.context
-            ])
+    def blocks = grepOutput.split('\n--\n')
+    for (block in blocks) {
+        for (patternMap in failurePatterns) {
+            if (block =~ patternMap.pattern) {
+                foundPatterns.add([description: patternMap.description, context: block])
+                break
+            }
         }
     }
     echo "Done checking for failure patterns..."

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -97,16 +97,22 @@ def sendFailureNotifications() {
         [pattern: 'sccache: error: Server startup failed: Address in use', description: "Sccache Error"]
     ]
 
+    // Patterns where the node name is useful for triage — captured by extracting
+    // NODE_NAME = <name> from the context block.
+    def gpuPatterns = ['cat: .* No such file or directory', 'GPU not found']
+
     // Build a single combined grep -E pattern and stream the log through it.
     // grep does the scanning natively so the full log is never loaded into Groovy.
-    // -B 2 -A 2 captures 2 lines of context around each match.
+    // -B 10 captures enough preceding lines to include NODE_NAME = <name>, which
+    // appears 6 lines before the cat: failure line in the build log.
+    // -A 2 captures 2 lines of context after each match.
     // || true prevents a non-zero grep exit code (no matches) from failing the stage.
     def combinedPattern = failurePatterns.collect { it.pattern }.join('|')
     echo "Checking for failure patterns..."
     def grepOutput = sh(
         script: """
             set +x
-            wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | grep -E -B 2 -A 2 '${combinedPattern}' || true
+            wget -q --no-check-certificate -O - ${BUILD_URL}consoleText | grep -E -B 10 -A 2 '${combinedPattern}' || true
         """,
         returnStdout: true
     ).trim()
@@ -121,12 +127,20 @@ def sendFailureNotifications() {
     // Adjacent matches share one block (no '--' separator), so all patterns must
     // be checked against every block. Deduplication prevents double-notifying on
     // the same description if a pattern appears in multiple blocks.
+    // For GPU-related patterns, also extract the node name from the context block.
     def foundPatterns = []
     def blocks = grepOutput.split('\n--\n')
     for (block in blocks) {
         for (patternMap in failurePatterns) {
             if ((block =~ patternMap.pattern) && !foundPatterns.any { it.description == patternMap.description }) {
-                foundPatterns.add([description: patternMap.description, context: block])
+                def nodeName = ""
+                if (gpuPatterns.contains(patternMap.pattern)) {
+                    def nodeNameMatcher = (block =~ /NODE_NAME\s*=\s*(\S+)/)
+                    if (nodeNameMatcher) {
+                        nodeName = nodeNameMatcher[0][1]
+                    }
+                }
+                foundPatterns.add([description: patternMap.description, context: block, nodeName: nodeName])
             }
         }
     }
@@ -135,9 +149,27 @@ def sendFailureNotifications() {
     for (patternMap in foundPatterns) {
         withCredentials([string(credentialsId: 'ck_ci_errors_webhook_url', variable: 'WEBHOOK_URL')]) {
         sh '''
+            # Create JSON payload with base64 data
+            echo "Creating JSON payload..."
+            {
+                printf '{\n'
+                printf '    "jobName": "%s",\n' "''' + env.JOB_NAME + '''"
+                printf '    "buildNumber": "%s",\n' "''' + env.BUILD_NUMBER + '''"
+                printf '    "jobUrl": "%s",\n' "''' + env.RUN_DISPLAY_URL + '''"
+                printf '    "detectedIssue": "%s",\n' "''' + patternMap.description + '''"
+                printf '    "logContext": "%s",\n' "''' + patternMap.context + '''"
+                printf '    "nodeName": "%s",\n' "''' + (patternMap.nodeName ? patternMap.nodeName : "") + '''"
+                printf '}\n'
+            } > webhook_payload.json
+            
+            echo "JSON payload created, size: $(wc -c < webhook_payload.json) bytes"
+            
             curl -X POST "${WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d '{"text": "\\n\\n**Build Failed**\\n\\n**Issues detected:** ''' + patternMap.description + '''\\n\\n**Log context:**\\n```\\n''' + patternMap.context.replace("'", "\\'") + '''\\n```\\n\\n**Job:** ''' + env.JOB_NAME + '''\\n\\n**Build:** #''' + env.BUILD_NUMBER + '''\\n\\n**URL:** ''' + env.RUN_DISPLAY_URL + '''"}'
+            -H "Content-Type: application/json" \
+            -d @webhook_payload.json
+            
+            # Clean up temporary file
+            rm -f webhook_payload.json
         '''
         }
     }
@@ -1455,9 +1487,7 @@ pipeline {
                     // sendFailureNotifications() correctly detects patterns in a large log.
                     sh 'for i in $(seq 1 30000); do echo "Dummy build log line $i: compiling and processing..."; done'
                     echo "cat: /dev/dri/renderD128: No such file or directory"
-                    sh 'for i in $(seq 1 30000); do echo "Dummy build log line $i: compiling and processing..."; done'
-                    echo "GPU not found"
-                    sh 'for i in $(seq 1 20000); do echo "Dummy build log line $i: compiling and processing..."; done'
+                    sh 'for i in $(seq 1 50000); do echo "Dummy build log line $i: compiling and processing..."; done'
                     error("TEST: Forcing stage failure to trigger sendFailureNotifications() and validate all failure pattern checks")
                 }
             }

--- a/projects/composablekernel/Jenkinsfile
+++ b/projects/composablekernel/Jenkinsfile
@@ -120,7 +120,7 @@ def sendFailureNotifications() {
     // Get the build log.
     def buildLog = currentBuild.rawBuild.getLog(Integer.MAX_VALUE).join('\n')
     echo "Checking for failure patterns..."
-    Check for patterns in the log.
+    // Check for patterns in the log.
     def foundPatterns = []
     for (patternMap in failurePatterns) {
         def result = checkForPattern(patternMap.pattern, buildLog)

--- a/projects/composablekernel/script/infra_helper/send_failure_notifications.sh
+++ b/projects/composablekernel/script/infra_helper/send_failure_notifications.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# send_failure_notifications.sh
+#
+# Scans the Jenkins build log for known infrastructure failure patterns and
+# sends a Teams webhook notification for each match.
+#
+# Required environment variables (Jenkins provides all except WEBHOOK_URL):
+#   BUILD_URL       - Jenkins build URL (e.g. http://host/job/foo/42/)
+#   JOB_NAME        - Jenkins job name
+#   BUILD_NUMBER    - Jenkins build number
+#   RUN_DISPLAY_URL - Jenkins Blue Ocean display URL
+#   WEBHOOK_URL     - Teams incoming webhook URL (passed via withCredentials)
+
+# Do not echo commands — the grep command contains all pattern strings and
+# would self-match if it appeared in the console log.
+set +x
+
+# ---------------------------------------------------------------------------
+# Failure patterns and their descriptions (parallel indexed arrays).
+# ---------------------------------------------------------------------------
+PATTERNS=(
+    'login attempt to .* failed with status: 401 Unauthorized'
+    'docker login failed'
+    'HTTP request sent .* 404 Not Found'
+    'cat: .* No such file or directory'
+    'GPU not found'
+    'Could not connect to Redis at .* Connection timed out'
+    'unauthorized: your account must log in with a Personal Access Token'
+    'sccache: error: Server startup failed: Address in use'
+    'No space left on device'
+)
+
+DESCRIPTIONS=(
+    "Docker registry authentication failed"
+    "Docker login failed"
+    "HTTP request failed with 404"
+    "Missing drivers"
+    "GPU not found"
+    "Redis connection timed out"
+    "Docker login failed"
+    "Sccache Error"
+    "Device space error"
+)
+
+# Indices into PATTERNS/DESCRIPTIONS for which a node name lookup is performed.
+NODE_PATTERN_INDICES=(3 4 8)  # cat: No such file, GPU not found, No space left on device
+
+# ---------------------------------------------------------------------------
+# Fetch and scan the log.
+# ---------------------------------------------------------------------------
+COMBINED_PATTERN=$(printf '%s\n' "${PATTERNS[@]}" | paste -sd '|')
+
+echo "Checking for failure patterns..."
+GREP_OUTPUT=$(wget -q --no-check-certificate -O - "${BUILD_URL}consoleText" \
+    | grep -E -B 2 -A 2 "${COMBINED_PATTERN}" || true)
+
+if [[ -z "$GREP_OUTPUT" ]]; then
+    echo "No failure patterns found in build log"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Process each grep context block.
+# ---------------------------------------------------------------------------
+# Track descriptions already notified to avoid duplicate notifications.
+declare -a NOTIFIED_DESCRIPTIONS=()
+
+process_block() {
+    local block="$1"
+    [[ -z "$block" ]] && return
+
+    for i in "${!PATTERNS[@]}"; do
+        local pattern="${PATTERNS[$i]}"
+        local description="${DESCRIPTIONS[$i]}"
+
+        # Skip if this description was already notified.
+        local already_notified=false
+        for notified in "${NOTIFIED_DESCRIPTIONS[@]:-}"; do
+            [[ "$notified" == "$description" ]] && already_notified=true && break
+        done
+        $already_notified && continue
+
+        # Check if this block contains the pattern.
+        if echo "$block" | grep -qE "$pattern"; then
+            NOTIFIED_DESCRIPTIONS+=("$description")
+
+            # For node-related patterns, find the most recent NODE_NAME before
+            # the failure via a single forward awk pass that exits immediately
+            # on the failure line, regardless of how many lines separate the two.
+            local node_name=""
+            for node_idx in "${NODE_PATTERN_INDICES[@]}"; do
+                if [[ "$node_idx" == "$i" ]]; then
+                    node_name=$(wget -q --no-check-certificate -O - "${BUILD_URL}consoleText" | awk '
+                        /NODE_NAME[[:space:]]*=/ { node = $NF }
+                        /'"$pattern"'/ { print node; exit }
+                    ')
+                    break
+                fi
+            done
+
+            # Escape context for safe embedding in a JSON string value:
+            # backslashes first, then quotes, then newlines.
+            local escaped_context
+            escaped_context=$(printf '%s' "$block" \
+                | sed 's/\\/\\\\/g' \
+                | sed 's/"/\\"/g' \
+                | sed ':a;N;$!ba;s/\n/\\n/g')
+
+            # Build JSON payload and send notification.
+            echo "Sending notification for: $description"
+            {
+                printf '{\n'
+                printf '    "jobName": "%s",\n'      "$JOB_NAME"
+                printf '    "buildNumber": "%s",\n'  "$BUILD_NUMBER"
+                printf '    "jobUrl": "%s",\n'       "$RUN_DISPLAY_URL"
+                printf '    "detectedIssue": "%s",\n' "$description"
+                printf '    "logContext": "%s",\n'   "$escaped_context"
+                printf '    "nodeName": "%s"\n'      "$node_name"
+                printf '}\n'
+            } > webhook_payload.json
+
+            curl -X POST "$WEBHOOK_URL" \
+                -H "Content-Type: application/json" \
+                -d @webhook_payload.json
+
+            rm -f webhook_payload.json
+        fi
+    done
+}
+
+# grep separates non-adjacent match groups with a line containing just "--".
+# Read line by line, accumulate into a block, and process when the separator
+# is hit. The final block has no trailing "--" so it is processed after the loop.
+current_block=""
+while IFS= read -r line; do
+    if [[ "$line" == "--" ]]; then
+        process_block "$current_block"
+        current_block=""
+    else
+        current_block+="$line"$'\n'
+    fi
+done <<< "$GREP_OUTPUT"
+process_block "$current_block"
+
+echo "Done failure pattern checking and notifications"


### PR DESCRIPTION
## Motivation

This PR re-enables CI infrastructure failure detection and notification, which had been disabled due to performance issues caused by loading large build logs (~80k lines) into memory for pattern scanning. The goal is to reliably detect known infrastructure failures (GPU errors, Docker authentication issues, disk space errors, etc.) and send actionable Teams notifications without hanging on large logs.

## Technical Details

- Replaced full build log loading and Groovy-based pattern scanning with a streaming wget | grep -E pipe. grep scans natively so the full log is never loaded into Groovy, resolving the hang on large logs.
- Combined all failure patterns into a single grep -E call to avoid multiple log fetches.
- The node name is now tracked with the observed failure.
- Added a new failure pattern for device's running out of space.

## Test Plan

- Forced failures in the "Determine CI Execution" stage with all 9 failure patterns echoed to the build log.
- Simulated large log sizes (~80k lines of dummy output) to validate pattern detection and node name extraction at realistic log scales, including patterns placed both before and after large blocks of dummy output.

## Test Result

All 9 failure patterns detected correctly. Teams notifications sent with accurate log context, node name, and job links. No hangs observed on 80k line simulated logs.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
