### PR TITLE
[hipDNN] add pointwise dynamic tolerance

### DIFF
--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -715,3 +715,124 @@ float calculateMatmulTolerance(ITensor& a, ITensor& b)
 }
 
 } // namespace hipdnn_test_sdk::utilities::matmul
+
+namespace hipdnn_test_sdk::utilities::pointwise
+{
+using hipdnn_data_sdk::types::bfloat16;
+using hipdnn_data_sdk::types::half;
+
+/**
+ * @brief Classification of pointwise operations by error characteristics.
+ *
+ * Each class has a distinct error multiplier C that reflects how many ULPs of
+ * divergence are expected between reference and GPU implementations.
+ * Backward ops get higher C values than forward due to chain rule amplification.
+ *
+ * Five categories (A-E), with D and E split into forward/backward:
+ * - Bitwise (A): mathematically exact, errors from casts/canonicalization only
+ * - Linear (B): single IEEE-rounded ops, error scales with operand magnitude
+ * - Rational (C): Newton-Raphson-based ops, input conditioning sensitive
+ * - Transcendental (D): polynomial/table approximations, implementation-dependent
+ * - Composite (E): compositions of transcendentals, error from worst component
+ */
+enum class PointwiseErrorClass : uint8_t
+{
+    BITWISE, ///< Comparisons, select, relu, abs, neg, identity, floor, ceil
+    LINEAR, ///< add, sub, mul, add_square
+    RATIONAL, ///< div, reciprocal, sqrt, rsqrt
+    TRANSCENDENTAL_FWD, ///< exp, log, sin, tan, tanh_fwd, sigmoid_fwd, erf, elu_fwd
+    TRANSCENDENTAL_BWD, ///< tanh_bwd, sigmoid_bwd, elu_bwd
+    COMPOSITE_FWD, ///< gelu_fwd, gelu_approx_tanh_fwd, softplus_fwd, swish_fwd
+    COMPOSITE_BWD ///< gelu_bwd, gelu_approx_tanh_bwd, softplus_bwd, swish_bwd
+};
+
+namespace detail
+{
+
+/// Returns the error multiplier C for a given error class and precision.
+/// C_high is for float/double compute; C_low is for half/bf16 compute.
+/// C_low ≈ 2 × C_high because low-precision polynomial evaluations
+/// accumulate proportionally more relative error per coefficient.
+template <typename ComputeType>
+constexpr double getErrorMultiplier(PointwiseErrorClass errorClass)
+{
+    constexpr bool IS_HIGH_PRECISION
+        = std::is_same_v<ComputeType, float> || std::is_same_v<ComputeType, double>;
+
+    switch(errorClass)
+    {
+    case PointwiseErrorClass::BITWISE:
+        return IS_HIGH_PRECISION ? 1.0 : 2.0;
+    case PointwiseErrorClass::LINEAR:
+        return IS_HIGH_PRECISION ? 2.0 : 4.0;
+    case PointwiseErrorClass::RATIONAL:
+        return IS_HIGH_PRECISION ? 4.0 : 8.0;
+    case PointwiseErrorClass::TRANSCENDENTAL_FWD:
+        return IS_HIGH_PRECISION ? 8.0 : 16.0;
+    case PointwiseErrorClass::TRANSCENDENTAL_BWD:
+        return IS_HIGH_PRECISION ? 12.0 : 24.0;
+    case PointwiseErrorClass::COMPOSITE_FWD:
+        return IS_HIGH_PRECISION ? 16.0 : 32.0;
+    case PointwiseErrorClass::COMPOSITE_BWD:
+        return IS_HIGH_PRECISION ? 24.0 : 48.0;
+    default:
+        return 1.0;
+    }
+}
+
+} // namespace detail
+
+/**
+ * @brief Calculates the expected tolerance for element-wise pointwise operations.
+ *
+ * Error model:
+ * @code
+ *   tolerance = C[class][precision] * epsilon_compute * scale
+ *             + (inputDowncast  ? epsilon_compute * scale : 0)
+ *             + (outputDowncast ? epsilon_output  * scale : 0)
+ * @endcode
+ *
+ * The @p scale parameter is typically @c max(|input|) for unbounded-output ops
+ * (exp, log, add, gelu), but should be @c 1.0 for bounded-output ops
+ * (sigmoid -> [0,1], tanh -> [-1,1], erf -> [-1,1]). The caller decides
+ * based on the operation being tested.
+ *
+ * @tparam OutputType  Data type of the output tensor.
+ * @tparam InputType   Data type of the input tensor(s).
+ * @tparam ComputeType Data type used for intermediate computation (default: float).
+ * @param scale        Error scaling factor. Use max(|input|) for unbounded ops,
+ *                     1.0 for bounded-output transcendentals (sigmoid, tanh, erf).
+ * @param errorClass   Classification of the pointwise operation.
+ * @return Calculated tolerance value as float.
+ */
+template <typename OutputType, typename InputType, typename ComputeType = float>
+float calculatePointwiseTolerance(double scale, PointwiseErrorClass errorClass)
+{
+    static_assert(std::is_same_v<ComputeType, float> || std::is_same_v<ComputeType, double>
+                      || std::is_same_v<ComputeType, half> || std::is_same_v<ComputeType, bfloat16>,
+                  "ComputeType must be float, double, half, or bfloat16");
+
+    auto epsilonCompute = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
+
+    // Core error: C * epsilon_compute * scale
+    double c = detail::getErrorMultiplier<ComputeType>(errorClass);
+    double tolerance = c * epsilonCompute * scale;
+
+    // Input casting error: added when InputType has higher precision than ComputeType.
+    auto inputEpsilon = static_cast<double>(std::numeric_limits<InputType>::epsilon());
+    if(inputEpsilon < epsilonCompute)
+    {
+        tolerance += epsilonCompute * scale;
+    }
+
+    // Output casting error: added when ComputeType has higher precision than OutputType.
+    auto outputEpsilon = static_cast<double>(std::numeric_limits<OutputType>::epsilon());
+    if(outputEpsilon > epsilonCompute)
+    {
+        tolerance += outputEpsilon * scale;
+    }
+
+    return static_cast<float>(tolerance);
+}
+
+} // namespace hipdnn_test_sdk::utilities::pointwise

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -774,8 +774,9 @@ constexpr double getErrorMultiplier(PointwiseErrorClass errorClass)
     case PointwiseErrorClass::COMPOSITE_FWD:
         return IS_HIGH_PRECISION ? 16.0 : 32.0;
     case PointwiseErrorClass::COMPOSITE_BWD:
