### PR TITLE
[hipDNN] Fix ASAN memory leaks in backend descriptor tests

### DIFF
--- a/projects/hipdnn/backend/tests/descriptors/TestBlockScaleQuantizeOperationDescriptor.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestBlockScaleQuantizeOperationDescriptor.cpp
@@ -343,6 +343,7 @@ TEST_F(TestBlockScaleQuantizeOperationDescriptor, GetAttributeTensorDescriptor)
                                        1,
                                        &elementCount,
                                        static_cast<void*>(&retrievedX)));
+    std::unique_ptr<HipdnnBackendDescriptor> ownedX(retrievedX);
 
     ASSERT_EQ(elementCount, 1);
     ASSERT_NE(retrievedX, nullptr);

--- a/projects/hipdnn/backend/tests/descriptors/TestDescriptorFromFlatBuffer.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestDescriptorFromFlatBuffer.cpp
@@ -459,6 +459,7 @@ TEST_F(TestConvolutionFwdOperationFromNode, GetAttributeWorksAfterFromNode)
                        1,
                        &xCount,
                        static_cast<void*>(&xTensorDesc));
+    std::unique_ptr<HipdnnBackendDescriptor> ownedXDesc(xTensorDesc);
     ASSERT_EQ(xCount, 1);
     ASSERT_NE(xTensorDesc, nullptr);
     int64_t xUid = 0;
@@ -475,6 +476,7 @@ TEST_F(TestConvolutionFwdOperationFromNode, GetAttributeWorksAfterFromNode)
                        1,
                        &wCount,
                        static_cast<void*>(&wTensorDesc));
+    std::unique_ptr<HipdnnBackendDescriptor> ownedWDesc(wTensorDesc);
     ASSERT_EQ(wCount, 1);
     ASSERT_NE(wTensorDesc, nullptr);
     int64_t wUid = 0;
@@ -491,6 +493,7 @@ TEST_F(TestConvolutionFwdOperationFromNode, GetAttributeWorksAfterFromNode)
                        1,
                        &yCount,
                        static_cast<void*>(&yTensorDesc));
+    std::unique_ptr<HipdnnBackendDescriptor> ownedYDesc(yTensorDesc);
     ASSERT_EQ(yCount, 1);
     ASSERT_NE(yTensorDesc, nullptr);
     int64_t yUid = 0;

--- a/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorBlockScaleQuantize.cpp
+++ b/projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorBlockScaleQuantize.cpp
@@ -140,8 +140,7 @@ TEST_F(TestGraphDescriptorBlockScaleQuantize, BuildFromSingleOperation)
     flatbuffers::Verifier verifier(static_cast<const uint8_t*>(serialized.ptr), serialized.size);
     ASSERT_TRUE(verifier.VerifyBuffer<Graph>());
 
-    auto graph = GetGraph(serialized.ptr);
-    auto graphT = graph->UnPack();
+    auto graphT = UnPackGraph(serialized.ptr);
 
     ASSERT_EQ(graphT->nodes.size(), 1);
     ASSERT_EQ(graphT->tensors.size(), 3);
@@ -184,7 +183,7 @@ TEST_F(TestGraphDescriptorBlockScaleQuantize, ComputeDataTypePreserved)
     desc->finalize();
 
     auto serialized = desc->getSerializedGraph();
-    auto graphT = GetGraph(serialized.ptr)->UnPack();
+    auto graphT = UnPackGraph(serialized.ptr);
 
     ASSERT_EQ(graphT->nodes.size(), 1);
     EXPECT_EQ(graphT->nodes[0]->compute_data_type, DataType::HALF);


### PR DESCRIPTION
## Summary

- `UnPackGraph` to wrap GraphT in unique_ptr
- Wrap raw `HipdnnBackendDescriptor*` pointers returned by `getAttribute()` in `std::unique_ptr` in `TestBlockScaleQuantizeOperationDescriptor` and `TestDescriptorFromFlatBuffer`

All 1382 backend tests pass clean under ASAN with zero leaks.

## Affected files

- `projects/hipdnn/backend/tests/descriptors/TestGraphDescriptorBlockScaleQuantize.cpp`
- `projects/hipdnn/backend/tests/descriptors/TestBlockScaleQuantizeOperationDescriptor.cpp`
- `projects/hipdnn/backend/tests/descriptors/TestDescriptorFromFlatBuffer.cpp`

## Test plan

- [x] Built with `BUILD_ADDRESS_SANITIZER=ON`
- [x] All 1382 `hipdnn_backend_tests` pass with zero ASAN leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)