### PR TITLE
fix(rocprim): various improvements to adjacent find

### DIFF
--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_find.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_find.hpp
@@ -117,7 +117,7 @@ struct adjacent_find_impl_kernels
                 ROCPRIM_UNROLL
                 for(unsigned int i = 1; i < items_per_thread; i++)
                 {
-                    if(thread_id + i * block_size < valid_in_last_iteration)
+                    if((i * block_size) + thread_id < valid_in_last_iteration)
                     {
                         output_value = op(output_value, transformed_input_values[i]);
                     }

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_find.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_find.hpp
@@ -24,7 +24,6 @@
 #include "device_config_helper.hpp"
 #include "ordered_block_id.hpp"
 
-#include "../../block/block_load.hpp"
 #include "../../block/block_reduce.hpp"
 #include "../../intrinsics/thread.hpp"
 
@@ -74,7 +73,9 @@ struct adjacent_find_impl_kernels
             1,
             TargetConfig::wavefront>; // TODO?: params.block_reduce_method>;
 
-        ROCPRIM_SHARED_MEMORY union
+        // 'tile_id' and 'global_reduce_output' are both pretty small, so we can get 
+        // away by storing it in a struct instead of a union.
+        ROCPRIM_SHARED_MEMORY struct
         {
             typename decltype(ordered_tile_id)::storage_type tile_id;
             std::size_t                                      global_reduce_output;
@@ -82,22 +83,30 @@ struct adjacent_find_impl_kernels
 
         // Get initial tile id
         const unsigned int thread_id = threadIdx.x;
-        std::size_t        tile_offset
-            = ordered_tile_id.get(threadIdx.x, storage.tile_id) * items_per_tile;
-
-        while(tile_offset < size)
+        while(true)
         {
+            // Get the block id as a reference to shared memory
+            const auto& til_id_ref
+                = ordered_tile_id.get_async(threadIdx.x, storage.tile_id);
+
             // First thread of each block loads the latest global adjacent index found
             if(thread_id == 0)
             {
                 storage.global_reduce_output = atomic_load(reduce_output);
             }
+
+            // Ensure LDS storage contains 'tile_id' and 'global_reduce_output'
             syncthreads();
 
-            // Early exit if a previous block or tile found an adjacent pair
-            if(storage.global_reduce_output < tile_offset)
+            // Load the tile offset from reference
+            const auto tile_offset            = til_id_ref * items_per_tile;
+            const bool is_tile_out_of_bounds  = tile_offset >= size;
+            const bool is_result_in_prev_tile = storage.global_reduce_output < tile_offset;
+
+            // Apply loop exit conditions
+            if(is_tile_out_of_bounds || is_result_in_prev_tile)
             {
-                return;
+                break;
             }
 
             // Do block reduction
@@ -145,9 +154,6 @@ struct adjacent_find_impl_kernels
                 // Store global minimum
                 atomic_min(reduce_output, output_value);
             }
-
-            // Get next tile's id
-            tile_offset = ordered_tile_id.get(threadIdx.x, storage.tile_id) * items_per_tile;
         }
     }
 };

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_find.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/device_adjacent_find.hpp
@@ -73,7 +73,7 @@ struct adjacent_find_impl_kernels
             1,
             TargetConfig::wavefront>; // TODO?: params.block_reduce_method>;
 
