### PR TITLE
[rocPRIM] Warn/Prevent rocPRIM benchmarks from being built on Windows

### DIFF
--- a/projects/rocprim/CHANGELOG.md
+++ b/projects/rocprim/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Full documentation for rocPRIM is available at [https://rocm.docs.amd.com/projects/rocPRIM/en/latest/](https://rocm.docs.amd.com/projects/rocPRIM/en/latest/).
 
+## rocPRIM 4.4.0 for ROCm 7.13
+
+### Changed
+
+* Building benchmarks on Windows is not currently possible because of the dependency on AMD SMI. 
+  * A CMake-level check has been added to prevent them from being built on Windows.
+  * The rmake.py build script no longer builds benchmarks by default on Windows when passed the `--clients` option.
+
 ## rocPRIM 4.3.0 for ROCm 7.12
 
 ### Optimizations

--- a/projects/rocprim/CMakeLists.txt
+++ b/projects/rocprim/CMakeLists.txt
@@ -90,6 +90,10 @@ if(BUILD_OFFLOAD_COMPRESS)
   endif()
 endif()
 
+if(WIN32 AND (BUILD_BENCHMARK OR BUILD_NAIVE_BENCHMARK))
+  message(FATAL_ERROR "rocPRIM benchmarks are not currently supported on Windows.")
+endif()
+
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(ROCPRIM_PROJECT_IS_TOP_LEVEL TRUE)
 else()

--- a/projects/rocprim/rmake.py
+++ b/projects/rocprim/rmake.py
@@ -176,7 +176,8 @@ def config_cmd():
         cmake_options.append( f"-DBUILD_TEST=ON -DBUILD_DIR={build_dir}" )
 
     if args.build_clients:
-        cmake_options.append( f"-DBUILD_TEST=ON -DBUILD_BENCHMARK=ON -DBUILD_EXAMPLE=ON -DBUILD_DIR={build_dir}" )
+        build_benchmarks = ("OFF" if OS_info["ID"] == "windows" else "ON")
+        cmake_options.append( f"-DBUILD_TEST=ON -DBUILD_BENCHMARK={build_benchmarks} -DBUILD_EXAMPLE=ON -DBUILD_DIR={build_dir}" )
 
     if args.no_offload_compress:
         cmake_options.append( f"-DBUILD_OFFLOAD_COMPRESS=OFF" )


### PR DESCRIPTION
## Motivation

Users who attempt to build benchmarks on Windows see built errors related to amdsmi.

## Technical Details

rocPRIM benchmarks can no longer be built on Windows because of primbench's dependency on AMD SMI, which is Linux-only.
This change:
- Adds a CMake-level fatal warning to alert users of this before they hit build errors.
- Modifies the rmake.py script to prevent BUILD_BENCHMARK from being set to ON when the --clients option is passed.

## Test Plan

Attempt to build rocPRIM with benchmarks enabled on Windows.
Can also try this by using `rmake.py` and passing the `--clients` option.

## Test Result

CMake-level errors and rmake.py changes work as expected.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
