### PR TITLE
[tensilelite] Print CMS schedule on validation failure

### DIFF
--- a/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CMSValidator.py
@@ -2284,6 +2284,7 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
                 continue
             status, message = check(scheduleInfo, context, code_path)
             if not status:
+                scheduleInfo.pretty_print()
                 return False, f"Code path {code_path}: {message}"
 
         # === Timeline-based checks ===
@@ -2300,6 +2301,7 @@ def isValid(scheduleInfo: 'ScheduleInfo', context: dict) -> tuple[bool, str]:
                 continue
             add_constraints(timeline, ctx)
             if error := validate_timeline(timeline):
+                scheduleInfo.pretty_print()
                 return False, f"Code path {code_path}: {error}"
 
     # All rules passed, considered valid.

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -270,15 +270,26 @@ class ScheduleInfo:
         return self._disabledPasses.get(pass_id)
 
     def pretty_print(self):
-        klen = max(len(k) for k in self.optSchedule.keys())
-        for k,v in self.optSchedule.items():
-            print(f"{k:>{klen}}: {v}")
-        
+        print("{")
+        keys = list(self.optSchedule.keys())
+        for i, k in enumerate(keys):
+            v = self.optSchedule[k]
+            comma = "," if i < len(keys) - 1 else ""
+            if len(v) == 1:
+                print(f"    '{k}': [{v[0]}]{comma}")
+            else:
+                print(f"    '{k}': [")
+                for j, row in enumerate(v):
+                    row_comma = "," if j < len(v) - 1 else ""
+                    print(f"        {row}{row_comma}")
+                print(f"    ]{comma}")
+        print("}")
+
         if snops := self.optSchedule.get('SNOP', []):
             print("---- SNOP code ----")
             for idx, code in zip(snops[0], self.snopCode):
                 print(f"{idx:>2}: {str(code).strip()}")
-        
+
         if syncs := self.optSchedule.get('SYNC', []):
             print("---- SYNC code ----")
             for idx, code in zip(syncs[0], self.syncCode):

--- a/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Components/CustomSchedule.py
@@ -272,17 +272,22 @@ class ScheduleInfo:
     def pretty_print(self):
         print("{")
         keys = list(self.optSchedule.keys())
+        maxKeyLen = max(len(k) for k in keys) if keys else 0
         for i, k in enumerate(keys):
             v = self.optSchedule[k]
             comma = "," if i < len(keys) - 1 else ""
+            pad = " " * (maxKeyLen - len(k))
             if len(v) == 1:
-                print(f"    '{k}': [{v[0]}]{comma}")
+                print(f"    '{k}':{pad} [{v[0]}]{comma}")
             else:
-                print(f"    '{k}': [")
+                # Align continuation rows after the opening bracket
+                bracketCol = 8 + maxKeyLen
+                indent = " " * (bracketCol + 1)
+                print(f"    '{k}':{pad} [")
                 for j, row in enumerate(v):
                     row_comma = "," if j < len(v) - 1 else ""
-                    print(f"        {row}{row_comma}")
-                print(f"    ]{comma}")
+                    print(f"{indent}{row}{row_comma}")
+                print(f"{' ' * bracketCol}]{comma}")
         print("}")
 
         if snops := self.optSchedule.get('SNOP', []):

--- a/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
+++ b/projects/hipblaslt/tensilelite/Tensile/Tests/unit/test_CustomSchedule.py
@@ -1020,7 +1020,6 @@ class TestCustomScheduleTF32:
         assert has_schedule
         assert isinstance(schedule_info, ScheduleInfo)
         assert schedule_info.numCodePaths == ncp