-        // 'tile_id' and 'global_reduce_output' are both pretty small, so we can get 
+        // 'tile_id' and 'global_reduce_output' are both pretty small, so we can get
         // away by storing it in a struct instead of a union.
         ROCPRIM_SHARED_MEMORY struct
         {
@@ -86,8 +86,7 @@ struct adjacent_find_impl_kernels
         while(true)
         {
             // Get the block id as a reference to shared memory
-            const auto& til_id_ref
-                = ordered_tile_id.get_async(threadIdx.x, storage.tile_id);
+            const auto& til_id_ref = ordered_tile_id.get_async(threadIdx.x, storage.tile_id);
 
             // First thread of each block loads the latest global adjacent index found
             if(thread_id == 0)

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2017-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/detail/ordered_block_id.hpp
@@ -109,6 +109,16 @@ struct ordered_block_id
         return storage.id;
     }
 
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    id_type& get_async(unsigned int tid, storage_type& storage)
+    {
+        if(tid == 0)
+        {
+            storage.id = ::rocprim::detail::atomic_add(this->id, 1);
+        }
+        return storage.id;
+    }
+
     /// Resets the ordered block id from host. Don't use this if we have an init kernel!
     /// Call `ordered_block_id::reset()` from that kernel instead.
     ROCPRIM_HOST ROCPRIM_INLINE
@@ -164,6 +174,12 @@ struct block_id_wrapper<T, false>
     {
         return ::rocprim::detail::block_id<0>();
     }
+
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    id_type get_async(unsigned int /*tid*/, storage_type& /*storage*/)
+    {
+        return ::rocprim::detail::block_id<0>();
+    }
 };
 
 template<class T>
@@ -212,6 +228,12 @@ struct block_id_wrapper<T, true>
         auto id = ordered_id.get(tid, storage);
         ::rocprim::syncthreads();
         return id;
+    }
+
+    ROCPRIM_DEVICE ROCPRIM_INLINE
+    id_type& get_async(unsigned int tid, storage_type& storage)
+    {
+        return ordered_id.get_async(tid, storage);
     }
 
     ::rocprim::detail::ordered_block_id<id_type> ordered_id;

--- a/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_find.hpp
+++ b/projects/rocprim/rocprim/include/rocprim/device/device_adjacent_find.hpp
@@ -139,10 +139,11 @@ hipError_t adjacent_find_impl(void* const       temporary_storage,
 
         const auto params = get_config<Selector>(Config{}, current_target);
 
-        const unsigned int                block_size       = params.kernel_config.block_size;
-        const unsigned int                items_per_thread = params.kernel_config.items_per_thread;
-        const unsigned int                items_per_block  = block_size * items_per_thread;
-        const unsigned int grid_size        = (size + items_per_block - 1) / items_per_block;
+        const unsigned int block_size       = params.kernel_config.block_size;
+        const unsigned int items_per_thread = params.kernel_config.items_per_thread;
+        const unsigned int items_per_block  = block_size * items_per_thread;
+        const unsigned int grid_size
+            = ::rocprim::detail::ceiling_div(size + items_per_block - 1, items_per_block);
         const unsigned int shared_mem_bytes = 0; /*no dynamic shared mem*/
 
         auto kernel = [=](auto target_config)
@@ -160,14 +161,13 @@ hipError_t adjacent_find_impl(void* const       temporary_storage,
 
         // Get grid size for maximum occupancy, as we may not be able to schedule all the blocks
         // at the same time
-        int min_grid_size      = 0;
-        int optimal_block_size = 0;
-        ROCPRIM_RETURN_ON_ERROR(
-            hipOccupancyMaxPotentialBlockSize(&min_grid_size,
-                                              &optimal_block_size,
-                                              adjacent_find_block_reduce_kernel.kernel,
-                                              shared_mem_bytes,
-                                              int(block_size)));
+        int min_grid_size = 0;
+        ROCPRIM_RETURN_ON_ERROR(rocprim::detail::grid_dim_for_max_active_blocks(
+            min_grid_size,
+            block_size,
+            adjacent_find_block_reduce_kernel.kernel,
+            stream));
+
         min_grid_size = std::min(static_cast<unsigned int>(min_grid_size), grid_size);
 
         if(debug_synchronous)


### PR DESCRIPTION
## Motivation

I was looking into this algorithm following a discussion with @stanleytsang-amd. I found a few inconsistencies, like improper grid size calculation.

* Fixes a few inconsistencies when invoking device adjacent find.
* Removes a syncthread by combining both atomic operations and swapping to a struct for LDS.

## Technical Details

From our email discussion, we could remove an extra syncthreads since the LDS footprint is sufficiently small here.

## Test Plan

Tests pass and no regressions.

## Test Result

Shouldn't really impact other kernels. See benchmarks on gfx908 (0.01 = 1% faster):
![0_adj_diff_ref_rel](https://github.com/user-attachments/assets/24f09745-c65b-4c8e-b7b7-83c253890df5)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