-    default:
         return IS_HIGH_PRECISION ? 24.0 : 48.0;
+    default:
+        throw std::logic_error("Unhandled PointwiseErrorClass — add it to getErrorMultiplier");
     }
 }
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -774,7 +774,6 @@ constexpr double getErrorMultiplier(PointwiseErrorClass errorClass)
     case PointwiseErrorClass::COMPOSITE_FWD:
         return IS_HIGH_PRECISION ? 16.0 : 32.0;
     case PointwiseErrorClass::COMPOSITE_BWD:
-        return IS_HIGH_PRECISION ? 24.0 : 48.0;
     default:
         return IS_HIGH_PRECISION ? 24.0 : 48.0;
     }

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -776,7 +776,7 @@ constexpr double getErrorMultiplier(PointwiseErrorClass errorClass)
     case PointwiseErrorClass::COMPOSITE_BWD:
         return IS_HIGH_PRECISION ? 24.0 : 48.0;
     default:
-        return 1.0;
+        return IS_HIGH_PRECISION ? 24.0 : 48.0;
     }
 }
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/DynamicTolerances.hpp
@@ -814,7 +814,7 @@ float calculatePointwiseTolerance(double scale, PointwiseErrorClass errorClass)
     auto epsilonCompute = static_cast<double>(std::numeric_limits<ComputeType>::epsilon());
 
     // Core error: C * epsilon_compute * scale
-    double c = detail::getErrorMultiplier<ComputeType>(errorClass);
+    const double c = detail::getErrorMultiplier<ComputeType>(errorClass);
     double tolerance = c * epsilonCompute * scale;
 
     // Input casting error: added when InputType has higher precision than ComputeType.

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp
@@ -93,10 +93,8 @@ inline PointwiseErrorClass classifyPointwiseOp(hipdnn_data_sdk::data_objects::Po
     case PointwiseMode::GELU_APPROX_TANH_BWD:
     case PointwiseMode::SOFTPLUS_BWD:
     case PointwiseMode::SWISH_BWD:
-        return PointwiseErrorClass::COMPOSITE_BWD;
-
     default:
-        return PointwiseErrorClass::COMPOSITE_BWD; // Conservative fallback
+        return PointwiseErrorClass::COMPOSITE_BWD;
     }
 }
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <stdexcept>
+
 #include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
 #include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
 
@@ -93,8 +95,9 @@ inline PointwiseErrorClass classifyPointwiseOp(hipdnn_data_sdk::data_objects::Po
     case PointwiseMode::GELU_APPROX_TANH_BWD:
     case PointwiseMode::SOFTPLUS_BWD:
     case PointwiseMode::SWISH_BWD:
-    default:
         return PointwiseErrorClass::COMPOSITE_BWD;
+    default:
+        throw std::logic_error("Unclassified PointwiseMode — add it to classifyPointwiseOp");
     }
 }
 

