### PR TITLE
[hipDNN] Add descale CPU reference for test_sdk

### DIFF
--- a/dnn-providers/hip-kernel-provider/src/integration_tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/integration_tests/CMakeLists.txt
@@ -40,12 +40,18 @@ target_link_libraries(
 add_dependencies(hip_kernel_provider_integration_tests hip_kernel_provider)
 
 if(ENABLE_ASM_SDPA_ENGINE)
-    target_sources(hip_kernel_provider_integration_tests PRIVATE
-        asm_sdpa_engine/IntegrationGpuSdpaForward.cpp
-    )
-    target_compile_definitions(hip_kernel_provider_integration_tests PRIVATE
-        AITER_ASM_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../engines/asm_sdpa_engine/asm/asm_kernels"
-    )
+    if(NOT HIPDNN_ENABLE_SDPA)
+        message(WARNING
+                "ENABLE_ASM_SDPA_ENGINE is ON but hipDNN was built with HIPDNN_ENABLE_SDPA=OFF. "
+                "Skipping SDPA integration tests. Rebuild hipDNN with -DHIPDNN_ENABLE_SDPA=ON to enable them.")
+    else()
+        target_sources(hip_kernel_provider_integration_tests PRIVATE
+            asm_sdpa_engine/IntegrationGpuSdpaForward.cpp
+        )
+        target_compile_definitions(hip_kernel_provider_integration_tests PRIVATE
+            AITER_ASM_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../engines/asm_sdpa_engine/asm/asm_kernels"
+        )
+    endif()
 endif()
 
 clang_tidy_check(hip_kernel_provider_integration_tests)
@@ -54,14 +60,20 @@ add_integration_test_target(hip_kernel_provider_integration_tests ${CMAKE_CURREN
     LABELS slow)
 
 if(ENABLE_ASM_SDPA_ENGINE)
-    set(ASM_KERNEL_ENV "HIPDNN_AITER_ASM_DIR=${CMAKE_BINARY_DIR}/hip_kernel_provider/asm_kernels")
-    if(COVERAGE_ENVIRONMENT)
-        set_tests_properties(hip_kernel_provider_integration_tests PROPERTIES
-            ENVIRONMENT "${COVERAGE_ENVIRONMENT};${ASM_KERNEL_ENV}"
-        )
+    if(NOT HIPDNN_ENABLE_SDPA)
+        message(WARNING
+                "ENABLE_ASM_SDPA_ENGINE is ON but hipDNN was built with HIPDNN_ENABLE_SDPA=OFF. "
+                "Skipping SDPA integration test environment setup.")
     else()
-        set_tests_properties(hip_kernel_provider_integration_tests PROPERTIES
-            ENVIRONMENT "${ASM_KERNEL_ENV}"
-        )
+        set(ASM_KERNEL_ENV "HIPDNN_AITER_ASM_DIR=${CMAKE_BINARY_DIR}/hip_kernel_provider/asm_kernels")
+        if(COVERAGE_ENVIRONMENT)
+            set_tests_properties(hip_kernel_provider_integration_tests PROPERTIES
+                ENVIRONMENT "${COVERAGE_ENVIRONMENT};${ASM_KERNEL_ENV}"
+            )
+        else()
+            set_tests_properties(hip_kernel_provider_integration_tests PROPERTIES
+                ENVIRONMENT "${ASM_KERNEL_ENV}"
+            )
+        endif()
     endif()
 endif()

--- a/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
+++ b/dnn-providers/hip-kernel-provider/src/tests/CMakeLists.txt
@@ -46,7 +46,13 @@ target_link_libraries(
 target_include_directories(hip_kernel_provider_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_LIST_DIR}/../../include)
 
 if(ENABLE_ASM_SDPA_ENGINE)
-    add_subdirectory(engines/asm_sdpa_engine)
+    if(NOT HIPDNN_ENABLE_SDPA)
+        message(WARNING
+                "ENABLE_ASM_SDPA_ENGINE is ON but hipDNN was built with HIPDNN_ENABLE_SDPA=OFF. "
+                "Skipping SDPA unit tests. Rebuild hipDNN with -DHIPDNN_ENABLE_SDPA=ON to enable them.")
+    else()
+        add_subdirectory(engines/asm_sdpa_engine)
+    endif()
 endif()
 
 clang_tidy_check(hip_kernel_provider_tests)

--- a/projects/composablekernel/include/ck_tile/core/tensor/tensor_descriptor.hpp
+++ b/projects/composablekernel/include/ck_tile/core/tensor/tensor_descriptor.hpp
@@ -236,12 +236,13 @@ transform_tensor_descriptor(const OldTensorDescriptor& old_tensor_desc,
 namespace detail {
 
 template <typename Lengths, typename Strides, index_t I, typename AccOld>
-CK_TILE_HOST_DEVICE constexpr auto calculate_element_space_size_impl(const Lengths& lengths,
-                                                                     const Strides& strides,
-                                                                     number<I> i,
-                                                                     AccOld acc_old)
+CK_TILE_HOST_DEVICE constexpr long_index_t calculate_element_space_size_impl(const Lengths& lengths,
+                                                                             const Strides& strides,
+                                                                             number<I> i,
+                                                                             AccOld acc_old)
 {
-    auto acc_new = acc_old + (lengths[i] - number<1>{}) * strides[i];
+    long_index_t acc_new = acc_old + static_cast<long_index_t>(lengths[i] - number<1>{}) *
+                                         static_cast<long_index_t>(strides[i]);
 
     if constexpr(i.value < Lengths::size() - 1)
     {
@@ -287,8 +288,12 @@ make_naive_tensor_descriptor(const tuple<Lengths...>& lengths,
 
     constexpr auto visible_dim_hidden_ids = typename arithmetic_sequence_gen<1, N + 1, 1>::type{};
 
-    const auto element_space_size =
+    const long_index_t element_space_size_long =
         detail::calculate_element_space_size_impl(lengths, strides, number<0>{}, long_number<1>{});
+    constexpr long_index_t element_space_size_clamp_value =
+        static_cast<long_index_t>(std::numeric_limits<index_t>::max());
+    const index_t element_space_size =
+        static_cast<index_t>(std::min(element_space_size_long, element_space_size_clamp_value));
 
     using GuaranteedVectorLengths =
         typename sequence_merge<typename uniform_sequence_gen<N, -1>::type,
@@ -323,8 +328,12 @@ make_naive_tensor_descriptor_with_offset(const tuple<Lengths...>& lengths,
                                          number<GuaranteedLastDimensionVectorStride> = number<-1>{})
 {
     const auto desc_0 = [&]() {
-        const auto element_space_size = detail::calculate_element_space_size_impl(
+        const auto element_space_size_long = detail::calculate_element_space_size_impl(
             lengths, strides, number<0>{}, long_number<1>{});
+        constexpr long_index_t element_space_size_clamp_value =
+            static_cast<long_index_t>(std::numeric_limits<index_t>::max());
+        const index_t element_space_size =
+            static_cast<index_t>(std::min(element_space_size_long, element_space_size_clamp_value));
 
         const auto transforms = make_tuple(make_offset_transform(element_space_size, os));
 

--- a/projects/hipcub/test/hipcub/test_hipcub_device_segmented_radix_sort.cpp.in
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_segmented_radix_sort.cpp.in
@@ -30,29 +30,21 @@
 #cmakedefine HIPCUB_TEST_TYPE_SLICE  @HIPCUB_TEST_TYPE_SLICE@
 
 #if   HIPCUB_TEST_SUITE_SLICE == 0
-    TYPED_TEST_P(SUITE, SortKeys                ) { sort_keys<TestFixture>(); } 
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeys);
+    TYPED_TEST_P(SUITE, SortKeys                    ) { sort_keys<TestFixture>(); }
+    TYPED_TEST_P(SUITE, SortKeysEmptyData           ) { sort_keys_empty_data<TestFixture>(); }
+    TYPED_TEST_P(SUITE, SortKeysUnspecifiedRanges   ) { sort_keys_unspecified_ranges<TestFixture>(); }
+    TYPED_TEST_P(SUITE, SortKeysLargeSegments       ) { sort_keys_large_segments<TestFixture>(); } 
+    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeys, SortKeysEmptyData, SortKeysUnspecifiedRanges, SortKeysLargeSegments);
 #elif HIPCUB_TEST_SUITE_SLICE == 1
-    TYPED_TEST_P(SUITE, SortPairs               ) { sort_pairs<TestFixture>(); } 
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairs);
+    TYPED_TEST_P(SUITE, SortPairs                    ) { sort_pairs<TestFixture>(); }
+    TYPED_TEST_P(SUITE, SortPairsUnspecifiedRanges   ) { sort_pairs_unspecified_ranges<TestFixture>(); } 
+    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairs, SortPairsUnspecifiedRanges);
 #elif HIPCUB_TEST_SUITE_SLICE == 2
     TYPED_TEST_P(SUITE, SortKeysDoubleBuffer    ) { sort_keys_double_buffer<TestFixture>(); } 
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysDoubleBuffer);
 #elif HIPCUB_TEST_SUITE_SLICE == 3
     TYPED_TEST_P(SUITE, SortPairsDoubleBuffer   ) { sort_pairs_double_buffer<TestFixture>(); } 
     REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairsDoubleBuffer);
-#elif HIPCUB_TEST_SUITE_SLICE == 4
-    TYPED_TEST_P(SUITE, SortKeysEmptyData       ) { sort_keys_empty_data<TestFixture>(); } 
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysEmptyData);
-#elif HIPCUB_TEST_SUITE_SLICE == 5
-    TYPED_TEST_P(SUITE, SortKeysLargeSegments   ) { sort_keys_large_segments<TestFixture>(); } 
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysLargeSegments);
-#elif HIPCUB_TEST_SUITE_SLICE == 6
-    TYPED_TEST_P(SUITE, SortKeysUnspecifiedRanges   ) { sort_keys_unspecified_ranges<TestFixture>(); } 
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysUnspecifiedRanges);
-#elif HIPCUB_TEST_SUITE_SLICE == 7
-    TYPED_TEST_P(SUITE, SortPairsUnspecifiedRanges   ) { sort_pairs_unspecified_ranges<TestFixture>(); } 
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairsUnspecifiedRanges);
 #endif
 
 #if   HIPCUB_TEST_TYPE_SLICE == 0
@@ -62,7 +54,7 @@
     INSTANTIATE(params<long long,          char,           false,  0,  64, 4000,   8000   >)
 #elif HIPCUB_TEST_TYPE_SLICE == 1
     INSTANTIATE(params<double,             unsigned int,   false,  0,  64, 2,      10     >) 
-    INSTANTIATE(params<double,             int,            true,   0,  64, 2000,   10000  >) 
+    INSTANTIATE(params<double,             int,            true,   0,  64, 2000,   10000  >)
     INSTANTIATE(params<float,              int,            false,  0,  32, 0,      1000   >) 
 
 // start_bit and end_bit

--- a/projects/hipcub/test/hipcub/test_hipcub_device_segmented_radix_sort.hpp
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_segmented_radix_sort.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2017-2024 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -95,7 +95,7 @@ inline void sort_keys()
             SCOPED_TRACE(testing::Message() << "with size= " << size);
             // Generate data
             std::vector<key_type> keys_input;