-        schedule_info.pretty_print()
         numMfma = (mi_wave_tile[0] * mi_wave_tile[1] *
                    3 *                      # tf32 emulated with 3 bf16
                    (1 if mi[0] == 16 else 2)   # two sub-iterations with mi32


### PR DESCRIPTION
## Motivation

Many new CMS schedules are programmatically generating indices which makes it hard to reason about validator feedback when indices are not visible.

For example, #5301 had the following validation issue `AssertionError: Code path 1: GRB @ idx=86 is not valid. It is guaranteed by the SWait @ idx=47 which is after the first corresponding LRB1 @ idx=59.`

The schedule for the GRBs was created as follows:
```Python
gr_inc_step = 1
...
grb    = [53,57,61, 64,69,75,79,84]
...
'GRB':    [duplicate_list_items(grb,                2, gr_inc_step),
           duplicate_list_items([i+1 for i in grb], 2, gr_inc_step)],
```

Without printing the schedule on a validation failure (or without the validator), reasoning about the GRBs is very difficult.

## Technical Details

Modify pretty_print to make it easier to see how instructions are scheduled differently across SIMDs.
Before
```Python
  SYNC: [[6, 9, 21, 21, 48, 48, 54, 57, 76]]
GRIncA: [[0, 1, 1, 1, 2, 3, 3, 3, 4]]
GRIncB: [[5, 5, 5, 7, 8, 9, 10, 19, 19]]
  LRA0: [[0, 0, 2, 2, 4, 4, 6, 6]]
  LRB0: [[11, 11, 13, 13, 15, 15, 17, 17]]
   GRA: [[22, 23, 25, 26, 29, 30, 33, 34, 37, 38, 41, 42, 45, 46, 49, 50], [23, 24, 26, 27, 30, 31, 34, 35, 38, 39, 42, 43, 46, 47, 50, 51]]
   GRB: [[53, 54, 57, 58, 61, 62, 64, 65, 69, 70, 75, 76, 79, 80, 84, 85], [54, 55, 58, 59, 62, 63, 65, 66, 70, 71, 76, 77, 80, 81, 85, 86]]
  LRSA: [[45]]
  LRSB: [[45]]
  LWSA: [[72]]
  LWSB: [[72]]
PackA0: [[7, 7, 7, 9, 9, 9, 8, 8, 10, 10, 8, 10, 11, 11, 12, 12, 19, 19, 20, 20, 21, 21, 13, 13, 14, 14, 19, 19, 22, 22, 23, 23, 15, 15, 16, 16, 19, 19, 24, 24, 25, 25, 17, 17, 18, 18, 19, 19, 26, 26, 27, 27]]
PackB0: [[28, 28, 29, 29, 36, 36, 37, 37, 38, 38, 30, 30, 31, 31, 36, 36, 39, 39, 40, 40, 32, 32, 33, 33, 36, 36, 41, 41, 42, 42, 34, 34, 35, 35, 36, 36, 43, 43, 44, 44]]
  LRA1: [[48, 48, 50, 50, 52, 52, 54, 54], [49, 49, 51, 51, 53, 53, 54, 54]]
  LRB1: [[59, 59, 61, 61, 63, 63, 65, 65]]
PackB1: [[77, 77, 78, 78, 85, 85, 86, 86, 87, 87, 79, 79, 80, 80, 85, 85, 88, 88, 89, 89, 81, 81, 82, 82, 85, 85, 90, 90, 91, 91, 83, 83, 84, 84, 85, 85, 92, 92, 93, 93]]
PackA1: [[55, 55, 55, 57, 57, 57, 55, 55, 57, 57, 56, 58, 59, 59, 60, 60, 67, 67, 68, 68, 69, 69, 61, 61, 62, 62, 67, 67, 70, 70, 71, 71, 63, 63, 64, 64, 67, 67, 72, 72, 73, 73, 65, 65, 66, 66, 67, 67, 74, 74, 75, 75]]
   LCC: [[94, 94]]
---- SYNC code ----
 6: s_waitcnt lgkmcnt(0)                               // wait for the first 4 LRAs before swapping/packing
 9: s_waitcnt lgkmcnt(0)                               // wait for the rest of LRAs before swapping/packing them
21: s_waitcnt lgkmcnt(0)                               // wait for LRBs before the packing them
21: s_barrier                                          // barrier before GR
48: s_waitcnt vmcnt(0)                                 // wait for the previous GRs
48: s_barrier
54: s_waitcnt lgkmcnt(0)                               // wait for the first two LRAs before packing
57: s_waitcnt lgkmcnt(0)                               // wait for the rest of LRAs before packing them
76: s_waitcnt lgkmcnt(0)                               // wait for LRBs before the packing them
```

After
```Python
{
    'SYNC': [[6, 9, 21, 21, 48, 48, 54, 57, 76]],
    'GRIncA': [[0, 1, 1, 1, 2, 3, 3, 3, 4]],
    'GRIncB': [[5, 5, 5, 7, 8, 9, 10, 19, 19]],
    'LRA0': [[0, 0, 2, 2, 4, 4, 6, 6]],
    'LRB0': [[11, 11, 13, 13, 15, 15, 17, 17]],
    'GRA': [
        [22, 23, 25, 26, 29, 30, 33, 34, 37, 38, 41, 42, 45, 46, 49, 50],
        [23, 24, 26, 27, 30, 31, 34, 35, 38, 39, 42, 43, 46, 47, 50, 51]
    ],
    'GRB': [
        [53, 54, 57, 58, 61, 62, 64, 65, 69, 70, 75, 76, 79, 80, 84, 85],
        [54, 55, 58, 59, 62, 63, 65, 66, 70, 71, 76, 77, 80, 81, 85, 86]
    ],
    'LRSA': [[45]],
    'LRSB': [[45]],
    'LWSA': [[72]],
    'LWSB': [[72]],
    'PackA0': [[7, 7, 7, 9, 9, 9, 8, 8, 10, 10, 8, 10, 11, 11, 12, 12, 19, 19, 20, 20, 21, 21, 13, 13, 14, 14, 19, 19, 22, 22, 23, 23, 15, 15, 16, 16, 19, 19, 24, 24, 25, 25, 17, 17, 18, 18, 19, 19, 26, 26, 27, 27]],
    'PackB0': [[28, 28, 29, 29, 36, 36, 37, 37, 38, 38, 30, 30, 31, 31, 36, 36, 39, 39, 40, 40, 32, 32, 33, 33, 36, 36, 41, 41, 42, 42, 34, 34, 35, 35, 36, 36, 43, 43, 44, 44]],
    'LRA1': [
        [48, 48, 50, 50, 52, 52, 54, 54],
        [49, 49, 51, 51, 53, 53, 54, 54]
    ],
    'LRB1': [[59, 59, 61, 61, 63, 63, 65, 65]],
    'PackB1': [[77, 77, 78, 78, 85, 85, 86, 86, 87, 87, 79, 79, 80, 80, 85, 85, 88, 88, 89, 89, 81, 81, 82, 82, 85, 85, 90, 90, 91, 91, 83, 83, 84, 84, 85, 85, 92, 92, 93, 93]],
    'PackA1': [[55, 55, 55, 57, 57, 57, 55, 55, 57, 57, 56, 58, 59, 59, 60, 60, 67, 67, 68, 68, 69, 69, 61, 61, 62, 62, 67, 67, 70, 70, 71, 71, 63, 63, 64, 64, 67, 67, 72, 72, 73, 73, 65, 65, 66, 66, 67, 67, 74, 74, 75, 75]],
    'LCC': [[94, 94]]
}
---- SYNC code ----
 6: s_waitcnt lgkmcnt(0)                               // wait for the first 4 LRAs before swapping/packing
 9: s_waitcnt lgkmcnt(0)                               // wait for the rest of LRAs before swapping/packing them
21: s_waitcnt lgkmcnt(0)                               // wait for LRBs before the packing them
21: s_barrier                                          // barrier before GR
48: s_waitcnt vmcnt(0)                                 // wait for the previous GRs
48: s_barrier
54: s_waitcnt lgkmcnt(0)                               // wait for the first two LRAs before packing
57: s_waitcnt lgkmcnt(0)                               // wait for the rest of LRAs before packing them
76: s_waitcnt lgkmcnt(0)                               // wait for LRBs before the packing them
```

## Test Plan

Run existing tests.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