--- a/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp
+++ b/projects/hipdnn/test_sdk/include/hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp
@@ -1,0 +1,125 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <hipdnn_data_sdk/data_objects/pointwise_attributes_generated.h>
+#include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
+
+namespace hipdnn_test_sdk::utilities::pointwise
+{
+
+/// Maps a PointwiseMode to its corresponding PointwiseErrorClass.
+///
+/// Classification follows the error model documented in DynamicTolerances.hpp:
+/// - BITWISE (A): exact ops — comparisons, select, relu, abs, neg, identity, floor, ceil
+/// - LINEAR (B): IEEE correctly-rounded — add, sub, mul, add_square
+/// - RATIONAL (C): Newton-Raphson — div, reciprocal, sqrt, rsqrt
+/// - TRANSCENDENTAL_FWD (D fwd): polynomial/table approx — exp, log, sin, tan, tanh, sigmoid, erf,
+///   elu
+/// - TRANSCENDENTAL_BWD (D bwd): chain rule amplification — tanh_bwd, sigmoid_bwd, elu_bwd
+/// - COMPOSITE_FWD (E fwd): compound nonlinear — gelu, gelu_approx_tanh, softplus, swish
+/// - COMPOSITE_BWD (E bwd): compound backward — gelu_bwd, gelu_approx_tanh_bwd, softplus_bwd,
+///   swish_bwd
+inline PointwiseErrorClass classifyPointwiseOp(hipdnn_data_sdk::data_objects::PointwiseMode mode)
+{
+    using hipdnn_data_sdk::data_objects::PointwiseMode;
+
+    switch(mode)
+    {
+    // Class A — Bitwise / Selection / Predicate
+    case PointwiseMode::ABS:
+    case PointwiseMode::NEG:
+    case PointwiseMode::IDENTITY:
+    case PointwiseMode::CEIL:
+    case PointwiseMode::FLOOR:
+    case PointwiseMode::CMP_EQ:
+    case PointwiseMode::CMP_GE:
+    case PointwiseMode::CMP_GT:
+    case PointwiseMode::CMP_LE:
+    case PointwiseMode::CMP_LT:
+    case PointwiseMode::CMP_NEQ:
+    case PointwiseMode::LOGICAL_AND:
+    case PointwiseMode::LOGICAL_OR:
+    case PointwiseMode::LOGICAL_NOT:
+    case PointwiseMode::BINARY_SELECT:
+    case PointwiseMode::GEN_INDEX:
+    case PointwiseMode::MAX_OP:
+    case PointwiseMode::MIN_OP:
+    case PointwiseMode::RELU_FWD:
+    case PointwiseMode::RELU_BWD:
+        return PointwiseErrorClass::BITWISE;
+
+    // Class B — Linear Arithmetic
+    case PointwiseMode::ADD:
+    case PointwiseMode::SUB:
+    case PointwiseMode::MUL:
+    case PointwiseMode::ADD_SQUARE:
+        return PointwiseErrorClass::LINEAR;
+
+    // Class C — Rational / Simple Nonlinear
+    case PointwiseMode::DIV:
+    case PointwiseMode::RECIPROCAL:
+    case PointwiseMode::SQRT:
+    case PointwiseMode::RSQRT:
+        return PointwiseErrorClass::RATIONAL;
+
+    // Class D fwd — Transcendentals (forward)
+    case PointwiseMode::EXP:
+    case PointwiseMode::LOG:
+    case PointwiseMode::SIN:
+    case PointwiseMode::TAN:
+    case PointwiseMode::TANH_FWD:
+    case PointwiseMode::SIGMOID_FWD:
+    case PointwiseMode::ERF:
+    case PointwiseMode::ELU_FWD:
+        return PointwiseErrorClass::TRANSCENDENTAL_FWD;
+
+    // Class D bwd — Transcendentals (backward)
+    case PointwiseMode::TANH_BWD:
+    case PointwiseMode::SIGMOID_BWD:
+    case PointwiseMode::ELU_BWD:
+        return PointwiseErrorClass::TRANSCENDENTAL_BWD;
+
+    // Class E fwd — Composite (forward)
+    case PointwiseMode::GELU_FWD:
+    case PointwiseMode::GELU_APPROX_TANH_FWD:
+    case PointwiseMode::SOFTPLUS_FWD:
+    case PointwiseMode::SWISH_FWD:
+        return PointwiseErrorClass::COMPOSITE_FWD;
+
+    // Class E bwd — Composite (backward)
+    case PointwiseMode::GELU_BWD:
+    case PointwiseMode::GELU_APPROX_TANH_BWD:
+    case PointwiseMode::SOFTPLUS_BWD:
+    case PointwiseMode::SWISH_BWD:
+        return PointwiseErrorClass::COMPOSITE_BWD;
+
+    default:
+        return PointwiseErrorClass::COMPOSITE_BWD; // Conservative fallback
+    }
+}
+
+/// Returns true if the pointwise operation has bounded output, meaning the caller
+/// should pass scale=1.0 rather than max(|input|) to calculatePointwiseTolerance.
+///
+/// Bounded-output ops:
+/// - SIGMOID_FWD: output in [0, 1]
+/// - TANH_FWD: output in [-1, 1]
+/// - ERF: output in [-1, 1]
+inline bool isBoundedOutput(hipdnn_data_sdk::data_objects::PointwiseMode mode)
+{
+    using hipdnn_data_sdk::data_objects::PointwiseMode;
+
+    switch(mode)
+    {
+    case PointwiseMode::SIGMOID_FWD:
+    case PointwiseMode::TANH_FWD:
+    case PointwiseMode::ERF:
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace hipdnn_test_sdk::utilities::pointwise

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
@@ -8,8 +8,6 @@
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
-#include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
-#include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
 #include <hipdnn_test_sdk/utilities/pointwise/CpuReferencePointwise.hpp>
 #include <hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp>
 
@@ -56,17 +54,6 @@ template <typename Input1Type,
 class CpuReferencePointwiseFixture : public ::testing::Test
 {
 protected:
-    float getMixedTypeTolerance() const
-    {
-        auto input1Tolerance = pointwise::getTolerance<Input1Type>();
-        auto input2Tolerance = pointwise::getTolerance<Input2Type>();
-        auto outputTolerance = pointwise::getTolerance<OutputType>();
-
-        return std::max({static_cast<float>(input1Tolerance),
-                         static_cast<float>(input2Tolerance),
-                         static_cast<float>(outputTolerance)});
-    }
-
     /// Calculates dynamic tolerance based on the operation and input data range.
     /// Takes the max of ComputeType-based and float-based tolerance because test
     /// expected values are computed from float constants (PI, E, TEST_VALUE_*),

--- a/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestCpuReferencePointwise.cpp
@@ -6,10 +6,12 @@
 #include <hipdnn_data_sdk/types.hpp>
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
+#include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
 #include <hipdnn_test_sdk/utilities/FlatbufferGraphTestUtils.hpp>
 #include <hipdnn_test_sdk/utilities/TestTolerances.hpp>
 #include <hipdnn_test_sdk/utilities/detail/CpuFpReferenceUtilities.hpp>
 #include <hipdnn_test_sdk/utilities/pointwise/CpuReferencePointwise.hpp>
+#include <hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp>
 
 using namespace hipdnn_test_sdk::utilities;
 using namespace hipdnn_data_sdk::utilities;
@@ -65,6 +67,22 @@ protected:
                          static_cast<float>(outputTolerance)});
     }
 
+    /// Calculates dynamic tolerance based on the operation and input data range.
+    /// Takes the max of ComputeType-based and float-based tolerance because test
+    /// expected values are computed from float constants (PI, E, TEST_VALUE_*),
+    /// so precision is bounded by float even when ComputeType is double.
+    float getDynamicTolerance(PointwiseMode mode, float scale) const
+    {
+        auto errorClass = pointwise::classifyPointwiseOp(mode);
+        auto effectiveScale = static_cast<double>(pointwise::isBoundedOutput(mode) ? 1.0f : scale);
+        auto tolerance
+            = pointwise::calculatePointwiseTolerance<OutputType, Input1Type, ComputeType>(
+                effectiveScale, errorClass);
+        auto floatFloor = pointwise::calculatePointwiseTolerance<OutputType, Input1Type, float>(
+            effectiveScale, errorClass);
+        return std::max(tolerance, floatFloor);
+    }
+
     // ======================= BINARY OPERATIONS =======================
 
     void testBinaryAddOperation()
@@ -82,7 +100,7 @@ protected:
         Tensor<OutputType> expected({1, 3, 2, 2});
         expected.fillWithValue(safeTestTypeCast<OutputType>(TEST_VALUE_3));
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ADD, TEST_VALUE_2);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -102,7 +120,7 @@ protected:
         Tensor<OutputType> expected({1, 3, 2, 2});
         expected.fillWithValue(safeTestTypeCast<OutputType>(TEST_VALUE_3));
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::SUB, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -177,7 +195,7 @@ protected:
         CpuReferencePointwiseImpl<OutputType, Input1Type, Input2Type>::pointwiseCompute(
             PointwiseMode::ADD, output, input1, input2);
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ADD, PI);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -243,7 +261,7 @@ protected:
         CpuReferencePointwiseImpl<OutputType, Input1Type, Input2Type>::pointwiseCompute(
             PointwiseMode::SUB, output, input1, input2);
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::SUB, E * E);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -263,7 +281,7 @@ protected:
         Tensor<OutputType> expected({2, 3, 10});
         expected.fillWithValue(safeTestTypeCast<OutputType>(TEST_VALUE_4));
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ADD, TEST_VALUE_2_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -296,7 +314,7 @@ protected:
         CpuReferencePointwiseImpl<OutputType, Input1Type, Input2Type>::pointwiseCompute(
             PointwiseMode::SUB, output, input1, input2);
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::SUB, E * E);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -317,7 +335,7 @@ protected:
         expected.setHostValue(
             safeTestTypeCast<OutputType>(PRECISION_TEST_A + PRECISION_TEST_B), 0, 0, 0, 0);
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ADD, PRECISION_TEST_B);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -345,7 +363,7 @@ protected:
         expected.setHostValue(safeTestTypeCast<OutputType>(static_cast<float>(10)), 3);
         expected.setHostValue(safeTestTypeCast<OutputType>(static_cast<float>(13)), 4);
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ADD, 8.0f);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -387,7 +405,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ADD, 40.0f);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -423,7 +441,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::SUB, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -460,7 +478,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::SUB, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -511,7 +529,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ADD, 30.0f);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -565,7 +583,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ADD, 103.0f);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -630,7 +648,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ADD, 30.0f);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -680,7 +698,7 @@ protected:
         expected.setHostValue(
             safeTestTypeCast<OutputType>(TEST_VALUE_1_5), 0, 2, 1, 1); // max(0, 1.5) = 1.5
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::RELU_FWD, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -757,7 +775,7 @@ protected:
                               1,
                               1); // dy=3.0, x=1.5>0: dx=3.0*1=3.0
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::RELU_BWD, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -816,7 +834,7 @@ protected:
         expected.setHostValue(
             safeTestTypeCast<OutputType>(TEST_VALUE_1), 0, 1, 1, 1); // 1.0 (in range)
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::RELU_FWD, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -901,7 +919,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::RELU_BWD, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -975,7 +993,7 @@ protected:
                               1,
                               1); // sigmoid(1.5)
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::SIGMOID_FWD, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1035,7 +1053,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::SIGMOID_BWD, TEST_VALUE_4);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1077,7 +1095,7 @@ protected:
         expected.setHostValue(
             safeTestTypeCast<OutputType>(std::tanh(TEST_VALUE_1_5)), 0, 1, 1, 1); // tanh(1.5)
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::TANH_FWD, TEST_VALUE_3);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1137,7 +1155,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::TANH_BWD, TEST_VALUE_4);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1207,7 +1225,7 @@ protected:
             1,
             1); // |-4| = 4
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ABS, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1242,7 +1260,7 @@ protected:
         expected.setHostValue(safeTestTypeCast<OutputType>(-TEST_VALUE_2_5), 0, 1, 1, 0); // -2.5
         expected.setHostValue(safeTestTypeCast<OutputType>(TEST_VALUE_4), 0, 1, 1, 1); // -(-4) = 4
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::NEG, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1314,7 +1332,7 @@ protected:
                               1,
                               1); // gelu_erf(1.5)
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::GELU_FWD, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1356,7 +1374,7 @@ protected:
         expected.setHostValue(safeTestTypeCast<OutputType>(geluTanh(-TEST_VALUE_5)), 0, 1, 1, 0);
         expected.setHostValue(safeTestTypeCast<OutputType>(geluTanh(TEST_VALUE_1_5)), 0, 1, 1, 1);
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::GELU_APPROX_TANH_FWD, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1394,7 +1412,7 @@ protected:
         expected.setHostValue(safeTestTypeCast<OutputType>(swish(-TEST_VALUE_5)), 0, 1, 1, 0);
         expected.setHostValue(safeTestTypeCast<OutputType>(swish(TEST_VALUE_1_5)), 0, 1, 1, 1);
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::SWISH_FWD, TEST_VALUE_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1422,7 +1440,7 @@ protected:
         expected.setHostValue(safeTestTypeCast<OutputType>(1.0f), 3); // max(0, 1) = 1
         expected.setHostValue(safeTestTypeCast<OutputType>(2.0f), 4); // max(0, 2) = 2
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::RELU_FWD, 2.0f);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1457,7 +1475,7 @@ protected:
             }
         }
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::ABS, 3.0f);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1476,7 +1494,7 @@ protected:
         Tensor<OutputType> expected({2, 3, 4});
         expected.fillWithValue(safeTestTypeCast<OutputType>(TEST_VALUE_2_5));
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::NEG, TEST_VALUE_2_5);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1495,7 +1513,7 @@ protected:
         Tensor<OutputType> expected({1, 1, 1, 1});
         expected.setHostValue(safeTestTypeCast<OutputType>(std::tanh(E)), 0, 0, 0, 0);
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::TANH_FWD, E);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }
@@ -1529,7 +1547,7 @@ protected:
         expected.setHostValue(safeTestTypeCast<OutputType>(TEST_VALUE_2_5), 0, 1, 1, 0); // 2.5
         expected.setHostValue(safeTestTypeCast<OutputType>(SQRT_2), 0, 1, 1, 1); // √2
 