-            if(std::is_floating_point<key_type>::value)
+            if constexpr(std::is_floating_point<key_type>::value)
             {
                 keys_input = test_utils::get_random_data<key_type>(size,
                                                                    (key_type)-1000,
@@ -169,7 +169,7 @@ inline void sort_keys()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            if(descending)
+            if constexpr(descending)
             {
                 HIP_CHECK(
                     hipcub::DeviceSegmentedRadixSort::SortKeysDescending(d_temporary_storage,
@@ -246,7 +246,7 @@ inline void sort_keys_empty_data()
 
             // Generate data
             std::vector<key_type> keys_input;
-            if(std::is_floating_point<key_type>::value)
+            if constexpr(std::is_floating_point<key_type>::value)
             {
                 keys_input = test_utils::get_random_data<key_type>(size,
                                                                    static_cast<key_type>(-1000),
@@ -300,7 +300,7 @@ inline void sort_keys_empty_data()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            if(descending)
+            if constexpr(descending)
             {
                 HIP_CHECK(
                     hipcub::DeviceSegmentedRadixSort::SortKeysDescending(d_temporary_storage,
@@ -373,7 +373,7 @@ inline void sort_keys_large_segments()
 
         // Generate data
         std::vector<key_type> keys_input;
-        if(std::is_floating_point<key_type>::value)
+        if constexpr(std::is_floating_point<key_type>::value)
         {
             keys_input = test_utils::get_random_data<key_type>(size,
                                                                static_cast<key_type>(-1000),
@@ -438,7 +438,7 @@ inline void sort_keys_large_segments()
         HIP_CHECK(
             test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-        if(descending)
+        if constexpr(descending)
         {
             HIP_CHECK(hipcub::DeviceSegmentedRadixSort::SortKeysDescending(d_temporary_storage,
                                                                            temporary_storage_bytes,
@@ -517,7 +517,7 @@ inline void sort_keys_unspecified_ranges()
 
             // Generate data
             std::vector<key_type> keys_input;
-            if(std::is_floating_point<key_type>::value)
+            if constexpr(std::is_floating_point<key_type>::value)
             {
                 keys_input = test_utils::get_random_data<key_type>(size,
                                                                    static_cast<key_type>(-1000),
@@ -618,7 +618,7 @@ inline void sort_keys_unspecified_ranges()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            if(descending)
+            if constexpr(descending)
             {
                 HIP_CHECK(
                     hipcub::DeviceSegmentedRadixSort::SortKeysDescending(d_temporary_storage,
@@ -700,7 +700,7 @@ inline void sort_pairs()
             SCOPED_TRACE(testing::Message() << "with size= " << size);
             // Generate data
             std::vector<key_type> keys_input;
-            if(std::is_floating_point<key_type>::value)
+            if constexpr(std::is_floating_point<key_type>::value)
             {
                 keys_input = test_utils::get_random_data<key_type>(size,
                                                                    (key_type)-1000,
@@ -799,7 +799,7 @@ inline void sort_pairs()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            if(descending)
+            if constexpr(descending)
             {
                 HIP_CHECK(
                     hipcub::DeviceSegmentedRadixSort::SortPairsDescending(d_temporary_storage,
@@ -897,7 +897,7 @@ inline void sort_pairs_unspecified_ranges()
 
             // Generate data
             std::vector<key_type> keys_input;
-            if(std::is_floating_point<key_type>::value)
+            if constexpr(std::is_floating_point<key_type>::value)
             {
                 keys_input = test_utils::get_random_data<key_type>(size,
                                                                    static_cast<key_type>(-1000),
@@ -1026,7 +1026,7 @@ inline void sort_pairs_unspecified_ranges()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            if(descending)
+            if constexpr(descending)
             {
                 HIP_CHECK(
                     hipcub::DeviceSegmentedRadixSort::SortPairsDescending(d_temporary_storage,
@@ -1123,7 +1123,7 @@ inline void sort_keys_double_buffer()
             SCOPED_TRACE(testing::Message() << "with size= " << size);
             // Generate data
             std::vector<key_type> keys_input;
-            if(std::is_floating_point<key_type>::value)
+            if constexpr(std::is_floating_point<key_type>::value)
             {
                 keys_input = test_utils::get_random_data<key_type>(size,
                                                                    (key_type)-1000,
@@ -1198,7 +1198,7 @@ inline void sort_keys_double_buffer()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            if(descending)
+            if constexpr(descending)
             {
                 HIP_CHECK(
                     hipcub::DeviceSegmentedRadixSort::SortKeysDescending(d_temporary_storage,
@@ -1280,7 +1280,7 @@ inline void sort_pairs_double_buffer()
             SCOPED_TRACE(testing::Message() << "with size= " << size);
             // Generate data
             std::vector<key_type> keys_input;
-            if(std::is_floating_point<key_type>::value)
+            if constexpr(std::is_floating_point<key_type>::value)
             {
                 keys_input = test_utils::get_random_data<key_type>(size,
                                                                    (key_type)-1000,
@@ -1380,7 +1380,7 @@ inline void sort_pairs_double_buffer()
             HIP_CHECK(
                 test_common_utils::hipMallocHelper(&d_temporary_storage, temporary_storage_bytes));
 
-            if(descending)
+            if constexpr(descending)
             {
                 HIP_CHECK(
                     hipcub::DeviceSegmentedRadixSort::SortPairsDescending(d_temporary_storage,

--- a/projects/hipcub/test/hipcub/test_hipcub_device_segmented_sort.cpp.in
+++ b/projects/hipcub/test/hipcub/test_hipcub_device_segmented_sort.cpp.in
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2022-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -56,9 +56,9 @@
 
     INSTANTIATE(params<char,      int, SortMethod::SortAscending,         1,      1239>) 
     INSTANTIATE(params<char,      int, SortMethod::SortDescending,        1,      1239>) 
-#elif HIPCUB_TEST_TYPE_SLICE == 1
     INSTANTIATE(params<char,      int, SortMethod::StableSortAscending,   1,      1239>) 
-    INSTANTIATE(params<char,      int, SortMethod::StableSortDescending,  1,      1239>) 
+    INSTANTIATE(params<char,      int, SortMethod::StableSortDescending,  1,      1239>)
+#elif HIPCUB_TEST_TYPE_SLICE == 1
 
     INSTANTIATE(params<float,     int, SortMethod::SortAscending,         0,      322>) 
     INSTANTIATE(params<float,     int, SortMethod::SortDescending,        0,      322>) 

--- a/projects/hipdnn/CMakeLists.txt
+++ b/projects/hipdnn/CMakeLists.txt
@@ -19,9 +19,21 @@ else()
     message(STATUS "hipDNN: JSON serialization enabled (requires nlohmann_json)")
 endif()
 
+option(HIPDNN_ENABLE_SDPA "Enable SDPA (Scaled Dot-Product Attention) support" OFF)
+
+if(HIPDNN_ENABLE_SDPA)
+    message(STATUS "hipDNN: SDPA support enabled")
+else()
+    message(STATUS "hipDNN: SDPA support disabled")
+endif()
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_compile_definitions(__HIP_PLATFORM_AMD__)
+
+if(HIPDNN_ENABLE_SDPA)
+    add_compile_definitions(HIPDNN_ENABLE_SDPA)
+endif()
 
 if(NOT CMAKE_TOOLCHAIN_FILE)
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ClangToolChain.cmake"

--- a/projects/hipdnn/frontend/CMakeLists.txt
+++ b/projects/hipdnn/frontend/CMakeLists.txt
@@ -40,6 +40,7 @@ set_target_properties(hipdnn_frontend PROPERTIES
 target_compile_definitions(
     hipdnn_frontend INTERFACE
     $<$<BOOL:${HIPDNN_FRONTEND_SKIP_JSON_LIB}>:HIPDNN_FRONTEND_SKIP_JSON_LIB>
+    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:HIPDNN_ENABLE_SDPA>
 )
 
 # Generate the config file from template

--- a/projects/hipdnn/frontend/cmake/hipdnn_frontendConfig.cmake.in
+++ b/projects/hipdnn/frontend/cmake/hipdnn_frontendConfig.cmake.in
@@ -7,6 +7,8 @@ include(CMakeFindDependencyMacro)
 find_dependency(hipdnn_data_sdk @HIPDNN_FRONTEND_DATA_SDK_MIN_VERSION@ CONFIG REQUIRED)
 find_dependency(hipdnn_backend @HIPDNN_FRONTEND_BACKEND_MIN_VERSION@ CONFIG REQUIRED)
 
+set(HIPDNN_ENABLE_SDPA @HIPDNN_ENABLE_SDPA@)
+
 include("${CMAKE_CURRENT_LIST_DIR}/hipdnn_frontendTargets.cmake")
 
 check_required_components(hipdnn_frontend)

--- a/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
+++ b/projects/hipdnn/frontend/include/hipdnn_frontend/Graph.hpp
@@ -85,8 +85,10 @@
 #include <hipdnn_frontend/attributes/PointwiseAttributes.hpp>
 #include <hipdnn_frontend/attributes/RMSNormAttributes.hpp>
 #include <hipdnn_frontend/attributes/ReductionAttributes.hpp>
+#ifdef HIPDNN_ENABLE_SDPA
 #include <hipdnn_frontend/attributes/SdpaAttributes.hpp>
 #include <hipdnn_frontend/attributes/SdpaBackwardAttributes.hpp>
+#endif
 #include <hipdnn_frontend/detail/BackendWrapper.hpp>
 #include <hipdnn_frontend/detail/ConvolutionFpropUnpacker.hpp>
 #include <hipdnn_frontend/detail/CreateBackendDescriptor.hpp>
@@ -115,8 +117,10 @@
 #include <hipdnn_frontend/node/PointwiseNode.hpp>
 #include <hipdnn_frontend/node/RMSNormNode.hpp>
 #include <hipdnn_frontend/node/ReductionNode.hpp>
+#ifdef HIPDNN_ENABLE_SDPA
 #include <hipdnn_frontend/node/SdpaBwdNode.hpp>
 #include <hipdnn_frontend/node/SdpaFwdNode.hpp>
+#endif
 #include <hipdnn_frontend/node/detail/TopologicalSortingUtils.hpp>
 
 #ifndef HIPDNN_FRONTEND_SKIP_JSON_LIB
@@ -2557,6 +2561,7 @@ public:
         return outputTensors;
     }
 
+#ifdef HIPDNN_ENABLE_SDPA
     /** @brief Scaled dot-product attention forward pass
      *
      * Computes scaled dot-product attention:
@@ -2697,6 +2702,7 @@ public:
 
         return {dq, dk, dv};
     }
+#endif // HIPDNN_ENABLE_SDPA
 
     /** @brief Convolution forward pass
      *

--- a/projects/hipdnn/frontend/tests/TestGraph.cpp
+++ b/projects/hipdnn/frontend/tests/TestGraph.cpp
@@ -9,7 +9,9 @@
 #include <hipdnn_frontend/attributes/CustomOpAttributes.hpp>
 #include <hipdnn_frontend/attributes/LayernormAttributes.hpp>
 #include <hipdnn_frontend/attributes/PointwiseAttributes.hpp>
+#ifdef HIPDNN_ENABLE_SDPA
 #include <hipdnn_frontend/attributes/SdpaAttributes.hpp>
+#endif
 #include <hipdnn_test_sdk/constants/ConvFpropConstants.hpp>
 #include <hipdnn_test_sdk/utilities/FrontendGraphFactory.hpp>
 #include <hipdnn_test_sdk/utilities/ToVec.hpp>
@@ -4893,6 +4895,7 @@ TEST_F(TestGraph, EngineOverrideConfigFromContentMatchesConvFpropGraph)
     EXPECT_FALSE(config->matchOperation("conv_fprop", {x8, w}).has_value());
 }
 
+#ifdef HIPDNN_ENABLE_SDPA
 TEST_F(TestGraph, SdpaFwdNodeCreation)
 {
     Graph graph;
@@ -4953,6 +4956,7 @@ TEST_F(TestGraph, SdpaFwdNodeCreationWithStats)
     auto validationResult = graph.validate();
     EXPECT_TRUE(validationResult.is_good()) << validationResult.get_message();
 }
+#endif // HIPDNN_ENABLE_SDPA
 
 TEST_F(TestGraph, CustomOpNodeCreation)
 {
@@ -6299,51 +6303,48 @@ TEST_P(TestGraphSerializationRoundTrip, JsonSerializeDeserializeForwardsData)
     EXPECT_EQ(capturedJson, jsonData);
 }
 
-// NOLINTNEXTLINE(cert-err58-cpp)
-INSTANTIATE_TEST_SUITE_P(
-    GraphTopologies,
-    TestGraphSerializationRoundTrip,
-    ::testing::Values(
+// This needs to be a helper function rather than being defined inline so that we can use preprocessor directives in it.
+// Embedding a directive within a macro has undefined behaviour.
+static std::vector<GraphTopologyParam> getGraphTopologyParams()
+{
+    std::vector<GraphTopologyParam> params = {
         // Single-node topologies via FrontendGraphFactory
-        GraphTopologyParam{
-            "BatchnormInference",
-            [](Graph& g) { g = FrontendGraphFactory::createBatchnormInferenceGraph(); }},
-        GraphTopologyParam{
-            "BatchnormTraining",
-            [](Graph& g) { g = FrontendGraphFactory::createBatchnormTrainingGraph(); }},
-        GraphTopologyParam{
-            "BatchnormBackward",
-            [](Graph& g) { g = FrontendGraphFactory::createBatchnormBackwardGraph(); }},
-        GraphTopologyParam{"ConvForward",
-                           [](Graph& g) { g = FrontendGraphFactory::createConvForwardGraph(); }},
-        GraphTopologyParam{
-            "ConvBackwardData",
-            [](Graph& g) { g = FrontendGraphFactory::createConvBackwardDataGraph(); }},
-        GraphTopologyParam{
-            "ConvBackwardWeights",
-            [](Graph& g) { g = FrontendGraphFactory::createConvBackwardWeightsGraph(); }},
-        GraphTopologyParam{"PointwiseUnary",
-                           [](Graph& g) { g = FrontendGraphFactory::createPointwiseUnaryGraph(); }},
-        GraphTopologyParam{
-            "PointwiseBinary",
-            [](Graph& g) { g = FrontendGraphFactory::createPointwiseBinaryGraph(); }},
-        GraphTopologyParam{"Matmul",
-                           [](Graph& g) { g = FrontendGraphFactory::createMatmulGraph(); }},
-        GraphTopologyParam{"Layernorm",
-                           [](Graph& g) { g = FrontendGraphFactory::createLayernormGraph(); }},
-        GraphTopologyParam{"Rmsnorm",
-                           [](Graph& g) { g = FrontendGraphFactory::createRmsnormGraph(); }},
-        GraphTopologyParam{"Reduction",
-                           [](Graph& g) { g = FrontendGraphFactory::createReductionGraph(); }},
-        GraphTopologyParam{"SdpaForward",
-                           [](Graph& g) { g = FrontendGraphFactory::createSdpaForwardGraph(); }},
-        GraphTopologyParam{"SdpaBackward",
-                           [](Graph& g) { g = FrontendGraphFactory::createSdpaBackwardGraph(); }},
+        {"BatchnormInference",
+         [](Graph& g) { g = FrontendGraphFactory::createBatchnormInferenceGraph(); }},
+        {"BatchnormTraining",
+         [](Graph& g) { g = FrontendGraphFactory::createBatchnormTrainingGraph(); }},
+        {"BatchnormBackward",
+         [](Graph& g) { g = FrontendGraphFactory::createBatchnormBackwardGraph(); }},
+        {"ConvForward", [](Graph& g) { g = FrontendGraphFactory::createConvForwardGraph(); }},
+        {"ConvBackwardData",
+         [](Graph& g) { g = FrontendGraphFactory::createConvBackwardDataGraph(); }},
+        {"ConvBackwardWeights",
+         [](Graph& g) { g = FrontendGraphFactory::createConvBackwardWeightsGraph(); }},
+        {"PointwiseUnary", [](Graph& g) { g = FrontendGraphFactory::createPointwiseUnaryGraph(); }},
+        {"PointwiseBinary",
+         [](Graph& g) { g = FrontendGraphFactory::createPointwiseBinaryGraph(); }},
+        {"Matmul", [](Graph& g) { g = FrontendGraphFactory::createMatmulGraph(); }},
+        {"Layernorm", [](Graph& g) { g = FrontendGraphFactory::createLayernormGraph(); }},
+        {"Rmsnorm", [](Graph& g) { g = FrontendGraphFactory::createRmsnormGraph(); }},
+        {"Reduction", [](Graph& g) { g = FrontendGraphFactory::createReductionGraph(); }},
+#ifdef HIPDNN_ENABLE_SDPA
+        {"SdpaForward", [](Graph& g) { g = FrontendGraphFactory::createSdpaForwardGraph(); }},
+        {"SdpaBackward", [](Graph& g) { g = FrontendGraphFactory::createSdpaBackwardGraph(); }},
+#endif
         // Multi-node topologies
-        GraphTopologyParam{
-            "ConvFwdBiasActiv",
-            [](Graph& g) { g = FrontendGraphFactory::createConvFwdBiasActivGraph(); }},
-        GraphTopologyParam{"ConvReluFusion", createConvReluFusionGraph},
-        GraphTopologyParam{"PointwiseChain", createPointwiseChainGraph},
-        GraphTopologyParam{"Diamond", createDiamondGraph}),
-    [](const ::testing::TestParamInfo<GraphTopologyParam>& info) { return info.param.name; });
+        {"ConvFwdBiasActiv",
+         [](Graph& g) { g = FrontendGraphFactory::createConvFwdBiasActivGraph(); }},
+        {"ConvReluFusion", createConvReluFusionGraph},
+        {"PointwiseChain", createPointwiseChainGraph},
+        {"Diamond", createDiamondGraph}};
+
+    return params;
+}
+
+// NOLINTNEXTLINE(cert-err58-cpp)
+INSTANTIATE_TEST_SUITE_P(GraphTopologies,
+                         TestGraphSerializationRoundTrip,
+                         ::testing::ValuesIn(getGraphTopologyParams()),
+                         [](const ::testing::TestParamInfo<GraphTopologyParam>& info) {
+                             return info.param.name;
+                         });

--- a/projects/hipdnn/samples/CMakeLists.txt
+++ b/projects/hipdnn/samples/CMakeLists.txt
@@ -67,7 +67,9 @@ add_hipdnn_sample(hipdnn_sample_fused_conv_fprop_bias_activ convolution/FusedCon
 add_hipdnn_sample(hipdnn_sample_conv_wgrad convolution/ConvWgrad.cpp)
 add_hipdnn_sample(hipdnn_sample_conv_fprop_deterministic convolution/ConvFpropDeterministic.cpp)
 
-add_hipdnn_sample(hipdnn_sample_sdpa_fprop sdpa/SdpaFprop.cpp)
+if(HIPDNN_ENABLE_SDPA)
+    add_hipdnn_sample(hipdnn_sample_sdpa_fprop sdpa/SdpaFprop.cpp)
+endif()
 
 add_hipdnn_sample(hipdnn_sample_serialization_roundtrip serialization/SerializationRoundTrip.cpp)
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp
@@ -1,0 +1,110 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cmath>
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
+#include <vector>
+
+namespace hipdnn_test_sdk::utilities
+{
+
+class CpuFpReferenceBlockScaleDequantize
+{
+public:
+    /// Block scale dequantize: Y[i] = X[i] * scale[block_of(i)]
+    ///
+    /// blockSize entries map to the trailing dimensions of the tensor.
+    /// For a tensor with N dims and blockSize with K entries, blockSize[i]
+    /// applies to dimension (N - K + i). scale_index[d] = x_index[d] / blockSize[i]
+    /// for blocked trailing dims, and scale_index[d] = x_index[d] for leading dims.
+    ///
+    /// @param x                Input tensor (blocked low-precision data)
+    /// @param scale            Per-block scale tensor
+    /// @param y                Output tensor (dequantized, same shape as x)
+    /// @param blockSize        Block size for each blocked dimension (from attributes)
+    /// @param isNegativeScale  If true, scale represents negative exponent: Y = X * 2^(-scale)
+    template <class XDataType, class ScaleDataType, class YDataType, class ComputeDataType = float>
+    static void dequantize(const hipdnn_data_sdk::utilities::TensorBase<XDataType>& x,
+                           const hipdnn_data_sdk::utilities::TensorBase<ScaleDataType>& scale,
+                           hipdnn_data_sdk::utilities::TensorBase<YDataType>& y,
+                           const std::vector<int32_t>& blockSize,
+                           bool isNegativeScale = false)
+    {
+        const auto& xDims = x.dims();
+        const auto& scaleDims = scale.dims();
+
+        if(xDims.empty())
+        {
+            throw std::runtime_error("BlockScaleDequantize requires non-empty tensor dimensions.");
+        }
+
+        // blockSize entries map to the trailing dimensions of the tensor.
+        std::vector<int64_t> effectiveBlockSize(xDims.size(), 1);
+        for(size_t i = 0; i < blockSize.size() && i < xDims.size(); ++i)
+        {
+            effectiveBlockSize[xDims.size() - blockSize.size() + i] = blockSize[i];
+        }
+
+        // Validate scale dimensions are consistent with data dims and block size.
+        // Scale must have the same rank as x — there is no dim-mapping for broadcast.
+        if(scaleDims.size() != xDims.size())
+        {
+            throw std::invalid_argument(
+                "BlockScaleDequantize: scale tensor rank (" + std::to_string(scaleDims.size())
+                + ") must equal input tensor rank (" + std::to_string(xDims.size()) + ").");
+        }
+
+        for(size_t d = 0; d < scaleDims.size(); ++d)
+        {
+            const auto expectedScaleDim
+                = (xDims[d] + effectiveBlockSize[d] - 1) / effectiveBlockSize[d];
+            if(scaleDims[d] != expectedScaleDim)
+            {
+                throw std::invalid_argument("BlockScaleDequantize: scale dim[" + std::to_string(d)
+                                            + "] is " + std::to_string(scaleDims[d])
+                                            + " but expected " + std::to_string(expectedScaleDim)
+                                            + " (ceil(" + std::to_string(xDims[d]) + " / "
+                                            + std::to_string(effectiveBlockSize[d]) + ")).");
+            }
+        }
+
+        auto dequantizeFunc = [&](const std::vector<int64_t>& xIndices) {
+            // Compute scale indices by dividing by block size for blocked dims.
+            // Size to scale rank — getIndex() throws if indices.size() > strides().size().
+            std::vector<int64_t> scaleIndices(scaleDims.size());
+            for(size_t d = 0; d < scaleDims.size(); ++d)
+            {
+                scaleIndices[d] = xIndices[d] / effectiveBlockSize[d];
+            }
+
+            auto xVal = static_cast<ComputeDataType>(x.getHostValue(xIndices));
+            auto scaleVal = static_cast<ComputeDataType>(scale.getHostValue(scaleIndices));
+
+            ComputeDataType yVal;
+            if(isNegativeScale)
+            {
+                // Negative scale: Y = X * 2^(-scale_value)
+                yVal = xVal * std::pow(static_cast<ComputeDataType>(2.0), -scaleVal);
+            }
+            else
+            {
+                // Normal scale: Y = X * scale
+                yVal = xVal * scaleVal;
+            }
+
+            y.setHostValue(static_cast<YDataType>(yVal), xIndices);
+        };
+
+        auto parallelFunc
+            = hipdnn_test_sdk::detail::makeParallelTensorFunctor(dequantizeFunc, xDims);
+        parallelFunc(std::thread::hardware_concurrency());
+
+        y.memory().markHostModified();
+    }
+};
+
+} // namespace hipdnn_test_sdk::utilities

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp
@@ -67,7 +67,7 @@ public:
                 return result.load(std::memory_order_relaxed);
             }
 
-            auto absDiff = static_cast<float>(fabs(implValue - refValue));
+            auto absDiff = fabs(static_cast<float>(implValue) - static_cast<float>(refValue));
             auto threshold
                 = _absoluteTolerance + _relativeTolerance * fabs(static_cast<float>(refValue));
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp
@@ -9,6 +9,12 @@
 namespace hipdnn_test_sdk::utilities
 {
 using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::fp4_e2m1;
+using hipdnn_data_sdk::types::fp6_e2m3;
+using hipdnn_data_sdk::types::fp6_e3m2;
+using hipdnn_data_sdk::types::fp8_e4m3;
+using hipdnn_data_sdk::types::fp8_e5m2;
+using hipdnn_data_sdk::types::fp8_e8m0;
 using hipdnn_data_sdk::types::half;
 }
 
@@ -40,6 +46,30 @@ constexpr auto datatypeToNative()
     {
         return bfloat16{};
     }
+    else if constexpr(DT == DataType::FP8_E4M3)
+    {
+        return fp8_e4m3{};
+    }
+    else if constexpr(DT == DataType::FP8_E5M2)
+    {
+        return fp8_e5m2{};
+    }
+    else if constexpr(DT == DataType::FP8_E8M0)
+    {
+        return fp8_e8m0{};
+    }
+    else if constexpr(DT == DataType::FP4_E2M1)
+    {
+        return fp4_e2m1{};
+    }
+    else if constexpr(DT == DataType::FP6_E2M3)
+    {
+        return fp6_e2m3{};
+    }
+    else if constexpr(DT == DataType::FP6_E3M2)
+    {
+        return fp6_e3m2{};
+    }
     else
     {
         // NOLINTNEXTLINE(misc-redundant-expression) Intentional: DT != DT is a dependent false for constexpr-if
@@ -47,7 +77,17 @@ constexpr auto datatypeToNative()
     }
 }
 
-inline std::variant<float, half, double, int32_t, bfloat16>
+inline std::variant<float,
+                    half,
+                    double,
+                    int32_t,
+                    bfloat16,
+                    fp8_e4m3,
+                    fp8_e5m2,
+                    fp8_e8m0,
+                    fp4_e2m1,
+                    fp6_e2m3,
+                    fp6_e3m2>
     datatypeToNativeVariant(hipdnn_flatbuffers_sdk::data_objects::DataType type)
 {
     using DataType = hipdnn_flatbuffers_sdk::data_objects::DataType;
@@ -68,6 +108,24 @@ inline std::variant<float, half, double, int32_t, bfloat16>
         break;
     case DataType::BFLOAT16:
         return bfloat16{};
+        break;
+    case DataType::FP8_E4M3:
+        return fp8_e4m3{};
+        break;
+    case DataType::FP8_E5M2:
+        return fp8_e5m2{};
+        break;
+    case DataType::FP8_E8M0:
+        return fp8_e8m0{};
+        break;
+    case DataType::FP4_E2M1:
+        return fp4_e2m1{};
+        break;
+    case DataType::FP6_E2M3:
+        return fp6_e2m3{};
+        break;
+    case DataType::FP6_E3M2:
+        return fp6_e3m2{};
         break;
     default:
         throw std::runtime_error("Error: Invalid type");
@@ -96,6 +154,30 @@ constexpr hipdnn_flatbuffers_sdk::data_objects::DataType nativeTypeToDataType()
     else if constexpr(std::is_same_v<T, bfloat16>)
     {
         return hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16;
+    }
+    else if constexpr(std::is_same_v<T, fp8_e4m3>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E4M3;
+    }
+    else if constexpr(std::is_same_v<T, fp8_e5m2>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E5M2;
+    }
+    else if constexpr(std::is_same_v<T, fp8_e8m0>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0;
+    }
+    else if constexpr(std::is_same_v<T, fp4_e2m1>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP4_E2M1;
+    }
+    else if constexpr(std::is_same_v<T, fp6_e2m3>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E2M3;
+    }
+    else if constexpr(std::is_same_v<T, fp6_e3m2>)
+    {
+        return hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E3M2;
     }
     else
     {

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp
@@ -2127,28 +2127,33 @@ inline flatbuffers::FlatBufferBuilder createValidEngineDetails(int64_t engineId)
 }
 
 inline flatbuffers::FlatBufferBuilder createValidBlockScaleDequantizeGraph(
-    const std::vector<int64_t>& strides = {65536, 1024, 32, 1},
-    const std::vector<int64_t>& dims = {2, 64, 32, 32},
+    const std::vector<int64_t>& strides = {65536, 2048, 64, 1},
+    const std::vector<int64_t>& dims = {2, 32, 32, 64},
     hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType
     = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
     hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    bool isNegativeScale = false,
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType
     = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
 {
     flatbuffers::FlatBufferBuilder builder;
     std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
         tensorAttributes;
 
-    const std::vector<int64_t> scaleDims = {2, 2, 32, 32};
-    const std::vector<int64_t> scaleStrides = {2048, 1024, 32, 1};
+    const std::vector<int64_t> scaleDims = {2, 32, 32, 2};
+    const std::vector<int64_t> scaleStrides = {2048, 64, 2, 1};
 
     tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
         builder, 1, "x", inputDataType, &strides, &dims));
 
     tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 2, "scale", inputDataType, &scaleStrides, &scaleDims));
+        builder, 2, "scale", scaleDataType, &scaleStrides, &scaleDims));
 
     tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
-        builder, 3, "y", inputDataType, &strides, &dims));
+        builder, 3, "y", outputDataType, &strides, &dims));
 
     const std::vector<int32_t> blockSize = {32};
     auto blockSizeVector = builder.CreateVector(blockSize);
@@ -2160,8 +2165,58 @@ inline flatbuffers::FlatBufferBuilder createValidBlockScaleDequantizeGraph(
             2, // scale uid
             3, // y uid
             blockSizeVector,
-            false // is_negative_scale
-        );
+            isNegativeScale);
+
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
+    auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(
+        builder,
+        "block_scale_dequantize",
+        computeDataType,
+        hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BlockScaleDequantizeAttributes,
+        blockScaleDequantizeAttributes.Union());
+    nodes.push_back(node);
+
+    auto graphOffset = hipdnn_flatbuffers_sdk::data_objects::CreateGraphDirect(
+        builder,
+        "test",
+        hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+        hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+        &tensorAttributes,
+        &nodes);
+    builder.Finish(graphOffset);
+    return builder;
+}
+
+inline flatbuffers::FlatBufferBuilder createValidBlockScaleDequantizeMxGraph(
+    hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType,
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType
+    = hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT)
+{
+    flatbuffers::FlatBufferBuilder builder;
+    std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::TensorAttributes>>
+        tensorAttributes;
+
+    const std::vector<int64_t> dims = {1, 4};
+    const std::vector<int64_t> strides = {4, 1};
+    const std::vector<int64_t> scaleDims = {1, 2};
+    const std::vector<int64_t> scaleStrides = {2, 1};
+
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 1, "x", inputDataType, &strides, &dims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 2, "scale", scaleDataType, &scaleStrides, &scaleDims));
+    tensorAttributes.push_back(hipdnn_flatbuffers_sdk::data_objects::CreateTensorAttributesDirect(
+        builder, 3, "y", outputDataType, &strides, &dims));
+
+    const std::vector<int32_t> blockSize = {2};
+    auto blockSizeVector = builder.CreateVector(blockSize);
+
+    auto blockScaleDequantizeAttributes
+        = hipdnn_flatbuffers_sdk::data_objects::CreateBlockScaleDequantizeAttributes(
+            builder, 1, 2, 3, blockSizeVector, false);
 
     std::vector<::flatbuffers::Offset<hipdnn_flatbuffers_sdk::data_objects::Node>> nodes;
     auto node = hipdnn_flatbuffers_sdk::data_objects::CreateNodeDirect(

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FrontendGraphFactory.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/FrontendGraphFactory.hpp
@@ -18,8 +18,10 @@
 #include <hipdnn_frontend/attributes/PointwiseAttributes.hpp>
 #include <hipdnn_frontend/attributes/RMSNormAttributes.hpp>
 #include <hipdnn_frontend/attributes/ReductionAttributes.hpp>
+#ifdef HIPDNN_ENABLE_SDPA
 #include <hipdnn_frontend/attributes/SdpaAttributes.hpp>
 #include <hipdnn_frontend/attributes/SdpaBackwardAttributes.hpp>
+#endif
 #include <hipdnn_frontend/attributes/TensorAttributes.hpp>
 
 namespace hipdnn_test_sdk::utilities
@@ -41,8 +43,10 @@ enum class OperationType
     LAYERNORM,
     RMSNORM,
     REDUCTION,
+#ifdef HIPDNN_ENABLE_SDPA
     SDPA_FORWARD,
     SDPA_BACKWARD,
+#endif
     POINTWISE_UNARY,
     POINTWISE_BINARY
 };
@@ -81,10 +85,12 @@ public:
             return createRmsnormGraph();
         case OperationType::REDUCTION:
             return createReductionGraph();
+#ifdef HIPDNN_ENABLE_SDPA
         case OperationType::SDPA_FORWARD:
             return createSdpaForwardGraph();
         case OperationType::SDPA_BACKWARD:
             return createSdpaBackwardGraph();
+#endif
         case OperationType::POINTWISE_UNARY:
             return createPointwiseUnaryGraph();
         case OperationType::POINTWISE_BINARY:
@@ -484,6 +490,7 @@ public:
         return graphObj;
     }
 
+#ifdef HIPDNN_ENABLE_SDPA
     /// SDPA Forward graph
     static Graph createSdpaForwardGraph()
     {
@@ -556,6 +563,7 @@ public:
 
         return graphObj;
     }
+#endif // HIPDNN_ENABLE_SDPA
 
     /// Pointwise Unary (RELU_FWD) graph
     static Graph createPointwiseUnaryGraph()
@@ -636,10 +644,12 @@ inline std::string operationTypeToString(OperationType op)
         return "RMSNorm";
     case OperationType::REDUCTION:
         return "Reduction";
+#ifdef HIPDNN_ENABLE_SDPA
     case OperationType::SDPA_FORWARD:
         return "SdpaForward";
     case OperationType::SDPA_BACKWARD:
         return "SdpaBackward";
+#endif
     case OperationType::POINTWISE_UNARY:
         return "PointwiseUnary";
     case OperationType::POINTWISE_BINARY:

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/CpuReferenceGraphExecutor.hpp
@@ -8,6 +8,7 @@
 
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferencePlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVarianceSignatureKey.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdPlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdPlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwPlan.hpp>
@@ -128,6 +129,8 @@ private:
             return detail::MatmulSignatureKey(node, tensorMap, computeType);
         case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::RMSNormAttributes:
             return detail::RMSNormFwdSignatureKey(node, tensorMap);
+        case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BlockScaleDequantizeAttributes:
+            return detail::BlockScaleDequantizeSignatureKey(node, tensorMap);
         case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::SdpaAttributes:
             return detail::SdpaFwdSignatureKey(node, tensorMap);
         case hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::ReductionAttributes:

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp
@@ -1,0 +1,158 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <variant>
+
+#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanBuilder.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/IGraphNodePlanExecutor.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanUtils.hpp>
+#include <hipdnn_test_sdk/utilities/detail/FlatbufferTensorAttributesUtils.hpp>
+
+namespace hipdnn_test_sdk::detail
+{
+
+struct BlockScaleDequantizeParams
+{
+    BlockScaleDequantizeParams(
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& xAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& scaleAttributes,
+        const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes& yAttributes,
+        std::vector<int32_t> blockSize,
+        bool isNegativeScale)
+        : xTensor(unpackTensorAttributes(xAttributes))
+        , scaleTensor(unpackTensorAttributes(scaleAttributes))
+        , yTensor(unpackTensorAttributes(yAttributes))
+        , blockSize(std::move(blockSize))
+        , isNegativeScale(isNegativeScale)
+    {
+    }
+
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT xTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT scaleTensor;
+    hipdnn_flatbuffers_sdk::data_objects::TensorAttributesT yTensor;
+    std::vector<int32_t> blockSize;
+    bool isNegativeScale;
+};
+
+template <typename XDataType,
+          typename ScaleDataType,
+          typename OutputDataType,
+          typename ComputeDataType>
+class BlockScaleDequantizePlan : public IGraphNodePlanExecutor
+{
+public:
+    BlockScaleDequantizePlan(BlockScaleDequantizeParams&& params)
+        : _params(std::move(params))
+    {
+    }
+
+    std::vector<int64_t> getOutputTensorIds() const override
+    {
+        return {_params.yTensor.uid};
+    }
+
+    void execute(const std::unordered_map<int64_t, void*>& variantPack) override
+    {
+        auto shallowXTensor
+            = createShallowTensor<XDataType>(_params.xTensor, variantPack.at(_params.xTensor.uid));
+
+        auto shallowYTensor = createShallowTensor<OutputDataType>(
+            _params.yTensor, variantPack.at(_params.yTensor.uid));
+
+        auto shallowScaleTensor = createShallowTensor<ScaleDataType>(
+            _params.scaleTensor, variantPack.at(_params.scaleTensor.uid));
+
+        utilities::CpuFpReferenceBlockScaleDequantize::
+            dequantize<XDataType, ScaleDataType, OutputDataType, ComputeDataType>(
+                *shallowXTensor,
+                *shallowScaleTensor,
+                *shallowYTensor,
+                _params.blockSize,
+                _params.isNegativeScale);
+    }
+
+private:
+    BlockScaleDequantizeParams _params;
+};
+
+template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ScaleDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+          hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
+class BlockScaleDequantizePlanBuilder : public IGraphNodePlanBuilder
+{
+public:
+    using XDataType = utilities::DataTypeToNative<XDataTypeEnum>;
+    using ScaleDataType = utilities::DataTypeToNative<ScaleDataTypeEnum>;
+    using OutputDataType = utilities::DataTypeToNative<OutputDataTypeEnum>;
+    using ComputeDataType = utilities::DataTypeToNative<ComputeDataTypeEnum>;
+
+    bool isApplicable(
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
+            tensorMap) const override
+    {
+        if(node.compute_data_type() != ComputeDataTypeEnum)
+        {
+            return false;
+        }
+
+        const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+        if(nodeAttributes == nullptr)
+        {
+            return false;
+        }
+
+        CHECK_TENSOR_EXISTS(tensorMap, nodeAttributes->x_tensor_uid());
+        CHECK_TENSOR_EXISTS(tensorMap, nodeAttributes->y_tensor_uid());
+        CHECK_TENSOR_EXISTS(tensorMap, nodeAttributes->scale_tensor_uid());
+
+        CHECK_TENSOR_TYPE(tensorMap, nodeAttributes->x_tensor_uid(), XDataTypeEnum);
+        CHECK_TENSOR_TYPE(tensorMap, nodeAttributes->y_tensor_uid(), OutputDataTypeEnum);
+        CHECK_TENSOR_TYPE(tensorMap, nodeAttributes->scale_tensor_uid(), ScaleDataTypeEnum);
+
+        return true;
+    }
+
+    std::unique_ptr<IGraphNodePlanExecutor>
+        buildNodePlan(const hipdnn_flatbuffers_sdk::flatbuffer_utilities::IGraph& graph,
+                      const hipdnn_flatbuffers_sdk::data_objects::Node& node) const override
+    {
+        const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+        if(nodeAttributes == nullptr)
+        {
+            throw std::runtime_error(
+                "Node attributes are not of type BlockScaleDequantizeAttributes");
+        }
+
+        const auto& tensorMap = graph.getTensorMap();
+
+        std::vector<int32_t> blockSize;
+        if(nodeAttributes->block_size() != nullptr)
+        {
+            const auto* bs = nodeAttributes->block_size();
+            blockSize.assign(bs->begin(), bs->end());
+        }
+
+        BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                          *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                          *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                          std::move(blockSize),
+                                          nodeAttributes->is_negative_scale());
+
+        return std::make_unique<
+            BlockScaleDequantizePlan<XDataType, ScaleDataType, OutputDataType, ComputeDataType>>(
+            std::move(params));
+    }
+};
+} // namespace hipdnn_test_sdk::detail

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp
@@ -1,0 +1,215 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <functional>
+#include <hipdnn_flatbuffers_sdk/data_objects/data_types_generated.h>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/FlatbufferTypeHelpers.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp>
+#include <ostream>
+
+namespace hipdnn_test_sdk::detail
+{
+
+struct BlockScaleDequantizeSignatureKey
+{
+    const hipdnn_flatbuffers_sdk::data_objects::NodeAttributes nodeType
+        = hipdnn_flatbuffers_sdk::data_objects::NodeAttributes::BlockScaleDequantizeAttributes;
+    hipdnn_flatbuffers_sdk::data_objects::DataType xDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType outputDataType;
+    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType;
+
+    BlockScaleDequantizeSignatureKey() = default;
+    constexpr BlockScaleDequantizeSignatureKey(
+        hipdnn_flatbuffers_sdk::data_objects::DataType x,
+        hipdnn_flatbuffers_sdk::data_objects::DataType scale,
+        hipdnn_flatbuffers_sdk::data_objects::DataType output,
+        hipdnn_flatbuffers_sdk::data_objects::DataType compute)
+        : xDataType(x)
+        , scaleDataType(scale)
+        , outputDataType(output)
+        , computeDataType(compute)
+    {
+    }
+
+    BlockScaleDequantizeSignatureKey(
+        const hipdnn_flatbuffers_sdk::data_objects::Node& node,
+        const std::unordered_map<int64_t,
+                                 const hipdnn_flatbuffers_sdk::data_objects::TensorAttributes*>&
+            tensorMap)
+    {
+        const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+        if(nodeAttributes == nullptr)
+        {
+            throw std::runtime_error(
+                "Node attributes could not be cast to BlockScaleDequantizeAttributes");
+        }
+
+        auto xTensorAttr = tensorMap.at(nodeAttributes->x_tensor_uid());
+        auto scaleTensorAttr = tensorMap.at(nodeAttributes->scale_tensor_uid());
+        auto yTensorAttr = tensorMap.at(nodeAttributes->y_tensor_uid());
+
+        if(xTensorAttr == nullptr || scaleTensorAttr == nullptr || yTensorAttr == nullptr)
+        {
+            throw std::runtime_error("One or more tensor attributes could not be found in the map, "
+                                     "failed to construct key");
+        }
+
+        xDataType = xTensorAttr->data_type();
+        scaleDataType = scaleTensorAttr->data_type();
+        computeDataType = node.compute_data_type();
+        outputDataType = yTensorAttr->data_type();
+    }
+
+    std::size_t operator()(const BlockScaleDequantizeSignatureKey& k) const noexcept
+    {
+        return k.hashSelf();
+    }
+
+    constexpr std::size_t hashSelf() const
+    {
+        return static_cast<std::size_t>(static_cast<int>(nodeType))
+               ^ (static_cast<std::size_t>(static_cast<int>(xDataType)) << 4)
+               ^ (static_cast<std::size_t>(static_cast<int>(scaleDataType)) << 8)
+               ^ (static_cast<std::size_t>(static_cast<int>(outputDataType)) << 12)
+               ^ (static_cast<std::size_t>(static_cast<int>(computeDataType)) << 16);
+    }
+
+    bool operator==(const BlockScaleDequantizeSignatureKey& other) const noexcept
+    {
+        return nodeType == other.nodeType && xDataType == other.xDataType
+               && scaleDataType == other.scaleDataType && outputDataType == other.outputDataType
+               && computeDataType == other.computeDataType;
+    }
+
+    static std::unordered_map<BlockScaleDequantizeSignatureKey,
+                              std::unique_ptr<IGraphNodePlanBuilder>,
+                              BlockScaleDequantizeSignatureKey>
+        getPlanBuilders()
+    {
+        std::unordered_map<BlockScaleDequantizeSignatureKey,
+                           std::unique_ptr<IGraphNodePlanBuilder>,
+                           BlockScaleDequantizeSignatureKey>
+            map;
+
+        // Float/Float/Float/Float (matches integration test defaults)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // Half input with float scale/output/compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // BFloat16 input with float scale/output/compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // Half input with float scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // BFloat16 input with float scale, bfloat16 output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::BFLOAT16,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP8 E4M3 input with E8M0 scale, float output/compute (real MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E4M3,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP8 E5M2 input with E8M0 scale, float output/compute (real MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E5M2,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP8 E4M3 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E4M3,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP8 E5M2 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E5M2,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP4 E2M1 input with E8M0 scale, float output/compute (MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP4_E2M1,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP4 E2M1 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP4_E2M1,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP6 E2M3 input with E8M0 scale, float output/compute (MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E2M3,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP6 E2M3 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E2M3,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP6 E3M2 input with E8M0 scale, float output/compute (MX dequantize)
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E3M2,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        // FP6 E3M2 input with E8M0 scale, half output, float compute
+        addPlanBuilder<hipdnn_flatbuffers_sdk::data_objects::DataType::FP6_E3M2,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FP8_E8M0,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::HALF,
+                       hipdnn_flatbuffers_sdk::data_objects::DataType::FLOAT>(map);
+
+        return map;
+    }
+
+    template <hipdnn_flatbuffers_sdk::data_objects::DataType XDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ScaleDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType OutputDataTypeEnum,
+              hipdnn_flatbuffers_sdk::data_objects::DataType ComputeDataTypeEnum>
+    static void addPlanBuilder(std::unordered_map<BlockScaleDequantizeSignatureKey,
+                                                  std::unique_ptr<IGraphNodePlanBuilder>,
+                                                  BlockScaleDequantizeSignatureKey>& map)
+    {
+        map[BlockScaleDequantizeSignatureKey(
+            XDataTypeEnum, ScaleDataTypeEnum, OutputDataTypeEnum, ComputeDataTypeEnum)]
+            = std::make_unique<BlockScaleDequantizePlanBuilder<XDataTypeEnum,
+                                                               ScaleDataTypeEnum,
+                                                               OutputDataTypeEnum,
+                                                               ComputeDataTypeEnum>>();
+    }
+};
+
+inline std::ostream& operator<<(std::ostream& os, const BlockScaleDequantizeSignatureKey& key)
+{
+    os << "BlockScaleDequantize(x=" << key.xDataType << ", scale=" << key.scaleDataType
+       << ", y=" << key.outputDataType << ", compute=" << key.computeDataType << ")";
+    return os;
+}
+
+} // namespace hipdnn_test_sdk::detail

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanBuilderRegistry.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanBuilderRegistry.hpp
@@ -10,6 +10,7 @@
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferencePlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVariancePlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainPlan.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdPlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdPlan.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/LayernormFpropPlan.hpp>

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanRegistrySignatureKey.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/cpu_graph_executor/detail/PlanRegistrySignatureKey.hpp
@@ -11,6 +11,7 @@
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormFwdInferenceWithVarianceSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BatchnormTrainSignatureKey.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionBwdSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionFwdSignatureKey.hpp>
 #include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/ConvolutionWrwSignatureKey.hpp>
@@ -39,6 +40,7 @@ using PlanRegistrySignatureKey = std::variant<BatchnormFwdInferenceSignatureKey,
                                               BatchnormFwdInferenceWithVarianceSignatureKey,
                                               BatchnormBwdSignatureKey,
                                               BatchnormTrainSignatureKey,
+                                              BlockScaleDequantizeSignatureKey,
                                               ConvolutionFwdSignatureKey,
                                               ConvolutionBwdSignatureKey,
                                               ConvolutionWrwSignatureKey,

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp
@@ -19,12 +19,25 @@
 namespace hipdnn_test_sdk::detail
 {
 using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::fp4_e2m1;
+using hipdnn_data_sdk::types::fp6_e2m3;
+using hipdnn_data_sdk::types::fp6_e3m2;
+using hipdnn_data_sdk::types::fp8_e4m3;
+using hipdnn_data_sdk::types::fp8_e5m2;
+using hipdnn_data_sdk::types::fp8_e8m0;
 using hipdnn_data_sdk::types::half;
 
-// Type trait to validate tensor types (arithmetic types + half + bfloat16)
+// Type trait to validate tensor types (arithmetic types + half + bfloat16 + fp8 types)
 template <typename T>
-constexpr bool IS_VALID_TENSOR_TYPE_V
-    = std::disjunction_v<std::is_arithmetic<T>, std::is_same<T, half>, std::is_same<T, bfloat16>>;
+constexpr bool IS_VALID_TENSOR_TYPE_V = std::disjunction_v<std::is_arithmetic<T>,
+                                                           std::is_same<T, half>,
+                                                           std::is_same<T, bfloat16>,
+                                                           std::is_same<T, fp4_e2m1>,
+                                                           std::is_same<T, fp6_e2m3>,
+                                                           std::is_same<T, fp6_e3m2>,
+                                                           std::is_same<T, fp8_e4m3>,
+                                                           std::is_same<T, fp8_e5m2>,
+                                                           std::is_same<T, fp8_e8m0>>;
 
 /**
  * @brief Safely convert between types while avoiding implicit precision loss warnings
@@ -46,6 +59,15 @@ inline TargetType safeConvert(const SourceType& value)
         // For bfloat16/half, explicitly convert through float to avoid precision warnings
         // These types lack direct constructors from double, only from float
         return static_cast<TargetType>(static_cast<float>(value));
+    }
+    else if constexpr(std::is_same_v<TargetType, fp4_e2m1> || std::is_same_v<TargetType, fp6_e2m3>
+                      || std::is_same_v<TargetType, fp6_e3m2>
+                      || std::is_same_v<TargetType, fp8_e4m3>
+                      || std::is_same_v<TargetType, fp8_e5m2>
+                      || std::is_same_v<TargetType, fp8_e8m0>)
+    {
+        // For FP8 types, convert through float
+        return TargetType(static_cast<float>(value));
     }
     else
     {

--- a/projects/hipdnn/test_sdk/tests/CMakeLists.txt
+++ b/projects/hipdnn/test_sdk/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
     main.cpp
     utilities/TestCpuFpReferenceBatchnorm.cpp
     utilities/TestCpuFpReferenceBatchnormWithVariance.cpp
+    utilities/TestCpuFpReferenceBlockScaleDequantize.cpp
     utilities/TestCpuFpReferenceRMSNorm.cpp
     utilities/TestCpuFpReferenceSdpa.cpp
     utilities/TestCpuFpReferenceConvolution.cpp
@@ -45,6 +46,8 @@ add_executable(
     utilities/TestSeeds.cpp
     utilities/TestTensorDiff.cpp
     utilities/TestVectorLoggingUtils.cpp
+    utilities/cpu_graph_executor/TestBlockScaleDequantizePlan.cpp
+    utilities/cpu_graph_executor/TestBlockScaleDequantizeSignatureKey.cpp
     utilities/cpu_graph_executor/TestBatchnormBwdPlan.cpp
     utilities/cpu_graph_executor/TestBatchnormBwdSignatureKey.cpp
     utilities/cpu_graph_executor/TestBatchnormFwdInferencePlan.cpp

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBlockScaleDequantize.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuFpReferenceBlockScaleDequantize.cpp
@@ -1,0 +1,416 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <hipdnn_data_sdk/types.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp>
+#include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
+
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_data_sdk::types;
+using hipdnn_test_sdk::detail::safeTestTypeCast;
+
+template <typename T1, typename T2, typename T3>
+struct TypeTriple
+{
+    using InputType = T1;
+    using ScaleType = T2;
+    using OutputType = T3;
+};
+
+// ============================================================================
+// Typed tests over input type: float/half/bfloat16 with float scale
+// ============================================================================
+
+using TypesBlockScaleDequantize = ::testing::Types<TypeTriple<float, float, float>,
+                                                   TypeTriple<half, float, float>,
+                                                   TypeTriple<bfloat16, float, float>>;
+
+template <class T>
+class CpuFpReferenceBlockScaleDequantizeTyped : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(CpuFpReferenceBlockScaleDequantizeTyped, TypesBlockScaleDequantize, );
+
+TYPED_TEST(CpuFpReferenceBlockScaleDequantizeTyped, IdentityScale)
+{
+    using XType = typename TypeParam::InputType;
+    using ScaleType = typename TypeParam::ScaleType;
+    using YType = typename TypeParam::OutputType;
+
+    // X: 2x4, Scale: 2x2 (block_size=2 along dim 1)
+    Tensor<XType> xTensor({2, 4});
+    Tensor<ScaleType> scaleTensor({2, 2});
+    Tensor<YType> yTensor({2, 4});
+
+    xTensor.fillWithValue(safeTestTypeCast<XType>(3.0f));
+    scaleTensor.fillWithValue(safeTestTypeCast<ScaleType>(1.0f));
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    for(int b = 0; b < 2; ++b)
+    {
+        for(int c = 0; c < 4; ++c)
+        {
+            EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(b, c)), 3.0f, tolerance);
+        }
+    }
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeTyped, BFloat16InBFloat16Out)
+{
+    // bfloat16 input, float scale, bfloat16 output — registered signature gap
+    Tensor<bfloat16> xTensor({1, 4});
+    Tensor<float> scaleTensor({1, 2});
+    Tensor<bfloat16> yTensor({1, 4});
+
+    xTensor.setHostValue(bfloat16(2.0f), 0, 0);
+    xTensor.setHostValue(bfloat16(4.0f), 0, 1);
+    xTensor.setHostValue(bfloat16(1.0f), 0, 2);
+    xTensor.setHostValue(bfloat16(3.0f), 0, 3);
+
+    scaleTensor.setHostValue(0.5f, 0, 0); // scales elements [0,1]
+    scaleTensor.setHostValue(2.0f, 0, 1); // scales elements [2,3]
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-2f; // bfloat16 has ~2 decimal digits of precision
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 0)), 2.0f * 0.5f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 1)), 4.0f * 0.5f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 2)), 1.0f * 2.0f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 3)), 3.0f * 2.0f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, NonTrivialScale)
+{
+    // X: 1x4, Scale: 1x2 => block_size=2 along dim 1
+    Tensor<float> xTensor({1, 4});
+    Tensor<float> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(1.0f, 0, 0);
+    xTensor.setHostValue(2.0f, 0, 1);
+    xTensor.setHostValue(3.0f, 0, 2);
+    xTensor.setHostValue(4.0f, 0, 3);
+
+    scaleTensor.setHostValue(2.0f, 0, 0); // scales elements [0,1]
+    scaleTensor.setHostValue(0.5f, 0, 1); // scales elements [2,3]
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 1.0f * 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 2.0f * 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 3.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), 4.0f * 0.5f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, MultiDimBlocking)
+{
+    // X: 2x4x8, Scale: 2x4x2 => block along trailing dim, block_size=4
+    // Use distinct per-block scale values so spot-checking can detect index mapping bugs.
+    Tensor<float> xTensor({2, 4, 8});
+    Tensor<float> scaleTensor({2, 4, 2});
+    Tensor<float> yTensor({2, 4, 8});
+
+    xTensor.fillWithValue(1.0f);
+
+    // Assign distinct scale values: scale[b][r][s] covers x[b][r][s*4..(s+1)*4-1]
+    float scaleVal = 1.0f;
+    for(int b = 0; b < 2; ++b)
+    {
+        for(int r = 0; r < 4; ++r)
+        {
+            for(int s = 0; s < 2; ++s)
+            {
+                scaleTensor.setHostValue(scaleVal, b, r, s);
+                scaleVal += 1.0f;
+            }
+        }
+    }
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {4}, false);
+
+    auto tolerance = 1e-5f;
+    // Block (0,0,0): x[0][0][0..3] => scale[0][0][0] = 1.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 0), 1.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 3), 1.0f, tolerance);
+    // Block (0,0,1): x[0][0][4..7] => scale[0][0][1] = 2.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 4), 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 7), 2.0f, tolerance);
+    // Block (0,1,0): x[0][1][0..3] => scale[0][1][0] = 3.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 1, 0), 3.0f, tolerance);
+    // Block (1,3,1): x[1][3][4..7] => scale[1][3][1] = 16.0 (last block)
+    EXPECT_NEAR(yTensor.getHostValue(1, 3, 4), 16.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(1, 3, 7), 16.0f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, MultiTrailingDimBlockSize)
+{
+    // X: 1x4x6, Scale: 1x2x3 => blockSize={2,2} blocks trailing two dims simultaneously
+    // dim 1: block_size=2 (4/2=2 scale entries), dim 2: block_size=2 (6/2=3 scale entries)
+    Tensor<float> xTensor({1, 4, 6});
+    Tensor<float> scaleTensor({1, 2, 3});
+    Tensor<float> yTensor({1, 4, 6});
+
+    xTensor.fillWithValue(1.0f);
+
+    // Assign distinct scale values per block so we can verify correct index mapping
+    // scale[0][s1][s2] covers x[0][s1*2..s1*2+1][s2*2..s2*2+1]
+    scaleTensor.setHostValue(1.0f, 0, 0, 0);
+    scaleTensor.setHostValue(2.0f, 0, 0, 1);
+    scaleTensor.setHostValue(3.0f, 0, 0, 2);
+    scaleTensor.setHostValue(4.0f, 0, 1, 0);
+    scaleTensor.setHostValue(5.0f, 0, 1, 1);
+    scaleTensor.setHostValue(6.0f, 0, 1, 2);
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2, 2}, false);
+
+    auto tolerance = 1e-5f;
+    // Block (0,0): x[0][0..1][0..1] => scale[0][0][0] = 1.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 0), 1.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1, 1), 1.0f, tolerance);
+    // Block (0,1): x[0][0..1][2..3] => scale[0][0][1] = 2.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 2), 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1, 3), 2.0f, tolerance);
+    // Block (0,2): x[0][0..1][4..5] => scale[0][0][2] = 3.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 0, 4), 3.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1, 5), 3.0f, tolerance);
+    // Block (1,0): x[0][2..3][0..1] => scale[0][1][0] = 4.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 2, 0), 4.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3, 1), 4.0f, tolerance);
+    // Block (1,2): x[0][2..3][4..5] => scale[0][1][2] = 6.0
+    EXPECT_NEAR(yTensor.getHostValue(0, 2, 4), 6.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3, 5), 6.0f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, NegativeXValues)
+{
+    // Dequantize is linear: negative x values should scale correctly
+    Tensor<float> xTensor({1, 4});
+    Tensor<float> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(-2.0f, 0, 0);
+    xTensor.setHostValue(-1.0f, 0, 1);
+    xTensor.setHostValue(0.0f, 0, 2);
+    xTensor.setHostValue(-4.0f, 0, 3);
+
+    scaleTensor.setHostValue(3.0f, 0, 0); // scales elements [0,1]
+    scaleTensor.setHostValue(0.5f, 0, 1); // scales elements [2,3]
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), -2.0f * 3.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), -1.0f * 3.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 0.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), -4.0f * 0.5f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, IsNegativeScaleFloat)
+{
+    // With is_negative_scale=true and float scale, Y = X * 2^(-scale)
+    Tensor<float> xTensor({1, 4});
+    Tensor<float> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(8.0f, 0, 0);
+    xTensor.setHostValue(8.0f, 0, 1);
+    xTensor.setHostValue(16.0f, 0, 2);
+    xTensor.setHostValue(16.0f, 0, 3);
+
+    scaleTensor.setHostValue(3.0f, 0, 0); // 2^(-3) = 0.125
+    scaleTensor.setHostValue(1.0f, 0, 1); // 2^(-1) = 0.5
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, true);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 8.0f * 0.125f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 8.0f * 0.125f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 16.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), 16.0f * 0.5f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp32, NormalScaleMultiplication)
+{
+    // Normal (non-negative) scale: Y = X * scale
+    Tensor<float> xTensor({1, 2});
+    Tensor<float> scaleTensor({1, 1});
+    Tensor<float> yTensor({1, 2});
+
+    xTensor.setHostValue(5.0f, 0, 0);
+    xTensor.setHostValue(10.0f, 0, 1);
+    scaleTensor.setHostValue(0.1f, 0, 0);
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 1.0f, tolerance);
+}
+
+// ============================================================================
+// FP8 E8M0 scale: standalone scale semantics test
+// ============================================================================
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp8, E8M0ScaleDequantize)
+{
+    // Test with fp8_e8m0 scale: scale value is 2^(biased_exp - 127)
+    // fp8_e8m0 with bits=127 => 2^0 = 1.0
+    // fp8_e8m0 with bits=128 => 2^1 = 2.0
+    Tensor<float> xTensor({1, 4});
+    Tensor<fp8_e8m0> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(3.0f, 0, 0);
+    xTensor.setHostValue(3.0f, 0, 1);
+    xTensor.setHostValue(5.0f, 0, 2);
+    xTensor.setHostValue(5.0f, 0, 3);
+
+    // scale[0] = 1.0 (bits=127), scale[1] = 2.0 (bits=128)
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(127), 0, 0);
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(128), 0, 1);
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 3.0f * 1.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 3.0f * 1.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 5.0f * 2.0f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), 5.0f * 2.0f, tolerance);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeFp8, IsNegativeScaleE8M0)
+{
+    // isNegativeScale=true with fp8_e8m0: Y = X * 2^(-float(scale))
+    // float(fp8_e8m0::from_bits(127)) = 2^0 = 1.0, so 2^(-1.0) = 0.5
+    // float(fp8_e8m0::from_bits(128)) = 2^1 = 2.0, so 2^(-2.0) = 0.25
+    Tensor<float> xTensor({1, 4});
+    Tensor<fp8_e8m0> scaleTensor({1, 2});
+    Tensor<float> yTensor({1, 4});
+
+    xTensor.setHostValue(8.0f, 0, 0);
+    xTensor.setHostValue(8.0f, 0, 1);
+    xTensor.setHostValue(16.0f, 0, 2);
+    xTensor.setHostValue(16.0f, 0, 3);
+
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(127), 0, 0); // float value = 1.0 => 2^(-1.0) = 0.5
+    scaleTensor.setHostValue(
+        fp8_e8m0::from_bits(128), 0, 1); // float value = 2.0 => 2^(-2.0) = 0.25
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, true);
+
+    auto tolerance = 1e-5f;
+    EXPECT_NEAR(yTensor.getHostValue(0, 0), 8.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 1), 8.0f * 0.5f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 2), 16.0f * 0.25f, tolerance);
+    EXPECT_NEAR(yTensor.getHostValue(0, 3), 16.0f * 0.25f, tolerance);
+}
+
+// ============================================================================
+// Validation error path tests
+// ============================================================================
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeValidation, ScaleRankExceedsXRank)
+{
+    // Scale tensor has more dimensions than x — should throw
+    const Tensor<float> xTensor({4});
+    const Tensor<float> scaleTensor({2, 2});
+    Tensor<float> yTensor({4});
+
+    EXPECT_THROW(
+        CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false),
+        std::invalid_argument);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeValidation, ScaleRankLessThanXRank)
+{
+    // Scale tensor has fewer dimensions than x — should throw (no broadcast support)
+    const Tensor<float> xTensor({2, 4});
+    const Tensor<float> scaleTensor({2});
+    Tensor<float> yTensor({2, 4});
+
+    EXPECT_THROW(
+        CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false),
+        std::invalid_argument);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeValidation, ScaleDimMismatch)
+{
+    // X: 1x4 with block_size=2 expects scale dims {1, 2}, but scale is {1, 3}
+    const Tensor<float> xTensor({1, 4});
+    const Tensor<float> scaleTensor({1, 3});
+    Tensor<float> yTensor({1, 4});
+
+    EXPECT_THROW(
+        CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false),
+        std::invalid_argument);
+}
+
+TEST(TestCpuFpReferenceBlockScaleDequantizeValidation, EmptyXDimsThrows)
+{
+    const Tensor<float> xTensor({});
+    const Tensor<float> scaleTensor({});
+    Tensor<float> yTensor({});
+
+    EXPECT_THROW(
+        CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false),
+        std::runtime_error);
+}
+
+// ============================================================================
+// MX dequantize typed tests: all narrow types with fp8_e8m0 scale
+// ============================================================================
+
+using MxDequantizeTypes = ::testing::Types<TypeTriple<fp8_e4m3, fp8_e8m0, float>,
+                                           TypeTriple<fp8_e4m3, fp8_e8m0, half>,
+                                           TypeTriple<fp8_e5m2, fp8_e8m0, float>,
+                                           TypeTriple<fp8_e5m2, fp8_e8m0, half>,
+                                           TypeTriple<fp4_e2m1, fp8_e8m0, float>,
+                                           TypeTriple<fp4_e2m1, fp8_e8m0, half>,
+                                           TypeTriple<fp6_e2m3, fp8_e8m0, float>,
+                                           TypeTriple<fp6_e2m3, fp8_e8m0, half>,
+                                           TypeTriple<fp6_e3m2, fp8_e8m0, float>,
+                                           TypeTriple<fp6_e3m2, fp8_e8m0, half>>;
+
+template <class T>
+class CpuFpReferenceMxDequantize : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(CpuFpReferenceMxDequantize, MxDequantizeTypes, );
+
+TYPED_TEST(CpuFpReferenceMxDequantize, WithE8m0Scale)
+{
+    using XType = typename TypeParam::InputType;
+    using ScaleType = typename TypeParam::ScaleType;
+    using YType = typename TypeParam::OutputType;
+
+    // MX dequantize: narrow input, fp8_e8m0 scale, float/half output
+    // scale[0] = 1.0 (bits=127), scale[1] = 2.0 (bits=128)
+    // x: {1, 1, 2, 2}, expected y: {1, 1, 4, 4}
+    Tensor<XType> xTensor({1, 4});
+    Tensor<ScaleType> scaleTensor({1, 2});
+    Tensor<YType> yTensor({1, 4});
+
+    xTensor.setHostValue(XType(1.0f), 0, 0);
+    xTensor.setHostValue(XType(1.0f), 0, 1);
+    xTensor.setHostValue(XType(2.0f), 0, 2);
+    xTensor.setHostValue(XType(2.0f), 0, 3);
+
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(127), 0, 0); // 1.0
+    scaleTensor.setHostValue(fp8_e8m0::from_bits(128), 0, 1); // 2.0
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(xTensor, scaleTensor, yTensor, {2}, false);
+
+    auto tolerance = 1e-2f;
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 0)), 1.0f * 1.0f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 1)), 1.0f * 1.0f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 2)), 2.0f * 2.0f, tolerance);
+    EXPECT_NEAR(static_cast<float>(yTensor.getHostValue(0, 3)), 2.0f * 2.0f, tolerance);
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BlockScaleDequantizeGraphUtils.hpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/BlockScaleDequantizeGraphUtils.hpp
@@ -1,0 +1,92 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_data_sdk/utilities/Tensor.hpp>
+#include <hipdnn_frontend/Graph.hpp>
+#include <hipdnn_frontend/Utilities.hpp>
+#include <hipdnn_frontend/attributes/BlockScaleDequantizeAttributes.hpp>
+#include <hipdnn_frontend/attributes/TensorAttributes.hpp>
+#include <hipdnn_test_sdk/constants/BlockScaleDequantizeConstants.hpp>
+#include <hipdnn_test_sdk/utilities/SdkFrontendTypeConversions.hpp>
+#include <hipdnn_test_sdk/utilities/Seeds.hpp>
+
+namespace hipdnn_sdk_test_utils
+{
+
+template <typename XType, typename ScaleType>
+struct BlockScaleDequantizeTensorBundle
+{
+    BlockScaleDequantizeTensorBundle(const std::vector<int64_t>& xDims,
+                                     const std::vector<int64_t>& scaleDims,
+                                     unsigned int seed
+                                     = hipdnn_test_sdk::utilities::getGlobalTestSeed())
+        : xTensor(xDims)
+        , scaleTensor(scaleDims)
+    {
+        xTensor.fillWithRandomValues(static_cast<XType>(0.0f), static_cast<XType>(1.0f), seed);
+        scaleTensor.fillWithRandomValues(
+            static_cast<ScaleType>(0.1f), static_cast<ScaleType>(2.0f), seed);
+    }
+
+    std::unordered_map<int64_t, void*>
+        createVariantPack(const hipdnn_frontend::graph::TensorAttributes& xTensorAttr,
+                          const hipdnn_frontend::graph::TensorAttributes& scaleTensorAttr)
+    {
+        std::unordered_map<int64_t, void*> variantPack;
+        variantPack[xTensorAttr.get_uid()] = xTensor.memory().hostData();
+        variantPack[scaleTensorAttr.get_uid()] = scaleTensor.memory().hostData();
+        return variantPack;
+    }
+
+    hipdnn_data_sdk::utilities::Tensor<XType> xTensor;
+    hipdnn_data_sdk::utilities::Tensor<ScaleType> scaleTensor;
+};
+
+template <typename XType, typename ScaleType>
+static std::tuple<std::shared_ptr<hipdnn_frontend::graph::Graph>,
+                  std::unordered_map<int64_t, void*>>
+    buildBlockScaleDequantizeGraph(BlockScaleDequantizeTensorBundle<XType, ScaleType>& tensorBundle,
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType xDataType,
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType yDataType,
+                                   hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType,
+                                   const std::vector<int32_t>& blockSize)
+{
+    using namespace hipdnn_tests::constants;
+
+    auto graph = std::make_shared<hipdnn_frontend::graph::Graph>();
+    graph->set_name("BlockScaleDequantizeTest");
+    graph->set_compute_data_type(
+        hipdnn_test_sdk::utilities::sdkToFrontendDataType(computeDataType));
+
+    auto xAttr = hipdnn_frontend::graph::makeTensorAttributes(
+        "x", hipdnn_test_sdk::utilities::sdkToFrontendDataType(xDataType), tensorBundle.xTensor);
+    xAttr.set_uid(K_BSD_TENSOR_X_UID);
+    auto xTensorAttr = std::make_shared<hipdnn_frontend::graph::TensorAttributes>(std::move(xAttr));
+
+    auto scaleAttr = hipdnn_frontend::graph::makeTensorAttributes(
+        "scale",
+        hipdnn_test_sdk::utilities::sdkToFrontendDataType(scaleDataType),
+        tensorBundle.scaleTensor);
+    scaleAttr.set_uid(K_BSD_TENSOR_SCALE_UID);
+    auto scaleTensorAttr
+        = std::make_shared<hipdnn_frontend::graph::TensorAttributes>(std::move(scaleAttr));
+
+    hipdnn_frontend::graph::BlockScaleDequantizeAttributes bsdAttrs;
+    bsdAttrs.set_name("block_scale_dequantize");
+    bsdAttrs.set_block_size(blockSize);
+
+    auto yTensorAttr = graph->block_scale_dequantize(xTensorAttr, scaleTensorAttr, bsdAttrs);
+
+    yTensorAttr->set_uid(K_BSD_TENSOR_Y_UID);
+    yTensorAttr->set_data_type(hipdnn_test_sdk::utilities::sdkToFrontendDataType(yDataType));
+
+    auto variantPack = tensorBundle.createVariantPack(*xTensorAttr, *scaleTensorAttr);
+
+    return std::make_tuple(graph, variantPack);
+}
+
+} // namespace hipdnn_sdk_test_utils

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBlockScaleDequantizePlan.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBlockScaleDequantizePlan.cpp
@@ -1,0 +1,452 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+
+#include <hipdnn_data_sdk/utilities/FlatbufferUtils.hpp>
+#include <hipdnn_data_sdk/utilities/ShapeUtilities.hpp>
+#include <hipdnn_flatbuffers_sdk/data_objects/graph_generated.h>
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceBlockScaleDequantize.hpp>
+#include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferDatatypeMapping.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/Seeds.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/GraphTensorBundle.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizePlan.hpp>
+
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_test_sdk::detail;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
+using namespace hipdnn_data_sdk::utilities;
+using namespace hipdnn_flatbuffers_sdk::flatbuffer_utilities;
+
+TEST(TestBlockScaleDequantizePlan, ExecutePlan)
+{
+    auto builder = createValidBlockScaleDequantizeGraph();
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graphWrapper.getNode(0);
+    const auto& tensorMap = graphWrapper.getTensorMap();
+
+    // Create two tensor bundles with same data for plan vs direct comparison
+    const unsigned int seed = getGlobalTestSeed();
+    GraphTensorBundle planBundle(tensorMap);
+    GraphTensorBundle directBundle(tensorMap);
+
+    // Fill x and scale with same random data
+    planBundle.getTensor(1).fillTensorWithRandomValues(0.0f, 1.0f, seed);
+    planBundle.getTensor(2).fillTensorWithRandomValues(0.1f, 2.0f, seed);
+    directBundle.getTensor(1).fillTensorWithRandomValues(0.0f, 1.0f, seed);
+    directBundle.getTensor(2).fillTensorWithRandomValues(0.1f, 2.0f, seed);
+
+    const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+    ASSERT_NE(nodeAttributes, nullptr);
+
+    std::vector<int32_t> blockSize;
+    if(nodeAttributes->block_size() != nullptr)
+    {
+        const auto* bs = nodeAttributes->block_size();
+        blockSize.assign(bs->begin(), bs->end());
+    }
+
+    // Execute via plan
+    BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                      blockSize,
+                                      nodeAttributes->is_negative_scale());
+
+    // Direct execution for reference
+    auto directXTensor
+        = createShallowTensor<float>(params.xTensor, directBundle.getTensor(1).rawHostData());
+    auto directScaleTensor
+        = createShallowTensor<float>(params.scaleTensor, directBundle.getTensor(2).rawHostData());
+    auto directYTensor
+        = createShallowTensor<float>(params.yTensor, directBundle.getTensor(3).rawHostData());
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(*directXTensor,
+                                                   *directScaleTensor,
+                                                   *directYTensor,
+                                                   blockSize,
+                                                   nodeAttributes->is_negative_scale());
+
+    // Plan execution
+    auto variantPack = planBundle.toHostVariantPack();
+    BlockScaleDequantizePlan<float, float, float, float> plan(std::move(params));
+    plan.execute(variantPack);
+
+    const float tolerance = 1e-5f;
+    const CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
+    EXPECT_TRUE(
+        cpuRefOutputValidation.allClose(directBundle.getTensor(3), planBundle.getTensor(3)));
+}
+
+TEST(TestBlockScaleDequantizePlan, ExecutePlanNegativeScale)
+{
+    auto builder = createValidBlockScaleDequantizeGraph(
+        {65536, 2048, 64, 1}, {2, 32, 32, 64}, DataType::FLOAT, DataType::FLOAT, true);
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graphWrapper.getNode(0);
+    const auto& tensorMap = graphWrapper.getTensorMap();
+
+    const unsigned int seed = getGlobalTestSeed();
+    GraphTensorBundle planBundle(tensorMap);
+    GraphTensorBundle directBundle(tensorMap);
+
+    planBundle.getTensor(1).fillTensorWithRandomValues(0.0f, 1.0f, seed);
+    planBundle.getTensor(2).fillTensorWithRandomValues(0.1f, 2.0f, seed);
+    directBundle.getTensor(1).fillTensorWithRandomValues(0.0f, 1.0f, seed);
+    directBundle.getTensor(2).fillTensorWithRandomValues(0.1f, 2.0f, seed);
+
+    const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+    ASSERT_NE(nodeAttributes, nullptr);
+    ASSERT_TRUE(nodeAttributes->is_negative_scale());
+
+    std::vector<int32_t> blockSize;
+    if(nodeAttributes->block_size() != nullptr)
+    {
+        const auto* bs = nodeAttributes->block_size();
+        blockSize.assign(bs->begin(), bs->end());
+    }
+
+    BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                      blockSize,
+                                      nodeAttributes->is_negative_scale());
+
+    auto directXTensor
+        = createShallowTensor<float>(params.xTensor, directBundle.getTensor(1).rawHostData());
+    auto directScaleTensor
+        = createShallowTensor<float>(params.scaleTensor, directBundle.getTensor(2).rawHostData());
+    auto directYTensor
+        = createShallowTensor<float>(params.yTensor, directBundle.getTensor(3).rawHostData());
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(
+        *directXTensor, *directScaleTensor, *directYTensor, blockSize, true);
+
+    auto variantPack = planBundle.toHostVariantPack();
+    BlockScaleDequantizePlan<float, float, float, float> plan(std::move(params));
+    plan.execute(variantPack);
+
+    const float tolerance = 1e-5f;
+    const CpuFpReferenceValidation<float> cpuRefOutputValidation(tolerance, tolerance);
+    EXPECT_TRUE(
+        cpuRefOutputValidation.allClose(directBundle.getTensor(3), planBundle.getTensor(3)));
+}
+
+TEST(TestBlockScaleDequantizePlanBuilder, PlanConstruction)
+{
+    auto builder = createValidBlockScaleDequantizeGraph();
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const BlockScaleDequantizePlanBuilder<DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        patient;
+
+    auto builtPlan = patient.buildNodePlan(graphWrapper, graphWrapper.getNode(0));
+
+    const bool result
+        = dynamic_cast<BlockScaleDequantizePlan<float, float, float, float>*>(builtPlan.get())
+          != nullptr;
+    EXPECT_TRUE(result);
+}
+
+TEST(TestBlockScaleDequantizePlanBuilder, IsApplicable)
+{
+    auto builder = createValidBlockScaleDequantizeGraph();
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const BlockScaleDequantizePlanBuilder<DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        floatPlanBuilder;
+
+    EXPECT_TRUE(
+        floatPlanBuilder.isApplicable(graphWrapper.getNode(0), graphWrapper.getTensorMap()));
+
+    const BlockScaleDequantizePlanBuilder<DataType::HALF,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        badTypesPlanBuilder;
+    EXPECT_FALSE(
+        badTypesPlanBuilder.isApplicable(graphWrapper.getNode(0), graphWrapper.getTensorMap()));
+
+    // MX combinations: FP8 input with E8M0 scale
+    auto mxBuilder = createValidBlockScaleDequantizeMxGraph(
+        DataType::FP8_E4M3, DataType::FP8_E8M0, DataType::FLOAT);
+    const GraphWrapper mxGraphWrapper(mxBuilder.GetBufferPointer(), mxBuilder.GetSize());
+
+    const BlockScaleDequantizePlanBuilder<DataType::FP8_E4M3,
+                                          DataType::FP8_E8M0,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        e4m3FloatBuilder;
+    EXPECT_TRUE(
+        e4m3FloatBuilder.isApplicable(mxGraphWrapper.getNode(0), mxGraphWrapper.getTensorMap()));
+
+    const BlockScaleDequantizePlanBuilder<DataType::FP8_E5M2,
+                                          DataType::FP8_E8M0,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        e5m2FloatBuilder;
+    EXPECT_FALSE(
+        e5m2FloatBuilder.isApplicable(mxGraphWrapper.getNode(0), mxGraphWrapper.getTensorMap()));
+}
+
+// ============================================================================
+// MX plan typed tests: all narrow types with fp8_e8m0 scale
+// ============================================================================
+
+template <DataType XDT, DataType ScaleDT, DataType OutputDT>
+struct MxPlanConfig
+{
+    static constexpr auto X_DATA_TYPE = XDT;
+    static constexpr auto SCALE_DATA_TYPE = ScaleDT;
+    static constexpr auto OUTPUT_DATA_TYPE = OutputDT;
+    using XType = DataTypeToNative<XDT>;
+    using ScaleType = DataTypeToNative<ScaleDT>;
+    using OutputType = DataTypeToNative<OutputDT>;
+};
+
+using MxPlanTypes
+    = ::testing::Types<MxPlanConfig<DataType::FP8_E4M3, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP8_E4M3, DataType::FP8_E8M0, DataType::HALF>,
+                       MxPlanConfig<DataType::FP8_E5M2, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP8_E5M2, DataType::FP8_E8M0, DataType::HALF>,
+                       MxPlanConfig<DataType::FP4_E2M1, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP4_E2M1, DataType::FP8_E8M0, DataType::HALF>,
+                       MxPlanConfig<DataType::FP6_E2M3, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP6_E2M3, DataType::FP8_E8M0, DataType::HALF>,
+                       MxPlanConfig<DataType::FP6_E3M2, DataType::FP8_E8M0, DataType::FLOAT>,
+                       MxPlanConfig<DataType::FP6_E3M2, DataType::FP8_E8M0, DataType::HALF>>;
+
+template <class T>
+class BlockScaleDequantizeMxPlan : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(BlockScaleDequantizeMxPlan, MxPlanTypes, );
+
+TYPED_TEST(BlockScaleDequantizeMxPlan, ExecutePlan)
+{
+    using namespace hipdnn_data_sdk::types;
+    using Config = TypeParam;
+    using XType = typename Config::XType;
+    using ScaleType = typename Config::ScaleType;
+    using OutputType = typename Config::OutputType;
+
+    auto builder = createValidBlockScaleDequantizeMxGraph(
+        Config::X_DATA_TYPE, Config::SCALE_DATA_TYPE, Config::OUTPUT_DATA_TYPE);
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graphWrapper.getNode(0);
+    const auto& tensorMap = graphWrapper.getTensorMap();
+    const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+    ASSERT_NE(nodeAttributes, nullptr);
+
+    std::vector<int32_t> blockSize;
+    if(nodeAttributes->block_size() != nullptr)
+    {
+        const auto* bs = nodeAttributes->block_size();
+        blockSize.assign(bs->begin(), bs->end());
+    }
+
+    GraphTensorBundle planBundle(tensorMap);
+    GraphTensorBundle directBundle(tensorMap);
+
+    // Set x values via raw host data
+    auto* planXData = static_cast<XType*>(planBundle.getTensor(1).rawHostData());
+    planXData[0] = XType(1.0f);
+    planXData[1] = XType(1.0f);
+    planXData[2] = XType(2.0f);
+    planXData[3] = XType(2.0f);
+
+    auto* directXData = static_cast<XType*>(directBundle.getTensor(1).rawHostData());
+    directXData[0] = XType(1.0f);
+    directXData[1] = XType(1.0f);
+    directXData[2] = XType(2.0f);
+    directXData[3] = XType(2.0f);
+
+    // Set scale values (fp8_e8m0): bits=127 => 1.0, bits=128 => 2.0
+    auto* planScaleData = static_cast<ScaleType*>(planBundle.getTensor(2).rawHostData());
+    planScaleData[0] = fp8_e8m0::from_bits(127);
+    planScaleData[1] = fp8_e8m0::from_bits(128);
+
+    auto* directScaleData = static_cast<ScaleType*>(directBundle.getTensor(2).rawHostData());
+    directScaleData[0] = fp8_e8m0::from_bits(127);
+    directScaleData[1] = fp8_e8m0::from_bits(128);
+
+    BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                      blockSize,
+                                      nodeAttributes->is_negative_scale());
+
+    // Direct reference execution
+    auto directXTensor
+        = createShallowTensor<XType>(params.xTensor, directBundle.getTensor(1).rawHostData());
+    auto directScaleTensor = createShallowTensor<ScaleType>(
+        params.scaleTensor, directBundle.getTensor(2).rawHostData());
+    auto directYTensor
+        = createShallowTensor<OutputType>(params.yTensor, directBundle.getTensor(3).rawHostData());
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(
+        *directXTensor, *directScaleTensor, *directYTensor, blockSize, false);
+
+    // Plan execution
+    auto variantPack = planBundle.toHostVariantPack();
+    BlockScaleDequantizePlan<XType, ScaleType, OutputType, float> plan(std::move(params));
+    plan.execute(variantPack);
+
+    const float tolerance = 1e-2f;
+    const CpuFpReferenceValidation<OutputType> cpuRefOutputValidation(tolerance, tolerance);
+    EXPECT_TRUE(
+        cpuRefOutputValidation.allClose(directBundle.getTensor(3), planBundle.getTensor(3)));
+}
+
+// ============================================================================
+// Non-float input plan typed tests: half/bfloat16 input with float scale
+// ============================================================================
+
+using NonFloatInputPlanTypes
+    = ::testing::Types<MxPlanConfig<DataType::HALF, DataType::FLOAT, DataType::FLOAT>,
+                       MxPlanConfig<DataType::HALF, DataType::FLOAT, DataType::HALF>,
+                       MxPlanConfig<DataType::BFLOAT16, DataType::FLOAT, DataType::FLOAT>,
+                       MxPlanConfig<DataType::BFLOAT16, DataType::FLOAT, DataType::BFLOAT16>>;
+
+template <class T>
+class BlockScaleDequantizeNonFloatInputPlan : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(BlockScaleDequantizeNonFloatInputPlan, NonFloatInputPlanTypes, );
+
+TYPED_TEST(BlockScaleDequantizeNonFloatInputPlan, ExecutePlan)
+{
+    using namespace hipdnn_data_sdk::types;
+    using Config = TypeParam;
+    using XType = typename Config::XType;
+    using ScaleType = typename Config::ScaleType;
+    using OutputType = typename Config::OutputType;
+
+    auto builder = createValidBlockScaleDequantizeMxGraph(
+        Config::X_DATA_TYPE, Config::SCALE_DATA_TYPE, Config::OUTPUT_DATA_TYPE);
+    const GraphWrapper graphWrapper(builder.GetBufferPointer(), builder.GetSize());
+
+    const auto& node = graphWrapper.getNode(0);
+    const auto& tensorMap = graphWrapper.getTensorMap();
+    const auto* nodeAttributes = node.attributes_as_BlockScaleDequantizeAttributes();
+    ASSERT_NE(nodeAttributes, nullptr);
+
+    std::vector<int32_t> blockSize;
+    if(nodeAttributes->block_size() != nullptr)
+    {
+        const auto* bs = nodeAttributes->block_size();
+        blockSize.assign(bs->begin(), bs->end());
+    }
+
+    GraphTensorBundle planBundle(tensorMap);
+    GraphTensorBundle directBundle(tensorMap);
+
+    // Set x values
+    auto* planXData = static_cast<XType*>(planBundle.getTensor(1).rawHostData());
+    planXData[0] = XType(1.0f);
+    planXData[1] = XType(1.0f);
+    planXData[2] = XType(2.0f);
+    planXData[3] = XType(2.0f);
+
+    auto* directXData = static_cast<XType*>(directBundle.getTensor(1).rawHostData());
+    directXData[0] = XType(1.0f);
+    directXData[1] = XType(1.0f);
+    directXData[2] = XType(2.0f);
+    directXData[3] = XType(2.0f);
+
+    // Set float scale values: scale[0] = 1.5, scale[1] = 2.0
+    auto* planScaleData = static_cast<ScaleType*>(planBundle.getTensor(2).rawHostData());
+    planScaleData[0] = ScaleType(1.5f);
+    planScaleData[1] = ScaleType(2.0f);
+
+    auto* directScaleData = static_cast<ScaleType*>(directBundle.getTensor(2).rawHostData());
+    directScaleData[0] = ScaleType(1.5f);
+    directScaleData[1] = ScaleType(2.0f);
+
+    BlockScaleDequantizeParams params(*tensorMap.at(nodeAttributes->x_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->scale_tensor_uid()),
+                                      *tensorMap.at(nodeAttributes->y_tensor_uid()),
+                                      blockSize,
+                                      nodeAttributes->is_negative_scale());
+
+    auto directXTensor
+        = createShallowTensor<XType>(params.xTensor, directBundle.getTensor(1).rawHostData());
+    auto directScaleTensor = createShallowTensor<ScaleType>(
+        params.scaleTensor, directBundle.getTensor(2).rawHostData());
+    auto directYTensor
+        = createShallowTensor<OutputType>(params.yTensor, directBundle.getTensor(3).rawHostData());
+
+    CpuFpReferenceBlockScaleDequantize::dequantize(
+        *directXTensor, *directScaleTensor, *directYTensor, blockSize, false);
+
+    auto variantPack = planBundle.toHostVariantPack();
+    BlockScaleDequantizePlan<XType, ScaleType, OutputType, float> plan(std::move(params));
+    plan.execute(variantPack);
+
+    const float tolerance = 1e-2f;
+    const CpuFpReferenceValidation<OutputType> cpuRefOutputValidation(tolerance, tolerance);
+    EXPECT_TRUE(
+        cpuRefOutputValidation.allClose(directBundle.getTensor(3), planBundle.getTensor(3)));
+}
+
+// ============================================================================
+// MX IsApplicable typed tests: narrow types with fp8_e8m0 scale
+// ============================================================================
+
+template <DataType CorrectDT, DataType WrongDT>
+struct MxIsApplicableConfig
+{
+    static constexpr auto CORRECT_DATA_TYPE = CorrectDT;
+    static constexpr auto WRONG_DATA_TYPE = WrongDT;
+};
+
+using MxIsApplicableTypes
+    = ::testing::Types<MxIsApplicableConfig<DataType::FP4_E2M1, DataType::FP6_E2M3>,
+                       MxIsApplicableConfig<DataType::FP6_E2M3, DataType::FP6_E3M2>,
+                       MxIsApplicableConfig<DataType::FP6_E3M2, DataType::FP4_E2M1>>;
+
+template <class T>
+class BlockScaleDequantizeMxIsApplicable : public ::testing::Test
+{
+};
+
+TYPED_TEST_SUITE(BlockScaleDequantizeMxIsApplicable, MxIsApplicableTypes, );
+
+TYPED_TEST(BlockScaleDequantizeMxIsApplicable, MatchingTypeIsApplicable)
+{
+    using Config = TypeParam;
+
+    auto mxBuilder = createValidBlockScaleDequantizeMxGraph(
+        Config::CORRECT_DATA_TYPE, DataType::FP8_E8M0, DataType::FLOAT);
+    const GraphWrapper mxGraphWrapper(mxBuilder.GetBufferPointer(), mxBuilder.GetSize());
+
+    const BlockScaleDequantizePlanBuilder<Config::CORRECT_DATA_TYPE,
+                                          DataType::FP8_E8M0,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        matchingBuilder;
+    EXPECT_TRUE(
+        matchingBuilder.isApplicable(mxGraphWrapper.getNode(0), mxGraphWrapper.getTensorMap()));
+
+    const BlockScaleDequantizePlanBuilder<Config::WRONG_DATA_TYPE,
+                                          DataType::FP8_E8M0,
+                                          DataType::FLOAT,
+                                          DataType::FLOAT>
+        wrongTypeBuilder;
+    EXPECT_FALSE(
+        wrongTypeBuilder.isApplicable(mxGraphWrapper.getNode(0), mxGraphWrapper.getTensorMap()));
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBlockScaleDequantizeSignatureKey.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestBlockScaleDequantizeSignatureKey.cpp
@@ -1,0 +1,103 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <hipdnn_flatbuffers_sdk/flatbuffer_utilities/GraphWrapper.hpp>
+#include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
+#include <hipdnn_test_sdk/utilities/cpu_graph_executor/detail/BlockScaleDequantizeSignatureKey.hpp>
+
+using namespace hipdnn_test_sdk::utilities;
+using namespace hipdnn_test_sdk::detail;
+using namespace hipdnn_flatbuffers_sdk::data_objects;
+using namespace hipdnn_data_sdk::utilities;
+
+TEST(TestBlockScaleDequantizeSignatureKey, EqualityOperator)
+{
+    const BlockScaleDequantizeSignatureKey key1{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key2{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    EXPECT_TRUE(key1 == key2);
+
+    const BlockScaleDequantizeSignatureKey key3{
+        DataType::HALF, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key4{
+        DataType::HALF, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    EXPECT_TRUE(key3 == key4);
+
+    const BlockScaleDequantizeSignatureKey key5{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key6{
+        DataType::HALF, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    EXPECT_FALSE(key5 == key6);
+
+    const BlockScaleDequantizeSignatureKey key7{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key8{
+        DataType::FLOAT, DataType::HALF, DataType::FLOAT, DataType::FLOAT};
+    EXPECT_FALSE(key7 == key8);
+
+    const BlockScaleDequantizeSignatureKey key9{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key10{
+        DataType::FLOAT, DataType::FLOAT, DataType::DOUBLE, DataType::FLOAT};
+    EXPECT_FALSE(key9 == key10);
+}
+
+TEST(TestBlockScaleDequantizeSignatureKey, HashFunction)
+{
+    const BlockScaleDequantizeSignatureKey key1{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key2{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+
+    EXPECT_EQ(key1.hashSelf(), key2.hashSelf());
+
+    const BlockScaleDequantizeSignatureKey key3{
+        DataType::HALF, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key4{
+        DataType::FLOAT, DataType::HALF, DataType::FLOAT, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key5{
+        DataType::FLOAT, DataType::FLOAT, DataType::HALF, DataType::FLOAT};
+    const BlockScaleDequantizeSignatureKey key6{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::HALF};
+
+    const auto hash3 = key3.hashSelf();
+    const auto hash4 = key4.hashSelf();
+    const auto hash5 = key5.hashSelf();
+    const auto hash6 = key6.hashSelf();
+
+    EXPECT_TRUE(hash3 != hash4 && hash3 != hash5 && hash4 != hash5 && hash3 != hash6
+                && hash4 != hash6 && hash5 != hash6);
+}
+
+TEST(TestBlockScaleDequantizeSignatureKey, Copy)
+{
+    const BlockScaleDequantizeSignatureKey original{
+        DataType::FLOAT, DataType::HALF, DataType::FLOAT, DataType::BFLOAT16};
+    const BlockScaleDequantizeSignatureKey copied{original};
+
+    EXPECT_TRUE(original == copied);
+    EXPECT_EQ(copied.xDataType, DataType::FLOAT);
+    EXPECT_EQ(copied.scaleDataType, DataType::HALF);
+    EXPECT_EQ(copied.outputDataType, DataType::FLOAT);
+    EXPECT_EQ(copied.computeDataType, DataType::BFLOAT16);
+}
+
+TEST(TestBlockScaleDequantizeSignatureKey, CreateFromNodeAndTensorMap)
+{
+    const BlockScaleDequantizeSignatureKey expectedKey{
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT};
+
+    auto builder = createValidBlockScaleDequantizeGraph();
+    const auto graphWrap = hipdnn_flatbuffers_sdk::flatbuffer_utilities::GraphWrapper(
+        builder.GetBufferPointer(), builder.GetSize());
+
+    const BlockScaleDequantizeSignatureKey keyFromNode(graphWrap.getNode(0),
+                                                       graphWrap.getTensorMap());
+
+    EXPECT_TRUE(keyFromNode == expectedKey);
+}

--- a/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/cpu_graph_executor/TestCpuReferenceGraphExecutor.cpp
@@ -9,10 +9,17 @@
 
 #include "BatchnormGraphUtils.hpp"
 #include "BatchnormTensorBundles.hpp"
+#include "BlockScaleDequantizeGraphUtils.hpp"
 #include "ConvolutionGraphUtils.hpp"
+#include "LayernormGraphUtils.hpp"
+#include "LayernormTensorBundles.hpp"
 #include "MatmulGraphUtils.hpp"
 #include "PointwiseGraphUtils.hpp"
 #include "PointwiseTensorBundles.hpp"
+#include "RMSNormGraphUtils.hpp"
+#include "RMSNormTensorBundles.hpp"
+#include "SdpaGraphUtils.hpp"
+#include "SdpaTensorBundles.hpp"
 
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/ShallowTensor.hpp>
@@ -239,6 +246,120 @@ public:
         CpuReferenceGraphExecutor().execute(
             serializedGraph.data(), serializedGraph.size(), variantPack);
     }
+
+    static void
+        runLayernormTest(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                         hipdnn_flatbuffers_sdk::data_objects::DataType scaleBiasDataType,
+                         hipdnn_flatbuffers_sdk::data_objects::DataType meanInvVarianceDataType,
+                         hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
+    {
+        const unsigned int seed = getGlobalTestSeed();
+        const std::vector<int64_t> dims = {1, 3, 14, 14};
+
+        auto graph = buildLayernormFpropGraph(inputDataType,
+                                              scaleBiasDataType,
+                                              meanInvVarianceDataType,
+                                              computeDataType,
+                                              dims,
+                                              2, // normalize over last 2 dims
+                                              TensorLayout::NCHW);
+
+        auto result = graph->validate();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        auto [serializedGraph, serErr] = graph->to_binary();
+        ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
+        const GraphWrapper graphWrapper(serializedGraph.data(), serializedGraph.size());
+
+        LayernormFpropTensorBundle tensorBundle(
+            graphWrapper.getNodeWrapper(0), graphWrapper.getTensorMap(), seed);
+
+        auto variantPack = tensorBundle.toHostVariantPack();
+
+        CpuReferenceGraphExecutor().execute(
+            serializedGraph.data(), serializedGraph.size(), variantPack);
+    }
+
+    static void runRMSNormTest(hipdnn_flatbuffers_sdk::data_objects::DataType inputDataType,
+                               hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+                               hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
+    {
+        const unsigned int seed = getGlobalTestSeed();
+        const std::vector<int64_t> dims = {1, 3, 14, 14};
+
+        auto graph = buildRMSNormFwdGraph(
+            inputDataType, scaleDataType, computeDataType, dims, TensorLayout::NCHW);
+
+        auto result = graph->validate();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        auto [serializedGraph, serErr] = graph->to_binary();
+        ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
+        const GraphWrapper graphWrapper(serializedGraph.data(), serializedGraph.size());
+
+        RMSNormFwdTensorBundle tensorBundle(
+            graphWrapper.getNodeWrapper(0), graphWrapper.getTensorMap(), seed);
+
+        auto variantPack = tensorBundle.toHostVariantPack();
+
+        CpuReferenceGraphExecutor().execute(
+            serializedGraph.data(), serializedGraph.size(), variantPack);
+    }
+
+    template <typename InputType>
+    static void runSdpaTest(hipdnn_flatbuffers_sdk::data_objects::DataType dataType)
+    {
+        // Q/K/V: [batch=1, heads=2, seq=4, head_dim=8]
+        const std::vector<int64_t> qDims = {1, 2, 4, 8};
+        const std::vector<int64_t> kDims = {1, 2, 4, 8};
+        const std::vector<int64_t> vDims = {1, 2, 4, 8};
+
+        SdpaFwdTensorBundle<InputType> tensorBundle(qDims, kDims, vDims);
+
+        auto graphTuple = buildSdpaFwdGraph(tensorBundle, dataType);
+
+        auto& graph = std::get<0>(graphTuple);
+        auto& variantPack = std::get<1>(graphTuple);
+
+        auto result = graph->validate();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        auto [serializedGraph, serErr] = graph->to_binary();
+        ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
+
+        CpuReferenceGraphExecutor().execute(
+            serializedGraph.data(), serializedGraph.size(), variantPack);
+    }
+
+    template <typename XType, typename ScaleType>
+    static void
+        runBlockScaleDequantizeTest(hipdnn_flatbuffers_sdk::data_objects::DataType xDataType,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType scaleDataType,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType yDataType,
+                                    hipdnn_flatbuffers_sdk::data_objects::DataType computeDataType)
+    {
+        const std::vector<int64_t> xDims = {2, 32, 32, 64};
+        const std::vector<int32_t> blockSize = {32};
+        // scale dims: ceil(64/32) = 2 for the blocked trailing dim
+        const std::vector<int64_t> scaleDims = {2, 32, 32, 2};
+
+        BlockScaleDequantizeTensorBundle<XType, ScaleType> tensorBundle(xDims, scaleDims);
+
+        auto graphTuple = buildBlockScaleDequantizeGraph(
+            tensorBundle, xDataType, scaleDataType, yDataType, computeDataType, blockSize);
+
+        auto& graph = std::get<0>(graphTuple);
+        auto& variantPack = std::get<1>(graphTuple);
+
+        auto result = graph->validate();
+        ASSERT_EQ(result.code, hipdnn_frontend::ErrorCode::OK) << result.err_msg;
+
+        auto [serializedGraph2, serErr2] = graph->to_binary();
+        ASSERT_TRUE(serErr2.is_good()) << serErr2.get_message();
+
+        CpuReferenceGraphExecutor().execute(
+            serializedGraph2.data(), serializedGraph2.size(), variantPack);
+    }
 };
 
 TEST(TestCpuReferenceGraphExecutor, BatchnormFwdInferenceAllFloats)
@@ -385,4 +506,64 @@ TEST(TestCpuReferenceGraphExecutor, PointwiseBinaryAdd)
     ASSERT_TRUE(serErr.is_good()) << serErr.get_message();
     CpuReferenceGraphExecutor().execute(
         serializedGraph.data(), serializedGraph.size(), variantPack);
+}
+
+TEST(TestCpuReferenceGraphExecutor, BlockScaleDequantizeAllFloats)
+{
+    TestCpuReferenceGraphExecutor::runBlockScaleDequantizeTest<float, float>(
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, BlockScaleDequantizeHalfInputFloatScale)
+{
+    TestCpuReferenceGraphExecutor::runBlockScaleDequantizeTest<half, float>(
+        DataType::HALF, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, BlockScaleDequantizeBFloat16InputFloatScale)
+{
+    TestCpuReferenceGraphExecutor::runBlockScaleDequantizeTest<bfloat16, float>(
+        DataType::BFLOAT16, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+
+TEST(TestCpuReferenceGraphExecutor, LayernormAllFloats)
+{
+    TestCpuReferenceGraphExecutor::runLayernormTest(
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, LayernormAllHalfs)
+{
+    TestCpuReferenceGraphExecutor::runLayernormTest(
+        DataType::HALF, DataType::HALF, DataType::HALF, DataType::HALF);
+}
+TEST(TestCpuReferenceGraphExecutor, LayernormAllBFloat16)
+{
+    TestCpuReferenceGraphExecutor::runLayernormTest(
+        DataType::BFLOAT16, DataType::BFLOAT16, DataType::BFLOAT16, DataType::BFLOAT16);
+}
+
+TEST(TestCpuReferenceGraphExecutor, RMSNormAllFloats)
+{
+    TestCpuReferenceGraphExecutor::runRMSNormTest(
+        DataType::FLOAT, DataType::FLOAT, DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, RMSNormAllHalfs)
+{
+    TestCpuReferenceGraphExecutor::runRMSNormTest(DataType::HALF, DataType::HALF, DataType::HALF);
+}
+TEST(TestCpuReferenceGraphExecutor, RMSNormAllBFloat16)
+{
+    TestCpuReferenceGraphExecutor::runRMSNormTest(
+        DataType::BFLOAT16, DataType::BFLOAT16, DataType::BFLOAT16);
+}
+
+TEST(TestCpuReferenceGraphExecutor, SdpaAllFloats)
+{
+    TestCpuReferenceGraphExecutor::runSdpaTest<float>(DataType::FLOAT);
+}
+TEST(TestCpuReferenceGraphExecutor, SdpaAllHalfs)
+{
+    TestCpuReferenceGraphExecutor::runSdpaTest<half>(DataType::HALF);
+}
+TEST(TestCpuReferenceGraphExecutor, SdpaAllBFloat16)
+{
+    TestCpuReferenceGraphExecutor::runSdpaTest<bfloat16>(DataType::BFLOAT16);
 }

--- a/projects/hipdnn/tests/frontend/CMakeLists.txt
+++ b/projects/hipdnn/tests/frontend/CMakeLists.txt
@@ -56,10 +56,10 @@ add_executable(
     IntegrationRMSNormDescriptorLowering.cpp
     IntegrationRMSNormForward.cpp
     IntegrationSetPluginPathsExt.cpp
-    IntegrationSdpaBwdDescriptorLowering.cpp
-    IntegrationSdpaBwdLifting.cpp
-    IntegrationSdpaFwdDescriptorLifting.cpp
-    IntegrationSdpaFwdDescriptorLowering.cpp
+    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:IntegrationSdpaBwdDescriptorLowering.cpp>
+    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:IntegrationSdpaBwdLifting.cpp>
+    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:IntegrationSdpaFwdDescriptorLifting.cpp>
+    $<$<BOOL:${HIPDNN_ENABLE_SDPA}>:IntegrationSdpaFwdDescriptorLowering.cpp>
 )
 
 target_compile_options(hipdnn_public_frontend_tests PRIVATE ${HIPDNN_WARNING_COMPILE_OPTIONS})

--- a/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.cpp.in
+++ b/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.cpp.in
@@ -37,28 +37,16 @@
 
 #if   ROCPRIM_TEST_SUITE_SLICE == 0
     TYPED_TEST_P(SUITE, SortKeys                ) { sort_keys<TestFixture>(); }
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeys);
+    TYPED_TEST_P(SUITE, SortKeysEmptyData       ) { sort_keys_empty_data<TestFixture>(); }
+    TYPED_TEST_P(SUITE, SortKeysUnspecifiedRanges   ) { sort_keys_unspecified_ranges<TestFixture>(); }
+    TYPED_TEST_P(SUITE, SortKeysLargeSegments   ) { sort_keys_large_segments<TestFixture>(); }
+    TYPED_TEST_P(SUITE, SortKeysDoubleBuffer    ) { sort_keys_double_buffer<TestFixture>(); } 
+    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeys, SortKeysEmptyData, SortKeysUnspecifiedRanges, SortKeysLargeSegments, SortKeysDoubleBuffer);
 #elif ROCPRIM_TEST_SUITE_SLICE == 1
     TYPED_TEST_P(SUITE, SortPairs               ) { sort_pairs<TestFixture>(); }
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairs);
-#elif ROCPRIM_TEST_SUITE_SLICE == 2
-    TYPED_TEST_P(SUITE, SortKeysDoubleBuffer    ) { sort_keys_double_buffer<TestFixture>(); }
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysDoubleBuffer);
-#elif ROCPRIM_TEST_SUITE_SLICE == 3
-    TYPED_TEST_P(SUITE, SortPairsDoubleBuffer   ) { sort_pairs_double_buffer<TestFixture>(); }
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairsDoubleBuffer);
-#elif ROCPRIM_TEST_SUITE_SLICE == 4
-    TYPED_TEST_P(SUITE, SortKeysEmptyData       ) { sort_keys_empty_data<TestFixture>(); }
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysEmptyData);
-#elif ROCPRIM_TEST_SUITE_SLICE == 5
-    TYPED_TEST_P(SUITE, SortKeysLargeSegments   ) { sort_keys_large_segments<TestFixture>(); }
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysLargeSegments);
-#elif ROCPRIM_TEST_SUITE_SLICE == 6
-    TYPED_TEST_P(SUITE, SortKeysUnspecifiedRanges   ) { sort_keys_unspecified_ranges<TestFixture>(); }
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortKeysUnspecifiedRanges);
-#elif ROCPRIM_TEST_SUITE_SLICE == 7
     TYPED_TEST_P(SUITE, SortPairsUnspecifiedRanges   ) { sort_pairs_unspecified_ranges<TestFixture>(); }
-    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairsUnspecifiedRanges);
+    TYPED_TEST_P(SUITE, SortPairsDoubleBuffer   ) { sort_pairs_double_buffer<TestFixture>(); } 
+    REGISTER_TYPED_TEST_SUITE_P(SUITE, SortPairs, SortPairsUnspecifiedRanges, SortPairsDoubleBuffer);
 #endif
 
 #if ROCPRIM_TEST_TYPE_SLICE == 0
@@ -68,35 +56,35 @@
     INSTANTIATE(params<long long,           common::custom_type<char, char, true>, false,  0, 64,  4000,   8000,  false, config_custom>)
 #elif ROCPRIM_TEST_TYPE_SLICE == 1
     INSTANTIATE(params<double,              unsigned int,                       false,  0, 64,  2,      10>)
-    INSTANTIATE(params<int8_t,              int8_t,                             true,   0, 8,   2000,   10000>)
-    INSTANTIATE(params<int8_t,              int8_t,                             false,  0, 8,   0,      1000>)
-    INSTANTIATE(params<uint8_t,             uint8_t,                            true,   0, 8,   2000,   10000>)
-#elif ROCPRIM_TEST_TYPE_SLICE == 2
-    INSTANTIATE(params<uint8_t,             uint8_t,                            false,  0, 8,   0,      1000>)
     INSTANTIATE(params<rocprim::half,       rocprim::half,                      true,   0, 16,  2000,   10000>)
     INSTANTIATE(params<rocprim::half,       rocprim::half,                      false,  0, 16,  0,      1000>)
+#elif ROCPRIM_TEST_TYPE_SLICE == 2
     INSTANTIATE(params<rocprim::bfloat16,   rocprim::bfloat16,                  true,   0, 16,  2000,   10000>)
-#elif ROCPRIM_TEST_TYPE_SLICE == 3
     INSTANTIATE(params<rocprim::bfloat16,   rocprim::bfloat16,                  false, 0, 16, 0, 1000>)
     INSTANTIATE(params<float,               int,                                false, 0, 32, 0, 1000>)
     INSTANTIATE(params<test_utils::custom_float_type, int,                      true,  0, 32, 0, 8192>)
 
+#elif ROCPRIM_TEST_TYPE_SLICE == 3
+    INSTANTIATE(params<int8_t,              int8_t,                             true,   0, 8,   2000,   10000>)
+    INSTANTIATE(params<int8_t,              int8_t,                             false,  0, 8,   0,      1000>)
+    INSTANTIATE(params<uint8_t,             uint8_t,                            true,   0, 8,   2000,   10000>)
+    INSTANTIATE(params<uint8_t,             uint8_t,                            false,  0, 8,   0,      1000>)
     // start_bit and end_bit
 
     INSTANTIATE(params<uint8_t,             uint8_t,                                true,   2, 5,   0,      10000>)
-#elif ROCPRIM_TEST_TYPE_SLICE == 4
     INSTANTIATE(params<uint8_t,             uint8_t,                                false,  2, 6,   1000,   10000>)
+#elif ROCPRIM_TEST_TYPE_SLICE == 4
     INSTANTIATE(params<unsigned short,      rocprim::half,                          true,   4, 10,  0,      10000>)
     INSTANTIATE(params<unsigned short,      rocprim::bfloat16,                      true,   4, 10,  0,      10000>)
     INSTANTIATE(params<unsigned char,       int,                                    true,   2, 5,   0,      100>)
 #elif ROCPRIM_TEST_TYPE_SLICE == 5
-    INSTANTIATE(params<unsigned short,      int,                                    true,   4, 10,  0,      10000>)
     INSTANTIATE(params<unsigned int,        short,                                  false,  3, 22,  1000,   10000>)
-    INSTANTIATE(params<unsigned int,        double,                                 true,   4, 21,  100,    100000>)
     INSTANTIATE(params<unsigned int,        short,                                  true,   0, 15,  100000, 200000>)
+    INSTANTIATE(params<unsigned int,        double,                                 true,   4, 21,  100,    100000>)
+    INSTANTIATE(params<unsigned int,        double,                                 true,   4, 21,  100,    100000, true>)
 #elif ROCPRIM_TEST_TYPE_SLICE == 6
+    INSTANTIATE(params<unsigned short,      int,                                    true,   4, 10,  0,      10000>)
+    INSTANTIATE(params<unsigned short,      int,                                    true,   4, 10,  0,      10000, true>)
     INSTANTIATE(params<unsigned long long,  char,                                   false,  8, 20,  0,      1000>)
     INSTANTIATE(params<unsigned short,      common::custom_type<double, double, true>,   false,  8, 11,  50,     200>)
-    INSTANTIATE(params<unsigned short,      int,                                    true,   4, 10,  0,      10000, true>)
-    INSTANTIATE(params<unsigned int,        double,                                 true,   4, 21,  100,    100000, true>)
 #endif

--- a/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.hpp
+++ b/projects/rocprim/test/rocprim/test_device_segmented_radix_sort.hpp
@@ -186,7 +186,7 @@ inline void sort_keys()
             test_utils::test_kernel_wrapper(
                 [&](void* d_temporary_storage, auto& temporary_storage_bytes)
                 {
-                    if(descending)
+                    if constexpr(descending)
                     {
                         return rocprim::segmented_radix_sort_keys_desc<config>(
                             d_temporary_storage,

--- a/projects/rocsparse/.github/CONTRIBUTING.md
+++ b/projects/rocsparse/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 AMD welcomes contributions to rocSPARSE from the community. Whether those contributions are bug reports, bug fixes, documentation additions, performance notes, or other improvements, we value collaboration with our users. We can build better solutions together. Please follow these details to help ensure your contributions will be successfully accepted.
 
-Our code contriubtion guidelines closely follow the model of [GitHub pull-requests](https://help.github.com/articles/using-pull-requests/).  This repository follows the [git flow](http://nvie.com/posts/a-successful-git-branching-model/) workflow, which dictates a /master branch where releases are cut, and a /develop branch which serves as an integration branch for new code.
+Our code contribution guidelines closely follow the model of [GitHub pull-requests](https://help.github.com/articles/using-pull-requests/).  This repository follows the [git flow](http://nvie.com/posts/a-successful-git-branching-model/) workflow, which dictates a /master branch where releases are cut, and a /develop branch which serves as an integration branch for new code.
 
 ## Issue Discussion ##
 
@@ -57,7 +57,7 @@ Some of the routines in rocSPARSE allow users to choose between multiple differe
 * Some algorithms may perform better or worse depending on whether a user intends to perform the computation only once or many times.
 * Some algorithms may exist to allow for reproducibility between runs, for example by not using atomic operations.
 * Some algorithms may exist because they do not require any additional memory allocation or analysis phase.
-* Some algorithms may handle different ranges in sparse matrix size, i.e number of rows or number of non-zeros.
+* Some algorithms may handle different ranges in sparse matrix size, i.e. number of rows or number of non-zeros.
 
 An opportunity exists here for contributors to add different algorithms that optimize for important user requirements and performance considerations. We encourage contributors to leverage the GitHub "Issues" tab to discuss possible additions they would like to add.
 
@@ -108,7 +108,7 @@ Also, githooks can be installed to format the code per-commit:
 
 When you create a pull request, you should target the default branch. Our current default branch is the **develop** branch, which serves as our integration branch.
 
-By submitting a pull request, you acknowlege and agree with the CLA below:
+By submitting a pull request, you acknowledge and agree with the CLA below:
 
 Contribution License Agreement
 1. The code I am contributing is mine, and I have the right to license it.
@@ -153,7 +153,7 @@ and adjust the date to the current year. When simply modifying a file, the date 
 
 See existing tests for guidance when adding your own.
 
-3. When modifiying an existing routine, add appropriate testing to test_<routine_name>.yaml file in directory `clients/tests/`.
+3. When modifying an existing routine, add appropriate testing to test_<routine_name>.yaml file in directory `clients/tests/`.
 
 4. Tests must have good code coverage.
 
@@ -172,9 +172,9 @@ So when adding a new routine that uses data/compute values please support at lea
 
 ### Process ###
 
-When a PR is raised targetting the develop branch in rocSPARSE, CI will be automatically triggered. This will:
+When a PR is raised targeting the develop branch in rocSPARSE, CI will be automatically triggered. This will:
 
-* Test that the PR passes static analysis (i.e ensure clang formatting rules have been followed).
+* Test that the PR passes static analysis (i.e. ensure clang formatting rules have been followed).
 * Test that the documentation can be properly built
 * Ensure that the PR compiles on different OS and GPU device architecture combinations
 * Ensure that all tests pass on different OS and GPU device architecture combinations

--- a/projects/rocsparse/CHANGELOG.md
+++ b/projects/rocsparse/CHANGELOG.md
@@ -17,6 +17,7 @@ Documentation for rocSPARSE is available at
 * Significant performance improvement for `rocsparse_Xgtsv_no_pivot`.
 
 ### Resolved issues
+* Fixed incorrect usage of `__syncthreads` in `bsrmm`, `csrmm` (row_split), and `csritilu0x`
 * Fixed incorrect usage of `__syncthreads` in `csx2dense`, `dense2csx`, `prune_dense2csr`, `csrcolor`, and `csrmm` (nnz_split)
 * Fix `rocsparse_[s|d|c|z]csric0` where `rocsparse_status_invalid_value` was being returned when the maximum number of non-zeros in any row is between 513 and 1024.
 * Fix compilation when using `--rocsparse_ILP64`
@@ -205,7 +206,7 @@ Documentation for rocSPARSE is available at
 * Fixed a race condition in `bsrgemm` that could on rare occasions cause incorrect results.
 * Fixed an issue in `hyb2csr` where the CSR row pointer array was not being properly filled when `n=0`, `coo_nnz=0`, or `ell_nnz=0`.
 * Fixed scaling in `rocsparse_Xhybmv` when only performing `y=beta*y`, for example, where `alpha==0` in `y=alpha*Ax+beta*y`.
-* Fixed `rocsparse_Xgemmi` failures when the y grid dimension is too large. This occured when n >= 65536.
+* Fixed `rocsparse_Xgemmi` failures when the y grid dimension is too large. This occurred when n >= 65536.
 
 ## rocSPARSE 3.2.0 for ROCm 6.2.0
 

--- a/projects/rocsparse/README.md
+++ b/projects/rocsparse/README.md
@@ -1,7 +1,7 @@
 # rocSPARSE
 
 rocSPARSE exposes a common interface that provides Basic Linear Algebra Subroutines (BLAS) for
-sparse computation. It's implemented on top of AMD
+sparse computation. It is implemented on top of AMD
 [ROCm](https://github.com/ROCm/ROCm) runtime and toolchains. rocSPARSE is
 created using the [HIP](https://github.com/ROCm/rocm-systems/tree/develop/projects/hip) programming
 language and optimized for AMD's latest discrete GPUs.

--- a/projects/rocsparse/clients/common/rocsparse_host.cpp
+++ b/projects/rocsparse/clients/common/rocsparse_host.cpp
@@ -6771,7 +6771,7 @@ void host_gtsv_interleaved_batch_lu(rocsparse_int m,
 #endif
         for(rocsparse_int j = 0; j < batch_count; j++)
         {
-            if(p[batch_count * i + j] <= i) // no pivoting occured, sum up result
+            if(p[batch_count * i + j] <= i) // no pivoting occurred, sum up result
             {
                 T temp = static_cast<T>(0);
                 for(rocsparse_int s = start[j]; s < i; s++)

--- a/projects/rocsparse/clients/testings/testing_bsr2csr.cpp
+++ b/projects/rocsparse/clients/testings/testing_bsr2csr.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,7 @@ void testing_bsr2csr_bad_arg(const Arguments& arg)
     // Create rocsparse handle
     rocsparse_local_handle local_handle;
 
-    // Create rocsparse decriptors
+    // Create rocsparse descriptors
     rocsparse_local_mat_descr local_bsr_descr;
     rocsparse_local_mat_descr local_csr_descr;
 

--- a/projects/rocsparse/clients/tools/rocsparseio-info.cpp
+++ b/projects/rocsparse/clients/tools/rocsparseio-info.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024-2025 Advanced Micro Devices, Inc.
+// Copyright (C) 2024-2026 Advanced Micro Devices, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -37,8 +37,8 @@ typedef struct
     uint64_t max_nnz_per_seq;
     uint64_t median_nnz_per_seq;
     bool     full_diagonal;
-    bool     symbolic_symetric;
-    bool     numeric_symetric;
+    bool     symbolic_symmetric;
+    bool     numeric_symmetric;
 
 } rocsparseio_statistics_csx;
 

--- a/projects/rocsparse/deps/external-gtest.cmake
+++ b/projects/rocsparse/deps/external-gtest.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2018-2021 Advanced Micro Devices, Inc. All rights Reserved.
+# Copyright (C) 2018-2026 Advanced Micro Devices, Inc. All rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -55,7 +55,7 @@ else( )
   else( )
     set( gtest_make "make" )
 
-    # The -j paramter does not work with nmake
+    # The -j parameter does not work with nmake
     if( NOT Cores EQUAL 0 )
       math( EXPR Cores "${Cores} + 1 " )
       list( APPEND gtest_make -j ${Cores} )

--- a/projects/rocsparse/docs/install/Windows_Install_Guide.rst
+++ b/projects/rocsparse/docs/install/Windows_Install_Guide.rst
@@ -14,7 +14,7 @@ For information on installing and building rocSPARSE on Linux, see :doc:`rocSPAR
 Prerequisites
 =============
 
-rocSPARSE on Windows requires an AMD HIP SDK-enabled platform. It's supported on the
+rocSPARSE on Windows requires an AMD HIP SDK-enabled platform. It is supported on the
 same Windows versions and toolchains that the HIP SDK supports. For more information, see
 :doc:`HIP SDK installation for Windows <rocm-install-on-windows:index>`.
 

--- a/projects/rocsparse/library/include/rocsparse-auxiliary.h
+++ b/projects/rocsparse/library/include/rocsparse-auxiliary.h
@@ -22,7 +22,7 @@
  * ************************************************************************ */
 
 /*! \file
- *  \brief rocsparse-auxiliary.h provides auxilary functions in rocsparse
+ *  \brief rocsparse-auxiliary.h provides auxiliary functions in rocsparse
  */
 
 #ifndef ROCSPARSE_AUXILIARY_H
@@ -2365,7 +2365,7 @@ rocsparse_status rocsparse_const_bell_get(rocsparse_const_spmat_descr descr,
  *  @param[out]
  *  cols                   number of columns in the sliced ELL matrix
  *  @param[out]
- *  nnz                    number of non-zeros in the sliced ELL matix.
+ *  nnz                    number of non-zeros in the sliced ELL matrix.
  *  @param[out]
  *  sell_slice_size        slice size in the sliced ELL matrix.
  *  @param[out]

--- a/projects/rocsparse/library/include/rocsparse-debugging.h
+++ b/projects/rocsparse/library/include/rocsparse-debugging.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -58,7 +58,7 @@ ROCSPARSE_EXPORT int rocsparse_state_debug_kernel_launch();
 /*! \ingroup aux_module
  *  \brief Enable debug arguments.
  * \details If the debug arguments is enabled then messages are displayed when errors occur during argument checking.
- *          It provide information to the user depending of the setup of the verbosity
+ *          It provides information to the user depending on the setup of the verbosity
  * \ref rocsparse_enable_debug_arguments_verbose, \ref rocsparse_disable_debug_arguments_verbose and \ref rocsparse_state_debug_arguments_verbose.
  * \note This routine ignores the environment variable ROCSPARSE_DEBUG_ARGUMENTS.
  * \note This routine enables debug arguments verbose with \ref rocsparse_enable_debug_arguments_verbose.
@@ -84,7 +84,7 @@ int rocsparse_state_debug_arguments();
 /*! \ingroup aux_module
  *  \brief Enable debug arguments verbose.
  *  \details If the debug arguments (verbose) is enabled then messages are displayed when errors occur during argument checking.
- *           It provide information to the user depending of the setup of the verbosity
+ *           It provides information to the user depending on the setup of the verbosity
  *  \note This routine ignores the environment variable ROCSPARSE_DEBUG_ARGUMENTS_VERBOSE)
  */
 ROCSPARSE_EXPORT
@@ -106,7 +106,7 @@ int rocsparse_state_debug_arguments_verbose();
 
 /*! \ingroup aux_module
  *  \brief Enable debug.
- * \details If the debug is enabled then code traces are generated when unsuccessful status returns occur. It provides information to the user depending of the set of the verbosity
+ * \details If the debug is enabled then code traces are generated when unsuccessful status returns occur. It provides information to the user depending on the setup of the verbosity
  * (\ref rocsparse_enable_debug_verbose, \ref rocsparse_disable_debug_verbose and \ref rocsparse_state_debug_verbose).
  *  \note This routine ignores the environment variable ROCSPARSE_DEBUG.
  * \note \ref rocsparse_enable_debug_verbose and \ref rocsparse_enable_debug_arguments are called.
@@ -155,7 +155,7 @@ void rocsparse_enable_debug_verbose();
 
 /*! \ingroup aux_module
  *  \brief Disable debug verbose.
- *  \note This routine disables debug arguments verbose with  \ref rocsparse_disable_debug_arguments.
+ *  \note This routine disables debug arguments verbose with \ref rocsparse_disable_debug_arguments.
  *  \note This routine ignores the environment variable ROCSPARSE_DEBUG_VERBOSE.
  */
 ROCSPARSE_EXPORT

--- a/projects/rocsparse/library/include/rocsparse-types.h
+++ b/projects/rocsparse/library/include/rocsparse-types.h
@@ -75,7 +75,7 @@ typedef struct _rocsparse_handle* rocsparse_handle;
  *
  *  \details
  *  The rocSPARSE error descriptor is a structure holding the information related to an error
- *  that occured during the execution of a rocSPARSE routine.
+ *  that occurred during the execution of a rocSPARSE routine.
  *  It should be destroyed using rocsparse_destroy_error().
  */
 typedef struct _rocsparse_error* rocsparse_error;
@@ -988,7 +988,7 @@ typedef enum rocsparse_singularity_
     rocsparse_singularity_none, /**< No singularity detected. */
     rocsparse_singularity_symbolic, /**< The sparsity pattern inherently prevents a full rank, e.g. missing diagonal element. */
     rocsparse_singularity_numeric_exact, /**< An exact zero was encountered during numerical calculation. */
-    rocsparse_singularity_numeric_near, /**< An near zero was encountered during numerical calculation, i.e. within a given tolerance. */
+    rocsparse_singularity_numeric_near, /**< A near zero was encountered during numerical calculation, i.e. within a given tolerance. */
 } rocsparse_singularity;
 
 /*! \ingroup types_module

--- a/projects/rocsparse/library/src/conversion/rocsparse_extract.hpp
+++ b/projects/rocsparse/library/src/conversion/rocsparse_extract.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2024-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -106,7 +106,7 @@ public:
     /// @param[in] target The target sparse matrix descriptor.
     /// @param[in] stage  The stage to use.
     /// @param[out] buffer_size_in_bytes The calculated buffer size in bytes.
-    /// @return rocsparse_status_success if the operation succesfull, the appropriate enumeration value otherwise.
+    /// @return rocsparse_status_success if the operation is successful, the appropriate enumeration value otherwise.
     ///
     virtual rocsparse_status buffer_size(rocsparse_handle            handle,
                                          rocsparse_const_spmat_descr source,
@@ -123,7 +123,7 @@ public:
     /// @param[in] stage  The stage to use.
     /// @param[in] buffer_size_in_bytes The calculated buffer size in bytes.
     /// @param[in] buffer The calculated buffer size in bytes.
-    /// @return rocsparse_status_success if the operation succesfull, the appropriate enumeration value otherwise.
+    /// @return rocsparse_status_success if the operation is successful, the appropriate enumeration value otherwise.
     ///
     virtual rocsparse_status run(rocsparse_handle            handle,
                                  rocsparse_const_spmat_descr source,

--- a/projects/rocsparse/library/src/level2/csrmv_device.h
+++ b/projects/rocsparse/library/src/level2/csrmv_device.h
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2018-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2018-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -288,7 +288,7 @@ namespace rocsparse
             // In a nutshell, the idea is to use all of the threads to stream the matrix
             // values into the local memory in a fast, coalesced manner. After that, the
             // per-row reductions are done out of the local memory, which is designed
-            // to handle non-coalsced accesses.
+            // to handle non-coalesced accesses.
 
             // The best method for reducing the local memory values depends on the number
             // of rows. The SC'14 paper discusses a CSR-Scalar style reduction where
@@ -358,7 +358,7 @@ namespace rocsparse
                 if(local_row < stop_row)
                 {
                     // This is dangerous -- will infinite loop if your last value is within
-                    // numThreadsForRed of MAX_UINT. Noticable performance gain to avoid a
+                    // numThreadsForRed of MAX_UINT. Noticeable performance gain to avoid a
                     // long induction variable here, though.
                     for(J local_cur_val = local_first_val + threadInBlock;
                         local_cur_val < local_last_val;
@@ -522,7 +522,7 @@ namespace rocsparse
             // the values still left in y will be added in using the atomic_add.
             //
             // Our solution is to have the first workgroup in one of these long-rows cases
-            // properly initaizlie the output vector. All the other workgroups working on this
+            // properly initialize the output vector. All the other workgroups working on this
             // row will spin-loop until that workgroup finishes its work.
 
             // First, figure out which workgroup you are in the row.
@@ -1039,7 +1039,7 @@ namespace rocsparse
         // (iterating over the row as needed for rows with length > WG size).
         // This means that we can more easily process everything with Vector that we would otherwise have done
         // with Longrows - which, in turn, means we can guarantee result reproducibility simply by avoiding Longrows
-        // use (-> no non-determinstic atomics), just set the bin threshold for Longrows to "infinity" (or "32").
+        // use (-> no non-deterministic atomics), just set the bin threshold for Longrows to "infinity" (or "32").
         T       temp_sum = static_cast<T>(0);
         const I vecStart = csr_row_ptr[row] - idx_base;
         const I vecEnd   = csr_row_ptr[row + 1] - idx_base;

--- a/projects/rocsparse/library/src/level3/bsrmm_device_small.h
+++ b/projects/rocsparse/library/src/level3/bsrmm_device_small.h
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights Reserved.
+ * Copyright (C) 2020-2026 Advanced Micro Devices, Inc. All rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -56,12 +56,9 @@ namespace rocsparse
                                                             rocsparse_order      order_C,
                                                             rocsparse_index_base idx_base)
     {
-        constexpr uint32_t PADDED_BSR_BLOCK_DIM = (BSR_BLOCK_DIM + 1);
-
         const int32_t tid  = hipThreadIdx_x;
         const J       gid  = hipBlockIdx_x * hipBlockDim_x + tid;
         const int32_t lid  = gid & (WF_SIZE - 1);
-        const int32_t wid  = tid / WF_SIZE;
         const J       nwfb = hipGridDim_x * hipBlockDim_x / (WF_SIZE * BSR_BLOCK_DIM);
         const J       col  = lid + hipBlockIdx_y * WF_SIZE;
 
@@ -72,9 +69,6 @@ namespace rocsparse
 
         // local row within block row
         const J local_row = (gid / WF_SIZE) % BSR_BLOCK_DIM;
-
-        __shared__ J shared_col[BLOCKSIZE / WF_SIZE][WF_SIZE];
-        __shared__ A shared_val[BLOCKSIZE / WF_SIZE][WF_SIZE * PADDED_BSR_BLOCK_DIM];
 
         for(J block_row = gid / (WF_SIZE * BSR_BLOCK_DIM); block_row < Mb; block_row += nwfb)
         {
@@ -87,118 +81,96 @@ namespace rocsparse
             {
                 const I k = j + lid;
 
-                shared_col[wid][lid]
+                const J my_col
                     = (k < block_row_end) ? BSR_BLOCK_DIM * (bsr_col_ind[k] - idx_base) : 0;
 
+                T my_val[BSR_BLOCK_DIM];
                 if(direction == rocsparse_direction_row)
                 {
-                    // Perform:
-                    // for(uint32_t l = 0; l < BSR_BLOCK_DIM; l++)
-                    // {
-                    //     shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + l]
-                    //         = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                    //                                               + BSR_BLOCK_DIM * local_row + l]
-                    //                               : static_cast<T>(0);
-                    // }
-                    // as unrolled loop.
-                    shared_val[wid][PADDED_BSR_BLOCK_DIM * lid]
-                        = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                        + BSR_BLOCK_DIM * local_row]
-                                              : static_cast<A>(0);
+                    my_val[0] = (k < block_row_end)
+                                    ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                             + BSR_BLOCK_DIM * local_row])
+                                    : static_cast<T>(0);
                     if(BSR_BLOCK_DIM >= 2)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 1]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * local_row + 1]
-                                                  : static_cast<A>(0);
+                        my_val[1] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * local_row + 1])
+                                        : static_cast<T>(0);
                     }
                     if(BSR_BLOCK_DIM >= 3)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 2]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * local_row + 2]
-                                                  : static_cast<A>(0);
+                        my_val[2] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * local_row + 2])
+                                        : static_cast<T>(0);
                     }
                     if(BSR_BLOCK_DIM >= 4)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 3]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * local_row + 3]
-                                                  : static_cast<A>(0);
+                        my_val[3] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * local_row + 3])
+                                        : static_cast<T>(0);
                     }
                 }
                 else
                 {
-                    // Perform:
-                    // for(uint32_t l = 0; l < BSR_BLOCK_DIM; l++)
-                    // {
-                    //     shared_val[wid][BSR_BLOCK_DIM * lid + l]
-                    //         = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                    //                                               + BSR_BLOCK_DIM * l + local_row]
-                    //                               : static_cast<T>(0);
-                    // }
-                    // as unrolled loop.
-                    shared_val[wid][PADDED_BSR_BLOCK_DIM * lid]
-                        = (k < block_row_end)
-                              ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k + local_row]
-                              : static_cast<A>(0);
+                    my_val[0] = (k < block_row_end) ? static_cast<T>(
+                                    bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k + local_row])
+                                                    : static_cast<T>(0);
                     if(BSR_BLOCK_DIM >= 2)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 1]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * 1 + local_row]
-                                                  : static_cast<A>(0);
+                        my_val[1] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * 1 + local_row])
+                                        : static_cast<T>(0);
                     }
                     if(BSR_BLOCK_DIM >= 3)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 2]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * 2 + local_row]
-                                                  : static_cast<A>(0);
+                        my_val[2] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * 2 + local_row])
+                                        : static_cast<T>(0);
                     }
                     if(BSR_BLOCK_DIM >= 4)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 3]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * 3 + local_row]
-                                                  : static_cast<A>(0);
+                        my_val[3] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * 3 + local_row])
+                                        : static_cast<T>(0);
                     }
                 }
 
-                __syncthreads();
-
-                if(col < N)
+                for(uint32_t i = 0; i < WF_SIZE; ++i)
                 {
-                    for(uint32_t i = 0; i < WF_SIZE; ++i)
+                    const J sc  = rocsparse::shfl(my_col, i, WF_SIZE);
+                    const T sv0 = rocsparse::shfl(my_val[0], i, WF_SIZE);
+                    if(col < N)
                     {
-                        // Perform:
-                        // for(uint32_t l = 0; l < BSR_BLOCK_DIM; l++)
-                        // {
-                        //     sum = rocsparse::fma<T>(shared_val[wid][PADDED_BSR_BLOCK_DIM * i + l],
-                        //                         dense_B[shared_col[wid][i] + l],
-                        //                         sum);
-                        // }
-                        // as unrolled loop.
-                        sum = rocsparse::fma<T>(shared_val[wid][PADDED_BSR_BLOCK_DIM * i],
-                                                dense_B[shared_col[wid][i] + colB],
-                                                sum);
-                        if(BSR_BLOCK_DIM >= 2)
+                        sum = rocsparse::fma<T>(sv0, dense_B[sc + colB], sum);
+                    }
+                    if(BSR_BLOCK_DIM >= 2)
+                    {
+                        const T sv1 = rocsparse::shfl(my_val[1], i, WF_SIZE);
+                        if(col < N)
                         {
-                            sum = rocsparse::fma<T>(shared_val[wid][PADDED_BSR_BLOCK_DIM * i + 1],
-                                                    dense_B[shared_col[wid][i] + 1 + colB],
-                                                    sum);
+                            sum = rocsparse::fma<T>(sv1, dense_B[sc + 1 + colB], sum);
                         }
-                        if(BSR_BLOCK_DIM >= 3)
+                    }
+                    if(BSR_BLOCK_DIM >= 3)
+                    {
+                        const T sv2 = rocsparse::shfl(my_val[2], i, WF_SIZE);
+                        if(col < N)
                         {
-                            sum = rocsparse::fma<T>(shared_val[wid][PADDED_BSR_BLOCK_DIM * i + 2],
-                                                    dense_B[shared_col[wid][i] + 2 + colB],
-                                                    sum);
+                            sum = rocsparse::fma<T>(sv2, dense_B[sc + 2 + colB], sum);
                         }
-                        if(BSR_BLOCK_DIM >= 4)
+                    }
+                    if(BSR_BLOCK_DIM >= 4)
+                    {
+                        const T sv3 = rocsparse::shfl(my_val[3], i, WF_SIZE);
+                        if(col < N)
                         {
-                            sum = rocsparse::fma<T>(shared_val[wid][PADDED_BSR_BLOCK_DIM * i + 3],
-                                                    dense_B[shared_col[wid][i] + 3 + colB],
-                                                    sum);
+                            sum = rocsparse::fma<T>(sv3, dense_B[sc + 3 + colB], sum);
                         }
                     }
                 }
@@ -262,23 +234,17 @@ namespace rocsparse
                                                             rocsparse_order      order_C,
                                                             rocsparse_index_base idx_base)
     {
-        constexpr uint32_t PADDED_BSR_BLOCK_DIM = (BSR_BLOCK_DIM + 1);
-
         const int tid        = hipThreadIdx_x;
         const J   gid        = hipBlockIdx_x * hipBlockDim_x + tid;
         const J   block_row  = gid / (WF_SIZE * BSR_BLOCK_DIM);
         const J   global_row = gid / WF_SIZE;
         const J   local_row  = (gid / WF_SIZE) % BSR_BLOCK_DIM;
         const int lid        = tid & (WF_SIZE - 1);
-        const int wid        = tid / WF_SIZE;
 
         if(block_row >= Mb)
         {
             return;
         }
-
-        __shared__ J shared_col[BLOCKSIZE / WF_SIZE][WF_SIZE];
-        __shared__ A shared_val[BLOCKSIZE / WF_SIZE][WF_SIZE * PADDED_BSR_BLOCK_DIM];
 
         const I block_row_start = bsr_row_ptr[block_row] - idx_base;
         const I block_row_end   = bsr_row_ptr[block_row + 1] - idx_base;
@@ -292,117 +258,100 @@ namespace rocsparse
             {
                 const I k = j + lid;
 
-                shared_col[wid][lid]
+                const J my_col
                     = (k < block_row_end) ? BSR_BLOCK_DIM * (bsr_col_ind[k] - idx_base) : 0;
 
+                T my_val[BSR_BLOCK_DIM];
                 if(direction == rocsparse_direction_row)
                 {
-                    // Perform:
-                    // for(uint32_t p = 0; p < BSR_BLOCK_DIM; p++)
-                    // {
-                    //     shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + p]
-                    //         = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                    //                                               + BSR_BLOCK_DIM * local_row + p]
-                    //                               : static_cast<T>(0);
-                    // }
-                    // as unrolled loop.
-                    shared_val[wid][PADDED_BSR_BLOCK_DIM * lid]
-                        = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                        + BSR_BLOCK_DIM * local_row]
-                                              : static_cast<A>(0);
+                    my_val[0] = (k < block_row_end)
+                                    ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                             + BSR_BLOCK_DIM * local_row])
+                                    : static_cast<T>(0);
                     if(BSR_BLOCK_DIM >= 2)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 1]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * local_row + 1]
-                                                  : static_cast<A>(0);
+                        my_val[1] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * local_row + 1])
+                                        : static_cast<T>(0);
                     }
                     if(BSR_BLOCK_DIM >= 3)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 2]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * local_row + 2]
-                                                  : static_cast<A>(0);
+                        my_val[2] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * local_row + 2])
+                                        : static_cast<T>(0);
                     }
                     if(BSR_BLOCK_DIM >= 4)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 3]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * local_row + 3]
-                                                  : static_cast<A>(0);
+                        my_val[3] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * local_row + 3])
+                                        : static_cast<T>(0);
                     }
                 }
                 else
                 {
-                    // Perform:
-                    // for(uint32_t p = 0; p < BSR_BLOCK_DIM; p++)
-                    // {
-                    //     shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + p]
-                    //         = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                    //                                               + BSR_BLOCK_DIM * p + local_row]
-                    //                               : static_cast<T>(0);
-                    // }
-                    // as unrolled loop.
-                    shared_val[wid][PADDED_BSR_BLOCK_DIM * lid]
-                        = (k < block_row_end)
-                              ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k + local_row]
-                              : static_cast<A>(0);
+                    my_val[0] = (k < block_row_end) ? static_cast<T>(
+                                    bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k + local_row])
+                                                    : static_cast<T>(0);
                     if(BSR_BLOCK_DIM >= 2)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 1]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * 1 + local_row]
-                                                  : static_cast<A>(0);
+                        my_val[1] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * 1 + local_row])
+                                        : static_cast<T>(0);
                     }
                     if(BSR_BLOCK_DIM >= 3)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 2]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * 2 + local_row]
-                                                  : static_cast<A>(0);
+                        my_val[2] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * 2 + local_row])
+                                        : static_cast<T>(0);
                     }
                     if(BSR_BLOCK_DIM >= 4)
                     {
-                        shared_val[wid][PADDED_BSR_BLOCK_DIM * lid + 3]
-                            = (k < block_row_end) ? bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
-                                                            + BSR_BLOCK_DIM * 3 + local_row]
-                                                  : static_cast<A>(0);
+                        my_val[3] = (k < block_row_end)
+                                        ? static_cast<T>(bsr_val[BSR_BLOCK_DIM * BSR_BLOCK_DIM * k
+                                                                 + BSR_BLOCK_DIM * 3 + local_row])
+                                        : static_cast<T>(0);
                     }
                 }
 
-                __syncthreads();
-
-                if(col < N)
+                for(uint32_t i = 0; i < WF_SIZE; ++i)
                 {
-                    for(uint32_t i = 0; i < WF_SIZE; ++i)
+                    const J sc  = rocsparse::shfl(my_col, i, WF_SIZE);
+                    const T sv0 = rocsparse::shfl(my_val[0], i, WF_SIZE);
+                    if(col < N)
                     {
-                        // Perform:
-                        // for(uint32_t p = 0; p < BSR_BLOCK_DIM; p++)
-                        // {
-                        //     T val_B = rocsparse::ldg(dense_B + col + ldb * (p + shared_col[wid][i]));
-                        //     sum = rocsparse::fma<T>(shared_val[wid][PADDED_BSR_BLOCK_DIM * i + p], val_B, sum);
-                        // }
-                        // as unrolled loop.
-                        T val_B = rocsparse::ldg(dense_B + col + ldb * shared_col[wid][i]);
-                        sum     = rocsparse::fma<T>(
-                            shared_val[wid][PADDED_BSR_BLOCK_DIM * i], val_B, sum);
-                        if(BSR_BLOCK_DIM >= 2)
+                        T val_B = rocsparse::ldg(dense_B + col + ldb * sc);
+                        sum     = rocsparse::fma<T>(sv0, val_B, sum);
+                    }
+                    if(BSR_BLOCK_DIM >= 2)
+                    {
+                        const T sv1 = rocsparse::shfl(my_val[1], i, WF_SIZE);
+                        if(col < N)
                         {
-                            val_B = rocsparse::ldg(dense_B + col + ldb * (1 + shared_col[wid][i]));
-                            sum   = rocsparse::fma<T>(
-                                shared_val[wid][PADDED_BSR_BLOCK_DIM * i + 1], val_B, sum);
+                            T val_B = rocsparse::ldg(dense_B + col + ldb * (1 + sc));
+                            sum     = rocsparse::fma<T>(sv1, val_B, sum);
                         }
-                        if(BSR_BLOCK_DIM >= 3)
+                    }
+                    if(BSR_BLOCK_DIM >= 3)
+                    {
+                        const T sv2 = rocsparse::shfl(my_val[2], i, WF_SIZE);
+                        if(col < N)
                         {
-                            val_B = rocsparse::ldg(dense_B + col + ldb * (2 + shared_col[wid][i]));
-                            sum   = rocsparse::fma<T>(
-                                shared_val[wid][PADDED_BSR_BLOCK_DIM * i + 2], val_B, sum);
+                            T val_B = rocsparse::ldg(dense_B + col + ldb * (2 + sc));
+                            sum     = rocsparse::fma<T>(sv2, val_B, sum);
                         }
-                        if(BSR_BLOCK_DIM >= 4)
+                    }
+                    if(BSR_BLOCK_DIM >= 4)
+                    {
+                        const T sv3 = rocsparse::shfl(my_val[3], i, WF_SIZE);
+                        if(col < N)
                         {
-                            val_B = rocsparse::ldg(dense_B + col + ldb * (3 + shared_col[wid][i]));
-                            sum   = rocsparse::fma<T>(
-                                shared_val[wid][PADDED_BSR_BLOCK_DIM * i + 3], val_B, sum);
+                            T val_B = rocsparse::ldg(dense_B + col + ldb * (3 + sc));
+                            sum     = rocsparse::fma<T>(sv3, val_B, sum);
                         }
                     }
                 }

--- a/projects/rocsparse/library/src/level3/csrmm_device_row_split.h
+++ b/projects/rocsparse/library/src/level3/csrmm_device_row_split.h
@@ -57,7 +57,6 @@ namespace rocsparse
         const uint32_t tid = hipThreadIdx_x;
         const J        gid = hipBlockIdx_x * BLOCKSIZE + tid;
         const uint32_t lid = gid & (WF_SIZE - 1);
-        const uint32_t wid = tid / WF_SIZE;
         const J        row = gid / WF_SIZE;
         const J        col = lid + hipBlockIdx_y * WF_SIZE;
 
@@ -70,9 +69,6 @@ namespace rocsparse
 
         const int64_t colB = col * ldb;
 
-        __shared__ J shared_col[BLOCKSIZE / WF_SIZE][WF_SIZE];
-        __shared__ T shared_val[BLOCKSIZE / WF_SIZE][WF_SIZE];
-
         const I row_start = csr_row_ptr[row + offsets_batch_stride_A * batch] - idx_base;
         const I row_end   = csr_row_ptr[row + 1 + offsets_batch_stride_A * batch] - idx_base;
 
@@ -82,31 +78,22 @@ namespace rocsparse
         {
             const I k = j + lid;
 
-            __syncthreads();
+            const J my_col = (k < row_end)
+                                 ? csr_col_ind[k + columns_values_batch_stride_A * batch] - idx_base
+                                 : 0;
+            const T my_val = (k < row_end) ? static_cast<T>(rocsparse::conj_val(
+                                 csr_val[k + columns_values_batch_stride_A * batch], conj_A))
+                                           : static_cast<T>(0);
 
-            if(k < row_end)
+            for(uint32_t i = 0; i < WF_SIZE; ++i)
             {
-                shared_col[wid][lid]
-                    = csr_col_ind[k + columns_values_batch_stride_A * batch] - idx_base;
-                shared_val[wid][lid] = rocsparse::conj_val(
-                    csr_val[k + columns_values_batch_stride_A * batch], conj_A);
-            }
-            else
-            {
-                shared_col[wid][lid] = 0;
-                shared_val[wid][lid] = static_cast<T>(0);
-            }
-
-            __syncthreads();
-
-            if(col < N)
-            {
-                for(uint32_t i = 0; i < WF_SIZE; ++i)
+                const J sc = rocsparse::shfl(my_col, i, WF_SIZE);
+                const T sv = rocsparse::shfl(my_val, i, WF_SIZE);
+                if(col < N)
                 {
                     sum = rocsparse::fma<T>(
-                        shared_val[wid][i],
-                        rocsparse::conj_val(
-                            dense_B[shared_col[wid][i] + colB + batch_stride_B * batch], conj_B),
+                        sv,
+                        rocsparse::conj_val(dense_B[sc + colB + batch_stride_B * batch], conj_B),
                         sum);
                 }
             }
@@ -454,7 +441,6 @@ namespace rocsparse
         const J        gid = hipBlockIdx_x * BLOCKSIZE + tid;
         const J        row = gid / WF_SIZE;
         const uint32_t lid = tid & (WF_SIZE - 1);
-        const uint32_t wid = tid / WF_SIZE;
 
         const uint32_t slid = lid & (SUB_WF_SIZE - 1);
         const uint32_t swid = lid / SUB_WF_SIZE;
@@ -465,9 +451,6 @@ namespace rocsparse
         {
             return;
         }
-
-        __shared__ int64_t shared_col[BLOCKSIZE / WF_SIZE][WF_SIZE];
-        __shared__ T       shared_val[BLOCKSIZE / WF_SIZE][WF_SIZE];
 
         const I row_start
             = rocsparse::nontemporal_load(csr_row_ptr + row + offsets_batch_stride_A * batch)
@@ -483,39 +466,28 @@ namespace rocsparse
         {
             const I k = j + lid;
 
-            __syncthreads();
+            const int64_t my_col
+                = (k < row_end)
+                      ? ldb
+                                * (rocsparse::nontemporal_load(
+                                       csr_col_ind + k + columns_values_batch_stride_A * batch)
+                                   - idx_base)
+                            + batch_stride_B * batch
+                      : 0;
+            const T my_val = (k < row_end) ? static_cast<T>(rocsparse::conj_val(
+                                 rocsparse::nontemporal_load(
+                                     csr_val + k + columns_values_batch_stride_A * batch),
+                                 conj_A))
+                                           : static_cast<T>(0);
 
-            if(k < row_end)
+            for(uint32_t i = 0; i < SUB_WF_SIZE; ++i)
             {
-                shared_col[wid][lid]
-                    = ldb
-                          * (rocsparse::nontemporal_load(csr_col_ind + k
-                                                         + columns_values_batch_stride_A * batch)
-                             - idx_base)
-                      + batch_stride_B * batch;
-                shared_val[wid][lid]
-                    = rocsparse::conj_val(rocsparse::nontemporal_load(
-                                              csr_val + k + columns_values_batch_stride_A * batch),
-                                          conj_A);
-            }
-            else
-            {
-                shared_col[wid][lid] = 0;
-                shared_val[wid][lid] = static_cast<T>(0);
-            }
-
-            __syncthreads();
-
-            if(col < col_end)
-            {
-                for(uint32_t i = 0; i < SUB_WF_SIZE; ++i)
+                const int64_t sc = rocsparse::shfl(my_col, SUB_WF_SIZE * swid + i, WF_SIZE);
+                const T       sv = rocsparse::shfl(my_val, SUB_WF_SIZE * swid + i, WF_SIZE);
+                if(col < col_end)
                 {
                     sum = rocsparse::fma<T>(
-                        shared_val[wid][SUB_WF_SIZE * swid + i],
-                        rocsparse::conj_val(
-                            rocsparse::ldg(dense_B + col + shared_col[wid][SUB_WF_SIZE * swid + i]),
-                            conj_B),
-                        sum);
+                        sv, rocsparse::conj_val(rocsparse::ldg(dense_B + col + sc), conj_B), sum);
                 }
             }
         }

--- a/projects/rocsparse/library/src/precond/itilu0/rocsparse_csritilu0x_sync_fusion.cpp
+++ b/projects/rocsparse/library/src/precond/itilu0/rocsparse_csritilu0x_sync_fusion.cpp
@@ -1,6 +1,6 @@
 /*! \file */
 /* ************************************************************************
- * Copyright (C) 2022-2025 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -76,12 +76,15 @@ namespace rocsparse
         {
             __shared__ floating_data_t<T> sdata[BLOCKSIZE / WFSIZE];
 
-            sdata[hipThreadIdx_x] = 0;
+            if(wid < nid)
+            {
+                sdata[wid] = 0;
+            }
             __syncthreads();
 
-            if(row0 < m_)
+            for(; iter < niter_; ++iter)
             {
-                for(; iter < niter_; ++iter)
+                if(row0 < m_)
                 {
                     if(compute_nrm_corr)
                     {
@@ -237,39 +240,43 @@ namespace rocsparse
                             }
                         }
                     }
+                }
 
-                    //
-                    // Finalize nrminf from shared memory.
-                    //
-                    if(compute_nrm_corr)
+                //
+                // Finalize nrminf from shared memory.
+                // All threads must participate in __syncthreads() and blockreduce_max.
+                //
+                if(compute_nrm_corr)
+                {
+                    rocsparse::wfreduce_max<WFSIZE>(&nrminf);
+                    if(lid == (WFSIZE - 1))
                     {
-                        rocsparse::wfreduce_max<WFSIZE>(&nrminf);
-                        if(lid == (WFSIZE - 1))
-                        {
-                            sdata[wid] = nrminf;
-                        }
-                        __syncthreads();
-
-                        rocsparse::blockreduce_max<BLOCKSIZE / WFSIZE>(hipThreadIdx_x, sdata);
-                        nrminf = sdata[0] / nrm0[0];
+                        sdata[wid] = nrminf;
                     }
+                    __syncthreads();
 
-                    if(compute_nrm_residual)
+                    rocsparse::blockreduce_max<BLOCKSIZE / WFSIZE>(hipThreadIdx_x, sdata);
+                    nrminf = sdata[0] / nrm0[0];
+                }
+
+                if(compute_nrm_residual)
+                {
+                    rocsparse::wfreduce_max<WFSIZE>(&nrminf_residual);
+                    if(lid == (WFSIZE - 1))
                     {
-                        rocsparse::wfreduce_max<WFSIZE>(&nrminf_residual);
-                        if(lid == (WFSIZE - 1))
-                        {
-                            sdata[wid] = nrminf_residual;
-                        }
-                        __syncthreads();
-
-                        rocsparse::blockreduce_max<BLOCKSIZE / WFSIZE>(hipThreadIdx_x, sdata);
-                        nrminf_residual = sdata[0] / nrm0[0];
+                        sdata[wid] = nrminf_residual;
                     }
+                    __syncthreads();
 
-                    //
-                    // COPY
-                    //
+                    rocsparse::blockreduce_max<BLOCKSIZE / WFSIZE>(hipThreadIdx_x, sdata);
+                    nrminf_residual = sdata[0] / nrm0[0];
+                }
+
+                //
+                // COPY
+                //
+                if(row0 < m_)
+                {
                     for(J row = row0; row < BLOCKSIZE * (hipBlockIdx_x + 1); row += nid)
                     {
                         if(row < m_)
@@ -292,18 +299,17 @@ namespace rocsparse
                             }
                         }
                     }
+                }
 
-                    if(stopping_criteria)
+                if(stopping_criteria)
+                {
+                    const bool success
+                        = (compute_nrm_corr && compute_nrm_residual)
+                              ? (nrminf <= tol_ && nrminf_residual <= tol_)
+                              : ((compute_nrm_corr) ? (nrminf <= tol_) : (nrminf_residual <= tol_));
+                    if(success)
                     {
-
-                        const bool success = (compute_nrm_corr && compute_nrm_residual)
-                                                 ? (nrminf <= tol_ && nrminf_residual <= tol_)
-                                                 : ((compute_nrm_corr) ? (nrminf <= tol_)
-                                                                       : (nrminf_residual <= tol_));
-                        if(success)
-                        {
-                            break;
-                        }
+                        break;
                     }
                 }
             }

--- a/projects/rocwmma/samples/community/CMakeLists.txt
+++ b/projects/rocwmma/samples/community/CMakeLists.txt
@@ -80,4 +80,5 @@ endfunction()
 #
 # Note: template.cpp is not built as a sample - it's only a reference template
 
+add_community_sample(simple_fusion_gemm ${CMAKE_CURRENT_SOURCE_DIR}/simple_fusion_gemm.cpp)
 add_community_sample(simple_gemm_act ${CMAKE_CURRENT_SOURCE_DIR}/simple_gemm_act.cpp)

--- a/projects/rocwmma/samples/community/simple_fusion_gemm.cpp
+++ b/projects/rocwmma/samples/community/simple_fusion_gemm.cpp
@@ -1,0 +1,1343 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <iostream>
+#include <vector>
+
+#include <hip/hip_ext.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_fp8.h>
+#include <hip/hip_runtime.h>
+
+#include <rocwmma/rocwmma.hpp>
+#include <rocwmma/rocwmma_transforms.hpp>
+
+#include "common.hpp"
+/* Motivation
+*
+* For this particular fusion 2 GEMM kernel:
+* D = A x B x C
+*
+* A, B, C= input tiles of MxK, KxN and NxK, respectively
+* D = final output tile, MxN
+* (M, N and K are block dimensions)
+*
+* For A x B phase, high performance can be
+* achieved through two general principles:
+* 1) Data re-use
+* 2) Latency hiding
+* And for S (the result of AxB) x C, the current performance isn’t particularly good.
+* This sample showcases fusing two matmuls and serves as a basic reference for users opting
+* to use rocWMMA for attention-style architectures.
+*
+*
+* Performance (GFX9, int8, compared to two separate GEMM kernel invocations):
+* +---------+---------+---------+------------+---------------+---------+
+* |    M    |    N    |    K    | Fused (ms) | 2x GEMM (ms)  | Speedup |
+* +=========+=========+=========+============+===============+=========+
+* |   8192  |   8192  |   128   |   1.2466   |     1.523     |  1.22x  |
+* |   1024  |   1024  |   128   |   0.1655   |     0.1863    |  1.13x  |
+* |   8192  |   8192  |    64   |   0.6523   |     0.8456    |  1.30x  |
+* |   1024  |   1024  |    64   |   0.0927   |     0.1143    |  1.23x  |
+* |   2048  |   2048  |   256   |   0.6057   |     0.7000    |  1.16x  |
+* +---------+---------+---------+------------+---------------+---------+
+*
+* The fused kernel achieves 10-30% speedup by eliminating the intermediate
+* global memory round-trip: the first GEMM result (S = A x B) is kept in
+* LDS and consumed directly by the second GEMM (D = S x C), avoiding the
+* cost of writing S to global memory and reading it back.
+*
+* K corresponds to the attention head dimension (typically 64 or 128).
+* The baseline measures two consecutive GEMM kernel launches using the
+* same grid and rocWMMA tile configuration as the fused version.
+*  
+* Unlike the other samples, we use a 1D grid instead of a 2D grid.
+* Since tensors in neural networks are typically 4-D (B, H, N, D or B, N, H, D),
+* with batch and head usually serving as the parallel dimensions,
+* we parallelize only along the M dimension and handle the N/K dimensions via loops.
+*
+* In the simple_gemm sample, each warp is responsible for computing
+* one output D tile of the final result. In the current sample, each
+* warp is now responsible for computing multiple D tiles, what we
+* might call a Warp Tile. Because Warp Tile blocks share data locality
+* in either the same row or column direction, warps can re-use input
+* data from A, B and C as they step through the K/N dimension for each block.
+*
+* Moreover, Warp Tiles processed by warps in a thread block
+* have common locality in the larger Macro Tile. In the Global D layout
+* shown below, data re-use opportunities await in D tiles aligned in the
+* same rows / columns. These will pass over the same input A/B/C values as
+* they march through the K/N dimension.
+*
+* Block size:      (BlockM x BlockN)
+* Warp tile size:  (BlocksX * BlockSize.x) x (BlocksY * BlockSize.y)
+* Macro Tile size: (TBlock.x * WarpTileSize.x) x (TBlock.y * WarpTileSize.y)
+*
+* Wave data share input A: same row
+* Wave data share input B: same col
+* Wave data share input C: same col
+*
+* Global D layout & warp assignment for BlocksX = BlocksY = 2, 2x2 Warps
+*
+* W (X, Y) = wave row X, col Y
+*                                     |--------- Macro Tile Y-------------|
+*                                     |-- Wave Tile Y --|
+*                                     |-BlockN-|
+*
+*                                      BlockN x BlocksY   BlockN x BlocksY
+*                                     |<--------------->|<--------------->|
+*      _ _   _ _      _ _          ___  ________ ________ ________ ________
+*       |     |        |            ^  |        |        |        |        |
+*       | Wave| BlockM |   BlockM   |  |        W        |        W        |
+*       | Tile|       _|_     x     |  |__   (0, 0)    __|__   (0, 1)    __|
+*       |  X  |            BlocksX  |  |                 |                 |
+* Macro |     |                     |  |                 |                 |
+*  Tile |    _|_                   _v_ |________|________|________|________|
+*   X   |                           ^  |        |        |        |        |
+*       |                  BlockM   |  |        W        |        W        |
+*       |                     x     |  |__   (1, 0)    __|__   (1, 1)    __|
+*       |                  BlocksX  |  |                 |                 |
+*       |                           |  |                 |                 |
+*      _|_                         _v_ |________|________|________|________|
+*
+*
+* From the above diagram, we can see that input A/B data can be shared within warps,
+* as well as between warps in the same threadblock. This means that warps in the same
+* thread block can share the input loading responsibilities if they synchronize stepping
+* through the K dimension for tiles at the same time.
+*
+* rocWMMA Cooperative API allows thread blocks to collaboratively move data from
+* one location to another. In this case, we will move data from global memory space to
+* local storage such that inter-warp data sharing is possible. Maximizing data re-use
+* in this way reduces costly access to global memory and improves performance.
+*
+* To maximize efficiency, we can structure the kernel to maximize bandwidth usage and keep
+* the compute resources as busy as possible at the same time. Using a pre-fetch technique,
+* we can fetch A/B inputs for the next K-step while keeping the compute resources busy
+* processing the current K-step. This helps to hide memory fetching latency.
+*
+* In general, the process would flow like the following:
+*
+*       Start
+*         |
+*         v
+*   Loop: ab_i = 0:B blocks
+*   ^            |
+*   |     Pre-Fetch Global A/B for K0
+*   |            |
+*   |     Store LDS buffer0
+*   |            |
+*   |            v
+*   |     Loop: i = 1:K-1
+*   |     ^         |
+*   |     |    Fetch Global A/B i+1; store LDS Buffer 1
+*   |     |         |
+*   |     |    Load LDS buffer0; Accum A x B
+*   |     |         |
+*   |     |    Swap buffer0, buffer1
+*   |     |         |
+*   |     |         |
+*   |     end_loop <-
+*   |            |
+*   |     type cast: int32 -> int8
+*   |            |
+*   |     Loop: sc_i = 0:C blocks
+*   |     ^            |
+*   |     |    Loop: i = 0:K-1
+*   |     |    ^         |
+*   |     |    |   Fetch Global C i; store LDS Buffer 1
+*   |     |    |         |
+*   |     |    |   C Load LDS buffer1; S Load LDS buffer0; Accum S x C
+*   |     |    |         |
+*   |     |    |         |
+*   |     |    end_loop <-
+*   |     |         |
+*   |     |         |
+*   |     end_loop <-
+*   |            |
+*   |            |
+*   -- end_loop <-
+*   Loop: sc_i = 0:C blocks
+*   ^            |
+*   |      Write D tile sc_i
+*   |            |
+*   |            |
+*   -- end_loop <-
+*         |
+*         v
+*        End
+*
+* Lds Mapping in AxB phase:
+* Buffer Width = LDS Width = BlockK
+* Matrix geometry for inputs A and B have a common dimension (BlockK).
+* We can fix one of the LDS dimensions to BlockK (in this case the width),
+* and insert blocks of different heights (BlockM, BlockN) to use the space
+* without the need of extra padding.
+*
+* Fragments of B must be transposed to fit this geometry,
+* and both fragments from A and B must accomodate LDS data layout.
+*
+* Lds Mapping in AxB phase:
+* After AxB, we reinterpret_cast LDS width = MACRO_TILE_Y, height = MACRO_TILE_X
+* to store result of A block x b block.
+* And the rest LDS is used to store GlobalRead Tile
+* (In fact, there is some wastage of LDS space.)
+*
+* Local Layout (LDS):
+*
+* Non - transposed A fragments [A0 ... AX-1] are placed first and occupy a total height
+* of Macro Tile X, where X = number of A blocks and Ck is the kth column of the A block.
+*
+* Transposed B fragments [B0 (T) ... BY-1 (T)] follow A fragments and occupy a total height of
+* Macro Tile Y, where Y = number of B blocks, and Rk is the kth row of the B block.
+*
+*
+*                        _____________BlockK_____________
+*                       |                                |
+*                       v                                v
+*                  (0,0) ----------------------------------->
+*          -->       -->  ______________    ...        ______
+*          |         |   |    |    |                  |      |
+*          |         |   |    |    |                  |      |
+*  Macro   |  BlockM |   | C0 | C1 | C2               | Ck-1 |   A0
+*  Tile X  |         |   |    |    |                  |      |
+*          |         --> |___ |___ |____    ...       |______|
+*          |         .
+*          |         .          ...  ...  ...  ...          AX-1
+*          -->
+*          -->       -->  ______________    ...        ______
+*          |         |   |    |    |                  |      |
+*          |         |   |    |    |                  |      |
+*  Macro   |  BlockN |   | R0 | R1 | R2               | Rk-1 |   B0 (T)
+*  Tile Y  |         |   |    |    |                  |      |
+*          |         --> |___ |___ |____    ...       |______|
+*          |         .
+*          |         .          ...  ...  ...  ...        BY-1 (T)
+*          -->                                           (MacroTileX + MacroTileY - 1, BlockK -1)
+*
+*                                     |--- LDS height = Macro Tile Y-------|
+*      _ _   _ _      _ _          ___  ________ ________ ________ ________
+*       |     |        |            ^  |        |        |        |        |
+*       | Wave| BlockM |   BlockM   |  |        |        |        |        |
+*       | Tile|       _|_     x     |  |__ __ _ | _ __ __|__ __ _ | _ __ __|
+*       |  X  |            BlocksX  |  |        |        |        |        |
+* Macro |     |                     |  |        |        |        |        |
+* TileX |    _|_                   _v_ |________|________|________|________|
+*       |                           ^  |        |        |        |        |
+*       |                  BlockM   |  |        |        |        |        |
+*       |                     x     |  |__ __ _ | _ __ __|__ __ _ | _ __ __|
+*       |                  BlocksX  |  |        |        |        |        |
+*       |                           |  |        |        |        |        |
+*      _|_                         _v_ |________|________|________|________|
+*       |     |        |            ^  |        |                          |
+*       | Wave| BlockM |   BlockM   |  |        |                          |
+*       | Tile|       _|_     x     |  |__ __ _ |                          |
+*       |  X  |            BlocksX  |  |        |                          |
+* Macro |     |                     |  |        |            Not           |
+* TileC |    _|_                   _v_ |________|            Used          |
+*       |                           ^  |        |                          |
+*       |                  BlockM   |  |        |                          |
+*       |                     x     |  |__ __ _ |                          |
+*       |                  BlocksX  |  |        |                          |
+*       |                           |  |        |                          |
+*      _|_                         _v_ |________|________ ________ ________|
+*
+*
+* Depending on the locality of the block being processed, warps load the corresponding
+* A and B inputs from LDS buffer and use them for the accumulation of AxB calculations.
+*/
+
+using namespace rocwmma;
+
+///
+/// Parameter configuration
+///
+
+/* Depending on the GPU architecture this sample is run on, the following kernel parameters need to
+*  be modified in order to obtain high performance.
+* _________________________________________________________________________________________
+*|         |           |           |           |          |          |          |          |
+*|         | ROCWMMA_M | ROCWMMA_N | ROCWMMA_K | BLOCKS_X | BLOCKS_Y | TBLOCK_X | TBLOCK_Y |
+*|_________|___________|___________|___________|__________|__________|__________|__________|
+*|         |           |           |           |          |          |          |          |
+*|  GFX_9  |    16     |    16     |    32     |    2     |    2     |   128    |    2     |
+*|_________|___________|___________|___________|__________|__________|__________|__________|
+*
+* __________________________________________
+*|         |                                |
+*|         |           WARP_SIZE            |
+*|_________|________________________________|
+*|         |                                |
+*|  GFX_9  | Constants::AMDGCN_WAVE_SIZE_64 |
+*|_________|________________________________|
+*/
+
+namespace gfx9Params
+{
+    enum kernelParams : uint32_t
+    {
+        ROCWMMA_M = 16u,
+        ROCWMMA_N = 16u,
+        ROCWMMA_K = 32u,
+        BLOCKS_X  = 2u,
+        BLOCKS_Y  = 2u,
+        TBLOCK_X  = 128u,
+        TBLOCK_Y  = 2u,
+        WARP_SIZE = Constants::AMDGCN_WAVE_SIZE_64
+    };
+}
+
+using namespace gfx9Params;
+
+///
+/// Types and Data Layouts
+///
+
+using InputT   = int8_t;
+using InputTV  = int8_t;
+using OutputT  = int32_t;
+using ComputeT = int32_t;
+using LDST     = float32_t;
+using LDST_new = hip_fp8_e4m3_fnuz;
+
+using DataLayoutA   = row_major;
+using DataLayoutB   = col_major;
+using DataLayoutC   = row_major;
+using DataLayoutLds = col_major;
+using DataLayoutV   = col_major;
+
+// It's for 2rd GEMM,currently not support modify
+// If switching to col_major, code modifications will be required.
+using DataLayoutLds_new = row_major;
+///
+/// Fragment types
+///
+
+// Warp tile: computed by each warp
+constexpr uint32_t WARP_TILE_X = BLOCKS_X * ROCWMMA_M;
+constexpr uint32_t WARP_TILE_Y = BLOCKS_Y * ROCWMMA_N;
+
+constexpr uint32_t els_per_thread  = ROCWMMA_M * ROCWMMA_N / WARP_SIZE;
+constexpr uint32_t threads_per_row = ROCWMMA_N / els_per_thread;
+
+// Macro Tile: computed by each thread block (workgroup)
+// Note: TBLOCK_X must be multiple of WARP_SIZE.
+constexpr uint32_t WARPS_X      = TBLOCK_X / WARP_SIZE;
+constexpr uint32_t WARPS_Y      = TBLOCK_Y;
+constexpr uint32_t MACRO_TILE_X = WARPS_X * WARP_TILE_X;
+constexpr uint32_t MACRO_TILE_Y = WARPS_Y * WARP_TILE_Y;
+constexpr uint32_t MACRO_TILE_K = WARPS_Y * BLOCKS_Y * ROCWMMA_K;
+
+// Mfma frags
+using MfmaFragA   = fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA>;
+using MfmaFragB   = fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutB>;
+using MfmaFragC   = fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, OutputT, DataLayoutC>;
+using MfmaFragD   = MfmaFragC;
+using MfmaFragAcc = fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, ComputeT, DataLayoutC>;
+
+using MfmaFragF8
+    = fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, MACRO_TILE_Y, hip_fp8_e4m3_fnuz, DataLayoutC>;
+
+using MfmaFragAcc2 = fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputTV, DataLayoutA>;
+
+using MfmaFragS = fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputTV, DataLayoutA>;
+using MfmaFragV = fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputTV, DataLayoutV>;
+
+// Global read (macro tile)
+using CoopScheduler = fragment_scheduler::coop_row_major_2d<TBLOCK_X, TBLOCK_Y>;
+using GRBuffA
+    = fragment<matrix_a, MACRO_TILE_X, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA, CoopScheduler>;
+using GRBuffB
+    = fragment<matrix_b, ROCWMMA_M, MACRO_TILE_Y, ROCWMMA_K, InputT, DataLayoutB, CoopScheduler>;
+
+using GRBuffS
+    = fragment<matrix_a, MACRO_TILE_X, ROCWMMA_N, ROCWMMA_K, InputTV, DataLayoutA, CoopScheduler>;
+using GRBuffV
+    = fragment<matrix_b, ROCWMMA_M, MACRO_TILE_Y, ROCWMMA_K, InputTV, DataLayoutV, CoopScheduler>;
+
+// Local write of global buffers (macro tile)
+// - Must match Lds data layout.
+// - Lds has transposed B frags.
+using LWBuffA = apply_data_layout_t<GRBuffA, DataLayoutLds>;
+using LWBuffB = apply_data_layout_t<apply_transpose_t<GRBuffB>, DataLayoutLds>;
+
+using LWBuffS = apply_data_layout_t<GRBuffS, DataLayoutLds_new>;
+using LWBuffV = apply_data_layout_t<apply_transpose_t<GRBuffV>, DataLayoutLds_new>;
+
+// Local read (mfma frags)
+// - Must match Lds data layout.
+// - Lds has transposed B frags.
+using LRFragA = apply_data_layout_t<MfmaFragA, DataLayoutLds>;
+using LRFragB = apply_data_layout_t<apply_transpose_t<MfmaFragB>, DataLayoutLds>;
+
+using LRFragS = apply_data_layout_t<MfmaFragS, DataLayoutLds_new>;
+using LRFragV = apply_data_layout_t<apply_transpose_t<MfmaFragV>, DataLayoutLds_new>;
+
+using LRFragAcc2 = apply_data_layout_t<MfmaFragAcc2, DataLayoutLds_new>;
+// #endif // (ROCWMMA_ARCH_GFX9 || ROCWMMA_ARCH_GFX11)
+
+///
+/// Wrapper functions: repeat mfma tile operations across entire warp tile.
+///
+
+// Cooperative global read / local write (Macro tile data movement)
+// Loads / stores a global data fragment cooperatively across warps. Each participating warp is
+// responsible for only a portion of the whole fragment.
+//
+// The cooperative operation is split into work items (SplitCount). Work items are consumed in
+// a round robin fashion by warps in the range of [0, WaveCount). The wave index determines the
+// order of the current wave in the collaboration pool.
+//
+// WaveCount, SplitCount and waveIndex parameters must match successive coop load / store calls
+// to ensure the entire fragment remains coherent.
+
+// Global A reads in cooperative mode (macro tile)
+ROCWMMA_DEVICE static inline void
+    globalReadCoopA(GRBuffA& grBuffA, InputT const* gAddrA, uint32_t lda)
+{
+    load_matrix_sync(grBuffA, gAddrA, lda);
+}
+
+// Global B reads in cooperative mode (macro tile)
+ROCWMMA_DEVICE static inline void
+    globalReadCoopB(GRBuffB& grBuffB, InputT const* gAddrB, uint32_t ldb)
+{
+    load_matrix_sync(grBuffB, gAddrB, ldb);
+}
+
+ROCWMMA_DEVICE static inline void
+    globalReadCoopV(GRBuffV& grBuffV, InputTV const* gAddrV, uint32_t ldV)
+{
+    load_matrix_sync(grBuffV, gAddrV, ldV);
+}
+
+// Local A writes in cooperative mode (macro tile)
+ROCWMMA_DEVICE static inline void
+    localWriteCoopA(InputT* ldsAddr, GRBuffA const& grBuffA, uint32_t ldsld)
+{
+    // No transpose, but apply the lds data layout
+    store_matrix_sync(ldsAddr, apply_data_layout<DataLayoutLds>(grBuffA), ldsld);
+}
+
+// Local B writes in cooperative mode (macro tile)
+ROCWMMA_DEVICE static inline void
+    localWriteCoopB(InputT* ldsAddr, GRBuffB const& grBuffB, uint32_t ldsld)
+{
+    // Transpose B and then apply lds data layout
+    store_matrix_sync(ldsAddr, apply_data_layout<DataLayoutLds>(apply_transpose(grBuffB)), ldsld);
+}
+
+ROCWMMA_DEVICE static inline void
+    localWriteCoopV(InputTV* ldsAddr, GRBuffV const& grBuffV, uint32_t ldsld)
+{
+    // Transpose B and then apply lds data layout
+    store_matrix_sync(
+        ldsAddr, apply_data_layout<DataLayoutLds_new>(apply_transpose(grBuffV)), ldsld);
+}
+
+// Local A reads for warp tile gemm, non-cooperative
+ROCWMMA_DEVICE static inline void
+    localReadA(MfmaFragA (&fragsA)[BLOCKS_X], InputT const* ldsAddrA, uint32_t ldsld)
+{
+    using FragShape = GetIOShape_t<LRFragA>;
+    using Mapper1d  = GetDataLayout_t<LRFragA>;
+
+    // Each A block is stacked vertically in LDS
+    auto blockStep = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldsld);
+
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; i++)
+    {
+        LRFragA tmp;
+        load_matrix_sync(tmp, ldsAddrA, ldsld);
+        fragsA[i] = apply_data_layout<DataLayoutA>(tmp);
+
+        ldsAddrA += blockStep;
+    }
+}
+
+ROCWMMA_DEVICE static inline void
+    localReadS(MfmaFragS (&fragsS)[BLOCKS_X], InputTV const* ldsAddrS, uint32_t ldsld)
+{
+    using FragShape = GetIOShape_t<LRFragS>;
+    using Mapper1d  = GetDataLayout_t<LRFragS>;
+
+    // Each A block is stacked vertically in LDS
+    auto blockStep = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldsld);
+
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; i++)
+    {
+        LRFragS tmp;
+        load_matrix_sync(tmp, ldsAddrS, ldsld);
+        fragsS[i] = apply_data_layout<DataLayoutA>(tmp);
+
+        ldsAddrS += blockStep;
+    }
+}
+
+// Local B reads for warp tile gemm, non-cooperative
+ROCWMMA_DEVICE static inline void
+    localReadB(MfmaFragB (&fragsB)[BLOCKS_Y], InputT const* ldsAddrB, uint32_t ldsld)
+{
+    using FragShape = GetIOShape_t<LRFragB>;
+    using Mapper1d  = GetDataLayout_t<LRFragB>;
+
+    // Each B block is stacked vertically in LDS
+    auto blockStep = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldsld);
+
+#pragma unroll
+    for(int i = 0; i < BLOCKS_Y; i++)
+    {
+        LRFragB tmp;
+        load_matrix_sync(tmp, ldsAddrB, ldsld);
+
+        // Transform back to MFMA tile
+        fragsB[i] = apply_data_layout<DataLayoutB>(apply_transpose(tmp));
+
+        ldsAddrB += blockStep;
+    }
+}
+
+ROCWMMA_DEVICE static inline void
+    localReadV(MfmaFragV (&fragsV)[BLOCKS_Y], InputTV const* ldsAddrV, uint32_t ldsld)
+{
+    using FragShape = GetIOShape_t<LRFragV>;
+    using Mapper1d  = GetDataLayout_t<LRFragV>;
+
+    // Each B block is stacked vertically in LDS
+    auto blockStep = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldsld);
+
+#pragma unroll
+    for(int i = 0; i < BLOCKS_Y; i++)
+    {
+        LRFragV tmp;
+        load_matrix_sync(tmp, ldsAddrV, ldsld);
+
+        // Transform back to MFMA tile
+        fragsV[i] = apply_data_layout<DataLayoutV>(apply_transpose(tmp));
+
+        ldsAddrV += blockStep;
+    }
+}
+
+// Global C reads for warp tile gemm, non-cooperative
+ROCWMMA_DEVICE static inline void
+    globalReadC(MfmaFragC (&fragC)[BLOCKS_X][BLOCKS_Y], OutputT const* gAddrC, uint32_t ldc)
+{
+    using FragShape = GetIOShape_t<MfmaFragC>;
+    using Mapper1d  = GetDataLayout_t<MfmaFragC>;
+
+    // Iterative offsets for each C block in the wave tile
+    auto blockStepX = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldc);
+    auto blockStepY = Mapper1d::fromMatrixCoord(make_coord2d(0u, FragShape::BlockWidth), ldc);
+
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; i++)
+    {
+        auto offsetY = 0u;
+#pragma unroll
+        for(int j = 0; j < BLOCKS_Y; j++)
+        {
+            load_matrix_sync(fragC[i][j], gAddrC + offsetY, ldc);
+            offsetY += blockStepY;
+        }
+        gAddrC += blockStepX;
+    }
+}
+
+// Global D writes for warp tile gemm, non-cooperative
+ROCWMMA_DEVICE static inline void
+    globalWriteD(OutputT* gAddrD, MfmaFragAcc const (&fragsD)[BLOCKS_X][BLOCKS_Y], uint32_t ldd)
+{
+    using FragShape = GetIOShape_t<MfmaFragD>;
+    using Mapper1d  = GetDataLayout_t<MfmaFragD>;
+
+    // Iterative offsets for each D block in the warp tile
+    auto blockStepX = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldd);
+    auto blockStepY = Mapper1d::fromMatrixCoord(make_coord2d(0u, FragShape::BlockWidth), ldd);
+
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; i++)
+    {
+        auto offsetY = 0u;
+#pragma unroll
+        for(int j = 0; j < BLOCKS_Y; j++)
+        {
+            store_matrix_sync(gAddrD + offsetY, fragsD[i][j], ldd);
+            offsetY += blockStepY;
+        }
+        gAddrD += blockStepX;
+    }
+}
+
+// Broadcast value to fragments in warp tile
+template <typename FragT>
+ROCWMMA_DEVICE static inline void fill(FragT (&frags)[BLOCKS_X][BLOCKS_Y],
+                                       GetDataType_t<FragT> value)
+{
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; i++)
+    {
+#pragma unroll
+        for(int j = 0; j < BLOCKS_Y; j++)
+        {
+            fill_fragment(frags[i][j], value);
+        }
+    }
+}
+
+ROCWMMA_DEVICE static inline void
+    localWriteAcc(MfmaFragAcc2 (&fragsAcc)[BLOCKS_X][BLOCKS_Y], InputT* ldsAddrAcc, uint32_t ldsld)
+{
+    using FragShape = GetIOShape_t<LRFragAcc2>;
+    using Mapper1d  = GetDataLayout_t<LRFragAcc2>;
+
+    auto blockStepX = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldsld);
+    auto blockStepY = Mapper1d::fromMatrixCoord(make_coord2d(0u, FragShape::BlockWidth), ldsld);
+
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; i++)
+    {
+        auto offsetY = 0u;
+#pragma unroll
+        for(int j = 0; j < BLOCKS_Y; j++)
+        {
+            store_matrix_sync(ldsAddrAcc + offsetY, fragsAcc[i][j], ldsld);
+            offsetY += blockStepY;
+        }
+        ldsAddrAcc += blockStepX;
+    }
+}
+
+ROCWMMA_DEVICE static inline void convertI32toI8(MfmaFragAcc (&frags_i32)[BLOCKS_X][BLOCKS_Y],
+                                                 MfmaFragAcc2 (&frags_i8)[BLOCKS_X][BLOCKS_Y])
+{
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; ++i)
+    {
+#pragma unroll
+        for(int j = 0; j < BLOCKS_Y; ++j)
+        {
+#pragma unroll
+            for(int k = 0; k < frags_i32[i][j].num_elements; ++k)
+            {
+                int32_t value = frags_i32[i][j].x[k];
+                if(value > INT8_MAX)
+                {
+                    frags_i8[i][j].x[k] = INT8_MAX;
+                }
+                else if(value < INT8_MIN)
+                {
+                    frags_i8[i][j].x[k] = INT8_MIN;
+                }
+                else
+                {
+                    frags_i8[i][j].x[k] = static_cast<int8_t>(value);
+                }
+            }
+        }
+    }
+}
+
+ROCWMMA_DEVICE static inline void svgemm(MfmaFragAcc (&fragsAccOut)[BLOCKS_X][BLOCKS_Y],
+                                         MfmaFragS const (&fragsA)[BLOCKS_X],
+                                         MfmaFragV const (&fragsB)[BLOCKS_Y],
+                                         MfmaFragAcc const (&fragsAccIn)[BLOCKS_X][BLOCKS_Y])
+{
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; i++)
+    {
+#pragma unroll
+        for(int j = 0; j < BLOCKS_Y; j++)
+        {
+            mma_sync(fragsAccOut[i][j], fragsA[i], fragsB[j], fragsAccIn[i][j]);
+        }
+    }
+}
+
+// Performs warp tile mfma
+ROCWMMA_DEVICE static inline void mfma(MfmaFragAcc (&fragsAccOut)[BLOCKS_X][BLOCKS_Y],
+                                       MfmaFragA const (&fragsA)[BLOCKS_X],
+                                       MfmaFragB const (&fragsB)[BLOCKS_Y],
+                                       MfmaFragAcc const (&fragsAccIn)[BLOCKS_X][BLOCKS_Y])
+{
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; i++)
+    {
+#pragma unroll
+        for(int j = 0; j < BLOCKS_Y; j++)
+        {
+            mma_sync(fragsAccOut[i][j], fragsA[i], fragsB[j], fragsAccIn[i][j]);
+        }
+    }
+}
+
+// Uniform multiply - add (FMA)
+// Performs D = alpha * acc + beta * C, where alpha, beta are uniform scalars
+ROCWMMA_DEVICE static inline void uniformFma(MfmaFragD (&fragsD)[BLOCKS_X][BLOCKS_Y],
+                                             ComputeT alpha,
+                                             MfmaFragAcc const (&fragsAcc)[BLOCKS_X][BLOCKS_Y],
+                                             ComputeT beta,
+                                             MfmaFragC const (&fragsC)[BLOCKS_X][BLOCKS_Y])
+{
+#pragma unroll
+    for(int i = 0; i < BLOCKS_X; i++)
+    {
+#pragma unroll
+        for(int j = 0; j < BLOCKS_Y; j++)
+        {
+            for(int k = 0; k < fragsD[i][j].num_elements; k++)
+            {
+                // Perform computation in ComputeT and cast back to OutputT
+                fragsD[i][j].x[k] = static_cast<OutputT>(
+                    alpha * fragsAcc[i][j].x[k] + beta * static_cast<ComputeT>(fragsC[i][j].x[k]));
+            }
+        }
+    }
+}
+
+template <int SV_ITERS>
+ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
+                                                          uint32_t       n,
+                                                          uint32_t       k,
+                                                          InputT const*  a,
+                                                          InputT const*  b,
+                                                          InputTV const* v,
+                                                          OutputT const* c,
+                                                          OutputT*       d,
+                                                          uint32_t       lda,
+                                                          uint32_t       ldb,
+                                                          uint32_t       ldv,
+                                                          uint32_t       ldd)
+{
+    if constexpr(!ROCWMMA_ARCH_HOST)
+    {
+        ///
+        /// 2D matrix coordinate setup
+        ///
+
+        // Tile Sizes
+        constexpr auto warpTileSize  = make_coord2d(WARP_TILE_X, WARP_TILE_Y); //(64,64)
+        constexpr auto macroTileSize = make_coord2d(MACRO_TILE_X, MACRO_TILE_Y); //(128,128)
+
+        // Local warp coordinate relative to current threadblock (wg).
+        constexpr auto warpDims        = make_coord2d(WARPS_X, WARPS_Y); //(2,2)
+        auto           localWarpCoord  = make_coord2d(threadIdx.x / WARP_SIZE, threadIdx.y);
+        auto           localWarpOffset = localWarpCoord * warpTileSize;
+
+        using MfmaFragDMap1d = GetDataLayout_t<MfmaFragD>;
+        
+        const int iterations = (n + MACRO_TILE_Y - 1) / MACRO_TILE_Y;
+
+        MfmaFragAcc fragsOut[SV_ITERS][BLOCKS_X][BLOCKS_Y];
+        for(int i = 0; i < SV_ITERS; i++)
+        {
+            fill(fragsOut[i], 0.0f);
+        }
+
+        for(int iter = 0; iter < iterations; iter++)
+        {
+            // Global matrix coordinates for C/D
+            auto macroTileCoord = make_coord2d(blockIdx.x, iter) * macroTileSize;
+            auto warpTileCoord  = macroTileCoord + localWarpOffset;
+
+            // Bounds check
+            auto warpTileBound = warpTileCoord + warpTileSize;
+            if(get<0>(warpTileBound) > m || get<1>(warpTileBound) > n)
+            {
+                return;
+            }
+
+            ///
+            /// 1D global read coordinate setup
+            ///
+            using GRBuffAMap1d = GetDataLayout_t<GRBuffA>;
+            using GRBuffBMap1d = GetDataLayout_t<GRBuffB>;
+
+            // Initial global read address offsets
+            auto globalReadOffsetA
+                = GRBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(macroTileCoord), 0u), lda);
+            auto globalReadOffsetB
+                = GRBuffBMap1d::fromMatrixCoord(make_coord2d(0u, get<1>(macroTileCoord)), ldb);
+
+            // Incremental global read address offsets
+            auto kStepOffsetA = GRBuffAMap1d::fromMatrixCoord(make_coord2d(0u, ROCWMMA_K), lda);
+            auto kStepOffsetB = GRBuffBMap1d::fromMatrixCoord(make_coord2d(ROCWMMA_K, 0u), ldb);
+
+            ///
+            /// Cooperative config for global read A / B
+            ///
+
+            // WorkItems will be split up by minimum IOCount to perform either global read or local write.
+            // These are inputs to cooperative functions.
+            constexpr auto warpCount = get<0>(warpDims) * get<1>(warpDims);
+
+            // Scheduling warp order is analogous to row major priority.
+            // E.g. Wg = (128, 2) = 2x2 warps
+            // (0, 0)   (0, 1)   Share Schedule: w0 = (0, 0), w1 = (0, 1),
+            // (1, 0)   (1, 1)                   w2 = (1, 0), w3 = (1, 1), count = 4
+            const auto warpIndex
+                = get<0>(localWarpCoord) * get<1>(warpDims) + get<1>(localWarpCoord);
+
+            ///
+            /// Perform initial global pre-fetch
+            ///
+
+            GRBuffA grBuffA;
+            GRBuffB grBuffB;
+
+            globalReadCoopA(grBuffA, a + globalReadOffsetA, lda);
+            globalReadCoopB(grBuffB, b + globalReadOffsetB, ldb);
+
+            globalReadOffsetA += kStepOffsetA;
+            globalReadOffsetB += kStepOffsetB;
+
+            ///
+            /// Setup LDS addressing
+            /// This kernel will use 2 separate LDS blocks for pipelining
+            /// the input prefetching during the accumulation loop
+            ///
+
+            HIP_DYNAMIC_SHARED(void*, localMemPtr);
+            using LWBuffAShape = GetIOShape_t<LWBuffA>;
+            using LWBuffBShape = GetIOShape_t<LWBuffB>;
+            using LWBuffAMap1d = GetDataLayout_t<LWBuffA>;
+            using LWBuffBMap1d = GetDataLayout_t<LWBuffB>;
+
+            constexpr uint32_t ldsWidth  = ROCWMMA_K;
+            constexpr uint32_t ldsHeight = LWBuffAShape::BlockHeight + LWBuffBShape::BlockHeight;
+            constexpr uint32_t sizeLds   = ldsHeight * ldsWidth;
+            constexpr uint32_t ldsld
+                = std::is_same_v<DataLayoutLds, row_major> ? ldsWidth : ldsHeight;
+
+            auto* ldsPtrLo = reinterpret_cast<InputT*>(localMemPtr);
+            auto* ldsPtrHi = ldsPtrLo + sizeLds;
+
+            // Local write offsets to start of A / B data
+            auto ldsWriteOffsetA = 0u;
+            auto ldsWriteOffsetB
+                = LWBuffAMap1d::fromMatrixCoord(make_coord2d(LWBuffAShape::BlockHeight, 0u), ldsld);
+
+            // Local read offsets for mfma frags
+            auto ldsReadOffsetA
+                = ldsWriteOffsetA
+                  + LWBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(localWarpOffset), 0u), ldsld);
+            auto ldsReadOffsetB
+                = ldsWriteOffsetB
+                  + LWBuffBMap1d::fromMatrixCoord(make_coord2d(get<1>(localWarpOffset), 0u), ldsld);
+
+            ///
+            /// Write prefetch to local
+            ///
+            localWriteCoopA(ldsPtrLo + ldsWriteOffsetA, grBuffA, ldsld);
+            localWriteCoopB(ldsPtrLo + ldsWriteOffsetB, grBuffB, ldsld);
+
+            ///
+            /// Initialize accumulation frags
+            ///
+            MfmaFragAcc fragsAcc[BLOCKS_X][BLOCKS_Y];
+            fill(fragsAcc, 0.0f);
+
+            ///
+            /// Synchronize warps and memory
+            ///
+            synchronize_workgroup();
+
+            ///
+            /// Accumulate A * B for all mfma frags in warp tile
+            ///
+            for(uint32_t currentK = ROCWMMA_K; currentK < k; currentK += ROCWMMA_K)
+            {
+                MfmaFragA fragsA[BLOCKS_X];
+                MfmaFragB fragsB[BLOCKS_Y];
+
+                // Local read mfma frags from first LDS buffer
+                localReadA(fragsA, ldsPtrLo + ldsReadOffsetA, ldsld);
+                localReadB(fragsB, ldsPtrLo + ldsReadOffsetB, ldsld);
+
+                // Prefetch next round of global frags
+                globalReadCoopA(grBuffA, a + globalReadOffsetA, lda);
+                globalReadCoopB(grBuffB, b + globalReadOffsetB, ldb);
+
+                // Advance offsets to next k step
+                globalReadOffsetA += kStepOffsetA;
+                globalReadOffsetB += kStepOffsetB;
+
+                // accum(A * B)
+                mfma(fragsAcc, fragsA, fragsB, fragsAcc);
+
+                // Write prefetch to second LDS buffer
+                localWriteCoopA(ldsPtrHi + ldsWriteOffsetA, grBuffA, ldsld);
+                localWriteCoopB(ldsPtrHi + ldsWriteOffsetB, grBuffB, ldsld);
+
+                // Make sure that all waves have finished reading / writing to lds for currentK.
+                synchronize_workgroup();
+
+                // Swap Lds buffers
+                auto* tmp = ldsPtrLo;
+                ldsPtrLo  = ldsPtrHi;
+                ldsPtrHi  = tmp;
+            }
+
+            ///
+            /// Clean up tail A * B
+            ///
+            MfmaFragA fragsA[BLOCKS_X];
+            MfmaFragB fragsB[BLOCKS_Y];
+
+            // Local read mfma frags
+            localReadA(fragsA, ldsPtrLo + ldsReadOffsetA, ldsld);
+            localReadB(fragsB, ldsPtrLo + ldsReadOffsetB, ldsld);
+            mfma(fragsAcc, fragsA, fragsB, fragsAcc); // to do: add write to lds
+
+            //  Here,we try use store/load_matrix_sync interface to get a row data by reset LDS height
+            //  and width logically.
+
+            MfmaFragAcc2 fragsTmp[BLOCKS_X][BLOCKS_Y];
+            convertI32toI8(fragsAcc, fragsTmp);
+
+            auto*              ldsPtr        = reinterpret_cast<InputTV*>(localMemPtr);
+            constexpr uint32_t ldsWidth_new  = MACRO_TILE_Y;
+            constexpr uint32_t ldsHeight_new = 8 * MACRO_TILE_X;
+            constexpr uint32_t ldsld_new
+                = std::is_same_v<DataLayoutLds_new, row_major> ? ldsWidth_new : ldsHeight_new;
+
+            auto ldsReadOffsetAcc = get<0>(localWarpOffset) * ldsld_new + get<1>(localWarpOffset);
+
+            localWriteAcc(fragsTmp, ldsPtr + ldsReadOffsetAcc, ldsld_new);
+            synchronize_workgroup();
+
+            ////    loop
+            for(int sv_iter = 0; sv_iter < SV_ITERS; sv_iter++)
+            {
+                auto sv_mToffset = sv_iter * get<1>(macroTileSize);
+                auto sv_wpoffset = sv_mToffset + get<1>(localWarpOffset);
+
+                ////  load v and calculate sv
+                using GRBuffVMap1d = GetDataLayout_t<GRBuffV>;
+                auto globalReadOffsetV
+                    = GRBuffVMap1d::fromMatrixCoord(make_coord2d(0u, get<1>(macroTileCoord)), 1u)
+                      + sv_iter * MACRO_TILE_Y * ldv;
+
+                auto kStepOffsetV = GRBuffVMap1d::fromMatrixCoord(make_coord2d(ROCWMMA_K, 0u), ldv);
+
+                GRBuffV grBuffV;
+
+                using LWBuffVShape = GetIOShape_t<LWBuffV>;
+                using LWBuffVMap1d = GetDataLayout_t<LWBuffV>;
+
+                auto ldsWriteOffsetV = MACRO_TILE_X * MACRO_TILE_Y;
+                auto ldsReadOffsetS  = get<0>(localWarpOffset) * ldsld_new;
+                auto ldsReadOffsetV  = ldsWriteOffsetV
+                                      + LWBuffVMap1d::fromMatrixCoord(
+                                          make_coord2d(get<1>(localWarpOffset), 0u), ldsld_new);
+
+                for(uint32_t currentK = 0; currentK < MACRO_TILE_Y; currentK += ROCWMMA_K)
+                {
+                    globalReadCoopV(grBuffV, v + globalReadOffsetV, ldv);
+                    globalReadOffsetV += kStepOffsetV;
+
+                    localWriteCoopV(ldsPtr + ldsWriteOffsetV, grBuffV, ldsld_new);
+                    synchronize_workgroup();
+
+                    //do gemm
+                    MfmaFragS fragsS[BLOCKS_X];
+                    MfmaFragV fragsV[BLOCKS_Y];
+
+                    // Local read mfma frags from first LDS buffer
+                    localReadS(fragsS, ldsPtr + ldsReadOffsetS, ldsld_new);
+                    ldsReadOffsetS += ROCWMMA_K;
+
+                    localReadV(fragsV, ldsPtr + ldsReadOffsetV, ldsld_new);
+
+                    // accum(S * V)
+                    svgemm(fragsOut[sv_iter], fragsS, fragsV, fragsOut[sv_iter]);
+                    // Make sure that all waves have finished reading / writing to lds for currentK.
+                    synchronize_workgroup();
+                }
+            }
+        }
+
+        for(int i = 0; i < SV_ITERS; i++)
+        {
+            auto Out_macroTileCoord = make_coord2d(blockIdx.x, i) * macroTileSize;
+            auto Out_warpTileCoord  = Out_macroTileCoord + localWarpOffset;
+
+            globalWriteD(
+                d + MfmaFragDMap1d::fromMatrixCoord(Out_warpTileCoord, ldd), fragsOut[i], ldd);
+        }
+    }
+}
+
+// Simple CPU GEMM implementation, no alpha/bias processing, only do d=a*b
+template <typename InputT,
+          typename OutputT,
+          typename ComputeT,
+          typename LayoutA,
+          typename LayoutB,
+          typename LayoutC,
+          typename LayoutD = LayoutC>
+ROCWMMA_HOST void gemm_cpu_simple(uint32_t      m,
+                                  uint32_t      n,
+                                  uint32_t      k,
+                                  InputT const* a,
+                                  InputT const* b,
+                                  OutputT*      d,
+                                  uint32_t      lda,
+                                  uint32_t      ldb,
+                                  uint32_t      ldd)
+{
+    auto rowMjr = [](uint32_t row, uint32_t col, uint32_t ld) { return row * ld + col; };
+    auto colMjr = [](uint32_t row, uint32_t col, uint32_t ld) { return col * ld + row; };
+
+    auto aIndex = std::is_same<LayoutA, rocwmma::row_major>::value ? rowMjr : colMjr;
+    auto bIndex = std::is_same<LayoutB, rocwmma::row_major>::value ? rowMjr : colMjr;
+    auto dIndex = std::is_same<LayoutD, rocwmma::row_major>::value ? rowMjr : colMjr;
+
+#pragma omp parallel for
+    for(int i = 0; i < m; ++i)
+    {
+#pragma omp parallel for
+        for(int j = 0; j < n; ++j)
+        {
+            ComputeT accum = static_cast<ComputeT>(0);
+            for(int h = 0; h < k; ++h)
+            {
+                accum += static_cast<ComputeT>(a[aIndex(i, h, lda)])
+                         * static_cast<ComputeT>(b[bIndex(h, j, ldb)]);
+            }
+            d[dIndex(i, j, ldd)] = accum;
+        }
+    }
+}
+
+ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, ComputeT beta)
+{
+    // Runtime checks for host parameters
+    uint32_t hTBLOCK_X    = gfx9Params::TBLOCK_X;
+    uint32_t hTBLOCK_Y    = gfx9Params::TBLOCK_Y;
+    uint32_t hBLOCKS_X    = gfx9Params::BLOCKS_X;
+    uint32_t hBLOCKS_Y    = gfx9Params::BLOCKS_Y;
+    uint32_t hROCWMMA_M   = gfx9Params::ROCWMMA_M;
+    uint32_t hROCWMMA_N   = gfx9Params::ROCWMMA_N;
+    uint32_t hROCWMMA_K   = gfx9Params::ROCWMMA_K;
+    uint32_t hWARP_TILE_X = hBLOCKS_X * hROCWMMA_M;
+    uint32_t hWARP_TILE_Y = hBLOCKS_Y * hROCWMMA_N;
+
+    // Runtime warp calculation (host code needs to query warpsize dynamically)
+    auto warpSize = getWarpSize();
+    auto macroTileSize
+        = rocwmma::make_coord2d(hTBLOCK_X / warpSize * hWARP_TILE_X, hTBLOCK_Y * hWARP_TILE_Y);
+    auto           MACRO_TILE_Y  = get<1>(macroTileSize);
+    const uint32_t sv_iterations = (k + MACRO_TILE_Y - 1) / MACRO_TILE_Y;
+
+    // Device check for supported block and wave sizes
+    if((isGfx11() || isGfx12()) && (hROCWMMA_M != 16 || hROCWMMA_N != 16))
+    {
+        std::cout << "Unsupported block size!\n";
+        return;
+    }
+
+    if(isGfx9() && (hROCWMMA_M != hROCWMMA_N) || (hROCWMMA_M != 16 && hROCWMMA_M != 32))
+    {
+        std::cout << "Unsupported block size!\n";
+        return;
+    }
+
+    if((isGfx11() || isGfx12()) && getWarpSize() != Constants::AMDGCN_WAVE_SIZE_32)
+    {
+        std::cout << "Unsupported wave size!\n";
+        return;
+    }
+
+    if(isGfx9() && getWarpSize() != Constants::AMDGCN_WAVE_SIZE_64)
+    {
+        std::cout << "Unsupported wave size!\n";
+        return;
+    }
+
+    // Bounds check
+    if((m < get<0>(macroTileSize) || n < get<1>(macroTileSize) || k < hROCWMMA_K)
+       || (m % hROCWMMA_M || n % hROCWMMA_N || k % hROCWMMA_K))
+    {
+        std::cout << "Unsupported matrix size!\n";
+        return;
+    }
+
+    // Layouts leading dims
+    int lda = std::is_same_v<DataLayoutA, row_major> ? k : m;
+    int ldb = std::is_same_v<DataLayoutB, row_major> ? n : k;
+    int ldc = std::is_same_v<DataLayoutC, row_major> ? n : m;
+    int ldd = std::is_same_v<DataLayoutC, row_major> ? k : m;
+    int ldv = std::is_same_v<DataLayoutV, row_major> ? k : n;
+
+    std::cout << "Initializing host data..." << std::endl;
+
+    // Initialize input matrices
+    std::vector<InputT>  matrixA(m * k);
+    std::vector<InputT>  matrixB(k * n);
+    std::vector<OutputT> matrixC(m * n);
+    std::vector<InputTV> matrixV(k * n);
+
+    // Fill outputs with NaN to catch contamination
+    std::vector<OutputT> matrixD(m * k, std::numeric_limits<OutputT>::signaling_NaN());
+
+    fillRand(matrixA.data(), m, k);
+    fillRand(matrixB.data(), k, n);
+    fillRand(matrixC.data(), m, n);
+    fillRand(matrixV.data(), n, k);
+
+    std::cout << "Initializing device data..." << std::endl;
+
+    // Allocate and copy device memory
+    InputT*  d_a;
+    InputT*  d_b;
+    InputTV* d_v;
+    OutputT* d_c;
+    OutputT* d_d;
+
+    const size_t bytesA = matrixA.size() * sizeof(InputT);
+    const size_t bytesB = matrixB.size() * sizeof(InputT);
+    const size_t bytesV = matrixV.size() * sizeof(InputTV);
+    const size_t bytesC = matrixC.size() * sizeof(OutputT);
+    const size_t bytesD = matrixD.size() * sizeof(OutputT);
+
+    CHECK_HIP_ERROR(hipMalloc(&d_a, bytesA));
+    CHECK_HIP_ERROR(hipMalloc(&d_b, bytesB));
+    CHECK_HIP_ERROR(hipMalloc(&d_v, bytesV));
+    CHECK_HIP_ERROR(hipMalloc(&d_c, bytesC));
+    CHECK_HIP_ERROR(hipMalloc(&d_d, bytesD));
+
+    CHECK_HIP_ERROR(hipMemcpy(d_a, matrixA.data(), bytesA, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_b, matrixB.data(), bytesB, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_v, matrixV.data(), bytesV, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_c, matrixC.data(), bytesC, hipMemcpyHostToDevice));
+    CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
+
+    auto blockDim = dim3(hTBLOCK_X, hTBLOCK_Y);
+    auto gridDim  = dim3(rocwmma::ceil_div(m, get<0>(macroTileSize)));
+
+    std::cout << "Launching GEMM kernel..." << std::endl;
+    std::cout << "gridDim (" << gridDim.x << " " << gridDim.y << ")" << " blockdim (" << blockDim.x
+              << " " << blockDim.y << ")" << std::endl;
+
+    // Uses 2 lds blocks for prefetch loop (A and B)
+    int ldsusage
+        = max(2u * sizeof(InputT) * (get<0>(macroTileSize) + get<1>(macroTileSize)) * hROCWMMA_K,
+              2u * sizeof(ComputeT) * get<0>(macroTileSize) * get<1>(macroTileSize));
+
+    auto rocwmmaKernel = [&]() {
+        // Instantiate kernel with compile-time SV_ITERS to avoid dynamic alloca/VLA in device code.
+        switch(sv_iterations)
+        {
+#define LAUNCH(SV)                                    \
+    case SV:                                          \
+    {                                                 \
+        hipEvent_t _start = nullptr, _stop = nullptr; \
+        hipExtLaunchKernelGGL(gemm_rocwmma_d<SV>,     \
+                              gridDim,                \
+                              blockDim,               \
+                              ldsusage,               \
+                              0,                      \
+                              _start,                 \
+                              _stop,                  \
+                              0u,                     \
+                              m,                      \
+                              n,                      \
+                              k,                      \
+                              d_a,                    \
+                              d_b,                    \
+                              d_v,                    \
+                              d_c,                    \
+                              d_d,                    \
+                              lda,                    \
+                              ldb,                    \
+                              ldv,                    \
+                              ldd);                   \
+    }                                                 \
+    break;
+            LAUNCH(1);
+            LAUNCH(2);
+            LAUNCH(3);
+            LAUNCH(4);
+            LAUNCH(5);
+            LAUNCH(6);
+            LAUNCH(7);
+            LAUNCH(8);
+            LAUNCH(9);
+            LAUNCH(10);
+            LAUNCH(11);
+            LAUNCH(12);
+            LAUNCH(13);
+            LAUNCH(14);
+            LAUNCH(15);
+            LAUNCH(16);
+            LAUNCH(17);
+            LAUNCH(18);
+            LAUNCH(19);
+            LAUNCH(20);
+            LAUNCH(21);
+            LAUNCH(22);
+            LAUNCH(23);
+            LAUNCH(24);
+            LAUNCH(25);
+            LAUNCH(26);
+            LAUNCH(27);
+            LAUNCH(28);
+            LAUNCH(29);
+            LAUNCH(30);
+            LAUNCH(31);
+            LAUNCH(32);
+#undef LAUNCH
+        default:
+            printf(
+                "Error: sv_iterations=%u exceeds supported max (32). Increase cases or reduce k.\n",
+                sv_iterations);
+            return;
+        }
+    };
+
+    constexpr uint32_t warmups    = 0u;
+    constexpr uint32_t recordRuns = 1u;
+
+    // Warm-up runs, not recorded
+    for(uint32_t i = 0; i < warmups; ++i)
+    {
+        rocwmmaKernel();
+    }
+
+    // Actual recorded runs
+    hipEvent_t startEvent, stopEvent;
+    CHECK_HIP_ERROR(hipEventCreate(&startEvent));
+    CHECK_HIP_ERROR(hipEventCreate(&stopEvent));
+
+    CHECK_HIP_ERROR(hipEventRecord(startEvent));
+    for(uint32_t i = 0; i < recordRuns; ++i)
+    {
+        rocwmmaKernel();
+        CHECK_HIP_ERROR(hipGetLastError());
+        CHECK_HIP_ERROR(hipStreamSynchronize(0));
+    }
+    CHECK_HIP_ERROR(hipEventRecord(stopEvent));
+    CHECK_HIP_ERROR(hipEventSynchronize(stopEvent));
+
+    auto elapsedTimeMs = 0.0f;
+    CHECK_HIP_ERROR(hipEventElapsedTime(&elapsedTimeMs, startEvent, stopEvent));
+
+    auto gFlops = calculateGFlops(m, n, k);
+    auto tFlopsPerSec
+        = calculateTFlopsPerSec(m, n, k, static_cast<double>(elapsedTimeMs), recordRuns);
+
+    CHECK_HIP_ERROR(hipEventDestroy(startEvent));
+    CHECK_HIP_ERROR(hipEventDestroy(stopEvent));
+
+    // Echo performance
+    std::cout << "TBlockX, TBlockY, " << "BlocksX, BlocksY, " << "BlkM, BlkN, BlkK, "
+              << "MatM, MatN, MatK, " << "alpha, lda, ldb, " << "beta, ldc, ldd, "
+              << "elapsedMs, Problem Size(GFlops), TFlops/s" << "," << "sizeof(InputT)"
+              << std::endl;
+
+    std::cout << hTBLOCK_X << ", " << hTBLOCK_Y << ", " << hBLOCKS_X << ", " << hBLOCKS_Y << ", "
+              << hROCWMMA_M << ", " << hROCWMMA_N << ", " << hROCWMMA_K << ", " << m << ", " << n
+              << ", " << k << ", " << alpha << ", " << lda << ", " << ldb << ", " << beta << ", "
+              << ldc << ", " << ldd << ", " << elapsedTimeMs << ", " << gFlops << ", "
+              << tFlopsPerSec << "," << sizeof(InputT) << std::endl;
+#if !NDEBUG
+
+    std::cout << "Validating result with reference..." << std::endl;
+
+    if((uint64_t)m * (uint64_t)n * (uint64_t)k > (2048ull * 2048ull * 2048ull))
+    {
+        std::cout << "Please wait. Large sizes can take a while!" << std::endl;
+    }
+
+    // Bring kernel result back to host
+    CHECK_HIP_ERROR(hipMemcpy(matrixD.data(), d_d, bytesD, hipMemcpyDeviceToHost));
+
+    // Setup and run reference computation
+    std::vector<OutputT> matrixT_ref(m * n, std::numeric_limits<OutputT>::signaling_NaN());
+    std::vector<InputT>  matrixTinput_ref(m * n, std::numeric_limits<OutputT>::signaling_NaN());
+    std::vector<OutputT> matrixD_ref(m * k, std::numeric_limits<OutputT>::signaling_NaN());
+    gemm_cpu_simple<InputT, OutputT, ComputeT, DataLayoutA, DataLayoutB, DataLayoutC>(
+        m, n, k, matrixA.data(), matrixB.data(), matrixT_ref.data(), lda, ldb, ldc);
+
+    // Convert int32 to int8
+    for(int i = 0; i < m; i++)
+    {
+        for(int j = 0; j < n; j++)
+        {
+            int32_t value = (matrixT_ref[i * n + j]);
+            if(value > INT8_MAX)
+            {
+                matrixTinput_ref[i * n + j] = INT8_MAX;
+            }
+            else if(value < INT8_MIN)
+            {
+                matrixTinput_ref[i * n + j] = INT8_MIN;
+            }
+            else
+            {
+                matrixTinput_ref[i * n + j] = static_cast<InputT>(value);
+            }
+        }
+    }
+
+    gemm_cpu_simple<InputT, OutputT, ComputeT, DataLayoutA, DataLayoutB, DataLayoutC>(
+        m, k, n, matrixTinput_ref.data(), matrixV.data(), matrixD_ref.data(), ldc, ldv, ldd);
+
+    auto res = compareEqual(matrixD.data(), matrixD_ref.data(), m * k);
+
+    if(std::get<0>(res) == false)
+    {
+        std::cout << "FAILED\n";
+    }
+    else
+    {
+        std::cout << "PASSED\n";
+    }
+
+    std::cout << "Max relative error: " << std::get<1>(res) << std::endl;
+
+#endif // !NDEBUG
+
+    // Release device memory
+    CHECK_HIP_ERROR(hipFree(d_a));
+    CHECK_HIP_ERROR(hipFree(d_b));
+    CHECK_HIP_ERROR(hipFree(d_c));
+    CHECK_HIP_ERROR(hipFree(d_v));
+    CHECK_HIP_ERROR(hipFree(d_d));
+
+    std::cout << "Finished!" << std::endl;
+}
+
+int main()
+{
+    if(isGfx9())
+        gemm_test(8192, 8192, 128, 1, 0);
+    else
+        std::cout << "This sample Not test on gfx11/gfx12 yet!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add CPU reference implementation for the block scale dequantize (descale) operation
- Add FP8 type support (E4M3, E5M2, E8M0) to `FlatbufferDatatypeMapping`, `CpuFpReferenceUtilities`, and `createTensor()` factory
- Wire BlockScaleDequantize into the existing CPU graph executor registry infrastructure
- Fix FP8 type arithmetic in `CpuFpReferenceValidation` (cast to float before subtraction)

## Details

### New files
| File | Purpose |
|------|---------|
| `CpuFpReferenceBlockScaleDequantize.hpp` | Core math: `Y[i] = X[i] * scale[block_of(i)]` with negative scale mode support |
| `BlockScaleDequantizePlan.hpp` | Plan executor + builder bridging flatbuffer graph nodes to CPU reference |
| `BlockScaleDequantizeSignatureKey.hpp` | Registry key with 9 type combinations (float, half, bfloat16, FP8 E4M3/E5M2 + E8M0) |
| 3 test files | 15 tests covering CPU reference math, plan execution, and signature keys |

### Modified files
- `FlatbufferDatatypeMapping.hpp` — FP8 type mappings in all 3 conversion functions + variant
- `CpuFpReferenceUtilities.hpp` — FP8 in `IS_VALID_TENSOR_TYPE_V` and `safeConvert`
- `Tensor.hpp` — `FP8_E8M0` case in `createTensor()`
- `CpuFpReferenceValidation.hpp` — Fix FP8 subtraction
- `PlanRegistrySignatureKey.hpp` / `PlanBuilderRegistry.hpp` / `CpuReferenceGraphExecutor.hpp` — Registry wiring

## Test plan
- [x] `hipdnn_test_sdk_tests --gtest_filter='*BlockScaleDequantize*'` — 15/15 pass
- [x] Full `hipdnn_test_sdk_tests` suite — 904/904 pass (1 pre-existing skip)