### PR TITLE
Build time optimization device_reduce

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce.hpp
@@ -66,8 +66,7 @@ template<
     class TargetConfig,
     bool WithInitialValue,
     class ResultType,
-    bool         FitLarger,
-    unsigned int FitItems,
+    unsigned int ItemsPerThread = TargetConfig::params.kernel_config.items_per_thread,
     class InputIterator,
     class OutputIterator,
     class InitValueType,
@@ -83,9 +82,6 @@ void block_reduce_kernel_impl(InputIterator input,
     static constexpr reduce_config_params params = TargetConfig::params;
 
     constexpr unsigned int block_size = params.kernel_config.block_size;
-    constexpr unsigned int items_per_thread
-        = FitLarger ? params.kernel_config.items_per_thread * FitItems
-                    : ceiling_div(params.kernel_config.items_per_thread, FitItems);
 
     using result_type = ResultType;
 
@@ -95,14 +91,14 @@ void block_reduce_kernel_impl(InputIterator input,
                                                       1,
                                                       1,
                                                       TargetConfig::wavefront>;
-    constexpr unsigned int items_per_block = block_size * items_per_thread;
+    constexpr unsigned int items_per_block = block_size * ItemsPerThread;
 
     const unsigned int flat_id             = ::rocprim::detail::block_thread_id<0>();
     const unsigned int flat_block_id       = ::rocprim::detail::block_id<0>();
     const size_t       block_offset        = flat_block_id * items_per_block;
     const unsigned int valid_in_last_block = input_size - block_offset;
 
-    result_type values[items_per_thread];
+    result_type values[ItemsPerThread];
     result_type output_value;
     // last incomplete block
     if(flat_block_id == (input_size / items_per_block))
@@ -114,7 +110,7 @@ void block_reduce_kernel_impl(InputIterator input,
 
         output_value = values[0];
         ROCPRIM_UNROLL
-        for(unsigned int i = 1; i < items_per_thread; i++)
+        for(unsigned int i = 1; i < ItemsPerThread; i++)
         {
             unsigned int offset = i * block_size;
             if(flat_id + offset < valid_in_last_block)

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_reduce.hpp
@@ -65,9 +65,9 @@ auto reduce_with_initial(T output, T initial_value, BinaryFunction reduce_op) ->
 template<
     class TargetConfig,
     bool WithInitialValue,
+    class ResultType,
     bool         FitLarger,
     unsigned int FitItems,
-    class ResultType,
     class InputIterator,
     class OutputIterator,
     class InitValueType,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -60,12 +60,6 @@ namespace detail
 #define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                               \
     do                                                                                            \
     {                                                                                             \
-        detail::target_arch target_arch;                                                          \
-        hipError_t          result = detail::host_target_arch(stream, target_arch);               \
-        if(result != hipSuccess)                                                                  \
-        {                                                                                         \
-            return result;                                                                        \
-        }                                                                                         \
         if(debug_synchronous)                                                                     \
         {                                                                                         \
             start = std::chrono::steady_clock::now();                                             \
@@ -188,7 +182,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             }
             auto block_reduce_kernel = [=](auto target_config)
             {
-                block_reduce_kernel_impl<decltype(target_config), false, true, 1, result_type>(
+                block_reduce_kernel_impl<decltype(target_config), false, result_type, true, 1>(
                     input + offset,
                     current_size,
                     block_prefixes + i * number_of_blocks_limit,
@@ -232,50 +226,138 @@ inline hipError_t reduce_impl(void*               temporary_storage,
         const unsigned int too_large = size > 0 ? items_per_block / size : 0;
         const unsigned int too_small = number_of_blocks;
 
-        if(too_small > 1)
+        if(debug_synchronous)
         {
-            // Decrease IPT for better utilisation
-            if(too_small <= 2)
-            {
-                SINGLE_REDUCE_KERNEL(true, 2);
-            }
-            else if(too_small <= 4)
-            {
-                SINGLE_REDUCE_KERNEL(true, 4);
-            }
-            else if(too_small <= 8)
-            {
-                SINGLE_REDUCE_KERNEL(true, 8);
-            }
-            else if(too_small <= 16)
-            {
-                SINGLE_REDUCE_KERNEL(true, 16);
-            }
+            start = std::chrono::steady_clock::now();
         }
-        else
+
+        auto block_reduce_kernel = [=](auto target_config) mutable
         {
-            // Increase IPT to prevent kernel launch
-            if(too_large >= 16)
+            if(too_small > 1)
             {
-                SINGLE_REDUCE_KERNEL(false, 16);
-            }
-            else if(too_large >= 8)
-            {
-                SINGLE_REDUCE_KERNEL(false, 8);
-            }
-            else if(too_large >= 4)
-            {
-                SINGLE_REDUCE_KERNEL(false, 4);
-            }
-            else if(too_large >= 2)
-            {
-                SINGLE_REDUCE_KERNEL(false, 2);
+                // Decrease IPT for better utilisation
+                if(too_small <= 2)
+                {
+                    block_reduce_kernel_impl<decltype(target_config),
+                                              WithInitialValue,
+                                              result_type,
+                                              true,
+                                              2>(input,
+                                                 size,
+                                                 output,
+                                                 initial_value,
+                                                 reduce_op);
+                }
+                else if(too_small <= 4)
+                {
+                    block_reduce_kernel_impl<decltype(target_config),
+                                              WithInitialValue,
+                                              result_type,
+                                              true,
+                                              4>(input,
+                                                 size,
+                                                 output,
+                                                 initial_value,
+                                                 reduce_op);
+                }
+                else if(too_small <= 8)
+                {
+                    block_reduce_kernel_impl<decltype(target_config),
+                                              WithInitialValue,
+                                              result_type,
+                                              true,
+                                              8>(input,
+                                                 size,
+                                                 output,
+                                                 initial_value,
+                                                 reduce_op);
+                }
+                else if(too_small <= 16)
+                {
+                    block_reduce_kernel_impl<decltype(target_config),
+                                              WithInitialValue,
+                                              result_type,
+                                              true,
+                                              16>(input,
+                                                  size,
+                                                  output,
+                                                  initial_value,
+                                                  reduce_op);
+                }
             }
             else
             {
-                SINGLE_REDUCE_KERNEL(false, 1);
+                // Increase IPT to prevent kernel launch
+                if(too_large >= 16)
+                {
+                    block_reduce_kernel_impl<decltype(target_config),
+                                              WithInitialValue,
+                                              result_type,
+                                              false,
+                                              16>(input,
+                                                  size,
+                                                  output,
+                                                  initial_value,
+                                                  reduce_op);
+                }
+                else if(too_large >= 8)
+                {
+                    block_reduce_kernel_impl<decltype(target_config),
+                                              WithInitialValue,
+                                              result_type,
+                                              false,
+                                              8>(input,
+                                                 size,
+                                                 output,
+                                                 initial_value,
+                                                 reduce_op);
+                }
+                else if(too_large >= 4)
+                {
+                    block_reduce_kernel_impl<decltype(target_config),
+                                              WithInitialValue,
+                                              result_type,
+                                              false,
+                                              4>(input,
+                                                 size,
+                                                 output,
+                                                 initial_value,
+                                                 reduce_op);
+                }
+                else if(too_large >= 2)
+                {
+                    block_reduce_kernel_impl<decltype(target_config),
+                                              WithInitialValue,
+                                              result_type,
+                                              false,
+                                              2>(input,
+                                                 size,
+                                                 output,
+                                                 initial_value,
+                                                 reduce_op);
+                }
+                else
+                {
+                    block_reduce_kernel_impl<decltype(target_config),
+                                              WithInitialValue,
+                                              result_type,
+                                              false,
+                                              1>(input,
+                                                 size,
+                                                 output,
+                                                 initial_value,
+                                                 reduce_op);
+                }
             }
-        }
+        };
+
+        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<Config, Selector>(current_target,
+                                                                      block_reduce_kernel,
+                                                                      dim3(1),
+                                                                      dim3(block_size),
+                                                                      0,
+                                                                      stream));
+        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);
     }
 
     return hipSuccess;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -211,6 +211,10 @@ inline hipError_t reduce_impl(void*               temporary_storage,
         const unsigned int too_large = size > 0 ? items_per_block / size : 0;
         const unsigned int too_small = number_of_blocks;
 
+        const unsigned int needed_ipt
+            = detail::next_power_of_two(too_large == 0 ? items_per_thread * too_small
+                                                       : ceiling_div(items_per_thread, too_large));
+
         if(debug_synchronous)
         {
             start = std::chrono::steady_clock::now();
@@ -228,9 +232,6 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                 [&](auto i)
                 {
                     constexpr unsigned ipt = 1 << i;
-                    const unsigned int needed_ipt = detail::next_power_of_two(
-                        too_large == 0 ? config_items_per_thread * too_small
-                                      : ceiling_div(config_items_per_thread, too_large));
 
                     if(needed_ipt == ipt)
                     {

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -57,7 +57,6 @@ namespace detail
         std::cout << " " << _d.count() * 1000 << " ms" << '\n';                              \
     }
 
-
 template<bool WithInitialValue, // true when inital_value should be used in reduction
          class Config,
          class InputIterator,
@@ -147,9 +146,9 @@ inline hipError_t reduce_impl(void*               temporary_storage,
     const unsigned int max_items_per_thread = get_max_items_per_thread(items_per_thread);
     const unsigned int max_number_of_blocks = max_items_per_thread / items_per_thread;
 
-    // We increase the items per thread with a maximum of 16.
-    // This means if the number_of_blocks is larger than 16 it
-    // will not fit in one kernel.
+    // We increase the items per thread with a maximum of 16x the input value.
+    // This ensures each thread processes enough work while keeping the total
+    // number of blocks manageable for a single kernel launch.
     if(number_of_blocks > max_number_of_blocks)
     {
         const auto aligned_size_limit = number_of_blocks_limit * items_per_block;
@@ -225,7 +224,8 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             constexpr unsigned int config_items_per_thread
                 = decltype(target_config)::params.kernel_config.items_per_thread;
 
-            constexpr unsigned int max_items_per_thread = get_max_items_per_thread(config_items_per_thread);
+            constexpr unsigned int max_items_per_thread
+                = get_max_items_per_thread(config_items_per_thread);
 
             // for(int i = 1; i <= max_items_per_thread; i*2)
             ::rocprim::detail::constexpr_for_lte<0, Log2<max_items_per_thread>::VALUE, 1>(

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -57,32 +57,6 @@ namespace detail
         std::cout << " " << _d.count() * 1000 << " ms" << '\n';                              \
     }
 
-#define SINGLE_REDUCE_KERNEL(fit_larger, fit_items)                                               \
-    do                                                                                            \
-    {                                                                                             \
-        if(debug_synchronous)                                                                     \
-        {                                                                                         \
-            start = std::chrono::steady_clock::now();                                             \
-        }                                                                                         \
-                                                                                                  \
-        auto block_reduce_kernel = [=](auto target_config) mutable                                \
-        {                                                                                         \
-            block_reduce_kernel_impl<decltype(target_config),                                     \
-                                     WithInitialValue,                                            \
-                                     fit_larger,                                                  \
-                                     fit_items,                                                   \
-                                     result_type>(input, size, output, initial_value, reduce_op); \
-        };                                                                                        \
-                                                                                                  \
-        ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<Config, Selector>(current_target,             \
-                                                                      block_reduce_kernel,        \
-                                                                      dim3(1),                    \
-                                                                      dim3(block_size),           \
-                                                                      0,                          \
-                                                                      stream));                   \
-        ROCPRIM_DETAIL_HIP_SYNC_AND_RETURN_ON_ERROR("block_reduce_kernel", size, start);          \
-    }                                                                                             \
-    while(0)
 
 template<bool WithInitialValue, // true when inital_value should be used in reduction
          class Config,
@@ -162,10 +136,21 @@ inline hipError_t reduce_impl(void*               temporary_storage,
         std::cout << "items_per_block " << items_per_block << '\n';
     }
 
+    const auto get_max_items_per_thread = [&](auto ipt)
+    {
+        return rocprim::max(
+            ipt,
+            rocprim::min(ipt * 16u,
+                         128u / static_cast<unsigned int>(sizeof(input_type) / sizeof(uint8_t))));
+    };
+
+    const unsigned int max_items_per_thread = get_max_items_per_thread(items_per_thread);
+    const unsigned int max_number_of_blocks = max_items_per_thread / items_per_thread;
+
     // We increase the items per thread with a maximum of 16.
     // This means if the number_of_blocks is larger than 16 it
     // will not fit in one kernel.
-    if(number_of_blocks > 16)
+    if(number_of_blocks > max_number_of_blocks)
     {
         const auto aligned_size_limit = number_of_blocks_limit * items_per_block;
 
@@ -236,126 +221,29 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             constexpr unsigned int config_items_per_thread
                 = decltype(target_config)::params.kernel_config.items_per_thread;
 
-            if(too_small > 1)
-            {
-                // Increase IPT for better utilisation
-                if(too_small <= 2)
+            constexpr unsigned int max_items_per_thread = get_max_items_per_thread(config_items_per_thread);
+
+            // for(int i = 1; i <= max_items_per_thread; i*2)
+            ::rocprim::detail::constexpr_for_lte<0, Log2<max_items_per_thread>::VALUE, 1>(
+                [&](auto i)
                 {
-                    constexpr unsigned int items_per_thread = config_items_per_thread * 2;
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-                }
-                else if(too_small <= 4)
-                {
-                    constexpr unsigned int items_per_thread = config_items_per_thread * 4;
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-                }
-                else if(too_small <= 8)
-                {
-                    constexpr unsigned int items_per_thread = config_items_per_thread * 8;
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-                }
-                else if(too_small <= 16)
-                {
-                    constexpr unsigned int items_per_thread = config_items_per_thread * 16;
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-                }
-            }
-            else
-            {
-                // Decrease IPT to prevent kernel launch
-                if(too_large >= 16u)
-                {
-                    constexpr unsigned int items_per_thread
-                        = ceiling_div(config_items_per_thread, 16u);
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-                }
-                else if(too_large >= 8)
-                {
-                    constexpr unsigned int items_per_thread
-                        = ceiling_div(config_items_per_thread, 8u);
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-                }
-                else if(too_large >= 4)
-                {
-                    constexpr unsigned int items_per_thread
-                        = ceiling_div(config_items_per_thread, 4u);
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-                }
-                else if(too_large >= 2)
-                {
-                    constexpr unsigned int items_per_thread
-                        = ceiling_div(config_items_per_thread, 2u);
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-                }
-                else
-                {
-                    constexpr unsigned int items_per_thread = config_items_per_thread;
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-                }
-            }
+                    constexpr unsigned ipt = 1 << i;
+                    const unsigned int needed_ipt = detail::next_power_of_two(
+                        too_large == 0 ? config_items_per_thread * too_small
+                                      : ceiling_div(config_items_per_thread, too_large));
+
+                    if(needed_ipt == ipt)
+                    {
+                        block_reduce_kernel_impl<decltype(target_config),
+                                                 WithInitialValue,
+                                                 result_type,
+                                                 ipt>(input,
+                                                      size,
+                                                      output,
+                                                      initial_value,
+                                                      reduce_op);
+                    }
+                });
         };
 
         ROCPRIM_RETURN_ON_ERROR(execute_launch_plan<Config, Selector>(current_target,

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -182,7 +182,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             }
             auto block_reduce_kernel = [=](auto target_config)
             {
-                block_reduce_kernel_impl<decltype(target_config), false, result_type, true, 1>(
+                block_reduce_kernel_impl<decltype(target_config), false, result_type>(
                     input + offset,
                     current_size,
                     block_prefixes + i * number_of_blocks_limit,
@@ -233,120 +233,131 @@ inline hipError_t reduce_impl(void*               temporary_storage,
 
         auto block_reduce_kernel = [=](auto target_config) mutable
         {
+            static constexpr reduce_config_params params = decltype(target_config)::params;
+
             if(too_small > 1)
             {
-                // Decrease IPT for better utilisation
+                // Increase IPT for better utilisation
                 if(too_small <= 2)
                 {
+                    constexpr unsigned int items_per_thread
+                        = params.kernel_config.items_per_thread * 2;
                     block_reduce_kernel_impl<decltype(target_config),
-                                              WithInitialValue,
-                                              result_type,
-                                              true,
-                                              2>(input,
-                                                 size,
-                                                 output,
-                                                 initial_value,
-                                                 reduce_op);
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
                 }
                 else if(too_small <= 4)
                 {
+                    constexpr unsigned int items_per_thread
+                        = params.kernel_config.items_per_thread * 4;
                     block_reduce_kernel_impl<decltype(target_config),
-                                              WithInitialValue,
-                                              result_type,
-                                              true,
-                                              4>(input,
-                                                 size,
-                                                 output,
-                                                 initial_value,
-                                                 reduce_op);
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
                 }
                 else if(too_small <= 8)
                 {
+                    constexpr unsigned int items_per_thread
+                        = params.kernel_config.items_per_thread * 8;
                     block_reduce_kernel_impl<decltype(target_config),
-                                              WithInitialValue,
-                                              result_type,
-                                              true,
-                                              8>(input,
-                                                 size,
-                                                 output,
-                                                 initial_value,
-                                                 reduce_op);
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
                 }
                 else if(too_small <= 16)
                 {
+                    constexpr unsigned int items_per_thread
+                        = params.kernel_config.items_per_thread * 16;
                     block_reduce_kernel_impl<decltype(target_config),
-                                              WithInitialValue,
-                                              result_type,
-                                              true,
-                                              16>(input,
-                                                  size,
-                                                  output,
-                                                  initial_value,
-                                                  reduce_op);
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
                 }
             }
             else
             {
-                // Increase IPT to prevent kernel launch
+                // Decrease IPT to prevent kernel launch
                 if(too_large >= 16)
                 {
+                    constexpr unsigned int items_per_thread
+                        = ceiling_div(params.kernel_config.items_per_thread, 16u);
                     block_reduce_kernel_impl<decltype(target_config),
-                                              WithInitialValue,
-                                              result_type,
-                                              false,
-                                              16>(input,
-                                                  size,
-                                                  output,
-                                                  initial_value,
-                                                  reduce_op);
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+
                 }
                 else if(too_large >= 8)
                 {
+                    constexpr unsigned int items_per_thread
+                        = ceiling_div(params.kernel_config.items_per_thread, 8u);
                     block_reduce_kernel_impl<decltype(target_config),
-                                              WithInitialValue,
-                                              result_type,
-                                              false,
-                                              8>(input,
-                                                 size,
-                                                 output,
-                                                 initial_value,
-                                                 reduce_op);
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
                 }
                 else if(too_large >= 4)
                 {
+                    constexpr unsigned int items_per_thread
+                        = ceiling_div(params.kernel_config.items_per_thread, 4u);
                     block_reduce_kernel_impl<decltype(target_config),
-                                              WithInitialValue,
-                                              result_type,
-                                              false,
-                                              4>(input,
-                                                 size,
-                                                 output,
-                                                 initial_value,
-                                                 reduce_op);
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
                 }
                 else if(too_large >= 2)
                 {
+                    constexpr unsigned int items_per_thread
+                        = ceiling_div(params.kernel_config.items_per_thread, 2u);
                     block_reduce_kernel_impl<decltype(target_config),
-                                              WithInitialValue,
-                                              result_type,
-                                              false,
-                                              2>(input,
-                                                 size,
-                                                 output,
-                                                 initial_value,
-                                                 reduce_op);
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
                 }
                 else
                 {
+                    constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
                     block_reduce_kernel_impl<decltype(target_config),
-                                              WithInitialValue,
-                                              result_type,
-                                              false,
-                                              1>(input,
-                                                 size,
-                                                 output,
-                                                 initial_value,
-                                                 reduce_op);
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
                 }
             }
         };

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -291,7 +291,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             else
             {
                 // Decrease IPT to prevent kernel launch
-                if(config_items_per_thread >= 16u && too_large >= 16u)
+                if(too_large >= 16u)
                 {
                     constexpr unsigned int items_per_thread
                         = ceiling_div(config_items_per_thread, 16u);
@@ -304,7 +304,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                                                                initial_value,
                                                                reduce_op);
                 }
-                else if(config_items_per_thread >= 8u && too_large >= 8)
+                else if(too_large >= 8)
                 {
                     constexpr unsigned int items_per_thread
                         = ceiling_div(config_items_per_thread, 8u);
@@ -317,7 +317,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                                                                initial_value,
                                                                reduce_op);
                 }
-                else if(config_items_per_thread >= 4u && too_large >= 4)
+                else if(too_large >= 4)
                 {
                     constexpr unsigned int items_per_thread
                         = ceiling_div(config_items_per_thread, 4u);
@@ -330,7 +330,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                                                                initial_value,
                                                                reduce_op);
                 }
-                else if(config_items_per_thread >= 2u && too_large >= 2)
+                else if(too_large >= 2)
                 {
                     constexpr unsigned int items_per_thread
                         = ceiling_div(config_items_per_thread, 2u);

--- a/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_reduce.hpp
@@ -233,15 +233,15 @@ inline hipError_t reduce_impl(void*               temporary_storage,
 
         auto block_reduce_kernel = [=](auto target_config) mutable
         {
-            static constexpr reduce_config_params params = decltype(target_config)::params;
+            constexpr unsigned int config_items_per_thread
+                = decltype(target_config)::params.kernel_config.items_per_thread;
 
             if(too_small > 1)
             {
                 // Increase IPT for better utilisation
                 if(too_small <= 2)
                 {
-                    constexpr unsigned int items_per_thread
-                        = params.kernel_config.items_per_thread * 2;
+                    constexpr unsigned int items_per_thread = config_items_per_thread * 2;
                     block_reduce_kernel_impl<decltype(target_config),
                                              WithInitialValue,
                                              result_type,
@@ -253,8 +253,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                 }
                 else if(too_small <= 4)
                 {
-                    constexpr unsigned int items_per_thread
-                        = params.kernel_config.items_per_thread * 4;
+                    constexpr unsigned int items_per_thread = config_items_per_thread * 4;
                     block_reduce_kernel_impl<decltype(target_config),
                                              WithInitialValue,
                                              result_type,
@@ -266,8 +265,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                 }
                 else if(too_small <= 8)
                 {
-                    constexpr unsigned int items_per_thread
-                        = params.kernel_config.items_per_thread * 8;
+                    constexpr unsigned int items_per_thread = config_items_per_thread * 8;
                     block_reduce_kernel_impl<decltype(target_config),
                                              WithInitialValue,
                                              result_type,
@@ -279,8 +277,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                 }
                 else if(too_small <= 16)
                 {
-                    constexpr unsigned int items_per_thread
-                        = params.kernel_config.items_per_thread * 16;
+                    constexpr unsigned int items_per_thread = config_items_per_thread * 16;
                     block_reduce_kernel_impl<decltype(target_config),
                                              WithInitialValue,
                                              result_type,
@@ -294,24 +291,10 @@ inline hipError_t reduce_impl(void*               temporary_storage,
             else
             {
                 // Decrease IPT to prevent kernel launch
-                if(too_large >= 16)
+                if(config_items_per_thread >= 16u && too_large >= 16u)
                 {
                     constexpr unsigned int items_per_thread
-                        = ceiling_div(params.kernel_config.items_per_thread, 16u);
-                    block_reduce_kernel_impl<decltype(target_config),
-                                             WithInitialValue,
-                                             result_type,
-                                             items_per_thread>(input,
-                                                               size,
-                                                               output,
-                                                               initial_value,
-                                                               reduce_op);
-
-                }
-                else if(too_large >= 8)
-                {
-                    constexpr unsigned int items_per_thread
-                        = ceiling_div(params.kernel_config.items_per_thread, 8u);
+                        = ceiling_div(config_items_per_thread, 16u);
                     block_reduce_kernel_impl<decltype(target_config),
                                              WithInitialValue,
                                              result_type,
@@ -321,10 +304,10 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                                                                initial_value,
                                                                reduce_op);
                 }
-                else if(too_large >= 4)
+                else if(config_items_per_thread >= 8u && too_large >= 8)
                 {
                     constexpr unsigned int items_per_thread
-                        = ceiling_div(params.kernel_config.items_per_thread, 4u);
+                        = ceiling_div(config_items_per_thread, 8u);
                     block_reduce_kernel_impl<decltype(target_config),
                                              WithInitialValue,
                                              result_type,
@@ -334,10 +317,23 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                                                                initial_value,
                                                                reduce_op);
                 }
-                else if(too_large >= 2)
+                else if(config_items_per_thread >= 4u && too_large >= 4)
                 {
                     constexpr unsigned int items_per_thread
-                        = ceiling_div(params.kernel_config.items_per_thread, 2u);
+                        = ceiling_div(config_items_per_thread, 4u);
+                    block_reduce_kernel_impl<decltype(target_config),
+                                             WithInitialValue,
+                                             result_type,
+                                             items_per_thread>(input,
+                                                               size,
+                                                               output,
+                                                               initial_value,
+                                                               reduce_op);
+                }
+                else if(config_items_per_thread >= 2u && too_large >= 2)
+                {
+                    constexpr unsigned int items_per_thread
+                        = ceiling_div(config_items_per_thread, 2u);
                     block_reduce_kernel_impl<decltype(target_config),
                                              WithInitialValue,
                                              result_type,
@@ -349,7 +345,7 @@ inline hipError_t reduce_impl(void*               temporary_storage,
                 }
                 else
                 {
-                    constexpr unsigned int items_per_thread = params.kernel_config.items_per_thread;
+                    constexpr unsigned int items_per_thread = config_items_per_thread;
                     block_reduce_kernel_impl<decltype(target_config),
                                              WithInitialValue,
                                              result_type,


### PR DESCRIPTION
## Motivation

`device_reduce` takes a long time to build, because of the many kernels that are being build for the last reduce step.

## Technical Details

There is an optimization for the last reduction step for changing IPT to accommodate more or less items in a block to prevent an extra reduce step or improve occupancy by reducing IPT. The first implementation was with every IPT variation having its own kernel. This works but does increase compilation time. I moved this logic inside the kernel, this does have one major drawback. Paths that are not taken in the logic still influence the whole kernel. So there were some performance issues with very high IPT, for example when `IPT*16` this means `16*16=256`, this seemed to influence the performance of cases which did not use this path. To counteract this behavior I put in this logic, `rocprim::min(ipt * 16u, 128u / static_cast<unsigned int>(sizeof(input_type) / sizeof(uint8_t)))` setting a max based on the size of the type. This seems to give the best results, where we keep (most) of the performance while more then halving in some cases the compilation time.



## Test Plan
Measure compilation times of the slow test test_hipcub_device_reduce and minimal change in performance.

## Test Result
In hipcub with develop:
```
time ninja test_hipcub_device_reduce
[6/6] Linking CXX executable test/hipcub/test_hipcub_device_reduce

real    4m30.159s
user    4m29.134s
sys     0m6.103s
```

In hipcub with this branch:
```
time ninja test_hipcub_device_reduce
[6/6] Linking CXX executable test/hipcub/test_hipcub_device_reduce

real    2m5.380s
user    2m8.335s
sys     0m2.162s
```
Here are the comparison results for different sizes in the rocprim benchmarks:
[comparison_results.zip](https://github.com/user-attachments/files/26110030/comparison_results.zip)


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