-        auto tolerance = getMixedTypeTolerance();
+        auto tolerance = getDynamicTolerance(PointwiseMode::IDENTITY, PI);
         auto validator = createAllCloseValidator<OutputType>(tolerance, tolerance);
         EXPECT_TRUE(validator->allClose(expected, output));
     }

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
@@ -1844,19 +1844,16 @@ TEST(TestCalculatePointwiseTolerance, BackwardToleranceExceedsForward)
 // and isBoundedOutput for code coverage.
 // =================================================================================================
 
-using hipdnn_data_sdk::data_objects::PointwiseMode;
 using hipdnn_data_sdk::data_objects::EnumNamesPointwiseMode;
 using hipdnn_data_sdk::data_objects::EnumValuesPointwiseMode;
+using hipdnn_data_sdk::data_objects::PointwiseMode;
 
 // Verify one representative per error class for correctness
 TEST(TestClassifyPointwiseOp, OnePerClassCorrect)
 {
-    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::ABS),
-              PointwiseErrorClass::BITWISE);
-    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::ADD),
-              PointwiseErrorClass::LINEAR);
-    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::DIV),
-              PointwiseErrorClass::RATIONAL);
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::ABS), PointwiseErrorClass::BITWISE);
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::ADD), PointwiseErrorClass::LINEAR);
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::DIV), PointwiseErrorClass::RATIONAL);
     EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::EXP),
               PointwiseErrorClass::TRANSCENDENTAL_FWD);
     EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::TANH_BWD),

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
@@ -1773,9 +1773,9 @@ TEST(TestCalculatePointwiseTolerance, LowPrecisionMultiplierNotLessThanHigh)
         auto epsBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
         auto epsHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
 
-        double cHigh = static_cast<double>(tolHigh) / epsFloat;
-        double cLowBf16 = static_cast<double>(tolLowBf16) / epsBf16;
-        double cLowHalf = static_cast<double>(tolLowHalf) / epsHalf;
+        const double cHigh = static_cast<double>(tolHigh) / epsFloat;
+        const double cLowBf16 = static_cast<double>(tolLowBf16) / epsBf16;
+        const double cLowHalf = static_cast<double>(tolLowHalf) / epsHalf;
 
         EXPECT_GE(cLowBf16, cHigh)
             << "C_low(bf16) < C_high for class " << static_cast<int>(errorClass);
@@ -1787,8 +1787,8 @@ TEST(TestCalculatePointwiseTolerance, LowPrecisionMultiplierNotLessThanHigh)
 // Test that calculatePointwiseTolerance detects wrong outputs
 TEST(TestCalculatePointwiseTolerance, DetectsFailure)
 {
-    std::vector<int64_t> dims = {1, 1, 1, 1};
-    std::vector<int64_t> strides = {1, 1, 1, 1};
+    const std::vector<int64_t> dims = {1, 1, 1, 1};
+    const std::vector<int64_t> strides = {1, 1, 1, 1};
 
     auto baseline = hipdnn_data_sdk::utilities::createTensor(
         hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides);

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
@@ -8,6 +8,7 @@
 #include <hipdnn_data_sdk/utilities/Tensor.hpp>
 #include <hipdnn_test_sdk/utilities/CpuFpReferenceValidation.hpp>
 #include <hipdnn_test_sdk/utilities/DynamicTolerances.hpp>
+#include <hipdnn_test_sdk/utilities/pointwise/PointwiseErrorClassification.hpp>
 #include <vector>
 
 using namespace hipdnn_test_sdk::utilities;
@@ -1836,4 +1837,67 @@ TEST(TestCalculatePointwiseTolerance, BackwardToleranceExceedsForward)
     auto transBwdBf16 = calculatePointwiseTolerance<bfloat16, bfloat16, bfloat16>(
         1.0, PointwiseErrorClass::TRANSCENDENTAL_BWD);
     EXPECT_GT(transBwdBf16, transFwdBf16);
+}
+
+// =================================================================================================
+// TestClassifyPointwiseOp — exercises every PointwiseMode branch in classifyPointwiseOp
+// and isBoundedOutput for code coverage.
+// =================================================================================================
+
+using hipdnn_data_sdk::data_objects::PointwiseMode;
+using hipdnn_data_sdk::data_objects::EnumNamesPointwiseMode;
+using hipdnn_data_sdk::data_objects::EnumValuesPointwiseMode;
+
+// Verify one representative per error class for correctness
+TEST(TestClassifyPointwiseOp, OnePerClassCorrect)
+{
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::ABS),
+              PointwiseErrorClass::BITWISE);
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::ADD),
+              PointwiseErrorClass::LINEAR);
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::DIV),
+              PointwiseErrorClass::RATIONAL);
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::EXP),
+              PointwiseErrorClass::TRANSCENDENTAL_FWD);
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::TANH_BWD),
+              PointwiseErrorClass::TRANSCENDENTAL_BWD);
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::GELU_FWD),
+              PointwiseErrorClass::COMPOSITE_FWD);
+    EXPECT_EQ(pointwise::classifyPointwiseOp(PointwiseMode::GELU_BWD),
+              PointwiseErrorClass::COMPOSITE_BWD);
+}
+
+// Exercise every enum value for branch coverage; verify result is a valid class
+TEST(TestClassifyPointwiseOp, AllModesReturnValidClass)
+{
+    for(auto mode : EnumValuesPointwiseMode())
+    {
+        if(mode == PointwiseMode::UNSET)
+        {
+            continue;
+        }
+        auto errorClass = pointwise::classifyPointwiseOp(mode);
+        EXPECT_LE(static_cast<uint8_t>(errorClass),
+                  static_cast<uint8_t>(PointwiseErrorClass::COMPOSITE_BWD))
+            << "invalid class for " << EnumNamesPointwiseMode()[static_cast<int>(mode)];
+    }
+}
+
+// Only SIGMOID_FWD, TANH_FWD, ERF are bounded; all others are not
+TEST(TestClassifyPointwiseOp, BoundedOutputCorrect)
+{
+    EXPECT_TRUE(pointwise::isBoundedOutput(PointwiseMode::SIGMOID_FWD));
+    EXPECT_TRUE(pointwise::isBoundedOutput(PointwiseMode::TANH_FWD));
+    EXPECT_TRUE(pointwise::isBoundedOutput(PointwiseMode::ERF));
+
+    for(auto mode : EnumValuesPointwiseMode())
+    {
+        if(mode == PointwiseMode::UNSET || mode == PointwiseMode::SIGMOID_FWD
+           || mode == PointwiseMode::TANH_FWD || mode == PointwiseMode::ERF)
+        {
+            continue;
+        }
+        EXPECT_FALSE(pointwise::isBoundedOutput(mode))
+            << EnumNamesPointwiseMode()[static_cast<int>(mode)] << " should not be bounded";
+    }
 }

--- a/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
+++ b/projects/hipdnn/test_sdk/tests/utilities/TestDynamicTolerances.cpp
@@ -1486,3 +1486,354 @@ TEST(TestCalculateMatmulTolerance, ThrowsOnOutputOverflow)
     // OutputType = half, so max ≈ 65504
     EXPECT_THROW((calculateMatmulTolerance<half, float, float>(a, b)), std::overflow_error);
 }
+
+// =================================================================================================
+// TestCalculatePointwiseTolerance
+// =================================================================================================
+
+using namespace hipdnn_test_sdk::utilities::pointwise;
+
+struct PointwiseToleranceTestCase
+{
+    double scale;
+    PointwiseErrorClass errorClass;
+    double expectedTolerance;
+
+    friend std::ostream& operator<<(std::ostream& os, const PointwiseToleranceTestCase& tc)
+    {
+        static constexpr std::array CLASS_NAMES = {"Bitwise",
+                                                   "Linear",
+                                                   "Rational",
+                                                   "TranscendentalFwd",
+                                                   "TranscendentalBwd",
+                                                   "CompositeFwd",
+                                                   "CompositeBwd"};
+        os << "scale: " << tc.scale
+           << ", errorClass: " << CLASS_NAMES[static_cast<uint8_t>(tc.errorClass)]
+           << ", expectedTolerance: " << tc.expectedTolerance;
+        return os;
+    }
+};
+
+template <typename T>
+std::vector<PointwiseToleranceTestCase> getPointwiseToleranceTestCases();
+
+// Float / Float / Float — C_high: Bitwise=1, Linear=2, Rational=4,
+//   TransFwd=8, TransBwd=12, CompFwd=16, CompBwd=24
+// tolerance = C * 2^-23 * scale, no cast errors
+template <>
+std::vector<PointwiseToleranceTestCase>
+    getPointwiseToleranceTestCases<TypeTriple<float, float, float>>()
+{
+    return {
+        {1.0, PointwiseErrorClass::BITWISE, 1.0 * std::pow(2.0, -23)},
+        {1.0, PointwiseErrorClass::LINEAR, 2.0 * std::pow(2.0, -23)},
+        {1.0, PointwiseErrorClass::RATIONAL, 4.0 * std::pow(2.0, -23)},
+        {1.0, PointwiseErrorClass::TRANSCENDENTAL_FWD, 8.0 * std::pow(2.0, -23)},
+        {1.0, PointwiseErrorClass::TRANSCENDENTAL_BWD, 12.0 * std::pow(2.0, -23)},
+        {1.0, PointwiseErrorClass::COMPOSITE_FWD, 16.0 * std::pow(2.0, -23)},
+        {1.0, PointwiseErrorClass::COMPOSITE_BWD, 24.0 * std::pow(2.0, -23)},
+        // CompositeBwd with large scale: C=24, scale=100. Tol = 2400 * 2^-23
+        {100.0, PointwiseErrorClass::COMPOSITE_BWD, 2400.0 * std::pow(2.0, -23)},
+    };
+}
+
+// Float / Double / Float — Input downcast (double -> float): +epsilon_compute * scale
+// tolerance = (C + 1) * 2^-23 * scale
+template <>
+std::vector<PointwiseToleranceTestCase>
+    getPointwiseToleranceTestCases<TypeTriple<float, double, float>>()
+{
+    return {
+        // Bitwise: (1 + 1) * 2^-23 = 2 * 2^-23
+        {1.0, PointwiseErrorClass::BITWISE, 2.0 * std::pow(2.0, -23)},
+        // Linear: (2 + 1) * 2^-23 = 3 * 2^-23
+        {1.0, PointwiseErrorClass::LINEAR, 3.0 * std::pow(2.0, -23)},
+        // CompositeFwd: (16 + 1) * 2^-23 = 17 * 2^-23
+        {1.0, PointwiseErrorClass::COMPOSITE_FWD, 17.0 * std::pow(2.0, -23)},
+        // CompositeBwd: (24 + 1) * 2^-23 = 25 * 2^-23
+        {1.0, PointwiseErrorClass::COMPOSITE_BWD, 25.0 * std::pow(2.0, -23)},
+    };
+}
+
+// Bfloat16 / Float / Float — Output downcast (float -> bfloat16): +2^-7 * scale
+// tolerance = C * 2^-23 * scale + 2^-7 * scale
+template <>
+std::vector<PointwiseToleranceTestCase>
+    getPointwiseToleranceTestCases<TypeTriple<bfloat16, float, float>>()
+{
+    return {
+        // Bitwise: 1 * 2^-23 + 2^-7
+        {1.0, PointwiseErrorClass::BITWISE, std::pow(2.0, -23) + std::pow(2.0, -7)},
+        // TranscendentalFwd: 8 * 2^-23 + 2^-7
+        {1.0,
+         PointwiseErrorClass::TRANSCENDENTAL_FWD,
+         8.0 * std::pow(2.0, -23) + std::pow(2.0, -7)},
+        // TranscendentalBwd: 12 * 2^-23 + 2^-7
+        {1.0,
+         PointwiseErrorClass::TRANSCENDENTAL_BWD,
+         12.0 * std::pow(2.0, -23) + std::pow(2.0, -7)},
+        // CompositeBwd with large scale: (24 * 2^-23 + 2^-7) * 100
+        {100.0,
+         PointwiseErrorClass::COMPOSITE_BWD,
+         100.0 * (24.0 * std::pow(2.0, -23) + std::pow(2.0, -7))},
+    };
+}
+
+// Bfloat16 / Bfloat16 / Bfloat16 — C_low: Bitwise=2, Linear=4, Rational=8,
+//   TransFwd=16, TransBwd=24, CompFwd=32, CompBwd=48
+// tolerance = C_low * 2^-7 * scale, no cast errors
+template <>
+std::vector<PointwiseToleranceTestCase>
+    getPointwiseToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()
+{
+    return {
+        {1.0, PointwiseErrorClass::BITWISE, 2.0 * std::pow(2.0, -7)},
+        {1.0, PointwiseErrorClass::LINEAR, 4.0 * std::pow(2.0, -7)},
+        {1.0, PointwiseErrorClass::RATIONAL, 8.0 * std::pow(2.0, -7)},
+        {1.0, PointwiseErrorClass::TRANSCENDENTAL_FWD, 16.0 * std::pow(2.0, -7)},
+        {1.0, PointwiseErrorClass::TRANSCENDENTAL_BWD, 24.0 * std::pow(2.0, -7)},
+        {1.0, PointwiseErrorClass::COMPOSITE_FWD, 32.0 * std::pow(2.0, -7)},
+        {1.0, PointwiseErrorClass::COMPOSITE_BWD, 48.0 * std::pow(2.0, -7)},
+    };
+}
+
+// Half / Float / Float — Output downcast (float -> half): +2^-10 * scale
+// tolerance = C * 2^-23 * scale + 2^-10 * scale
+template <>
+std::vector<PointwiseToleranceTestCase>
+    getPointwiseToleranceTestCases<TypeTriple<half, float, float>>()
+{
+    return {
+        // Bitwise: 1 * 2^-23 + 2^-10
+        {1.0, PointwiseErrorClass::BITWISE, std::pow(2.0, -23) + std::pow(2.0, -10)},
+        // TranscendentalFwd: 8 * 2^-23 + 2^-10
+        {1.0,
+         PointwiseErrorClass::TRANSCENDENTAL_FWD,
+         8.0 * std::pow(2.0, -23) + std::pow(2.0, -10)},
+        // TranscendentalBwd: 12 * 2^-23 + 2^-10
+        {1.0,
+         PointwiseErrorClass::TRANSCENDENTAL_BWD,
+         12.0 * std::pow(2.0, -23) + std::pow(2.0, -10)},
+        // CompositeBwd with large scale: (24 * 2^-23 + 2^-10) * 100
+        {100.0,
+         PointwiseErrorClass::COMPOSITE_BWD,
+         100.0 * (24.0 * std::pow(2.0, -23) + std::pow(2.0, -10))},
+    };
+}
+
+// Half / Half / Half — C_low: Bitwise=2, Linear=4, Rational=8,
+//   TransFwd=16, TransBwd=24, CompFwd=32, CompBwd=48
+// tolerance = C_low * 2^-10 * scale, no cast errors
+template <>
+std::vector<PointwiseToleranceTestCase>
+    getPointwiseToleranceTestCases<TypeTriple<half, half, half>>()
+{
+    return {
+        {1.0, PointwiseErrorClass::BITWISE, 2.0 * std::pow(2.0, -10)},
+        {1.0, PointwiseErrorClass::LINEAR, 4.0 * std::pow(2.0, -10)},
+        {1.0, PointwiseErrorClass::RATIONAL, 8.0 * std::pow(2.0, -10)},
+        {1.0, PointwiseErrorClass::TRANSCENDENTAL_FWD, 16.0 * std::pow(2.0, -10)},
+        {1.0, PointwiseErrorClass::TRANSCENDENTAL_BWD, 24.0 * std::pow(2.0, -10)},
+        {1.0, PointwiseErrorClass::COMPOSITE_FWD, 32.0 * std::pow(2.0, -10)},
+        {1.0, PointwiseErrorClass::COMPOSITE_BWD, 48.0 * std::pow(2.0, -10)},
+    };
+}
+
+template <typename Out, typename In, typename Comp>
+class TestCalculatePointwiseTolerance : public ::testing::TestWithParam<PointwiseToleranceTestCase>
+{
+protected:
+    void verifyTolerance()
+    {
+        const auto& params = GetParam();
+
+        auto tol = calculatePointwiseTolerance<Out, In, Comp>(params.scale, params.errorClass);
+
+        auto expected = static_cast<float>(params.expectedTolerance);
+
+        EXPECT_NEAR(tol, expected, 1e-10f);
+    }
+};
+
+using TestCalculatePointwiseToleranceFp32 = TestCalculatePointwiseTolerance<float, float, float>;
+TEST_P(TestCalculatePointwiseToleranceFp32, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculatePointwiseToleranceFp32,
+    ::testing::ValuesIn(getPointwiseToleranceTestCases<TypeTriple<float, float, float>>()));
+
+using TestCalculatePointwiseToleranceInputDouble
+    = TestCalculatePointwiseTolerance<float, double, float>;
+TEST_P(TestCalculatePointwiseToleranceInputDouble, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculatePointwiseToleranceInputDouble,
+    ::testing::ValuesIn(getPointwiseToleranceTestCases<TypeTriple<float, double, float>>()));
+
+using TestCalculatePointwiseToleranceComputeFloatBfp16
+    = TestCalculatePointwiseTolerance<bfloat16, float, float>;
+TEST_P(TestCalculatePointwiseToleranceComputeFloatBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculatePointwiseToleranceComputeFloatBfp16,
+    ::testing::ValuesIn(getPointwiseToleranceTestCases<TypeTriple<bfloat16, float, float>>()));
+
+using TestCalculatePointwiseToleranceBfp16
+    = TestCalculatePointwiseTolerance<bfloat16, bfloat16, bfloat16>;
+TEST_P(TestCalculatePointwiseToleranceBfp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculatePointwiseToleranceBfp16,
+    ::testing::ValuesIn(
+        getPointwiseToleranceTestCases<TypeTriple<bfloat16, bfloat16, bfloat16>>()));
+
+using TestCalculatePointwiseToleranceComputeFloatFp16
+    = TestCalculatePointwiseTolerance<half, float, float>;
+TEST_P(TestCalculatePointwiseToleranceComputeFloatFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculatePointwiseToleranceComputeFloatFp16,
+    ::testing::ValuesIn(getPointwiseToleranceTestCases<TypeTriple<half, float, float>>()));
+
+using TestCalculatePointwiseToleranceFp16 = TestCalculatePointwiseTolerance<half, half, half>;
+TEST_P(TestCalculatePointwiseToleranceFp16, VerifyTolerance)
+{
+    this->verifyTolerance();
+}
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    TestCalculatePointwiseToleranceFp16,
+    ::testing::ValuesIn(getPointwiseToleranceTestCases<TypeTriple<half, half, half>>()));
+
+// Bitwise must produce non-zero tolerance (epsilon floor prevents 0-tolerance fragility)
+TEST(TestCalculatePointwiseTolerance, BitwiseHasNonZeroTolerance)
+{
+    // float/float/float: C=1 * 2^-23 * 1.0 > 0
+    auto tol = calculatePointwiseTolerance<float, float, float>(1.0, PointwiseErrorClass::BITWISE);
+    EXPECT_GT(tol, 0.0f);
+
+    // half/half/half: C=1 * 2^-10 * 1.0 > 0
+    auto tolHalf = calculatePointwiseTolerance<half, half, half>(1.0, PointwiseErrorClass::BITWISE);
+    EXPECT_GT(tolHalf, 0.0f);
+
+    // bfloat16/bfloat16/bfloat16: C=1 * 2^-7 * 1.0 > 0
+    auto tolBf16 = calculatePointwiseTolerance<bfloat16, bfloat16, bfloat16>(
+        1.0, PointwiseErrorClass::BITWISE);
+    EXPECT_GT(tolBf16, 0.0f);
+}
+
+// Test that tolerance scales linearly with scale
+TEST(TestCalculatePointwiseTolerance, ScalesWithScale)
+{
+    auto tol1 = calculatePointwiseTolerance<float, float, float>(1.0, PointwiseErrorClass::LINEAR);
+    auto tol100
+        = calculatePointwiseTolerance<float, float, float>(100.0, PointwiseErrorClass::LINEAR);
+
+    EXPECT_NEAR(tol100 / tol1, 100.0f, 1e-3f);
+}
+
+// Test that C_low >= C_high for all error classes (invariant)
+TEST(TestCalculatePointwiseTolerance, LowPrecisionMultiplierNotLessThanHigh)
+{
+    for(auto errorClass : {PointwiseErrorClass::BITWISE,
+                           PointwiseErrorClass::LINEAR,
+                           PointwiseErrorClass::RATIONAL,
+                           PointwiseErrorClass::TRANSCENDENTAL_FWD,
+                           PointwiseErrorClass::TRANSCENDENTAL_BWD,
+                           PointwiseErrorClass::COMPOSITE_FWD,
+                           PointwiseErrorClass::COMPOSITE_BWD})
+    {
+        // Compare tolerance for low-precision compute vs high-precision compute,
+        // both with same type for input/output to isolate the C multiplier.
+        auto tolHigh = calculatePointwiseTolerance<float, float, float>(1.0, errorClass);
+        auto tolLowBf16
+            = calculatePointwiseTolerance<bfloat16, bfloat16, bfloat16>(1.0, errorClass);
+        auto tolLowHalf = calculatePointwiseTolerance<half, half, half>(1.0, errorClass);
+
+        // Normalize by epsilon to extract C: tol = C * epsilon * inputScale
+        // C_high = tolHigh / epsilon_float, C_low_bf16 = tolLowBf16 / epsilon_bf16
+        auto epsFloat = static_cast<double>(std::numeric_limits<float>::epsilon());
+        auto epsBf16 = static_cast<double>(std::numeric_limits<bfloat16>::epsilon());
+        auto epsHalf = static_cast<double>(std::numeric_limits<half>::epsilon());
+
+        double cHigh = static_cast<double>(tolHigh) / epsFloat;
+        double cLowBf16 = static_cast<double>(tolLowBf16) / epsBf16;
+        double cLowHalf = static_cast<double>(tolLowHalf) / epsHalf;
+
+        EXPECT_GE(cLowBf16, cHigh)
+            << "C_low(bf16) < C_high for class " << static_cast<int>(errorClass);
+        EXPECT_GE(cLowHalf, cHigh)
+            << "C_low(half) < C_high for class " << static_cast<int>(errorClass);
+    }
+}
+
+// Test that calculatePointwiseTolerance detects wrong outputs
+TEST(TestCalculatePointwiseTolerance, DetectsFailure)
+{
+    std::vector<int64_t> dims = {1, 1, 1, 1};
+    std::vector<int64_t> strides = {1, 1, 1, 1};
+
+    auto baseline = hipdnn_data_sdk::utilities::createTensor(
+        hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides);
+    auto actualPassing = hipdnn_data_sdk::utilities::createTensor(
+        hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides);
+    auto actualFailing = hipdnn_data_sdk::utilities::createTensor(
+        hipdnn_data_sdk::data_objects::DataType::FLOAT, dims, strides);
+
+    // For float/float/float, TRANSCENDENTAL_FWD, scale=1.0:
+    // tol = 8 * 2^-23 ≈ 9.54e-7 (no cast errors, clean C * epsilon * scale)
+    baseline->fillTensorWithValue(1.0f);
+    actualPassing->fillTensorWithValue(1.0f + 1.0e-7f); // Error 1e-7 < 9.54e-7
+    actualFailing->fillTensorWithValue(1.0f + 2.0e-6f); // Error 2e-6 > 9.54e-7
+
+    auto tol = calculatePointwiseTolerance<float, float, float>(
+        1.0, PointwiseErrorClass::TRANSCENDENTAL_FWD);
+
+    auto validator = hipdnn_test_sdk::utilities::createAllCloseValidator(
+        hipdnn_data_sdk::data_objects::DataType::FLOAT, tol, 0);
+
+    bool valid = validator->allClose(*baseline, *actualPassing);
+    EXPECT_TRUE(valid);
+
+    valid = validator->allClose(*baseline, *actualFailing);
+    EXPECT_FALSE(valid);
+}
+
+// Test that backward ops always have higher tolerance than forward ops
+TEST(TestCalculatePointwiseTolerance, BackwardToleranceExceedsForward)
+{
+    auto transFwd = calculatePointwiseTolerance<float, float, float>(
+        1.0, PointwiseErrorClass::TRANSCENDENTAL_FWD);
+    auto transBwd = calculatePointwiseTolerance<float, float, float>(
+        1.0, PointwiseErrorClass::TRANSCENDENTAL_BWD);
+    EXPECT_GT(transBwd, transFwd);
+
+    auto compFwd
+        = calculatePointwiseTolerance<float, float, float>(1.0, PointwiseErrorClass::COMPOSITE_FWD);
+    auto compBwd
+        = calculatePointwiseTolerance<float, float, float>(1.0, PointwiseErrorClass::COMPOSITE_BWD);
+    EXPECT_GT(compBwd, compFwd);
+
+    // Same invariant for low precision
+    auto transFwdBf16 = calculatePointwiseTolerance<bfloat16, bfloat16, bfloat16>(
+        1.0, PointwiseErrorClass::TRANSCENDENTAL_FWD);
+    auto transBwdBf16 = calculatePointwiseTolerance<bfloat16, bfloat16, bfloat16>(
+        1.0, PointwiseErrorClass::TRANSCENDENTAL_BWD);
+    EXPECT_GT(transBwdBf16, transFwdBf16);
+}


### PR DESCRIPTION
## Motivation


Pointwise operations used static, type-only tolerances (`1e-5f` for float, `1e-2f` for bf16) that ignore the operation being tested and its input range. A single tolerance per type cannot distinguish between a bitwise-exact relu and a composite `gelu_approx_tanh`, leading to either over-permissive tolerances for simple ops or under-permissive tolerances for complex ones.
## Plan

Use a class-based error model:

```
tolerance = C[class][precision] * epsilon_compute * scale
          + (inputDowncast  ? epsilon_compute * scale : 0)
          + (outputDowncast ? epsilon_output  * scale : 0)
```

- Classify all 47 `PointwiseMode` values into 7 error classes (BITWISE through COMPOSITE_BWD) based on observable error behavior, not internal op counts
- C constants: 1-24 for float/double, 2-48 for half/bf16 (`C_low = 2 * C_high`)
- Scale: `max(|input|)` for unbounded ops, `1.0` for bounded (sigmoid, tanh, erf) — handled automatically by `isBoundedOutput()`
- Cast errors added when input is downcast to compute type or compute is downcast to output type
- Float-epsilon floor for double-compute tests (test expected values are float-precision)

Introduced `PointwiseErrorClass` to decouple the tolerance formula from the flatbuffer-generated `PointwiseMode enum`, keeping `DynamicTolerances.hpp` dependency-free like the existing conv functions.  

**Files**: `DynamicTolerances.hpp` (enum + tolerance function), `PointwiseErrorClassification.hpp` (mode-to-class mapping), `TestDynamicTolerances.cpp` (unit tests), `TestCpuReferencePointwise.cpp` (integration). 

## Tests

- 39 new unit tests: 6 type combos (float, double, half, bf16 with various cast configurations) x 7 error classes + supplementary invariant tests (nonzero bitwise, linear scaling, C_low >= C_high, bwd > fwd, failure detection)
- All 157 existing `CpuReferencePointwise` tests pass with dynamic tolerances replacing 18 static `getMixedTypeTolerance()` calls
